### PR TITLE
Also publish a :debug docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,7 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           build-args: |
             DEBUG=true
+          push: true
           # push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,14 +73,5 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          build-args: |
-            DEBUG=true
-          push: true
-          # push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
-          labels: ${{ steps.meta.outputs.labels }}
-          target: release
-          platforms: linux/amd64,linux/arm64
+      - run: docker build -t ghcr.io/coilhq/tigerbeetle:debug .
+      - run: docker push ghcr.io/coilhq/tigerbeetle:debug

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,4 +82,4 @@ jobs:
           tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
           labels: ${{ steps.meta.outputs.labels }}
           target: release
-          platforms: linux/amd64,linux/arm6
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,7 +78,8 @@ jobs:
         with:
           build-args: |
             DEBUG=true
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
+          labels: ${{ steps.meta.outputs.labels }}
           target: release
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,6 +79,6 @@ jobs:
           build-args: |
             DEBUG=true
           push: ${{ github.event_name != 'pull_request' }}
-          tags: debug
+          tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
           target: release
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,3 +54,31 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           target: release
           platforms: linux/amd64,linux/arm64
+
+  build-and-push-debug:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            DEBUG=true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: debug
+          target: release
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,5 +73,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker build -t ghcr.io/coilhq/tigerbeetle:debug .
-      - run: docker push ghcr.io/coilhq/tigerbeetle:debug
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
+          labels: ${{ steps.meta.outputs.labels }}
+          target: release
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,4 +81,5 @@ jobs:
           tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
           labels: ${{ steps.meta.outputs.labels }}
           target: release
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            DEBUG=true
           tags: ghcr.io/${{ env.IMAGE_NAME }}:debug
           labels: ${{ steps.meta.outputs.labels }}
           target: release

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ preference.
 First provision TigerBeetle's data directory.
 
 ```bash
-$ docker run -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle \
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle \
     format --cluster=0 --replica=0 /data/0_0.tigerbeetle
 info(io): creating "0_0.tigerbeetle"...
 info(io): allocating 660.140625MiB...
@@ -33,7 +33,7 @@ info(io): allocating 660.140625MiB...
 Then run the server.
 
 ```bash
-$ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle \
+$ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle \
     start --addresses=0.0.0.0:3000 /data/0_0.tigerbeetle
 info(io): opening "0_0.tigerbeetle"...
 info(main): 0: cluster=0: listening on 0.0.0.0:3000

--- a/docs/setup/from-source.md
+++ b/docs/setup/from-source.md
@@ -40,7 +40,7 @@ CLI](../usage/node-cli).
 ## Debugging panics
 
 If TigerBeetle panics and you can reproduce the panic, you can get a
-better stacktrace by switching to a debug build.
+better stack trace by switching to a debug build.
 
 ```bash
 $ DEBUG=true scripts/install.sh

--- a/docs/setup/from-source.md
+++ b/docs/setup/from-source.md
@@ -35,3 +35,15 @@ info(main): 0: cluster=0: listening on 127.0.0.1:3000
 Now you can connect to the running server with any client. For a quick
 start, try [creating accounts and transfers in the Node
 CLI](../usage/node-cli).
+
+
+## Debugging panics
+
+If TigerBeetle panics and you can reproduce the panic, you can get a
+better stacktrace by switching to a debug build.
+
+```bash
+$ DEBUG=true scripts/install.sh
+```
+
+And then running the server again.

--- a/docs/setup/with-docker-compose.md
+++ b/docs/setup/with-docker-compose.md
@@ -3,9 +3,9 @@
 First, provision the data file for each node:
 
 ```
-$ docker run -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle format --cluster=0 --replica=0 /data/0_0.tigerbeetle
-$ docker run -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle format --cluster=0 --replica=1 /data/0_1.tigerbeetle
-$ docker run -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle format --cluster=0 --replica=2 /data/0_2.tigerbeetle
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=0 /data/0_0.tigerbeetle
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=1 /data/0_1.tigerbeetle
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=2 /data/0_2.tigerbeetle
 ```
 
 Then create a docker-compose.yml file:
@@ -29,24 +29,21 @@ version: "3.7"
 
 services:
   tigerbeetle_0:
-    container_name: tigerbeetle_0
-    image: ghcr.io/coilhq/tigerbeetle
+    image: ghcr.io/tigerbeetledb/tigerbeetle
     command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_0.tigerbeetle"
     network_mode: host
     volumes:
       - ./data:/data
 
   tigerbeetle_1:
-    container_name: tigerbeetle_1
-    image: ghcr.io/coilhq/tigerbeetle
+    image: ghcr.io/tigerbeetledb/tigerbeetle
     command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_1.tigerbeetle"
     network_mode: host
     volumes:
       - ./data:/data
 
   tigerbeetle_2:
-    container_name: tigerbeetle_2
-    image: ghcr.io/coilhq/tigerbeetle
+    image: ghcr.io/tigerbeetledb/tigerbeetle
     command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_2.tigerbeetle"
     network_mode: host
     volumes:
@@ -85,3 +82,13 @@ tigerbeetle_1    | info(clock): 1: system time is 78ns ahead
 Now you can connect to the running server with any client. For a quick
 start, try [creating accounts and transfers in the Node
 CLI](../usage/node-cli).
+
+## Debugging panics
+
+If TigerBeetle panics and you can reproduce the panic, you can get a
+better stacktrace by switching to a debug image (by using the `:debug`
+Docker image tag).
+
+```bash
+ghcr.io/tigerbeetledb/tigerbeetle:debug
+```

--- a/docs/setup/with-docker-compose.md
+++ b/docs/setup/with-docker-compose.md
@@ -86,7 +86,7 @@ CLI](../usage/node-cli).
 ## Debugging panics
 
 If TigerBeetle panics and you can reproduce the panic, you can get a
-better stacktrace by switching to a debug image (by using the `:debug`
+better stack trace by switching to a debug image (by using the `:debug`
 Docker image tag).
 
 ```bash

--- a/docs/setup/with-docker.md
+++ b/docs/setup/with-docker.md
@@ -29,7 +29,7 @@ CLI](../usage/node-cli).
 ## Debugging panics
 
 If TigerBeetle panics and you can reproduce the panic, you can get a
-better stacktrace by switching to a debug image (by using the `:debug`
+better stack trace by switching to a debug image (by using the `:debug`
 Docker image tag).
 
 ```bash

--- a/docs/setup/with-docker.md
+++ b/docs/setup/with-docker.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 First provision TigerBeetle's data directory.
 
 ```bash
-$ docker run -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle \
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle \
     format --cluster=0 --replica=0 /data/0_0.tigerbeetle
 info(io): creating "0_0.tigerbeetle"...
 info(io): allocating 660.140625MiB...
@@ -16,7 +16,7 @@ info(io): allocating 660.140625MiB...
 Then run the server.
 
 ```bash
-$ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/coilhq/tigerbeetle \
+$ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle \
     start --addresses=0.0.0.0:3000 /data/0_0.tigerbeetle
 info(io): opening "0_0.tigerbeetle"...
 info(main): 0: cluster=0: listening on 0.0.0.0:3000
@@ -25,3 +25,14 @@ info(main): 0: cluster=0: listening on 0.0.0.0:3000
 Now you can connect to the running server with any client. For a quick
 start, try [creating accounts and transfers in the Node
 CLI](../usage/node-cli).
+
+## Debugging panics
+
+If TigerBeetle panics and you can reproduce the panic, you can get a
+better stacktrace by switching to a debug image (by using the `:debug`
+Docker image tag).
+
+```bash
+$ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle:debug \
+    start --addresses=0.0.0.0:3000 /data/0_0.tigerbeetle
+```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,10 +8,11 @@ fi
 set -eEuo pipefail
 
 scripts/install_zig.sh
-echo "Building TigerBeetle..."
 if [[ "$debug" == "true" ]]; then
+    echo "Building Tigerbeetle debug..."
     zig/zig build -Dcpu=baseline
 else
+    echo "Building TigerBeetle..."
     zig/zig build -Dcpu=baseline -Drelease-safe
 fi
 mv zig-out/bin/tigerbeetle .

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,5 +3,9 @@ set -eEuo pipefail
 
 scripts/install_zig.sh
 echo "Building TigerBeetle..."
-zig/zig build -Dcpu=baseline -Drelease-safe
+if [[ "$DEBUG" == "true" ]]; then
+    zig/zig build -Dcpu=baseline -Drelease-safe
+else
+    zig/zig build -Dcpu=baseline
+fi
 mv zig-out/bin/tigerbeetle .

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
+
+debug="$DEBUG"
+if [[ "$1" == "--debug" ]]; then
+    debug="true"
+fi
+
 set -eEuo pipefail
 
 scripts/install_zig.sh
 echo "Building TigerBeetle..."
-if [[ "$DEBUG" == "true" ]]; then
+if [[ "$debug" == "true" ]]; then
     zig/zig build -Dcpu=baseline -Drelease-safe
 else
     zig/zig build -Dcpu=baseline

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,8 +10,8 @@ set -eEuo pipefail
 scripts/install_zig.sh
 echo "Building TigerBeetle..."
 if [[ "$debug" == "true" ]]; then
-    zig/zig build -Dcpu=baseline -Drelease-safe
-else
     zig/zig build -Dcpu=baseline
+else
+    zig/zig build -Dcpu=baseline -Drelease-safe
 fi
 mv zig-out/bin/tigerbeetle .


### PR DESCRIPTION
When you get a panic in a docker environment right now it's not easy to switch to a debug image to get a better stack trace.

So the idea here is to have a docker image like :latest but with the debug flag on. So `docker run ghcr.io/tigerbeetledb/tigerbeetle:debug`