### PR TITLE
LSM: BlockFreeSet checkpoint

### DIFF
--- a/src/lsm/block_free_set.zig
+++ b/src/lsm/block_free_set.zig
@@ -127,8 +127,8 @@ pub const BlockFreeSet = struct {
 
     /// Free all staged blocks.
     pub fn checkpoint(set: *BlockFreeSet) void {
-        var iter = set.staging.iterator(.{ .kind = .set });
-        while (iter.next()) |block| {
+        var it = set.staging.iterator(.{ .kind = .set });
+        while (it.next()) |block| {
             set.staging.unset(block);
             const address = block + 1;
             set.release(address);


### PR DESCRIPTION
Add `BlockFreeSet.release_at_next_checkpoint`, which defers freeing the block until the next `BlockFreeSet.checkpoint` call.

Deferring the actual freeing of the block prevents the following issue (described by Joran):

1. Imagine we have working superblock `sequence=7` on disk which has the manifest referencing `table A` with blocks `{ 1, 2, 3 }` and with these blocks marked as acquired in the block free set that’s encoded in the superblock trailer on disk.
2. We compact `table A` into the next level and then release blocks `{ 1, 2, 3 }` back to `BlockFreeSet`.
3. We then convert the mutable table to a new immutable `table B` in memory.
4. As it happens, when this new table is created, it acquires newly released blocks `{ 1, 2, 3 }` from `BlockFreeSet`.
5. We then flush the table to disk, which means writing blocks `{ 1, 2, 3 }`.
6. At this point, we haven’t checkpointed the staging superblock with `sequence=8` that has all these changes.
7. Then, we crash.
8. We recover with working superblock `sequence=7` which references `table A` with blocks `{ 1, 2, 3 }`.
9. However, these blocks are no longer valid.