### PR TITLE
Fix .bat line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.zig text=auto eol=lf
+*.bat text=auto eol=crlf


### PR DESCRIPTION
None of scripts/*.bat ran for me on Windows 11 until I changed their line endings to CRLF. This commit updates .gitattributes to check out batch files out with CRLF endings.