### PR TITLE
VSR: Checkpoint after compact

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -302,6 +302,7 @@ comptime {
     assert(tcp_sndbuf_replica <= 16 * 1024 * 1024);
     assert(tcp_sndbuf_client <= 16 * 1024 * 1024);
 
+    assert(journal_slot_count % lsm_batch_multiple == 0);
     assert(journal_size_max == journal_size_headers + journal_size_prepares);
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -307,7 +307,8 @@ comptime {
     //   A    B    C    D    E
     //   |····|····|····|····|
     //
-    // - ("|" delineates measures/batches; "·" is a prepare in the WAL.)
+    // - ("|" delineates measures, where a measure is a multiple of prepare batches.)
+    // - ("·" is a prepare in the WAL.)
     // - The Replica triggers a checkpoint at "E".
     // - The entries between "A" and "D" are on-disk in level 0.
     // - The entries between "D" and "E" are in-memory in the immutable table.

--- a/src/config.zig
+++ b/src/config.zig
@@ -302,8 +302,24 @@ comptime {
     assert(tcp_sndbuf_replica <= 16 * 1024 * 1024);
     assert(tcp_sndbuf_client <= 16 * 1024 * 1024);
 
+    // For the given WAL (lsm_batch_multiple=4):
+    //
+    //   A    B    C    D    E
+    //   |····|····|····|····|
+    //
+    // - ("|" delineates measures/batches; "·" is a prepare in the WAL.)
+    // - The Replica triggers a checkpoint at "E".
+    // - The entries between "A" and "D" are on-disk in level 0.
+    // - The entries between "D" and "E" are in-memory in the immutable table.
+    // - So the checkpoint only includes "A…D".
+    //
+    // The journal must have at least two measures (batches) to ensure at least one is checkpointed.
+    assert(journal_slot_count >= lsm_batch_multiple * 2);
     assert(journal_slot_count % lsm_batch_multiple == 0);
     assert(journal_size_max == journal_size_headers + journal_size_prepares);
+
+    // The LSM tree uses half-measures to balance compaction.
+    assert(lsm_batch_multiple % 2 == 0);
 }
 
 pub const is_32_bit = @sizeOf(usize) == 4; // TODO Return a compile error if we are not 32-bit.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -44,7 +44,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         );
         const PostedGroove = @import("lsm/posted_groove.zig").PostedGrooveType(Storage);
 
-        const Forest = ForestType(Storage, .{
+        pub const Forest = ForestType(Storage, .{
             .accounts = AccountsGroove,
             .transfers = TransfersGroove,
             .posted = PostedGroove,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -344,16 +344,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.forest.tick();
         }
 
-        pub fn compact(self: *StateMachine, callback: fn (*StateMachine) void, op: u64) void {
-            // TODO self.forest.compact(op, callback);
-            _ = op;
-            callback(self);
-        }
-
-        pub fn checkpoint(self: *StateMachine, callback: fn (*StateMachine) void, op: u64) void {
-            // TODO self.forest.checkpoint(op, checkpoint_callback);
-            _ = op;
-            callback(self);
+        pub fn compact(self: *StateMachine, callback: fn (*Forest) void, op: u64) void {
+            self.forest.compact(callback, op);
         }
 
         fn execute(

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2405,8 +2405,9 @@ pub fn Replica(
             self.state_machine.compact(commit_op_compact_callback, self.commit_prepare.?.header.op);
         }
 
-        fn commit_op_compact_callback(state_machine: *StateMachine) void {
-            const self = @fieldParentPtr(Self, "state_machine", state_machine);
+        fn commit_op_compact_callback(forest: *StateMachine.Forest) void {
+            const state_machine = @fieldParentPtr(StateMachine, "forest", forest);
+            const self = @fieldParentPtr(Replica, "state_machine", state_machine);
             assert(self.committing);
             assert(self.commit_callback != null);
             assert(self.op_checkpoint == self.superblock.staging.vsr_state.commit_min);


### PR DESCRIPTION
Checkpoint the `Forest` and then `SuperBlock` every `config.lsm_batch_multiple` ops.

Added `op_ceiling()` to hopefully avoid off-by-one errors when using `op_checkpoint` to compute the maximum op that can be received.
`op_checkpoint` starts at 0, then goes to 3, 7, 11, etc.

Also includes an assertion fix required for WAL wrapping.

Untested.