### PR TITLE
Fix storage tick

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -149,10 +149,6 @@ const Command = struct {
 
         while (true) {
             replica.tick();
-            command.io.tick() catch |err| {
-                log.warn("tick: {}", .{err});
-                std.debug.panic("io tick: {}", .{err});
-            };
             try command.io.run_for_ns(config.tick_ms * std.time.ns_per_ms);
         }
     }

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -260,6 +260,10 @@ pub fn main() !void {
                     }
                 }
             }
+
+            // NOTE IO is ticked by the top-level since it may
+            // be shared by more than one replica, for example during tests.
+            // storage.tick();
         }
 
         for (cluster.replicas) |*replica| {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -260,8 +260,6 @@ pub fn main() !void {
                     }
                 }
             }
-
-            storage.tick();
         }
 
         for (cluster.replicas) |*replica, index| {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -261,16 +261,16 @@ pub fn main() !void {
                 }
             }
 
-            // NOTE IO is ticked by the top-level since it may
-            // be shared by more than one replica, for example during tests.
-            // storage.tick();
+            storage.tick();
         }
 
-        for (cluster.replicas) |*replica| {
+        for (cluster.replicas) |*replica, index| {
             switch (cluster.health[replica.replica]) {
                 .up => |*ticks| {
                     ticks.* -|= 1;
                     replica.tick();
+                    cluster.storages[index].tick();
+
                     cluster.state_checker.check_state(replica.replica) catch |err| {
                         fatal(.correctness, "state checker error: {}", .{err});
                     };

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -84,9 +84,10 @@ pub const Storage = struct {
     }
 
     pub fn tick(storage: *Storage) void {
-        _ = storage;
-        // IO is ticked by the top-level (e.g. main.zig) since it may
-        // be shared by more than one replica, for example during tests.
+        storage.io.tick() catch |err| {
+            log.warn("tick: {}", .{err});
+            std.debug.panic("io.tick(): {}", .{err});
+        };
     }
 
     pub fn read_sectors(

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -530,7 +530,10 @@ pub fn ReplicaType(
 
             // TODO Replica owns Time; should it tick() here instead of Clock?
             self.clock.tick();
-            self.journal.storage.tick();
+
+            // Storage/IO is ticked by top-level in case of multiple replicas sharing the same IO.
+            // self.journal.storage.tick();
+
             self.grid.tick();
             self.state_machine.tick();
             self.message_bus.tick();


### PR DESCRIPTION
`Storage.tick()` was commented out from a previous commit to enforce that `IO.tick()` is called instead at the top-level in case of multiple `Storage` instances. A few mechanisms like replica format and open worked only with `Storage` and relied on its tick() driving IO. This PR reimplements `Storage.tick()` to call `IO.tick()` and fixes/documents the call-sites where it should be called at top-level.