### PR TITLE
Drop clients references on docs home page

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,15 +22,6 @@ Once you've got a TigerBeetle server, check out:
 
 * [Creating accounts and transfers in the Node CLI](./usage/node-cli)
 
-# Clients
-
-When you're ready to integrate your application with TigerBeetle,
-check out the language-specific docs:
-
-* [Node](./clients/node)
-* [Java](./clients/java)
-* [Go](./clients/go)
-
 # Reference
 
 To understand TigerBeetle's data model, see:


### PR DESCRIPTION
Sorry, link checks are done in the docs generator (not part of this repo at the moment) and I didn't catch these in the last PR.

I've run it against this branch now though so should be good after this. :)