### PR TITLE
Fix broken install on darwin

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -430,6 +430,7 @@ pub const IO = struct {
         IsDir,
         SystemResources,
         Unseekable,
+        ConnectionTimedOut,
     } || os.UnexpectedError;
 
     pub fn read(
@@ -481,6 +482,7 @@ pub const IO = struct {
                             .NXIO => error.Unseekable,
                             .OVERFLOW => error.Unseekable,
                             .SPIPE => error.Unseekable,
+                            .TIMEDOUT => error.ConnectionTimedOut,
                             else => |err| os.unexpectedErrno(err),
                         };
                     }


### PR DESCRIPTION
While following the Quickstart on a 2018 MacBook Pro, after running 

    scripts/install.sh

I've got the following exception

    ./src/storage.zig:189:18: error: expected type 'io.darwin.ReadError', found 'error{ConnectionTimedOut}'
                error.ConnectionTimedOut,
                     ^
    ./zig/lib/std/os.zig:521:5: note: 'error.ConnectionTimedOut' not a member of destination error set
        ConnectionTimedOut,
        ^
    tigerbeetle...The following command exited with error code 1:
    ./tigerbeetle/zig/zig build-exe ./tigerbeetle/src/main.zig -OReleaseSafe --cache-dir ./tigerbeetle/zig-cache --global-cache-dir ~/.cache/zig --name tigerbeetle -target native-native -mcpu x86_64 --enable-cache
    error: the following build command failed with exit code 1:
    ./tigerbeetle/zig-cache/o/9a26526d85723d3f56f183ce39ae0ead/build ./tigerbeetle/zig/zig ./tigerbeetle ./tigerbeetle/zig-cache ~/.cache/zig -Dcpu=baseline -Drelease-safe

I've just started looking at zig this week so forgive me if I'm miss-interpreting the error or missing something with the fix on this PR.

