### PR TITLE
SuperBlock: ClientTable: Fix extra increment

### DIFF
--- a/src/vsr/superblock_client_table.zig
+++ b/src/vsr/superblock_client_table.zig
@@ -111,7 +111,6 @@ pub const ClientTable = struct {
                 assert(entries_count < client_table.sorted.len);
                 assert(entry.reply.header.command == .reply);
                 client_table.sorted[entries_count] = entry;
-                entries_count += 1;
             }
         }
 


### PR DESCRIPTION
This bug was hit when during checkpoint when there was only a single client id in the table. The assertion hit was:

`assert(a.reply.header.client != b.reply.header.client);`