### PR TITLE
Point projects link at classic not Beta boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ BetaBeetle, the beta distributed version of TigerBeetle, was developed from Janu
 
 ## TigerBeetle (under active development)
 
-The production version of **TigerBeetle is now under active development**. Our [DESIGN doc](docs/DESIGN.md) provides an overview of TigerBeetle's data structures and our [project board](https://github.com/coilhq/tigerbeetle/projects) provides a glimpse of where we want to go.
+The production version of **TigerBeetle is now under active development**. Our [DESIGN doc](docs/DESIGN.md) provides an overview of TigerBeetle's data structures and our [project board](https://github.com/coilhq/tigerbeetle/projects?type=classic) provides a glimpse of where we want to go.
 
 ## QuickStart
 


### PR DESCRIPTION
The current link expands to the Beta view which is blank so it looks like the link is wrong. It's just that all of your projects are in the "Classic" view.

![image](https://user-images.githubusercontent.com/3925912/181028405-d62d5127-f4b5-4be0-860c-c97c9f995306.png)
