### PR TITLE
VSR: increase message pool capacity

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -228,7 +228,7 @@ const TimedQueue = struct {
         if (self.batches.head_ptr()) |starting_batch| {
             log.debug("sending first batch...", .{});
             self.batch_start = now;
-            var message = self.client.get_message();
+            const message = self.client.get_message();
             defer self.client.unref(message);
 
             std.mem.copy(
@@ -286,7 +286,7 @@ const TimedQueue = struct {
         }
 
         if (self.batches.head_ptr()) |next_batch| {
-            var message = self.client.get_message();
+            const message = self.client.get_message();
             defer self.client.unref(message);
 
             std.mem.copy(

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -228,9 +228,7 @@ const TimedQueue = struct {
         if (self.batches.head_ptr()) |starting_batch| {
             log.debug("sending first batch...", .{});
             self.batch_start = now;
-            var message = self.client.get_message() orelse {
-                @panic("Client message pool has been exhausted. Cannot execute batch.");
-            };
+            var message = self.client.get_message();
             defer self.client.unref(message);
 
             std.mem.copy(
@@ -288,9 +286,7 @@ const TimedQueue = struct {
         }
 
         if (self.batches.head_ptr()) |next_batch| {
-            var message = self.client.get_message() orelse {
-                @panic("Client message pool has been exhausted.");
-            };
+            var message = self.client.get_message();
             defer self.client.unref(message);
 
             std.mem.copy(

--- a/src/config.zig
+++ b/src/config.zig
@@ -96,8 +96,15 @@ pub const pipelining_max = clients_max;
 pub const connection_delay_min_ms = 50;
 pub const connection_delay_max_ms = 1000;
 
-/// The maximum number of outgoing messages that may be queued on a connection.
-pub const connection_send_queue_max = pipelining_max;
+/// The maximum number of outgoing messages that may be queued on a replica connection.
+pub const connection_send_queue_max_replica = pipelining_max;
+
+/// The maximum number of outgoing messages that may be queued on a client connection.
+/// The client has one in-flight request, and occasionally a ping.
+pub const connection_send_queue_max_client = 2;
+
+/// The maximum number of outgoing requests that may be queued on a client (including the in-flight request).
+pub const client_request_queue_max = 32;
 
 /// The maximum number of connections in the kernel's complete connection queue pending an accept():
 /// If the backlog argument is greater than the value in `/proc/sys/net/core/somaxconn`, then it is

--- a/src/config.zig
+++ b/src/config.zig
@@ -171,33 +171,6 @@ pub const io_depth_read = 8;
 /// The maximum number of concurrent write I/O operations to allow at once.
 pub const io_depth_write = 8;
 
-/// The number of full-sized messages allocated at initialization by the message pool.
-/// There must be enough messages to ensure that the replica can always progress, to avoid deadlock.
-pub const message_bus_messages_max = messages_max: {
-    const client_table_messages_max = clients_max;
-    const journal_messages_max = io_depth_read + io_depth_write;
-    const loopback_queue_messages_max = 1;
-    // +1 is the `prepare`, replicas_max is the corresponding `prepare_ok`.
-    const pipelining_messages_max = pipelining_max * (1 + replicas_max);
-    // There are 3 quorums:
-    // - start_view_change_from_other_replicas
-    // - do_view_change_from_all_replicas
-    // - nack_prepare_from_other_replicas
-    const quorum_messages_max = 3 * replicas_max;
-
-    // +1 to account for the Connection's `recv_message`.
-    const connection_messages_max = connection_send_queue_max + 1;
-    const message_bus_messages_max = connections_max * connection_messages_max;
-
-    break :messages_max pipelining_messages_max + quorum_messages_max +
-        loopback_queue_messages_max + client_table_messages_max + journal_messages_max +
-        messages_bus_messages_max;
-};
-
-/// The number of header-sized messages allocated at initialization by the message bus.
-/// These are much smaller/cheaper and we can therefore have many of them.
-pub const message_bus_headers_max = connections_max * connection_send_queue_max * 2;
-
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.
 pub const tick_ms = 10;

--- a/src/demo.zig
+++ b/src/demo.zig
@@ -53,7 +53,7 @@ pub fn request(
 
     message_bus.set_on_message(*Client, &client, Client.on_message);
 
-    var message = client.get_message() orelse unreachable;
+    var message = client.get_message();
     defer client.unref(message);
 
     const body = std.mem.asBytes(&batch);

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -23,8 +23,7 @@ pub const messages_max = messages_max: {
     const client_table_messages_max = config.clients_max;
     const journal_messages_max = config.io_depth_read + config.io_depth_write;
     const loopback_queue_messages_max = 1;
-    // +1 is the `prepare`, replicas_max is the corresponding `prepare_ok`.
-    const pipelining_messages_max = config.pipelining_max * (1 + config.replicas_max);
+    const pipelining_messages_max = config.pipelining_max;
     // There are 3 quorums:
     // - start_view_change_from_other_replicas
     // - do_view_change_from_all_replicas
@@ -46,7 +45,7 @@ pub const headers_max = headers_max: {
     const loopback_queue_messages_max = 1;
     const message_bus_messages_max = config.connections_max * config.connection_send_queue_max;
     break :headers_max loopback_queue_messages_max + message_bus_messages_max;
-}; //TODO connections_max * connection_send_queue_max * 2;
+};
 
 comptime {
     // These conditions are necessary (but not sufficient) to prevent deadlocks.

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -108,10 +108,10 @@ pub const MessagePool = struct {
         return ret;
     }
 
-    /// Get an unused message with a buffer of config.message_size_max. If no such message is
-    /// available, an error is returned. The returned message has exactly one reference.
-    pub fn get_message(pool: *MessagePool) ?*Message {
-        const ret = pool.free_list orelse return null;
+    /// Get an unused message with a buffer of config.message_size_max.
+    /// The returned message has exactly one reference.
+    pub fn get_message(pool: *MessagePool) *Message {
+        const ret = pool.free_list.?;
         pool.free_list = ret.next;
         ret.next = null;
         assert(ret.references == 0);

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -24,11 +24,8 @@ pub const messages_max = messages_max: {
     const journal_messages_max = config.io_depth_read + config.io_depth_write;
     const loopback_queue_messages_max = 1;
     const pipelining_messages_max = config.pipelining_max;
-    // There are 3 quorums:
-    // - start_view_change_from_other_replicas
-    // - do_view_change_from_all_replicas
-    // - nack_prepare_from_other_replicas
-    const quorum_messages_max = 3 * config.replicas_max;
+    // Only 1 quorum stores messages (QuorumMessages): do_view_change_from_all_replicas.
+    const quorum_messages_max = config.replicas_max;
 
     // +1 to account for the Connection's `recv_message`.
     const connection_messages_max = config.connection_send_queue_max + 1;

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -49,7 +49,7 @@ pub const MessagePool = struct {
 
     /// List of currently unused messages of message_size_max_padded
     free_list: ?*Message,
-    /// List of currently usused header-sized messages
+    /// List of currently unused header-sized messages
     header_only_free_list: ?*Message,
 
     pub fn init(allocator: mem.Allocator) error{OutOfMemory}!MessagePool {

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -22,7 +22,7 @@ const message_size_max_padded = config.message_size_max + config.sector_size;
 pub const messages_max_replica = messages_max: {
     var sum: usize = 0;
 
-    sum += config.io_depth_read + config.io_depth_write; // journal I/O
+    sum += config.io_depth_read + config.io_depth_write; // Journal I/O
     sum += config.clients_max; // Replica.client_table
     sum += 1; // Replica.loopback_queue
     sum += config.pipelining_max; // Replica.pipeline

--- a/src/ring_buffer.zig
+++ b/src/ring_buffer.zig
@@ -76,6 +76,13 @@ pub fn RingBuffer(comptime T: type, comptime size: usize) type {
             self.advance_tail();
         }
 
+        /// Add an element to a RingBuffer, and assert that the capacity is sufficient.
+        pub fn push_assume_capacity(self: *Self, item: T) void {
+            self.push(item) catch |err| switch (err) {
+                error.NoSpaceLeft => unreachable,
+            };
+        }
+
         /// Remove and return the next item, if any.
         pub fn pop(self: *Self) ?T {
             const result = self.head() orelse return null;

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -265,7 +265,7 @@ fn send_request(random: std.rand.Random) bool {
     // While hashing the client ID with the request body prevents input collisions across clients,
     // it's still possible for the same client to generate the same body, and therefore input hash.
     const client_input = StateMachine.hash(client.id, body);
-    checker_request_queue.push(client_input) catch unreachable;
+    checker_request_queue.push_assume_capacity(client_input);
     std.log.scoped(.test_client).debug("client {} sending input={x}", .{
         client_index,
         client_input,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -244,7 +244,7 @@ fn send_request(random: std.rand.Random) bool {
     if (client.request_queue.full()) return false;
     if (checker_request_queue.full()) return false;
 
-    const message = client.get_message() orelse return false;
+    const message = client.get_message();
     defer client.unref(message);
 
     const body_size_max = config.message_size_max - @sizeOf(Header);

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -213,7 +213,7 @@ pub fn main() !void {
 
     assert(cluster.state_checker.convergence());
 
-    output.info("\n          PASSED", .{});
+    output.info("\n          PASSED ({} ticks)", .{tick});
 }
 
 /// Returns true, `p` percent of the time, else false.

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -198,10 +198,6 @@ pub const Cluster = struct {
             var it = message_bus.pool.free_list;
             while (it) |message| : (it = message.next) messages_in_pool += 1;
         }
-        {
-            var it = message_bus.pool.header_only_free_list;
-            while (it) |message| : (it = message.next) messages_in_pool += 1;
-        }
 
         const total_messages = message_pool.messages_max + message_pool.headers_max;
         assert(messages_in_network + messages_in_pool == total_messages);

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -199,7 +199,7 @@ pub const Cluster = struct {
             while (it) |message| : (it = message.next) messages_in_pool += 1;
         }
 
-        const total_messages = message_pool.messages_max + message_pool.headers_max;
+        const total_messages = message_pool.messages_max_replica;
         assert(messages_in_network + messages_in_pool == total_messages);
 
         replica.* = try Replica.init(

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -6,7 +6,8 @@ const config = @import("../config.zig");
 
 const StateChecker = @import("state_checker.zig").StateChecker;
 
-const MessagePool = @import("../message_pool.zig").MessagePool;
+const message_pool = @import("../message_pool.zig");
+const MessagePool = message_pool.MessagePool;
 const Message = MessagePool.Message;
 
 const Network = @import("network.zig").Network;
@@ -202,7 +203,7 @@ pub const Cluster = struct {
             while (it) |message| : (it = message.next) messages_in_pool += 1;
         }
 
-        const total_messages = config.message_bus_messages_max + config.message_bus_headers_max;
+        const total_messages = message_pool.messages_max + message_pool.headers_max;
         assert(messages_in_network + messages_in_pool == total_messages);
 
         replica.* = try Replica.init(

--- a/src/test/message_bus.zig
+++ b/src/test/message_bus.zig
@@ -6,12 +6,13 @@ const config = @import("../config.zig");
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Message = MessagePool.Message;
 const Header = @import("../vsr.zig").Header;
+const ProcessType = @import("../vsr.zig").ProcessType;
 
 const Network = @import("network.zig").Network;
 
 const log = std.log.scoped(.message_bus);
 
-pub const Process = union(enum) {
+pub const Process = union(ProcessType) {
     replica: u8,
     client: u128,
 };
@@ -35,7 +36,7 @@ pub const MessageBus = struct {
         network: *Network,
     ) !MessageBus {
         return MessageBus{
-            .pool = try MessagePool.init(allocator),
+            .pool = try MessagePool.init(allocator, @as(ProcessType, process)),
             .network = network,
             .cluster = cluster,
             .process = process,

--- a/src/test/message_bus.zig
+++ b/src/test/message_bus.zig
@@ -62,7 +62,7 @@ pub const MessageBus = struct {
 
     pub fn tick(_: *MessageBus) void {}
 
-    pub fn get_message(bus: *MessageBus) ?*Message {
+    pub fn get_message(bus: *MessageBus) *Message {
         return bus.pool.get_message();
     }
 

--- a/src/test/network.zig
+++ b/src/test/network.zig
@@ -139,10 +139,7 @@ pub const Network = struct {
 
         const target_bus = &network.buses.items[path.target];
 
-        const message = target_bus.get_message() orelse {
-            log.debug("deliver_message: target message bus has no free messages, dropping", .{});
-            return;
-        };
+        const message = target_bus.get_message();
         defer target_bus.unref(message);
 
         std.mem.copy(u8, message.buffer, packet.message.buffer);

--- a/src/test/network.zig
+++ b/src/test/network.zig
@@ -28,7 +28,7 @@ pub const Network = struct {
         message: *Message,
 
         pub fn deinit(packet: *const Packet, path: PacketSimulatorPath) void {
-            const source_bus = &packet.network.busses.items[path.source];
+            const source_bus = &packet.network.buses.items[path.source];
             source_bus.unref(packet.message);
         }
     };
@@ -43,7 +43,7 @@ pub const Network = struct {
     options: NetworkOptions,
     packet_simulator: PacketSimulator(Packet),
 
-    busses: std.ArrayListUnmanaged(MessageBus),
+    buses: std.ArrayListUnmanaged(MessageBus),
     processes: std.ArrayListUnmanaged(u128),
 
     pub fn init(
@@ -55,8 +55,8 @@ pub const Network = struct {
         const process_count = client_count + replica_count;
         assert(process_count <= std.math.maxInt(u8));
 
-        var busses = try std.ArrayListUnmanaged(MessageBus).initCapacity(allocator, process_count);
-        errdefer busses.deinit(allocator);
+        var buses = try std.ArrayListUnmanaged(MessageBus).initCapacity(allocator, process_count);
+        errdefer buses.deinit(allocator);
 
         var processes = try std.ArrayListUnmanaged(u128).initCapacity(allocator, process_count);
         errdefer processes.deinit(allocator);
@@ -71,18 +71,18 @@ pub const Network = struct {
             .allocator = allocator,
             .options = options,
             .packet_simulator = packet_simulator,
-            .busses = busses,
+            .buses = buses,
             .processes = processes,
         };
     }
 
     pub fn deinit(network: *Network) void {
-        // TODO: deinit the busses themselves when they gain a deinit()
-        network.busses.deinit(network.allocator);
+        // TODO: deinit the buses themselves when they gain a deinit()
+        network.buses.deinit(network.allocator);
         network.processes.deinit(network.allocator);
     }
 
-    /// Returns the address (index into Network.busses)
+    /// Returns the address (index into Network.buses)
     pub fn init_message_bus(network: *Network, cluster: u32, process: Process) !*MessageBus {
         const raw_process = switch (process) {
             .replica => |replica| replica,
@@ -97,9 +97,9 @@ pub const Network = struct {
         const bus = try MessageBus.init(network.allocator, cluster, process, network);
 
         network.processes.appendAssumeCapacity(raw_process);
-        network.busses.appendAssumeCapacity(bus);
+        network.buses.appendAssumeCapacity(bus);
 
-        return &network.busses.items[network.busses.items.len - 1];
+        return &network.buses.items[network.buses.items.len - 1];
     }
 
     pub fn send_message(network: *Network, message: *Message, path: Path) void {
@@ -131,13 +131,13 @@ pub const Network = struct {
     }
 
     pub fn get_message_bus(network: *Network, process: Process) *MessageBus {
-        return &network.busses.items[network.process_to_address(process)];
+        return &network.buses.items[network.process_to_address(process)];
     }
 
     fn deliver_message(packet: Packet, path: PacketSimulatorPath) void {
         const network = packet.network;
 
-        const target_bus = &network.busses.items[path.target];
+        const target_bus = &network.buses.items[path.target];
 
         const message = target_bus.get_message() orelse {
             log.debug("deliver_message: target message bus has no free messages, dropping", .{});

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -8,12 +8,13 @@ const Cluster = @import("cluster.zig").Cluster;
 const Network = @import("network.zig").Network;
 const StateMachine = @import("state_machine.zig").StateMachine;
 
-const MessagePool = @import("../message_pool.zig").MessagePool;
+const message_pool = @import("../message_pool.zig");
+const MessagePool = message_pool.MessagePool;
 const Message = MessagePool.Message;
 
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
-const RequestQueue = RingBuffer(u128, config.message_bus_messages_max - 1);
+const RequestQueue = RingBuffer(u128, message_pool.messages_max - 1);
 const StateTransitions = std.AutoHashMap(u128, u64);
 
 const log = std.log.scoped(.state_checker);

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -14,7 +14,7 @@ const Message = MessagePool.Message;
 
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
-const RequestQueue = RingBuffer(u128, message_pool.messages_max_client - 1);
+const RequestQueue = RingBuffer(u128, config.client_request_queue_max);
 const StateTransitions = std.AutoHashMap(u128, u64);
 
 const log = std.log.scoped(.state_checker);

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -14,7 +14,7 @@ const Message = MessagePool.Message;
 
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
-const RequestQueue = RingBuffer(u128, message_pool.messages_max - 1);
+const RequestQueue = RingBuffer(u128, message_pool.messages_max_client - 1);
 const StateTransitions = std.AutoHashMap(u128, u64);
 
 const log = std.log.scoped(.state_checker);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -15,6 +15,8 @@ pub const Client = @import("vsr/client.zig").Client;
 pub const Clock = @import("vsr/clock.zig").Clock;
 pub const Journal = @import("vsr/journal.zig").Journal;
 
+pub const ProcessType = enum { replica, client };
+
 /// Viewstamped Replication protocol commands:
 pub const Command = enum(u8) {
     reserved,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -206,7 +206,7 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
         }
 
         /// Acquires a message from the message bus if one is available.
-        pub fn get_message(self: *Self) ?*Message {
+        pub fn get_message(self: *Self) *Message {
             return self.message_bus.get_message();
         }
 
@@ -388,7 +388,7 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
             assert(header.cluster == self.cluster);
             assert(header.size == @sizeOf(Header));
 
-            const message = self.message_bus.pool.get_message() orelse return null;
+            const message = self.message_bus.pool.get_message();
             defer self.message_bus.unref(message);
 
             message.header.* = header;
@@ -402,8 +402,7 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
         fn register(self: *Self) void {
             if (self.request_number > 0) return;
 
-            var message = self.message_bus.get_message() orelse
-                @panic("register: no message available to register a session with the cluster");
+            var message = self.message_bus.get_message();
             defer self.message_bus.unref(message);
 
             // We will set parent, context, view and checksums only when sending for the first time:

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -389,7 +389,7 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
             assert(header.cluster == self.cluster);
             assert(header.size == @sizeOf(Header));
 
-            const message = self.message_bus.pool.get_header_only_message() orelse return null;
+            const message = self.message_bus.pool.get_message() orelse return null;
             defer self.message_bus.unref(message);
 
             message.header.* = header;

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -7,7 +7,8 @@ const vsr = @import("../vsr.zig");
 const Header = vsr.Header;
 
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
-const Message = @import("../message_pool.zig").MessagePool.Message;
+const message_pool = @import("../message_pool.zig");
+const Message = message_pool.MessagePool.Message;
 
 const log = std.log.scoped(.client);
 
@@ -67,7 +68,7 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
         /// A client is allowed at most one inflight request at a time at the protocol layer.
         /// We therefore queue any further concurrent requests made by the application layer.
         /// We must leave one message free to receive with.
-        request_queue: RingBuffer(Request, config.message_bus_messages_max - 1) = .{},
+        request_queue: RingBuffer(Request, message_pool.messages_max - 1) = .{},
 
         /// The number of ticks without a reply before the client resends the inflight request.
         /// Dynamically adjusted as a function of recent request round-trip time.

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -195,13 +195,11 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
 
             const was_empty = self.request_queue.empty();
 
-            self.request_queue.push(.{
+            self.request_queue.push_assume_capacity(.{
                 .user_data = user_data,
                 .callback = callback,
                 .message = message.ref(),
-            }) catch |err| switch (err) {
-                error.NoSpaceLeft => unreachable, // Already verified that there is room.
-            };
+            });
 
             // If the queue was empty, then there is no request inflight and we must send this one:
             if (was_empty) self.send_request_for_the_first_time(message);
@@ -424,13 +422,11 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
 
             assert(self.request_queue.empty());
 
-            self.request_queue.push(.{
+            self.request_queue.push_assume_capacity(.{
                 .user_data = 0,
                 .callback = undefined,
                 .message = message.ref(),
-            }) catch |err| switch (err) {
-                error.NoSpaceLeft => unreachable, // This is the first request.
-            };
+            });
 
             self.send_request_for_the_first_time(message);
         }

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -67,8 +67,7 @@ pub fn Client(comptime StateMachine: type, comptime MessageBus: type) type {
 
         /// A client is allowed at most one inflight request at a time at the protocol layer.
         /// We therefore queue any further concurrent requests made by the application layer.
-        /// We must leave one message free to receive with.
-        request_queue: RingBuffer(Request, message_pool.messages_max - 1) = .{},
+        request_queue: RingBuffer(Request, config.client_request_queue_max) = .{},
 
         /// The number of ticks without a reply before the client resends the inflight request.
         /// Dynamically adjusted as a function of recent request round-trip time.

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -510,11 +510,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             const physical_size = vsr.sector_ceil(exact.size);
             assert(physical_size >= exact.size);
 
-            const message = replica.message_bus.get_message() orelse {
-                self.read_prepare_log(op, checksum, "no message available");
-                callback(replica, null, null);
-                return;
-            };
+            const message = replica.message_bus.get_message();
             defer replica.message_bus.unref(message);
 
             // Skip the disk read if the header is all we need:
@@ -658,7 +654,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             }
             assert(offset < self.size_headers);
 
-            const message = replica.message_bus.get_message() orelse unreachable;
+            const message = replica.message_bus.get_message();
             defer replica.message_bus.unref(message);
 
             // We use the count of reads executing to know when both versions have finished reading:

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1683,6 +1683,7 @@ pub fn Replica(
             }
 
             messages.set(message.header.replica);
+            assert(messages.count() <= self.replica_count);
 
             // Count the number of unique messages now received:
             const count = messages.count();
@@ -3470,7 +3471,9 @@ pub fn Replica(
             while (messages_iter.next()) |replica| {
                 assert(replica < self.replica_count);
             }
+
             messages.setIntersection(QuorumCounterNull);
+            assert(messages.count() == 0);
         }
 
         fn reset_quorum_do_view_change(self: *Self) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1457,15 +1457,20 @@ pub fn Replica(
             });
             while (ok_from_all_replicas_iterator.next()) |replica| {
                 // Ensure we don't wait for replicas that don't exist.
+                // The bits between `replica_count` and `replicas_max` are always unset,
+                // since they don't actually represent replicas.
                 if (replica == self.replica_count) {
                     assert(self.replica_count < config.replicas_max);
                     break;
                 }
+                assert(replica < self.replica_count);
 
                 if (replica != self.replica) {
                     waiting[waiting_len] = @intCast(u8, replica);
                     waiting_len += 1;
                 }
+            } else {
+                assert(self.replica_count == config.replicas_max);
             }
 
             if (waiting_len == 0) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -608,7 +608,7 @@ pub fn Replica(
 
             log.debug("{}: on_request: prepare {}", .{ self.replica, message.header.checksum });
 
-            self.pipeline.push(.{ .message = message.ref() }) catch unreachable;
+            self.pipeline.push_assume_capacity(.{ .message = message.ref() });
             assert(self.pipeline.count >= 1);
 
             if (self.pipeline.count == 1) {
@@ -3206,7 +3206,7 @@ pub fn Replica(
                 prepare.?.header.checksum,
             });
 
-            self.pipeline.push(.{ .message = prepare.?.ref() }) catch unreachable;
+            self.pipeline.push_assume_capacity(.{ .message = prepare.?.ref() });
             assert(self.pipeline.count >= 1);
 
             self.repairing_pipeline = true;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2185,7 +2185,7 @@ pub fn Replica(
             assert(header.view == self.view or header.command == .request_start_view);
             assert(header.size == @sizeOf(Header));
 
-            const message = self.message_bus.pool.get_header_only_message() orelse return null;
+            const message = self.message_bus.pool.get_message() orelse return null;
             defer self.message_bus.unref(message);
 
             message.header.* = header;


### PR DESCRIPTION
Fixes #69.

## Bug

Each replica `pipeline` stores `config.pipelining_max == config.clients_max` prepare messages. Each of those prepares has up to `config.replicas_max` `prepare_ok` messages.

If all messages in the pool are allocated to `prepare_ok`s of future prepares (see https://gist.github.com/sentientwaffle/dfc2dfa666a3f2e6afd3a3a16bea1df9 for an example `pipeline` state), the `prepare_ok` messages for the next-in-line (blocking) prepare are just dropped. The other replicas retry sending them, but this happens indefinitely, since the blocked replica is deadlocked.

```
[debug] (vsr): 0: prepare_timeout fired
[debug] (vsr): 0: prepare_timeout backing off
[debug] (vsr): 0: prepare_timeout after=535..949 (rtt=30 min=10 max=1000 attempts=236)
[debug] (replica): 0: on_prepare_timeout: waiting for replica 1
[debug] (replica): 0: on_prepare_timeout: waiting for replica 2
[debug] (replica): 0: on_prepare_timeout: waiting for replica 3
[debug] (replica): 0: on_prepare_timeout: waiting for replica 4
[debug] (replica): 0: on_prepare_timeout: waiting for replica 5
[debug] (replica): 0: on_prepare_timeout: replicating to replica 2
```

In the VOPR, the drop triggers the `deliver_message: target message bus has no free messages, dropping` log message.

## Fix

`config.message_bus_messages_max` must be greater than `pipelining_max × (1 + replicas_max)` (`+1` to account for the prepares, not just the `prepare_ok`s). And that doesn't include the messages that may be allocated elsewhere, e.g. I/O, quorum messages, etc.

## Seeds

Debugged using the seed:
- `14308390800935580042`: This is the one I used for debugging. Replica 0 is stuck waiting for a quorum of `prepare_ok` messages, but all of its `Message`s are already allocated in the `pipeline`.

This patch also fixes the following seeds:
- `10230879186405206692`
- `16623794497874437158`

## Misc

- Includes @jorangreef's suggested fix: make the control flow more obvious (in `client.zig`) to avoid a message leak when the `request_queue` is full.
- Also includes fix for some typos.
