### PR TITLE
LSM: Block Address Determinism

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -86,6 +86,14 @@ jobs:
       - run: ./scripts/install_zig.sh
       - run: zig/zig build fuzz_vsr_superblock -- --seed 123
 
+  fuzz_vsr_superblock_free_set:
+    name: 'Fuzz VSR SuperBlock Quorums'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./scripts/install_zig.sh
+      - run: zig/zig build fuzz_vsr_superblock_free_set -- --seed 123
+
   fuzz_vsr_superblock_quorums:
     name: 'Fuzz VSR SuperBlock Quorums'
     runs-on: ubuntu-latest

--- a/build.zig
+++ b/build.zig
@@ -197,6 +197,26 @@ pub fn build(b: *std.build.Builder) void {
     }
 
     {
+        const fuzz_vsr_superblock_free_set = b.addExecutable(
+            "fuzz_vsr_superblock_free_set",
+            "src/vsr/superblock_free_set_fuzz.zig",
+        );
+        fuzz_vsr_superblock_free_set.setMainPkgPath("src");
+        fuzz_vsr_superblock_free_set.setTarget(target);
+        fuzz_vsr_superblock_free_set.setBuildMode(mode);
+        fuzz_vsr_superblock_free_set.omit_frame_pointer = false;
+
+        const run_cmd = fuzz_vsr_superblock_free_set.run();
+        if (b.args) |args| run_cmd.addArgs(args);
+
+        const run_step = b.step(
+            "fuzz_vsr_superblock_free_set",
+            "Fuzz the SuperBlock FreeSet. Args: [--seed <seed>]",
+        );
+        run_step.dependOn(&run_cmd.step);
+    }
+
+    {
         const fuzz_vsr_superblock_quorums = b.addExecutable(
             "fuzz_vsr_superblock_quorums",
             "src/vsr/superblock_quorums_fuzz.zig",

--- a/src/config.zig
+++ b/src/config.zig
@@ -263,6 +263,8 @@ pub const lsm_growth_factor = 8;
 /// The maximum key size for an LSM tree in bytes.
 pub const lsm_key_size_max = 32;
 
+/// The maximum cumulative size of a table — computed as the sum of the size of the index block,
+/// filter blocks, and data blocks.
 pub const lsm_table_size_max = 64 * 1024 * 1024;
 
 /// Size of nodes used by the LSM tree manifest implementation.

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -60,6 +60,8 @@ pub fn ewah(comptime Word: type) type {
 
         /// Decodes the compressed bitset in `source` into `target_words`.
         /// Returns the number of *words* written to `target_words`.
+        // TODO Refactor to return an error when `source` is invalid,
+        // so that we can test invalid encodings.
         pub fn decode(source: []align(@alignOf(Word)) const u8, target_words: []Word) usize {
             assert(source.len % @sizeOf(Word) == 0);
             assert(source.len >= @sizeOf(Marker));

--- a/src/lsm/README.md
+++ b/src/lsm/README.md
@@ -47,7 +47,7 @@ The first half of the bar compacts even levels while the latter compacts odd lev
 Mutable table changes are sorted and compacted into the immutable table.
 The immutable table is compacted into level 0 during the odd level half of the bar.
 
-At any given point, there are at most `levels/2` compactions running concurrently.
+At any given point, there are at most `⌈levels/2⌉` compactions running concurrently.
 The source level is denoted as `level_a` and the target level as `level_b`.
 The last level in the LSM tree has no target level so it is never a source level.
 Each compaction compacts a [single table](#table-selection) from `level_a` into all tables in

--- a/src/lsm/README.md
+++ b/src/lsm/README.md
@@ -63,15 +63,20 @@ Invariants:
     * Allow the per-level table limits to overflow if needed (for example, if we may compact a table
       from level `A` to level `B`, where level `B` is already full).
     * Start compactions from even levels that have reached their table limit.
+    * Acquire reservations from the Free Set for all blocks (upper-bound) that will be written
+      during this half-bar.
 
 2. First half-bar, last beat:
     * Finish ticking any incomplete even-level compactions.
     * Assert on callback completion that all compactions are complete.
+    * Release reservations from the Free Set.
 
 3. Second half-bar, first beat ("middle beat"):
     * Assert no compactions are currently running.
     * Start compactions from odd levels that have reached their table limit.
     * Compact the immutable table if it contains any sorted values (it might be empty).
+    * Acquire reservations from the Free Set for all blocks (upper-bound) that will be written
+      during this half-bar.
 
 4. Second half-bar, last beat:
     * Finish ticking any incomplete odd-level and immutable table compactions.
@@ -79,6 +84,7 @@ Invariants:
     * Assert on callback completion that no level's table count overflows.
     * Flush, clear, and sort mutable table values into immutable table for next bar.
     * Remove input tables that are invisible to all current and persisted snapshots.
+    * Release reservations from the Free Set.
 
 ### Compaction Selection Policy
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -303,12 +303,12 @@ pub fn CompactionType(
             // This is safe; iterator_b makes a copy of the block before calling us.
             const grid = compaction.grid;
             for (Table.index_data_addresses_used(index_block)) |address| {
-                grid.release_at_checkpoint(address);
+                grid.release(address);
             }
             for (Table.index_filter_addresses_used(index_block)) |address| {
-                grid.release_at_checkpoint(address);
+                grid.release(address);
             }
-            grid.release_at_checkpoint(Table.index_block_address(index_block));
+            grid.release(Table.index_block_address(index_block));
         }
 
         pub fn compact_tick(compaction: *Compaction, callback: Callback) void {

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -231,10 +231,10 @@ pub fn CompactionType(
 
             compaction.* = .{
                 .grid = grid,
-                // Reserve enough blocks to write our output tables in the worst case:
+                // Reserve enough blocks to write our output tables in the worst case, where:
                 // - no tombstones are dropped,
-                // - and no values are overwritten
-                // - all tables are full
+                // - no values are overwritten,
+                // - and all tables are full.
                 //
                 // We must reserve before doing any async work so that the block acquisition order
                 // is deterministic (relative to other concurrent compactions).

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -121,6 +121,7 @@ pub fn CompactionType(
         };
 
         grid: *Grid,
+        grid_reservation: Grid.Reservation,
         range: Manifest.CompactionRange,
 
         /// `op_min` is the first op/beat of this compaction's half-bar.
@@ -165,6 +166,7 @@ pub fn CompactionType(
             return Compaction{
                 // Assigned by start()
                 .grid = undefined,
+                .grid_reservation = undefined,
                 .range = undefined,
                 .op_min = undefined,
                 .drop_tombstones = undefined,
@@ -227,6 +229,20 @@ pub fn CompactionType(
 
             compaction.* = .{
                 .grid = grid,
+                // Reserve enough blocks to write our output tables in the worst case:
+                // - no tombstones are dropped,
+                // - and no values are overwritten
+                // - all tables are full
+                //
+                // We must reserve before doing any async work so that the block acquisition order
+                // is deterministic (relative to other concurrent compactions).
+                // TODO The replica must stop accepting requests if it runs out of blocks/capacity,
+                // rather than panicking here.
+                // TODO(Compaction Pacing): Reserve smaller increments, at the start of each beat.
+                // (And likewise release the reservation at the end of each beat, instead of at the
+                // end of each half-bar).
+                // TODO(Move Table) Don't reserve these when we just move the table to the next level.
+                .grid_reservation = grid.reserve(range.table_count * Table.block_count_max).?,
                 .range = range,
                 .op_min = op_min,
                 .drop_tombstones = drop_tombstones,
@@ -441,7 +457,7 @@ pub fn CompactionType(
             {
                 compaction.table_builder.data_block_finish(.{
                     .cluster = compaction.grid.superblock.working.cluster,
-                    .address = compaction.grid.acquire(),
+                    .address = compaction.grid.acquire(compaction.grid_reservation),
                 });
 
                 // Mark the finished data block as writable for the next compact_tick() call.
@@ -457,7 +473,7 @@ pub fn CompactionType(
             {
                 compaction.table_builder.filter_block_finish(.{
                     .cluster = compaction.grid.superblock.working.cluster,
-                    .address = compaction.grid.acquire(),
+                    .address = compaction.grid.acquire(compaction.grid_reservation),
                 });
 
                 // Mark the finished filter block as writable for the next compact_tick() call.
@@ -473,7 +489,7 @@ pub fn CompactionType(
             {
                 const table = compaction.table_builder.index_block_finish(.{
                     .cluster = compaction.grid.superblock.working.cluster,
-                    .address = compaction.grid.acquire(),
+                    .address = compaction.grid.acquire(compaction.grid_reservation),
                     .snapshot_min = snapshot_min_for_table_output(compaction.op_min),
                     // TODO(Persistent Snapshots) set snapshot_max to the minimum snapshot_max of
                     // all the (original) input tables.
@@ -539,6 +555,10 @@ pub fn CompactionType(
             assert(compaction.callback == null);
             assert(compaction.io_pending == 0);
             assert(compaction.merge_done);
+
+            // TODO(Beat Pacing) This should really be where the compaction callback is invoked,
+            // but currently that can occur multiple times per beat.
+            compaction.grid.forfeit(compaction.grid_reservation);
 
             compaction.status = .idle;
             compaction.merge_done = false;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -153,6 +153,8 @@ pub fn CompactionType(
         level_b: u8,
         level_a_input: ?TableInfo,
 
+        tables_output_count: usize = 0,
+
         pub fn init(allocator: mem.Allocator) !Compaction {
             var iterator_a = try IteratorA.init(allocator);
             errdefer iterator_a.deinit(allocator);
@@ -500,6 +502,9 @@ pub fn CompactionType(
                 compaction.index.block = compaction.table_builder.index_block;
                 assert(!compaction.index.writable);
                 compaction.index.writable = true;
+
+                compaction.tables_output_count += 1;
+                assert(compaction.tables_output_count <= compaction.range.table_count);
             }
         }
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -201,7 +201,7 @@ const Environment = struct {
         env.change_state(.forest_checkpointing, .superblock_checkpointing);
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
             .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
-            .commit_min = env.checkpoint_op.? + 1,
+            .commit_min = env.checkpoint_op.?,
             .commit_max = env.checkpoint_op.? + 1,
             .view_normal = 0,
             .view = 0,

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -83,6 +83,7 @@ const Environment = struct {
     forest: Forest,
     // We need @fieldParentPtr() of forest, so we can't use an optional Forest.
     forest_exists: bool,
+    checkpoint_op: ?u64 = null,
 
     fn init(env: *Environment, storage: *Storage) !void {
         env.state = .uninit;
@@ -187,7 +188,8 @@ const Environment = struct {
         env.change_state(.forest_compacting, .forest_open);
     }
 
-    pub fn checkpoint(env: *Environment) void {
+    pub fn checkpoint(env: *Environment, op: u64) void {
+        env.checkpoint_op = op - config.lsm_batch_multiple;
         env.change_state(.forest_open, .forest_checkpointing);
         env.forest.checkpoint(forest_checkpoint_callback);
         env.tick_until_state_change(.forest_checkpointing, .superblock_checkpointing);
@@ -199,11 +201,12 @@ const Environment = struct {
         env.change_state(.forest_checkpointing, .superblock_checkpointing);
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
             .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
-            .commit_min = env.superblock.working.vsr_state.commit_min + 1,
-            .commit_max = env.superblock.working.vsr_state.commit_max + 1,
+            .commit_min = env.checkpoint_op.? + 1,
+            .commit_max = env.checkpoint_op.? + 1,
             .view_normal = 0,
             .view = 0,
         });
+        env.checkpoint_op = null;
     }
 
     fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
@@ -255,8 +258,7 @@ const Environment = struct {
             switch (fuzz_op) {
                 .compact => |compact| {
                     env.compact(compact.op);
-                    if (compact.checkpoint)
-                        env.checkpoint();
+                    if (compact.checkpoint) env.checkpoint(compact.op);
                 },
                 .put_account => |account| {
                     env.forest.grooves.accounts.put(&account);
@@ -346,6 +348,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random) ![]const FuzzOp {
                 const checkpoint =
                     // Can only checkpoint on the last beat of the bar.
                     compact_op % config.lsm_batch_multiple == config.lsm_batch_multiple - 1 and
+                    compact_op > config.lsm_batch_multiple and
                     // Checkpoint at roughly the same rate as log wraparound.
                     random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
                 break :compact FuzzOp{

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -187,7 +187,10 @@ pub fn GridType(comptime Storage: type) type {
         pub fn acquire(grid: *Grid) u64 {
             // We will reject incoming data before it reaches the point
             // where storage is full, so this assertion is safe.
-            return grid.superblock.free_set.acquire().?;
+            const reservation = grid.superblock.free_set.reserve(1).?;
+            defer grid.superblock.free_set.forfeit();
+
+            return grid.superblock.free_set.acquire(reservation).?;
         }
 
         /// This function should be used to release addresses, instead of release()

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -188,7 +188,7 @@ pub fn GridType(comptime Storage: type) type {
             // We will reject incoming data before it reaches the point
             // where storage is full, so this assertion is safe.
             const reservation = grid.superblock.free_set.reserve(1).?;
-            defer grid.superblock.free_set.forfeit();
+            defer grid.superblock.free_set.forfeit(reservation);
 
             return grid.superblock.free_set.acquire(reservation).?;
         }

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -190,7 +190,7 @@ pub fn GridType(comptime Storage: type) type {
             return grid.superblock.free_set.acquire().?;
         }
 
-        /// This function should be used to release addresses, instead of release_at_checkpoint()
+        /// This function should be used to release addresses, instead of release()
         /// on the free set directly, as this also demotes the address within the block cache.
         /// This reduces conflict misses in the block cache, by freeing ways soon after they are
         /// released.
@@ -199,12 +199,12 @@ pub fn GridType(comptime Storage: type) type {
         /// checkpoint.
         ///
         /// Asserts that the address is not currently being read from or written to.
-        pub fn release_at_checkpoint(grid: *Grid, address: u64) void {
+        pub fn release(grid: *Grid, address: u64) void {
             grid.assert_not_writing(address, null);
             grid.assert_not_reading(address, null);
 
             grid.cache.demote(address);
-            grid.superblock.free_set.release_at_checkpoint(address);
+            grid.superblock.free_set.release(address);
         }
 
         /// Assert that the address is not currently being written to.

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -547,6 +547,13 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             return true;
         }
 
+        pub fn reserve(manifest: *Manifest) void {
+            assert(manifest.compact_callback == null);
+            assert(manifest.checkpoint_callback == null);
+
+            manifest.manifest_log.reserve();
+        }
+
         pub fn compact(manifest: *Manifest, callback: Callback) void {
             assert(manifest.compact_callback == null);
             assert(manifest.checkpoint_callback == null);

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -549,6 +549,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
         pub fn compact(manifest: *Manifest, callback: Callback) void {
             assert(manifest.compact_callback == null);
+            assert(manifest.checkpoint_callback == null);
             manifest.compact_callback = callback;
 
             manifest.manifest_log.compact(manifest_log_compact_callback);
@@ -557,6 +558,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         fn manifest_log_compact_callback(manifest_log: *ManifestLog) void {
             const manifest = @fieldParentPtr(Manifest, "manifest_log", manifest_log);
             assert(manifest.compact_callback != null);
+            assert(manifest.checkpoint_callback == null);
 
             const callback = manifest.compact_callback.?;
             manifest.compact_callback = null;
@@ -564,6 +566,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         }
 
         pub fn checkpoint(manifest: *Manifest, callback: Callback) void {
+            assert(manifest.compact_callback == null);
             assert(manifest.checkpoint_callback == null);
             manifest.checkpoint_callback = callback;
 
@@ -572,6 +575,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
         fn manifest_log_checkpoint_callback(manifest_log: *ManifestLog) void {
             const manifest = @fieldParentPtr(Manifest, "manifest_log", manifest_log);
+            assert(manifest.compact_callback == null);
             assert(manifest.checkpoint_callback != null);
 
             const callback = manifest.checkpoint_callback.?;

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -84,10 +84,13 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         /// The maximum number of table updates to the manifest by a half-measure of table
         /// compaction (not including manifest log compaction).
         ///
-        /// Input tables are removed from the manifest.
-        /// Output tables are removed from the manifest.
+        /// Input tables are updated in the manifest (snapshot_max is reduced).
+        /// Input tables are removed from the manifest (if not held by a persistent snapshot).
+        /// Output tables are inserted into the manifest.
+        // TODO If insert-then-remove can update in-memory, then we can only count input tables once.
         pub const compaction_appends_max = tree.compactions_max *
-            (tree.compaction_tables_input_max +
+            (tree.compaction_tables_input_max + // Update snapshot_max.
+            tree.compaction_tables_input_max + // Remove.
             tree.compaction_tables_output_max);
 
         const blocks_count_appends = util.div_ceil(compaction_appends_max, Block.entry_count_max);

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -530,7 +530,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             );
             assert(!manifest.queued_for_compaction(block_reference.address));
 
-            manifest_log.grid.release_at_checkpoint(block_reference.address);
+            manifest_log.grid.release(block_reference.address);
 
             const callback = manifest_log.read_callback.?;
             manifest_log.reading = false;

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -3,8 +3,8 @@
 //! Invariants checked:
 //!
 //! - Checkpoint flushes all buffered log blocks (including partial blocks).
-//! - The ManifestLog after recovery matches the ManifestLog after checkpoint.
-//! - The SuperBlock.Manifest after recovery matches the SuperBlock.Manifest after checkpoint.
+//! - The state of the ManifestLog/SuperBlock.Manifest immediately after recovery matches
+//!   the state of the ManifestLog/SuperBlock.Manifest immediately after the latest checkpoint.
 //! - SuperBlock.Manifest.open() only returns the latest version of each table.
 //! - SuperBlock.Manifest's compaction queue contains any blocks which:
 //!   - contain fewer than entry_count_max entries, or
@@ -30,8 +30,8 @@ const fuzz = @import("../test/fuzz.zig");
 
 const storage_size_max = data_file_size_min + config.block_size * 1024;
 
-const entries_max_per_block = ManifestLog.Block.entry_count_max;
-const entries_max_buffered = entries_max_per_block *
+const entries_max_block = ManifestLog.Block.entry_count_max;
+const entries_max_buffered = entries_max_block *
     std.meta.fieldInfo(ManifestLog, .blocks).field_type.count_max;
 
 pub fn main() !void {

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -200,6 +200,7 @@ pub fn TableType(
             );
 
             // Compute the number of data and filter blocks by solving the constraints:
+            // * the cumulative table size must not exceed lsm_table_size_max
             // * the filter and data blocks' metadata must fix in the index block
             // * the filter blocks must index all data blocks
             // * minimize the number of filter blocks

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -126,6 +126,8 @@ pub fn TableType(
         const block_body_size = block_size - @sizeOf(vsr.Header);
 
         pub const layout = layout: {
+            @setEvalBranchQuota(10_000);
+
             assert(block_size % config.sector_size == 0);
             assert(math.isPowerOfTwo(table_size_max));
             assert(math.isPowerOfTwo(block_size));
@@ -182,7 +184,8 @@ pub fn TableType(
             assert((block_keys_layout_count * key_size) % config.cache_line_size == 0);
 
             const block_key_layout_size = block_keys_layout_count * key_size;
-            const block_key_count = block_keys_layout_count - 1;
+            const block_key_count =
+                if (block_keys_layout_count == 0) 0 else block_keys_layout_count - 1;
 
             const block_value_count_max = @divFloor(
                 block_body_size - block_key_layout_size,
@@ -235,13 +238,18 @@ pub fn TableType(
                 .filter_block_count_max = filter_blocks,
 
                 // The number of data blocks covered by a single filter block.
-                .filter_data_block_count_max = filter_data_block_count_max,
+                .filter_data_block_count_max = std.math.min(
+                    filter_data_block_count_max,
+                    data_blocks,
+                ),
             };
         };
 
         const index_block_count = 1;
-        const filter_block_count_max = layout.filter_block_count_max;
+        pub const filter_block_count_max = layout.filter_block_count_max;
         pub const data_block_count_max = layout.data_block_count_max;
+        pub const block_count_max =
+            index_block_count + filter_block_count_max + data_block_count_max;
 
         const index = struct {
             const size = @sizeOf(vsr.Header) + filter_checksums_size + data_checksums_size +
@@ -554,21 +562,23 @@ pub fn TableType(
                 }
 
                 assert(@divExact(data.key_layout_size, key_size) == data.key_count + 1);
-                const key_layout_bytes = @alignCast(
-                    @alignOf(Key),
-                    block[data.key_layout_offset..][0..data.key_layout_size],
-                );
-                const key_layout = mem.bytesAsValue([data.key_count + 1]Key, key_layout_bytes);
+                if (data.key_count > 0) {
+                    const key_layout_bytes = @alignCast(
+                        @alignOf(Key),
+                        block[data.key_layout_offset..][0..data.key_layout_size],
+                    );
+                    const key_layout = mem.bytesAsValue([data.key_count + 1]Key, key_layout_bytes);
 
-                const e = eytzinger(data.key_count, data.value_count_max);
-                e.layout_from_keys_or_values(
-                    Key,
-                    Value,
-                    key_from_value,
-                    sentinel_key,
-                    values,
-                    key_layout,
-                );
+                    const e = eytzinger(data.key_count, data.value_count_max);
+                    e.layout_from_keys_or_values(
+                        Key,
+                        Value,
+                        key_from_value,
+                        sentinel_key,
+                        values,
+                        key_layout,
+                    );
+                }
 
                 const values_padding = mem.sliceAsBytes(values_max[builder.value..]);
                 const block_padding = block[data.padding_offset..][0..data.padding_size];

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -51,6 +51,14 @@ const half_bar_beat_count = @divExact(config.lsm_batch_multiple, 2);
 /// The maximum number of tables for a single tree.
 pub const table_count_max = table_count_max_for_tree(config.lsm_growth_factor, config.lsm_levels);
 
+// +1: from level A
+// +2: from level B, on either edge of the lsm_growth_factor tables.
+pub const compaction_tables_input_max = 1 + config.lsm_growth_factor + 2;
+pub const compaction_tables_output_max = compaction_tables_input_max;
+
+/// The maximum number of concurrent compactions (per tree).
+pub const compactions_max = div_ceil(config.lsm_levels, 2);
+
 pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_name: []const u8) type {
     const Key = TreeTable.Key;
     const Value = TreeTable.Value;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -558,6 +558,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 config.lsm_batch_multiple,
             });
 
+            if (start) tree.manifest.reserve();
+
             // Try to start compacting the immutable table.
             const even_levels = compaction_beat < half_bar_beat_count;
             if (even_levels) {

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -51,9 +51,16 @@ const half_bar_beat_count = @divExact(config.lsm_batch_multiple, 2);
 /// The maximum number of tables for a single tree.
 pub const table_count_max = table_count_max_for_tree(config.lsm_growth_factor, config.lsm_levels);
 
-// +1: from level A
-// +2: from level B, on either edge of the lsm_growth_factor tables.
-pub const compaction_tables_input_max = 1 + config.lsm_growth_factor + 2;
+/// The upper-bound count of input tables to a single tree's compaction.
+///
+/// +1: from level A
+/// +1: from level B, with one edge overlapping the lsm_growth_factor tables.
+///     (This is not +2 because input table selection is least-overlap. If the input table overlaps
+///     on both edges, there must be another table with less overlap to select).
+pub const compaction_tables_input_max = 1 + config.lsm_growth_factor + 1;
+
+/// The upper-bound count of output tables from a single tree's compaction.
+/// In the "worst" case, no keys are overwritten/merged, and no tombstones are dropped.
 pub const compaction_tables_output_max = compaction_tables_input_max;
 
 /// The maximum number of concurrent compactions (per tree).

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -75,10 +75,10 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 pub const lookup_transfers = operation_batch_max(.lookup_transfers);
 
                 comptime {
-                    assert(create_accounts >= 0);
-                    assert(create_transfers >= 0);
-                    assert(lookup_accounts >= 0);
-                    assert(lookup_transfers >= 0);
+                    assert(create_accounts > 0);
+                    assert(create_transfers > 0);
+                    assert(lookup_accounts > 0);
+                    assert(lookup_transfers > 0);
                 }
 
                 fn operation_batch_max(comptime operation: Operation) usize {

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -780,6 +780,7 @@ pub const Storage = struct {
             vsr.Header,
             storage.memory[block_offset..][0..@sizeOf(vsr.Header)],
         )[0];
+        assert(storage.memory_written.isSet(@divExact(block_offset, config.sector_size)));
         assert(block_header.valid_checksum());
         assert(block_header.size <= config.block_size);
 

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -772,19 +772,22 @@ pub const Storage = struct {
         return mem.bytesAsSlice(MessageRaw, storage.memory[offset..][0..size]);
     }
 
-    pub fn grid_block(storage: *const Storage, address: u64) []const u8 {
+    pub fn grid_block(
+        storage: *const Storage,
+        address: u64,
+    ) *align(config.sector_size) const [config.block_size]u8 {
         assert(address > 0);
 
         const block_offset = vsr.Zone.grid.offset((address - 1) * config.block_size);
-        const block_header = mem.bytesAsSlice(
+        const block_header = mem.bytesToValue(
             vsr.Header,
             storage.memory[block_offset..][0..@sizeOf(vsr.Header)],
-        )[0];
+        );
         assert(storage.memory_written.isSet(@divExact(block_offset, config.sector_size)));
         assert(block_header.valid_checksum());
         assert(block_header.size <= config.block_size);
 
-        return storage.memory[block_offset..][0..block_header.size];
+        return storage.memory[block_offset..][0..config.block_size];
     }
 };
 

--- a/src/test/storage_checker.zig
+++ b/src/test/storage_checker.zig
@@ -3,18 +3,19 @@
 //! At each replica compact and checkpoint, check that storage is byte-for-byte identical across
 //! replicas.
 //!
-//! Areas checked at compaction (half-measure):
-//! - Acquired Grid blocks (ignores skipped recovery compactions)
+//! Areas verified at compaction (half-measure):
+//! - Acquired Grid blocks (ignores skipped recovery compactions) (TODO)
 //!
-//! Areas checked at checkpoint:
-//! - WAL headers
+//! Areas verified at checkpoint:
 //! - WAL prepares
 //! - SuperBlock Manifest, FreeSet, ClientTable
 //! - Acquired Grid blocks
 //!
-//! Areas not checked:
-//! - SuperBlock sectors
-//! - Non-allocated Grid blocks
+//! Areas not verified:
+//! - SuperBlock sectors, which hold replica-specific state.
+//! - WAL headers, which may differ because the WAL writes deliberately corrupt redundant headers
+//!   to faulty slots to ensure recovery is consistent.
+//! - Non-allocated Grid blocks, which may differ due to state transfer.
 const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.storage_checker);
@@ -46,10 +47,8 @@ const Checkpoint = struct {
     checksum_superblock_manifest: u128,
     checksum_superblock_free_set: u128,
     checksum_superblock_client_table: u128,
-    checksum_wal_headers: u128,
     checksum_wal_prepares: u128,
     checksum_grid: u128,
-    vsr_state: SuperBlockSector.VSRState,
 };
 
 pub const StorageChecker = struct {
@@ -85,6 +84,7 @@ pub const StorageChecker = struct {
         // Until then our grid's checksum is too far ahead.
         if (replica.superblock.working.vsr_state.op_compacted(replica.commit_min)) return;
 
+        // TODO(Beat Compaction) Remove when deterministic beat compaction is implemented.
         const half_measure_beat_count = @divExact(config.lsm_batch_multiple, 2);
         if ((replica.commit_min + 1) % half_measure_beat_count != 0) return;
 
@@ -124,10 +124,8 @@ pub const StorageChecker = struct {
             .checksum_superblock_manifest = 0,
             .checksum_superblock_free_set = 0,
             .checksum_superblock_client_table = 0,
-            .checksum_wal_headers = checksum_wal_headers(storage),
             .checksum_wal_prepares = checksum_wal_prepares(storage),
             .checksum_grid = checksum_grid(replica),
-            .vsr_state = working.vsr_state,
         };
 
         inline for (.{
@@ -177,21 +175,15 @@ pub const StorageChecker = struct {
         if (fail) return error.StorageMismatch;
     }
 
-    fn checksum_wal_headers(storage: *const Storage) u128 {
-        return vsr.checksum(std.mem.sliceAsBytes(storage.wal_headers()));
-    }
-
     fn checksum_wal_prepares(storage: *const Storage) u128 {
-        const wal_prepares = storage.wal_prepares();
         var checksum: u128 = 0;
-        for (storage.wal_headers()) |h, i| {
-            assert(h.command == .prepare or h.command == .reserved);
-            assert(h.size <= config.message_size_max);
-            assert(h.checksum == wal_prepares[i].header.checksum);
+        for (storage.wal_prepares()) |*prepare| {
+            assert(prepare.header.valid_checksum());
+            assert(prepare.header.command == .prepare);
 
             // Only checksum the actual message header+body. Any leftover space is nondeterministic,
             // because the current prepare may have overwritten a longer message.
-            checksum ^= vsr.checksum(std.mem.asBytes(&wal_prepares[i])[0..h.size]);
+            checksum ^= vsr.checksum(std.mem.asBytes(prepare)[0..prepare.header.size]);
         }
         return checksum;
     }

--- a/src/test/storage_checker.zig
+++ b/src/test/storage_checker.zig
@@ -4,7 +4,9 @@
 //! replicas.
 //!
 //! Areas verified at compaction (half-measure):
-//! - Acquired Grid blocks (ignores skipped recovery compactions) (TODO)
+//! - Acquired Grid blocks (ignores skipped recovery compactions)
+//!  TODO Because ManifestLog acquires blocks potentially several beats prior to actually writing
+//!  the block, this check will need to be removed or use a different strategy.
 //!
 //! Areas verified at checkpoint:
 //! - WAL prepares

--- a/src/test/storage_checker.zig
+++ b/src/test/storage_checker.zig
@@ -193,7 +193,9 @@ pub const StorageChecker = struct {
         var acquired = replica.superblock.free_set.blocks.iterator(.{ .kind = .unset });
         var checksum: u128 = 0;
         while (acquired.next()) |address_index| {
-            checksum ^= vsr.checksum(storage.grid_block(address_index + 1));
+            const block = storage.grid_block(address_index + 1);
+            const block_header = std.mem.bytesToValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+            checksum ^= vsr.checksum(block[0..block_header.size]);
         }
         return checksum;
     }

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -316,6 +316,7 @@ pub const superblock_trailer_manifest_size_max = blk: {
 
     // Use a multiple of sector * reference so that the size is exactly divisible without padding:
     // For example, this 2.5 MiB manifest trailer == 65536 references == 65536 * 511 or 34m tables.
+    // TODO Size this relative to the expected number of tables & fragmentation.
     break :blk 16 * config.sector_size * SuperBlockManifest.BlockReferenceSize;
 };
 

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -15,6 +15,7 @@ const div_ceil = @import("../util.zig").div_ceil;
 pub const Reservation = struct {
     block_base: usize,
     block_count: usize,
+    /// An identifer for each reservation cycle, to verify that old reservations are not reused.
     session: usize,
 };
 
@@ -204,7 +205,7 @@ pub const FreeSet = struct {
         };
     }
 
-    /// After invoking `forfeit()`, any previous reservations must never be used.
+    /// After invoking `forfeit()`, the reservation must never be used again.
     pub fn forfeit(set: *FreeSet, reservation: Reservation) void {
         assert(set.reservation_session == reservation.session);
 

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -10,6 +10,13 @@ const config = @import("../config.zig");
 const ewah = @import("../ewah.zig").ewah(usize);
 const div_ceil = @import("../util.zig").div_ceil;
 
+/// This is logically a range of addresses within the FreeSet, but its actual fields are block
+/// indexes for ease of calculation.
+pub const AddressReservation = struct {
+    block_base: usize,
+    block_count: usize,
+};
+
 /// The 0 address is reserved for usage as a sentinel and will never be returned by acquire().
 ///
 /// Set bits indicate free blocks, unset bits are allocated.
@@ -18,6 +25,12 @@ pub const FreeSet = struct {
     /// That is, if a shard has any free blocks, the corresponding index bit is set.
     index: DynamicBitSetUnmanaged,
     blocks: DynamicBitSetUnmanaged,
+
+    /// The number of blocks that are reserved, counting both acquired and free blocks
+    /// from the start of `blocks`.
+    /// Alternatively, the index of the first non-reserved block in `blocks`.
+    blocks_reserved: usize = 0,
+
     /// Set bits indicate blocks to be released at the next checkpoint.
     staging: DynamicBitSetUnmanaged,
 
@@ -28,7 +41,7 @@ pub const FreeSet = struct {
     //
     // e.g. 10TiB disk ÷ 64KiB/block ÷ 512*8 blocks/shard ÷ 8 shards/byte = 5120B index
     const shard_cache_lines = 8;
-    const shard_size = shard_cache_lines * config.cache_line_size * @bitSizeOf(u8);
+    pub const shard_size = shard_cache_lines * config.cache_line_size * @bitSizeOf(u8);
     comptime {
         assert(shard_size == 4096);
         assert(@bitSizeOf(MaskInt) == 64);
@@ -96,17 +109,82 @@ pub const FreeSet = struct {
         }
     }
 
+    /// Reserve `reserve_count` free blocks. The blocks are not acquired yet.
+    ///
+    /// Concurrent callers must reserve free blocks before acquiring them to ensure that
+    /// acquisition order is deterministic despite concurrent jobs acquiring blocks in
+    /// nondeterministic order. The reservation lifecycle is:
+    ///
+    /// 1. Setup: In deterministic order, each job (e.g. compaction) calls `reserve()` to reserve
+    ///    the upper bound of blocks that it may need to acquire to complete.
+    /// 2. Work: The jobs run concurrently. Each job acquires blocks only from its respective
+    ///    reservation (via `acquire_reserved()`).
+    /// 3. Finish: When all jobs are finished, all leftover reserved blocks are forfeited by
+    ///    `reserve_done()`.
+    ///
+    /// Invariants:
+    /// - If a reservation is returned, it covers exactly `reserve_count` free blocks, along with
+    ///   any interleaved already-acquired blocks.
+    /// - Active reservations are exclusive (i.e. disjoint).
+    ///   (A reservation is active until `reserve_done()` is called.)
+    ///
+    /// Returns a range which can be used with `acquire_reserved()`.
+    /// Returns null if there are not enough blocks free and vacant.
+    /// The caller should consider the returned AddressReservation as opaque and immutable.
+    pub fn reserve(set: *FreeSet, reserve_count: usize) ?AddressReservation {
+        assert(reserve_count > 0);
+
+        var shard_start = find_first_set_bit(
+            set.index,
+            @divFloor(set.blocks_reserved, shard_size),
+            set.index.bit_length,
+        ) orelse return null;
+
+        var block = std.math.max(
+            shard_start * shard_size,
+            set.blocks_reserved,
+        );
+
+        var reserved: usize = 0;
+        while (reserved < reserve_count) : (reserved += 1) {
+            block = 1 + (find_first_set_bit(
+                set.blocks,
+                block,
+                set.blocks.bit_length,
+            ) orelse return null);
+        }
+
+        const block_base = set.blocks_reserved;
+        const block_count = block - set.blocks_reserved;
+        set.blocks_reserved += block_count;
+
+        return AddressReservation{
+            .block_base = block_base,
+            .block_count = block_count,
+        };
+    }
+
+    pub fn reserve_done(set: *FreeSet) void {
+        set.blocks_reserved = 0;
+    }
+
     /// Marks a free block as allocated, and returns the address.
     /// Returns null if no free block is available.
+    // TODO remove
     pub fn acquire(set: *FreeSet) ?u64 {
-        const block = blk: {
-            if (set.index.findFirstSet()) |shard| {
-                break :blk set.find_free_block_in_shard(shard) orelse unreachable;
-            } else {
-                return null;
-            }
-        };
-        const shard = block / shard_size;
+        if (set.index.findFirstSet()) |shard| {
+            const block = set.find_free_block_in_shard(shard).?;
+            const address = block + 1;
+            set.acquire_address(address);
+            return address;
+        }
+        return null;
+    }
+
+    /// Mark the specified free block as allocated.
+    fn acquire_address(set: *FreeSet, address: u64) void {
+        const block = address - 1;
+        const shard = @divFloor(block, shard_size);
         assert(set.index.isSet(shard));
         assert(set.blocks.isSet(block));
         assert(!set.staging.isSet(block));
@@ -114,9 +192,41 @@ pub const FreeSet = struct {
         set.blocks.unset(block);
         // Update the index when every block in the shard is allocated.
         if (set.find_free_block_in_shard(shard) == null) set.index.unset(shard);
+    }
+
+    /// Marks a free block from the reservation as allocated, and returns the address.
+    ///
+    /// Invariants:
+    ///
+    ///   - An acquired block cannot be acquired again until it has been released and the release
+    ///     has been checkpointed.
+    ///
+    /// Returns null if no free block is available in the reservation.
+    // TODO rename to acquire()
+    pub fn acquire_reserved(set: *FreeSet, reservation: AddressReservation) ?u64 {
+        assert(reservation.block_count > 0);
+        assert(reservation.block_base < set.blocks_reserved);
+        assert(reservation.block_base + reservation.block_count <= set.blocks_reserved);
+
+        const shard = find_first_set_bit(
+            set.index,
+            @divFloor(reservation.block_base, shard_size),
+            div_ceil(reservation.block_base + reservation.block_count, shard_size),
+        ) orelse return null;
+
+        const reservation_start = std.math.max(
+            shard * shard_size,
+            reservation.block_base,
+        );
+        const reservation_end = reservation.block_base + reservation.block_count;
+        const block = find_first_set_bit(set.blocks, reservation_start, reservation_end) orelse return null;
+        assert(block >= reservation.block_base);
+        assert(block <= reservation.block_base + reservation.block_count);
 
         const address = block + 1;
-        return @intCast(u64, address);
+        set.acquire_address(address);
+
+        return address;
     }
 
     fn find_free_block_in_shard(set: *FreeSet, shard: usize) ?usize {
@@ -132,20 +242,12 @@ pub const FreeSet = struct {
         return set.blocks.isSet(block);
     }
 
-    /// Given the address, marks an allocated block as free.
-    pub fn release(set: *FreeSet, address: u64) void {
-        const block = address - 1;
-        assert(!set.blocks.isSet(block));
-        assert(!set.staging.isSet(block));
-
-        set.index.set(block / shard_size);
-        set.blocks.set(block);
-    }
-
     /// Leave the address allocated for now, but free it at the next checkpoint.
+    /// This ensures that it will not be overwritten during the current checkpoint — the block may
+    /// still be needed if we crash and recover from the current checkpoint.
     /// (TODO) If the block was created since the last checkpoint then it's safe to free immediately.
     ///        This may reduce space amplification, especially for smaller datasets.
-    pub fn release_at_checkpoint(set: *FreeSet, address: u64) void {
+    pub fn release(set: *FreeSet, address: u64) void {
         const block = address - 1;
         assert(!set.blocks.isSet(block));
         assert(!set.staging.isSet(block));
@@ -153,13 +255,26 @@ pub const FreeSet = struct {
         set.staging.set(block);
     }
 
+    /// Given the address, marks an allocated block as free.
+    fn release_now(set: *FreeSet, address: u64) void {
+        const block = address - 1;
+        assert(!set.blocks.isSet(block));
+        assert(!set.staging.isSet(block));
+
+        set.index.set(@divFloor(block, shard_size));
+        set.blocks.set(block);
+    }
+
     /// Free all staged blocks.
+    /// Checkpoint must not be called while there are outstanding reservations.
     pub fn checkpoint(set: *FreeSet) void {
+        assert(set.blocks_reserved == 0);
+
         var it = set.staging.iterator(.{ .kind = .set });
         while (it.next()) |block| {
             set.staging.unset(block);
             const address = block + 1;
-            set.release(address);
+            set.release_now(address);
         }
         assert(set.staging.count() == 0);
     }
@@ -190,8 +305,9 @@ pub const FreeSet = struct {
     pub fn decode(set: *FreeSet, source: []align(@alignOf(usize)) const u8) void {
         // Verify that this FreeSet is entirely unallocated.
         assert(set.index.count() == set.index.bit_length);
+        assert(set.blocks_reserved == 0);
 
-        const words_decoded = ewah.decode(source, bitset_masks(set.blocks));
+        const words_decoded = ewah.decode(source, bit_set_masks(set.blocks));
         assert(words_decoded * @bitSizeOf(MaskInt) <= set.blocks.bit_length);
 
         var shard: usize = 0;
@@ -213,8 +329,9 @@ pub const FreeSet = struct {
     /// The encoded data does *not* include staged changes.
     pub fn encode(set: FreeSet, target: []align(@alignOf(usize)) u8) usize {
         assert(target.len == FreeSet.encode_size_max(set.blocks.bit_length));
+        assert(set.blocks_reserved == 0);
 
-        return ewah.encode(bitset_masks(set.blocks), target);
+        return ewah.encode(bit_set_masks(set.blocks), target);
     }
 
     /// Returns `blocks_count` rounded down to the nearest multiple of shard and word bit count.
@@ -232,9 +349,9 @@ pub const FreeSet = struct {
     }
 };
 
-fn bitset_masks(bitset: DynamicBitSetUnmanaged) []usize {
-    const len = div_ceil(bitset.bit_length, @bitSizeOf(MaskInt));
-    return bitset.masks[0..len];
+fn bit_set_masks(bit_set: DynamicBitSetUnmanaged) []usize {
+    const len = div_ceil(bit_set.bit_length, @bitSizeOf(MaskInt));
+    return bit_set.masks[0..len];
 }
 
 test "FreeSet highest_address_acquired" {
@@ -249,13 +366,13 @@ test "FreeSet highest_address_acquired" {
     try expectEqual(@as(?u64, 3), set.acquire());
 
     try expectEqual(@as(?u64, 3), set.highest_address_acquired());
-    set.release(2);
+    set.release_now(2);
     try expectEqual(@as(?u64, 3), set.highest_address_acquired());
 
-    set.release(3);
+    set.release_now(3);
     try expectEqual(@as(?u64, 1), set.highest_address_acquired());
 
-    set.release(1);
+    set.release_now(1);
     try expectEqual(@as(?u64, null), set.highest_address_acquired());
 
     try expectEqual(@as(?u64, 1), set.acquire());
@@ -263,7 +380,7 @@ test "FreeSet highest_address_acquired" {
     try expectEqual(@as(?u64, 3), set.acquire());
 
     {
-        set.release_at_checkpoint(3);
+        set.release(3);
         try expectEqual(@as(?u64, 3), set.highest_address_acquired());
 
         set.include_staging();
@@ -277,16 +394,82 @@ test "FreeSet highest_address_acquired" {
 }
 
 test "FreeSet acquire/release" {
-    const blocks_in_tb = (1 << 40) / config.block_size;
-    try test_block_shards_count(5120 * 8, 10 * blocks_in_tb);
-    try test_block_shards_count(5120 * 8 - 1, 10 * blocks_in_tb - FreeSet.shard_size);
-    try test_block_shards_count(1, FreeSet.shard_size); // Must be at least one index bit.
-
     try test_acquire_release(FreeSet.shard_size);
     try test_acquire_release(2 * FreeSet.shard_size);
     try test_acquire_release(63 * FreeSet.shard_size);
     try test_acquire_release(64 * FreeSet.shard_size);
     try test_acquire_release(65 * FreeSet.shard_size);
+}
+
+fn test_acquire_release(blocks_count: usize) !void {
+    const expectEqual = std.testing.expectEqual;
+    // Acquire everything, then release, then acquire again.
+    var set = try FreeSet.init(std.testing.allocator, blocks_count);
+    defer set.deinit(std.testing.allocator);
+
+    var empty = try FreeSet.init(std.testing.allocator, blocks_count);
+    defer empty.deinit(std.testing.allocator);
+
+    var i: usize = 0;
+    while (i < blocks_count) : (i += 1) try expectEqual(@as(?u64, i + 1), set.acquire());
+    try expectEqual(@as(?u64, null), set.acquire());
+
+    try expectEqual(@as(u64, set.blocks.bit_length), set.count_acquired());
+    try expectEqual(@as(u64, 0), set.count_free());
+
+    i = 0;
+    while (i < blocks_count) : (i += 1) set.release_now(@as(u64, i + 1));
+    try expect_free_set_equal(empty, set);
+
+    try expectEqual(@as(u64, 0), set.count_acquired());
+    try expectEqual(@as(u64, set.blocks.bit_length), set.count_free());
+
+    i = 0;
+    while (i < blocks_count) : (i += 1) try expectEqual(@as(?u64, i + 1), set.acquire());
+    try expectEqual(@as(?u64, null), set.acquire());
+}
+
+test "FreeSet block shard count" {
+    const blocks_in_tb = (1 << 40) / config.block_size;
+    try test_block_shards_count(5120 * 8, 10 * blocks_in_tb);
+    try test_block_shards_count(5120 * 8 - 1, 10 * blocks_in_tb - FreeSet.shard_size);
+    try test_block_shards_count(1, FreeSet.shard_size); // Must be at least one index bit.
+}
+
+fn test_block_shards_count(expect_shards_count: usize, blocks_count: usize) !void {
+    var set = try FreeSet.init(std.testing.allocator, blocks_count);
+    defer set.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(expect_shards_count, set.index.bit_length);
+}
+
+test "FreeSet.reserve/acquire_reserved" {
+    var set = try FreeSet.init(std.testing.allocator, 4096);
+    defer set.deinit(std.testing.allocator);
+
+    _ = set.reserve(1);
+    set.reserve_done();
+
+    var base: usize = 1; // Start at 1 because addresses are >0.
+    {
+        const range = set.reserve(2).?;
+        try std.testing.expectEqual(set.acquire_reserved(range), base + 0);
+        try std.testing.expectEqual(set.acquire_reserved(range), base + 1);
+        try std.testing.expectEqual(set.acquire_reserved(range), null);
+    }
+    base += 2;
+
+    {
+        const range1 = set.reserve(2).?;
+        const range2 = set.reserve(2).?;
+        try std.testing.expectEqual(set.acquire_reserved(range1), base + 0);
+        try std.testing.expectEqual(set.acquire_reserved(range2), base + 2);
+        try std.testing.expectEqual(set.acquire_reserved(range1), base + 1);
+        try std.testing.expectEqual(set.acquire_reserved(range1), null);
+        try std.testing.expectEqual(set.acquire_reserved(range2), base + 3);
+        try std.testing.expectEqual(set.acquire_reserved(range2), null);
+    }
+    base += 4;
 }
 
 test "FreeSet checkpoint" {
@@ -311,7 +494,7 @@ test "FreeSet checkpoint" {
         i = 0;
         while (i < set.blocks.bit_length) : (i += 1) {
             try expectEqual(@as(?u64, i + 1), set.acquire());
-            set.release_at_checkpoint(i + 1);
+            set.release(i + 1);
 
             // These count functions treat staged blocks as allocated.
             try expectEqual(@as(u64, i + 1), set.count_acquired());
@@ -333,7 +516,7 @@ test "FreeSet checkpoint" {
     i = 0;
     while (i < set.blocks.bit_length) : (i += 1) {
         try expectEqual(@as(?u64, i + 1), set.acquire());
-        set.release_at_checkpoint(i + 1);
+        set.release(i + 1);
     }
 
     var set_encoded = try std.testing.allocator.alignedAlloc(
@@ -365,41 +548,6 @@ test "FreeSet checkpoint" {
         set_decoded.decode(set_encoded[0..set_encoded_length]);
         try expect_free_set_equal(full, set_decoded);
     }
-}
-
-fn test_acquire_release(blocks_count: usize) !void {
-    const expectEqual = std.testing.expectEqual;
-    // Acquire everything, then release, then acquire again.
-    var set = try FreeSet.init(std.testing.allocator, blocks_count);
-    defer set.deinit(std.testing.allocator);
-
-    var empty = try FreeSet.init(std.testing.allocator, blocks_count);
-    defer empty.deinit(std.testing.allocator);
-
-    var i: usize = 0;
-    while (i < blocks_count) : (i += 1) try expectEqual(@as(?u64, i + 1), set.acquire());
-    try expectEqual(@as(?u64, null), set.acquire());
-
-    try expectEqual(@as(u64, set.blocks.bit_length), set.count_acquired());
-    try expectEqual(@as(u64, 0), set.count_free());
-
-    i = 0;
-    while (i < blocks_count) : (i += 1) set.release(@as(u64, i + 1));
-    try expect_free_set_equal(empty, set);
-
-    try expectEqual(@as(u64, 0), set.count_acquired());
-    try expectEqual(@as(u64, set.blocks.bit_length), set.count_free());
-
-    i = 0;
-    while (i < blocks_count) : (i += 1) try expectEqual(@as(?u64, i + 1), set.acquire());
-    try expectEqual(@as(?u64, null), set.acquire());
-}
-
-fn test_block_shards_count(expect_shards_count: usize, blocks_count: usize) !void {
-    var set = try FreeSet.init(std.testing.allocator, blocks_count);
-    defer set.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(expect_shards_count, set.index.bit_length);
 }
 
 test "FreeSet encode, decode, encode" {
@@ -466,10 +614,10 @@ fn test_encode(patterns: []const TestPattern) !void {
         // The `index` will start out zero-filled. Every non-zero pattern will update the
         // corresponding index bit with a one (probably many times) to ensure it ends up synced
         // with `blocks`.
-        std.mem.set(usize, bitset_masks(decoded_expect.index), 0);
+        std.mem.set(usize, bit_set_masks(decoded_expect.index), 0);
 
         // Fill the bitset according to the patterns.
-        var blocks = bitset_masks(decoded_expect.blocks);
+        var blocks = bit_set_masks(decoded_expect.blocks);
         var blocks_offset: usize = 0;
         for (patterns) |pattern| {
             var i: usize = 0;
@@ -504,15 +652,15 @@ fn test_encode(patterns: []const TestPattern) !void {
 }
 
 fn expect_free_set_equal(a: FreeSet, b: FreeSet) !void {
-    try expect_bitset_equal(a.blocks, b.blocks);
-    try expect_bitset_equal(a.index, b.index);
-    try expect_bitset_equal(a.staging, b.staging);
+    try expect_bit_set_equal(a.blocks, b.blocks);
+    try expect_bit_set_equal(a.index, b.index);
+    try expect_bit_set_equal(a.staging, b.staging);
 }
 
-fn expect_bitset_equal(a: DynamicBitSetUnmanaged, b: DynamicBitSetUnmanaged) !void {
+fn expect_bit_set_equal(a: DynamicBitSetUnmanaged, b: DynamicBitSetUnmanaged) !void {
     try std.testing.expectEqual(a.bit_length, b.bit_length);
-    const a_masks = bitset_masks(a);
-    const b_masks = bitset_masks(b);
+    const a_masks = bit_set_masks(a);
+    const b_masks = bit_set_masks(b);
     for (a_masks) |aw, i| try std.testing.expectEqual(aw, b_masks[i]);
 }
 
@@ -572,8 +720,8 @@ test "FreeSet encode/decode manual" {
     defer decoded_actual.deinit(std.testing.allocator);
 
     decoded_actual.decode(encoded_expect);
-    try std.testing.expectEqual(decoded_expect.len, bitset_masks(decoded_actual.blocks).len);
-    try std.testing.expectEqualSlices(usize, &decoded_expect, bitset_masks(decoded_actual.blocks));
+    try std.testing.expectEqual(decoded_expect.len, bit_set_masks(decoded_actual.blocks).len);
+    try std.testing.expectEqualSlices(usize, &decoded_expect, bit_set_masks(decoded_actual.blocks));
 
     // Test encode.
     var encoded_actual = try std.testing.allocator.alignedAlloc(
@@ -587,60 +735,66 @@ test "FreeSet encode/decode manual" {
     try std.testing.expectEqual(encoded_expect.len, encoded_actual_length);
 }
 
-// Returns the index of a set bit (relative to the start of the bitset)
-// within start…end (inclusive…exclusive).
-fn find_first_set_bit(bitset: DynamicBitSetUnmanaged, start: usize, end: usize) ?usize {
-    assert(end <= bitset.bit_length);
-    const word_start = start / @bitSizeOf(MaskInt);
-    const word_offset = @mod(start, @bitSizeOf(MaskInt));
-    const word_end = div_ceil(end, @bitSizeOf(MaskInt));
-    assert(word_start < word_end);
+/// Returns the index of this first set bit (relative to the start of the bitset) within
+/// the range bit_min…bit_max (inclusive…exclusive).
+fn find_first_set_bit(bit_set: DynamicBitSetUnmanaged, bit_min: usize, bit_max: usize) ?usize {
+    assert(bit_max >= bit_min);
+    assert(bit_max <= bit_set.bit_length);
+
+    const word_start = @divFloor(bit_min, @bitSizeOf(MaskInt)); // Inclusive.
+    const word_offset = @mod(bit_min, @bitSizeOf(MaskInt));
+    const word_end = div_ceil(bit_max, @bitSizeOf(MaskInt)); // Exclusive.
+    if (word_end == word_start) return null;
+    assert(word_end > word_start);
 
     // Only iterate over the subset of bits that were requested.
-    var iter = bitset.iterator(.{});
-    iter.words_remain = bitset.masks[word_start + 1 .. word_end];
+    var iterator = bit_set.iterator(.{});
+    iterator.words_remain = bit_set.masks[word_start + 1 .. word_end];
     const mask = ~@as(MaskInt, 0);
-    iter.bits_remain = bitset.masks[word_start] & std.math.shl(MaskInt, mask, word_offset);
+    iterator.bits_remain = bit_set.masks[word_start] & std.math.shl(MaskInt, mask, word_offset);
 
-    const b = start - word_offset + (iter.next() orelse return null);
-    return if (b < end) b else null;
+    const b = bit_min - word_offset + (iterator.next() orelse return null);
+    return if (b < bit_max) b else null;
 }
 
 test "find_first_set_bit" {
-    const BitSet = DynamicBitSetUnmanaged;
-    const window = 8;
+    var prng = std.rand.DefaultPrng.init(123);
+    const random = prng.random();
 
-    // Verify that only bits within the specified range are returned.
-    var size: usize = @bitSizeOf(BitSet.MaskInt);
-    while (size <= @bitSizeOf(BitSet.MaskInt) * 2) : (size += 1) {
-        var set = try BitSet.initEmpty(std.testing.allocator, size);
-        defer set.deinit(std.testing.allocator);
+    var bit_length: usize = 1;
+    while (bit_length <= @bitSizeOf(std.DynamicBitSetUnmanaged.MaskInt) * 4) : (bit_length += 1) {
+        var bit_set = try std.DynamicBitSetUnmanaged.initEmpty(std.testing.allocator, bit_length);
+        defer bit_set.deinit(std.testing.allocator);
 
-        var s: usize = 0;
-        while (s < size - window) : (s += 1) {
-            var b: usize = 0;
-            while (b < size) : (b += 1) {
-                set.set(b);
-                const expect = if (s <= b and b < s + window) b else null;
-                try std.testing.expectEqual(expect, find_first_set_bit(set, s, s + window));
-                set.unset(b);
-            }
+        const p = random.uintLessThan(usize, 100);
+        var b: usize = 0;
+        while (b < bit_length) : (b += 1) bit_set.setValue(b, p < random.uintLessThan(usize, 100));
+
+        var i: usize = 0;
+        while (i < 20) : (i += 1) try test_find_first_set_bit(random, bit_set);
+    }
+}
+
+fn test_find_first_set_bit(random: std.rand.Random, bit_set: DynamicBitSetUnmanaged) !void {
+    const bit_min = random.uintLessThan(usize, bit_set.bit_length);
+    const bit_max = random.uintLessThan(usize, bit_set.bit_length - bit_min) + bit_min;
+    assert(bit_max >= bit_min);
+    assert(bit_max <= bit_set.bit_length);
+
+    const bit_actual = find_first_set_bit(bit_set, bit_min, bit_max);
+    if (bit_actual) |bit| {
+        assert(bit_set.isSet(bit));
+        assert(bit >= bit_min);
+        assert(bit < bit_max);
+    }
+
+    var iterator = bit_set.iterator(.{ .kind = .set });
+    while (iterator.next()) |bit| {
+        if (bit_min <= bit and bit < bit_max) {
+            try std.testing.expectEqual(bit_actual, bit);
+            break;
         }
-    }
-
-    {
-        // Make sure the first bit is returned.
-        var set = try BitSet.initEmpty(std.testing.allocator, 16);
-        defer set.deinit(std.testing.allocator);
-        set.set(2);
-        set.set(5);
-        try std.testing.expectEqual(@as(?usize, 2), find_first_set_bit(set, 1, 9));
-    }
-
-    {
-        // Don't return a bit outside of the bitset's interval, even with `initFull`.
-        var set = try BitSet.initFull(std.testing.allocator, 56);
-        defer set.deinit(std.testing.allocator);
-        try std.testing.expectEqual(@as(?usize, null), find_first_set_bit(set, 56, 56));
+    } else {
+        try std.testing.expectEqual(bit_actual, null);
     }
 }

--- a/src/vsr/superblock_free_set_fuzz.zig
+++ b/src/vsr/superblock_free_set_fuzz.zig
@@ -1,0 +1,256 @@
+//! Fuzz FreeSet reserve/acquire/release flow.
+//!
+//! This fuzzer does *not* cover FreeSet encoding/decoding.
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.fuzz_vsr_superblock_free_set);
+
+const FreeSet = @import("./superblock_free_set.zig").FreeSet;
+const AddressReservation = @import("./superblock_free_set.zig").AddressReservation;
+const fuzz = @import("../test/fuzz.zig");
+
+pub fn main() !void {
+    const allocator = std.testing.allocator;
+    const args = try fuzz.parse_fuzz_args(allocator);
+
+    var prng = std.rand.DefaultPrng.init(args.seed);
+
+    const blocks_count = FreeSet.shard_size * (1 + prng.random().uintLessThan(usize, 10));
+    const events = try generate_events(allocator, prng.random(), blocks_count);
+    defer allocator.free(events);
+
+    try run_fuzz(allocator, blocks_count, events);
+}
+
+fn run_fuzz(
+    allocator: std.mem.Allocator,
+    blocks_count: usize,
+    events: []const FreeSetEvent,
+) !void {
+    var free_set = try FreeSet.init(allocator, blocks_count);
+    defer free_set.deinit(allocator);
+
+    var free_set_model = try FreeSetModel.init(allocator, blocks_count);
+    defer free_set_model.deinit(allocator);
+
+    var active_reservations = std.ArrayList(AddressReservation).init(allocator);
+    defer active_reservations.deinit();
+
+    var active_addresses = std.ArrayList(u64).init(allocator);
+    defer active_addresses.deinit();
+
+    for (events) |event| {
+        log.debug("event={}", .{event});
+        switch (event) {
+            .reserve => |reserve| {
+                const reservation_actual = free_set.reserve(reserve.blocks);
+                const reservation_expect = free_set_model.reserve(reserve.blocks);
+                assert(std.meta.eql(reservation_expect, reservation_actual));
+                if (reservation_expect) |reservation| {
+                    try active_reservations.append(reservation);
+                }
+            },
+            .reserve_done => {
+                free_set.reserve_done();
+                free_set_model.reserve_done();
+                active_reservations.clearRetainingCapacity();
+            },
+            .acquire => |data| {
+                if (active_reservations.items.len == 0) continue;
+                const reservation = active_reservations.items[
+                    data.reservation % active_reservations.items.len
+                ];
+                const address_actual = free_set.acquire_reserved(reservation);
+                const address_expect = free_set_model.acquire_reserved(reservation);
+                assert(std.meta.eql(address_expect, address_actual));
+                if (address_expect) |address| {
+                    try active_addresses.append(address);
+                }
+            },
+            .release => |data| {
+                if (active_addresses.items.len == 0) continue;
+
+                const address = active_addresses.swapRemove(data.address % active_addresses.items.len);
+                free_set.release(address);
+                free_set_model.release(address);
+            },
+            .checkpoint => {
+                free_set.reserve_done();
+                free_set_model.reserve_done();
+                active_reservations.clearRetainingCapacity();
+
+                free_set.checkpoint();
+                free_set_model.checkpoint();
+            },
+        }
+
+        assert(free_set_model.count_free() == free_set.count_free());
+        assert(free_set_model.count_acquired() == free_set.count_acquired());
+        assert(std.meta.eql(
+            free_set_model.highest_address_acquired(),
+            free_set.highest_address_acquired(),
+        ));
+    }
+}
+
+const FreeSetEventType = std.meta.Tag(FreeSetEvent);
+const FreeSetEvent = union(enum) {
+    reserve: struct { blocks: usize },
+    reserve_done: void,
+    acquire: struct { reservation: usize },
+    release: struct { address: usize },
+    checkpoint: void,
+};
+
+fn generate_events(
+    allocator: std.mem.Allocator,
+    random: std.rand.Random,
+    blocks_count: usize,
+) ![]const FreeSetEvent {
+    const event_distribution = fuzz.Distribution(FreeSetEventType){
+        .reserve = 1 + random.float(f64) * 100,
+        .reserve_done = 1,
+        .acquire = random.float(f64) * 1000,
+        .release = if (random.boolean()) 0 else 500 * random.float(f64),
+        .checkpoint = random.floatExp(f64) * 10,
+    };
+
+    const events = try allocator.alloc(FreeSetEvent, std.math.min(
+        @as(usize, blocks_count * 1000),
+        fuzz.random_int_exponential(random, usize, blocks_count * 100),
+    ));
+    errdefer allocator.free(events);
+
+    log.info("event_distribution = {d:.2}", .{event_distribution});
+    log.info("event_count = {d}", .{events.len});
+
+    const reservation_blocks_mean = 1 + random.uintLessThan(usize, @divFloor(blocks_count, 20));
+    for (events) |*event| {
+        event.* = switch (fuzz.random_enum(random, FreeSetEventType, event_distribution)) {
+            .reserve => FreeSetEvent{ .reserve = .{
+                .blocks = 1 + fuzz.random_int_exponential(random, usize, reservation_blocks_mean),
+            } },
+            .reserve_done => FreeSetEvent{ .reserve_done = {} },
+            .acquire => FreeSetEvent{ .acquire = .{ .reservation = random.int(usize) } },
+            .release => FreeSetEvent{ .release = .{
+                .address = random.int(usize),
+            } },
+            .checkpoint => FreeSetEvent{ .checkpoint = {} },
+        };
+    }
+    return events;
+}
+
+const FreeSetModel = struct {
+    /// Set bits indicate acquired blocks.
+    blocks_acquired: std.DynamicBitSetUnmanaged,
+
+    /// Set bits indicate blocks that will be released at the next checkpoint.
+    blocks_released: std.DynamicBitSetUnmanaged,
+
+    blocks_reserved: usize = 0,
+
+    fn init(allocator: std.mem.Allocator, blocks_count: usize) !FreeSetModel {
+        var blocks_acquired = try std.DynamicBitSetUnmanaged.initEmpty(allocator, blocks_count);
+        errdefer blocks_acquired.deinit(allocator);
+
+        var blocks_released = try std.DynamicBitSetUnmanaged.initEmpty(allocator, blocks_count);
+        errdefer blocks_released.deinit(allocator);
+
+        return FreeSetModel{
+            .blocks_acquired = blocks_acquired,
+            .blocks_released = blocks_released,
+        };
+    }
+
+    fn deinit(set: *FreeSetModel, allocator: std.mem.Allocator) void {
+        set.blocks_acquired.deinit(allocator);
+        set.blocks_released.deinit(allocator);
+    }
+
+    pub fn count_free(set: FreeSetModel) u64 {
+        return set.blocks_acquired.capacity() - set.blocks_acquired.count();
+    }
+
+    pub fn count_acquired(set: FreeSetModel) u64 {
+        return set.blocks_acquired.count();
+    }
+
+    pub fn highest_address_acquired(set: FreeSetModel) ?u64 {
+        const block = set.blocks_acquired.iterator(.{
+            .direction = .reverse,
+        }).next() orelse return null;
+        return block + 1;
+    }
+
+    pub fn acquire_reserved(set: *FreeSetModel, reservation: AddressReservation) ?u64 {
+        assert(reservation.block_count > 0);
+        assert(reservation.block_base < set.blocks_acquired.capacity());
+        assert(reservation.block_base < set.blocks_reserved);
+        assert(reservation.block_base + reservation.block_count <= set.blocks_reserved);
+
+        var iterator = set.blocks_acquired.iterator(.{ .kind = .unset });
+        while (iterator.next()) |block| {
+            if (block >= reservation.block_base and
+                block < reservation.block_base + reservation.block_count)
+            {
+                assert(!set.blocks_acquired.isSet(block));
+                set.blocks_acquired.set(block);
+
+                const address = block + 1;
+                return address;
+            }
+        }
+        return null;
+    }
+
+    pub fn reserve(set: *FreeSetModel, reserve_count: usize) ?AddressReservation {
+        assert(reserve_count > 0);
+
+        var blocks_found_free: usize = 0;
+        var iterator = set.blocks_acquired.iterator(.{ .kind = .unset });
+        while (iterator.next()) |block| {
+            if (block < set.blocks_reserved) continue;
+
+            blocks_found_free += 1;
+            if (blocks_found_free == reserve_count) {
+                const block_count = block + 1 - set.blocks_reserved;
+                const block_base = set.blocks_reserved;
+                set.blocks_reserved += block_count;
+
+                return AddressReservation{
+                    .block_base = block_base,
+                    .block_count = block_count,
+                };
+            }
+        }
+        return null;
+    }
+
+    pub fn reserve_done(set: *FreeSetModel) void {
+        set.blocks_reserved = 0;
+    }
+
+    pub fn is_free(set: *FreeSetModel, address: u64) bool {
+        return !set.blocks_acquired.isSet(address - 1);
+    }
+
+    pub fn release(set: *FreeSetModel, address: u64) void {
+        const block = address - 1;
+        set.blocks_released.set(block);
+    }
+
+    pub fn checkpoint(set: *FreeSetModel) void {
+        assert(set.blocks_reserved == 0);
+
+        var iterator = set.blocks_released.iterator(.{});
+        while (iterator.next()) |block| {
+            assert(set.blocks_released.isSet(block));
+            assert(set.blocks_acquired.isSet(block));
+
+            set.blocks_released.unset(block);
+            set.blocks_acquired.unset(block);
+        }
+        assert(set.blocks_released.count() == 0);
+    }
+};

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -120,7 +120,9 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64) !void {
         // Trailers are only updated on-disk by checkpoint(), never view_change().
         // Trailers must not be mutated while a checkpoint() is in progress.
         if (!env.pending.contains(.checkpoint) and random.boolean()) {
-            _ = env.superblock.free_set.acquire().?;
+            const range = env.superblock.free_set.reserve(1).?;
+            _ = env.superblock.free_set.acquire(range).?;
+            env.superblock.free_set.reserve_done();
         }
     }
 }

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -122,7 +122,7 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64) !void {
         if (!env.pending.contains(.checkpoint) and random.boolean()) {
             const range = env.superblock.free_set.reserve(1).?;
             _ = env.superblock.free_set.acquire(range).?;
-            env.superblock.free_set.reserve_done();
+            env.superblock.free_set.forfeit(range);
         }
     }
 }

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -167,7 +167,6 @@ const Environment = struct {
         assert(!env.pending_verify);
         assert(env.pending.contains(.view_change) == env.superblock.view_change_in_progress());
 
-        // TODO(Zig): Change this to const once std.PriorityQueue's type signature is fixed.
         const write = env.superblock.storage.writes.peek();
         env.superblock.storage.tick();
 
@@ -181,12 +180,17 @@ const Environment = struct {
     fn verify(env: *Environment) !void {
         assert(!env.pending_verify);
 
-        // Reset `superblock_verify` so that it can be reused.
-        env.superblock_verify.opened = false;
-        var free_set_iterator = env.superblock_verify.free_set.blocks.iterator(.{ .kind = .unset });
-        while (free_set_iterator.next()) |block_bit| {
-            const block_address = block_bit + 1;
-            env.superblock_verify.free_set.release(block_address);
+        {
+            // Reset `superblock_verify` so that it can be reused.
+            env.superblock_verify.opened = false;
+            var free_set_iterator = env.superblock_verify.free_set.blocks.iterator(.{
+                .kind = .unset,
+            });
+            while (free_set_iterator.next()) |block_bit| {
+                const block_address = block_bit + 1;
+                env.superblock_verify.free_set.release(block_address);
+            }
+            env.superblock_verify.free_set.checkpoint();
         }
 
         // Duplicate the `superblock`'s storage so it is not modified by `superblock_verify`'s

--- a/src/vsr/superblock_manifest.zig
+++ b/src/vsr/superblock_manifest.zig
@@ -8,8 +8,7 @@ const mem = std.mem;
 const config = @import("../config.zig");
 const util = @import("../util.zig");
 
-// TODO Determine upper bound of manifest blocks per tree and assert it.
-// (And use it to size the trailer zone).
+// TODO Compute & use the upper bound of manifest blocks (per tree) to size the trailer zone.
 
 /// SuperBlock.Manifest schema:
 /// │ [manifest.count]u128 │ Tree id (for the owner of the ManifestLog)

--- a/src/vsr/superblock_manifest.zig
+++ b/src/vsr/superblock_manifest.zig
@@ -8,6 +8,9 @@ const mem = std.mem;
 const config = @import("../config.zig");
 const util = @import("../util.zig");
 
+// TODO Determine upper bound of manifest blocks per tree and assert it.
+// (And use it to size the trailer zone).
+
 /// SuperBlock.Manifest schema:
 /// │ [manifest.count]u128 │ Tree id (for the owner of the ManifestLog)
 /// │ [manifest.count]u128 │ ManifestLog block checksum
@@ -179,6 +182,8 @@ pub const Manifest = struct {
     }
 
     /// Addresses must be unique across all appends, or remove() must be called first.
+    /// Warning: The caller is responsible for ensuring that concurrent tree compactions call
+    /// append() in a deterministic order with respect to each other.
     pub fn append(manifest: *Manifest, tree: u128, checksum: u128, address: u64) void {
         assert(address > 0);
         assert(manifest.index_for_address(address) == null);


### PR DESCRIPTION
## Background

To enable efficient recovery and additional verification, TigerBeetle's LSM storage will be deterministic.

There are presently three bugs preventing LSM from being deterministic at checkpoint:

1. All concurrent compactions of a half-measure (from different levels & trees) acquire blocks from the FreeSet concurrently.
2. `SuperBlock.Manifest.append()` is called after `ManifestLog` blocks are written. Manifest block writes from different trees are concurrent with one other, so this is nondeterministic.
3. `ManifestLog.append()` is called concurrently by all running level compactions within tree.

This PR fixes **1** and **2**.
**3** is deferred for a future PR (see below).

## 1: Block Reservation

Previously all concurrent compactions acquire block addresses on an as-needed basis (for both output tables and manifest log blocks).

This is convenient, but because compaction progress is nondeterministic (based on IO ordering) block acquisition order — and therefore storage in general — is likewise nondeterministic.

To fix this:
- Each compaction (per tree/level) reserves an upper bound of block addresses that it may require for compaction.
- The manifest log also reserves the upper bound of block addresses that it may require for compaction.

A compaction or manifest log then acquires a subset of the blocks from its reservation. These acquisitions may be concurrent _between reservations_ without compromising storage determinism. (Within a reservation, acquisitions must still be sequential).

The "lifecycle" of a reservation is documented in `superblock_free_set.zig`.

## 2: `SuperBlock.Manifest.append()`

`SuperBlock.Manifest.append()` is now handled by `ManifestLog.flush()`, which in turn is called synchronously relative to the start of a compaction-beat or checkpoint.

## 3: `ManifestLog.append()`

The `ManifestLog.append()` nondeterminism is _not resolved by this PR._ It will be fixed for free by compaction pacing, assuming we compact the levels of each tree sequentially (with trees still concurrent). (Sequential compaction of levels is also friendlier to SSD garbage collection).

Because this issue isn't fixed yet, the VOPR's `StorageChecker` remains disabled.

## Testing

- `FreeSet` fuzzer:
  - Fuzz the reserve/acquire/forfeit/release lifecycle.
  - Encoding/decoding is covered by the EWAH fuzzer (and extended in an upcoming PR).
- `ManifestLog` fuzzer:
  - Extended to verify `SuperBlock.Manifest.compaction_set` membership.
  - Don't interleave more `append()`s between `compact()`s than the actual Tree will need.
- `Tree`/`Forest` fuzzers: See `8749454`.

## Future Work

In addition to fixing `ManifestLog.append()` determinism, per-beat compaction determinism will enable stricter (smaller) block reservations, which will reduce block fragmentation.
