### PR TITLE
Scripts: Download correct Zig version

### DIFF
--- a/scripts/install_zig.sh
+++ b/scripts/install_zig.sh
@@ -40,9 +40,9 @@ ZIG_TARGET="zig-$ZIG_OS-$ZIG_ARCH"
 
 # Determine the build, split the JSON line on whitespace and extract the 2nd field, then remove quotes and commas:
 if command -v wget &> /dev/null; then
-    ZIG_URL=`wget --quiet -O - https://ziglang.org/download/index.json | grep "$ZIG_TARGET" | grep "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
+    ZIG_URL=`wget --quiet -O - https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
 else
-    ZIG_URL=`curl --silent https://ziglang.org/download/index.json | grep "$ZIG_TARGET" | grep "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
+    ZIG_URL=`curl --silent https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
 fi
 
 # Ensure that the release is actually hosted on the ziglang.org website:


### PR DESCRIPTION
Fixes https://github.com/coilhq/tigerbeetle/issues/87.

The script greps Zig's version list for the version matching `$ZIG_RELEASE`. But `https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.1740+971ef7b9c.tar.xz` actually matches `0.9.1`, because grep interprets the version's dots as wildcards.

Fix: `grep -F` treats the pattern as a literal string rather than a regular expression.