### PR TITLE
Async commit

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -167,12 +167,6 @@ const Command = struct {
             });
         }
 
-        var state_machine = try StateMachine.init(
-            command.allocator,
-            config.accounts_max,
-            config.transfers_max,
-            config.commits_max,
-        );
         var time: Time = .{};
         var message_bus = try MessageBus.init(
             command.allocator,
@@ -189,7 +183,11 @@ const Command = struct {
             &time,
             &command.storage,
             &message_bus,
-            &state_machine,
+            .{
+                .accounts_max = config.accounts_max,
+                .transfers_max = config.transfers_max,
+                .transfers_pending_max = config.commits_max,
+            },
         );
         message_bus.set_on_message(*Replica, &replica, Replica.on_message);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -186,7 +186,7 @@ const Command = struct {
             .{
                 .accounts_max = config.accounts_max,
                 .transfers_max = config.transfers_max,
-                .transfers_pending_max = config.commits_max,
+                .transfers_pending_max = config.transfers_pending_max,
             },
         );
         message_bus.set_on_message(*Replica, &replica, Replica.on_message);

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -26,6 +26,7 @@ pub const messages_max_replica = messages_max: {
     sum += config.clients_max; // Replica.client_table
     sum += 1; // Replica.loopback_queue
     sum += config.pipeline_max; // Replica.pipeline
+    sum += 1; // Replica.commit_prepare
     // Replica.do_view_change_from_all_replicas quorum:
     // Replica.recovery_response_quorum is only used for recovery and does not increase the limit.
     // All other quorums are bitsets.

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -115,6 +115,14 @@ pub fn main() !void {
             .restart_probability = 0.01,
             .restart_stability = random.uintLessThan(u32, 1_000),
         },
+        .state_machine_options = .{
+            .commit_prefetch_min = random.uintLessThan(u64, 10),
+            .commit_prefetch_mean = 10 + random.uintLessThan(u64, 10),
+            .commit_compact_min = random.uintLessThan(u64, 10),
+            .commit_compact_mean = 10 + random.uintLessThan(u64, 10),
+            .commit_checkpoint_min = random.uintLessThan(u64, 10),
+            .commit_checkpoint_mean = 10 + random.uintLessThan(u64, 10),
+        },
     });
     defer cluster.destroy();
 
@@ -157,7 +165,6 @@ pub fn main() !void {
         \\          crash_stability={} ticks
         \\          restart_probability={d}%
         \\          restart_stability={} ticks
-        \\
     , .{
         seed,
         replica_count,
@@ -187,6 +194,23 @@ pub fn main() !void {
         cluster.options.health_options.crash_stability,
         cluster.options.health_options.restart_probability * 100,
         cluster.options.health_options.restart_stability,
+    });
+    // Split because "32 arguments max are supported per format call".
+    output.info(
+        \\          commit_prefetch_mean={} ticks
+        \\          commit_prefetch_min={} ticks
+        \\          commit_compact_mean={} ticks
+        \\          commit_compact_min={} ticks
+        \\          commit_checkpoint_mean={} ticks
+        \\          commit_checkpoint_min={} ticks
+        \\
+    , .{
+        cluster.options.state_machine_options.commit_prefetch_min,
+        cluster.options.state_machine_options.commit_prefetch_mean,
+        cluster.options.state_machine_options.commit_compact_min,
+        cluster.options.state_machine_options.commit_compact_mean,
+        cluster.options.state_machine_options.commit_checkpoint_min,
+        cluster.options.state_machine_options.commit_checkpoint_mean,
     });
 
     var requests_sent: u64 = 0;

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -328,7 +328,6 @@ fn args_next(args: *std.process.ArgIterator, allocator: std.mem.Allocator) ?[:0]
 }
 
 fn on_change_replica(replica: *Replica) void {
-    assert(cluster.state_machines[replica.replica].state == replica.state_machine.state);
     cluster.state_checker.check_state(replica.replica);
 }
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -116,9 +116,10 @@ pub fn main() !void {
             .restart_stability = random.uintLessThan(u32, 1_000),
         },
         .state_machine_options = .{
-            .commit_prefetch_mean = 5 + random.uintLessThan(u64, 10),
-            .commit_compact_mean = 5 + random.uintLessThan(u64, 10),
-            .commit_checkpoint_mean = 5 + random.uintLessThan(u64, 10),
+            .seed = random.int(u64),
+            .prefetch_mean = 5 + random.uintLessThan(u64, 10),
+            .compact_mean = 5 + random.uintLessThan(u64, 10),
+            .checkpoint_mean = 5 + random.uintLessThan(u64, 10),
         },
     });
     defer cluster.destroy();
@@ -162,9 +163,9 @@ pub fn main() !void {
         \\          crash_stability={} ticks
         \\          restart_probability={d}%
         \\          restart_stability={} ticks
-        \\          commit_prefetch_mean={} ticks
-        \\          commit_compact_mean={} ticks
-        \\          commit_checkpoint_mean={} ticks
+        \\          prefetch_mean={} ticks
+        \\          compact_mean={} ticks
+        \\          checkpoint_mean={} ticks
         \\
     , .{
         seed,
@@ -195,9 +196,9 @@ pub fn main() !void {
         cluster.options.health_options.crash_stability,
         cluster.options.health_options.restart_probability * 100,
         cluster.options.health_options.restart_stability,
-        cluster.options.state_machine_options.commit_prefetch_mean,
-        cluster.options.state_machine_options.commit_compact_mean,
-        cluster.options.state_machine_options.commit_checkpoint_mean,
+        cluster.options.state_machine_options.prefetch_mean,
+        cluster.options.state_machine_options.compact_mean,
+        cluster.options.state_machine_options.checkpoint_mean,
     });
 
     var requests_sent: u64 = 0;
@@ -254,7 +255,6 @@ pub fn main() !void {
             switch (cluster.health[replica.replica]) {
                 .up => |*ticks| {
                     ticks.* -|= 1;
-                    replica.state_machine.tick();
                     replica.tick();
                     cluster.state_checker.check_state(replica.replica);
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -243,6 +243,7 @@ pub fn main() !void {
             switch (cluster.health[replica.replica]) {
                 .up => |*ticks| {
                     ticks.* -|= 1;
+                    replica.state_machine.tick();
                     replica.tick();
                     cluster.state_checker.check_state(replica.replica);
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -116,12 +116,9 @@ pub fn main() !void {
             .restart_stability = random.uintLessThan(u32, 1_000),
         },
         .state_machine_options = .{
-            .commit_prefetch_min = random.uintLessThan(u64, 10),
-            .commit_prefetch_mean = 10 + random.uintLessThan(u64, 10),
-            .commit_compact_min = random.uintLessThan(u64, 10),
-            .commit_compact_mean = 10 + random.uintLessThan(u64, 10),
-            .commit_checkpoint_min = random.uintLessThan(u64, 10),
-            .commit_checkpoint_mean = 10 + random.uintLessThan(u64, 10),
+            .commit_prefetch_mean = 5 + random.uintLessThan(u64, 10),
+            .commit_compact_mean = 5 + random.uintLessThan(u64, 10),
+            .commit_checkpoint_mean = 5 + random.uintLessThan(u64, 10),
         },
     });
     defer cluster.destroy();
@@ -165,6 +162,10 @@ pub fn main() !void {
         \\          crash_stability={} ticks
         \\          restart_probability={d}%
         \\          restart_stability={} ticks
+        \\          commit_prefetch_mean={} ticks
+        \\          commit_compact_mean={} ticks
+        \\          commit_checkpoint_mean={} ticks
+        \\
     , .{
         seed,
         replica_count,
@@ -194,22 +195,8 @@ pub fn main() !void {
         cluster.options.health_options.crash_stability,
         cluster.options.health_options.restart_probability * 100,
         cluster.options.health_options.restart_stability,
-    });
-    // Split because "32 arguments max are supported per format call".
-    output.info(
-        \\          commit_prefetch_mean={} ticks
-        \\          commit_prefetch_min={} ticks
-        \\          commit_compact_mean={} ticks
-        \\          commit_compact_min={} ticks
-        \\          commit_checkpoint_mean={} ticks
-        \\          commit_checkpoint_min={} ticks
-        \\
-    , .{
-        cluster.options.state_machine_options.commit_prefetch_min,
         cluster.options.state_machine_options.commit_prefetch_mean,
-        cluster.options.state_machine_options.commit_compact_min,
         cluster.options.state_machine_options.commit_compact_mean,
-        cluster.options.state_machine_options.commit_checkpoint_min,
         cluster.options.state_machine_options.commit_checkpoint_mean,
     });
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -134,6 +134,21 @@ pub const StateMachine = struct {
         assert(sum_reserved_timestamps == 0);
     }
 
+    pub fn prefetch(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
+        // TODO
+        callback(self);
+    }
+
+    pub fn compact(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
+        // TODO self.forest.compact(op_number, callback);
+        callback(self);
+    }
+
+    pub fn checkpoint(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
+        // TODO self.forest.checkpoint(op_number, checkpoint_callback);
+        callback(self);
+    }
+
     pub fn commit(
         self: *StateMachine,
         client: u128,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -76,7 +76,7 @@ pub const StateMachine = struct {
         };
     }
 
-    pub fn deinit(self: *StateMachine) void {
+    pub fn deinit(self: *StateMachine, _: std.mem.Allocator) void {
         self.accounts.deinit();
         self.transfers.deinit();
         self.posted.deinit();

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -134,18 +134,29 @@ pub const StateMachine = struct {
         assert(sum_reserved_timestamps == 0);
     }
 
-    pub fn prefetch(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
+    pub fn prefetch(
+        self: *StateMachine,
+        op_number: u64,
+        operation: Operation,
+        input: []const u8,
+        callback: fn(*StateMachine) void,
+    ) void {
         // TODO
+        _ = op_number;
+        _ = operation;
+        _ = input;
         callback(self);
     }
 
     pub fn compact(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
         // TODO self.forest.compact(op_number, callback);
+        _ = op_number;
         callback(self);
     }
 
     pub fn checkpoint(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
         // TODO self.forest.checkpoint(op_number, checkpoint_callback);
+        _ = op_number;
         callback(self);
     }
 

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -33,6 +33,7 @@ pub const ClusterOptions = struct {
     network_options: NetworkOptions,
     storage_options: Storage.Options,
     health_options: HealthOptions,
+    state_machine_options: StateMachine.Options,
 };
 
 pub const HealthOptions = struct {
@@ -147,7 +148,10 @@ pub const Cluster = struct {
                 &cluster.times[replica_index],
                 &cluster.storages[replica_index],
                 message_bus,
-                .{ .seed = cluster.options.seed },
+                .{
+                    .seed = cluster.options.seed,
+                    .options = cluster.options.state_machine_options,
+                },
             );
             message_bus.set_on_message(*Replica, replica, Replica.on_message);
         }
@@ -315,7 +319,10 @@ pub const Cluster = struct {
             &cluster.times[replica_index],
             &cluster.storages[replica_index],
             message_bus,
-            .{ .seed = cluster.options.seed },
+            .{
+                .seed = cluster.options.seed,
+                .options = cluster.options.state_machine_options,
+            },
         );
         message_bus.set_on_message(*Replica, replica, Replica.on_message);
         replica.on_change_state = cluster.on_change_state;

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -148,10 +148,7 @@ pub const Cluster = struct {
                 &cluster.times[replica_index],
                 &cluster.storages[replica_index],
                 message_bus,
-                .{
-                    .seed = cluster.options.seed,
-                    .options = cluster.options.state_machine_options,
-                },
+                cluster.options.state_machine_options,
             );
             message_bus.set_on_message(*Replica, replica, Replica.on_message);
         }
@@ -319,10 +316,7 @@ pub const Cluster = struct {
             &cluster.times[replica_index],
             &cluster.storages[replica_index],
             message_bus,
-            .{
-                .seed = cluster.options.seed,
-                .options = cluster.options.state_machine_options,
-            },
+            cluster.options.state_machine_options,
         );
         message_bus.set_on_message(*Replica, replica, Replica.on_message);
         replica.on_change_state = cluster.on_change_state;

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -36,10 +36,11 @@ pub const StateChecker = struct {
     transitions: u64 = 0,
 
     pub fn init(allocator: mem.Allocator, cluster: *Cluster) !StateChecker {
-        const state = cluster.state_machines[0].state;
+        const state = cluster.replicas[0].state_machine.state;
 
         var state_machine_states: [config.replicas_max]u128 = undefined;
-        for (cluster.state_machines) |state_machine, i| {
+        for (cluster.replicas) |*replica, i| {
+            const state_machine = &replica.state_machine;
             assert(state_machine.state == state);
             state_machine_states[i] = state_machine.state;
         }
@@ -66,7 +67,7 @@ pub const StateChecker = struct {
         const cluster = @fieldParentPtr(Cluster, "state_checker", state_checker);
 
         const a = state_checker.state_machine_states[replica];
-        const b = cluster.state_machines[replica].state;
+        const b = cluster.replicas[replica].state_machine.state;
 
         if (b == a) return;
         state_checker.state_machine_states[replica] = b;

--- a/src/test/state_machine.zig
+++ b/src/test/state_machine.zig
@@ -39,7 +39,7 @@ pub const StateMachine = struct {
         };
     }
 
-    pub fn deinit(_: *StateMachine) void {}
+    pub fn deinit(_: *StateMachine, _: std.mem.Allocator) void {}
 
     pub fn tick(state_machine: *StateMachine) void {
         if (state_machine.callback) |callback| {

--- a/src/test/state_machine.zig
+++ b/src/test/state_machine.zig
@@ -45,14 +45,13 @@ pub const StateMachine = struct {
 
     pub fn deinit(_: *StateMachine) void {}
 
-    // TODO Is this part of StateMachine's API?
-    pub fn tick(self: *StateMachine) void {
-        if (self.callback) |callback| {
-            if (self.callback_ticks == 0) {
-                self.callback = null;
-                callback(self);
+    pub fn tick(state_machine: *StateMachine) void {
+        if (state_machine.callback) |callback| {
+            if (state_machine.callback_ticks == 0) {
+                state_machine.callback = null;
+                callback(state_machine);
             } else {
-                self.callback_ticks -= 1;
+                state_machine.callback_ticks -= 1;
             }
         }
     }
@@ -69,7 +68,7 @@ pub const StateMachine = struct {
     }
 
     pub fn prefetch(
-        self: *StateMachine,
+        state_machine: *StateMachine,
         op_number: u64,
         operation: Operation,
         input: []const u8,
@@ -78,26 +77,26 @@ pub const StateMachine = struct {
         _ = op_number;
         _ = operation;
         _ = input;
-        assert(self.callback == null);
-        assert(self.callback_ticks == 0);
-        self.callback = callback;
-        self.callback_ticks = self.latency(self.options.commit_prefetch_mean);
+        assert(state_machine.callback == null);
+        assert(state_machine.callback_ticks == 0);
+        state_machine.callback = callback;
+        state_machine.callback_ticks = state_machine.latency(state_machine.options.commit_prefetch_mean);
     }
 
-    pub fn compact(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
+    pub fn compact(state_machine: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
         _ = op_number;
-        assert(self.callback == null);
-        assert(self.callback_ticks == 0);
-        self.callback = callback;
-        self.callback_ticks = self.latency(self.options.commit_compact_mean);
+        assert(state_machine.callback == null);
+        assert(state_machine.callback_ticks == 0);
+        state_machine.callback = callback;
+        state_machine.callback_ticks = state_machine.latency(state_machine.options.commit_compact_mean);
     }
 
-    pub fn checkpoint(self: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
+    pub fn checkpoint(state_machine: *StateMachine, op_number: u64, callback: fn(*StateMachine) void) void {
         _ = op_number;
-        assert(self.callback == null);
-        assert(self.callback_ticks == 0);
-        self.callback = callback;
-        self.callback_ticks = self.latency(self.options.commit_checkpoint_mean);
+        assert(state_machine.callback == null);
+        assert(state_machine.callback_ticks == 0);
+        state_machine.callback = callback;
+        state_machine.callback_ticks = state_machine.latency(state_machine.options.commit_checkpoint_mean);
     }
 
     pub fn commit(
@@ -145,7 +144,7 @@ pub const StateMachine = struct {
         return @bitCast(u128, target[0..16].*);
     }
 
-    fn latency(self: *StateMachine, mean: u64) u64 {
-        return self.prng.random().uintLessThan(u64, 2 * mean);
+    fn latency(state_machine: *StateMachine, mean: u64) u64 {
+        return state_machine.prng.random().uintLessThan(u64, 2 * mean);
     }
 };

--- a/src/test/state_machine.zig
+++ b/src/test/state_machine.zig
@@ -13,13 +13,19 @@ pub const StateMachine = struct {
         hash,
     };
 
+    pub const Config = struct {
+        seed: u64,
+    };
+
     state: u128,
     prepare_timestamp: u64 = 0,
     commit_timestamp: u64 = 0,
 
-    pub fn init(seed: u64) StateMachine {
-        return .{ .state = hash(0, std.mem.asBytes(&seed)) };
+    pub fn init(_: std.mem.Allocator, config: Config) !StateMachine {
+        return StateMachine{ .state = hash(0, std.mem.asBytes(&config.seed)) };
     }
+
+    pub fn deinit(_: *StateMachine) void {}
 
     pub fn prepare(
         state_machine: *StateMachine,
@@ -35,10 +41,13 @@ pub const StateMachine = struct {
     pub fn commit(
         state_machine: *StateMachine,
         client: u128,
+        op_number: u64,
         operation: Operation,
         input: []const u8,
         output: []u8,
     ) usize {
+        _ = op_number;
+
         switch (operation) {
             .reserved, .root => unreachable,
             .register => return 0,


### PR DESCRIPTION
Add placeholder async functions `prefetch`/`compact`/`checkpoint` to `StateMachine`. Call them from `Replica`.
The replica must be careful about performing certain operations while it is busy committing.

**Superseded by https://github.com/coilhq/tigerbeetle/pull/127**