### PR TITLE
LSM: fixing Compaction interactions with iterators

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -85,7 +85,7 @@ pub fn CompactionType(
         );
 
         const MergeStreamSelector = struct {
-            fn peek(compaction: *const Compaction, stream_id: u32) error{Empty, Buffering}!Key {
+            fn peek(compaction: *const Compaction, stream_id: u32) error{Empty, Drained}!Key {
                 return switch (stream_id) {
                     0 => compaction.iterator_a.peek(),
                     1 => compaction.iterator_b.peek(),
@@ -504,7 +504,7 @@ pub fn CompactionType(
             const stream_empty = struct {
                 fn empty(it: anytype) bool {
                     _ = it.peek() catch |err| switch (err) {
-                        error.Buffering => {},
+                        error.Drained => {},
                         error.Empty => {
                             assert(it.buffered_all_values());
                             return true;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -333,14 +333,28 @@ pub fn CompactionType(
             compaction.io_start();
             defer compaction.io_finish();
 
-            // Start reading blocks from the iterator to merge them.
-            if (compaction.iterator_a.tick()) compaction.io_start();
-            if (compaction.iterator_b.tick()) compaction.io_start();
+            // Start reading blocks from the iterators to merge them.
+            compaction.io_read_start(&compaction.iterator_a);
+            compaction.io_read_start(&compaction.iterator_b);
 
             // Start writing blocks prepared by the merge iterator from a previous compact_tick().
             compaction.io_write_start(.data);
             compaction.io_write_start(.filter);
             compaction.io_write_start(.index);
+        }
+
+        fn io_read_start(compaction: *Compaction, iterator: anytype) void {
+            switch (@TypeOf(iterator.*)) {
+                IteratorA => assert(iterator == &compaction.iterator_a),
+                IteratorB => assert(iterator == &compaction.iterator_b),
+                else => unreachable,
+            }
+            
+            // Generate the IO for the iterator before-hand as tick() could complete inline before 
+            // returning true/false causing io_finish() to be called prematurely by the callbacks
+            // setup in start(). If tick() does no I/O, we cancel this premature io_start()
+            compaction.io_start();
+            if (!iterator.tick()) compaction.io_finish();
         }
 
         const BlockWriteField = enum { data, filter, index };

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -403,7 +403,7 @@ pub fn GridType(comptime Storage: type) type {
             // from the cache on the next tick. This keeps start_read() asynchronous.
             // Note that this must be called after we have checked for an in
             // progress read targeting the same address.
-            if (grid.cache.get(read.address) != null) {
+            if (grid.cache.exists(read.address)) {
                 grid.read_cached_queue.push(read);
                 return;
             }

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -130,10 +130,15 @@ pub fn GridType(comptime Storage: type) type {
         write_iops: IOPS(WriteIOP, write_iops_max) = .{},
         write_queue: FIFO(Write) = .{},
 
+        /// `read_iops` maintains a list of ReadIOPs currently performing 
+        /// storage.read_sector() on a unique address. Reads with the same address are coalesced
+        /// to be resolved by the same ReadIOP if they're submitted by `start_read()` or 
+        /// already queued in `read_queue`. 
         read_iops: IOPS(ReadIOP, read_iops_max) = .{},
         read_queue: FIFO(Read) = .{},
 
-        // Reads that were found to be in the cache on start_read().
+        /// Reads that were found to be in the cache on start_read() and queued to be resolved on
+        /// the next tick(). This keeps read_block() always asynchronous to the caller.
         read_cached_queue: FIFO(Read) = .{},
         // TODO interrogate this list and do recovery in Replica.tick().
         read_recovery_queue: FIFO(Read) = .{},

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -14,7 +14,10 @@ pub fn KWayMergeIterator(
     comptime k_max: u32,
     /// Peek the next key in the stream identified by stream_index.
     /// For example, peek(stream_index=2) returns user_streams[2][0].
-    comptime stream_peek: fn (context: *const Context, stream_index: u32) error{Empty, Pending}!Key,
+    comptime stream_peek: fn (
+        context: *const Context,
+        stream_index: u32,
+    ) error{Empty, Buffering}!Key,
     comptime stream_pop: fn (context: *Context, stream_index: u32) Value,
     /// Returns true if stream A has higher precedence than stream B.
     /// This is used to deduplicate values across streams.
@@ -106,7 +109,7 @@ pub fn KWayMergeIterator(
                 it.keys[0] = key;
                 it.down_heap();
             } else |err| switch (err) {
-                error.Pending => return null,
+                error.Buffering => return null,
                 error.Empty => {
                     it.swap(0, it.k - 1);
                     it.k -= 1;
@@ -213,7 +216,7 @@ fn TestContext(comptime k_max: u32) type {
             return math.order(a, b);
         }
 
-        fn stream_peek(context: *const Self, stream_index: u32) error{Empty, Pending}!u32 {
+        fn stream_peek(context: *const Self, stream_index: u32) error{Empty, Buffering}!u32 {
             const stream = context.streams[stream_index];
             if (stream.len == 0) return error.Empty;
             return stream[0].key;

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -17,7 +17,7 @@ pub fn KWayMergeIterator(
     comptime stream_peek: fn (
         context: *const Context,
         stream_index: u32,
-    ) error{Empty, Buffering}!Key,
+    ) error{Empty, Drained}!Key,
     comptime stream_pop: fn (context: *Context, stream_index: u32) Value,
     /// Returns true if stream A has higher precedence than stream B.
     /// This is used to deduplicate values across streams.
@@ -69,7 +69,7 @@ pub fn KWayMergeIterator(
                 it.keys[it.k] = stream_peek(context, stream_index) catch |err| switch (err) {
                     // On initialization, the streams should either have data already 
                     // buffered up to peek or be empty and have no more values to produce.
-                    error.Buffering => unreachable,
+                    error.Drained => unreachable,
                     error.Empty => continue,
                 };
                 it.streams[it.k] = stream_index;
@@ -108,7 +108,7 @@ pub fn KWayMergeIterator(
 
                 const root = it.streams[0];
                 const key = stream_peek(it.context, root) catch |err| switch (err) {
-                    error.Buffering => return null,
+                    error.Drained => return null,
                     error.Empty => {
                         it.swap(0, it.k - 1);
                         it.k -= 1;
@@ -219,8 +219,8 @@ fn TestContext(comptime k_max: u32) type {
             return math.order(a, b);
         }
 
-        fn stream_peek(context: *const Self, stream_index: u32) error{Empty, Buffering}!u32 {
-            // TODO: test for Buffering somehow as well
+        fn stream_peek(context: *const Self, stream_index: u32) error{Empty, Drained}!u32 {
+            // TODO: test for Drained somehow as well
             const stream = context.streams[stream_index];
             if (stream.len == 0) return error.Empty;
             return stream[0].key;

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -103,26 +103,24 @@ pub fn KWayMergeIterator(
         }
 
         fn pop_internal(it: *Self) ?Value {
-            while (true) {
-                if (it.k == 0) return null;
+            if (it.k == 0) return null;
 
-                const root = it.streams[0];
-                const value = stream_pop(it.context, root);
+            const root = it.streams[0];
+            const value = stream_pop(it.context, root);
 
-                if (stream_peek(it.context, root)) |key| {
-                    it.keys[0] = key;
+            if (stream_peek(it.context, root)) |key| {
+                it.keys[0] = key;
+                it.down_heap();
+            } else |err| switch (err) {
+                error.Drained => {},
+                error.Empty => {
+                    it.swap(0, it.k - 1);
+                    it.k -= 1;
                     it.down_heap();
-                } else |err| switch (err) {
-                    error.Drained => {},
-                    error.Empty => {
-                        it.swap(0, it.k - 1);
-                        it.k -= 1;
-                        it.down_heap();
-                    },
-                }
-
-                return value;
+                },
             }
+
+            return value;
         }
 
         fn up_heap(it: *Self, start: u32) void {

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -107,19 +107,21 @@ pub fn KWayMergeIterator(
                 if (it.k == 0) return null;
 
                 const root = it.streams[0];
-                const key = stream_peek(it.context, root) catch |err| switch (err) {
-                    error.Drained => return null,
+                const value = stream_pop(it.context, root);
+
+                if (stream_peek(it.context, root)) |key| {
+                    it.keys[0] = key;
+                    it.down_heap();
+                } else |err| switch (err) {
+                    error.Drained => {},
                     error.Empty => {
                         it.swap(0, it.k - 1);
                         it.k -= 1;
                         it.down_heap();
-                        continue;
                     },
-                };
+                }
 
-                it.keys[0] = key;
-                it.down_heap();
-                return stream_pop(it.context, root);
+                return value;
             }
         }
 

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -287,14 +287,14 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
             if (it.values.head_ptr_const()) |value| return key_from_value(value);
 
             const scope = it.tables.head_ptr_const() orelse {
-                // NOTE: Even if there are no values to peek, some may be unbuffered.
+                // Even if there are no values available to peek, some may be unbuffered.
                 // We call buffered_all_values() to distinguish between the iterator
-                // being empty and needing to tic() to refill values.
+                // being empty and needing to tick() to refill values.
                 if (!it.buffered_all_values()) return error.Drained;
                 return error.Empty;
             };
 
-            return scope.table_iterator.peek() catch unreachable;
+            return scope.table_iterator.peek();
         }
 
         /// This may only be called after peek() has returned non-null.

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -281,16 +281,16 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
         /// Returns either:
         /// - the next Key, if available.
         /// - error.Empty when there are no values remaining to iterate.
-        /// - error.Buffering when the iterator isn't empty, but the values 
+        /// - error.Drained when the iterator isn't empty, but the values 
         ///   still need to be buffered into memory via tick().
-        pub fn peek(it: LevelIterator) error{Empty, Buffering}!Key {
+        pub fn peek(it: LevelIterator) error{Empty, Drained}!Key {
             if (it.values.head_ptr_const()) |value| return key_from_value(value);
 
             const scope = it.tables.head_ptr_const() orelse {
                 // NOTE: Even if there are no values to peek, some may be unbuffered.
                 // We call buffered_all_values() to distinguish between the iterator
                 // being empty and needing to tic() to refill values.
-                if (!it.buffered_all_values()) return error.Buffering;
+                if (!it.buffered_all_values()) return error.Drained;
                 return error.Empty;
             };
 
@@ -306,7 +306,7 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
 
             _ = table_iterator.peek() catch |err| switch (err) {
                 error.Empty => it.tables.advance_head(),
-                error.Buffering => {},
+                error.Drained => {},
             };
 
             return value;

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -214,7 +214,7 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
                 const table = &it.tables.head_ptr().?.table_iterator;
                 while (true) {
                     _ = table.peek() catch break;
-                    it.values.push(table.pop()) catch unreachable;
+                    it.values.push_assume_capacity(table.pop());
                 }
                 it.tables.advance_head();
             }

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -297,7 +297,7 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
             return scope.table_iterator.peek();
         }
 
-        /// This may only be called after peek() has returned non-null.
+        /// This may only be called after peek() returns a Key (and not Empty or Drained)
         pub fn pop(it: *LevelIterator) Value {
             if (it.values.pop()) |value| return value;
 

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -281,7 +281,11 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
             if (it.values.head_ptr_const()) |value| return key_from_value(value);
 
             const scope = it.tables.head_ptr_const() orelse {
-                assert(it.buffered_all_values());
+                // NOTE No values to peek may still mean some are unbuffered.
+                // The caller should use buffered_all_values() to distinguish between 
+                // the iterator being empty and having to tick() to refill values.
+                //
+                // assert(it.buffered_all_values());
                 return null;
             };
             return scope.table_iterator.peek().?;

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -278,13 +278,18 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
                 it.buffered_value_count() >= Table.data.value_count_max;
         }
 
+        /// Returns either:
+        /// - the next Key, if available.
+        /// - error.Empty when there are no values remaining to iterate.
+        /// - error.Buffering when the iterator isn't empty, but the values 
+        ///   still need to be buffered into memory via tick().
         pub fn peek(it: LevelIterator) error{Empty, Buffering}!Key {
             if (it.values.head_ptr_const()) |value| return key_from_value(value);
 
             const scope = it.tables.head_ptr_const() orelse {
-                // NOTE No values to peek may still mean some are unbuffered.
-                // We use buffered_all_values() to distinguish between 
-                // the iterator being empty and having to tick() to refill values.
+                // NOTE: Even if there are no values to peek, some may be unbuffered.
+                // We call buffered_all_values() to distinguish between the iterator
+                // being empty and needing to tic() to refill values.
                 if (!it.buffered_all_values()) return error.Buffering;
                 return error.Empty;
             };

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -188,7 +188,8 @@ pub fn SetAssociativeCache(
             mem.set(u64, self.clocks.words, 0);
         }
 
-        /// Checks if a key exists without bumping up its counts value.
+        /// Returns whether an entry with the given key is cached, 
+        /// without modifying the entry's counter.
         pub fn exists(self: *Self, key: Key) bool {
             const set = self.associate(key);
             return self.search(set, key) != null;

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -188,6 +188,12 @@ pub fn SetAssociativeCache(
             mem.set(u64, self.clocks.words, 0);
         }
 
+        /// Checks if a key exists without bumping up its counts value.
+        pub fn exists(self: *Self, key: Key) bool {
+            const set = self.associate(key);
+            return self.search(set, key) != null;
+        }
+
         pub fn get(self: *Self, key: Key) ?*align(value_alignment) Value {
             const set = self.associate(key);
             const way = self.search(set, key) orelse return null;

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -187,7 +187,8 @@ pub fn TableImmutableIteratorType(comptime Table: type, comptime Storage: type) 
             return true; // All values are "buffered" in memory.
         }
 
-        pub fn peek(it: *const TableImmutableIterator) error{Empty, Buffering}!Table.Key {
+        pub fn peek(it: *const TableImmutableIterator) error{Empty, Drained}!Table.Key {
+            // NOTE: This iterator is never Drained as all values are in memory (tick is a no-op).
             assert(!it.table.free);
             if (it.values_index == it.table.values.len) return error.Empty;
             return Table.key_from_value(&it.table.values[it.values_index]);

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -187,9 +187,9 @@ pub fn TableImmutableIteratorType(comptime Table: type, comptime Storage: type) 
             return true; // All values are "buffered" in memory.
         }
 
-        pub fn peek(it: *const TableImmutableIterator) ?Table.Key {
+        pub fn peek(it: *const TableImmutableIterator) error{Empty, Buffering}!Table.Key {
             assert(!it.table.free);
-            if (it.values_index == it.table.values.len) return null;
+            if (it.values_index == it.table.values.len) return error.Empty;
             return Table.key_from_value(&it.table.values[it.values_index]);
         }
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -262,9 +262,9 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
         /// Returns either:
         /// - the next Key, if available.
         /// - error.Empty when there are no values remaining to iterate.
-        /// - error.Buffering when the iterator isn't empty, but the values 
+        /// - error.Drained when the iterator isn't empty, but the values 
         ///   still need to be buffered into memory via tick().
-        pub fn peek(it: TableIterator) error{Empty, Buffering}!Table.Key {
+        pub fn peek(it: TableIterator) error{Empty, Drained}!Table.Key {
             assert(!it.read_pending);
             assert(!it.read_table_index);
 
@@ -274,7 +274,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
                 // NOTE: Even if there are no values to peek, some may be unbuffered.
                 // We call buffered_all_values() to distinguish between the iterator
                 // being empty and needing to tic() to refill values.
-                if (!it.buffered_all_values()) return error.Buffering;
+                if (!it.buffered_all_values()) return error.Drained;
                 return error.Empty;
             };
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -282,7 +282,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
             return Table.key_from_value(&values[it.value]);
         }
 
-        /// This is only safe to call after peek() has returned non-null.
+        /// This may only be called after peek() returns a Key (and not Empty or Drained)
         pub fn pop(it: *TableIterator) Table.Value {
             assert(!it.read_pending);
             assert(!it.read_table_index);

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -262,7 +262,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
         /// Returns either:
         /// - the next Key, if available.
         /// - error.Empty when there are no values remaining to iterate.
-        /// - error.Drained when the iterator isn't empty, but the values 
+        /// - error.Drained when the iterator isn't empty, but some values 
         ///   still need to be buffered into memory via tick().
         pub fn peek(it: TableIterator) error{Empty, Drained}!Table.Key {
             assert(!it.read_pending);


### PR DESCRIPTION
### MergeIterator stream_peek()

There are times when `peek()` on the `TableIterator` (and transitively, the `LevelIterator`) will return null without being empty. This happens if it runs out of values buffered in memory and needs to tick() again. Unfortunately, the `MergeIterato`r currently assumes that `peek()` returning null means the iterator is completed and stops accessing it / removes it from its heap data structure.

`MergeIterator.stream_peek()` now can return a third state of Pending which means that, on the given iterator being merged, `peek()` would return null but `buffered_all_values()` would return false. This ensures iterators are accessed until they are truly empty.

### Compaction iterator IO tracking

There was a bug in the order IO was tracked during Compaction. `tick()` would be called on an iterator which would initiate IO on the Grid. The Grid would service the IO from the cache and complete it inline. This bubbles up and calls `Compaction.io_finish()` early. `tick()` returns true that IO started and does `Compaction.io_start()` but it was too late.

A fix is to do `Compaction.io_start()` before calling `tick()`. If it returns true, `io_finish()` will be called either inline or eventually. If it returns false, Compaction calls `io_finish()` itself to cancel it out.

### Manifest invisible table iterator issues

One of the last issues is that `assert_no_invisible_tables()` is being hit at a checkpoint(). When the even/odd compactions complete, they end up calling `remove_invisible_tables` for their level, which all happens before the checkpoint. It seems as though some invisible tables still remain according to the ManifestLevels.

Changing `remove_invisible_tables` to iterate all levels and not use the KeyRange as a hint seems to address this for `lsm/test.zig` but it's still an issue in the rafiki tests. Other attempts (to no luck in rafiki) include re-creating the iterator in a loop to get the next table to mitigate the possibility of invalidation by removal, and removing from all levels at the end of the fourth beat instead of when Compactions are done.

This bug is left unresolved in this PR until a good fix can be found, but the other changes are still worth getting merged in the mean time.