### PR TITLE
Linting bash scripts using shellcheck

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eEuo pipefail
 
-# Runber of replicas to benchmark
+# Number of replicas to benchmark
 REPLICAS=${REPLICAS:-0}
 
 # Install Zig if it does not already exist:

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-set -e
+set -eEuo pipefail
+
+# Runber of replicas to benchmark
+REPLICAS=${REPLICAS:-0}
 
 # Install Zig if it does not already exist:
 if [ ! -d "zig" ]; then
@@ -22,7 +25,7 @@ function onerror {
         cat benchmark.log
     fi
 
-    for I in 0
+    for I in $REPLICAS
     do
         echo "Stopping replica $I..."
     done
@@ -30,20 +33,20 @@ function onerror {
 }
 trap onerror EXIT
 
-for I in 0
+for I in $REPLICAS
 do
     echo "Initializing replica $I..."
     FILE="./cluster_0000000000_replica_00${I}.tigerbeetle"
-    if [ -f $FILE ]; then
-        rm $FILE
+    if [ -f "$FILE" ]; then
+        rm "$FILE"
     fi
-    ./tigerbeetle init --directory=. --cluster=0 --replica=$I > benchmark.log 2>&1
+    ./tigerbeetle init --directory=. --cluster=0 --replica="$I" > benchmark.log 2>&1
 done
 
-for I in 0
+for I in $REPLICAS
 do
     echo "Starting replica $I..."
-    ./tigerbeetle start --directory=. --cluster=0 --addresses=3001 --replica=$I > benchmark.log 2>&1 &
+    ./tigerbeetle start --directory=. --cluster=0 --addresses=3001 --replica="$I" > benchmark.log 2>&1 &
 done
 
 # Wait for replicas to start, listen and connect:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -eEuo pipefail
+
 scripts/install_zig.sh
 echo "Building TigerBeetle..."
 zig/zig build -Dcpu=baseline -Drelease-safe

--- a/scripts/install_zig.sh
+++ b/scripts/install_zig.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
-set -e
+set -eEuo pipefail
 
 ZIG_RELEASE_DEFAULT="0.9.1"
-
 # Default to the release build, or allow the latest dev build, or an explicit release version:
-if [ -z "$1" ]; then
-    ZIG_RELEASE=$ZIG_RELEASE_DEFAULT
-elif [ "$1" == "latest" ]; then
+ZIG_RELEASE=${1:-$ZIG_RELEASE_DEFAULT}
+if [ "$ZIG_RELEASE" == "latest" ]; then
     ZIG_RELEASE="builds"
-else
-    ZIG_RELEASE=$1
 fi
 
 # Validate the release version explicitly:
@@ -23,7 +19,7 @@ else
 fi
 
 # Determine the architecture:
-if [ `uname -m` == 'arm64' ] || [ `uname -m` == 'aarch64' ]; then
+if [[ $(uname -m) == 'arm64' ]] || [[ $(uname -m) == 'aarch64' ]]; then
     ZIG_ARCH="aarch64"
 else
     ZIG_ARCH="x86_64"
@@ -42,9 +38,9 @@ ZIG_TARGET="zig-$ZIG_OS-$ZIG_ARCH"
 if command -v wget &> /dev/null; then
     # -4 forces `wget` to connect to ipv4 addresses, as ipv6 fails to resolve on certain distros.
     # Only A records (for ipv4) are used in DNS:
-    ZIG_URL=`wget -4 --quiet -O - https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
+    ZIG_URL=$(wget -4 --quiet -O - https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g')
 else
-    ZIG_URL=`curl --silent https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
+    ZIG_URL=$(curl --silent https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g')
 fi
 
 # Ensure that the release is actually hosted on the ziglang.org website:
@@ -54,31 +50,31 @@ if [ -z "$ZIG_URL" ]; then
 fi
 
 # Work out the filename from the URL, as well as the directory without the ".tar.xz" file extension:
-ZIG_TARBALL=`basename "$ZIG_URL"`
-ZIG_DIRECTORY=`basename "$ZIG_TARBALL" .tar.xz`
+ZIG_TARBALL=$(basename "$ZIG_URL")
+ZIG_DIRECTORY=$(basename "$ZIG_TARBALL" .tar.xz)
 
 # Download, making sure we download to the same output document, without wget adding "-1" etc. if the file was previously partially downloaded:
 echo "Downloading $ZIG_URL..."
 if command -v wget &> /dev/null; then
     # -4 forces `wget` to connect to ipv4 addresses, as ipv6 fails to resolve on certain distros.
     # Only A records (for ipv4) are used in DNS:
-    wget -4 --quiet --show-progress --output-document=$ZIG_TARBALL $ZIG_URL
+    wget -4 --quiet --show-progress --output-document="$ZIG_TARBALL" "$ZIG_URL"
 else
-    curl --silent --progress-bar --output $ZIG_TARBALL $ZIG_URL
+    curl --silent --progress-bar --output "$ZIG_TARBALL" "$ZIG_URL"
 fi
 
 # Extract and then remove the downloaded tarball:
 echo "Extracting $ZIG_TARBALL..."
-tar -xf $ZIG_TARBALL
-rm $ZIG_TARBALL
+tar -xf "$ZIG_TARBALL"
+rm "$ZIG_TARBALL"
 
 # Replace any existing Zig installation so that we can install or upgrade:
 echo "Installing $ZIG_DIRECTORY to 'zig' in current working directory..."
 rm -rf zig
-mv $ZIG_DIRECTORY zig
+mv "$ZIG_DIRECTORY" zig
 
 # It's up to the user to add this to their path if they want to:
 ZIG_BIN="$(pwd)/zig/zig"
 
-ZIG_VERSION=`$ZIG_BIN version`
+ZIG_VERSION=$($ZIG_BIN version)
 echo "Congratulations, you have successfully installed Zig $ZIG_VERSION to $ZIG_BIN. Enjoy!"

--- a/scripts/upgrade_ubuntu_kernel.sh
+++ b/scripts/upgrade_ubuntu_kernel.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -e
+set -eEuo pipefail
 
 # Assert that we are only upgrading the kernel for Ubuntu, and not another distribution:
-DISTRIBUTION=`lsb_release -i | awk '{print $3}'`
-if [ $DISTRIBUTION != "Ubuntu" ]; then
+DISTRIBUTION=$(lsb_release -i | awk '{print $3}')
+if [ "$DISTRIBUTION" != "Ubuntu" ]; then
     echo "This script must be run on Ubuntu."
     exit 1
 fi

--- a/scripts/vopr.sh
+++ b/scripts/vopr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eEuo pipefail
 
 # Install Zig if it does not already exist:
 if [ ! -d "zig" ]; then
@@ -11,10 +11,10 @@ if [ ! -d "zig" ]; then
 fi
 
 # If a seed is provided as an argument then replay the seed, otherwise test a 1,000 seeds:
-if [ "$1" ]; then
+if [ "${1:-}" ]; then
 
     # Build in fast ReleaseSafe mode if required, useful where you don't need debug logging:
-    if [ "$2" == "-OReleaseSafe" ]; then
+    if [ "${2:-}" == "-OReleaseSafe" ]; then
         echo "Replaying seed $1 in ReleaseSafe mode..."
         BUILD_MODE="-OReleaseSafe"
     else
@@ -23,10 +23,10 @@ if [ "$1" ]; then
     fi
     echo ""
 
-    zig/zig run src/simulator.zig $BUILD_MODE -- $1
+    zig/zig run src/simulator.zig $BUILD_MODE -- "$1"
 else
     zig/zig build-exe src/simulator.zig -OReleaseSafe
-    for I in {1..1000}
+    for _ in {1..1000}
     do
         ./simulator
     done


### PR DESCRIPTION
This PR fixes some anti-patterns on the bash scripts found on scripts/ as reported by shellcheck.

If you don't have shellcheck installed you can use it via docker with:

    docker run --rm -v $(pwd)/scripts:/mnt/scripts koalaman/shellcheck:v0.8.0 $(ls scripts/*.sh)

Here are the issues it found:

    In scripts/benchmark.sh line 25:
        for I in 0
                ^-- SC2043 (warning): This loop will only ever run once. Bad quoting or missing glob/expansion?


    In scripts/benchmark.sh line 33:
    for I in 0
            ^-- SC2043 (warning): This loop will only ever run once. Bad quoting or missing glob/expansion?


    In scripts/benchmark.sh line 43:
    for I in 0
            ^-- SC2043 (warning): This loop will only ever run once. Bad quoting or missing glob/expansion?


    In scripts/install_zig.sh line 26:
    if [ `uname -m` == 'arm64' ] || [ `uname -m` == 'aarch64' ]; then
        ^--------^ SC2046 (warning): Quote this to prevent word splitting.
        ^--------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                                      ^--------^ SC2046 (warning): Quote this to prevent word splitting.
                                      ^--------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
    if [ $(uname -m) == 'arm64' ] || [ $(uname -m) == 'aarch64' ]; then


    In scripts/install_zig.sh line 45:
        ZIG_URL=`wget -4 --quiet -O - https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
        ZIG_URL=$(wget -4 --quiet -O - https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g')


    In scripts/install_zig.sh line 47:
        ZIG_URL=`curl --silent https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g'`
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
        ZIG_URL=$(curl --silent https://ziglang.org/download/index.json | grep -F "$ZIG_TARGET" | grep -F "$ZIG_RELEASE" | awk '{print $2}' | sed 's/[",]//g')


    In scripts/install_zig.sh line 57:
    ZIG_TARBALL=`basename "$ZIG_URL"`
                ^-------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
    ZIG_TARBALL=$(basename "$ZIG_URL")


    In scripts/install_zig.sh line 58:
    ZIG_DIRECTORY=`basename "$ZIG_TARBALL" .tar.xz`
                  ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
    ZIG_DIRECTORY=$(basename "$ZIG_TARBALL" .tar.xz)


    In scripts/install_zig.sh line 65:
        wget -4 --quiet --show-progress --output-document=$ZIG_TARBALL $ZIG_URL
                                                          ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
        wget -4 --quiet --show-progress --output-document="$ZIG_TARBALL" "$ZIG_URL"


    In scripts/install_zig.sh line 67:
        curl --silent --progress-bar --output $ZIG_TARBALL $ZIG_URL
                                              ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
        curl --silent --progress-bar --output "$ZIG_TARBALL" "$ZIG_URL"


    In scripts/install_zig.sh line 72:
    tar -xf $ZIG_TARBALL
            ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
    tar -xf "$ZIG_TARBALL"


    In scripts/install_zig.sh line 73:
    rm $ZIG_TARBALL
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
    rm "$ZIG_TARBALL"


    In scripts/install_zig.sh line 78:
    mv $ZIG_DIRECTORY zig
      ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
    mv "$ZIG_DIRECTORY" zig


    In scripts/install_zig.sh line 83:
    ZIG_VERSION=`$ZIG_BIN version`
                ^----------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
    ZIG_VERSION=$($ZIG_BIN version)


    In scripts/upgrade_ubuntu_kernel.sh line 5:
    DISTRIBUTION=`lsb_release -i | awk '{print $3}'`
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

    Did you mean: 
    DISTRIBUTION=$(lsb_release -i | awk '{print $3}')


    In scripts/upgrade_ubuntu_kernel.sh line 6:
    if [ $DISTRIBUTION != "Ubuntu" ]; then
        ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
    if [ "$DISTRIBUTION" != "Ubuntu" ]; then


    In scripts/vopr.sh line 26:
        zig/zig run src/simulator.zig $BUILD_MODE -- $1
                                                    ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean: 
        zig/zig run src/simulator.zig $BUILD_MODE -- "$1"


    In scripts/vopr.sh line 29:
        for I in {1..1000}
        ^-^ SC2034 (warning): I appears unused. Verify use (or export if used externally).

    For more information:
      https://www.shellcheck.net/wiki/SC2034 -- I appears unused. Verify use (or ...
      https://www.shellcheck.net/wiki/SC2043 -- This loop will only ever run once...
      https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
