### PR TITLE
LSM: Drain grid read cache on tick().

### DIFF
--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -175,7 +175,7 @@ pub fn GridType(comptime Storage: type) type {
             //
             // Even still, there should still be a cap on reads processed to prevent going over
             // any implicit time slice expected of Grid.tick(). This limit is fairly arbitrary.
-            var max_retry: u32 = grid.read_iops_max * 4;
+            var max_retry: u32 = Grid.read_iops_max * 4;
             while (grid.read_cached_queue.pop()) |read| {
                 if (grid.cache.get(read.address)) |block| {
                     read.callback(read, block);

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -170,17 +170,21 @@ pub fn GridType(comptime Storage: type) type {
             // Resolve reads that were seen in the cache during start_read()
             // but deferred to be asynchronously resolved on the next tick.
             //
-            // Make a copy to avoid a potential infinite loop here.
-            // If any new reads are added to the read_cached_queue they will be started on
-            // the next tick.
-            var copy = grid.read_cached_queue;
-            grid.read_cached_queue = .{};
-            while (copy.pop()) |read| {
+            // Drains directly from the queue to that cache reads that could be serviced immediately
+            // aren't deferred until the next tick (which could be milliseconds from IO.run_for_ns).
+            //
+            // Even still, there should still be a cap on reads processed to prevent going over
+            // any implicit time slice expected of Grid.tick(). This limit is fairly arbitrary.
+            var max_retry: u32 = grid.read_iops_max * 4;
+            while (grid.read_cached_queue.pop()) |read| {
                 if (grid.cache.get(read.address)) |block| {
                     read.callback(read, block);
                 } else {
                     grid.start_read(read);
                 }
+
+                max_retry -|= 1;
+                if (max_retry == 0) break;
             }
         }
 

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -170,12 +170,14 @@ pub fn GridType(comptime Storage: type) type {
             // Resolve reads that were seen in the cache during start_read()
             // but deferred to be asynchronously resolved on the next tick.
             //
-            // Drains directly from the queue to that cache reads that could be serviced immediately
-            // aren't deferred until the next tick (which could be milliseconds from IO.run_for_ns).
+            // Drain directly from the queue so that new cache reads (added upon completion of old 
+            // cache reads) that can be serviced immediately aren't deferred until the next tick 
+            // (which may be milliseconds later due to IO.run_for_ns). This is necessary to ensure 
+            // that groove prefetch completes promptly.
             //
-            // Even still, there should still be a cap on reads processed to prevent going over
+            // Even still, we cap the reads processed to prevent going over
             // any implicit time slice expected of Grid.tick(). This limit is fairly arbitrary.
-            var max_retry: u32 = Grid.read_iops_max * 4;
+            var retry_max: u32 = 100_000;
             while (grid.read_cached_queue.pop()) |read| {
                 if (grid.cache.get(read.address)) |block| {
                     read.callback(read, block);
@@ -183,8 +185,8 @@ pub fn GridType(comptime Storage: type) type {
                     grid.start_read(read);
                 }
 
-                max_retry -|= 1;
-                if (max_retry == 0) break;
+                retry_max -= 1;
+                if (retry_max == 0) break;
             }
         }
 


### PR DESCRIPTION
To avoid having CPU work that could be executed pile up until the next Grid tick (which could be `config.tick_ms` away), make sure to evaluate more deferred cache reads in the tick() function.

Evaluating deferred cache reads could queue even more in their callbacks. To account for them, we dequeue from the cache queue directly instead of making a copy. This potentially allows for continuous dequeuing as more are added, so there is an (arbitrary for now) bound on how many deferred cache reads can be evaluated in the same tick().