### PR TITLE
LSM: Snapshot sequence semantics simplification

### DIFF
--- a/src/lsm/README.md
+++ b/src/lsm/README.md
@@ -1,4 +1,35 @@
+# Glossary
+
+- _bar_/_measure_: `lsm_batch_multiple` beats; unit of incremental compaction.
+- _beat_: `op % lsm_batch_multiple`; Single step of an incremental compaction.
+- _groove_: A collection of LSM trees, storing objects and their indices.
+- _immutable table_: in-memory table; one per tree. Used to periodically flush the mutable table to
+  disk.
+- _level_: Between `0` and `lsm_levels - 1` (usually `lsm_levels = 7`).
+- _forest_: a collection of grooves.
+- _manifest_: index of table and level metadata; one per tree.
+- _mutable table_: in-memory table; one per tree. All tree updates are applied only to this table.
+- _snapshot_: sequence number which selects the queryable partition of on-disk tables.
+
 # Tree
+## Tables
+
+A tree is a hierarchy of in-memory and on-disk tables. There are three categories of tables:
+
+- The [mutable table](table_mutable.zig) is an in-memory table.
+  - Each tree has a single mutable table.
+  - All tree updates, inserts, and removes are applied to the mutable table.
+  - The mutable table's size is allocated to accommodate a full bar of updates.
+- The [immutable table](table_immutable.zig) is an in-memory table.
+  - Each tree has a single immutable table.
+  - The mutable table's contents are periodically moved to the immutable table,
+    where they are stored while being flushed to level `0`.
+- Level `0` … level `config.lsm_levels - 1` each contain an exponentially increasing number of
+  on-disk tables.
+  - Each tree has as many as `config.lsm_growth_factor ^ (level + 1)` tables per level.
+    (`config.lsm_growth_factor` is typically 8).
+  - Within a given level and snapshot, the tables' key ranges are [disjoint](manifest_level.zig).
+
 ## Compaction
 
 Tree compaction runs to the sound of music!
@@ -8,104 +39,143 @@ To avoid write amplification stalls and bound latency, compaction is done increm
 
 A full compaction phase is denoted as a bar or measure, using terms from music notation.
 Each bar consists of `lsm_batch_multiple` beats or "compaction ticks" of work.
-A compaction beat is started asynchronously with `compact()` which takes a callback and
-the op that was just committed.
+A compaction tick executes asynchronously immediately after every commit, with
+`beat = commit.op % lsm_batch_multiple`.
 
-A bar is split in half according to the "first" down beat and "middle" down beat.
+A bar is split in half according to the "first" beat and "middle" beat.
 The first half of the bar compacts even levels while the latter compacts odd levels.
 Mutable table changes are sorted and compacted into the immutable table.
 The immutable table is compacted into level 0 during the odd level half of the bar.
 
-At any given point, there are at most levels/2 compactions running concurrently.
+At any given point, there are at most `levels/2` compactions running concurrently.
 The source level is denoted as `level_a` and the target level as `level_b`.
 The last level in the LSM tree has no target level so it is never a source level.
+Each compaction compacts a [single table](#table-selection) from `level_a` into all tables in
+`level_b` which intersect the `level_a` table's key range.
 
-Assuming a bar/`lsm_batch_multiple` of 4, the invariants can be described as follows:
-
+Invariants:
 * At the end of every beat, there is space in mutable table for the next beat.
-* The manifest info for the compaction's input tables is updated at the end of the half-bar.
-* The manifest info for the compaction's output tables is updated during the compaction.
 * The manifest is compacted at the end of every beat.
-* The compactions' output tables are not visible until the compaction has finished.
+* The compactions' output tables are not [visible](#snapshots-and-compaction) until the compaction has finished.
 
-1. (first) down beat of the bar:
+1. First half-bar, first beat ("first beat"):
     * Assert no compactions are currently running.
-    * Allow level visible table counts to overflow if needed.
-    * Start even level compactions if there's any tables to compact.
+    * Allow the per-level table limits to overflow if needed (for example, if we may compact a table
+      from level `A` to level `B`, where level `B` is already full).
+    * Start compactions from even levels that have reached their table limit.
 
-2. (second) up beat of the bar:
-    * Finish ticking running even-level compactions.
+2. First half-bar, last beat:
+    * Finish ticking any incomplete even-level compactions.
     * Assert on callback completion that all compactions are complete.
 
-3. (third) down beat of the bar:
+3. Second half-bar, first beat ("middle beat"):
     * Assert no compactions are currently running.
-    * Start odd level compactions if there are any tables to compact, and only if we must.
-    * Compact the immutable table if it contains any sorted values (it could be empty).
+    * Start odd level compactions if there are any tables to compact.
+    * Start compactions from odd levels that have reached their table limit.
+    * Compact the immutable table if it contains any sorted values (it might be empty).
 
-4. (fourth) last beat of the bar:
-    * Finish ticking running odd-level and immutable table compactions.
+4. Second half-bar, last beat:
+    * Finish ticking any incomplete odd-level and immutable table compactions.
     * Assert on callback completion that all compactions are complete.
-    * Assert on callback completion that no level's visible table count overflows.
+    * Assert on callback completion that no level's table count overflows.
     * Flush, clear, and sort mutable table values into immutable table for next bar.
+    * Remove input tables that are invisible to all current and persisted snapshots.
 
+### Compaction Selection Policy
+
+Compaction targets the table from level `A` which overlaps the fewest tables of level `B`.
+
+For example, in the following table (with `lsm_growth_factor=2`), each table is depicted as the range of keys it includes. The tables with uppercase letters would be chosen for compaction next.
+
+```
+Level 0   A─────────────H       l───────────────────────────z
+Level 1   a───────e             L─M   o───────s   u───────y
+Level 2     b───d e─────h i───k l───n o─p q───s   u─v w─────z
+(Keys)    a b c d e f g h i j k l m n o p q r s t u v w x y z
+```
+
+Links:
+- [`Manifest.compaction_table`](manifest.zig)
+- [Constructing and Analyzing the LSM Compaction Design Space](http://vldb.org/pvldb/vol14/p2216-sarkar.pdf) describes the tradeoffs of various data movement policies. TigerBeetle implements the "least overlapping with parent" policy.
+- [Option of Compaction Priority](https://rocksdb.org/blog/2016/01/29/compaction_pri.html)
 
 ## Snapshots
+
+Each table has a minimum and maximum integer snapshot (`snapshot_min` and `snapshot_max`).
+
+Each query targets a particular snapshot. A table `T` is "visible" to a snapshot `S` when
+
+```
+T.snapshot_min ≤ S ≤ T.snapshot_max
+```
+
+and is "invisible" to the snapshot otherwise.
+
+Compaction does not modify tables in place — it copies data. Snapshots control and distinguish which copies are useful, and which can be deleted. Snapshots can also be persisted, enabling queries against past states of the tree (unimplemented; future work).
+
 ### Snapshots and Compaction
 
 Consider the half-bar compaction beginning at op=`X` (`12`), with `lsm_batch_multiple=M` (`8`).
 Each half-bar contains `N=M/2` (`4`) beats. The next half-bar begins at `Y=X+N` (`16`).
 
-During the compaction `X` (op=`X…Y-1`; `12…15`), each commit prefetches from the snapshot equal to
-the first op of the compaction. As shown, they continue to query the old (input) tables.
+During the half-bar compaction `X` (op=`X…Y-1`; `12…15`), each commit prefetches from the snapshot
+equal to the first op of the compaction. As shown, they continue to query the old (input) tables.
 
-During the compaction `X`:
+During the half-bar compaction `X`:
 - `snapshot_max` of each input table is truncated to `Y-1` (`15`).
 - `snapshot_min` of each output table is initialized to `Y` (`16`).
 
 ```
-  0   4   8  12  16  20  24  (op, snapshot)
-  ┼───┬───┼───┬───┼───┬───┼
-              ####
-  ····────────X────────····  (input  tables, before compaction)
-  ····────────────           (input  tables,  after compaction)
-                  Y────····  (output tables,  after compaction)
+0   4   8  12  16  20  24  (op, snapshot)
+┼───┬───┼───┬───┼───┬───┼
+            ####
+····────────X────────····  (input  tables, before compaction)
+····────────────           (input  tables,  after compaction)
+                Y────····  (output tables,  after compaction)
 ```
 
 Beginning from the next op after the compaction (`Y`; `16`):
 - The output tables of the above compaction `X` are visible.
 - The input tables of the above compaction `X` are invisible.
 - Therefore, it will lookup from the output tables, but ignore the input tables.
-- Commits must not prefetch from the output tables of `X` before the compaction half-bar
-  has finished, since those tables are incomplete.
+- Callers must not query from the output tables of `X` before the compaction half-bar has finished
+  (i.e. before the end of beat `Y-1` (`15`)), since those tables are incomplete.
 
 At this point the input tables can be removed if they are invisible to all persistent snapshots.
 
+### Snapshot Queries
+
+Each tree tracks the highest snapshot safe to query from (`tree.lookup_snapshot_max`), to ensure that
+an ongoing compaction's incomplete output tables are not visible. Queries targeting
+`tree.lookup_snapshot_max` always read from the mutable and immutable tables — so each commit can
+see all previous commits' updates.)
+
+TODO(Persistent Snapshots): Expand this section.
 
 ### Snapshot Values
 
 The on-disk tables visible to a snapshot `B` do not contain the updates from the commit with op `B`.
+Rather, the snapshot `B` corresponds to the TODO
 
 Consider the following diagram (`lsm_batch_multiple=8`):
 
 ```
-  0   4   8  12  16  20  24  28  (op, snapshot)
-  ┼───┬───┼───┬───┼───┬───┼───┬
-          ,,,,,,,,........
-          ↑A      ↑B      ↑C
+0   4   8  12  16  20  24  28  (op, snapshot)
+┼───┬───┼───┬───┼───┬───┼───┬
+        ,,,,,,,,........
+        ↑A      ↑B      ↑C
 ```
 
 Compaction is driven by the commits of ops `B→C` (`16…23`):
+- Updates from ops `0→A` (`0…7`) are on-disk.
 - Updates from ops `A→B` (`8…15`) are in the immutable table.
+  - These updates were moved to the immutable table from the immutable table at the end of op `B-1`
+    (`15`).
+  - These updates will exist in the immutable table until it is reset at the end of op `C-1` (`23`).
 - Updates from ops `B→C` (`16…23`) are added to the mutable table (by the respective commit).
-- `lookup_snapshot_max` is `B` (`16`).
-  (Lookups against this snapshot read from the mutable and immutable tables (`A→C`; `8…23`) —
-  that is, each commit can see all previous commits' updates.)
+- `tree.lookup_snapshot_max` is `B` (`16`).
 
 At the end of the last beat of the compaction bar (`23`):
-- Updates from ops `A→B` (`8…15`) are on disk (level 0).
+- Updates from ops `0→B` (`0…15`) are on disk.
 - Updates from ops `B→C` (`16…23`) are moved from the mutable table to the immutable table.
-- `lookup_snapshot_max` is `C` (`24`).
-
-### Snapshot Coordination
-
-Because the `Forest` and `Groove` coordinate `compact()` calls across all trees, snapshots are coordinated across all trees.
+- `tree.lookup_snapshot_max` is `C` (`24`).

--- a/src/lsm/README.md
+++ b/src/lsm/README.md
@@ -1,0 +1,111 @@
+# Tree
+## Compaction
+
+Tree compaction runs to the sound of music!
+
+Compacting LSM trees involves merging and moving tables into the next levels as needed.
+To avoid write amplification stalls and bound latency, compaction is done incrementally.
+
+A full compaction phase is denoted as a bar or measure, using terms from music notation.
+Each bar consists of `lsm_batch_multiple` beats or "compaction ticks" of work.
+A compaction beat is started asynchronously with `compact()` which takes a callback and
+the op that was just committed.
+
+A bar is split in half according to the "first" down beat and "middle" down beat.
+The first half of the bar compacts even levels while the latter compacts odd levels.
+Mutable table changes are sorted and compacted into the immutable table.
+The immutable table is compacted into level 0 during the odd level half of the bar.
+
+At any given point, there are at most levels/2 compactions running concurrently.
+The source level is denoted as `level_a` and the target level as `level_b`.
+The last level in the LSM tree has no target level so it is never a source level.
+
+Assuming a bar/`lsm_batch_multiple` of 4, the invariants can be described as follows:
+
+* At the end of every beat, there is space in mutable table for the next beat.
+* The manifest info for the compaction's input tables is updated at the end of the half-bar.
+* The manifest info for the compaction's output tables is updated during the compaction.
+* The manifest is compacted at the end of every beat.
+* The compactions' output tables are not visible until the compaction has finished.
+
+1. (first) down beat of the bar:
+    * Assert no compactions are currently running.
+    * Allow level visible table counts to overflow if needed.
+    * Start even level compactions if there's any tables to compact.
+
+2. (second) up beat of the bar:
+    * Finish ticking running even-level compactions.
+    * Assert on callback completion that all compactions are complete.
+
+3. (third) down beat of the bar:
+    * Assert no compactions are currently running.
+    * Start odd level compactions if there are any tables to compact, and only if we must.
+    * Compact the immutable table if it contains any sorted values (it could be empty).
+
+4. (fourth) last beat of the bar:
+    * Finish ticking running odd-level and immutable table compactions.
+    * Assert on callback completion that all compactions are complete.
+    * Assert on callback completion that no level's visible table count overflows.
+    * Flush, clear, and sort mutable table values into immutable table for next bar.
+
+
+## Snapshots
+### Snapshots and Compaction
+
+Consider the half-bar compaction beginning at op=`X` (`12`), with `lsm_batch_multiple=M` (`8`).
+Each half-bar contains `N=M/2` (`4`) beats. The next half-bar begins at `Y=X+N` (`16`).
+
+During the compaction `X` (op=`X…Y-1`; `12…15`), each commit prefetches from the snapshot equal to
+the first op of the compaction. As shown, they continue to query the old (input) tables.
+
+During the compaction `X`:
+- `snapshot_max` of each input table is truncated to `Y-1` (`15`).
+- `snapshot_min` of each output table is initialized to `Y` (`16`).
+
+```
+  0   4   8  12  16  20  24  (op, snapshot)
+  ┼───┬───┼───┬───┼───┬───┼
+              ####
+  ····────────X────────····  (input  tables, before compaction)
+  ····────────────           (input  tables,  after compaction)
+                  Y────····  (output tables,  after compaction)
+```
+
+Beginning from the next op after the compaction (`Y`; `16`):
+- The output tables of the above compaction `X` are visible.
+- The input tables of the above compaction `X` are invisible.
+- Therefore, it will lookup from the output tables, but ignore the input tables.
+- Commits must not prefetch from the output tables of `X` before the compaction half-bar
+  has finished, since those tables are incomplete.
+
+At this point the input tables can be removed if they are invisible to all persistent snapshots.
+
+
+### Snapshot Values
+
+The on-disk tables visible to a snapshot `B` do not contain the updates from the commit with op `B`.
+
+Consider the following diagram (`lsm_batch_multiple=8`):
+
+```
+  0   4   8  12  16  20  24  28  (op, snapshot)
+  ┼───┬───┼───┬───┼───┬───┼───┬
+          ,,,,,,,,........
+          ↑A      ↑B      ↑C
+```
+
+Compaction is driven by the commits of ops `B→C` (`16…23`):
+- Updates from ops `A→B` (`8…15`) are in the immutable table.
+- Updates from ops `B→C` (`16…23`) are added to the mutable table (by the respective commit).
+- `lookup_snapshot_max` is `B` (`16`).
+  (Lookups against this snapshot read from the mutable and immutable tables (`A→C`; `8…23`) —
+  that is, each commit can see all previous commits' updates.)
+
+At the end of the last beat of the compaction bar (`23`):
+- Updates from ops `A→B` (`8…15`) are on disk (level 0).
+- Updates from ops `B→C` (`16…23`) are moved from the mutable table to the immutable table.
+- `lookup_snapshot_max` is `C` (`24`).
+
+### Snapshot Coordination
+
+Because the `Forest` and `Groove` coordinate `compact()` calls across all trees, snapshots are coordinated across all trees.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -565,7 +565,7 @@ fn ForestTestType(comptime StorageProvider: type) type {
                     }
                 }
 
-                // At the end of a compaction measure, record how many will be checkpointed next.
+                // At the end of a compaction bar, record how many will be checkpointed next.
                 if (self.op % config.lsm_batch_multiple == config.lsm_batch_multiple - 1) {
                     self.accounts.next_checkpoint = @intCast(u32, self.accounts.inserted.items.len);
                     self.transfers.next_checkpoint = @intCast(u32, self.transfers.inserted.items.len);

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -138,6 +138,9 @@ fn IndexTreeType(
 
 /// A Groove is a collection of LSM trees auto generated for fields on a struct type
 /// as well as custom derived fields from said struct type.
+///
+/// Invariants:
+/// - Between beats, all of a groove's trees share the same lookup_snapshot_max.
 pub fn GrooveType(
     comptime Storage: type,
     comptime Object: type,
@@ -553,7 +556,9 @@ pub fn GrooveType(
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.ids.lookup_snapshot_max;
+            const snapshot_max = groove.objects.lookup_snapshot_max;
+            assert(snapshot_max == groove.ids.lookup_snapshot_max);
+
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -553,7 +553,7 @@ pub fn GrooveType(
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.ids.prefetch_snapshot_max;
+            const snapshot_max = groove.ids.lookup_snapshot_max;
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 
@@ -717,7 +717,7 @@ pub fn GrooveType(
                                 worker.context.snapshot,
                                 worker.lookup_id.key,
                             ) == null or
-                            worker.context.groove.objects.lookup_from_memory(
+                                worker.context.groove.objects.lookup_from_memory(
                                 worker.context.snapshot,
                                 id_tree_value.timestamp,
                             ) == null,

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -66,7 +66,7 @@ pub fn TableInfoType(comptime Table: type) type {
         /// disk.
         ///
         /// Instead, prefetch will continue to query the compaction's input tables until the
-        /// half-measure of compaction completes. At that point `tree.prefetch_snapshot_max` is
+        /// half-bar of compaction completes. At that point `tree.prefetch_snapshot_max` is
         /// updated (to the compaction's `compaction_op`), simultaneously rendering the old (input)
         /// tables invisible, and the new (output) tables visible.
         pub fn visible(table: *const TableInfo, snapshot: u64) bool {

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -167,7 +167,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             // We may query the input tables of an ongoing compaction, but must not query the
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
-            const snapshot_max = groove.tree.prefetch_snapshot_max;
+            const snapshot_max = groove.tree.lookup_snapshot_max;
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -360,8 +360,11 @@ const Environment = struct {
             defer op += 1;
 
             // Checkpoint when the forest finishes compaction.
+            // Don't repeat a checkpoint (commit_min must always advance).
             const checkpoint_op = op -| config.lsm_batch_multiple;
-            if (checkpoint_op % config.lsm_batch_multiple == config.lsm_batch_multiple - 1) {
+            if (checkpoint_op % config.lsm_batch_multiple == config.lsm_batch_multiple - 1 and
+                checkpoint_op != env.superblock.staging.vsr_state.commit_min)
+            {
                 // Checkpoint the forest then superblock
                 env.superblock.staging.vsr_state.commit_min = checkpoint_op;
                 env.superblock.staging.vsr_state.commit_max = checkpoint_op;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2542,7 +2542,7 @@ pub fn ReplicaType(
             //
             // The checkpoint is triggered at "E".
             // At this point, ops 6 and 7 are in the in-memory immutable table.
-            // They will only be compacted to disk in the next measure.
+            // They will only be compacted to disk in the next bar.
             // Therefore, only ops "A..D" are committed to disk.
             // Thus, the SuperBlock's `commit_min` is set to 7-2=5.
             const vsr_state_new = .{
@@ -2671,7 +2671,7 @@ pub fn ReplicaType(
 
             if (self.superblock.working.vsr_state.op_compacted(prepare.header.op)) {
                 // We are recovering from a checkpoint. Prior to the crash, the client table was
-                // updated with entries for one measure beyond the op_checkpoint.
+                // updated with entries for one bar beyond the op_checkpoint.
                 assert(self.op_checkpoint == self.superblock.working.vsr_state.commit_min);
                 if (self.client_table().get(prepare.header.client)) |entry| {
                     assert(entry.reply.header.command == .reply);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -141,8 +141,8 @@ pub const SuperBlockSector = extern struct {
             state.* = new;
         }
 
-        /// Compaction is one measure ahead of superblock's commit_min.
-        /// The commits from the measure following commit_min were in the mutable table, and
+        /// Compaction is one bar ahead of superblock's commit_min.
+        /// The commits from the bar following commit_min were in the mutable table, and
         /// thus not preserved in the checkpoint.
         /// But the corresponding `compact()` updates were preserved, and must not be repeated
         /// to ensure determinstic storage.


### PR DESCRIPTION
Modified for a more manageable mental model.

The progression of snapshots over successive compactions was difficult to visualize. From a messy mental model came bugs, contradictory documentation, and weak invariants.

### Snapshot semantics:
- (These are hopefully more thoroughly explained within the code+docs).
- `compaction.snapshot` is now the first beat of the compaction. (And renamed to `compaction.op_min`; more below).
  - This is neither the `snapshot_max` of the input tables, nor the `snapshot_min` of the output tables...
  - But it can easily derive both.
  - And it is even better, because it can't be confused for either. (I did this constantly before).
  - As a round number (a multiple of a half-bar start-beat) it is easier to visualize and remember (at least for me) than one-minus-what-measure-was-this-again. (Previously the compaction snapshot tied into the commit op of the data being compacted to disk, which is one measure behind the compact's op. But this is hard to reason about so I scrapped it. I document the (absence of) a relationship between snapshots and ops in `lsm/README.md`.)
- `lookup_snapshot_max` is now always the first beat of a half-bar, instead of sometimes being sometimes 1 less than that until it is incremented.
- Invariants now enforced:
  - In `lookup_from_memory()`, if the mutable table is visible, then the immutable table must also be visible. (This would have caught several earlier bugs).
  - A compaction's input tables must be visible to the `compaction.snapshot`.

### Bug fixes:
- `Tree.compact()`: When recovering from a checkpoint, we skip replaying one bar of compactions. But we still must compact the mutable → immutable table at the last beat of that (otherwise) skipped measure.
- `lsm/test.zig`: Don't checkpoint the same op twice.

### Naming:
- Rename `prefetch_snapshot_max` to `lookup_snapshot_max`. "Prefetching" is the Groove's concern — the Tree only knows about lookups. (Tree documentation still refers to prefetching because it is useful for understanding how lookups correlate to compaction ops).
- Rename "measure" to "bar" — same meaning, more concise.
- Rename `compaction.snapshot` to `compaction.op_min`. I was on the fence about this — `op_min` is a better description of where it comes from, but `snapshot` is a better description of how it is used. I settled on `op_min` because it is more specific ("snapshot" is very general). With `op_min` it is obvious what the value is.

### Documentation refactoring:
- Remove the over-complicated chart showing repeated compactions, in favor of a smaller, simpler, more general chart that is explored in more detail.
- Move the excellent "Tree compaction runs to the sound of music!" to a more prominent location.
  - Add a note about `compact` taking an op, since "compaction op" is referred to often.
  - Change "there's only levels/2 max compactions happening" to "there are at most levels/2 compactions running" (slightly more accurate).
  - Fix an out-of-date note about when/how the manifest info is updated.
  - Add a note about output table visibility.
- The `lookup_snapshot_max` chart is moved to be less prominent, since it is less critical for reasoning about snapshots. This chart is also simplified with a reduced emphasis on `compaction_op`, and benefits from the now-round `lookup_snapshot_max`.
