### PR TITLE
Add a script to estimate lsm bandwidth and throughput

### DIFF
--- a/scripts/compaction_bounds.zig
+++ b/scripts/compaction_bounds.zig
@@ -1,0 +1,160 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const Transfer = @import("../src/tigerbeetle.zig").Transfer;
+const IndexCompositeKeyType = @import("../src/lsm/groove.zig").IndexCompositeKeyType;
+const StateMachine = @import("../src/state_machine.zig").StateMachineType(
+    @import("../src/storage.zig").Storage,
+    .{
+        .message_body_size_max = config.message_body_size_max,
+    },
+);
+const config = @import("../src/config.zig");
+
+pub fn main() !void {
+    std.debug.print("Workload: 1_000_000 transfers/s.\n\n", .{});
+
+    const transfers_per_second = 1_000_000;
+    const transfers_per_batch = StateMachine.constants.batch_max.create_transfers;
+
+    const cases = .{
+        // The current code.
+        .current,
+        // Change level 0 to only contain 1 level.
+        .small_level_0,
+        // Change the immutable table to config.lsm_table_size_max.
+        // (Complicates compaction pacing.)
+        .large_immutable_table,
+        // Change the disk tables to match the size of the immutable table.
+        .small_disk_tables,
+        .small_level_0_and_small_disk_tables,
+    };
+    inline for (cases) |case| {
+        std.debug.print("{}:\n", .{case});
+
+        const existing_transfer_counts = [_]usize{
+            1_000_000,
+            10_000_000,
+            100_000_000,
+            1_000_000_000,
+        };
+        for (existing_transfer_counts) |existing_transfer_count| {
+            var read_bytes_per_second: usize = 0;
+            var write_bytes_per_second: usize = 0;
+
+            // Every transfer must be written to the WAL.
+            write_bytes_per_second += transfers_per_second * @sizeOf(Transfer);
+
+            const field_names = [_][]const u8{
+                "id",
+                "debit_account_id",
+                "credit_account_id",
+                "user_data",
+                "pending_id",
+                "timeout",
+                "ledger",
+                "code",
+                "amount",
+                "timestamp",
+                "balance",
+            };
+            inline for (field_names) |field_name| {
+                const Value = comptime if (std.meta.eql(field_name, "timestamp"))
+                    // Object tree.
+                    Transfer
+                else if (std.meta.eql(field_name, "balance"))
+                    // Proposed balance tree.
+                    struct {
+                        account_id: u128,
+                        transfer_id: u128,
+                        debits_pending: u64,
+                        debits_posted: u64,
+                        credits_pending: u64,
+                        credits_posted: u64,
+                    }
+                else
+                    // Secondary index.
+                    IndexCompositeKeyType(@TypeOf(@field(@as(Transfer, undefined), field_name)));
+
+                const values_per_immutable_table = switch (case) {
+                    .current, .small_level_0, .small_disk_tables, .small_level_0_and_small_disk_tables => transfers_per_batch * config.lsm_batch_multiple,
+                    .large_immutable_table => @divTrunc(config.lsm_table_size_max, @sizeOf(Value)),
+                    else => unreachable,
+                };
+                const values_per_disk_table = switch (case) {
+                    .current, .small_level_0, .large_immutable_table => @divTrunc(config.lsm_table_size_max, @sizeOf(Value)),
+                    .small_disk_tables, .small_level_0_and_small_disk_tables => transfers_per_batch * config.lsm_batch_multiple,
+                    else => unreachable,
+                };
+                const table_count = try std.math.divCeil(usize, existing_transfer_count, values_per_disk_table);
+
+                const tables_on_level_0 = switch (case) {
+                    .current, .large_immutable_table, .small_disk_tables => config.lsm_growth_factor,
+                    .small_level_0, .small_level_0_and_small_disk_tables => 1,
+                    else => unreachable,
+                };
+
+                var level_count: usize = 0;
+                {
+                    var table_count_remaining: usize = table_count;
+                    var tables_per_level: usize = tables_on_level_0;
+                    while (table_count_remaining > 0) {
+                        level_count += 1;
+                        table_count_remaining = table_count_remaining -| tables_per_level;
+                        tables_per_level *= config.lsm_growth_factor;
+                    }
+                }
+
+                if (!std.meta.eql(field_name, "timestamp")) {
+                    // The object tree does not need to be compacted so just count write bandwidth per value.
+                    write_bytes_per_second += transfers_per_second * @sizeOf(Value);
+                } else {
+                    // We compact the immutable table into level 0 whenever the immutable tables is full;
+                    const level_0_compactions_per_second = try std.math.divCeil(usize, transfers_per_second, values_per_immutable_table);
+                    // Lower levels are compacted whenever we need room for ingress from above.
+                    const level_n_compactions_per_second = try std.math.divCeil(usize, transfers_per_second, values_per_disk_table);
+
+                    read_bytes_per_second +=
+                        level_0_compactions_per_second * (
+                    // Read all tables on level 0
+                        (tables_on_level_0 * values_per_disk_table * @sizeOf(Value)));
+                    read_bytes_per_second +=
+                        (level_count -| 1) *
+                        level_n_compactions_per_second *
+                        // Read 1 table from level a and config.lsm_growth_factor tables from level b.
+                        (1 + config.lsm_growth_factor) * values_per_disk_table *
+                        @sizeOf(Value);
+
+                    write_bytes_per_second +=
+                        level_0_compactions_per_second * (
+                    // Write the immutable table
+                        (values_per_immutable_table * @sizeOf(Value)) +
+                        // Rewrite all tables on level 0
+                        (tables_on_level_0 * values_per_disk_table * @sizeOf(Value)));
+                    write_bytes_per_second +=
+                        (level_count -| 1) *
+                        level_n_compactions_per_second *
+                        // Rewrite 1 table from level a and config.lsm_growth_factor tables from level b.
+                        (1 + config.lsm_growth_factor) * values_per_disk_table *
+                        @sizeOf(Value);
+                }
+
+                // TODO Calculate bandwidth for checkpoint - smaller tables mean cheaper compactions but a larger manifest.
+            }
+
+            std.debug.print("Existing transfers = {d:>10.0}. Read ~= {d:>5.2} gb/s. Write ~= {d:>5.2} gb/s. Throughput at 4gb/s ~= {d:>7.0} transfers/s.\n", .{
+                existing_transfer_count,
+                @intToFloat(f64, read_bytes_per_second) / 1024 / 1024 / 1024,
+                @intToFloat(f64, write_bytes_per_second) / 1024 / 1024 / 1024,
+                transfers_per_second * ((4 * 1024 * 1024 * 1024) / @intToFloat(f64, read_bytes_per_second + write_bytes_per_second)),
+            });
+        }
+
+        std.debug.print("\n", .{});
+    }
+}
+
+const ReadWrite = struct {
+    read: usize,
+    write: usize,
+};

--- a/scripts/compaction_bounds.zig
+++ b/scripts/compaction_bounds.zig
@@ -118,7 +118,7 @@ pub fn main() !void {
                         3 * config.block_size;
                 }
 
-                if (!std.meta.eql(field_name, "timestamp")) {
+                if (std.meta.eql(field_name, "timestamp")) {
                     // The object tree does not need to be compacted so just count write bandwidth per value.
                     write_bytes_per_second += transfers_per_second * @sizeOf(Value);
                 } else {

--- a/scripts/compaction_bounds.zig
+++ b/scripts/compaction_bounds.zig
@@ -128,15 +128,16 @@ pub fn main() !void {
                     const level_n_compactions_per_second = try std.math.divCeil(usize, transfers_per_second, values_per_disk_table);
 
                     read_bytes_per_second +=
-                        level_0_compactions_per_second * (
-                    // Read all tables on level 0
-                        (tables_on_level_0 * values_per_disk_table * @sizeOf(Value)));
+                        level_0_compactions_per_second *
+                        // Read all tables on level 0
+                        tables_on_level_0 *
+                        values_per_disk_table * @sizeOf(Value);
                     read_bytes_per_second +=
                         (level_count -| 1) *
                         level_n_compactions_per_second *
                         // Read 1 table from level a and config.lsm_growth_factor tables from level b.
-                        (1 + config.lsm_growth_factor) * values_per_disk_table *
-                        @sizeOf(Value);
+                        (1 + config.lsm_growth_factor) *
+                        values_per_disk_table * @sizeOf(Value);
 
                     write_bytes_per_second +=
                         level_0_compactions_per_second * (

--- a/scripts/compaction_bounds.zig
+++ b/scripts/compaction_bounds.zig
@@ -105,6 +105,19 @@ pub fn main() !void {
                     }
                 }
 
+                if (std.meta.eql(field_name, "balance")) {
+                    // We have to read credit/debit account/balance to validate each transfer.
+                    read_bytes_per_second +=
+                        transfers_per_second *
+                        // We must lookup: credit account id, debit account id, credit account, debit account, credit balance, debit balance
+                        6 *
+                        // In the worst case we have to check every level.
+                        // TODO We're using the balance level_count as a bound on the account level_count - we should model the number of accounts instead.
+                        level_count *
+                        // For each lookup we must read: index block, filter block, data block
+                        3 * config.block_size;
+                }
+
                 if (!std.meta.eql(field_name, "timestamp")) {
                     // The object tree does not need to be compacted so just count write bandwidth per value.
                     write_bytes_per_second += transfers_per_second * @sizeOf(Value);

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -80,7 +80,7 @@ const IdTreeValue = extern struct {
 };
 
 /// Normalizes index tree field types into either u64 or u128 for CompositeKey
-fn IndexCompositeKeyType(comptime Field: type) type {
+pub fn IndexCompositeKeyType(comptime Field: type) type {
     switch (@typeInfo(Field)) {
         .Enum => |e| {
             return switch (@bitSizeOf(e.tag_type)) {


### PR DESCRIPTION
(Assumes the worst-case number of level b tables per compaction.)

Current output:

```
Workload: 1_000_000 transfers/s.

.current:
Existing transfers =    1000000. Read ~= 15.50 gb/s. Write ~= 15.90 gb/s. Throughput at 4gb/s ~=  127371 transfers/s.
Existing transfers =   10000000. Read ~= 16.63 gb/s. Write ~= 17.03 gb/s. Throughput at 4gb/s ~=  118856 transfers/s.
Existing transfers =  100000000. Read ~= 17.75 gb/s. Write ~= 18.15 gb/s. Throughput at 4gb/s ~=  111408 transfers/s.
Existing transfers = 1000000000. Read ~= 18.88 gb/s. Write ~= 19.28 gb/s. Throughput at 4gb/s ~=  104838 transfers/s.

.small_level_0:
Existing transfers =    1000000. Read ~=  3.06 gb/s. Write ~=  3.47 gb/s. Throughput at 4gb/s ~=  612632 transfers/s.
Existing transfers =   10000000. Read ~=  4.19 gb/s. Write ~=  4.59 gb/s. Throughput at 4gb/s ~=  455622 transfers/s.
Existing transfers =  100000000. Read ~=  5.31 gb/s. Write ~=  5.72 gb/s. Throughput at 4gb/s ~=  362674 transfers/s.
Existing transfers = 1000000000. Read ~=  6.44 gb/s. Write ~=  6.84 gb/s. Throughput at 4gb/s ~=  301223 transfers/s.

.large_immutable_table:
Existing transfers =    1000000. Read ~=  1.00 gb/s. Write ~=  1.41 gb/s. Throughput at 4gb/s ~= 1661045 transfers/s.
Existing transfers =   10000000. Read ~=  2.13 gb/s. Write ~=  2.53 gb/s. Throughput at 4gb/s ~=  858715 transfers/s.
Existing transfers =  100000000. Read ~=  3.25 gb/s. Write ~=  3.66 gb/s. Throughput at 4gb/s ~=  579029 transfers/s.
Existing transfers = 1000000000. Read ~=  4.38 gb/s. Write ~=  4.78 gb/s. Throughput at 4gb/s ~=  436771 transfers/s.

.small_disk_tables:
Existing transfers =    1000000. Read ~=  2.06 gb/s. Write ~=  2.46 gb/s. Throughput at 4gb/s ~=  884782 transfers/s.
Existing transfers =   10000000. Read ~=  3.15 gb/s. Write ~=  3.55 gb/s. Throughput at 4gb/s ~=  596988 transfers/s.
Existing transfers =  100000000. Read ~=  4.24 gb/s. Write ~=  4.64 gb/s. Throughput at 4gb/s ~=  450464 transfers/s.
Existing transfers = 1000000000. Read ~=  5.33 gb/s. Write ~=  5.73 gb/s. Throughput at 4gb/s ~=  361691 transfers/s.

.small_level_0_and_small_disk_tables:
Existing transfers =    1000000. Read ~=  2.30 gb/s. Write ~=  2.70 gb/s. Throughput at 4gb/s ~=  799169 transfers/s.
Existing transfers =   10000000. Read ~=  3.39 gb/s. Write ~=  3.79 gb/s. Throughput at 4gb/s ~=  556745 transfers/s.
Existing transfers =  100000000. Read ~=  4.48 gb/s. Write ~=  4.88 gb/s. Throughput at 4gb/s ~=  427166 transfers/s.
Existing transfers = 1000000000. Read ~=  5.57 gb/s. Write ~=  5.97 gb/s. Throughput at 4gb/s ~=  346516 transfers/s.
```