### PR TITLE
VOPR: Don't crash until a prepare is written

### DIFF
--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -214,6 +214,19 @@ pub const Cluster = struct {
             return false;
         }
 
+        // TODO Remove this workaround when VSR recovery protocol is disabled.
+        for (replica.journal.prepare_inhabited) |inhabited, i| {
+            if (i == 0) {
+                // Ignore the root header.
+            } else {
+                if (inhabited) break;
+            }
+        } else {
+            // Only crash when at least one header has been written to the WAL.
+            // An empty WAL would skip recovery after a crash.
+            return false;
+        }
+
         // Ensure that the replica can eventually recover without this replica.
         // Verify that each op is recoverable by the current healthy cluster (minus the replica we
         // are trying to crash).


### PR DESCRIPTION
If a replica crashes and is restarted, it *must* use recovery protocol after restart.
(If the replica starts with no prepares (excluding root) it assumes it is starting for the first time after cluster initialization, and skips recovery protocol).

Fixes https://github.com/coilhq/tigerbeetle/issues/113 (seed `8770239035259319625`).