### PR TITLE
VSR/StateMachine: Async commit hooks (rebased)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -167,12 +167,6 @@ const Command = struct {
             });
         }
 
-        var state_machine = try StateMachine.init(
-            command.allocator,
-            config.accounts_max,
-            config.transfers_max,
-            config.commits_max,
-        );
         var time: Time = .{};
         var message_bus = try MessageBus.init(
             command.allocator,
@@ -189,7 +183,11 @@ const Command = struct {
             &time,
             &command.storage,
             &message_bus,
-            &state_machine,
+            .{
+                .accounts_max = config.accounts_max,
+                .transfers_max = config.transfers_max,
+                .transfers_pending_max = config.transfers_pending_max,
+            },
         );
         message_bus.set_on_message(*Replica, &replica, Replica.on_message);
 

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -26,6 +26,7 @@ pub const messages_max_replica = messages_max: {
     sum += config.clients_max; // Replica.client_table
     sum += 1; // Replica.loopback_queue
     sum += config.pipeline_max; // Replica.pipeline
+    sum += 1; // Replica.commit_prepare
     // Replica.do_view_change_from_all_replicas quorum:
     // Replica.recovery_response_quorum is only used for recovery and does not increase the limit.
     // All other quorums are bitsets.

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -115,6 +115,12 @@ pub fn main() !void {
             .restart_probability = 0.01,
             .restart_stability = random.uintLessThan(u32, 1_000),
         },
+        .state_machine_options = .{
+            .seed = random.int(u64),
+            .prefetch_mean = 5 + random.uintLessThan(u64, 10),
+            .compact_mean = 5 + random.uintLessThan(u64, 10),
+            .checkpoint_mean = 5 + random.uintLessThan(u64, 10),
+        },
     });
     defer cluster.destroy();
 
@@ -157,6 +163,9 @@ pub fn main() !void {
         \\          crash_stability={} ticks
         \\          restart_probability={d}%
         \\          restart_stability={} ticks
+        \\          prefetch_mean={} ticks
+        \\          compact_mean={} ticks
+        \\          checkpoint_mean={} ticks
         \\
     , .{
         seed,
@@ -187,6 +196,9 @@ pub fn main() !void {
         cluster.options.health_options.crash_stability,
         cluster.options.health_options.restart_probability * 100,
         cluster.options.health_options.restart_stability,
+        cluster.options.state_machine_options.prefetch_mean,
+        cluster.options.state_machine_options.compact_mean,
+        cluster.options.state_machine_options.checkpoint_mean,
     });
 
     var requests_sent: u64 = 0;
@@ -328,7 +340,6 @@ fn args_next(args: *std.process.ArgIterator, allocator: std.mem.Allocator) ?[:0]
 }
 
 fn on_change_replica(replica: *Replica) void {
-    assert(cluster.state_machines[replica.replica].state == replica.state_machine.state);
     cluster.state_checker.check_state(replica.replica);
 }
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -171,9 +171,11 @@ pub fn StateMachineType(comptime Storage: type) type {
         pub fn prefetch(
             self: *StateMachine,
             callback: fn (*StateMachine) void,
+            op: u64,
             operation: Operation,
             input: []align(16) const u8,
         ) void {
+            _ = op;
             assert(self.prefetch_input == null);
             assert(self.prefetch_callback == null);
             self.prefetch_input = input;
@@ -313,13 +315,13 @@ pub fn StateMachineType(comptime Storage: type) type {
         pub fn commit(
             self: *StateMachine,
             client: u128,
-            op_number: u64,
+            op: u64,
             operation: Operation,
             input: []const u8,
             output: []u8,
         ) usize {
             _ = client;
-            _ = op_number;
+            _ = op;
 
             const result = switch (operation) {
                 .root => unreachable,
@@ -336,6 +338,18 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.forest.grooves.posted.prefetch_clear();
 
             return result;
+        }
+
+        pub fn compact(self: *StateMachine, op: u64, callback: fn (*StateMachine) void) void {
+            // TODO self.forest.compact(op, callback);
+            _ = op;
+            callback(self);
+        }
+
+        pub fn checkpoint(self: *StateMachine, op: u64, callback: fn (*StateMachine) void) void {
+            // TODO self.forest.checkpoint(op, checkpoint_callback);
+            _ = op;
+            callback(self);
         }
 
         fn execute(
@@ -1284,9 +1298,11 @@ test "linked accounts" {
     const StateMachine = StateMachineType(Storage);
     var state_machine = try StateMachine.init(
         testing.allocator,
-        accounts_max,
-        transfers_max,
-        transfers_pending_max,
+        .{
+            .accounts_max = accounts_max,
+            .transfers_max = transfers_max,
+            .transfers_pending_max = transfers_pending_max,
+        },
     );
     defer state_machine.deinit();
 

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -33,6 +33,7 @@ pub const ClusterOptions = struct {
     network_options: NetworkOptions,
     storage_options: Storage.Options,
     health_options: HealthOptions,
+    state_machine_options: StateMachine.Options,
 };
 
 pub const HealthOptions = struct {
@@ -59,7 +60,6 @@ pub const Cluster = struct {
     allocator: mem.Allocator,
     options: ClusterOptions,
 
-    state_machines: []StateMachine,
     storages: []Storage,
     times: []Time,
     replicas: []Replica,
@@ -81,9 +81,6 @@ pub const Cluster = struct {
 
         const cluster = try allocator.create(Cluster);
         errdefer allocator.destroy(cluster);
-
-        const state_machines = try allocator.alloc(StateMachine, options.replica_count);
-        errdefer allocator.free(state_machines);
 
         const storages = try allocator.alloc(Storage, options.replica_count);
         errdefer allocator.free(storages);
@@ -112,7 +109,6 @@ pub const Cluster = struct {
         cluster.* = .{
             .allocator = allocator,
             .options = options,
-            .state_machines = state_machines,
             .storages = storages,
             .times = times,
             .replicas = replicas,
@@ -132,7 +128,6 @@ pub const Cluster = struct {
                 .offset_coefficient_A = 0,
                 .offset_coefficient_B = 0,
             };
-            cluster.state_machines[replica_index] = StateMachine.init(options.seed);
             cluster.storages[replica_index] = try Storage.init(
                 allocator,
                 config.journal_size_max,
@@ -153,7 +148,7 @@ pub const Cluster = struct {
                 &cluster.times[replica_index],
                 &cluster.storages[replica_index],
                 message_bus,
-                &cluster.state_machines[replica_index],
+                cluster.options.state_machine_options,
             );
             message_bus.set_on_message(*Replica, replica, Replica.on_message);
         }
@@ -280,7 +275,6 @@ pub const Cluster = struct {
         // Reset the storage before the replica so that pending writes can (partially) finish.
         cluster.storages[replica_index].reset();
         replica.deinit(cluster.allocator);
-        cluster.state_machines[replica_index] = StateMachine.init(cluster.options.seed);
 
         // The message bus and network should be left alone, as messages
         // may still be inflight to/from this replica. However, we should
@@ -322,7 +316,7 @@ pub const Cluster = struct {
             &cluster.times[replica_index],
             &cluster.storages[replica_index],
             message_bus,
-            &cluster.state_machines[replica_index],
+            cluster.options.state_machine_options,
         );
         message_bus.set_on_message(*Replica, replica, Replica.on_message);
         replica.on_change_state = cluster.on_change_state;

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -37,10 +37,11 @@ pub const StateChecker = struct {
     transitions: u64 = 0,
 
     pub fn init(allocator: mem.Allocator, cluster: *Cluster) !StateChecker {
-        const state = cluster.state_machines[0].state;
+        const state = cluster.replicas[0].state_machine.state;
 
         var state_machine_states: [config.replicas_max]u128 = undefined;
-        for (cluster.state_machines) |state_machine, i| {
+        for (cluster.replicas) |*replica, i| {
+            const state_machine = &replica.state_machine;
             assert(state_machine.state == state);
             state_machine_states[i] = state_machine.state;
         }
@@ -67,7 +68,7 @@ pub const StateChecker = struct {
         const cluster = @fieldParentPtr(Cluster, "state_checker", state_checker);
 
         const a = state_checker.state_machine_states[replica];
-        const b = cluster.state_machines[replica].state;
+        const b = cluster.replicas[replica].state_machine.state;
 
         if (b == a) return;
         state_checker.state_machine_states[replica] = b;

--- a/src/test/state_machine.zig
+++ b/src/test/state_machine.zig
@@ -17,12 +17,40 @@ pub fn StateMachineType(comptime Storage: type) type {
             hash,
         };
 
+        /// Minimum/mean number of ticks to perform the specified operation.
+        /// Each mean must be greater-or-equal-to their respective minimum.
+        pub const Options = struct {
+            seed: u64,
+            prefetch_mean: u64,
+            compact_mean: u64,
+            checkpoint_mean: u64,
+        };
+
+        options: Options,
         state: u128,
+        prng: std.rand.DefaultPrng,
         prepare_timestamp: u64 = 0,
         commit_timestamp: u64 = 0,
 
-        pub fn init(seed: u64) StateMachine {
-            return .{ .state = hash(0, std.mem.asBytes(&seed)) };
+        pub fn init(seed: u64, options: Options) StateMachine {
+            return .{
+                .state = hash(0, std.mem.asBytes(&seed)),
+                .options = options,
+                .prng = std.rand.DefaultPrng.init(options.seed),
+            };
+        }
+
+        pub fn deinit(_: *StateMachine, _: std.mem.Allocator) void {}
+
+        pub fn tick(state_machine: *StateMachine) void {
+            if (state_machine.callback) |callback| {
+                if (state_machine.callback_ticks == 0) {
+                    state_machine.callback = null;
+                    callback(state_machine);
+                } else {
+                    state_machine.callback_ticks -= 1;
+                }
+            }
         }
 
         pub fn prepare(
@@ -36,13 +64,32 @@ pub fn StateMachineType(comptime Storage: type) type {
             return state_machine.prepare_timestamp;
         }
 
+        pub fn prefetch(
+            state_machine: *StateMachine,
+            callback: fn (*StateMachine) void,
+            op: u64,
+            operation: Operation,
+            input: []const u8,
+        ) void {
+            _ = op;
+            _ = operation;
+            _ = input;
+            assert(state_machine.callback == null);
+            assert(state_machine.callback_ticks == 0);
+            state_machine.callback = callback;
+            state_machine.callback_ticks = state_machine.latency(state_machine.options.prefetch_mean);
+        }
+
         pub fn commit(
             state_machine: *StateMachine,
             client: u128,
+            op: u64,
             operation: Operation,
             input: []const u8,
             output: []u8,
         ) usize {
+            _ = op;
+
             switch (operation) {
                 .reserved, .root => unreachable,
                 .register => return 0,
@@ -70,12 +117,40 @@ pub fn StateMachineType(comptime Storage: type) type {
             }
         }
 
+        pub fn compact(
+            state_machine: *StateMachine,
+            op: u64,
+            callback: fn (*StateMachine) void,
+        ) void {
+            _ = op;
+            assert(state_machine.callback == null);
+            assert(state_machine.callback_ticks == 0);
+            state_machine.callback = callback;
+            state_machine.callback_ticks = state_machine.latency(state_machine.options.compact_mean);
+        }
+
+        pub fn checkpoint(
+            state_machine: *StateMachine,
+            op: u64,
+            callback: fn (*StateMachine) void,
+        ) void {
+            _ = op;
+            assert(state_machine.callback == null);
+            assert(state_machine.callback_ticks == 0);
+            state_machine.callback = callback;
+            state_machine.callback_ticks = state_machine.latency(state_machine.options.checkpoint_mean);
+        }
+
         pub fn hash(state: u128, input: []const u8) u128 {
             var key: [32]u8 = [_]u8{0} ** 32;
             std.mem.copy(u8, key[0..16], std.mem.asBytes(&state));
             var target: [32]u8 = undefined;
             std.crypto.hash.Blake3.hash(input, &target, .{ .key = key });
             return @bitCast(u128, target[0..16].*);
+        }
+
+        fn latency(state_machine: *StateMachine, mean: u64) u64 {
+            return state_machine.prng.random().uintLessThan(u64, 2 * mean);
         }
     };
 }


### PR DESCRIPTION
- StateMachine
  - Move into Replica.
  - Add `tick()` to `StateMachine`'s API. The simulator's `StateMachine` needs it, and now it is an "official" function. It is invoked by `Replica.tick()`.
- Replica: Async commit hooks: Fix issues arising from async commit changes, including:
  - Move pop-head-of-pipeline into `commit_op_prefetch_callback` to maintain the `commit_min + 1 == pipeline.head.op` invariant.
  - Fix pipeline check: In `commit_done`, only verify the pipeline if we are a leader in normal mode, since otherwise the pipeline isn't going to be committed anyway, and may be out of date.
  - In `commit_op_prefetch_callback`, a normal-mode leader can always pop the pipeline head. Since they are normal mode, everything prior to the pipeline was already committed.
  - Allow do_view_change while committing
    - This is safe (and much simpler than my original solution: https://github.com/coilhq/tigerbeetle/pull/122#issuecomment-1200343153). Even if the new DVC fails to arrive, the old one has the same headers. If there were enough acks for it to be committed, the new leader will not be able to discard the header — it will survive the view change.
- Replica (other):
  - Improve validation after/around commit.
  - Rename `Replica`'s commit functions to emphasize the symmetry between the journal and pipeline commit code paths.
Simulator
  - In the simulator, vary the latency of `commit_{prefetch,compact,checkpoint}`.
- In `flush_loopback_queue`, document a few missing cases in which a message is sent to self.