### PR TITLE
Fix outdated client usage

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -255,14 +255,14 @@ const TimedQueue = struct {
             .create_accounts => {
                 const create_accounts_results = std.mem.bytesAsSlice(tb.CreateAccountsResult, value);
                 if (create_accounts_results.len > 0) {
-                    log.err("CreateAccountsResults={s}", .{create_accounts_results});
+                    log.err("CreateAccountsResults={any}", .{create_accounts_results});
                     @panic("Unexpected result creating accounts.");
                 }
             },
             .create_transfers => {
                 const create_transfers_results = std.mem.bytesAsSlice(tb.CreateTransfersResult, value);
                 if (create_transfers_results.len > 0) {
-                    log.err("CreateTransfersResults={s}", .{create_transfers_results});
+                    log.err("CreateTransfersResults={any}", .{create_transfers_results});
                     @panic("Unexpected result creating transfers.");
                 }
 

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -40,7 +40,7 @@ var accounts = [_]tb.Account{
         .user_data = 0,
         .reserved = [_]u8{0} ** 48,
         .ledger = 2,
-        .code = 0,
+        .code = 1,
         .flags = .{},
         .debits_pending = 0,
         .debits_posted = 0,
@@ -52,7 +52,7 @@ var accounts = [_]tb.Account{
         .user_data = 0,
         .reserved = [_]u8{0} ** 48,
         .ledger = 2,
-        .code = 0,
+        .code = 1,
         .flags = .{},
         .debits_pending = 0,
         .debits_posted = 0,
@@ -104,17 +104,18 @@ pub fn main() !void {
 
     for (transfers) |*transfer, index| {
         transfer.* = .{
-            .id = index,
+            .id = index + 1,
             .debit_account_id = accounts[0].id,
             .credit_account_id = accounts[1].id,
-            .pending_id = 0,
             .user_data = 0,
             .reserved = 0,
-            .code = 0,
+            .pending_id = 0,
+            .timeout = 0,
             .ledger = 2,
+            .code = 1,
             .flags = .{},
             .amount = 1,
-            .timeout = 0,
+            .timestamp = 0,
         };
     }
 
@@ -240,8 +241,6 @@ const TimedQueue = struct {
             @panic("Client returned error during benchmarking.");
         };
 
-        log.debug("response={s}", .{std.mem.bytesAsSlice(tb.CreateAccountsResult, value)});
-
         const self: *TimedQueue = @intToPtr(*TimedQueue, @intCast(usize, user_data));
         const completed_batch: ?Batch = self.batches.pop();
         assert(completed_batch != null);
@@ -253,8 +252,20 @@ const TimedQueue = struct {
         });
         const latency = now - self.batch_start.?;
         switch (operation) {
-            .create_accounts => {},
+            .create_accounts => {
+                const create_accounts_results = std.mem.bytesAsSlice(tb.CreateAccountsResult, value);
+                if (create_accounts_results.len > 0) {
+                    log.err("CreateAccountsResults={s}", .{create_accounts_results});
+                    @panic("Unexpected result creating accounts.");
+                }
+            },
             .create_transfers => {
+                const create_transfers_results = std.mem.bytesAsSlice(tb.CreateTransfersResult, value);
+                if (create_transfers_results.len > 0) {
+                    log.err("CreateTransfersResults={s}", .{create_transfers_results});
+                    @panic("Unexpected result creating transfers.");
+                }
+
                 if (latency > self.transfers_latency_max) {
                     self.transfers_latency_max = latency;
                 }

--- a/src/demo_01_create_accounts.zig
+++ b/src/demo_01_create_accounts.zig
@@ -11,11 +11,11 @@ pub fn main() !void {
             .reserved = [_]u8{0} ** 48,
             .ledger = 710, // Let's use the ISO-4217 Code Number for ZAR
             .code = 1000, // A chart of accounts code to describe this as a clearing account.
-            .flags = .{},
+            .flags = .{ .debits_must_not_exceed_credits = true },
             .debits_pending = 0,
             .debits_posted = 0,
             .credits_pending = 0,
-            .credits_posted = 0,
+            .credits_posted = 10000, // Let's start with some liquidity.
         },
         Account{
             .id = 2,

--- a/src/demo_01_create_accounts.zig
+++ b/src/demo_01_create_accounts.zig
@@ -11,11 +11,11 @@ pub fn main() !void {
             .reserved = [_]u8{0} ** 48,
             .ledger = 710, // Let's use the ISO-4217 Code Number for ZAR
             .code = 1000, // A chart of accounts code to describe this as a clearing account.
-            .flags = .{ .debits_must_not_exceed_credits = true },
+            .flags = .{},
             .debits_pending = 0,
             .debits_posted = 0,
             .credits_pending = 0,
-            .credits_posted = 10000, // Let's start with some liquidity.
+            .credits_posted = 0,
         },
         Account{
             .id = 2,


### PR DESCRIPTION
Fixes:

- `benchmark.zig` did not check return codes, causing the program to ignore failed batches and report unrealistic performance measurements.

- Incorrect usage of zeroed values at `code=0` for account/transfer creation and `transfer.id=0` for the first transfer of the batch.

- `demo_01_create_accounts.zig` was creating a new account with `credits_posted=10000`, causing the operation to fail with `credits_posted_must_be_zero`.

**Notes**

As discussed with @sentientwaffle, I noticed the fields `ledger`, `code`, and `amount` **are allowed to be zero** as a convenience when posting/voiding transfers.

From[`demo_05_post_pending_transfers.zig`](https://github.com/tigerbeetledb/tigerbeetle/blob/main/src/demo_05_post_pending_transfers.zig#L7-L19)

It's worth noting that this feature is not mentioned anywhere in the documentation.