### PR TITLE
C client hangs when submitting concurrent requests

### DIFF
--- a/src/c/tb_client/signal.zig
+++ b/src/c/tb_client/signal.zig
@@ -12,8 +12,6 @@ const log = std.log.scoped(.tb_client_signal);
 /// when notification occurs from another thread.
 /// It does this by using OS sockets (which are thread safe) 
 /// to resolve IO.Completions on the tigerbeetle thread.
-///
-/// TODO: implement a simpler version of this eventually..
 pub const Signal = struct {
     io: *IO,
     server_socket: os.socket_t,

--- a/src/c/tb_client/signal.zig
+++ b/src/c/tb_client/signal.zig
@@ -274,11 +274,11 @@ pub const Signal = struct {
             .Acquire,
             .Acquire,
         ) orelse {
-            const retry = (self.on_signal_fn)(self);
+            const pending = (self.on_signal_fn)(self);
             self.wait();
 
-            // Wakes up immediately if there are still packets to process.
-            if (retry) self.notify();
+            // Run again on the next tick if there are still packets to process.
+            if (pending) self.notify();
             return;
         };
 

--- a/src/c/tb_client/signal.zig
+++ b/src/c/tb_client/signal.zig
@@ -24,7 +24,7 @@ pub const Signal = struct {
     recv_buffer: [1]u8,
     send_buffer: [1]u8,
 
-    on_signal_fn: fn (*Signal) void,
+    on_signal_fn: fn (*Signal) bool,
     state: Atomic(enum(u8) {
         running,
         waiting,
@@ -32,7 +32,7 @@ pub const Signal = struct {
         shutdown,
     }),
 
-    pub fn init(self: *Signal, io: *IO, on_signal_fn: fn (*Signal) void) !void {
+    pub fn init(self: *Signal, io: *IO, on_signal_fn: fn (*Signal) bool) !void {
         self.io = io;
         self.server_socket = os.socket(
             os.AF.INET,
@@ -274,8 +274,12 @@ pub const Signal = struct {
             .Acquire,
             .Acquire,
         ) orelse {
-            (self.on_signal_fn)(self);
-            return self.wait();
+            const retry = (self.on_signal_fn)(self);
+            self.wait();
+
+            // Wakes up immediately if there are still packets to process.
+            if (retry) self.notify();
+            return;
         };
 
         switch (state) {

--- a/src/c/tb_client/thread.zig
+++ b/src/c/tb_client/thread.zig
@@ -163,7 +163,7 @@ pub fn ThreadType(
 
             self.retry = .{};
             self.submitted = .{};
-            self.available_messages = message_pool.messages_max_client;
+            self.available_messages = config.client_request_queue_max;
             self.on_completion_fn = on_completion_fn;
 
             log.debug("init: initializing Signal.", .{});
@@ -215,7 +215,7 @@ pub fn ThreadType(
             }
         }
 
-        fn on_signal(signal: *Signal) void {
+        fn on_signal(signal: *Signal) bool {
             const self = @fieldParentPtr(Self, "signal", signal);
             self.client.tick();
 
@@ -242,6 +242,9 @@ pub fn ThreadType(
                 self.available_messages -= 1;
                 self.request(packet, message);
             }
+
+            // Returns true if we have used all available messages.
+            return self.available_messages == 0;
         }
 
         fn request(self: *Self, packet: *Packet, message: *Message) void {


### PR DESCRIPTION
- `Thread.available_messages` was being initialized with `message_pool.messages_max_client`.
This value accounts for more messages than is allowed by `config.client_request_queue_max`, causing the client to exceed the request queue.

- Added a `bool` return to `on_signal_fn`, indicating that there are still packets to be processed, causing the signal to be notified immediately.

Closes #230 