### PR TITLE
LSM: Don't overwrite non-owned memory with undefined in Groove 

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -606,9 +606,7 @@ pub fn GrooveType(
                 // but `context` is required for the last loop condition check.
                 context.workers_busy += 1;
 
-                // -1 to ignore the extra worker.
-                while (context.workers_busy - 1 < context.workers.len) {
-                    const worker = &context.workers[context.workers_busy - 1];
+                for (context.workers) |*worker| {
                     worker.* = .{ .context = context };
                     context.workers_busy += 1;
                     if (!worker.lookup_start()) break;

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -609,7 +609,7 @@ pub fn GrooveType(
                 for (context.workers) |*worker| {
                     worker.* = .{ .context = context };
                     context.workers_busy += 1;
-                    if (!worker.lookup_start()) break;
+                    if (!worker.lookup_start_next()) break;
                 }
 
                 assert(context.workers_busy >= 1);
@@ -642,13 +642,19 @@ pub fn GrooveType(
 
             /// Returns true if asynchronous I/O has been started.
             /// Returns false if there are no more IDs to prefetch.
-            fn lookup_start(worker: *PrefetchWorker) bool {
+            fn lookup_start_next(worker: *PrefetchWorker) bool {
                 const groove = worker.context.groove;
 
                 const id = worker.context.id_iterator.next() orelse {
                     groove.prefetch_ids.clearRetainingCapacity();
                     assert(groove.prefetch_ids.count() == 0);
-                    worker.context.worker_finished();
+
+                    // Since worker_finished() may cause the entire prefetch to finish and call
+                    // the provided callback, we must not set worker to undefined after calling
+                    // worker_finished() as the memory may already be used for something else.
+                    const context = worker.context;
+                    worker.* = undefined;
+                    context.worker_finished();
                     return false;
                 };
 
@@ -685,10 +691,10 @@ pub fn GrooveType(
                             id_tree_value.timestamp,
                         );
                     } else {
-                        worker.lookup_finish();
+                        _ = worker.lookup_start_next();
                     }
                 } else {
-                    worker.lookup_finish();
+                    _ = worker.lookup_start_next();
                 }
             }
 
@@ -703,13 +709,7 @@ pub fn GrooveType(
                 assert(!ObjectTreeHelpers(Object).tombstone(object));
 
                 worker.context.groove.prefetch_objects.putAssumeCapacityNoClobber(object.*, {});
-                worker.lookup_finish();
-            }
-
-            fn lookup_finish(worker: *PrefetchWorker) void {
-                if (!worker.lookup_start()) {
-                    worker.* = undefined;
-                }
+                _ = worker.lookup_start_next();
             }
         };
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -628,9 +628,7 @@ pub fn GrooveType(
                 context.groove.prefetch_ids.clearRetainingCapacity();
                 assert(context.groove.prefetch_ids.count() == 0);
 
-                const callback = context.callback;
-                context.* = undefined;
-                callback(context);
+                context.callback(context);
             }
         };
 
@@ -644,12 +642,7 @@ pub fn GrooveType(
 
             fn lookup_start_next(worker: *PrefetchWorker) void {
                 const id = worker.context.id_iterator.next() orelse {
-                    // Since worker_finished() may cause the entire prefetch to finish and call
-                    // the provided callback, we must not set worker to undefined after calling
-                    // worker_finished() as the memory may already be used for something else.
-                    const context = worker.context;
-                    worker.* = undefined;
-                    context.worker_finished();
+                    worker.context.worker_finished();
                     return;
                 };
 

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -238,9 +238,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 // but `context` is required for the last loop condition check.
                 context.workers_busy += 1;
 
-                // -1 to ignore the extra worker.
-                while (context.workers_busy - 1 < context.workers.len) {
-                    const worker = &context.workers[context.workers_busy - 1];
+                for (context.workers) |*worker| {
                     worker.* = .{ .context = context };
                     context.workers_busy += 1;
                     if (!worker.lookup_start()) break;

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -260,9 +260,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 context.groove.prefetch_ids.clearRetainingCapacity();
                 assert(context.groove.prefetch_ids.count() == 0);
 
-                const callback = context.callback;
-                context.* = undefined;
-                callback(context);
+                context.callback(context);
             }
         };
 
@@ -274,12 +272,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             /// Returns false if there are no more IDs to prefetch.
             fn lookup_start_next(worker: *PrefetchWorker) void {
                 const id = worker.context.id_iterator.next() orelse {
-                    // Since worker_finished() may cause the entire prefetch to finish and call
-                    // the provided callback, we must not set worker to undefined after calling
-                    // worker_finished() as the memory may already be used for something else.
-                    const context = worker.context;
-                    worker.* = undefined;
-                    context.worker_finished();
+                    worker.context.worker_finished();
                     return;
                 };
 

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -241,7 +241,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 for (context.workers) |*worker| {
                     worker.* = .{ .context = context };
                     context.workers_busy += 1;
-                    if (!worker.lookup_start_next()) break;
+                    worker.lookup_start_next();
                 }
 
                 assert(context.workers_busy >= 1);
@@ -255,8 +255,10 @@ pub fn PostedGrooveType(comptime Storage: type) type {
 
             fn finish(context: *PrefetchContext) void {
                 assert(context.workers_busy == 0);
-                assert(context.groove.prefetch_ids.count() == 0);
+
                 assert(context.id_iterator.next() == null);
+                context.groove.prefetch_ids.clearRetainingCapacity();
+                assert(context.groove.prefetch_ids.count() == 0);
 
                 const callback = context.callback;
                 context.* = undefined;
@@ -270,39 +272,32 @@ pub fn PostedGrooveType(comptime Storage: type) type {
 
             /// Returns true if asynchronous I/O has been started.
             /// Returns false if there are no more IDs to prefetch.
-            fn lookup_start_next(worker: *PrefetchWorker) bool {
-                const groove = worker.context.groove;
-
+            fn lookup_start_next(worker: *PrefetchWorker) void {
                 const id = worker.context.id_iterator.next() orelse {
-                    groove.prefetch_ids.clearRetainingCapacity();
-                    assert(groove.prefetch_ids.count() == 0);
-
                     // Since worker_finished() may cause the entire prefetch to finish and call
                     // the provided callback, we must not set worker to undefined after calling
                     // worker_finished() as the memory may already be used for something else.
                     const context = worker.context;
                     worker.* = undefined;
                     context.worker_finished();
-                    return false;
+                    return;
                 };
 
                 if (config.verify) {
                     // This is checked in prefetch_enqueue()
-                    assert(groove.tree.get_cached(id.*) == null);
+                    assert(worker.context.groove.tree.get_cached(id.*) == null);
                 }
 
                 // If not in the LSM tree's cache, the object must be read from disk and added
                 // to the auxillary prefetch_objects hash map.
                 // TODO: this LSM tree function needlessly checks the LSM tree's cache a
                 // second time. Adding API to the LSM tree to avoid this may be worthwhile.
-                groove.tree.lookup(
+                worker.context.groove.tree.lookup(
                     lookup_id_callback,
                     &worker.lookup_id,
                     snapshot_latest,
                     id.*,
                 );
-
-                return true;
             }
 
             fn lookup_id_callback(
@@ -325,7 +320,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                         },
                     }
                 }
-                _ = worker.lookup_start_next();
+                worker.lookup_start_next();
             }
         };
 

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -125,9 +125,7 @@ pub const Storage = struct {
 
         const target = read.target();
         if (target.len == 0) {
-            const callback = read.callback;
-            read.* = undefined;
-            callback(read);
+            read.callback(read);
             return;
         }
 
@@ -309,9 +307,7 @@ pub const Storage = struct {
         write.buffer = write.buffer[bytes_written..];
 
         if (write.buffer.len == 0) {
-            const callback = write.callback;
-            write.* = undefined;
-            callback(write);
+            write.callback(write);
             return;
         }
 

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -239,9 +239,7 @@ pub const Storage = struct {
             }
         }
 
-        const callback = read.callback;
-        read.* = undefined;
-        callback(read);
+        read.callback(read);
     }
 
     pub fn write_sectors(
@@ -293,9 +291,7 @@ pub const Storage = struct {
             }
         }
 
-        const callback = write.callback;
-        write.* = undefined;
-        callback(write);
+        write.callback(write);
     }
 
     fn assert_bounds_and_alignment(storage: *const Storage, buffer: []const u8, offset: u64) void {

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1827,10 +1827,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
                 self.lock_sectors(@fieldParentPtr(Self.Write, "range", waiting));
             }
 
-            // The callback may set range, so we can't set range to undefined after the callback.
-            const callback = range.callback;
-            range.* = undefined;
-            callback(write);
+            range.callback(write);
         }
 
         pub fn writing(self: *Self, op: u64, checksum: u128) bool {


### PR DESCRIPTION
Two other cleanup commits are included as well, see the commit messages for detail.