### PR TITLE
Add release artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Create zip of release build
       run: zip -9 tigerbeetle-$RUNNER_OS-x64-$GIT_TAG.zip tigerbeetle
 
-    - run: ls -lah
-      name: "Debug files"
-
     - name: Get Github ID for tag
       run: |
         echo "RELEASE_ID=`curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/tigerbeetledb/tigerbeetle/releases/tags/$GIT_TAG | jq '.id'`" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,5 @@ jobs:
         curl --fail \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Content-Type: application/zip" \
-          --data-binary @./tigerbeetle-linux-x64-$GIT_TAG.zip \
-          "https://uploads.github.com/repos/tigerbeetledb/tigerbeetle/releases/$RELEASE_ID/assets?name=tigerbeetle-linux-x64-$GIT_TAG.zip"
+          --data-binary @./tigerbeetle-$RUNNER_OS-x64-$GIT_TAG.zip \
+          "https://uploads.github.com/repos/tigerbeetledb/tigerbeetle/releases/$RELEASE_ID/assets?name=tigerbeetle-$RUNNER_OS-x64-$GIT_TAG.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Build and publish artifacts
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_and_upload_binaries:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build tigerbeetle
+      run: ./scripts/install.sh
+
+    # Note: this only creates builds on the platform being built. So
+    # this does not build for M1 Macs. Maybe in the future we could
+    # use Zig's cross-platform builds instead of relying on the
+    # current platform and different Github Actions runners.
+    - name: Create zip of release build
+      run: zip -9 tigerbeetle-$RUNNER_OS-x64-$GIT_TAG tigerbeetle
+
+    - name: Store current tag
+      run: echo "GIT_TAG=`git tag --points-at HEAD`" >> $GITHUB_ENV
+
+    - name: Get Github ID for tag
+      run: |
+        echo "RELEASE_ID=`curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/tigerbeetledb/tigerbeetle/releases/tags/$GIT_TAG | jq '.id'`" >> $GITHUB_ENV
+    - name: Upload on release
+      run: |
+        curl --fail \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/zip" \
+          --data-binary @./tigerbeetle-linux-x64-$GIT_TAG.zip \
+          "https://uploads.github.com/repos/tigerbeetledb/tigerbeetle/releases/$RELEASE_ID/assets?name=tigerbeetle-linux-x64-$GIT_TAG.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
     - name: Build tigerbeetle
       run: ./scripts/install.sh
 
+    - name: Store current tag
+      run: echo "GIT_TAG=`git tag --points-at HEAD`" >> $GITHUB_ENV
+
     # Note: this only creates builds on the platform being built. So
     # this does not build for M1 Macs. Maybe in the future we could
     # use Zig's cross-platform builds instead of relying on the
     # current platform and different Github Actions runners.
     - name: Create zip of release build
       run: zip -9 tigerbeetle-$RUNNER_OS-x64-$GIT_TAG.zip tigerbeetle
-
-    - name: Store current tag
-      run: echo "GIT_TAG=`git tag --points-at HEAD`" >> $GITHUB_ENV
 
     - run: ls -lah
       name: "Debug files"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     # use Zig's cross-platform builds instead of relying on the
     # current platform and different Github Actions runners.
     - name: Create zip of release build
-      run: zip -9 tigerbeetle-$RUNNER_OS-x64-$GIT_TAG tigerbeetle
+      run: zip -9 tigerbeetle-$RUNNER_OS-x64-$GIT_TAG.zip tigerbeetle
 
     - name: Store current tag
       run: echo "GIT_TAG=`git tag --points-at HEAD`" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Store current tag
       run: echo "GIT_TAG=`git tag --points-at HEAD`" >> $GITHUB_ENV
 
+    - run: ls -lah
+      name: "Debug files"
+
     - name: Get Github ID for tag
       run: |
         echo "RELEASE_ID=`curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/tigerbeetledb/tigerbeetle/releases/tags/$GIT_TAG | jq '.id'`" >> $GITHUB_ENV


### PR DESCRIPTION
How this works:

1. Create a new release in the Github UI (technically this can be scripted but I normally just do it manually)
2. Once the release is created, Github Actions kicks off this yaml
3. Binaries are built on macos and linux, zipped, and uploaded to the Github release page

[Here's a sample release built from this branch](https://github.com/tigerbeetledb/tigerbeetle/releases/tag/0.0.0-rc1).

![image](https://user-images.githubusercontent.com/3925912/189357680-66ee6540-4b4d-4930-84ad-5967fbeaf062.png)
