### PR TITLE
Test/review segmented array

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -146,4 +146,18 @@ pub fn build(b: *std.build.Builder) void {
         const run_step = b.step("lsm_forest_fuzz", "Fuzz the LSM forest. Args: [--seed <seed>]");
         run_step.dependOn(&run_cmd.step);
     }
+
+    {
+        const lsm_segmented_array_fuzz = b.addExecutable("lsm_segmented_array_fuzz", "src/lsm/segmented_array_fuzz.zig");
+        lsm_segmented_array_fuzz.setMainPkgPath("src");
+        lsm_segmented_array_fuzz.setTarget(target);
+        lsm_segmented_array_fuzz.setBuildMode(mode);
+
+        const run_cmd = lsm_segmented_array_fuzz.run();
+        run_cmd.step.dependOn(b.getInstallStep());
+        if (b.args) |args| run_cmd.addArgs(args);
+
+        const run_step = b.step("lsm_segmented_array_fuzz", "Fuzz the LSM segmented array. Args: [--seed <seed>]");
+        run_step.dependOn(&run_cmd.step);
+    }
 }

--- a/src/benchmark_array_search.zig
+++ b/src/benchmark_array_search.zig
@@ -105,7 +105,7 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: *std.rand.Random) 
             const target = value_picker[v % value_picker.len];
             const page = &pages[page_index];
             const bounds = Eytzinger.search_values(K, V, V.key_compare, &page.keys, &page.values, target);
-            const hit = bounds[binary_search(K, V, V.key_from_value, V.key_compare, bounds, target)];
+            const hit = bounds[binary_search(K, V, V.key_from_value, V.key_compare, bounds, target, .{})];
 
             assert(hit.key == target);
             if (i % pages.len == 0) v += 1;
@@ -136,7 +136,7 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: *std.rand.Random) 
         while (i < layout.searches) : (i += 1) {
             const target = value_picker[v % value_picker.len];
             const page = &pages[page_picker[i % page_picker.len]];
-            const hit = page.values[binary_search(K, V, V.key_from_value, V.key_compare, page.values[0..], target)];
+            const hit = page.values[binary_search(K, V, V.key_from_value, V.key_compare, page.values[0..], target, .{})];
 
             assert(hit.key == target);
             if (i % pages.len == 0) v += 1;
@@ -307,7 +307,7 @@ fn binary_search_keys(
     assert(keys.len == layout.keys_count);
     assert(values.len == layout.values_count);
 
-    const key_index = binary_search(Key, Key, V.key_from_key, compare_keys, keys, key);
+    const key_index = binary_search(Key, Key, V.key_from_key, compare_keys, keys, key, .{});
     const key_stride = layout.values_count / layout.keys_count;
     const high = key_index * key_stride;
     if (key_index < keys.len and keys[key_index] == key) {

--- a/src/eytzinger_benchmark.zig
+++ b/src/eytzinger_benchmark.zig
@@ -105,7 +105,7 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: *std.rand.Random) 
             const target = value_picker[v % value_picker.len];
             const page = &pages[page_index];
             const bounds = Eytzinger.search_values(K, V, V.key_compare, &page.keys, &page.values, target);
-            const hit = bounds[binary_search(K, V, V.key_from_value, V.key_compare, bounds, target)];
+            const hit = bounds[binary_search(K, V, V.key_from_value, V.key_compare, bounds, target, .{})];
 
             assert(hit.key == target);
             if (i % pages.len == 0) v += 1;
@@ -136,7 +136,7 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: *std.rand.Random) 
         while (i < layout.searches) : (i += 1) {
             const target = value_picker[v % value_picker.len];
             const page = &pages[page_picker[i % page_picker.len]];
-            const hit = page.values[binary_search(K, V, V.key_from_value, V.key_compare, page.values[0..], target)];
+            const hit = page.values[binary_search(K, V, V.key_from_value, V.key_compare, page.values[0..], target, .{})];
 
             assert(hit.key == target);
             if (i % pages.len == 0) v += 1;
@@ -307,7 +307,7 @@ fn binary_search_keys(
     assert(keys.len == layout.keys_count);
     assert(values.len == layout.values_count);
 
-    const key_index = binary_search(Key, Key, V.key_from_key, compare_keys, keys, key);
+    const key_index = binary_search(Key, Key, V.key_from_key, compare_keys, keys, key, .{});
     const key_stride = layout.values_count / layout.keys_count;
     const high = key_index * key_stride;
     if (key_index < keys.len and keys[key_index] == key) {

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const math = std.math;
-const config = @import("../config.zig");
+
+pub const Config = struct {
+    verify: bool = false,
+};
 
 // TODO Add prefeching when @prefetch is available: https://github.com/ziglang/zig/issues/3600.
 //
@@ -23,6 +26,7 @@ pub fn binary_search_values_raw(
     comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
     values: []const Value,
     key: Key,
+    comptime config: Config,
 ) u32 {
     if (values.len == 0) return 0;
 
@@ -80,6 +84,7 @@ pub inline fn binary_search_keys_raw(
     comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
     keys: []const Key,
     key: Key,
+    comptime config: Config,
 ) u32 {
     return binary_search_values_raw(
         Key,
@@ -92,6 +97,7 @@ pub inline fn binary_search_keys_raw(
         compare_keys,
         keys,
         key,
+        config,
     );
 }
 
@@ -107,8 +113,9 @@ pub inline fn binary_search_values(
     comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
     values: []const Value,
     key: Key,
+    comptime config: Config,
 ) BinarySearchResult {
-    const index = binary_search_values_raw(Key, Value, key_from_value, compare_keys, values, key);
+    const index = binary_search_values_raw(Key, Value, key_from_value, compare_keys, values, key, config);
     return .{
         .index = index,
         .exact = index < values.len and compare_keys(key_from_value(&values[index]), key) == .eq,
@@ -120,8 +127,9 @@ pub inline fn binary_search_keys(
     comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
     keys: []const Key,
     key: Key,
+    comptime config: Config,
 ) BinarySearchResult {
-    const index = binary_search_keys_raw(Key, compare_keys, keys, key);
+    const index = binary_search_keys_raw(Key, compare_keys, keys, key, config);
     return .{
         .index = index,
         .exact = index < keys.len and compare_keys(keys[index], key) == .eq,
@@ -175,6 +183,7 @@ const test_binary_search = struct {
                 compare_keys,
                 keys,
                 target_key,
+                .{ .verify = true },
             );
 
             if (log) std.debug.print("expected: {}, actual: {}\n", .{ expect, actual });
@@ -203,6 +212,7 @@ const test_binary_search = struct {
                 compare_keys,
                 keys,
                 target_key,
+                .{ .verify = true },
             );
             try std.testing.expectEqual(expect.index, actual.index);
             try std.testing.expectEqual(expect.exact, actual.exact);
@@ -239,6 +249,7 @@ const test_binary_search = struct {
             compare_keys,
             keys,
             target_key,
+            .{ .verify = true },
         );
 
         if (log) std.debug.print("expected: {}, actual: {}\n", .{ expect, actual });

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -82,9 +82,10 @@ pub fn ManifestLevelType(
                 }
             }.key_from_value,
             compare_keys,
+            .{},
         );
 
-        pub const Tables = SegmentedArray(TableInfo, NodePool, table_count_max);
+        pub const Tables = SegmentedArray(TableInfo, NodePool, table_count_max, .{});
 
         // These two segmented arrays are parallel. That is, the absolute indexes of maximum key
         // and corresponding TableInfo are the same. However, the number of nodes, node index, and
@@ -582,6 +583,7 @@ pub fn TestContext(
                     compare_keys,
                     context.reference.items,
                     table.key_max,
+                    .{},
                 );
                 // Can't be equal as the tables may not overlap
                 if (index < context.reference.items.len) {
@@ -607,6 +609,7 @@ pub fn TestContext(
                 compare_keys,
                 context.reference.items,
                 new_key_min,
+                .{},
             );
 
             if (i > 0) {

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -94,6 +94,7 @@ pub fn main() !void {
                     return std.math.order(a, b);
                 }
             }.compare_keys,
+            .{ .verify = false },
         );
 
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/src/lsm/segmented_array_fuzz.zig
+++ b/src/lsm/segmented_array_fuzz.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+
+const fuzz = @import("../test/fuzz.zig");
+const segmented_array = @import("segmented_array.zig");
+
+pub fn main() !void {
+    const fuzz_args = try fuzz.parse_fuzz_args(std.testing.allocator);
+    try segmented_array.run_tests(fuzz_args.seed, .{ .verify = true });
+}

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -841,6 +841,7 @@ pub fn TableType(
                 compare_keys,
                 Table.index_data_keys_used(index_block),
                 key,
+                .{},
             );
             assert(data_block_index < index_data_blocks_used(index_block));
             return data_block_index;
@@ -927,6 +928,7 @@ pub fn TableType(
                 compare_keys,
                 values,
                 key,
+                .{},
             );
             if (result.exact) {
                 const value = &values[result.index];

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -124,6 +124,7 @@ pub fn TableImmutableType(comptime Table: type) type {
                 compare_keys,
                 table.values,
                 key,
+                .{},
             );
             if (result.exact) {
                 const value = &table.values[result.index];

--- a/src/test/fuzz.zig
+++ b/src/test/fuzz.zig
@@ -2,6 +2,9 @@
 
 const std = @import("std");
 const assert = std.debug.assert;
+const mem = std.mem;
+
+const log = std.log.scoped(.fuzz);
 
 /// Returns an integer of type `T` with an exponential distribution of rate `avg`.
 /// Note: If you specify a very high rate then `std.math.maxInt(T)` may be over-represented.
@@ -44,4 +47,62 @@ pub fn random_enum(
         if (choice < 0) return @intToEnum(Enum, enum_field.value);
     }
     unreachable;
+}
+
+pub const FuzzArgs = struct {
+    seed: u64,
+};
+
+/// Parse common command-line arguments to fuzzers:
+///
+///    [--seed u64]
+///        Sets the seed used for the random number generator.
+pub fn parse_fuzz_args(allocator: mem.Allocator) !FuzzArgs {
+    var seed: ?u64 = null;
+
+    var args = std.process.args();
+
+    // Discard executable name.
+    allocator.free(try args.next(allocator).?);
+
+    while (args.next(allocator)) |arg_or_err| {
+        const arg = try arg_or_err;
+        defer allocator.free(arg);
+
+        if (std.mem.eql(u8, arg, "--seed")) {
+            const seed_string_or_err = args.next(allocator) orelse
+                std.debug.panic("Expected an argument to --seed", .{});
+            const seed_string = try seed_string_or_err;
+            defer allocator.free(seed_string);
+
+            if (seed != null) {
+                std.debug.panic("Received more than one \"--seed\"", .{});
+            }
+            seed = std.fmt.parseInt(u64, seed_string, 10) catch |err|
+                std.debug.panic(
+                "Could not parse \"{}\" as an integer seed: {}",
+                .{ std.zig.fmtEscapes(seed_string), err },
+            );
+        } else {
+            // When run with `--test-cmd`,
+            // `zig run` also passes the location of the zig binary as an extra arg.
+            // I don't know how to turn this off, so we just skip such args.
+            if (!std.mem.endsWith(u8, arg, "zig")) {
+                std.debug.panic("Unrecognized argument: \"{}\"", .{std.zig.fmtEscapes(arg)});
+            }
+        }
+    }
+
+    if (seed == null) {
+        // If no seed was given, use a random seed instead.
+        var buffer: [@sizeOf(u64)]u8 = undefined;
+        try std.os.getrandom(&buffer);
+        seed = @bitCast(u64, buffer);
+    }
+
+    log.info("Fuzz seed = {}", .{seed.?});
+
+    return FuzzArgs{
+        .seed = seed.?,
+    };
 }


### PR DESCRIPTION
* Add tests whose insert pattern let's us reach the worst case layout, and test insert/delete at the end of `array.nodes`.
* Remove some redundant branches and function calls.
* Add some extra asserts (eg for `@ptrCast` which does not check size/alignment).
* Simplify the implementation of `insert`.
* Add a `verify` function which documents and asserts the segmented_array invariants.
* Add a `verify` option to SegmentedArrayType. If true, call `array.verify` as pre- and post- condition for every public function.
* Add segmented_array_fuzz which runs the existing tests with a random seed.
* Move some common fuzzing code into test/fuzz.zig

No perf regressions.

On main (with config.verify = false):

```
[16:35:05] jamie@vessel /home/jamie/tigerbeetle
> zig build-exe src/lsm/segmented_array_benchmark.zig -OReleaseSafe
 --main-pkg-path src && sudo benchmark ./segmented_array_benchmark
cset: --> last message, executed args into cpuset "/user", new pid is: 10403
KeyType=u64 ValueCount=_____33 ValueSize=112B NodeSize=___256B LookupTime=____20ns
KeyType=u64 ValueCount=_____34 ValueSize=112B NodeSize=___256B LookupTime=____19ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___256B LookupTime=____89ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___512B LookupTime=___110ns
KeyType=u64 ValueCount=_____64 ValueSize=112B NodeSize=_16384B LookupTime=____17ns
KeyType=u64 ValueCount=____512 ValueSize=112B NodeSize=_16384B LookupTime=____27ns
KeyType=u64 ValueCount=___4096 ValueSize=112B NodeSize=_16384B LookupTime=___152ns
KeyType=u64 ValueCount=__32768 ValueSize=112B NodeSize=_16384B LookupTime=___263ns
KeyType=u64 ValueCount=_262144 ValueSize=112B NodeSize=_16384B LookupTime=___488ns
KeyType=u64 ValueCount=2097152 ValueSize=112B NodeSize=_16384B LookupTime=___987ns

 Performance counter stats for './segmented_array_benchmark':

                75      context-switches
                 0      cpu-migrations
           197,529      page-faults
    40,968,464,171      cpu_core/cpu-cycles/
   101,745,736,225      cpu_core/instructions/
    28,688,028,403      cpu_core/branches/
       243,094,945      cpu_core/branch-misses/
     1,781,177,231      cpu_core/cache-references/
     1,034,736,623      cpu_core/cache-misses/
    48,805,689,075      cpu_core/bus-cycles/
               175      raw_syscalls:sys_enter

      19.555169880 seconds time elapsed

      19.250530000 seconds user
       0.303992000 seconds sys


[16:36:39] jamie@vessel /home/jamie/tigerbeetle
> zig build-exe src/lsm/segmented_array_benchmark.zig -OReleaseSafe --main-pkg-path src && sudo benchmark ./segmented_array_benchmark
cset: --> last message, executed args into cpuset "/user", new pid is: 10447
KeyType=u64 ValueCount=_____33 ValueSize=112B NodeSize=___256B LookupTime=____20ns
KeyType=u64 ValueCount=_____34 ValueSize=112B NodeSize=___256B LookupTime=____19ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___256B LookupTime=____90ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___512B LookupTime=___110ns
KeyType=u64 ValueCount=_____64 ValueSize=112B NodeSize=_16384B LookupTime=____18ns
KeyType=u64 ValueCount=____512 ValueSize=112B NodeSize=_16384B LookupTime=____27ns
KeyType=u64 ValueCount=___4096 ValueSize=112B NodeSize=_16384B LookupTime=___152ns
KeyType=u64 ValueCount=__32768 ValueSize=112B NodeSize=_16384B LookupTime=___264ns
KeyType=u64 ValueCount=_262144 ValueSize=112B NodeSize=_16384B LookupTime=___488ns
KeyType=u64 ValueCount=2097152 ValueSize=112B NodeSize=_16384B LookupTime=___983ns

 Performance counter stats for './segmented_array_benchmark':

                93      context-switches
                 0      cpu-migrations
           197,529      page-faults
    40,946,693,969      cpu_core/cpu-cycles/
   101,746,258,341      cpu_core/instructions/
    28,688,130,575      cpu_core/branches/
       243,400,687      cpu_core/branch-misses/
     1,816,658,640      cpu_core/cache-references/
     1,021,026,768      cpu_core/cache-misses/
    48,779,455,725      cpu_core/bus-cycles/
               175      raw_syscalls:sys_enter

      19.545839347 seconds time elapsed

      19.240307000 seconds user
       0.303989000 seconds sys
```

On this branch:

```
[16:32:04] jamie@vessel /home/jamie/tigerbeetle
> zig build-exe src/lsm/segmented_array_benchmark.zig -OReleaseSafe --main-pkg-path src && sudo bench
mark ./segmented_array_benchmark
cset: --> last message, executed args into cpuset "/user", new pid is: 10075
KeyType=u64 ValueCount=_____33 ValueSize=112B NodeSize=___256B LookupTime=____20ns
KeyType=u64 ValueCount=_____34 ValueSize=112B NodeSize=___256B LookupTime=____20ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___256B LookupTime=____96ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___512B LookupTime=____74ns
KeyType=u64 ValueCount=_____64 ValueSize=112B NodeSize=_16384B LookupTime=____17ns
KeyType=u64 ValueCount=____512 ValueSize=112B NodeSize=_16384B LookupTime=____27ns
KeyType=u64 ValueCount=___4096 ValueSize=112B NodeSize=_16384B LookupTime=___155ns
KeyType=u64 ValueCount=__32768 ValueSize=112B NodeSize=_16384B LookupTime=___284ns
KeyType=u64 ValueCount=_262144 ValueSize=112B NodeSize=_16384B LookupTime=___502ns
KeyType=u64 ValueCount=2097152 ValueSize=112B NodeSize=_16384B LookupTime=___968ns

 Performance counter stats for './segmented_array_benchmark':

             4,385      context-switches
                 0      cpu-migrations
           197,491      page-faults
    40,547,470,292      cpu_core/cpu-cycles/
   101,786,888,922      cpu_core/instructions/
    28,694,719,721      cpu_core/branches/
       236,789,457      cpu_core/branch-misses/
     1,782,098,265      cpu_core/cache-references/
       991,949,040      cpu_core/cache-misses/
    48,326,923,970      cpu_core/bus-cycles/
               175      raw_syscalls:sys_enter

      19.617357773 seconds time elapsed

      19.025033000 seconds user
       0.342550000 seconds sys


[16:32:26] jamie@vessel /home/jamie/tigerbeetle
> zig build-exe src/lsm/segmented_array_benchmark.zig -OReleaseSafe --main-pkg-path src && sudo benchmark ./segmented_array_benchmark
cset: --> last message, executed args into cpuset "/user", new pid is: 10117
KeyType=u64 ValueCount=_____33 ValueSize=112B NodeSize=___256B LookupTime=____20ns
KeyType=u64 ValueCount=_____34 ValueSize=112B NodeSize=___256B LookupTime=____20ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___256B LookupTime=____96ns
KeyType=u64 ValueCount=___1024 ValueSize=112B NodeSize=___512B LookupTime=____75ns
KeyType=u64 ValueCount=_____64 ValueSize=112B NodeSize=_16384B LookupTime=____17ns
KeyType=u64 ValueCount=____512 ValueSize=112B NodeSize=_16384B LookupTime=____27ns
KeyType=u64 ValueCount=___4096 ValueSize=112B NodeSize=_16384B LookupTime=___154ns
KeyType=u64 ValueCount=__32768 ValueSize=112B NodeSize=_16384B LookupTime=___272ns
KeyType=u64 ValueCount=_262144 ValueSize=112B NodeSize=_16384B LookupTime=___483ns
KeyType=u64 ValueCount=2097152 ValueSize=112B NodeSize=_16384B LookupTime=___961ns

 Performance counter stats for './segmented_array_benchmark':

                67      context-switches
                 0      cpu-migrations
           197,491      page-faults
    40,403,793,828      cpu_core/cpu-cycles/
   101,756,955,706      cpu_core/instructions/
    28,687,686,428      cpu_core/branches/
       237,059,774      cpu_core/branch-misses/
     1,746,541,211      cpu_core/cache-references/
       990,559,408      cpu_core/cache-misses/
    48,133,168,525      cpu_core/bus-cycles/
               175      raw_syscalls:sys_enter

      19.286375016 seconds time elapsed

      18.979326000 seconds user
       0.305973000 seconds sys
```