### PR TITLE
Improves install_zig.bat script

### DIFF
--- a/scripts/install_zig.bat
+++ b/scripts/install_zig.bat
@@ -86,7 +86,11 @@ if exist %ZIG_DIRECTORY%\ (
 
 :: Extract and then remove the downloaded tarball:
 echo Extracting %ZIG_TARBALL%...
-powershell -Command "Expand-Archive %ZIG_TARBALL% -DestinationPath ."
+
+:: Hiding Powershell's progress bar during the extraction
+SET PS_DISABLE_PROGRESS="$ProgressPreference=[System.Management.Automation.ActionPreference]::SilentlyContinue"
+powershell -Command "%PS_DISABLE_PROGRESS%;Expand-Archive %ZIG_TARBALL% -DestinationPath ."
+
 if not exist %ZIG_TARBALL% (
   echo Failed to extract zip file.
   exit 1


### PR DESCRIPTION
Improve this script by hiding the progress bar during the `Expand-Archive` command.

It's a Powershell's well-known issue, on my machine the time required to extract the file dropped from 3min to +-30 seconds. This change is more a UX enhancement than a fix.