### PR TITLE
Add docker-compose docs

### DIFF
--- a/docs/DOCKER_COMPOSE.md
+++ b/docs/DOCKER_COMPOSE.md
@@ -32,8 +32,6 @@ services:
     container_name: tigerbeetle_0
     image: ghcr.io/coilhq/tigerbeetle
     command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_0.tigerbeetle"
-    ports:
-      - "3001"
     network_mode: host
     volumes:
       - ./data:/data
@@ -41,9 +39,7 @@ services:
   tigerbeetle_1:
     container_name: tigerbeetle_1
     image: ghcr.io/coilhq/tigerbeetle
-    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 0_1.tigerbeetle"
-    ports:
-      - "3002"
+    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_1.tigerbeetle"
     network_mode: host
     volumes:
       - ./data:/data
@@ -51,16 +47,38 @@ services:
   tigerbeetle_2:
     container_name: tigerbeetle_2
     image: ghcr.io/coilhq/tigerbeetle
-    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 0_2.tigerbeetle"
-    ports:
-      - "3003"
+    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_2.tigerbeetle"
     network_mode: host
     volumes:
-      - ./data:./data
+      - ./data:/data
 ```
 
 And run it:
 
 ```
 $ docker-compose up
+docker-compose up
+Starting tigerbeetle_0   ... done
+Starting tigerbeetle_2   ... done
+Recreating tigerbeetle_1 ... done
+Attaching to tigerbeetle_0, tigerbeetle_2, tigerbeetle_1
+tigerbeetle_1    | info(io): opening "0_1.tigerbeetle"...
+tigerbeetle_2    | info(io): opening "0_2.tigerbeetle"...
+tigerbeetle_0    | info(io): opening "0_0.tigerbeetle"...
+tigerbeetle_0    | info(main): 0: cluster=0: listening on 0.0.0.0:3001
+tigerbeetle_2    | info(main): 2: cluster=0: listening on 0.0.0.0:3003
+tigerbeetle_1    | info(main): 1: cluster=0: listening on 0.0.0.0:3002
+tigerbeetle_0    | info(message_bus): connected to replica 1
+tigerbeetle_0    | info(message_bus): connected to replica 2
+tigerbeetle_1    | info(message_bus): connected to replica 2
+tigerbeetle_1    | info(message_bus): connection from replica 0
+tigerbeetle_2    | info(message_bus): connection from replica 0
+tigerbeetle_2    | info(message_bus): connection from replica 1
+tigerbeetle_0    | info(clock): 0: system time is 83ns ahead
+tigerbeetle_2    | info(clock): 2: system time is 83ns ahead
+tigerbeetle_1    | info(clock): 1: system time is 78ns ahead
+
+... and so on ...
 ```
+
+Now you can connect to TigerBeetle with any TigerBeetle client.


### PR DESCRIPTION
Pulling in @lewisdaly 's example from https://github.com/tigerbeetledb/tigerbeetle/issues/74.

A couple differences:

* Use ghcr.io image instead of local one (this is easier for non-devs, since they don't need to build the image locally)
* Drop the ports section (docker-compose fails since this conflicts with network-mode: host)

![image](https://user-images.githubusercontent.com/3925912/188636647-4a1a91f9-895a-4fa5-a27d-531fbb800abd.png)
