### PR TITLE
Replace EOL Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10 AS build
+FROM ubuntu:20.04 AS build
 
 RUN  apt-get update \
   && apt-get install -y wget xz-utils


### PR DESCRIPTION
The docker [`build-and-push`](https://github.com/coilhq/tigerbeetle/blob/main/.github/workflows/docker.yml#L24) GitHub Actions workflow has been failing with errors related to the [Dockerfile](https://github.com/coilhq/tigerbeetle/blob/main/Dockerfile#L1)'s Ubuntu 20.10 base image, which has reached end of life:
```
The repository 'http://archive.ubuntu.com/ubuntu groovy Release' does not have a Release file.
```
