### PR TITLE
VSR: Move formatting into `replica.zig`

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -76,7 +76,8 @@ pub fn main() !void {
     var address = [_]std.net.Address{try std.net.Address.parseIp4("127.0.0.1", config.port)};
 
     var io = try IO.init(32, 0);
-    var message_bus = try MessageBus.init(allocator, cluster_id, address[0..], client_id, &io);
+    var message_pool = try MessagePool.init(allocator, .client);
+    var message_bus = try MessageBus.init(allocator, cluster_id, address[0..], client_id, &io, &message_pool);
     defer message_bus.deinit();
 
     var client = try Client.init(

--- a/src/demo.zig
+++ b/src/demo.zig
@@ -37,7 +37,8 @@ pub fn request(
     var io = try IO.init(32, 0);
     defer io.deinit();
 
-    var message_bus = try MessageBus.init(allocator, cluster_id, &addresses, client_id, &io);
+    var message_pool = try MessagePool.init(allocator, .client);
+    var message_bus = try MessageBus.init(allocator, cluster_id, &addresses, client_id, &io, &message_pool);
     defer message_bus.deinit();
 
     var client = try Client.init(

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,10 +16,12 @@ const Time = @import("time.zig").Time;
 const Storage = @import("storage.zig").Storage;
 
 const MessageBus = @import("message_bus.zig").MessageBusReplica;
+const MessagePool = @import("message_pool.zig").MessagePool;
 const StateMachine = @import("state_machine.zig").StateMachineType(Storage);
 
 const vsr = @import("vsr.zig");
 const Replica = vsr.Replica(StateMachine, MessageBus, Storage, Time);
+const ReplicaFormatter = vsr.ReplicaFormatter(Storage);
 
 const SuperBlock = vsr.SuperBlockType(Storage);
 const superblock_zone_size = @import("vsr/superblock.zig").superblock_zone_size;
@@ -65,43 +67,31 @@ fn init(io: *IO, cluster: u32, replica: u8, dir_fd: os.fd_t) !void {
 
 const Command = struct {
     allocator: mem.Allocator,
-    fd: os.fd_t,
     io: IO,
     pending: u64,
     storage: Storage,
-    superblock: SuperBlock,
-    superblock_context: SuperBlock.Context,
     addresses: ?[]std.net.Address,
+
+    superblock: ?SuperBlock,
+    superblock_context: SuperBlock.Context,
+    replica_formatter: ReplicaFormatter,
 
     pub fn format(allocator: mem.Allocator, cluster: u32, replica: u8, path: [:0]const u8) !void {
         const fd = try open_file(path, true);
-
-        {
-            const write_size_max = 4 * 1024 * 1024;
-            var write: [write_size_max]u8 = undefined;
-            var offset: u64 = superblock_zone_size;
-            while (true) {
-                const write_size = vsr.format_journal(cluster, offset, &write);
-                if (write_size == 0) break;
-                {
-                    var written: usize = 0;
-                    while (written < write_size) {
-                        written += try os.write(fd, write[0..write_size][written..]);
-                    }
-                }
-                offset += write_size;
-            }
-        }
-
         var command: Command = undefined;
         try command.init(allocator, fd, null);
 
-        command.superblock.format(format_callback, &command.superblock_context, .{
-            .cluster = cluster,
-            .replica = replica,
-            .size_max = config.size_max, // This can later become a runtime arg, to cap storage.
-        });
+        var message_pool = try MessagePool.init(allocator, .replica);
+        command.replica_formatter = try ReplicaFormatter.init(
+            allocator,
+            cluster,
+            replica,
+            &command.storage,
+            &message_pool,
+        );
+        defer command.replica_formatter.deinit(allocator);
 
+        try command.replica_formatter.format(format_callback);
         try command.run();
     }
 
@@ -118,7 +108,7 @@ const Command = struct {
         var command: Command = undefined;
         try command.init(allocator, fd, addresses);
 
-        command.superblock.open(open_callback, &command.superblock_context);
+        command.superblock.?.open(open_callback, &command.superblock_context);
         try command.run();
 
         // After opening the superblock, we immediately start the main event loop and remain there.
@@ -143,8 +133,8 @@ const Command = struct {
         while (command.pending > 0) try command.io.run_for_ns(std.time.ns_per_ms);
     }
 
-    fn format_callback(superblock_context: *SuperBlock.Context) void {
-        const command = @fieldParentPtr(Command, "superblock_context", superblock_context);
+    fn format_callback(replica_formatter: *ReplicaFormatter) void {
+        const command = @fieldParentPtr(Command, "replica_formatter", replica_formatter);
         command.pending -= 1;
     }
 
@@ -153,12 +143,12 @@ const Command = struct {
         command.pending -= 1;
 
         // TODO log an error and exit instead. This is reachable if we e.g. run out of memory.
-        command.event_loop() catch unreachable;
+        command.start_loop() catch unreachable;
     }
 
-    fn event_loop(command: *Command) !void {
-        const cluster = command.superblock.working.cluster;
-        const replica_index = command.superblock.working.replica;
+    fn start_loop(command: *Command) !void {
+        const cluster = command.superblock.?.working.cluster;
+        const replica_index = command.superblock.?.working.replica;
 
         if (replica_index >= command.addresses.?.len) {
             fatal("all --addresses must be provided (cluster={}, replica={})", .{
@@ -168,33 +158,39 @@ const Command = struct {
         }
 
         var time: Time = .{};
+        var message_pool = try MessagePool.init(command.allocator, .replica);
         var message_bus = try MessageBus.init(
             command.allocator,
             cluster,
             command.addresses.?,
             replica_index,
             &command.io,
+            &message_pool,
         );
+        errdefer message_bus.deinit();
+
         var replica = try Replica.init(
             command.allocator,
-            cluster,
-            @intCast(u8, command.addresses.?.len),
-            replica_index,
-            &time,
-            &command.storage,
-            &message_bus,
             .{
-                .accounts_max = config.accounts_max,
-                .transfers_max = config.transfers_max,
-                .transfers_pending_max = config.transfers_pending_max,
+                .cluster = cluster,
+                .replica_count = @intCast(u8, command.addresses.?.len),
+                .replica_index = replica_index,
+                .time = &time,
+                .storage = &command.storage,
+                .message_bus = &message_bus,
+                .state_machine_options = .{
+                    .accounts_max = config.accounts_max,
+                    .transfers_max = config.transfers_max,
+                    .transfers_pending_max = config.transfers_pending_max,
+                },
             },
         );
         message_bus.set_on_message(*Replica, &replica, Replica.on_message);
 
         log.info("cluster={} replica={}: listening on {}", .{
-            cluster,
-            replica_index,
-            command.addresses.?[replica_index],
+            replica.cluster,
+            replica.replica,
+            command.addresses.?[replica.replica],
         });
 
         while (true) {
@@ -211,18 +207,15 @@ const Command = struct {
         addresses: ?[]std.net.Address,
     ) !void {
         command.allocator = allocator;
-        command.fd = fd;
+        command.superblock = null;
 
         command.io = try IO.init(128, 0);
         errdefer command.io.deinit();
 
         command.pending = 0;
 
-        command.storage = try Storage.init(&command.io, command.fd);
+        command.storage = try Storage.init(&command.io, fd);
         errdefer command.storage.deinit();
-
-        command.superblock = try SuperBlock.init(allocator, &command.storage);
-        errdefer command.superblock.deinit(allocator);
 
         command.addresses = addresses;
     }

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -35,7 +35,7 @@ fn MessageBusImpl(comptime process_type: vsr.ProcessType) type {
     return struct {
         const Self = @This();
 
-        pool: MessagePool,
+        pool: *MessagePool,
         io: *IO,
 
         cluster: u32,
@@ -90,6 +90,7 @@ fn MessageBusImpl(comptime process_type: vsr.ProcessType) type {
                 .client => u128,
             },
             io: *IO,
+            message_pool: *MessagePool,
         ) !Self {
             // There must be enough connections for all replicas and at least one client.
             assert(config.connections_max > configuration.len);
@@ -112,7 +113,7 @@ fn MessageBusImpl(comptime process_type: vsr.ProcessType) type {
             };
 
             var bus: Self = .{
-                .pool = try MessagePool.init(allocator, process_type),
+                .pool = message_pool,
                 .io = io,
                 .cluster = cluster,
                 .configuration = configuration,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -340,13 +340,13 @@ pub fn StateMachineType(comptime Storage: type) type {
             return result;
         }
 
-        pub fn compact(self: *StateMachine, op: u64, callback: fn (*StateMachine) void) void {
+        pub fn compact(self: *StateMachine, callback: fn (*StateMachine) void, op: u64) void {
             // TODO self.forest.compact(op, callback);
             _ = op;
             callback(self);
         }
 
-        pub fn checkpoint(self: *StateMachine, op: u64, callback: fn (*StateMachine) void) void {
+        pub fn checkpoint(self: *StateMachine, callback: fn (*StateMachine) void, op: u64) void {
             // TODO self.forest.checkpoint(op, checkpoint_callback);
             _ = op;
             callback(self);

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -142,13 +142,15 @@ pub const Cluster = struct {
 
             replica.* = try Replica.init(
                 allocator,
-                options.cluster,
-                options.replica_count,
-                @intCast(u8, replica_index),
-                &cluster.times[replica_index],
-                &cluster.storages[replica_index],
-                message_bus,
-                cluster.options.state_machine_options,
+                .{
+                    .cluster = options.cluster,
+                    .replica_count = options.replica_count,
+                    .replica_index = @intCast(u8, replica_index),
+                    .time = &cluster.times[replica_index],
+                    .storage = &cluster.storages[replica_index],
+                    .message_bus = message_bus,
+                    .state_machine_options = cluster.options.state_machine_options,
+                },
             );
             message_bus.set_on_message(*Replica, replica, Replica.on_message);
         }
@@ -310,13 +312,15 @@ pub const Cluster = struct {
 
         replica.* = try Replica.init(
             cluster.allocator,
-            cluster.options.cluster,
-            cluster.options.replica_count,
-            @intCast(u8, replica_index),
-            &cluster.times[replica_index],
-            &cluster.storages[replica_index],
-            message_bus,
-            cluster.options.state_machine_options,
+            .{
+                .cluster = cluster.options.cluster,
+                .replica_count = cluster.options.replica_count,
+                .replica_index = @intCast(u8, replica_index),
+                .time = &cluster.times[replica_index],
+                .storage = &cluster.storages[replica_index],
+                .message_bus = message_bus,
+                .state_machine_options = cluster.options.state_machine_options,
+            },
         );
         message_bus.set_on_message(*Replica, replica, Replica.on_message);
         replica.on_change_state = cluster.on_change_state;

--- a/src/test/state_machine.zig
+++ b/src/test/state_machine.zig
@@ -32,9 +32,9 @@ pub fn StateMachineType(comptime Storage: type) type {
         prepare_timestamp: u64 = 0,
         commit_timestamp: u64 = 0,
 
-        pub fn init(seed: u64, options: Options) StateMachine {
-            return .{
-                .state = hash(0, std.mem.asBytes(&seed)),
+        pub fn init(_: std.mem.Allocator, options: Options) !StateMachine {
+            return StateMachine{
+                .state = hash(0, std.mem.asBytes(&options.seed)),
                 .options = options,
                 .prng = std.rand.DefaultPrng.init(options.seed),
             };
@@ -119,8 +119,8 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         pub fn compact(
             state_machine: *StateMachine,
-            op: u64,
             callback: fn (*StateMachine) void,
+            op: u64,
         ) void {
             _ = op;
             assert(state_machine.callback == null);
@@ -131,8 +131,8 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         pub fn checkpoint(
             state_machine: *StateMachine,
-            op: u64,
             callback: fn (*StateMachine) void,
+            op: u64,
         ) void {
             _ = op;
             assert(state_machine.callback == null);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -11,7 +11,7 @@ const config = @import("config.zig");
 pub const Version: u8 = 0;
 
 pub const Replica = @import("vsr/replica.zig").Replica;
-pub const ReplicaFormatter = @import("vsr/replica.zig").ReplicaFormatter;
+pub const ReplicaFormatType = @import("vsr/replica.zig").ReplicaFormatType;
 pub const Status = @import("vsr/replica.zig").Status;
 pub const Client = @import("vsr/client.zig").Client;
 pub const Clock = @import("vsr/clock.zig").Clock;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -11,6 +11,7 @@ const config = @import("config.zig");
 pub const Version: u8 = 0;
 
 pub const Replica = @import("vsr/replica.zig").Replica;
+pub const ReplicaFormatter = @import("vsr/replica.zig").ReplicaFormatter;
 pub const Status = @import("vsr/replica.zig").Status;
 pub const Client = @import("vsr/client.zig").Client;
 pub const Clock = @import("vsr/clock.zig").Clock;

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -397,7 +397,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
         queue_tail: ?*Context = null,
 
         pub fn init(
-            allocator: mem.Allocator, 
+            allocator: mem.Allocator,
             storage: *Storage,
             message_pool: *MessagePool,
         ) !SuperBlock {


### PR DESCRIPTION
- Move formatting (from superblock) into `replica.zig`.
- Rewrite WAL formatting to be async (previously used `os.write()`).

Previously the `MessagePool` was owned by the `MessageBus`, but this introduced a circular dependency: `SuperBlock` requires a `MessagePool`, `MessageBus` requires `cluster`, `cluster` is retrieved from the `SuperBlock`. I resolved this by moving `MessagePool` out and passing `MessageBus` a reference to the pool.

The `MessageBus` is required by the `Replica`, but must be initialized outside because we support different implementations (for now — see https://github.com/coilhq/tigerbeetle/issues/71).
But it must be initialized _after_ the `SuperBlock` is opened, since it requires the `cluster`.