### PR TITLE
LSM: fix update_tables() logging non-updated tables

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -296,7 +296,7 @@ pub fn CompactionType(
         fn update_manifest(compaction: *Compaction, buffer: *TableInfoBuffer) void {
             assert(buffer == &compaction.update_level_b or buffer == &compaction.insert_level_b);
 
-            const tables: []const TableInfo = buffer.drain();
+            const tables: []TableInfo = buffer.drain();
             if (tables.len == 0) return;
 
             for (tables) |table| {

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -280,11 +280,13 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             // TODO Verify that tables can be found exactly before returning.
         }
 
+        /// Updates the snapshot_max on the provide tables for the given level.
+        /// The tables provided are mutable to allow their snapshots to be updated.
         pub fn update_tables(
             manifest: *Manifest,
             level: u8,
             snapshot: u64,
-            tables: []const TableInfo,
+            tables: []TableInfo,
         ) void {
             assert(tables.len > 0);
 
@@ -293,11 +295,8 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
             // Appends update changes to the manifest log
             for (tables) |*table| {
-                var updated_table = table.*;
-                updated_table.snapshot_max = snapshot;
-
                 const log_level = @intCast(u7, level);
-                manifest.manifest_log.insert(log_level, &updated_table);
+                manifest.manifest_log.insert(log_level, table);
             }
         }
 

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -293,8 +293,11 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
             // Appends update changes to the manifest log
             for (tables) |*table| {
+                var updated_table = table.*;
+                updated_table.snapshot_max = snapshot;
+
                 const log_level = @intCast(u7, level);
-                manifest.manifest_log.insert(log_level, table);
+                manifest.manifest_log.insert(log_level, &updated_table);
             }
         }
 


### PR DESCRIPTION
@sentientwaffle Discovered that the tables passed into `Manifest.update_tables` were being used to update the `ManifestLevel` table snapshots, but were being inserted into the `ManifestLog` without those updates. This is a proposed fix for that.