### PR TITLE
LSM: Fix: Remove invisible tables promptly

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -63,10 +63,10 @@
 //!      T₃ I         $────                   ⎤
 //!      T₄  O        $    ?───────────────── ⎦
 //!                            ┅┅┅┅
-//!      T₄ I             $?───────·········· ⎤  In this compaction, T₃ was untouched by the
-//!      T₅  O            $        ·········· ⎦  previous compaction (ops 12…15), so its snapshots
-//!      T₄ I             $────────           ⎤  cover a wider interval.
-//!      T₅  O            $        ?───────── ⎦
+//!      T₄ I              ?──$────·········· ⎤  In this compaction, T₃ was untouched by the
+//!      T₅  O                $    ·········· ⎦  previous compaction (ops 12…15), so its snapshots
+//!      T₄ I              ───$────           ⎤  cover a wider interval.
+//!      T₅  O                $    ?───────── ⎦
 //!                                ┅┅┅┅
 //!      T₅ I                     $?───······ ⎤  During compaction, prefetch() queries the old input
 //!      T₆  O                    $    ······ ⎦  tables until the compaction half-measure completes.


### PR DESCRIPTION
Fix this crash:

    src/lsm/manifest.zig:327:23: 0x45d2be in lsm.manifest.ManifestType(lsm.table.TableType(u128,lsm.groove.IdTreeValue,lsm.groove.IdTreeValue.compare_keys,lsm.groove.IdTreeValue.key_from_value,554112867134706473364364839029663282043,lsm.groove.IdTreeValue.tombstone,lsm.groove.IdTreeValue.tombstone_from_key),test.storage.Storage).assert_no_invisible_tables (simulator)
                    assert(it.next() == null);
                          ^
    src/lsm/tree.zig:988:57: 0x436bff in lsm.tree.TreeType(lsm.table.TableType(u128,lsm.groove.IdTreeValue,lsm.groove.IdTreeValue.compare_keys,lsm.groove.IdTreeValue.key_from_value,554112867134706473364364839029663282043,lsm.groove.IdTreeValue.tombstone,lsm.groove.IdTreeValue.tombstone_from_key),test.storage.Storage,[]const u8{65,99,99,111,117,110,116,46,105,100}).checkpoint (simulator)
                    tree.manifest.assert_no_invisible_tables(snapshot);
                                                            ^
    src/lsm/groove.zig:956:34: 0x41764b in lsm.groove.GrooveType(test.storage.Storage,tigerbeetle.Account,(struct state_machine.struct:33:14 constant)).checkpoint (simulator)
                groove.ids.checkpoint(Join.tree_callback(.ids));
                                     ^

In other words, at checkpoint, there are invisible tables (which are supposed to have been cleaned up already).

The problem is twofold:

1. We only remove invisible tables from level B after a compaction. Rather than waiting for them to be cleaned up by a future compaction, we can clean them up more efficiently if we do so immediately — we know their key range, so we don't have to iterate through the full manifest level. Also, from a "compaction is deterministic" point of view, it makes more sense to clean them up as soon as possible.

2. `Tree.compact_done` calls `manifest.remove_invisible_tables()` with `compaction.snapshot`, instead of (the just-updated) `prefetch_snapshot_max` which is farther ahead.

Other changes:

- Fix the compaction snapshot diagram, which incorrectly depicted the `compaction.snapshot` during the `T₄ → T₅` compaction.
- Add an additional assert to `Manifest.remove_invisible_tables()`. When `config.verify` is set, check that there are no invisible tables left. This may be too strong if we change how `remove_invisible_tables` is used, but for the current caller it should act as an earlier verification (so we don't have to wait until checkpoint if invisible tables are missed).
- Clarify comments in `Tree.compact_done`. Saying that invisible tables are "created" during compaction is misleading — the tables already existed, we just modified their snapshot to make them invisible.

Context: https://github.com/tigerbeetledb/tigerbeetle/pull/177 "Manifest invisible table iterator issues"