### PR TITLE
LSM: Fixes: Grid.release_at_checkpoint; Tree.TableMutable.ValuesCache

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -48,22 +48,22 @@ pub const memory_size_max_default = 1024 * 1024 * 1024;
 
 /// The maximum number of accounts to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
-pub const cache_accounts_max = switch (deployment_environment) {
+pub const cache_accounts_max = std.math.floorPowerOfTwo(usize, switch (deployment_environment) {
     .production => 100_000,
     else => 10_000,
-};
+});
 
 /// The maximum number of transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
 /// We allocate more capacity than the number of transfers for a safe hash table load factor.
-pub const cache_transfers_max = switch (deployment_environment) {
+pub const cache_transfers_max = std.math.floorPowerOfTwo(usize, switch (deployment_environment) {
     .production => 1_000_000,
     else => 100_000,
-};
+});
 
 /// The maximum number of two-phase transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
-pub const cache_transfers_pending_max = cache_transfers_max;
+pub const cache_transfers_pending_max = std.math.floorPowerOfTwo(usize, cache_transfers_max);
 
 /// The maximum number of batch entries in the journal file:
 /// A batch entry may contain many transfers, so this is not a limit on the number of transfers.
@@ -358,6 +358,11 @@ comptime {
 
     // The LSM tree uses half-measures to balance compaction.
     assert(lsm_batch_multiple % 2 == 0);
+
+    // SetAssociativeCache requires a power-of-two cardinality.
+    assert(std.math.isPowerOfTwo(accounts_max));
+    assert(std.math.isPowerOfTwo(transfers_max));
+    assert(std.math.isPowerOfTwo(transfers_pending_max));
 }
 
 pub const is_32_bit = @sizeOf(usize) == 4; // TODO Return a compile error if we are not 32-bit.

--- a/src/config.zig
+++ b/src/config.zig
@@ -48,22 +48,22 @@ pub const memory_size_max_default = 1024 * 1024 * 1024;
 
 /// The maximum number of accounts to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
-pub const cache_accounts_max = std.math.floorPowerOfTwo(usize, switch (deployment_environment) {
-    .production => 100_000,
-    else => 10_000,
-});
+pub const cache_accounts_max = switch (deployment_environment) {
+    .production => 64 * 1024,
+    else => 8 * 1024,
+};
 
 /// The maximum number of transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
 /// We allocate more capacity than the number of transfers for a safe hash table load factor.
-pub const cache_transfers_max = std.math.floorPowerOfTwo(usize, switch (deployment_environment) {
-    .production => 1_000_000,
-    else => 100_000,
-});
+pub const cache_transfers_max = switch (deployment_environment) {
+    .production => 1024 * 1024,
+    else => 64 * 1024,
+};
 
 /// The maximum number of two-phase transfers to store in memory:
 /// This impacts the amount of memory allocated at initialization by the server.
-pub const cache_transfers_pending_max = std.math.floorPowerOfTwo(usize, cache_transfers_max);
+pub const cache_transfers_pending_max = cache_transfers_max;
 
 /// The maximum number of batch entries in the journal file:
 /// A batch entry may contain many transfers, so this is not a limit on the number of transfers.

--- a/src/config.zig
+++ b/src/config.zig
@@ -360,9 +360,9 @@ comptime {
     assert(lsm_batch_multiple % 2 == 0);
 
     // SetAssociativeCache requires a power-of-two cardinality.
-    assert(std.math.isPowerOfTwo(accounts_max));
-    assert(std.math.isPowerOfTwo(transfers_max));
-    assert(std.math.isPowerOfTwo(transfers_pending_max));
+    assert(std.math.isPowerOfTwo(cache_accounts_max));
+    assert(std.math.isPowerOfTwo(cache_transfers_max));
+    assert(std.math.isPowerOfTwo(cache_transfers_pending_max));
 }
 
 pub const is_32_bit = @sizeOf(usize) == 4; // TODO Return a compile error if we are not 32-bit.

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -283,9 +283,13 @@ pub fn CompactionType(
             // Release the table's block addresses in the Grid as it will be made invisible.
             // This is safe; iterator_b makes a copy of the block before calling us.
             const grid = compaction.grid;
-            for (Table.index_data_addresses_used(index_block)) |address| grid.release(address);
-            for (Table.index_filter_addresses_used(index_block)) |address| grid.release(address);
-            grid.release(Table.index_block_address(index_block));
+            for (Table.index_data_addresses_used(index_block)) |address| {
+                grid.release_at_checkpoint(address);
+            }
+            for (Table.index_filter_addresses_used(index_block)) |address| {
+                grid.release_at_checkpoint(address);
+            }
+            grid.release_at_checkpoint(Table.index_block_address(index_block));
         }
 
         pub fn compact_tick(compaction: *Compaction, callback: Callback) void {

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -53,30 +53,30 @@
 //!      T₁ I  $───                           ⎤
 //!      T₂  O $   ?───────────────────────── ⎦
 //!                ┅┅┅┅
-//!      T₁ I     $?───······················ ⎤  Each compaction is depicted by two steps:
-//!      T₂  O    $    ······················ ⎦  "during" and "after".
-//!      T₁ I     $────                       ⎤
-//!      T₂  O    $    ?───────────────────── ⎦
+//!      T₂ I     $?───······················ ⎤  Each compaction is depicted by two steps:
+//!      T₃  O    $    ······················ ⎦  "during" and "after".
+//!      T₂ I     $────                       ⎤
+//!      T₃  O    $    ?───────────────────── ⎦
 //!                    ┅┅┅┅
-//!      T₂ I         $?───·················· ⎤  Output tables have snapshot_max=maxInt(u64).
-//!      T₃  O        $    ·················· ⎦
-//!      T₂ I         $────                   ⎤
-//!      T₃  O        $    ?───────────────── ⎦
+//!      T₃ I         $?───·················· ⎤  Output tables have snapshot_max=maxInt(u64).
+//!      T₄  O        $    ·················· ⎦
+//!      T₃ I         $────                   ⎤
+//!      T₄  O        $    ?───────────────── ⎦
 //!                            ┅┅┅┅
-//!      T₃ I             $?───────·········· ⎤  In this compaction, T₃ was untouched by the
-//!      T₄  O            $        ·········· ⎦  previous compaction (ops 12…15), so its snapshots
-//!      T₃ I             $────────           ⎤  cover a wider interval.
-//!      T₄  O            $        ?───────── ⎦
+//!      T₄ I             $?───────·········· ⎤  In this compaction, T₃ was untouched by the
+//!      T₅  O            $        ·········· ⎦  previous compaction (ops 12…15), so its snapshots
+//!      T₄ I             $────────           ⎤  cover a wider interval.
+//!      T₅  O            $        ?───────── ⎦
 //!                                ┅┅┅┅
-//!      T₄ I                     $?───······ ⎤  During compaction, prefetch() queries the old input
-//!      T₅  O                    $    ······ ⎦  tables until the compaction half-measure completes.
-//!      T₄ I                     $────       ⎤
-//!      T₅  O                    $    ?───── ⎦
+//!      T₅ I                     $?───······ ⎤  During compaction, prefetch() queries the old input
+//!      T₆  O                    $    ······ ⎦  tables until the compaction half-measure completes.
+//!      T₅ I                     $────       ⎤
+//!      T₆  O                    $    ?───── ⎦
 //!                                    ┅┅┅┅
-//!      T₅ I                         $?───·· ⎤  Once prefetch can query from the new output tables,
-//!      T₆  O                        $    ·· ⎦  the old tables can be removed if they are invisible
-//!      T₅ I                         $────·· ⎤  to all saved snapshots.
-//!      T₆  O                        $    ?─ ⎦
+//!      T₆ I                         $?───·· ⎤  Once prefetch can query from the new output tables,
+//!      T₇  O                        $    ·· ⎦  the old tables can be removed if they are invisible
+//!      T₆ I                         $────·· ⎤  to all saved snapshots.
+//!      T₇  O                        $    ?─ ⎦
 //!            ┼───┬───┼───┬───┼───┬───┼───┬─ beat
 //!            0   4   8  12  16  20  24  28  op/snapshot
 //!

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -140,7 +140,7 @@ pub fn CompactionType(
 
         manifest: *Manifest,
         level_b: u8,
-        remove_level_a: ?TableInfo,
+        input_level_a: ?TableInfo,
 
         pub fn init(allocator: mem.Allocator) !Compaction {
             var iterator_a = try IteratorA.init(allocator);
@@ -174,7 +174,7 @@ pub fn CompactionType(
                 // Assigned by start()
                 .manifest = undefined,
                 .level_b = undefined,
-                .remove_level_a = null,
+                .input_level_a = null,
             };
         }
 
@@ -231,7 +231,7 @@ pub fn CompactionType(
 
                 .manifest = manifest,
                 .level_b = level_b,
-                .remove_level_a = if (table_a) |table| table.* else null,
+                .input_level_a = if (table_a) |table| table.* else null,
             };
 
             assert(!compaction.index.writable);
@@ -485,9 +485,10 @@ pub fn CompactionType(
             assert(compaction.iterator_b.buffered_all_values());
             assert(compaction.iterator_b.peek() == null);
 
-            // Remove the level_a table if it was provided; it has been merged into level_b.
+            // Mark the level_a table as invisible if it was provided;
+            // it has been merged into level_b.
             // TODO: Release the grid blocks associated with level_a as well
-            if (compaction.remove_level_a) |*level_a_table| {
+            if (compaction.input_level_a) |*level_a_table| {
                 const level_a = compaction.level_b - 1;
                 compaction.manifest.update_table(level_a, compaction.snapshot, level_a_table);
                 assert(level_a_table.snapshot_max == compaction.snapshot);

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -140,7 +140,7 @@ pub fn CompactionType(
 
         manifest: *Manifest,
         level_b: u8,
-        input_level_a: ?TableInfo,
+        level_a_input: ?TableInfo,
 
         pub fn init(allocator: mem.Allocator) !Compaction {
             var iterator_a = try IteratorA.init(allocator);
@@ -174,7 +174,7 @@ pub fn CompactionType(
                 // Assigned by start()
                 .manifest = undefined,
                 .level_b = undefined,
-                .input_level_a = null,
+                .level_a_input = null,
             };
         }
 
@@ -231,7 +231,7 @@ pub fn CompactionType(
 
                 .manifest = manifest,
                 .level_b = level_b,
-                .input_level_a = if (table_a) |table| table.* else null,
+                .level_a_input = if (table_a) |table| table.* else null,
             };
 
             assert(!compaction.index.writable);
@@ -488,7 +488,7 @@ pub fn CompactionType(
             // Mark the level_a table as invisible if it was provided;
             // it has been merged into level_b.
             // TODO: Release the grid blocks associated with level_a as well
-            if (compaction.input_level_a) |*level_a_table| {
+            if (compaction.level_a_input) |*level_a_table| {
                 const level_a = compaction.level_b - 1;
                 compaction.manifest.update_table(level_a, compaction.snapshot, level_a_table);
                 assert(level_a_table.snapshot_max == compaction.snapshot);

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -485,15 +485,14 @@ pub fn CompactionType(
             assert(compaction.iterator_b.buffered_all_values());
             assert(compaction.iterator_b.peek() == null);
 
-            // Remove the level_a table if it was provided given it's now been merged into level_b.
+            // Remove the level_a table if it was provided; it has been merged into level_b.
             // TODO: Release the grid blocks associated with level_a as well
-            if (compaction.level_b != 0) {
+            if (compaction.remove_level_a) |*level_a_table| {
                 const level_a = compaction.level_b - 1;
-
-                if (compaction.remove_level_a) |*level_a_table| {
-                    compaction.manifest.update_table(level_a, compaction.snapshot, level_a_table);
-                    assert(level_a_table.snapshot_max == compaction.snapshot);
-                }
+                compaction.manifest.update_table(level_a, compaction.snapshot, level_a_table);
+                assert(level_a_table.snapshot_max == compaction.snapshot);
+            } else {
+                assert(compaction.level_b == 0);
             }
 
             // Finally, mark Compaction as officially complete and ready to be reset().

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -377,7 +377,17 @@ pub fn GridType(comptime Storage: type) type {
                 // 2. All of the Grid's Read IOPS are occupied, so queue the read.
                 // 3. The replica checkpoints.
                 // 4. The read dequeues, but the requested block is no longer allocated.
-                // TODO(State Transfer) How does a non-repairable block trigger state transfer?
+                // TODO(State Transfer):
+                // 1. If a local read results in a fault, then the replica should attempt a
+                //    remote read.
+                // 2. If a remote replica has the block then it responds (and the local read
+                //    completes), otherwise it nacks.
+                // 3. If we receive too many nacks or if we get the feeling that we are too far
+                //    behind (perhaps the primary nacks), then complete the read callback but now
+                //    with a null result, so that it unwinds the stack all the way back to VSR,
+                //    which then initiates state transfer. At present, we expect that reads always
+                //    return a block, so to support this bubbling up, we'll need to make the block
+                //    result optional.
                 unreachable;
             }
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -421,7 +421,7 @@ pub fn GrooveType(
         /// sufficient to query this hashmap alone to know the state of the LSM trees.
         prefetch_objects: PrefetchObjects,
 
-        /// The snapshot to prefetch for.
+        /// The snapshot to prefetch from.
         prefetch_snapshot: ?u64,
 
         pub const Options = struct {
@@ -553,7 +553,7 @@ pub fn GrooveType(
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.ids.compacted_snapshot_max();
+            const snapshot_max = groove.ids.compaction_op_done;
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -553,7 +553,7 @@ pub fn GrooveType(
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.ids.compaction_op_done;
+            const snapshot_max = groove.ids.prefetch_snapshot_max;
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 
@@ -699,8 +699,9 @@ pub fn GrooveType(
                     }
 
                     if (worker.context.groove.objects.lookup_from_memory(
-                        worker.context.snapshot, id_tree_value.timestamp)) |object|
-                    {
+                        worker.context.snapshot,
+                        id_tree_value.timestamp,
+                    )) |object| {
                         // The object is not a tombstone; the ID and Object trees are in sync.
                         assert(!ObjectTreeHelpers(Object).tombstone(object));
 

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -34,7 +34,7 @@ pub fn TableInfoType(comptime Table: type) type {
         /// This value is set to the current snapshot tick on table creation.
         snapshot_min: u64,
 
-        /// The maximum snapshot that can see this table (with exclusive bounds).
+        /// The maximum snapshot that can see this table (with inclusive bounds).
         /// This value is set to the current snapshot tick on table deletion.
         snapshot_max: u64 = math.maxInt(u64),
 
@@ -66,7 +66,8 @@ pub fn TableInfoType(comptime Table: type) type {
             // The reason to use (exclusive, inclusive) bounds rather than the more conventional
             // (inclusive, exclusive) bounds is that this enables prefetches to query an ongoing
             // compaction's input tables (rather than the output tables, which are not ready)
-            // by querying the `compaction.snapshot`.
+            // by querying the `tree.compaction_op_done`.
+            // When the compaction finishes, `compaction_op_done` is bumped to `compaction_op`.
 
             // assert(snapshot != table.snapshot_min);
             // assert(snapshot != table.snapshot_max);
@@ -324,6 +325,8 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         }
 
         /// Returns the next table in the range, after `key_exclusive` if provided.
+        ///
+        /// * The table returned is visible to `snapshot`.
         pub fn next_table(
             manifest: *const Manifest,
             level: u8,

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -60,13 +60,18 @@ pub fn TableInfoType(comptime Table: type) type {
             // them invisible. It will also scan for tables that are invisible with the same snapshot.
             //
             // We can then relax this range check to be
-            // - inclusive to snapshot_min (new tables are inserted with snapshot=snapshot_min)
-            // - exclusive to snapshot_max (tables are removed / made invisible by setting snapshot_max)
+            // - exclusive to snapshot_min (new tables are inserted with snapshot=snapshot_min)
+            // - inclusive to snapshot_max (tables are removed / made invisible by setting snapshot_max)
+            //
+            // The reason to use (exclusive, inclusive) bounds rather than the more conventional
+            // (inclusive, exclusive) bounds is that this enables prefetches to query an ongoing
+            // compaction's input tables (rather than the output tables, which are not ready)
+            // by querying the `compaction.snapshot`.
 
             // assert(snapshot != table.snapshot_min);
             // assert(snapshot != table.snapshot_max);
 
-            return table.snapshot_min <= snapshot and snapshot < table.snapshot_max;
+            return table.snapshot_min < snapshot and snapshot <= table.snapshot_max;
         }
 
         pub fn invisible(table: *const TableInfo, snapshots: []const u64) bool {

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -235,8 +235,8 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             assert(level < config.lsm_levels);
             assert(compare_keys(key_min, key_max) != .gt);
 
-            // Scan and queue tables for removal in descending order to avoid
-            // buffer flushes which update the manifest_level invalidating subsequent iterator entries.
+            // Remove tables in descending order to avoid desynchronizing the iterator from
+            // the ManifestLevel.
             const direction = .descending;
             const snapshots = [_]u64{snapshot};
             const manifest_level = &manifest.levels[level];

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -42,9 +42,10 @@
 //! * The sides of each rectangle depict:
 //!   * left:   table.key_min (the diagram is inclusive, and the table.key_min is inclusive)
 //!   * right:  table.key_max (the diagram is EXCLUSIVE, but the table.key_max is INCLUSIVE)
-//!   * bottom: table.snapshot_min (exclusive)
-//!   * top:    table.snapshot_max (exclusive)
+//!   * bottom: table.snapshot_min (inclusive)
+//!   * top:    table.snapshot_max (inclusive)
 //! * (Not depicted: tables may have `table.key_min == table.key_max`.)
+//! * (Not depicted: the newest set of tables would have `table.snapshot_max == maxInt(u64)`.)
 //!
 const std = @import("std");
 const assert = std.debug.assert;

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -406,6 +406,22 @@ pub fn ManifestLevelType(
 
             return adjusted;
         }
+
+        /// The function is only used for verification; it is not performance-critical.
+        pub fn contains(level: Self, table: *const TableInfo) bool {
+            assert(config.verify);
+
+            var level_tables = level.iterator(.visible, &.{
+                table.snapshot_min,
+            }, .ascending, KeyRange{
+                .key_min = table.key_min,
+                .key_max = table.key_max,
+            });
+            while (level_tables.next()) |level_table| {
+                if (level_table.equal(table)) return true;
+            }
+            return false;
+        }
     };
 }
 

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -47,8 +47,8 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         const SuperBlock = SuperBlockType(Storage);
         const Grid = GridType(Storage);
 
-        const BlockPtr = *align(config.sector_size) [config.block_size]u8;
-        const BlockPtrConst = *align(config.sector_size) const [config.block_size]u8;
+        const BlockPtr = Grid.BlockPtr;
+        const BlockPtrConst = Grid.BlockPtrConst;
 
         pub const Callback = fn (manifest_log: *ManifestLog) void;
 
@@ -115,13 +115,13 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         /// Set for the duration of `compact`.
         reading: bool = false,
         read: Grid.Read = undefined,
-        read_callback: Callback = undefined,
+        read_callback: ?Callback = null,
         read_block_reference: ?SuperBlock.Manifest.BlockReference = null,
 
         /// Set for the duration of `flush` and `checkpoint`.
         writing: bool = false,
         write: Grid.Write = undefined,
-        write_callback: Callback = undefined,
+        write_callback: ?Callback = null,
 
         pub fn init(allocator: mem.Allocator, grid: *Grid, tree_hash: u128) !ManifestLog {
             // TODO RingBuffer for .pointer should be extended to take care of alignment:
@@ -163,6 +163,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(!manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
+            assert(manifest_log.read_callback == null);
 
             assert(manifest_log.blocks.count == 0);
             assert(manifest_log.blocks_closed == 0);
@@ -206,9 +207,9 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 manifest_log.open_event = undefined;
                 manifest_log.open_iterator = undefined;
 
-                const callback = manifest_log.read_callback;
+                const callback = manifest_log.read_callback.?;
                 manifest_log.reading = false;
-                manifest_log.read_callback = undefined;
+                manifest_log.read_callback = null;
                 assert(manifest_log.read_block_reference == null);
 
                 callback(manifest_log);
@@ -327,6 +328,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
+            assert(manifest_log.write_callback == null);
 
             manifest_log.writing = true;
             manifest_log.write_callback = callback;
@@ -351,8 +353,8 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                     assert(manifest_log.entry_count < entry_count_max);
                 }
 
-                const callback = manifest_log.write_callback;
-                manifest_log.write_callback = undefined;
+                const callback = manifest_log.write_callback.?;
+                manifest_log.write_callback = null;
                 manifest_log.writing = false;
 
                 callback(manifest_log);
@@ -417,13 +419,13 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
+            assert(manifest_log.read_callback == null);
             manifest_log.read_callback = callback;
             manifest_log.flush(compact_flush_callback);
         }
 
         fn compact_flush_callback(manifest_log: *ManifestLog) void {
-            const callback = manifest_log.read_callback;
-            manifest_log.read_callback = undefined;
+            const callback = manifest_log.read_callback.?;
 
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
@@ -437,7 +439,6 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 assert(block.address > 0);
 
                 manifest_log.reading = true;
-                manifest_log.read_callback = callback;
                 manifest_log.read_block_reference = block;
 
                 manifest_log.grid.read_block(
@@ -448,6 +449,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                     .manifest,
                 );
             } else {
+                manifest_log.read_callback = null;
                 callback(manifest_log);
             }
         }
@@ -514,9 +516,9 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
             manifest_log.grid.release_at_checkpoint(block_reference.address);
 
-            const callback = manifest_log.read_callback;
+            const callback = manifest_log.read_callback.?;
             manifest_log.reading = false;
-            manifest_log.read_callback = undefined;
+            manifest_log.read_callback = null;
             manifest_log.read_block_reference = null;
 
             callback(manifest_log);
@@ -526,6 +528,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
+            assert(manifest_log.write_callback == null);
 
             manifest_log.writing = true;
             manifest_log.write_callback = callback;

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -434,6 +434,9 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
             const manifest: *SuperBlock.Manifest = &manifest_log.superblock.manifest;
 
+            // Compact a single manifest block — to minimize latency spikes, we want to do the bare
+            // minimum of compaction work required.
+            // TODO Compact more than 1 block if fragmentation is outstripping the compaction rate.
             if (manifest.oldest_block_queued_for_compaction(manifest_log.tree_hash)) |block| {
                 assert(block.tree == manifest_log.tree_hash);
                 assert(block.address > 0);

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -248,6 +248,10 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 }
             }
 
+            if (block_entry_count(block) < entry_count_max) {
+                manifest.queue_for_compaction(block_reference.address);
+            }
+
             log.debug("{}: opened: checksum={} address={} entries={}", .{
                 manifest_log.tree_hash,
                 block_reference.checksum,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -512,7 +512,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             );
             assert(!manifest.queued_for_compaction(block_reference.address));
 
-            manifest_log.grid.release(block_reference.address);
+            manifest_log.grid.release_at_checkpoint(block_reference.address);
 
             const callback = manifest_log.read_callback;
             manifest_log.reading = false;

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -74,7 +74,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
         const PrefetchIDs = std.AutoHashMapUnmanaged(u128, void);
         const PrefetchObjects = std.AutoHashMapUnmanaged(u128, bool); // true:posted, false:voided
 
-        cache: *Tree.ValueCache,
+        cache: *Tree.TableMutable.ValuesCache,
         tree: Tree,
 
         /// Object IDs enqueued to be prefetched.
@@ -88,6 +88,9 @@ pub fn PostedGrooveType(comptime Storage: type) type {
         /// the commit are both passed to the LSM trees and mirrored in this hash map. It is always
         /// sufficient to query this hashmap alone to know the state of the LSM trees.
         prefetch_objects: PrefetchObjects,
+
+        /// The snapshot to prefetch for.
+        prefetch_snapshot: ?u64,
 
         /// This field is necessary to expose the same open()/compact()/checkpoint() function
         /// signatures as the real Groove type.
@@ -107,11 +110,10 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             options: Options,
         ) !PostedGroove {
             // Cache is heap-allocated to pass a pointer into the Object tree.
-            const cache = try allocator.create(Tree.ValueCache);
+            const cache = try allocator.create(Tree.TableMutable.ValuesCache);
             errdefer allocator.destroy(cache);
 
-            cache.* = .{};
-            try cache.ensureTotalCapacity(allocator, options.cache_entries_max);
+            cache.* = try Tree.TableMutable.ValuesCache.init(allocator, options.cache_entries_max);
             errdefer cache.deinit(allocator);
 
             var tree = try Tree.init(
@@ -139,6 +141,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
 
                 .prefetch_ids = prefetch_ids,
                 .prefetch_objects = prefetch_objects,
+                .prefetch_snapshot = null,
             };
         }
 
@@ -157,9 +160,17 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             return groove.prefetch_objects.get(id);
         }
 
-        /// Must be called directly after the state machine commit is finished and prefetch results
-        /// are no longer needed.
-        pub fn prefetch_clear(groove: *PostedGroove) void {
+        /// Must be called directly before the state machine begins queuing ids for prefetch.
+        pub fn prefetch_setup(groove: *PostedGroove, snapshot: u64) void {
+            assert(snapshot <= snapshot_latest);
+
+            if (groove.prefetch_snapshot == null) {
+                groove.prefetch_snapshot = snapshot;
+            } else {
+                // If there is a leftover snapshot, then prefetch() was never called, so there
+                // must already be no queued objects or ids.
+            }
+
             groove.prefetch_objects.clearRetainingCapacity();
             assert(groove.prefetch_objects.count() == 0);
             assert(groove.prefetch_ids.count() == 0);
@@ -169,7 +180,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
         /// We tolerate duplicate IDs enqueued by the state machine.
         /// For example, if all unique operations require the same two dependencies.
         pub fn prefetch_enqueue(groove: *PostedGroove, id: u128) void {
-            if (groove.tree.get_cached(id)) |value| {
+            if (groove.tree.lookup_from_memory(groove.prefetch_snapshot.?, id)) |value| {
                 switch (value.data) {
                     .posted => groove.prefetch_objects.putAssumeCapacity(value.id, true),
                     .voided => groove.prefetch_objects.putAssumeCapacity(value.id, false),
@@ -181,8 +192,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
         }
 
         /// Ensure the objects corresponding to all ids enqueued with prefetch_enqueue() are
-        /// in memory, either in the value cache of the object tree or in the prefetch_objects
-        /// backup hash map.
+        /// available in `prefetch_objects`.
         pub fn prefetch(
             groove: *PostedGroove,
             callback: fn (*PrefetchContext) void,
@@ -191,14 +201,17 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             context.* = .{
                 .groove = groove,
                 .callback = callback,
+                .snapshot = groove.prefetch_snapshot.?,
                 .id_iterator = groove.prefetch_ids.keyIterator(),
             };
+            groove.prefetch_snapshot = null;
             context.start_workers();
         }
 
         pub const PrefetchContext = struct {
             groove: *PostedGroove,
             callback: fn (*PrefetchContext) void,
+            snapshot: u64,
 
             id_iterator: PrefetchIDs.KeyIterator,
 
@@ -259,18 +272,18 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 };
 
                 if (config.verify) {
-                    // This is checked in prefetch_enqueue()
-                    assert(worker.context.groove.tree.get_cached(id.*) == null);
+                    // This was checked in prefetch_enqueue().
+                    assert(worker.context.groove.tree.lookup_from_memory(worker.context.snapshot, id.*) == null);
                 }
 
                 // If not in the LSM tree's cache, the object must be read from disk and added
                 // to the auxillary prefetch_objects hash map.
                 // TODO: this LSM tree function needlessly checks the LSM tree's cache a
                 // second time. Adding API to the LSM tree to avoid this may be worthwhile.
-                worker.context.groove.tree.lookup(
+                worker.context.groove.tree.lookup_from_levels(
                     lookup_id_callback,
                     &worker.lookup_id,
-                    snapshot_latest,
+                    worker.context.snapshot,
                     id.*,
                 );
             }
@@ -360,7 +373,7 @@ test "PostedGroove" {
 
     _ = PostedGroove.prefetch_enqueue;
     _ = PostedGroove.prefetch;
-    _ = PostedGroove.prefetch_clear;
+    _ = PostedGroove.prefetch_setup;
 
     std.testing.refAllDecls(PostedGroove.PrefetchWorker);
     std.testing.refAllDecls(PostedGroove.PrefetchContext);

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -167,7 +167,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.tree.compacted_snapshot_max();
+            const snapshot_max = groove.tree.compaction_op_done;
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -167,7 +167,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.tree.compaction_op_done;
+            const snapshot_max = groove.tree.prefetch_snapshot_max;
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -174,8 +174,8 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             if (groove.prefetch_snapshot == null) {
                 groove.prefetch_objects.clearRetainingCapacity();
             } else {
-                // If there is a leftover snapshot, then prefetch() was never called, so there
-                // must already be no queued objects or ids.
+                // If there is a snapshot already set from the previous prefetch_setup(), then its
+                // prefetch() was never called, so there must already be no queued objects or ids.
             }
 
             groove.prefetch_snapshot = snapshot_target;

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -212,8 +212,7 @@ pub fn SetAssociativeCache(
             const set = self.associate(key);
             const way = self.search(set, key) orelse return;
 
-            const count = self.counts.get(set.offset + way);
-            self.counts.set(set.offset + way, div_ceil(count, 2));
+            self.counts.set(set.offset + way, 1);
         }
 
         /// If the key is present in the set, returns the way. Otherwise returns null.

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -60,7 +60,7 @@ pub fn TableMutableType(comptime Table: type) type {
         pub fn init(
             allocator: mem.Allocator,
             values_cache: ?*ValuesCache,
-            cache_entries_max: u32,
+            commit_entries_max: u32,
         ) !TableMutable {
             comptime assert(config.lsm_batch_multiple > 0);
             assert(commit_entries_max > 0);

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -313,7 +313,7 @@ const Environment = struct {
         const iterations = 4;
 
         var op: u64 = 1;
-        var id: u128 = 0;
+        var id: u128 = 1;
         var timestamp: u64 = 42;
         var crash_probability = std.rand.DefaultPrng.init(1337);
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -18,6 +18,7 @@ const StateMachine = @import("../state_machine.zig").StateMachineType(Storage);
 const GridType = @import("grid.zig").GridType;
 const GrooveType = @import("groove.zig").GrooveType;
 const Forest = StateMachine.Forest;
+const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const Grid = GridType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
@@ -244,6 +245,7 @@ const Environment = struct {
                 assertion.verify_count = std.math.min(commit_entries_max, assertion.objects.len);
                 if (assertion.verify_count == 0) return;
 
+                assertion.groove.prefetch_setup(snapshot_latest);
                 for (assertion.objects[0..assertion.verify_count]) |*object| {
                     assertion.groove.prefetch_enqueue(object.id);
                 }
@@ -256,7 +258,6 @@ const Environment = struct {
                 assert(assertion.verify_count > 0);
 
                 {
-                    defer assertion.groove.prefetch_clear();
                     for (assertion.objects[0..assertion.verify_count]) |*object| {
                         log.debug("verifying {} for id={}", .{ visibility, object.id });
                         const result = assertion.groove.get(object.id);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -14,7 +14,7 @@
 //!   .   op is in mutable table (in memory)
 //!   ,   op is in immutable table (in memory)
 //!   #   op is on disk
-//!   ✓   checkpoint may follow compact()
+//!   ✓   checkpoint() may follow compact()
 //!
 //!   0 2 4 6 8 0 2 4 6
 //!   ┼───┬───┼───┬───┼
@@ -27,7 +27,7 @@
 //!   ...←.→  ╷       ╷     commit;compact( 5) start/end ⎥ - when the LSM is starting on a freshly
 //!   ...←..→ ╷       ╷     commit;compact( 6) start/end ⎥   formatted data file, and also
 //!   ...←...→╷       ╷     commit;compact( 7) start    ⎤⎥ - when the LSM is recovering from a crash
-//!   ,,,,,,,↔╷       ╷  ✓         compact( 7)       end⎦⎦   before any checkpoint.
+//!   ,,,,,,,↔╷       ╷  ✓         compact( 7)       end⎦⎦   before any checkpoint (see below).
 //!   ,,,,,,,←→       ╷     commit;compact( 8) start/end
 //!   ,,,,,,,←.→      ╷     commit;compact( 9) start/end
 //!   ,,,,,,,←..→     ╷     commit;compact(10) start/end

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -197,9 +197,9 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.prefetch_callback = callback;
 
             // TODO(Snapshots) Pass in the target snapshot.
-            self.forest.grooves.accounts.prefetch_setup(snapshot_latest);
-            self.forest.grooves.transfers.prefetch_setup(snapshot_latest);
-            self.forest.grooves.posted.prefetch_setup(snapshot_latest);
+            self.forest.grooves.accounts.prefetch_setup(null);
+            self.forest.grooves.transfers.prefetch_setup(null);
+            self.forest.grooves.posted.prefetch_setup(null);
 
             return switch (operation) {
                 .reserved, .root, .register => unreachable,
@@ -1074,6 +1074,10 @@ const TestContext = struct {
 
         ctx.superblock = try SuperBlock.init(allocator, &ctx.storage, &ctx.message_pool);
         errdefer ctx.superblock.deinit(allocator);
+
+        // Pretend that the superblock is open so that the Forest can initialize.
+        ctx.superblock.opened = true;
+        ctx.superblock.working.vsr_state.commit_min = 0;
 
         ctx.grid = try Grid.init(allocator, &ctx.superblock);
         errdefer ctx.grid.deinit(allocator);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2669,10 +2669,28 @@ pub fn ReplicaType(
             reply.header.set_checksum_body(reply.body());
             reply.header.set_checksum();
 
-            if (reply.header.operation == .register) {
-                self.create_client_table_entry(reply);
+            if (self.op_checkpoint == 0 or
+                prepare.header.op > self.op_checkpoint + config.lsm_batch_multiple)
+            {
+                if (reply.header.operation == .register) {
+                    self.create_client_table_entry(reply);
+                } else {
+                    self.update_client_table_entry(reply);
+                }
             } else {
-                self.update_client_table_entry(reply);
+                // We are recovering from a checkpoint. Prior to the crash, the client table was
+                // updated with entries for one measure beyond the op_checkpoint.
+                assert(self.op_checkpoint == self.superblock.working.vsr_state.commit_min);
+                if (self.client_table().get(prepare.header.client)) |entry| {
+                    assert(entry.reply.header.command == .reply);
+                    assert(entry.reply.header.op >= prepare.header.op);
+                }
+
+                log.debug("{}: commit_op: skip client table update: prepare.op={} checkpoint={}", .{
+                    self.replica,
+                    prepare.header.op,
+                    self.op_checkpoint,
+                });
             }
 
             if (self.leader_index(self.view) == self.replica) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3540,14 +3540,24 @@ pub fn ReplicaType(
         ///
         /// For a replica with journal_slot_count=8 and lsm_batch_multiple=2:
         ///
-        ///   |01|23|45|67| (initial log fill)
-        ///   |89|01|23|45| (first wrap of log)
-        ///   |67|89|01|23| (second wrap of log)
+        ///   checkpoint() call      0   1   2   3
+        ///   op_checkpoint          0   5  11  17
+        ///   op_checkpoint_next     5  11  17  23
+        ///   op_checkpoint_trigger  7  13  19  25
         ///
-        ///   checkpoint() call      0   1   2
-        ///   op_checkpoint          0   5  11
-        ///   op_checkpoint_next     5  11  17
-        ///   op_checkpoint_trigger  7  13  19
+        ///     commit log (ops)           │ write-ahead log (slots)
+        ///     0   4   8   2   6   0   4  │ 0---4---
+        ///   0 ─────✓·%                   │ 01234✓6%   initial log fill
+        ///   1 ───────────✓·%             │ 890✓2%45   first wrap of log
+        ///   2 ─────────────────✓·%       │ 6✓8%0123   second wrap of log
+        ///   3 ───────────────────────✓·% │ 4%67890✓   third wrap of log
+        ///
+        /// Legend:
+        ///
+        ///   ─/✓  op on disk at checkpoint
+        ///   ·/%  op in memory at checkpoint
+        ///     ✓  op_checkpoint
+        ///     %  op_checkpoint_trigger
         ///
         fn op_checkpoint_next(self: *const Self) u64 {
             assert(self.op_checkpoint <= self.commit_min);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -140,6 +140,15 @@ pub const SuperBlockSector = extern struct {
             assert(state.would_be_updated_by(new));
             state.* = new;
         }
+
+        /// Compaction is one measure ahead of superblock's commit_min.
+        /// The commits from the measure following commit_min were in the mutable table, and
+        /// thus not preserved in the checkpoint.
+        /// But the corresponding `compact()` updates were preserved, and must not be repeated
+        /// to ensure determinstic storage.
+        pub fn op_compacted(state: VSRState, op: u64) bool {
+            return state.commit_min > 0 and op <= state.commit_min + config.lsm_batch_multiple;
+        }
     };
 
     pub const Snapshot = extern struct {

--- a/src/vsr/superblock_client_table.zig
+++ b/src/vsr/superblock_client_table.zig
@@ -194,17 +194,15 @@ pub const ClientTable = struct {
 
         size = std.mem.alignForward(size, @alignOf(u8));
         var bodies = source[size .. source.len - @sizeOf(u32)];
-        assert(bodies.len > 0);
 
-        var i: u32 = 0;
-        while (i < entries_count) : (i += 1) {
+        for (headers) |header, i| {
             // Prepare the entry with a message.
             var entry: Entry = undefined;
             entry.reply = client_table.message_pool.get_message();
 
             // Read the header and session for the entry.
             entry.session = sessions[i];
-            entry.reply.header.* = headers[i];
+            entry.reply.header.* = header;
             assert(entry.reply.header.valid_checksum());
             assert(entry.reply.header.command == .reply);
             assert(entry.reply.header.commit >= entry.session);

--- a/src/vsr/superblock_manifest.zig
+++ b/src/vsr/superblock_manifest.zig
@@ -116,6 +116,10 @@ pub const Manifest = struct {
     }
 
     pub fn decode(manifest: *Manifest, source: []align(@alignOf(u128)) const u8) void {
+        assert(manifest.count == 0);
+        assert(manifest.tables.count() == 0);
+        assert(manifest.compaction_set.count() == 0);
+
         manifest.count = @intCast(u32, @divExact(source.len, BlockReferenceSize));
         assert(manifest.count <= manifest.count_max);
 


### PR DESCRIPTION
These two changes are mostly unrelated, except they both hinge on the `SetAssociativeCache`.

## `Grid.release_at_checkpoint()`

Fix crash on `if (verify) assert(self.search(set, key) == null);`.

Explanation of bug:

1. (During compaction)
2. The first level B table is fully buffered, so release its blocks (`Grid.release()`).
    1. Release the block addresses from the free set at the next checkpoint (not yet).
    2. Remove the blocks from the `SetAssociativeCache` (right now).
3. (Keep compacting the rest of level B)
4. While compaction is still running, the `StateMachine` handles a request that queries the block we just released. This adds it back to the cache.
5. After checkpoint, the released block is reassigned. We try to write the new version to the cache (`put_no_clobber`), but there is already an (old) entry there!
(We want to release the blocks mid-compaction rather than later because the index block is in memory — we don't want to risk missing the cache later and having to do IO to get it back.)

Explanation of fix:

1. In `Grid.release()`, instead of removing the entry from the `Grid` cache (we may still need it after all), just knock its "score" in the `SetAssociativeCache` down.
2. Relax the `SetAssociativeCache.search` assertion.

## `Tree.TableMutable.ValuesCache`

- Change the values cache from a `HashMap` to a `SetAssociativeCache`.
- Hook the cache up so that it is updated and correctly accessed.
- The cache is only for reads from the current snapshot.
- Move the values cache into the `TableMutable` because they are accessed similarly:
  - both are synchronous (in-memory)
  - both are only checked when reading from the current snapshot
  - both must not have out-of-date values
- Change `prefetch_clear()` to `prefetch_setup(snapshot)`. We were already calling it at the beginning of a commit rather than the end to simplify the `StateMachine` unit test structure.
  - Right now the state machine always passes `snapshot_latest`.
- Refactor `Groove.lookup` and prefetching to keep the in-memory table access (cache, mutable, immutable) all in one place. The caller is responsible for checking the in-memory lookup before falling back to the (on-disk) levels.
- Fix the `values_cache` comment, which previously (incorrectly) indicated that the value cache was shared between multiple types.

## Don't read unwritten tables

This fixes an issue where tables' blocks were being read from disk before the block was ever written.
This is what happens:
1. Compaction is running...
2. Compaction marks input tables with `snapshot_max = compaction_snapshot`.
3. Compaction marks output tables with `snapshot_min = compaction_snapshot` (and `snapshot_max = intMax(u64)`).
4. But the tables' snapshots are updated before the compaction finishes! And before the blocks are written to disk. This is important because it means compaction doesn't need to buffer the changes.
  - Aside: This isn't a new bug, but it was hidden until the "ManifestLevel: SegmentedArray binary search" (https://github.com/tigerbeetledb/tigerbeetle/pull/165) refactor removed the need for batched manifest updates.

Fix:
- Add `Tree.compacted_snapshot_max()`:
  - Don't ever query a higher snapshot — this function handles the logic of "Which snapshot is securely on disk and safe to query?"
  - Only query the mutable table when `snapshot == tree.compacted_snapshot_max()`.
  - When a tree recovers from a checkpoint, it needs to know what op was last committed (`superblock.working.vsr_state.commit_min`). `Tree.init()` now requires that the superblock is opened. The tests are updated accordingly.
- `snapshot_min` is now *exclusive*.
- `snapshot_max` is now *inclusive*.
- Don't ever `compact(op:0)` (even in the `lsm/test.zig`). `replica.zig` doesn't. (This allows a tighter assertion in `compact()`).
- `prefetch_setup`'s op is now optional, to allow the tree to use the current snapshot (which isn't known by the state machine).
- Fix a typo in `PostedGroove`.

## Don't remove invisible tables until new tables are ready

Summary:
*Do not remove (compaction input) invisible tables until prefetch() can query the new (compaction output) tables.*

Details:
- Track `compaction_op_done` explicitly, rather than deriving it from `compaction_op`. Not only is this approach simpler and easier to follow, it grants the tree more control over when prefetch can switch to using the newer snapshot.
- Avoid duplicate `compact(op)` calls. Compacting the same op twice due to a crash can lead to nondeterministic storage when combined with crash/recover.
  - Document the relationship between `compaction_op`, `compaction_op_done`, and their behavior after recovery from checkpoint.
- Don't remove invisible tables until all sub-compactions of a half-measure compaction have finished. In more detail:
  - Previously each full compaction shared a snapshot; now each half-compaction has its own snapshot (see `compaction_snapshot_for_op`). This allows the output tables of the first half to be used for prefetch() during the second half. My reasoning is that we want to start using the new tables as soon as it is safe to do so, since they are warm in the cache. If we wait until the end of the full compaction, they may have been evicted by old tables.
  - Previously we removed the invisible tables as each level's compaction finished, rather than removing all invisible tables together when all of the levels' compactions finish. But we essentially need to atomically switch from the old tables to the new, by updating the prefetch snapshot from the old `compaction_op_done` to the new `compaction_op`.

Misc fixes:
- Rename `Compaction.remove_level_a` to `Compaction.input_level_a`. Compaction will not always result in the old table's removal. And even when it does, that removal is not immediate (and not the `Compaction`'s responsibility). I want to disambiguate between "remove a table" and "make a table invisible by updating its snapshot_max".
- Update some outdated comments.