### PR TITLE
LSM review & documentation

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -50,16 +50,16 @@ pub const memory_size_max_default = 1024 * 1024 * 1024;
 /// The maximum number of accounts to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
 pub const cache_accounts_max = switch (deployment_environment) {
-    .production => 1_000_000,
-    else => 100_000,
+    .production => 100_000,
+    else => 10_000,
 };
 
 /// The maximum number of transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
 /// We allocate more capacity than the number of transfers for a safe hash table load factor.
 pub const cache_transfers_max = switch (deployment_environment) {
-    .production => 100_000_000,
-    else => 1_000_000,
+    .production => 1_000_000,
+    else => 100_000,
 };
 
 /// The maximum number of two-phase transfers to store in memory:

--- a/src/config.zig
+++ b/src/config.zig
@@ -67,14 +67,23 @@ pub const transfers_max = switch (deployment_environment) {
 pub const transfers_pending_max = transfers_max;
 
 // TODO Move these to a separate "internal computed constants" file.
+// 128 == @sizeOf(Header)
+const message_body_accounts = @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Account));
+const message_body_transfers = @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Transfer));
+
 /// The maximum number of objects that may be changed by a commit.
 /// See `Groove.init`'s `commit_count_max` for more detail.
-// 128 == @sizeOf(Header)
 // *2 because creating a transfer will update 2 accounts.
-pub const commit_count_max_accounts = 2 * @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Account));
+pub const commit_count_max_accounts = 2 * message_body_accounts;
 // *2 because creating a post/void-transfer queries the post/void transfer and the pending transfer.
-pub const commit_count_max_transfers = 2 * @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Transfer));
-pub const commit_count_max_posted = @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Transfer));
+pub const commit_count_max_transfers = 2 * message_body_transfers;
+pub const commit_count_max_posted = message_body_transfers;
+
+// *2 to fetch a transfer's debit/credit accounts.
+pub const prefetch_count_max_accounts = 2 * message_body_accounts;
+// *2 to fetch pending and post/void transfer.
+pub const prefetch_count_max_transfers = 2 * message_body_transfers;
+pub const prefetch_count_max_posted = message_body_transfers;
 
 /// The maximum number of batch entries in the journal file:
 /// A batch entry may contain many transfers, so this is not a limit on the number of transfers.

--- a/src/config.zig
+++ b/src/config.zig
@@ -239,8 +239,12 @@ pub const lsm_trees = 30;
 /// A higher number of levels increases read amplification, as well as total storage capacity.
 pub const lsm_levels = 7;
 
-/// The number of tables at level i (0≤i<lsm_levels) is `pow(lsm_growth_factor, i+1)`.
-/// A higher growth factor increases write amplification, but decreases read amplification.
+/// The number of tables at level i (0 ≤ i < lsm_levels) is `pow(lsm_growth_factor, i+1)`.
+/// A higher growth factor increases write amplification (by increasing the number of tables in
+/// level B that overlap a table in level A in a compaction), but decreases read amplification (by
+/// reducing the height of the tree and thus the number of levels that must be probed). Since read
+/// amplification can be optimized more easily (with filters and caching), we target a growth
+/// factor of 8 for lower write amplification rather than the more typical growth factor of 10.
 pub const lsm_growth_factor = 8;
 
 /// The maximum key size for an LSM tree in bytes.

--- a/src/config.zig
+++ b/src/config.zig
@@ -66,25 +66,6 @@ pub const transfers_max = switch (deployment_environment) {
 /// This impacts the amount of memory allocated at initialization by the server.
 pub const transfers_pending_max = transfers_max;
 
-// TODO Move these to a separate "internal computed constants" file.
-// 128 == @sizeOf(Header)
-const message_body_accounts = @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Account));
-const message_body_transfers = @divFloor(message_size_max - 128, @sizeOf(tigerbeetle.Transfer));
-
-/// The maximum number of objects that may be changed by a commit.
-/// See `Groove.init`'s `commit_count_max` for more detail.
-// *2 because creating a transfer will update 2 accounts.
-pub const commit_count_max_accounts = 2 * message_body_accounts;
-// *2 because creating a post/void-transfer queries the post/void transfer and the pending transfer.
-pub const commit_count_max_transfers = 2 * message_body_transfers;
-pub const commit_count_max_posted = message_body_transfers;
-
-// *2 to fetch a transfer's debit/credit accounts.
-pub const prefetch_count_max_accounts = 2 * message_body_accounts;
-// *2 to fetch pending and post/void transfer.
-pub const prefetch_count_max_transfers = 2 * message_body_transfers;
-pub const prefetch_count_max_posted = message_body_transfers;
-
 /// The maximum number of batch entries in the journal file:
 /// A batch entry may contain many transfers, so this is not a limit on the number of transfers.
 /// We need this limit to allocate space for copies of batch headers at the start of the journal.
@@ -255,7 +236,7 @@ pub const block_count_max = @divExact(16 * 1024 * 1024 * 1024 * 1024, block_size
 pub const lsm_trees = 30;
 
 /// The number of levels in an LSM tree.
-/// Higher levels increases read amplification, but increase total storage capacity.
+/// A higher number of levels increases read amplification, as well as total storage capacity.
 pub const lsm_levels = 7;
 
 /// The number of tables at level i (0≤i<lsm_levels) is `pow(lsm_growth_factor, i+1)`.
@@ -374,10 +355,6 @@ comptime {
 
     // The LSM tree uses half-measures to balance compaction.
     assert(lsm_batch_multiple % 2 == 0);
-
-    assert(commit_count_max_accounts > 0);
-    assert(commit_count_max_transfers > 0);
-    assert(commit_count_max_posted > 0);
 }
 
 pub const is_32_bit = @sizeOf(usize) == 4; // TODO Return a compile error if we are not 32-bit.

--- a/src/config.zig
+++ b/src/config.zig
@@ -49,7 +49,7 @@ pub const memory_size_max_default = 1024 * 1024 * 1024;
 
 /// The maximum number of accounts to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
-pub const accounts_max = switch (deployment_environment) {
+pub const cache_accounts_max = switch (deployment_environment) {
     .production => 1_000_000,
     else => 100_000,
 };
@@ -57,14 +57,14 @@ pub const accounts_max = switch (deployment_environment) {
 /// The maximum number of transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
 /// We allocate more capacity than the number of transfers for a safe hash table load factor.
-pub const transfers_max = switch (deployment_environment) {
+pub const cache_transfers_max = switch (deployment_environment) {
     .production => 100_000_000,
     else => 1_000_000,
 };
 
 /// The maximum number of two-phase transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
-pub const transfers_pending_max = transfers_max;
+pub const cache_transfers_pending_max = cache_transfers_max;
 
 /// The maximum number of batch entries in the journal file:
 /// A batch entry may contain many transfers, so this is not a limit on the number of transfers.

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1,4 +1,4 @@
-//! Compaction moves and merges a table's values into the next level.
+//! Compaction moves or merges a table's values into the next level.
 //!
 //!
 //! Compaction overview:
@@ -16,9 +16,10 @@
 //! 3. Create an iterator from the sort-merge of table A and the concatenation of tables B.
 //!    If the same key exists in level A and B, take A's and discard B's. †
 //!
-//! 4. Collect the sort-merge iterator into a sequence of new tables.
+//! 4. Write the sort-merge iterator into a sequence of new tables on disk.
 //!
-//! 5. Update the old level-B tables in the Manifest with their new `snapshot_max`.
+//! 5. Update the old level-B tables in the Manifest with their new `snapshot_max` so that they
+//!    become invisible to subsequent read transactions.
 //!
 //! 6. Insert the new level-B tables into the Manifest.
 //!
@@ -36,7 +37,6 @@ const log = std.log.scoped(.compaction);
 const config = @import("../config.zig");
 
 const GridType = @import("grid.zig").GridType;
-const BlockOperation = @import("grid.zig").BlockOperation;
 const ManifestType = @import("manifest.zig").ManifestType;
 const KWayMergeIterator = @import("k_way_merge.zig").KWayMergeIterator;
 const TableIteratorType = @import("table_iterator.zig").TableIteratorType;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1,3 +1,32 @@
+//! Compaction moves and merges a table's values into the next level.
+//!
+//!
+//! Compaction overview:
+//!
+//! 1. Given:
+//!
+//!   - levels A and B, where A+1=B
+//!   - a single table in level A ("table A")
+//!   - all tables from level B which intersect table A's key range ("tables B")
+//!     (This can include anything between 0 tables and all of level B's tables.)
+//!
+//! 2. If table A's key range is disjoint from the keys in level B, move table A into level B.
+//!    All done! (But if the key ranges intersect, jump to step 3).
+//!
+//! 3. Create an iterator from the sort-merge of table A and the concatenation of tables B.
+//!    If the same key exists in level A and B, take A's and discard B's. †
+//!
+//! 4. Collect the sort-merge iterator into a sequence of new tables.
+//!
+//! 5. Update the old level-B tables in the Manifest with their new `snapshot_max`.
+//!
+//! 6. Insert the new level-B tables into the Manifest.
+//!
+//!
+//! † When A's value is a tombstone, there is a special case for garbage collection. When either:
+//! * level B is the final level, or
+//! * A's key does not exist in B or any deeper level,
+//! then the tombstone is omitted from the compacted output (see: `compaction_must_drop_tombstones`).
 const std = @import("std");
 const mem = std.mem;
 const math = std.math;
@@ -7,6 +36,7 @@ const log = std.log.scoped(.compaction);
 const config = @import("../config.zig");
 
 const GridType = @import("grid.zig").GridType;
+const BlockOperation = @import("grid.zig").BlockOperation;
 const ManifestType = @import("manifest.zig").ManifestType;
 const KWayMergeIterator = @import("k_way_merge.zig").KWayMergeIterator;
 const TableIteratorType = @import("table_iterator.zig").TableIteratorType;
@@ -338,6 +368,7 @@ pub fn CompactionType(
             // This happens after IO for the first reads complete.
             if (compaction.merge_iterator == null) {
                 compaction.merge_iterator = MergeIterator.init(compaction, k, .ascending);
+                assert(!compaction.merge_iterator.?.empty());
             }
 
             assert(!compaction.data.writable);

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -27,7 +27,6 @@ pub fn CompositeKey(comptime Field: type) type {
             comptime {
                 assert(@sizeOf(Value) == @sizeOf(Field) * 2);
                 assert(@alignOf(Value) == @alignOf(Field));
-                // Assert that there is no implicit padding in the struct.
                 assert(@sizeOf(Value) * 8 == @bitSizeOf(Value));
             }
         };
@@ -40,7 +39,6 @@ pub fn CompositeKey(comptime Field: type) type {
         comptime {
             assert(@sizeOf(Self) == @sizeOf(Field) * 2);
             assert(@alignOf(Self) == @alignOf(Field));
-            // Assert that there is no implicit padding in the struct.
             assert(@sizeOf(Self) * 8 == @bitSizeOf(Self));
         }
 

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -27,6 +27,8 @@ pub fn CompositeKey(comptime Field: type) type {
             comptime {
                 assert(@sizeOf(Value) == @sizeOf(Field) * 2);
                 assert(@alignOf(Value) == @alignOf(Field));
+                // Assert that there is no implicit padding in the struct.
+                assert(@sizeOf(Value) * 8 == @bitSizeOf(Value));
             }
         };
 
@@ -38,6 +40,8 @@ pub fn CompositeKey(comptime Field: type) type {
         comptime {
             assert(@sizeOf(Self) == @sizeOf(Field) * 2);
             assert(@alignOf(Self) == @alignOf(Field));
+            // Assert that there is no implicit padding in the struct.
+            assert(@sizeOf(Self) * 8 == @bitSizeOf(Self));
         }
 
         pub inline fn compare_keys(a: Self, b: Self) math.Order {

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -46,7 +46,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
         },
     });
 
-    const AllGrooveOptions = @Type(.{
+    const _GroovesOptions = @Type(.{
         .Struct = .{
             .layout = .Auto,
             .fields = groove_options_fields,
@@ -67,7 +67,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             open,
         };
 
-        pub const Options = AllGrooveOptions;
+        pub const GroovesOptions = _GroovesOptions;
 
         join_op: ?JoinOp = null,
         join_pending: usize = 0,
@@ -82,7 +82,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             grid: *Grid,
             node_count: u32,
             // (e.g.) .{ .transfers = .{ .cache_size = 128, … }, .accounts = … }
-            all_groove_options: AllGrooveOptions,
+            grooves_options: GroovesOptions,
         ) !Forest {
             // NodePool must be allocated to pass in a stable address for the Grooves.
             const node_pool = try allocator.create(NodePool);
@@ -104,7 +104,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             inline for (std.meta.fields(Grooves)) |groove_field| {
                 const groove = &@field(grooves, groove_field.name);
                 const Groove = @TypeOf(groove.*);
-                const groove_options: Groove.Options = @field(all_groove_options, groove_field.name);
+                const groove_options: Groove.Options = @field(grooves_options, groove_field.name);
 
                 groove.* = try Groove.init(
                     allocator,

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -55,12 +55,6 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
         },
     });
 
-    //const AllGrooveOptions = std.enums.EnumFieldStruct(
-    //    std.meta.FieldEnum(@TypeOf(groove_config)),
-    //    GrooveOptions,
-    //    null,
-    //);
-
     return struct {
         const Forest = @This();
 
@@ -72,6 +66,8 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             checkpoint,
             open,
         };
+
+        pub const Options = AllGrooveOptions;
 
         join_op: ?JoinOp = null,
         join_pending: usize = 0,
@@ -85,7 +81,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             allocator: mem.Allocator,
             grid: *Grid,
             node_count: u32,
-            // (e.g.) .{ .transfers = .{ .cache_size = 128, .commit_count_max = n }, .accounts = same }
+            // (e.g.) .{ .transfers = .{ .cache_size = 128, … }, .accounts = … }
             all_groove_options: AllGrooveOptions,
         ) !Forest {
             // NodePool must be allocated to pass in a stable address for the Grooves.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -81,7 +81,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             allocator: mem.Allocator,
             grid: *Grid,
             node_count: u32,
-            // (e.g.) .{ .transfers = .{ .cache_cardinality_max = 128, … }, .accounts = … }
+            // (e.g.) .{ .transfers = .{ .cache_entries_max = 128, … }, .accounts = … }
             grooves_options: GroovesOptions,
         ) !Forest {
             // NodePool must be allocated to pass in a stable address for the Grooves.
@@ -423,15 +423,15 @@ fn ForestTestType(comptime StorageProvider: type) type {
     const size_max = (512 + 64) * 1024 * 1024;
 
     const node_count = 1024;
-    const cache_cardinality_max = 2 * 1024 * 1024;
+    const cache_entries_max = 2 * 1024 * 1024;
     const forest_config = .{
         .transfers = .{
-            .cache_cardinality_max = cache_cardinality_max,
-            .commit_count_max = 8191 * 2,
+            .cache_entries_max = cache_entries_max,
+            .commit_entries_max = 8191 * 2,
         },
         .accounts = .{
-            .cache_cardinality_max = cache_cardinality_max,
-            .commit_count_max = 8191,
+            .cache_entries_max = cache_entries_max,
+            .commit_entries_max = 8191,
         },
     };
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -81,7 +81,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             allocator: mem.Allocator,
             grid: *Grid,
             node_count: u32,
-            // (e.g.) .{ .transfers = .{ .cache_size = 128, … }, .accounts = … }
+            // (e.g.) .{ .transfers = .{ .cache_cardinality_max = 128, … }, .accounts = … }
             grooves_options: GroovesOptions,
         ) !Forest {
             // NodePool must be allocated to pass in a stable address for the Grooves.
@@ -423,14 +423,14 @@ fn ForestTestType(comptime StorageProvider: type) type {
     const size_max = (512 + 64) * 1024 * 1024;
 
     const node_count = 1024;
-    const cache_size = 2 * 1024 * 1024;
+    const cache_cardinality_max = 2 * 1024 * 1024;
     const forest_config = .{
         .transfers = .{
-            .cache_size = cache_size,
+            .cache_cardinality_max = cache_cardinality_max,
             .commit_count_max = 8191 * 2,
         },
         .accounts = .{
-            .cache_size = cache_size,
+            .cache_cardinality_max = cache_cardinality_max,
             .commit_count_max = 8191,
         },
     };

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -13,10 +13,10 @@ const SetAssociativeCache = @import("set_associative_cache.zig").SetAssociativeC
 const log = std.log.scoped(.grid);
 
 /// A block's type is implicitly determined by how its address is stored (e.g. in the index block).
-/// BlockOperation is an additional check that a block has the expected type on read.
+/// BlockType is an additional check that a block has the expected type on read.
 ///
-/// The BlockOperation is stored in the block's `header.operation`.
-pub const BlockOperation = enum(u8) {
+/// The BlockType is stored in the block's `header.operation`.
+pub const BlockType = enum(u8) {
     /// Unused; verifies that no block is written with a default 0 operation.
     reserved = 0,
 
@@ -25,12 +25,12 @@ pub const BlockOperation = enum(u8) {
     filter = 3,
     data = 4,
 
-    pub inline fn from(operation_vsr: vsr.Operation) BlockOperation {
-        return @intToEnum(BlockOperation, @enumToInt(operation_vsr));
+    pub inline fn from(vsr_operation: vsr.Operation) BlockType {
+        return @intToEnum(BlockType, @enumToInt(vsr_operation));
     }
 
-    pub inline fn operation(operation_block: BlockOperation) vsr.Operation {
-        return @intToEnum(vsr.Operation, @enumToInt(operation_block));
+    pub inline fn operation(block_type: BlockType) vsr.Operation {
+        return @intToEnum(vsr.Operation, @enumToInt(block_type));
     }
 };
 
@@ -110,7 +110,7 @@ pub fn GridType(comptime Storage: type) type {
             callback: fn (*Grid.Read, BlockPtrConst) void,
             address: u64,
             checksum: u128,
-            operation: BlockOperation,
+            block_type: BlockType,
 
             /// Link for read_queue/read_recovery_queue/ReadIOP.reads linked lists.
             next: ?*Read = null,
@@ -340,11 +340,11 @@ pub fn GridType(comptime Storage: type) type {
             read: *Grid.Read,
             address: u64,
             checksum: u128,
-            operation: BlockOperation,
+            block_type: BlockType,
         ) void {
             assert(grid.superblock.opened);
             assert(address > 0);
-            assert(operation != .reserved);
+            assert(block_type != .reserved);
             assert(!grid.superblock.free_set.is_free(address));
             grid.assert_not_writing(address, null);
 
@@ -352,7 +352,7 @@ pub fn GridType(comptime Storage: type) type {
                 .callback = callback,
                 .address = address,
                 .checksum = checksum,
-                .operation = operation,
+                .block_type = block_type,
             };
 
             if (grid.read_recursion_guard) {
@@ -436,6 +436,7 @@ pub fn GridType(comptime Storage: type) type {
 
             const address = iop.reads.peek().?.address;
             const checksum = iop.reads.peek().?.checksum;
+            const block_type = iop.reads.peek().?.block_type;
 
             const checksum_valid = header.valid_checksum();
             const checksum_body_valid = checksum_valid and
@@ -445,13 +446,14 @@ pub fn GridType(comptime Storage: type) type {
             if (checksum_valid and checksum_body_valid and checksum_match) {
                 assert(!grid.read_recursion_guard);
                 assert(header.op == address);
+                assert(header.operation == block_type.operation());
 
                 grid.read_recursion_guard = true;
                 defer grid.read_recursion_guard = false;
                 while (iop.reads.pop()) |read| {
                     assert(read.address == address);
                     assert(read.checksum == checksum);
-                    assert(read.operation == BlockOperation.from(header.operation));
+                    assert(read.block_type == BlockType.from(header.operation));
                     read.callback(read, iop.block);
                 }
             } else {
@@ -461,8 +463,16 @@ pub fn GridType(comptime Storage: type) type {
                     log.err("invalid checksum body at address {}", .{address});
                 } else if (!checksum_match) {
                     log.err(
-                        "expected address={} checksum={}, found address={} checksum={}",
-                        .{ address, checksum, header.op, header.checksum },
+                        "expected address={} checksum={} block_type={}, " ++
+                        "found address={} checksum={} block_type={}",
+                        .{
+                            address,
+                            checksum,
+                            block_type,
+                            header.op,
+                            header.checksum,
+                            @enumToInt(header.operation),
+                        },
                     );
                 } else {
                     unreachable;

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -420,15 +420,13 @@ pub fn GrooveType(
         /// sufficient to query this hashmap alone to know the state of the LSM trees.
         prefetch_objects: PrefetchObjects,
 
-        pub const IndexTreesOptions = IndexTreesOptions;
-
         pub const Options = struct {
             /// TODO Improve unit in this name to make more clear what should be passed.
             /// For example, is this a size in bytes or a count in objects? It's a count in objects,
             /// but the name poorly reflects this.
-            cache_cardinality_max: u32,
+            cache_entries_max: u32,
             /// The maximum number of objects that might be prefetched by a batch.
-            prefetch_count_max: u32,
+            prefetch_entries_max: u32,
 
             tree_options_object: ObjectTree.Options,
             tree_options_id: IdTree.Options,
@@ -446,7 +444,7 @@ pub fn GrooveType(
             errdefer allocator.destroy(objects_cache);
 
             objects_cache.* = .{};
-            try objects_cache.ensureTotalCapacity(allocator, options.cache_cardinality_max);
+            try objects_cache.ensureTotalCapacity(allocator, options.cache_entries_max);
             errdefer objects_cache.deinit(allocator);
 
             // Intialize the object LSM tree.
@@ -464,7 +462,7 @@ pub fn GrooveType(
             errdefer allocator.destroy(ids_cache);
 
             ids_cache.* = .{};
-            try ids_cache.ensureTotalCapacity(allocator, options.cache_cardinality_max);
+            try ids_cache.ensureTotalCapacity(allocator, options.cache_entries_max);
             errdefer ids_cache.deinit(allocator);
 
             var id_tree = try IdTree.init(
@@ -499,11 +497,11 @@ pub fn GrooveType(
             }
 
             var prefetch_ids = PrefetchIDs{};
-            try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_count_max);
+            try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_entries_max);
             errdefer prefetch_ids.deinit(allocator);
 
             var prefetch_objects = PrefetchObjects{};
-            try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_count_max);
+            try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_entries_max);
             errdefer prefetch_objects.deinit(allocator);
 
             return Groove{

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -426,7 +426,7 @@ pub fn GrooveType(
             /// TODO Improve unit in this name to make more clear what should be passed.
             /// For example, is this a size in bytes or a count in objects? It's a count in objects,
             /// but the name poorly reflects this.
-            cache_size: u32,
+            cache_cardinality_max: u32,
             /// The maximum number of objects that might be prefetched by a batch.
             prefetch_count_max: u32,
 
@@ -446,7 +446,7 @@ pub fn GrooveType(
             errdefer allocator.destroy(objects_cache);
 
             objects_cache.* = .{};
-            try objects_cache.ensureTotalCapacity(allocator, options.cache_size);
+            try objects_cache.ensureTotalCapacity(allocator, options.cache_cardinality_max);
             errdefer objects_cache.deinit(allocator);
 
             // Intialize the object LSM tree.
@@ -464,7 +464,7 @@ pub fn GrooveType(
             errdefer allocator.destroy(ids_cache);
 
             ids_cache.* = .{};
-            try ids_cache.ensureTotalCapacity(allocator, options.cache_size);
+            try ids_cache.ensureTotalCapacity(allocator, options.cache_cardinality_max);
             errdefer ids_cache.deinit(allocator);
 
             var id_tree = try IdTree.init(

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -423,8 +423,6 @@ pub fn GrooveType(
         pub const IndexTreesOptions = IndexTreesOptions;
 
         pub const Options = struct {
-            /// The cache size is meant to be computed based on the left over available memory
-            /// that tigerbeetle was given to allocate from CLI arguments.
             /// TODO Improve unit in this name to make more clear what should be passed.
             /// For example, is this a size in bytes or a count in objects? It's a count in objects,
             /// but the name poorly reflects this.

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -25,7 +25,12 @@ pub fn KWayMergeIterator(
 
         context: *Context,
 
-        /// Sorted array of keys, with each key representing the next key in each stream.
+        /// Array of keys, with each key representing the next key in each stream.
+        ///
+        /// Structured as a binary heap:
+        /// * When `direction=ascending`, keys are ordered low-to-high.
+        /// * When `direction=descending`, keys are ordered high-to-low.
+        /// * Equivalent keys are ordered from high precedence to low.
         keys: [k_max]Key,
 
         /// For each key in keys above, the corresponding index of the stream containing that key.
@@ -53,7 +58,8 @@ pub fn KWayMergeIterator(
                 .direction = direction,
             };
 
-            // We must loop on stream_index but assign at it.k, as k may be less than stream_index.
+            // We must loop on stream_index but assign at it.k, as k may be less than stream_index
+            // when there are empty streams.
             // TODO Do we have test coverage for this edge case?
             var stream_index: u32 = 0;
             while (stream_index < stream_count_max) : (stream_index += 1) {

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -15,7 +15,6 @@ const GridType = @import("grid.zig").GridType;
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
 const ManifestLevelType = @import("manifest_level.zig").ManifestLevelType;
 const NodePool = @import("node_pool.zig").NodePool(config.lsm_manifest_node_size, 16);
-const SegmentedArray = @import("segmented_array.zig").SegmentedArray;
 
 pub fn TableInfoType(comptime Table: type) type {
     const Key = Table.Key;
@@ -24,8 +23,11 @@ pub fn TableInfoType(comptime Table: type) type {
     return extern struct {
         const TableInfo = @This();
 
+        /// Checksum of the table's index block.
         checksum: u128,
+        /// Address of the table's index block.
         address: u64,
+        /// Unused.
         flags: u64 = 0,
 
         /// The minimum snapshot that can see this table (with exclusive bounds).
@@ -36,8 +38,8 @@ pub fn TableInfoType(comptime Table: type) type {
         /// This value is set to the current snapshot tick on table deletion.
         snapshot_max: u64 = math.maxInt(u64),
 
-        key_min: Key,
-        key_max: Key,
+        key_min: Key, // inclusive
+        key_max: Key, // inclusive
 
         comptime {
             assert(@sizeOf(TableInfo) == 48 + Table.key_size * 2);
@@ -103,7 +105,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         const Grid = GridType(Storage);
         const Callback = fn (*Manifest) void;
 
-        /// Levels beyond level 0 have tables with disjoint key ranges.
         /// Here, we use a structure with indexes over the segmented array for performance.
         const Level = ManifestLevelType(NodePool, Key, TableInfo, compare_keys, table_count_max);
         const KeyRange = Level.KeyRange;
@@ -190,7 +191,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             const manifest_level = &manifest.levels[level];
             manifest_level.insert_table(manifest.node_pool, table);
 
-            // Appends insert changes to the manifest log
+            // Append insert changes to the manifest log
             const log_level = @intCast(u7, level);
             manifest.manifest_log.insert(log_level, table);
 
@@ -209,7 +210,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             manifest_level.set_snapshot_max(snapshot, table);
             assert(table.snapshot_max == snapshot);
 
-            // Appends update changes to the manifest log
+            // Append update changes to the manifest log
             const log_level = @intCast(u7, level);
             manifest.manifest_log.insert(log_level, table);
         }
@@ -249,6 +250,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             }
         }
 
+        /// Returns an iterator over tables that might contain `key` (but are not guaranteed to).
         pub fn lookup(manifest: *Manifest, snapshot: u64, key: Key) LookupIterator {
             return .{
                 .manifest = manifest,
@@ -258,11 +260,12 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         }
 
         pub const LookupIterator = struct {
-            manifest: *Manifest,
+            manifest: *const Manifest,
             snapshot: u64,
             key: Key,
             level: u8 = 0,
             inner: ?Level.Iterator = null,
+            // Verifies that we never check a newer table after an older one.
             precedence: ?u64 = null,
 
             pub fn next(it: *LookupIterator) ?*const TableInfo {

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -38,8 +38,8 @@ pub fn TableInfoType(comptime Table: type) type {
         /// This value is set to the current snapshot tick on table deletion.
         snapshot_max: u64 = math.maxInt(u64),
 
-        key_min: Key, // inclusive
-        key_max: Key, // inclusive
+        key_min: Key, // Inclusive.
+        key_max: Key, // Inclusive.
 
         comptime {
             assert(@sizeOf(TableInfo) == 48 + Table.key_size * 2);

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -203,8 +203,8 @@ pub fn ManifestLevelType(
         };
 
         pub const KeyRange = struct {
-            key_min: Key, // inclusive
-            key_max: Key, // inclusive
+            key_min: Key, // Inclusive.
+            key_max: Key, // Inclusive.
         };
 
         pub fn iterator(

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -31,8 +31,15 @@ const vsr = @import("../vsr.zig");
 
 const SuperBlockType = vsr.SuperBlockType;
 const GridType = @import("grid.zig").GridType;
+const BlockOperation = @import("grid.zig").BlockOperation;
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
+/// ManifestLog block schema:
+/// │ vsr.Header                  │
+/// │ [entry_count_max]Label      │ level index, insert|remove
+/// │ [≤entry_count_max]TableInfo │
+/// │ […]u8{0}                    │ padding (to end of block)
+/// Label and TableInfo entries correspond.
 pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
     return struct {
         const ManifestLog = @This();
@@ -105,11 +112,13 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         open_event: OpenEvent = undefined,
         open_iterator: SuperBlock.Manifest.IteratorReverse = undefined,
 
+        /// Set for the duration of `compact`.
         reading: bool = false,
         read: Grid.Read = undefined,
         read_callback: Callback = undefined,
         read_block_reference: ?SuperBlock.Manifest.BlockReference = null,
 
+        /// Set for the duration of `flush` and `checkpoint`.
         writing: bool = false,
         write: Grid.Write = undefined,
         write_callback: Callback = undefined,
@@ -155,6 +164,10 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
 
+            assert(manifest_log.blocks.count == 0);
+            assert(manifest_log.blocks_closed == 0);
+            assert(manifest_log.entry_count == 0);
+
             manifest_log.open_event = event;
             manifest_log.open_iterator = manifest_log.superblock.manifest.iterator_reverse(
                 manifest_log.tree_hash,
@@ -171,6 +184,10 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(manifest_log.reading);
             assert(!manifest_log.writing);
 
+            assert(manifest_log.blocks.count == 0);
+            assert(manifest_log.blocks_closed == 0);
+            assert(manifest_log.entry_count == 0);
+
             manifest_log.read_block_reference = manifest_log.open_iterator.next();
 
             if (manifest_log.read_block_reference) |block| {
@@ -182,6 +199,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                     &manifest_log.read,
                     block.address,
                     block.checksum,
+                    .manifest,
                 );
             } else {
                 manifest_log.opened = true;
@@ -304,6 +322,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             manifest_log.entry_count += 1;
         }
 
+        /// `flush` does not close a partial block; that is only necessary during `checkpoint`.
         pub fn flush(manifest_log: *ManifestLog, callback: Callback) void {
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
@@ -395,18 +414,21 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         }
 
         pub fn compact(manifest_log: *ManifestLog, callback: Callback) void {
+            assert(manifest_log.opened);
             assert(!manifest_log.reading);
+            assert(!manifest_log.writing);
             manifest_log.read_callback = callback;
-            manifest_log.flush(flush_callback);
+            manifest_log.flush(compact_flush_callback);
         }
 
-        fn flush_callback(manifest_log: *ManifestLog) void {
+        fn compact_flush_callback(manifest_log: *ManifestLog) void {
             const callback = manifest_log.read_callback;
             manifest_log.read_callback = undefined;
 
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
+            assert(manifest_log.blocks_closed == 0);
 
             const manifest: *SuperBlock.Manifest = &manifest_log.superblock.manifest;
 
@@ -419,17 +441,18 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 manifest_log.read_block_reference = block;
 
                 manifest_log.grid.read_block(
-                    compact_callback,
+                    compact_read_block_callback,
                     &manifest_log.read,
                     block.address,
                     block.checksum,
+                    .manifest,
                 );
             } else {
                 callback(manifest_log);
             }
         }
 
-        fn compact_callback(read: *Grid.Read, block: BlockPtrConst) void {
+        fn compact_read_block_callback(read: *Grid.Read, block: BlockPtrConst) void {
             const manifest_log = @fieldParentPtr(ManifestLog, "read", read);
             assert(manifest_log.opened);
             assert(manifest_log.reading);
@@ -519,6 +542,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         }
 
         fn acquire_block(manifest_log: *ManifestLog) void {
+            assert(manifest_log.opened);
             assert(manifest_log.entry_count == 0);
             assert(!manifest_log.blocks.full());
 
@@ -554,6 +578,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             // Zero unused tables, and padding:
             mem.set(u8, block[header.size..], 0);
 
+            header.operation = BlockOperation.manifest.operation();
             header.set_checksum_body(block[@sizeOf(vsr.Header)..header.size]);
             header.set_checksum();
 
@@ -573,6 +598,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
         fn verify_block(block: BlockPtrConst, checksum: ?u128, address: ?u64) void {
             const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+            assert(BlockOperation.from(header.operation) == .manifest);
 
             if (config.verify) {
                 assert(header.valid_checksum());
@@ -623,6 +649,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
             // Encode the smaller type first because this will be multiplied by entry_count_max.
             const labels_size = entry_count_max * @sizeOf(Label);
+            assert(labels_size == labels_size_max);
             const tables_size = entry_count * @sizeOf(TableInfo);
 
             return @sizeOf(vsr.Header) + labels_size + tables_size;
@@ -649,14 +676,14 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         fn tables(block: BlockPtr) *[entry_count_max]TableInfo {
             return mem.bytesAsSlice(
                 TableInfo,
-                block[@sizeOf(vsr.Header) + entry_count_max ..][0..tables_size_max],
+                block[@sizeOf(vsr.Header) + labels_size_max ..][0..tables_size_max],
             )[0..entry_count_max];
         }
 
         fn tables_const(block: BlockPtrConst) *const [entry_count_max]TableInfo {
             return mem.bytesAsSlice(
                 TableInfo,
-                block[@sizeOf(vsr.Header) + entry_count_max ..][0..tables_size_max],
+                block[@sizeOf(vsr.Header) + labels_size_max ..][0..tables_size_max],
             )[0..entry_count_max];
         }
     };

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -44,7 +44,6 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 return value.id;
             }
 
-            // TODO(ifreund): disallow this id in the state machine.
             const sentinel_key = math.maxInt(u128);
 
             inline fn tombstone(value: *const Value) bool {
@@ -101,6 +100,8 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             /// For example, is this a size in bytes or a count in objects? It's a count in objects,
             /// but the name poorly reflects this.
             cache_size: u32,
+            /// The maximum number of objects that might be prefetched by a batch.
+            prefetch_count_max: u32,
             /// In general, the commit count max for a field, depends on the field's object,
             /// how many objects might be changed by a batch:
             ///   (config.message_size_max - sizeOf(vsr.header))
@@ -119,8 +120,6 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             /// However, create_transfers will put 2 accounts (8191 * 2) for every transfer, and
             /// some of these accounts may exist, requiring a remove/put to update the index.
             commit_count_max: u32,
-            /// The maximum number of objects that might be prefetched by a batch.
-            prefetch_count_max: u32,
         };
 
         pub fn init(

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -93,32 +93,10 @@ pub fn PostedGrooveType(comptime Storage: type) type {
         /// signatures as the real Groove type.
         callback: ?fn (*PostedGroove) void = null,
 
+        /// See comments for Groove.Options.
         pub const Options = struct {
-            /// The cache size is meant to be computed based on the left over available memory
-            /// that tigerbeetle was given to allocate from CLI arguments.
-            /// TODO Improve unit in this name to make more clear what should be passed.
-            /// For example, is this a size in bytes or a count in objects? It's a count in objects,
-            /// but the name poorly reflects this.
             cache_size: u32,
-            /// The maximum number of objects that might be prefetched by a batch.
             prefetch_count_max: u32,
-            /// In general, the commit count max for a field, depends on the field's object,
-            /// how many objects might be changed by a batch:
-            ///   (config.message_size_max - sizeOf(vsr.header))
-            /// For example, there are at most 8191 transfers in a batch.
-            /// So commit_count_max=8191 for transfer objects and indexes.
-            ///
-            /// However, if a transfer is ever mutated, then this will double commit_count_max
-            /// since the old index might need to be removed, and the new index inserted.
-            ///
-            /// A way to see this is by looking at the state machine. If a transfer is inserted,
-            /// how many accounts and transfer put/removes will be generated?
-            ///
-            /// This also means looking at the state machine operation that will generate the
-            /// most put/removes in the worst case.
-            /// For example, create_accounts will put at most 8191 accounts.
-            /// However, create_transfers will put 2 accounts (8191 * 2) for every transfer, and
-            /// some of these accounts may exist, requiring a remove/put to update the index.
             commit_count_max: u32,
         };
 

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -95,7 +95,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
 
         /// See comments for Groove.Options.
         pub const Options = struct {
-            cache_size: u32,
+            cache_cardinality_max: u32,
             prefetch_count_max: u32,
             commit_count_max: u32,
         };
@@ -111,7 +111,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             errdefer allocator.destroy(cache);
 
             cache.* = .{};
-            try cache.ensureTotalCapacity(allocator, options.cache_size);
+            try cache.ensureTotalCapacity(allocator, options.cache_cardinality_max);
             errdefer cache.deinit(allocator);
 
             var tree = try Tree.init(

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -95,9 +95,9 @@ pub fn PostedGrooveType(comptime Storage: type) type {
 
         /// See comments for Groove.Options.
         pub const Options = struct {
-            cache_cardinality_max: u32,
-            prefetch_count_max: u32,
-            commit_count_max: u32,
+            cache_entries_max: u32,
+            prefetch_entries_max: u32,
+            commit_entries_max: u32,
         };
 
         pub fn init(
@@ -111,7 +111,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             errdefer allocator.destroy(cache);
 
             cache.* = .{};
-            try cache.ensureTotalCapacity(allocator, options.cache_cardinality_max);
+            try cache.ensureTotalCapacity(allocator, options.cache_entries_max);
             errdefer cache.deinit(allocator);
 
             var tree = try Tree.init(
@@ -120,17 +120,17 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 grid,
                 cache,
                 .{
-                    .commit_count_max = options.commit_count_max,
+                    .commit_entries_max = options.commit_entries_max,
                 },
             );
             errdefer tree.deinit(allocator);
 
             var prefetch_ids = PrefetchIDs{};
-            try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_count_max);
+            try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_entries_max);
             errdefer prefetch_ids.deinit(allocator);
 
             var prefetch_objects = PrefetchObjects{};
-            try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_count_max);
+            try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_entries_max);
             errdefer prefetch_objects.deinit(allocator);
 
             return PostedGroove{

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -10,13 +10,14 @@ const binary_search_keys = @import("binary_search.zig").binary_search_keys;
 const Direction = @import("direction.zig").Direction;
 
 /// A "segmented array" is an array with efficient (amortized) random-insert/remove operations.
+/// Also known as an "unrolled linked list": https://en.wikipedia.org/wiki/Unrolled_linked_list
 ///
-/// The structure consists of an arraylist of "nodes". Each node is a non-empty array of T.
+/// The structure consists of an array list of "nodes". Each node is a non-empty array of T.
 /// When a node fills, it is split into two adjacent, partially-full nodes.
 /// When a node empties, it is joined with a nearby node.
 ///
 /// An absolute index is offset from the start of the segmented array.
-/// A relative index is offset from the start of the node.
+/// A relative index is offset from the start of a node.
 pub fn SegmentedArray(
     comptime T: type,
     comptime NodePool: type,

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -119,15 +119,12 @@ pub fn main() !void {
 
         const timer = try std.time.Timer.start();
         const repetitions = std.math.max(1, @divFloor(samples, queries.len));
-        // Sum the results, just to make sure the compiler doesn't optimize all of this out.
-        var sum: Key = 0;
         var j: usize = 0;
         while (j < repetitions) : (j += 1) {
             for (queries) |query| {
-                sum += array.absolute_index_for_cursor(array.search(query));
+                std.mem.doNotOptimizeAway(array.absolute_index_for_cursor(array.search(query)));
             }
         }
-        assert(sum > 0);
         const time = timer.read() / repetitions / queries.len;
 
         try stdout.print("KeyType={} ValueCount={:_>7} ValueSize={:_>2}B NodeSize={:_>6}B LookupTime={:_>6}ns\n", .{

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -12,8 +12,47 @@ const div_ceil = @import("../util.zig").div_ceil;
 const eytzinger = @import("eytzinger.zig").eytzinger;
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 
+const BlockOperation = @import("grid.zig").BlockOperation;
 const TableInfoType = @import("manifest.zig").TableInfoType;
 
+/// A table is a set of blocks:
+///
+/// * Index block (1)
+/// * Filter blocks (at most `filter_block_count_max`)
+///   Each filter block summarizes the keys for several adjacent (in terms of key range) data blocks.
+/// * Data blocks (at most `data_block_count_max`)
+///   Store the actual keys/values, along with a small index of the keys to optimize lookups.
+///
+///
+/// Every block begins with a `vsr.Header` that includes:
+///
+/// * `checksum`, `checksum_body` verify the data integrity.
+/// * `cluster` is the cluster id.
+/// * `command` is `.block`.
+/// * `op` is the block address.
+/// * `size` is the block size excluding padding.
+///
+/// Index block schema:
+/// │ vsr.Header                   │ commit=filter_block_count,
+/// │                              │ request=data_block_count,
+/// │                              │ timestamp=snapshot_min
+/// │ [filter_block_count_max]u128 │ checksums of filter blocks
+/// │ [data_block_count_max]u128   │ checksums of data blocks
+/// │ [data_block_count_max]Key    │ the maximum/last key in the respective data block
+/// │ [filter_block_count_max]u64  │ addresses of filter blocks
+/// │ [data_block_count_max]u64    │ addresses of data blocks
+/// │ […]u8{0}                     │ padding (to end of block)
+///
+/// Filter block schema:
+/// │ vsr.Header │
+/// │ […]u8      │ A split-block Bloom filter, "containing" every key from as many as
+/// │            │   `filter_data_block_count_max` data blocks.
+///
+/// Data block schema:
+/// │ vsr.Header               │
+/// │ [block_key_count + 1]Key │ Eytzinger-layout keys from a subset of the values.
+/// │ [≤value_count_max]Value  │ At least one value (no empty tables).
+/// │ […]u8{0}                 │ padding (to end of block)
 pub fn TableType(
     comptime TableKey: type,
     comptime TableValue: type,
@@ -84,7 +123,7 @@ pub fn TableType(
         const table_block_count_max = @divExact(table_size_max, block_size);
         const block_body_size = block_size - @sizeOf(vsr.Header);
 
-        pub const layout = blk: {
+        pub const layout = layout: {
             assert(block_size % config.sector_size == 0);
             assert(math.isPowerOfTwo(table_size_max));
             assert(math.isPowerOfTwo(block_size));
@@ -158,15 +197,18 @@ pub fn TableType(
                 block_value_count_max * filter_bytes_per_key,
             );
 
+            // Compute the number of data and filter blocks by solving the constraints:
+            // * the filter and data blocks' metadata must fix in the index block
+            // * the filter blocks must index all data blocks
+            // * minimize the number of filter blocks
+            // * maximize the number of data blocks
             var data_blocks = table_block_count_max - index_block_count;
-            var data_index_size = 0;
             var filter_blocks = 0;
-            var filter_index_size = 0;
             while (true) : (data_blocks -= 1) {
-                data_index_size = data_index_entry_size * data_blocks;
-
                 filter_blocks = div_ceil(data_blocks, filter_data_block_count_max);
-                filter_index_size = filter_index_entry_size * filter_blocks;
+
+                const data_index_size = data_index_entry_size * data_blocks;
+                const filter_index_size = filter_index_entry_size * filter_blocks;
 
                 const index_size = @sizeOf(vsr.Header) + data_index_size + filter_index_size;
                 const table_block_count = index_block_count + filter_blocks + data_blocks;
@@ -178,14 +220,18 @@ pub fn TableType(
             const table_block_count = index_block_count + filter_blocks + data_blocks;
             assert(table_block_count <= table_block_count_max);
 
-            break :blk .{
+            break :layout .{
+                // The number of keys per data block.
                 .block_key_count = block_key_count,
+                // The number of bytes used by the keys in the data block.
                 .block_key_layout_size = block_key_layout_size,
+                // The maximum number of values in a data block.
                 .block_value_count_max = block_value_count_max,
 
                 .data_block_count_max = data_blocks,
                 .filter_block_count_max = filter_blocks,
 
+                // The number of data blocks covered by a single filter block.
                 .filter_data_block_count_max = filter_data_block_count_max,
             };
         };
@@ -397,21 +443,11 @@ pub fn TableType(
             }
         }
 
-        fn blocks_used(table: *Table) u32 {
-            assert(!table.free);
-            return Table.index_blocks_used(&table.blocks[0]);
-        }
-
-        fn filter_blocks_used(table: *Table) u32 {
-            assert(!table.free);
-            return Table.index_filter_blocks_used(&table.blocks[0]);
-        }
-
         pub const Builder = struct {
             const TableInfo = TableInfoType(Table);
 
-            key_min: Key = undefined,
-            key_max: Key = undefined,
+            key_min: Key = undefined, // inclusive
+            key_max: Key = undefined, // inclusive
 
             index_block: BlockPtr,
             filter_block: BlockPtr,
@@ -496,6 +532,7 @@ pub fn TableType(
                 // For each block we write the sorted values, initialize the Eytzinger layout,
                 // complete the block header, and add the block's max key to the table index.
 
+                assert(options.address > 0);
                 assert(builder.value > 0);
 
                 const block = builder.data_block;
@@ -545,6 +582,7 @@ pub fn TableType(
                     .request = @intCast(u32, values.len),
                     .size = block_size - @intCast(u32, values_padding.len + block_padding.len),
                     .command = .block,
+                    .operation = BlockOperation.data.operation(),
                 };
 
                 header.set_checksum_body(block[@sizeOf(vsr.Header)..header.size]);
@@ -587,6 +625,7 @@ pub fn TableType(
 
             pub fn filter_block_finish(builder: *Builder, options: FilterFinishOptions) void {
                 assert(!builder.filter_block_empty());
+                assert(options.address > 0);
 
                 const header_bytes = builder.filter_block[0..@sizeOf(vsr.Header)];
                 const header = mem.bytesAsValue(vsr.Header, header_bytes);
@@ -595,6 +634,7 @@ pub fn TableType(
                     .op = options.address,
                     .size = block_size - filter.padding_size,
                     .command = .block,
+                    .operation = BlockOperation.filter.operation(),
                 };
 
                 const body = builder.filter_block[@sizeOf(vsr.Header)..header.size];
@@ -626,6 +666,7 @@ pub fn TableType(
             };
 
             pub fn index_block_finish(builder: *Builder, options: IndexFinishOptions) TableInfo {
+                assert(options.address > 0);
                 assert(builder.data_block_count > 0);
                 assert(builder.value == 0);
                 assert(builder.data_blocks_in_filter == 0);
@@ -658,6 +699,7 @@ pub fn TableType(
                     .timestamp = options.snapshot_min,
                     .size = index.size,
                     .command = .block,
+                    .operation = BlockOperation.index.operation(),
                 };
                 header.set_checksum_body(index_block[@sizeOf(vsr.Header)..header.size]);
                 header.set_checksum();

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -22,7 +22,10 @@ pub fn TableImmutableType(comptime Table: type) type {
         snapshot_min: u64,
         free: bool,
 
+        /// `commit_count_max` is the maximum number of Values that can be inserted by a single commit.
         pub fn init(allocator: mem.Allocator, commit_count_max: u32) !TableImmutable {
+            assert(commit_count_max > 0);
+
             // The in-memory immutable table is the same size as the mutable table:
             const value_count_max = commit_count_max * config.lsm_batch_multiple;
             const data_block_count = div_ceil(value_count_max, Table.data.value_count_max);
@@ -45,11 +48,13 @@ pub fn TableImmutableType(comptime Table: type) type {
         }
 
         pub inline fn key_min(table: *const TableImmutable) Key {
+            assert(!table.free);
             assert(table.values.len > 0);
             return key_from_value(&table.values[0]);
         }
 
         pub inline fn key_max(table: *const TableImmutable) Key {
+            assert(!table.free);
             assert(table.values.len > 0);
             return key_from_value(&table.values[table.values.len - 1]);
         }
@@ -96,7 +101,7 @@ pub fn TableImmutableType(comptime Table: type) type {
                     assert(i > 0);
                     const left_key = key_from_value(&sorted_values[i - 1]);
                     const right_key = key_from_value(&sorted_values[i]);
-                    assert(compare_keys(left_key, right_key) != .gt);
+                    assert(compare_keys(left_key, right_key) == .lt);
                 }
             }
 
@@ -140,7 +145,7 @@ pub fn TableImmutableIteratorType(comptime Table: type, comptime Storage: type) 
         const TableImmutableIterator = @This();
         const TableImmutable = TableImmutableType(Table);
 
-        table: *TableImmutable,
+        table: *const TableImmutable,
         values_index: u32,
 
         pub fn init(allocator: mem.Allocator) !TableImmutableIterator {
@@ -158,7 +163,7 @@ pub fn TableImmutableIteratorType(comptime Table: type, comptime Storage: type) 
         }
 
         pub const Context = struct {
-            table: *TableImmutable,
+            table: *const TableImmutable,
         };
 
         pub fn start(
@@ -174,21 +179,23 @@ pub fn TableImmutableIteratorType(comptime Table: type, comptime Storage: type) 
         }
 
         pub fn tick(it: *const TableImmutableIterator) bool {
-            _ = it;
+            assert(!it.table.free);
             return false; // No I/O is performed as it's all in memory.
         }
 
         pub fn buffered_all_values(it: *const TableImmutableIterator) bool {
-            _ = it;
+            assert(!it.table.free);
             return true; // All values are "buffered" in memory.
         }
 
         pub fn peek(it: *const TableImmutableIterator) ?Table.Key {
+            assert(!it.table.free);
             if (it.values_index == it.table.values.len) return null;
             return Table.key_from_value(&it.table.values[it.values_index]);
         }
 
         pub fn pop(it: *TableImmutableIterator) Table.Value {
+            assert(!it.table.free);
             defer it.values_index += 1;
             return it.table.values[it.values_index];
         }

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -22,12 +22,12 @@ pub fn TableImmutableType(comptime Table: type) type {
         snapshot_min: u64,
         free: bool,
 
-        /// `commit_count_max` is the maximum number of Values that can be inserted by a single commit.
-        pub fn init(allocator: mem.Allocator, commit_count_max: u32) !TableImmutable {
-            assert(commit_count_max > 0);
+        /// `commit_entries_max` is the maximum number of Values that can be inserted by a single commit.
+        pub fn init(allocator: mem.Allocator, commit_entries_max: u32) !TableImmutable {
+            assert(commit_entries_max > 0);
 
             // The in-memory immutable table is the same size as the mutable table:
-            const value_count_max = commit_count_max * config.lsm_batch_multiple;
+            const value_count_max = commit_entries_max * config.lsm_batch_multiple;
             const data_block_count = div_ceil(value_count_max, Table.data.value_count_max);
             assert(data_block_count <= Table.data_block_count_max);
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -101,8 +101,8 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
 
         pub const Context = struct {
             grid: *Grid,
-            address: u64, // table index block address
-            checksum: u128, // table index block checksum
+            address: u64, // Table index block address.
+            checksum: u128, // Table index block checksum.
             index_block_callback: ?IndexBlockCallback = null,
         };
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -9,6 +9,7 @@ const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 const ManifestType = @import("manifest.zig").ManifestType;
 const GridType = @import("grid.zig").GridType;
 
+/// A TableIterator iterates a table's values in ascending-key order.
 pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
     return struct {
         const TableIterator = @This();
@@ -100,8 +101,8 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
 
         pub const Context = struct {
             grid: *Grid,
-            address: u64,
-            checksum: u128,
+            address: u64, // table index block address
+            checksum: u128, // table index block checksum
             index_block_callback: ?IndexBlockCallback = null,
         };
 
@@ -148,6 +149,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
                     &it.read,
                     it.address,
                     it.checksum,
+                    .index,
                 );
                 return true;
             }
@@ -171,12 +173,13 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
 
             assert(!it.read_pending);
             it.read_pending = true;
-            it.grid.read_block(on_read, &it.read, address, checksum);
+            it.grid.read_block(on_read, &it.read, address, checksum, .data);
         }
 
         fn on_read_table_index(read: *Grid.Read, block: Grid.BlockPtrConst) void {
             const it = @fieldParentPtr(TableIterator, "read", read);
             assert(it.read_pending);
+            assert(it.data_block_index == 0);
             it.read_pending = false;
 
             assert(it.read_table_index);
@@ -194,6 +197,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
             const read_pending = it.tick();
             // After reading the table index, we always read at least one data block.
             assert(read_pending);
+            assert(it.read_pending);
         }
 
         fn on_read(read: *Grid.Read, block: Grid.BlockPtrConst) void {

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -23,12 +23,12 @@ pub fn TableMutableType(comptime Table: type) type {
         value_count_max: u32,
         values: Values = .{},
 
-        /// `commit_count_max` is the maximum number of Values that can be inserted by a single commit.
-        pub fn init(allocator: mem.Allocator, commit_count_max: u32) !TableMutable {
+        /// `commit_entries_max` is the maximum number of Values that can be inserted by a single commit.
+        pub fn init(allocator: mem.Allocator, commit_entries_max: u32) !TableMutable {
             comptime assert(config.lsm_batch_multiple > 0);
-            assert(commit_count_max > 0);
+            assert(commit_entries_max > 0);
 
-            const value_count_max = commit_count_max * config.lsm_batch_multiple;
+            const value_count_max = commit_entries_max * config.lsm_batch_multiple;
             const data_block_count = div_ceil(value_count_max, Table.data.value_count_max);
             assert(data_block_count <= Table.data_block_count_max);
 

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -54,8 +54,8 @@ pub fn TableMutableType(comptime Table: type) type {
             // If the key is already present in the hash map, the old key will not be overwritten
             // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
             // level getOrPut() API and manually overwrite the old key.
-            const gop = table.values.getOrPutAssumeCapacity(value.*);
-            gop.key_ptr.* = value.*;
+            const upsert = table.values.getOrPutAssumeCapacity(value.*);
+            upsert.key_ptr.* = value.*;
 
             // The hash map's load factor may allow for more capacity because of rounding:
             assert(table.values.count() <= table.value_count_max);
@@ -65,8 +65,8 @@ pub fn TableMutableType(comptime Table: type) type {
             // If the key is already present in the hash map, the old key will not be overwritten
             // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
             // level getOrPut() API and manually overwrite the old key.
-            const gop = table.values.getOrPutAssumeCapacity(value.*);
-            gop.key_ptr.* = tombstone_from_key(key_from_value(value));
+            const upsert = table.values.getOrPutAssumeCapacity(value.*);
+            upsert.key_ptr.* = tombstone_from_key(key_from_value(value));
 
             assert(table.values.count() <= table.value_count_max);
         }

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -22,8 +22,8 @@ pub fn TableMutableType(comptime Table: type) type {
 
         value_count_max: u32,
         values: Values = .{},
-        dirty: bool = false,
 
+        /// `commit_count_max` is the maximum number of Values that can be inserted by a single commit.
         pub fn init(allocator: mem.Allocator, commit_count_max: u32) !TableMutable {
             comptime assert(config.lsm_batch_multiple > 0);
             assert(commit_count_max > 0);
@@ -59,19 +59,20 @@ pub fn TableMutableType(comptime Table: type) type {
 
             // The hash map's load factor may allow for more capacity because of rounding:
             assert(table.values.count() <= table.value_count_max);
-            table.dirty = true;
         }
 
         pub fn remove(table: *TableMutable, value: *const Value) void {
             // If the key is already present in the hash map, the old key will not be overwritten
             // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
             // level getOrPut() API and manually overwrite the old key.
-            const tombstone = tombstone_from_key(key_from_value(value));
-            const gop = table.values.getOrPutAssumeCapacity(tombstone);
-            gop.key_ptr.* = tombstone;
+            const gop = table.values.getOrPutAssumeCapacity(value.*);
+            gop.key_ptr.* = tombstone_from_key(key_from_value(value));
+
             assert(table.values.count() <= table.value_count_max);
         }
 
+        /// This may return `false` even when committing would succeed — it pessimistically
+        /// assumes that none of the batch's keys are already in `table.values`.
         pub fn can_commit_batch(table: *TableMutable, batch_count: u32) bool {
             assert(batch_count <= table.value_count_max);
             return (table.count() + batch_count) <= table.value_count_max;
@@ -81,7 +82,6 @@ pub fn TableMutableType(comptime Table: type) type {
             assert(table.values.count() > 0);
             table.values.clearRetainingCapacity();
             assert(table.values.count() == 0);
-            table.dirty = false;
         }
 
         pub fn count(table: *const TableMutable) u32 {

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -28,12 +28,12 @@ const Environment = struct {
     const size_max = vsr.Zone.superblock.size().? + vsr.Zone.wal.size().? + (512 + 64) * 1024 * 1024;
 
     const node_count = 1024;
-    const cache_size = 2 * 1024 * 1024;
+    const cache_cardinality_max = 2 * 1024 * 1024;
     const forest_options = StateMachine.forest_options(.{
         .lsm_forest_node_count = undefined, // ignored by StateMachine.forest_options()
-        .cache_size_accounts = cache_size,
-        .cache_size_transfers = cache_size,
-        .cache_size_posted = cache_size,
+        .cache_cardinality_accounts = cache_cardinality_max,
+        .cache_cardinality_transfers = cache_cardinality_max,
+        .cache_cardinality_posted = cache_cardinality_max,
         .message_body_size_max = config.message_size_max - @sizeOf(vsr.Header),
     });
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -42,7 +42,7 @@ const Forest = ForestType(Storage, .{
 const Environment = struct {
     const cluster = 32;
     const replica = 4;
-    const size_max = (512 + 64) * 1024 * 1024;
+    const size_max = vsr.Zone.superblock.size().? + vsr.Zone.wal.size().? + (512 + 64) * 1024 * 1024;
 
     const node_count = 1024;
     const cache_size = 2 * 1024 * 1024;
@@ -50,10 +50,12 @@ const Environment = struct {
         .transfers = .{
             .cache_size = cache_size,
             .commit_count_max = 8191 * 2,
+            .prefetch_count_max = 8191 * 2,
         },
         .accounts = .{
             .cache_size = cache_size,
             .commit_count_max = 8191,
+            .prefetch_count_max = 8191,
         },
     };
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -29,7 +29,7 @@ const Environment = struct {
 
     const node_count = 1024;
     const cache_size = 2 * 1024 * 1024;
-    const forest_options: Forest.Options = StateMachine.forest_options(.{
+    const forest_options = StateMachine.forest_options(.{
         .lsm_forest_node_count = undefined, // ignored by StateMachine.forest_options()
         .cache_size_accounts = cache_size,
         .cache_size_transfers = cache_size,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -122,7 +122,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             /// The maximum number of keys that may be committed per batch.
             ///
             /// In general, the commit count max for a field depends on the field's object —
-            /// how many objects might be changed by a batch:
+            /// how many objects might be inserted/updated/removed by a batch:
             ///   (config.message_size_max - sizeOf(vsr.header))
             /// For example, there are at most 8191 transfers in a batch.
             /// So commit_count_max=8191 for transfer objects and indexes.
@@ -459,8 +459,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
         //
         //  - (third) down beat of the measure:
         //      * assert: no compactions are currently running.
-        //      * start odd level compactions if there's any tables to compact.
-        //      * compact immutable table if it contains any sorted values (could be empty).
+        //      * start odd level compactions if there are any tables to compact, and only if we must.
+        //      * compact the immutable table if it contains any sorted values (it could be empty).
         //
         //  - (fourth) last beat of the measure:
         //      * finish ticking running odd-level and immutable table compactions.

--- a/src/main.zig
+++ b/src/main.zig
@@ -127,9 +127,9 @@ const Command = struct {
             .state_machine_options = .{
                 // TODO Tune lsm_forest_node_count better.
                 .lsm_forest_node_count = 4096,
-                .cache_size_accounts = config.accounts_max,
-                .cache_size_transfers = config.transfers_max,
-                .cache_size_posted = config.transfers_pending_max,
+                .cache_cardinality_accounts = config.cache_accounts_max,
+                .cache_cardinality_transfers = config.cache_transfers_max,
+                .cache_cardinality_posted = config.cache_transfers_pending_max,
                 .message_body_size_max = config.message_size_max - @sizeOf(vsr.Header),
             },
             .message_bus_options = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,6 +130,12 @@ const Command = struct {
                 .cache_size_accounts = config.accounts_max,
                 .cache_size_transfers = config.transfers_max,
                 .cache_size_posted = config.transfers_pending_max,
+                .commit_count_max_accounts = config.commit_count_max_accounts,
+                .commit_count_max_transfers = config.commit_count_max_transfers,
+                .commit_count_max_posted = config.commit_count_max_posted,
+                .prefetch_count_max_accounts = config.prefetch_count_max_accounts,
+                .prefetch_count_max_transfers = config.prefetch_count_max_transfers,
+                .prefetch_count_max_posted = config.prefetch_count_max_posted,
             },
             .message_bus_options = .{
                 .configuration = addresses,
@@ -148,6 +154,7 @@ const Command = struct {
 
         while (true) {
             replica.tick();
+            command.storage.tick();
             try command.io.run_for_ns(config.tick_ms * std.time.ns_per_ms);
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -149,7 +149,10 @@ const Command = struct {
 
         while (true) {
             replica.tick();
-            command.storage.tick();
+            command.io.tick() catch |err| {
+                log.warn("tick: {}", .{err});
+                std.debug.panic("io tick: {}", .{err});
+            };
             try command.io.run_for_ns(config.tick_ms * std.time.ns_per_ms);
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -127,9 +127,9 @@ const Command = struct {
             .state_machine_options = .{
                 // TODO Tune lsm_forest_node_count better.
                 .lsm_forest_node_count = 4096,
-                .cache_cardinality_accounts = config.cache_accounts_max,
-                .cache_cardinality_transfers = config.cache_transfers_max,
-                .cache_cardinality_posted = config.cache_transfers_pending_max,
+                .cache_entries_accounts = config.cache_accounts_max,
+                .cache_entries_transfers = config.cache_transfers_max,
+                .cache_entries_posted = config.cache_transfers_pending_max,
                 .message_body_size_max = config.message_size_max - @sizeOf(vsr.Header),
             },
             .message_bus_options = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,12 +130,7 @@ const Command = struct {
                 .cache_size_accounts = config.accounts_max,
                 .cache_size_transfers = config.transfers_max,
                 .cache_size_posted = config.transfers_pending_max,
-                .commit_count_max_accounts = config.commit_count_max_accounts,
-                .commit_count_max_transfers = config.commit_count_max_transfers,
-                .commit_count_max_posted = config.commit_count_max_posted,
-                .prefetch_count_max_accounts = config.prefetch_count_max_accounts,
-                .prefetch_count_max_transfers = config.prefetch_count_max_transfers,
-                .prefetch_count_max_posted = config.prefetch_count_max_posted,
+                .message_body_size_max = config.message_size_max - @sizeOf(vsr.Header),
             },
             .message_bus_options = .{
                 .configuration = addresses,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -131,9 +131,6 @@ pub fn main() !void {
             .prefetch_mean = 5 + random.uintLessThan(u64, 10),
             .compact_mean = 5 + random.uintLessThan(u64, 10),
             .checkpoint_mean = 5 + random.uintLessThan(u64, 10),
-            .commit_count_max_accounts = config.commit_count_max_accounts,
-            .commit_count_max_transfers = config.commit_count_max_transfers,
-            .commit_count_max_posted = config.commit_count_max_posted,
         },
     };
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -261,7 +261,6 @@ pub fn main() !void {
                     }
                 }
             }
-            storage.tick();
         }
 
         for (cluster.replicas) |*replica| {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -131,6 +131,9 @@ pub fn main() !void {
             .prefetch_mean = 5 + random.uintLessThan(u64, 10),
             .compact_mean = 5 + random.uintLessThan(u64, 10),
             .checkpoint_mean = 5 + random.uintLessThan(u64, 10),
+            .commit_count_max_accounts = config.commit_count_max_accounts,
+            .commit_count_max_transfers = config.commit_count_max_transfers,
+            .commit_count_max_posted = config.commit_count_max_posted,
         },
     };
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -888,7 +888,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             return self.forest.grooves.posted.get(pending_id);
         }
 
-        pub fn forest_options(options: Options) Forest.Options {
+        pub fn forest_options(options: Options) Forest.GroovesOptions {
             const batch_accounts_max = @intCast(u32, @divFloor(
                 options.message_body_size_max,
                 @sizeOf(Account),

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -65,9 +65,9 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         pub const Options = struct {
             lsm_forest_node_count: u32,
-            cache_size_accounts: u32,
-            cache_size_transfers: u32,
-            cache_size_posted: u32,
+            cache_cardinality_accounts: u32,
+            cache_cardinality_transfers: u32,
+            cache_cardinality_posted: u32,
             message_body_size_max: usize,
         };
 
@@ -902,7 +902,7 @@ pub fn StateMachineType(comptime Storage: type) type {
 
             return .{
                 .accounts = .{
-                    .cache_size = options.cache_size_accounts,
+                    .cache_cardinality_max = options.cache_cardinality_accounts,
                     .prefetch_count_max = std.math.max(
                         // create_account()/lookup_account() looks up 1 account per item.
                         batch_accounts_max,
@@ -955,7 +955,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                     },
                 },
                 .transfers = .{
-                    .cache_size = options.cache_size_transfers,
+                    .cache_cardinality_max = options.cache_cardinality_transfers,
                     // *2 to fetch pending and post/void transfer.
                     .prefetch_count_max = 2 * batch_transfers_max,
                     .tree_options_object = .{ .commit_count_max = batch_transfers_max },
@@ -972,7 +972,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                     },
                 },
                 .posted = .{
-                    .cache_size = options.cache_size_posted,
+                    .cache_cardinality_max = options.cache_cardinality_posted,
                     .prefetch_count_max = batch_transfers_max,
                     .commit_count_max = batch_transfers_max,
                 },
@@ -1050,9 +1050,9 @@ const TestContext = struct {
     state_machine: StateMachine,
 
     fn init(ctx: *TestContext, allocator: mem.Allocator, options: struct {
-        cache_size_accounts: u32,
-        cache_size_transfers: u32,
-        cache_size_posted: u32,
+        cache_cardinality_accounts: u32,
+        cache_cardinality_transfers: u32,
+        cache_cardinality_posted: u32,
     }) !void {
         ctx.storage = try Storage.init(
             allocator,
@@ -1084,9 +1084,9 @@ const TestContext = struct {
 
         ctx.state_machine = try StateMachine.init(allocator, &ctx.grid, .{
             .lsm_forest_node_count = 1,
-            .cache_size_accounts = options.cache_size_accounts,
-            .cache_size_transfers = options.cache_size_transfers,
-            .cache_size_posted = options.cache_size_posted,
+            .cache_cardinality_accounts = options.cache_cardinality_accounts,
+            .cache_cardinality_transfers = options.cache_cardinality_transfers,
+            .cache_cardinality_posted = options.cache_cardinality_posted,
             // Overestimate the batch size (in order overprovision commit_count_max)
             // because the test never compacts.
             .message_body_size_max = 1000 * @sizeOf(Account),
@@ -1456,9 +1456,9 @@ test "create/lookup/rollback accounts" {
 
     var context: TestContext = undefined;
     try context.init(testing.allocator, .{
-        .cache_size_accounts = vectors.len,
-        .cache_size_transfers = 0,
-        .cache_size_posted = 0,
+        .cache_cardinality_accounts = vectors.len,
+        .cache_cardinality_transfers = 0,
+        .cache_cardinality_posted = 0,
     });
     defer context.deinit(testing.allocator);
 
@@ -1521,9 +1521,9 @@ test "linked accounts" {
 
     var context: TestContext = undefined;
     try context.init(testing.allocator, .{
-        .cache_size_accounts = accounts_max,
-        .cache_size_transfers = transfers_max,
-        .cache_size_posted = transfers_pending_max,
+        .cache_cardinality_accounts = accounts_max,
+        .cache_cardinality_transfers = transfers_max,
+        .cache_cardinality_posted = transfers_pending_max,
     });
     defer context.deinit(testing.allocator);
 
@@ -1608,9 +1608,9 @@ test "create/lookup/rollback transfers" {
 
     var context: TestContext = undefined;
     try context.init(testing.allocator, .{
-        .cache_size_accounts = accounts.len,
-        .cache_size_transfers = 1,
-        .cache_size_posted = 0,
+        .cache_cardinality_accounts = accounts.len,
+        .cache_cardinality_transfers = 1,
+        .cache_cardinality_posted = 0,
     });
     defer context.deinit(testing.allocator);
 
@@ -2287,9 +2287,9 @@ test "create/lookup/rollback 2-phase transfers" {
 
     var context: TestContext = undefined;
     try context.init(testing.allocator, .{
-        .cache_size_accounts = accounts.len,
-        .cache_size_transfers = 100,
-        .cache_size_posted = 1,
+        .cache_cardinality_accounts = accounts.len,
+        .cache_cardinality_transfers = 100,
+        .cache_cardinality_posted = 1,
     });
     defer context.deinit(testing.allocator);
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -71,6 +71,9 @@ pub fn StateMachineType(comptime Storage: type) type {
             commit_count_max_accounts: u32,
             commit_count_max_transfers: u32,
             commit_count_max_posted: u32,
+            prefetch_count_max_accounts: u32,
+            prefetch_count_max_transfers: u32,
+            prefetch_count_max_posted: u32,
         };
 
         prepare_timestamp: u64,
@@ -99,14 +102,17 @@ pub fn StateMachineType(comptime Storage: type) type {
                     .accounts = .{
                         .cache_size = options.cache_size_accounts,
                         .commit_count_max = options.commit_count_max_accounts,
+                        .prefetch_count_max = options.prefetch_count_max_accounts,
                     },
                     .transfers = .{
                         .cache_size = options.cache_size_transfers,
                         .commit_count_max = options.commit_count_max_transfers,
+                        .prefetch_count_max = options.prefetch_count_max_transfers,
                     },
                     .posted = .{
                         .cache_size = options.cache_size_posted,
                         .commit_count_max = options.commit_count_max_posted,
+                        .prefetch_count_max = options.prefetch_count_max_posted,
                     },
                 },
             );
@@ -1015,6 +1021,9 @@ const TestContext = struct {
             .commit_count_max_accounts = 1000,
             .commit_count_max_transfers = 1000,
             .commit_count_max_posted = 1000,
+            .prefetch_count_max_accounts = 1000,
+            .prefetch_count_max_transfers = 1000,
+            .prefetch_count_max_posted = 1000,
         });
         errdefer ctx.state_machine.deinit(allocator);
     }

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -84,10 +84,8 @@ pub const Storage = struct {
     }
 
     pub fn tick(storage: *Storage) void {
-        storage.io.tick() catch |err| {
-            log.warn("tick: {}", .{err});
-            std.debug.panic("storage tick: {}", .{err});
-        };
+        _ = storage;
+        // IO is ticked by the top-level (e.g. main.zig).
     }
 
     pub fn read_sectors(

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -85,7 +85,8 @@ pub const Storage = struct {
 
     pub fn tick(storage: *Storage) void {
         _ = storage;
-        // IO is ticked by the top-level (e.g. main.zig).
+        // IO is ticked by the top-level (e.g. main.zig) since it may
+        // be shared by more than one replica, for example during tests.
     }
 
     pub fn read_sectors(

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
-pub const config = @import("config.zig");
-
 pub const Account = extern struct {
     id: u128,
     /// Opaque third-party identifier to link this account (many-to-one) to an external entity.

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -2,6 +2,7 @@ test {
     _ = @import("vsr.zig");
     _ = @import("vsr/journal.zig");
     _ = @import("vsr/marzullo.zig");
+    _ = @import("vsr/superblock.zig");
     _ = @import("vsr/superblock_manifest.zig");
     _ = @import("vsr/superblock_free_set.zig");
     // TODO: clean up logging of clock test and enable it here.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -112,7 +112,7 @@ pub const Operation = enum(u8) {
             @compileError("StateMachine.Operation must have a 'reserved' field with value 0");
         }
         if (!@hasField(Op, "root") or std.meta.fieldInfo(Op, .root).value != 1) {
-            @compileError("StateMachine.Operation must have an 'root' field with value 1");
+            @compileError("StateMachine.Operation must have a 'root' field with value 1");
         }
         if (!@hasField(Op, "register") or std.meta.fieldInfo(Op, .register).value != 2) {
             @compileError("StateMachine.Operation must have a 'register' field with value 2");

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -530,6 +530,7 @@ pub fn ReplicaType(
 
             // TODO Replica owns Time; should it tick() here instead of Clock?
             self.clock.tick();
+            self.journal.storage.tick();
             self.grid.tick();
             self.state_machine.tick();
             self.message_bus.tick();

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -716,6 +716,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             if (superblock.free_set.highest_address_acquired()) |address| {
                 staging.size += address * config.block_size;
             }
+            assert(staging.size >= data_file_size_min);
             assert(staging.size <= staging.size_max);
 
             staging.free_set_size = @intCast(u32, superblock.free_set.encode(target));
@@ -1148,7 +1149,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             } else if (context.copy == stopping_copy_for_sequence(superblock.working.sequence)) {
                 @panic("superblock manifest lost");
             } else {
-                log.debug("open: read_manifest: broken copy={}", .{ context.copy });
+                log.debug("open: read_manifest: corrupt copy={}", .{ context.copy });
                 context.copy += 1;
                 superblock.read_manifest(context);
             }
@@ -1213,7 +1214,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             } else if (context.copy == stopping_copy_for_sequence(superblock.working.sequence)) {
                 @panic("superblock free set lost");
             } else {
-                log.debug("open: read_free_set: broken copy={}", .{ context.copy });
+                log.debug("open: read_free_set: corrupt copy={}", .{ context.copy });
                 context.copy += 1;
                 superblock.read_free_set(context);
             }
@@ -1283,7 +1284,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             } else if (context.copy == stopping_copy_for_sequence(superblock.working.sequence)) {
                 @panic("superblock client table lost");
             } else {
-                log.debug("open: read_client_table: broken copy={}", .{ context.copy });
+                log.debug("open: read_client_table: corrupt copy={}", .{ context.copy });
                 context.copy += 1;
                 superblock.read_client_table(context);
             }

--- a/src/vsr/superblock_client_table.zig
+++ b/src/vsr/superblock_client_table.zig
@@ -45,7 +45,7 @@ pub const ClientTable = struct {
         try entries.ensureTotalCapacity(allocator, @intCast(u32, config.clients_max));
         assert(entries.capacity() >= config.clients_max);
 
-        const sorted = try allocator.alloc(*const Entry, entries.capacity());
+        const sorted = try allocator.alloc(*const Entry, config.clients_max);
         errdefer allocator.free(sorted);
 
         return ClientTable{
@@ -229,7 +229,7 @@ pub const ClientTable = struct {
     }
 
     pub fn capacity(client_table: *const ClientTable) usize {
-        return client_table.entries.capacity();
+        return client_table.sorted.len;
     }
 
     pub fn get(client_table: *ClientTable, client: u128) ?*Entry {

--- a/src/vsr/superblock_client_table.zig
+++ b/src/vsr/superblock_client_table.zig
@@ -184,16 +184,16 @@ pub const ClientTable = struct {
         size = std.mem.alignForward(size, @alignOf(vsr.Header));
         const headers = mem.bytesAsSlice(
             vsr.Header,
-            source[size .. entries_count * @sizeOf(vsr.Header)],
+            source[size..][0 .. entries_count * @sizeOf(vsr.Header)],
         );
         size += mem.sliceAsBytes(headers).len;
 
         size = std.mem.alignForward(size, @alignOf(u64));
-        const sessions = mem.bytesAsSlice(u64, source[size .. entries_count * @sizeOf(u64)]);
+        const sessions = mem.bytesAsSlice(u64, source[size..][0 .. entries_count * @sizeOf(u64)]);
         size += mem.sliceAsBytes(sessions).len;
 
         size = std.mem.alignForward(size, @alignOf(u8));
-        var bodies = source[size..];
+        var bodies = source[size .. source.len - @sizeOf(u32)];
         assert(bodies.len > 0);
 
         var i: u32 = 0;

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -14,8 +14,8 @@ const div_ceil = @import("../util.zig").div_ceil;
 ///
 /// Set bits indicate free blocks, unset bits are allocated.
 pub const FreeSet = struct {
-    // Each bit of `index` is the OR of `shard_size` bits of `blocks`.
-    // That is, if a shard has any free blocks, the corresponding index bit is set.
+    /// Each bit of `index` is the OR of `shard_size` bits of `blocks`.
+    /// That is, if a shard has any free blocks, the corresponding index bit is set.
     index: DynamicBitSetUnmanaged,
     blocks: DynamicBitSetUnmanaged,
     /// Set bits indicate blocks to be released at the next checkpoint.

--- a/src/vsr/superblock_manifest.zig
+++ b/src/vsr/superblock_manifest.zig
@@ -35,8 +35,8 @@ pub const Manifest = struct {
     compaction_set: std.AutoHashMapUnmanaged(u64, void),
 
     pub const TableExtent = struct {
-        block: u64, // ManifestLog block address
-        entry: u32, // index within the ManifestLog Label/TableInfo arrays
+        block: u64, // ManifestLog block address.
+        entry: u32, // Index within the ManifestLog Label/TableInfo arrays.
     };
 
     pub fn init(


### PR DESCRIPTION
Specific changes:

- `Groove`: Use `mem.indexOf` instead of `mem.containsAtLeast` — the latter returns `true` even if the hash was reused.
- `Groove.deinit`/`PostedGroove.deinnit`: Remove some assertions — `deinit` may be called while a "join" operation is in progress.
- `SegmentedArray`: Make `Cursor` "generic", so that cursors from different `SegmentedArray`s are not interchangeable. As a bonus, this makes the `SegmentedArray` that a cursor refers to somewhat self-documenting.
- `Tree`: Panic if `checkpoint` is called on an invalid beat, rather than just silently not checkpointing.
- `Grid`: Add `BlockOperation` for additional block type verification.

Misc
- Move `commit_count_max_*` into `config.zig`
- Move `storage.tick()` from `Forest` to `main`. `Storage` doesn't belong to the `Forest`.
- Add `prefetch_count_max` options to `Groove`/`StateMachine`.

Not included above:
- Many new (or tighter) assertions.
- Additional and updated documentation
- Formatting
- Remove dead code.
- Move `storage.tick()` out of `Forest` into `main`. (`Forest` doesn't own the storage). Also, simulator was already calling `storage.tick()`.

