### PR TITLE
VSR: Request dirty prepare

### DIFF
--- a/src/demo_05_post_pending_transfers.zig
+++ b/src/demo_05_post_pending_transfers.zig
@@ -13,8 +13,8 @@ pub fn main() !void {
             .reserved = 0,
             .pending_id = 1001,
             .timeout = 0,
-            .ledger = 0,// Honor original Transfer ledger.
-            .code = 0,// Honor original Transfer code.
+            .ledger = 0, // Honor original Transfer ledger.
+            .code = 0, // Honor original Transfer code.
             .flags = .{ .post_pending_transfer = true }, // Post the pending two-phase transfer.
             .amount = 0, // Inherit the amount from the pending transfer.
         },

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -227,7 +227,7 @@ pub const Cluster = struct {
             return false;
         }
 
-        // Ensure that the replica can eventually recover without this replica.
+        // Ensure that the cluster can eventually recover without this replica.
         // Verify that each op is recoverable by the current healthy cluster (minus the replica we
         // are trying to crash).
         // TODO Remove this workaround when VSR recovery protocol is disabled.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2002,8 +2002,8 @@ pub fn Replica(
 
                     assert(self.status == .view_change);
                     assert(self.leader_index(self.view) == self.replica);
-                    assert(self.replica != message.header.replica);
-                    assert(self.nack_prepare_op.? == message.header.op);
+                    assert(message.header.replica != self.replica);
+                    assert(message.header.op == self.nack_prepare_op.?);
                 },
                 else => unreachable,
             }


### PR DESCRIPTION
Improve availability of `on_request_prepare` by always calling `Journal.read_prepare_with_op_and_checksum`, not `Journal.read_prepare` — even when the header is in memory. This prevents a deadlock when:
  1. Replica 2 has op=26, but it is faulty.
  2. Replica 1 does not have op=26.
  3. Replica 0 has op=26, but after crashing and recovering, op=26 was recovered as `fix` (i.e. dirty but not faulty).

One thing to note is that `request_prepare` will now keep trying to read the prepare from the WAL _even if the slot is marked faulty_. It did that before too, but only when there was no in-memory header.

See https://github.com/coilhq/tigerbeetle/issues/109#issuecomment-1201798385 for more detail.

---

Other changes:

- WAL: Move the `message.size == @sizeOf(Header)` optimization from `read_prepare` to `read_prepare_with_op_and_checksum` so that `on_request_prepare` can take advantage of it.
- Simulator: Log when storage faults are enabled/disabled per replica.
- Tinker with a few log messages/levels.
- Add an unrelated assertion to `Journal.read_prepare_with_op_and_checksum`.
- Remove dead code in `count_quorum` (unused because `start_view_change` and `nack_prepare` use `QuorumCounter`s instead of `QuorumMessages`. Move their assertions to `count_message_and_receive_quorum_exactly_once`.
- Remove invalid assertion from `repair_header`. It was only not failing because the WAL doesn't wrap yet.