### PR TITLE
StateMachine: Unit test tables

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1166,42 +1166,37 @@ const TestContext = struct {
         ctx.* = undefined;
     }
 
-    fn ca(context: *TestContext, account_vector: AccountVector) !void {
-        const account = account_vector.object;
+    fn create_account(context: *TestContext, account: Account, result: CreateAccountResult) !void {
         const result_actual = context.state_machine.create_account(&account);
-        try expectEqual(account_vector.result, result_actual);
+        try expectEqual(result, result_actual);
 
-        if (account_vector.result == .ok) {
+        if (result == .ok) {
             try expectEqual(account, context.state_machine.get_account(account.id).?.*);
         }
     }
 
-    fn put_account(context: *TestContext, account: Account) !void {
-        context.state_machine.forest.grooves.accounts.put(&account);
-        try expectEqual(account, context.state_machine.get_account(account.id).?.*);
-    }
-
-    fn create_transfer(context: *TestContext, transfer_vector: TransferVector) !void {
-        const transfer = transfer_vector.object;
+    fn create_transfer(
+        context: *TestContext,
+        transfer: Transfer,
+        result: CreateTransferResult,
+    ) !void {
         const result_actual = context.state_machine.create_transfer(&transfer);
-        try expectEqual(transfer_vector.result, result_actual);
+        try expectEqual(result, result_actual);
     }
 
     fn create_objects(
         context: *TestContext,
-        comptime Object: type,
-        vectors: []const Vector(Object),
+        comptime Vector: type,
+        vectors: []const Vector,
     ) !void {
-        const operation = switch (Object) {
-            Account => .create_accounts,
-            Transfer => .create_transfers,
+        const operation = switch (Vector) {
+            TestAccount => .create_accounts,
+            TestTransfer => .create_transfers,
             else => unreachable,
         };
 
-        var objects = std.BoundedArray(Object, 32).init(0) catch unreachable;
-        for (vectors) |vector| {
-            objects.appendAssumeCapacity(vector.object);
-        }
+        var objects = std.BoundedArray(Vector.Object, 32).init(0) catch unreachable;
+        for (vectors) |vector| objects.appendAssumeCapacity(vector.object(0));
 
         const request = mem.sliceAsBytes(objects.slice());
         const reply = try testing.allocator.alignedAlloc(u8, 16, 4096);
@@ -1221,7 +1216,7 @@ const TestContext = struct {
         }
         assert(results_index == results.len);
 
-        if (Object == Account) {
+        if (Vector == TestAccount) {
             for (objects.slice()) |vector, i| {
                 if (vectors[i].result != .ok) continue;
                 try expectEqual(vector, context.state_machine.get_account(vector.id).?.*);
@@ -1233,276 +1228,330 @@ const TestContext = struct {
     }
 };
 
-const N = false;
-const Y = true;
+const TestAction = union(enum) {
+    // Create an account and check the result.
+    account: TestAccount,
 
-// Account.id, Transfer.id
-const id0: u128 = 0;
-const id1: u128 = 1;
-const id2: u128 = 2;
-const id3: u128 = 3;
-const id4: u128 = 4;
-const id5: u128 = 5;
-const id6: u128 = 6;
-const id7: u128 = 7;
-const idZ: u128 = math.maxInt(u128);
+    accounts_batch_start: void,
+    accounts_batch_end: void,
+    accounts: TestAccount,
 
-// Account.user_data, Transfer.user_data
-const ud0: u128 = id0;
-const ud1: u128 = id1;
-const ud2: u128 = id2;
+    account_exists: struct {
+        id: u128,
+        exists: bool,
+    },
+    // Create a transfer and check the result.
+    transfer: TestTransfer,
+    // Check an account's balance.
+    balance: struct {
+        account: u128,
+        debits_pending: u64,
+        debits_posted: u64,
+        credits_pending: u64,
+        credits_posted: u64,
+    },
+    // Set the account's balance.
+    balance_set: struct {
+        account: u128,
+        debits_pending: u64,
+        debits_posted: u64,
+        credits_pending: u64,
+        credits_posted: u64,
+    },
+    rollback_account: u128,
+    rollback_transfer: u128,
+};
 
-// Transfer.amount, Account.{debits,credits}_{pending,posted}
-const a0: u64 = 0;
-const a1: u64 = 1;
-const aZ: u64 = math.maxInt(u64);
-
-// Account.reserved
-const ar0 = [_]u8{0} ** 48;
-const ar1 = [_]u8{1} ** 48;
-
-// Account.flags.padding
-const afp0: u13 = 0;
-const afp1: u13 = 1;
-
-// Transfer.reserved
-const tr0: u128 = 0;
-const tr1: u128 = 1;
-
-// Transfer.timeout
-const to0: u64 = 0;
-
-// Transfer.flags.padding
-const p0: u12 = 0;
-const p1: u12 = 1;
-
-fn A(
+const TestAccount = struct {
     id: u128,
-    user_data: u128,
-    reserved: [48]u8,
+    user_data: u128 = 0,
+    reserved: enum { @"0", @"1" } = .@"0",
     ledger: u32,
     code: u16,
-    flags_linked: bool,
-    flags_debits_must_not_exceed_credits: bool,
-    flags_credits_must_not_exceed_debits: bool,
-    flags_padding: u13,
-    debits_pending: u64,
-    debits_posted: u64,
-    credits_pending: u64,
-    credits_posted: u64,
-    timestamp: u64,
+    flags_linked: ?enum { LNK } = null,
+    flags_debits_must_not_exceed_credits: ?enum { @"D<C" } = null,
+    flags_credits_must_not_exceed_debits: ?enum { @"C<D" } = null,
+    flags_padding: u13 = 0,
+    debits_pending: u64 = 0,
+    debits_posted: u64 = 0,
+    credits_pending: u64 = 0,
+    credits_posted: u64 = 0,
     result: CreateAccountResult,
-) AccountVector {
-    return .{
-        .object = Account{
-            .id = id,
-            .user_data = user_data,
-            .reserved = reserved,
-            .ledger = ledger,
-            .code = code,
-            .flags = .{
-                .linked = flags_linked,
-                .debits_must_not_exceed_credits = flags_debits_must_not_exceed_credits,
-                .credits_must_not_exceed_debits = flags_credits_must_not_exceed_debits,
-                .padding = flags_padding,
-            },
-            .debits_pending = debits_pending,
-            .debits_posted = debits_posted,
-            .credits_pending = credits_pending,
-            .credits_posted = credits_posted,
-            .timestamp = timestamp,
-        },
-        .result = result,
-    };
-}
 
-fn T(
+    const Object = Account;
+
+    fn object(a: TestAccount, timestamp: u64) Object {
+        return .{
+            .id = a.id,
+            .user_data = a.user_data,
+            .reserved = switch (a.reserved) {
+                .@"0" => [_]u8{0} ** 48,
+                .@"1" => [_]u8{1} ** 48,
+            },
+            .ledger = a.ledger,
+            .code = a.code,
+            .flags = .{
+                .linked = a.flags_linked != null,
+                .debits_must_not_exceed_credits = a.flags_debits_must_not_exceed_credits != null,
+                .credits_must_not_exceed_debits = a.flags_credits_must_not_exceed_debits != null,
+                .padding = a.flags_padding,
+            },
+            .debits_pending = a.debits_pending,
+            .debits_posted = a.debits_posted,
+            .credits_pending = a.credits_pending,
+            .credits_posted = a.credits_posted,
+            .timestamp = timestamp,
+        };
+    }
+};
+
+const TestTransfer = struct {
     id: u128,
     debit_account_id: u128,
     credit_account_id: u128,
-    user_data: u128,
-    reserved: u128,
-    pending_id: u128,
-    timeout: u64,
+    user_data: u128 = 0,
+    reserved: u128 = 0,
+    pending_id: u128 = 0,
+    timeout: u64 = 0,
     ledger: u32,
     code: u16,
-    flags_linked: bool,
-    flags_pending: bool,
-    flags_post_pending_transfer: bool,
-    flags_void_pending_transfer: bool,
-    flags_padding: u12,
-    amount: u64,
-    timestamp: u64,
+    flags_linked: ?enum { LNK } = null,
+    flags_pending: ?enum { PEN } = null,
+    flags_post_pending_transfer: ?enum { POS } = null,
+    flags_void_pending_transfer: ?enum { VOI } = null,
+    flags_padding: u12 = 0,
+    amount: u64 = 0,
     result: CreateTransferResult,
-) TransferVector {
-    return .{
-        .object = .{
-            .id = id,
-            .debit_account_id = debit_account_id,
-            .credit_account_id = credit_account_id,
-            .user_data = user_data,
-            .reserved = reserved,
-            .pending_id = pending_id,
-            .timeout = timeout,
-            .ledger = ledger,
-            .code = code,
+
+    const Object = Transfer;
+
+    fn object(t: TestTransfer, timestamp: u64) Object {
+        return .{
+            .id = t.id,
+            .debit_account_id = t.debit_account_id,
+            .credit_account_id = t.credit_account_id,
+            .user_data = t.user_data,
+            .reserved = t.reserved,
+            .pending_id = t.pending_id,
+            .timeout = t.timeout,
+            .ledger = t.ledger,
+            .code = t.code,
             .flags = .{
-                .linked = flags_linked,
-                .pending = flags_pending,
-                .post_pending_transfer = flags_post_pending_transfer,
-                .void_pending_transfer = flags_void_pending_transfer,
-                .padding = flags_padding,
+                .linked = t.flags_linked != null,
+                .pending = t.flags_pending != null,
+                .post_pending_transfer = t.flags_post_pending_transfer != null,
+                .void_pending_transfer = t.flags_void_pending_transfer != null,
+                .padding = t.flags_padding,
             },
-            .amount = amount,
+            .amount = t.amount,
             .timestamp = timestamp,
-        },
-        .result = result,
-    };
-}
+        };
+    }
+};
 
-fn Vector(comptime Object: type) type {
-    assert(Object == Account or Object == Transfer);
-    return struct {
-        object: Object,
-        result: switch (Object) {
-            Account => CreateAccountResult,
-            Transfer => CreateTransferResult,
-            else => unreachable,
-        },
-    };
-}
+fn check(comptime test_table: []const u8) !void {
+    const table = @import("test/table.zig").table;
+    const allocator = std.testing.allocator;
 
-const AccountVector = Vector(Account);
-const TransferVector = Vector(Transfer);
+    var context: TestContext = undefined;
+    try context.init(allocator);
+    defer context.deinit(allocator);
+
+    const test_actions = try table(allocator, TestAction, test_table);
+    defer test_actions.deinit();
+
+    var accounts = std.AutoHashMap(u128, Account).init(allocator);
+    defer accounts.deinit();
+
+    var transfers = std.AutoHashMap(u128, Transfer).init(allocator);
+    defer transfers.deinit();
+
+    var batch_accounts: ?std.ArrayList(TestAccount) = null;
+    defer if (batch_accounts) |a| a.deinit();
+
+    const timestamp_base = context.state_machine.commit_timestamp + 1;
+    for (test_actions.items) |test_action, i| {
+        switch (test_action) {
+            .account => |a| {
+                assert(batch_accounts == null);
+
+                const account = a.object(timestamp_base + i);
+                if (a.result == .ok) try accounts.putNoClobber(a.id, account);
+                try context.create_account(account, a.result);
+            },
+            .accounts_batch_start => {
+                assert(batch_accounts == null);
+                batch_accounts = std.ArrayList(TestAccount).init(allocator);
+            },
+            .accounts => |a| try batch_accounts.?.append(a),
+            .accounts_batch_end => {
+                try context.create_objects(TestAccount, batch_accounts.?.items);
+                batch_accounts.?.deinit();
+                batch_accounts = null;
+            },
+            .account_exists => |a| {
+                const account = context.state_machine.get_account(a.id);
+                if (a.exists) {
+                    try expectEqual(a.id, account.?.id);
+                } else {
+                    try expectEqual(@as(?*const Account, null), account);
+                }
+            },
+            .transfer => |t| {
+                const transfer = t.object(timestamp_base + i);
+                if (t.result == .ok) try transfers.putNoClobber(t.id, transfer);
+                try context.create_transfer(transfer, t.result);
+            },
+            .balance => |b| {
+                const account = context.state_machine.get_account(b.account).?.*;
+                try expectEqual(b.debits_pending, account.debits_pending);
+                try expectEqual(b.debits_posted, account.debits_posted);
+                try expectEqual(b.credits_pending, account.credits_pending);
+                try expectEqual(b.credits_posted, account.credits_posted);
+            },
+            .balance_set => |b| {
+                var account = context.state_machine.get_account(b.account).?.*;
+                account.debits_pending = b.debits_pending;
+                account.debits_posted = b.debits_posted;
+                account.credits_pending = b.credits_pending;
+                account.credits_posted = b.credits_posted;
+                context.state_machine.forest.grooves.accounts.put(&account);
+            },
+            .rollback_account => |id| {
+                const account = accounts.get(id).?;
+                context.state_machine.create_account_rollback(&account);
+            },
+            .rollback_transfer => |id| {
+                const transfer = transfers.get(id).?;
+                assert(context.state_machine.get_transfer(transfer.id) != null);
+
+                context.state_machine.create_transfer_rollback(&transfer);
+                try expect(context.state_machine.get_transfer(transfer.id) == null);
+                if (transfer.flags.post_pending_transfer or transfer.flags.void_pending_transfer) {
+                    try expect(context.state_machine.get_posted(transfer.pending_id) == null);
+                }
+            },
+        }
+    }
+}
 
 test "create/lookup/rollback accounts" {
-    var c: TestContext = undefined;
-    try c.init(testing.allocator);
-    defer c.deinit(testing.allocator);
-
-    const account_vectors = [_]AccountVector{
-        A(id1, ud2, ar0, 3, 4, N, N, N, afp0, a0, a0, a0, a0, 1, .ok),
-        A(id0, ud0, ar1, 0, 0, N, Y, Y, afp1, a1, a1, a1, a1, 2, .reserved_flag),
-        A(id0, ud0, ar1, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .reserved_field),
-        A(id0, ud0, ar0, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .id_must_not_be_zero),
-        A(idZ, ud0, ar0, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .id_must_not_be_int_max),
-        A(id1, ud1, ar0, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .ledger_must_not_be_zero),
-        A(id1, ud1, ar0, 9, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .code_must_not_be_zero),
-        A(id1, ud1, ar0, 9, 9, N, Y, Y, afp0, aZ, aZ, aZ, aZ, 2, .mutually_exclusive_flags),
-        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a1, a1, a1, a1, 2, .debits_pending_must_be_zero),
-        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a1, a1, a1, 2, .debits_posted_must_be_zero),
-        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a0, a1, a1, 2, .credits_pending_must_be_zero),
-        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a0, a0, a1, 2, .credits_posted_must_be_zero),
-        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_flags),
-        A(id1, ud1, ar0, 9, 9, N, N, Y, afp0, a0, a0, a0, a0, 2, .exists_with_different_flags),
-        A(id1, ud1, ar0, 9, 9, N, N, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_user_data),
-        A(id1, ud2, ar0, 9, 9, N, N, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_ledger),
-        A(id1, ud2, ar0, 3, 9, N, N, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_code),
-        A(id1, ud2, ar0, 3, 4, N, N, N, afp0, a0, a0, a0, a0, 2, .exists),
-    };
-
-    for (account_vectors[0..]) |account_vector| {
-        try c.ca(account_vector);
-    }
-
-    c.state_machine.create_account_rollback(&account_vectors[0].object);
-    try expect(c.state_machine.get_account(id1) == null);
-    try expect(c.state_machine.get_account(id2) == null);
+    try check(
+        \\ account A1 U2 _ L3 C4 _   _   _  _  0  0  0  0 ok
+        \\ account A0  _ 1 L0 C0 _ D<C C<D P1  1  1  1  1 reserved_flag
+        \\ account A0  _ 1 L0 C0 _ D<C C<D  _  1  1  1  1 reserved_field
+        \\ account A0  _ _ L0 C0 _ D<C C<D  _  1  1  1  1 id_must_not_be_zero
+        \\ account -0  _ _ L0 C0 _ D<C C<D  _  1  1  1  1 id_must_not_be_int_max
+        \\ account A1 U1 _ L0 C0 _ D<C C<D  _  1  1  1  1 ledger_must_not_be_zero
+        \\ account A1 U1 _ L9 C0 _ D<C C<D  _  1  1  1  1 code_must_not_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C C<D  _ -0 -0 -0 -0 mutually_exclusive_flags
+        \\ account A1 U1 _ L9 C9 _ D<C   _  _  1  1  1  1 debits_pending_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  1  1  1 debits_posted_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  0  1  1 credits_pending_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  0  0  1 credits_posted_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  0  0  0 exists_with_different_flags
+        \\ account A1 U1 _ L9 C9 _   _ C<D  _  0  0  0  0 exists_with_different_flags
+        \\ account A1 U1 _ L9 C9 _   _   _  _  0  0  0  0 exists_with_different_user_data
+        \\ account A1 U2 _ L9 C9 _   _   _  _  0  0  0  0 exists_with_different_ledger
+        \\ account A1 U2 _ L3 C9 _   _   _  _  0  0  0  0 exists_with_different_code
+        \\ account A1 U2 _ L3 C4 _   _   _  _  0  0  0  0 exists
+        \\
+        \\ account_exists A1 true
+        \\ account_exists A2 false
+        \\
+        \\ rollback_account A1
+        \\ account_exists A1 false
+        \\ account_exists A2 false
+    );
 }
 
 test "linked accounts" {
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    try context.create_objects(Account, &.{
-        // An individual event (successful):
-        A(id7, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+    try check(
+    // An individual event (successful):
+        \\ accounts_batch_start
+        \\   accounts A7 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // A chain of 4 events (the last event in the chain closes the chain with linked=false):
         // Commit/rollback.
-        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
         // Commit/rollback.
-        A(id2, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        \\   accounts A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
         // Fail with .exists.
-        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .exists),
+        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists
         // Fail without committing.
-        A(id3, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        \\   accounts A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed
 
         // An individual event (successful):
         // This does not see any effect from the failed chain above.
-        A(id1, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        \\   accounts A1 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // A chain of 2 events (the first event fails the chain):
-        A(id1, ud0, ar0, 1, 2, Y, N, N, afp0, a0, a0, a0, a0, 0, .exists_with_different_flags),
-        A(id2, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        \\   accounts A1 _ _ L1 C2 LNK _ _ _ 0 0 0 0 exists_with_different_flags
+        \\   accounts A2 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed
 
         // An individual event (successful):
-        A(id2, ud1, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        \\   accounts A2 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // A chain of 2 events (the last event fails the chain):
-        A(id3, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
-        A(id1, ud0, ar0, 2, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .exists_with_different_ledger),
+        \\   accounts A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
+        \\   accounts A1 _ _ L2 C1   _ _ _ _ 0 0 0 0 exists_with_different_ledger
 
         // A chain of 2 events (successful):
-        A(id3, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .ok),
-        A(id4, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
-    });
+        \\   accounts A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
+        \\   accounts A4 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+        \\ accounts_batch_end
+    );
 
     // TODO How can we test that events were in fact rolled back in LIFO order?
     // All our rollback handlers appear to be commutative.
 }
 
 test "linked_event_chain_open" {
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    try context.create_objects(Account, &.{
+    try check(
+        \\ accounts_batch_start
         // A chain of 3 events (the last event in the chain closes the chain with linked=false):
-        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .ok),
-        A(id2, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .ok),
-        A(id3, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
+        \\   accounts A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
+        \\   accounts A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // An open chain of 2 events:
-        A(id4, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
-        A(id5, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_chain_open),
-    });
-
-    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id4));
-    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id5));
+        \\   accounts A4 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
+        \\   accounts A5 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
+        \\ accounts_batch_end
+        \\
+        \\ account_exists A1 true
+        \\ account_exists A2 true
+        \\ account_exists A3 true
+        \\ account_exists A4 false
+        \\ account_exists A5 false
+    );
 }
 
 test "linked_event_chain_open for an already failed batch" {
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    try context.create_objects(Account, &.{
+    try check(
+        \\ accounts_batch_start
         // An individual event (successful):
-        A(id1, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        \\   accounts A1 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // An open chain of 3 events (the second one fails):
-        A(id2, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
-        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .exists_with_different_flags),
-        A(id3, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_chain_open),
-    });
-
-    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id2));
-    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id3));
+        \\   accounts A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
+        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists_with_different_flags
+        \\   accounts A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
+        \\ accounts_batch_end
+        \\
+        \\ account_exists A1 true
+        \\ account_exists A2 false
+        \\ account_exists A3 false
+    );
 }
 
 test "linked_event_chain_open for a batch of 1" {
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    try context.create_objects(Account, &.{
-        // Just one event with linked = true
-        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_chain_open),
-    });
-
-    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id1));
+    try check(
+        \\ accounts_batch_start
+        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
+        \\ accounts_batch_end
+        \\ account_exists A1 false
+    );
 }
 
 // The goal is to ensure that:
@@ -1510,275 +1559,161 @@ test "linked_event_chain_open for a batch of 1" {
 // 2. enums tested in the order that they are defined, for easier auditing of coverage, and that
 // 3. state machine logic cannot be reordered in any way, breaking determinism.
 test "create/lookup/rollback transfers" {
-    var c: TestContext = undefined;
-    try c.init(testing.allocator);
-    defer c.deinit(testing.allocator);
+    try check(
+        \\ account  A1 _ _ L1 C1 _   _   _ _ 0 0 0 0 ok
+        \\ account  A2 _ _ L2 C2 _   _   _ _ 0 0 0 0 ok
+        \\ account  A3 _ _ L1 C1 _   _   _ _ 0 0 0 0 ok
+        \\ account  A4 _ _ L1 C1 _ D<C   _ _ 0 0 0 0 ok
+        \\ account  A5 _ _ L1 C1 _   _ C<D _ 0 0 0 0 ok
 
-    const A1 = A(id1, ud0, ar0, 1, 1, N, N, N, afp0, 100, 200, a0, a0, 0, .ok).object;
-    const A2 = A(id2, ud0, ar0, 2, 2, N, N, N, afp0, a0, a0, a0, a0, 0, .ok).object;
-    const A3 = A(id3, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, 110, 210, 0, .ok).object;
-    const A4 = A(id4, ud0, ar0, 1, 1, N, Y, N, afp0, 20, aZ - 500 - 200, a0, aZ - 500, 0, .ok).object;
-    const A5 = A(id5, ud0, ar0, 1, 1, N, N, Y, afp0, a0, aZ - 1000, 10, aZ - 1000 - 100, 0, .ok).object;
-    for ([_]Account{ A1, A2, A3, A4, A5 }) |account| try c.put_account(account);
+        // Set up initial balances.
+        \\ balance_set A1  100   200    0     0
+        \\ balance_set A2    0     0    0     0
+        \\ balance_set A3    0     0  110   210
+        \\ balance_set A4   20  -700    0  -500
+        \\ balance_set A5    0 -1000   10 -1100
 
-    const t: u64 = c.state_machine.prepare_timestamp + 1;
-    const toZ: u64 = (std.math.maxInt(u64) - t) + 1;
-
-    const vectors = [_]TransferVector{
-        T(id0, id0, id0, ud0, tr1, id1, to0, 0, 0, N, Y, N, N, p1, 0, t, .reserved_flag),
-        T(id0, id0, id0, ud0, tr1, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .reserved_field),
-        T(id0, id0, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .id_must_not_be_zero),
-        T(idZ, id0, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .id_must_not_be_int_max),
-        T(id1, id0, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .debit_account_id_must_not_be_zero),
-        T(id1, idZ, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .debit_account_id_must_not_be_int_max),
-        T(id1, 100, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .credit_account_id_must_not_be_zero),
-        T(id1, 100, idZ, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .credit_account_id_must_not_be_int_max),
-        T(id1, 100, 100, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .accounts_must_be_different),
-        T(id1, 100, 200, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .pending_id_must_be_zero),
-        T(id1, 100, 200, ud0, tr0, id0, to0, 0, 0, N, Y, N, N, p0, 0, t, .pending_transfer_must_timeout),
-        T(id1, 100, 200, ud0, tr0, id0, toZ, 0, 0, N, N, N, N, p0, 0, t, .timeout_reserved_for_pending_transfer),
-        T(id1, 100, 200, ud0, tr0, id0, toZ, 0, 0, N, Y, N, N, p0, 0, t, .ledger_must_not_be_zero),
-        T(id1, 100, 200, ud0, tr0, id0, toZ, 9, 0, N, Y, N, N, p0, 0, t, .code_must_not_be_zero),
-        T(id1, 100, 200, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 0, t, .amount_must_not_be_zero),
-        T(id1, 100, 200, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 9, t, .debit_account_not_found),
-        T(id1, id1, 200, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 9, t, .credit_account_not_found),
-        T(id1, id1, id2, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 1, t, .accounts_must_have_the_same_ledger),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 1, t, .transfer_must_have_the_same_ledger_as_accounts),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A1.debits_pending + 1, t, .overflows_debits_pending),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A3.credits_pending + 1, t, .overflows_credits_pending),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A1.debits_posted + 1, t, .overflows_debits_posted),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A3.credits_posted + 1, t, .overflows_credits_posted),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A1.debits_pending - A1.debits_posted + 1, t, .overflows_debits),
-        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A3.credits_pending - A3.credits_posted + 1, t, .overflows_credits),
-        T(id1, id4, id5, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, A4.credits_posted - A4.debits_pending - A4.debits_posted + 1, t, .overflows_timeout),
-        T(id1, id4, id5, ud0, tr0, id0, to0, 1, 1, N, N, N, N, p0, A4.credits_posted - A4.debits_pending - A4.debits_posted + 1, t, .exceeds_credits),
-        T(id1, id4, id5, ud0, tr0, id0, to0, 1, 1, N, N, N, N, p0, A5.debits_posted - A5.credits_pending - A5.credits_posted + 1, t, .exceeds_debits),
-        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 1, N, Y, N, N, p0, 123, t, .ok),
+        // Transfer.
+        \\ transfer T0 A0 A0  _ R1 T1   _ L0 C0 _ PEN _ _ P1    0 reserved_flag
+        \\ transfer T0 A0 A0  _ R1 T1   _ L0 C0 _ PEN _ _  _    0 reserved_field
+        \\ transfer T0 A0 A0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 id_must_not_be_zero
+        \\ transfer -0 A0 A0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 id_must_not_be_int_max
+        \\ transfer T1 A0 A0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 debit_account_id_must_not_be_zero
+        \\ transfer T1 -0 A0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 debit_account_id_must_not_be_int_max
+        \\ transfer T1 A8 A0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 credit_account_id_must_not_be_zero
+        \\ transfer T1 A8 -0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 credit_account_id_must_not_be_int_max
+        \\ transfer T1 A8 A8  _  _ T1   _ L0 C0 _ PEN _ _  _    0 accounts_must_be_different
+        \\ transfer T1 A8 A9  _  _ T1   _ L0 C0 _ PEN _ _  _    0 pending_id_must_be_zero
+        \\ transfer T1 A8 A9  _  _  _   _ L0 C0 _ PEN _ _  _    0 pending_transfer_must_timeout
+        \\ transfer T1 A8 A9  _  _  _  -0 L0 C0 _   _ _ _  _    0 timeout_reserved_for_pending_transfer
+        \\ transfer T1 A8 A9  _  _  _  -0 L0 C0 _ PEN _ _  _    0 ledger_must_not_be_zero
+        \\ transfer T1 A8 A9  _  _  _  -0 L9 C0 _ PEN _ _  _    0 code_must_not_be_zero
+        \\ transfer T1 A8 A9  _  _  _  -0 L9 C1 _ PEN _ _  _    0 amount_must_not_be_zero
+        \\ transfer T1 A8 A9  _  _  _  -0 L9 C1 _ PEN _ _  _    9 debit_account_not_found
+        \\ transfer T1 A1 A9  _  _  _  -0 L9 C1 _ PEN _ _  _    9 credit_account_not_found
+        \\ transfer T1 A1 A2  _  _  _  -0 L9 C1 _ PEN _ _  _    1 accounts_must_have_the_same_ledger
+        \\ transfer T1 A1 A3  _  _  _  -0 L9 C1 _ PEN _ _  _    1 transfer_must_have_the_same_ledger_as_accounts
+        \\ transfer T1 A1 A3  _  _  _  -0 L1 C1 _ PEN _ _  _  -99 overflows_debits_pending  // amount = max - A1.debits_pending + 1
+        \\ transfer T1 A1 A3  _  _  _  -0 L1 C1 _ PEN _ _  _ -109 overflows_credits_pending // amount = max - A3.credits_pending + 1
+        \\ transfer T1 A1 A3  _  _  _  -0 L1 C1 _ PEN _ _  _ -199 overflows_debits_posted   // amount = max - A1.debits_posted + 1
+        \\ transfer T1 A1 A3  _  _  _  -0 L1 C1 _ PEN _ _  _ -209 overflows_credits_posted  // amount = max - A3.credits_posted + 1
+        \\ transfer T1 A1 A3  _  _  _  -0 L1 C1 _ PEN _ _  _ -299 overflows_debits          // amount = max - A1.debits_pending - A1.debits_posted + 1
+        \\ transfer T1 A1 A3  _  _  _  -0 L1 C1 _ PEN _ _  _ -319 overflows_credits         // amount = max - A3.credits_pending - A3.credits_posted + 1
+        \\ transfer T1 A4 A5  _  _  _  -0 L1 C1 _ PEN _ _  _  199 overflows_timeout         // amount = A4.credits_posted - A4.debits_pending - A4.debits_posted + 1
+        \\ transfer T1 A4 A5  _  _  _   _ L1 C1 _   _ _ _  _  199 exceeds_credits           // amount = A4.credits_posted - A4.debits_pending - A4.debits_posted + 1
+        \\ transfer T1 A4 A5  _  _  _   _ L1 C1 _   _ _ _  _   91 exceeds_debits            // amount = A5.debits_posted - A5.credits_pending - A5.credits_posted + 1
+        \\ transfer T1 A1 A3  _  _  _ 999 L1 C1 _ PEN _ _  _  123 ok
 
         // Ensure that idempotence is only checked after validation.
-        T(id1, id1, id3, ud0, tr0, id0, 1e4, 2, 1, N, Y, N, N, p0, 123, t + 1, .transfer_must_have_the_same_ledger_as_accounts),
-        T(id1, id1, id3, ud1, tr0, id0, to0, 1, 2, N, N, N, N, p0, aZ, t + 1, .exists_with_different_flags),
-        T(id1, id3, id1, ud1, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_debit_account_id),
-        T(id1, id1, id4, ud1, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_credit_account_id),
-        T(id1, id1, id3, ud1, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_user_data),
-        T(id1, id1, id3, ud0, tr0, id0, 2e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_timeout),
-        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_code),
-        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 1, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_amount),
-        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 1, N, Y, N, N, p0, 123, t + 1, .exists),
-        T(id2, id3, id1, ud0, tr0, id0, to0, 1, 2, N, N, N, N, p0, 7, t + 1, .ok),
-        T(id3, id1, id3, ud0, tr0, id0, to0, 1, 2, N, N, N, N, p0, 3, t + 2, .ok),
-    };
-
-    for (vectors) |vector| {
-        try c.create_transfer(vector);
-        if (vector.result == .ok) {
-            try expectEqual(vector.object, c.state_machine.get_transfer(vector.object.id).?.*);
-        }
-    }
-
-    // Transfer 3:
-    try test_account_balances(&c.state_machine, id1, 100 + 123, 200 + 3, 0, 7);
-    try test_account_balances(&c.state_machine, id3, 0, 7, 110 + 123, 210 + 3);
-    c.state_machine.create_transfer_rollback(c.state_machine.get_transfer(id3).?);
-    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 7);
-    try test_account_balances(&c.state_machine, id3, 0, 7, 110 + 123, 210);
-    try expect(c.state_machine.get_transfer(id3) == null);
-
-    // Transfer 2:
-    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 7);
-    try test_account_balances(&c.state_machine, id3, 0, 7, 110 + 123, 210);
-    c.state_machine.create_transfer_rollback(c.state_machine.get_transfer(id2).?);
-    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 0);
-    try test_account_balances(&c.state_machine, id3, 0, 0, 110 + 123, 210);
-    try expect(c.state_machine.get_transfer(id2) == null);
-
-    // Transfer 1:
-    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 0);
-    try test_account_balances(&c.state_machine, id3, 0, 0, 110 + 123, 210);
-    c.state_machine.create_transfer_rollback(c.state_machine.get_transfer(id1).?);
-    try test_account_balances(&c.state_machine, id1, 100, 200, 0, 0);
-    try test_account_balances(&c.state_machine, id3, 0, 0, 110, 210);
-    try expect(c.state_machine.get_transfer(id1) == null);
+        \\ transfer  T1  A1  A3  _  _  _ 999 L2 C1 _ PEN _ _  _  123 transfer_must_have_the_same_ledger_as_accounts
+        \\ transfer  T1  A1  A3 U1  _  _   _ L1 C2 _   _ _ _  _   -0 exists_with_different_flags
+        \\ transfer  T1  A3  A1 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_debit_account_id
+        \\ transfer  T1  A1  A4 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_credit_account_id
+        \\ transfer  T1  A1  A3 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_user_data
+        \\ transfer  T1  A1  A3  _  _  _ 998 L1 C2 _ PEN _ _  _   -0 exists_with_different_timeout
+        \\ transfer  T1  A1  A3  _  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_code
+        \\ transfer  T1  A1  A3  _  _  _ 999 L1 C1 _ PEN _ _  _   -0 exists_with_different_amount
+        \\ transfer  T1  A1  A3  _  _  _ 999 L1 C1 _ PEN _ _  _  123 exists
+        \\ transfer  T2  A3  A1  _  _  _   _ L1 C2 _   _ _ _  _    7 ok
+        \\ transfer  T3  A1  A3  _  _  _   _ L1 C2 _   _ _ _  _    3 ok
+        \\
+        \\ balance A1 223 203   0   7
+        \\ balance A3   0   7 233 213
+        \\
+        \\ rollback_transfer T3
+        \\ balance A1 223 200   0   7
+        \\ balance A3   0   7 233 210
+        \\
+        \\ rollback_transfer T2
+        \\ balance A1 223 200   0   0
+        \\ balance A3   0   0 233 210
+        \\
+        \\ rollback_transfer T1
+        \\ balance A1 100 200   0   0
+        \\ balance A3   0   0 110 210
+    );
 }
 
 test "create/lookup/rollback 2-phase transfers" {
-    var c: TestContext = undefined;
-    try c.init(testing.allocator);
-    defer c.deinit(testing.allocator);
+    try check(
+        \\ account  A1 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ account  A2 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
 
-    const A1 = A(id1, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok).object;
-    const A2 = A(id2, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok).object;
-    for ([_]Account{ A1, A2 }) |account| try c.put_account(account);
+        // First phase.
+        \\ transfer   T1 A1 A2  _ _   _    _ L1 C1 _   _   _   _ _ 15 ok // Not pending!
+        \\ transfer   T2 A1 A2  _ _   _ 1000 L1 C1 _ PEN   _   _ _ 15 ok
+        \\ transfer   T3 A1 A2  _ _   _   50 L1 C1 _ PEN   _   _ _ 15 ok
+        \\ transfer   T4 A1 A2  _ _   _    1 L1 C1 _ PEN   _   _ _ 15 ok
+        \\ transfer   T5 A1 A2 U9 _   _   50 L1 C1 _ PEN   _   _ _  7 ok
 
-    const transfers_pending = [_]TransferVector{
-        T(id1, id1, id2, ud0, tr0, id0, to0, 1, 1, N, N, N, N, p0, 15, 0, .ok),
-        T(id2, id1, id2, ud0, tr0, id0, 1e3, 1, 1, N, Y, N, N, p0, 15, 0, .ok),
-        T(id3, id1, id2, ud0, tr0, id0, 5e0, 1, 1, N, Y, N, N, p0, 15, 0, .ok),
-        T(id4, id1, id2, ud0, tr0, id0, 1e0, 1, 1, N, Y, N, N, p0, 15, 0, .ok),
-        T(id5, id1, id2, 789, tr0, id0, 6e0, 1, 1, N, Y, N, N, p0, 7, 0, .ok),
-    };
+        // Check balances before resolving.
+        \\ balance  A1 52 15  0  0
+        \\ balance  A2  0  0 52 15
 
-    try c.create_objects(Transfer, transfers_pending[0..]);
+        // Second phase.
+        \\ transfer T101 A1 A2 U1 _  T2    _ L1 C1 _   _ POS   _ _ 13 ok
+        \\ transfer T101 A8 A9 U2 _  T0   50 L6 C7 _ PEN POS VOI _ 16 cannot_post_and_void_pending_transfer
+        \\ transfer T101 A8 A9 U2 _  T0   50 L6 C7 _ PEN   _ VOI _ 16 pending_transfer_cannot_post_or_void_another
+        \\ transfer T101 A8 A9 U2 _  T0   50 L6 C7 _   _   _ VOI _ 16 timeout_reserved_for_pending_transfer
+        \\ transfer T101 A8 A9 U2 _  T0    _ L6 C7 _   _   _ VOI _ 16 pending_id_must_not_be_zero
+        \\ transfer T101 A8 A9 U2 _  -0    _ L6 C7 _   _   _ VOI _ 16 pending_id_must_not_be_int_max
+        \\ transfer T101 A8 A9 U2 _ 101    _ L6 C7 _   _   _ VOI _ 16 pending_id_must_be_different
+        \\ transfer T101 A8 A9 U2 _ 102    _ L6 C7 _   _   _ VOI _ 16 pending_transfer_not_found
+        \\ transfer T101 A8 A9 U2 _  T1    _ L6 C7 _   _   _ VOI _ 16 pending_transfer_not_pending
+        \\ transfer T101 A8 A9 U2 _  T2    _ L6 C7 _   _   _ VOI _ 16 pending_transfer_has_different_debit_account_id
+        \\ transfer T101 A1 A9 U2 _  T2    _ L6 C7 _   _   _ VOI _ 16 pending_transfer_has_different_credit_account_id
+        \\ transfer T101 A1 A2 U2 _  T2    _ L6 C7 _   _   _ VOI _ 16 pending_transfer_has_different_ledger
+        \\ transfer T101 A1 A2 U2 _  T2    _ L1 C7 _   _   _ VOI _ 16 pending_transfer_has_different_code
+        \\ transfer T101 A1 A2 U2 _  T2    _ L1 C1 _   _   _ VOI _ 16 exceeds_pending_transfer_amount
+        \\ transfer T101 A1 A2 U2 _  T2    _ L1 C1 _   _   _ VOI _ 14 pending_transfer_has_different_amount
+        \\ transfer T101 A1 A2 U2 _  T2    _ L1 C1 _   _   _ VOI _ 15 exists_with_different_flags
+        \\ transfer T101 A1 A2 U2 _  T3    _ L1 C1 _   _ POS   _ _ 14 exists_with_different_pending_id
+        \\ transfer T101 A1 A2 U2 _  T2    _ L1 C1 _   _ POS   _ _ 14 exists_with_different_user_data
+        \\ transfer T101 A1 A2 U0 _  T2    _ L1 C1 _   _ POS   _ _ 14 exists_with_different_user_data
+        \\ transfer T101 A1 A2 U1 _  T2    _ L1 C1 _   _ POS   _ _ 14 exists_with_different_amount
+        \\ transfer T101 A1 A2 U1 _  T2    _ L1 C1 _   _ POS   _ _  _ exists_with_different_amount
+        \\ transfer T101 A1 A2 U1 _  T2    _ L1 C1 _   _ POS   _ _ 13 exists
+        \\ transfer T102 A1 A2 U1 _  T2    _ L1 C1 _   _ POS   _ _ 13 pending_transfer_already_posted
+        \\ transfer T103 A1 A2 U1 _  T3    _ L1 C1 _   _   _ VOI _ 15 ok
+        \\ transfer T102 A1 A2 U1 _  T3    _ L1 C1 _   _ POS   _ _ 13 pending_transfer_already_voided
+        \\ transfer T102 A1 A2 U1 _  T4    _ L1 C1 _   _   _ VOI _ 15 pending_transfer_expired
+        \\ transfer T105 A0 A0 U0 _  T5    _ L0 C0 _   _ POS   _ _  _ ok
 
-    // Test balances before posting:
-    try test_account_balances(&c.state_machine, id1, 52, 15, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 52, 15);
+        // Check balances after resolving.
+        \\ balance  A1 15 35  0  0
+        \\ balance  A2  0  0 15 35
+        \\ rollback_transfer 101 // Rollback posting transfer (different amount).
+        \\ balance A1 30 22  0  0
+        \\ balance A2  0  0 30 22
+        \\ rollback_transfer 103 // Rollback voiding transfer.
+        \\ balance A1 45 22  0  0
+        \\ balance A2  0  0 45 22
+        \\ rollback_transfer 105 // Rollback posting transfer (zero amount).
+        \\ balance A1 52 15  0  0
+        \\ balance A2  0  0 52 15
 
-    const t: u64 = c.state_machine.commit_timestamp;
-    const transfer_resolutions = [_]TransferVector{
-        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 13, t + 1, .ok),
-        T(101, 1e1, 2e1, ud2, tr0, id0, 5e1, 6, 7, N, Y, Y, Y, p0, 16, t + 2, .cannot_post_and_void_pending_transfer),
-        T(101, 1e1, 2e1, ud2, tr0, id0, 5e1, 6, 7, N, Y, N, Y, p0, 16, t + 2, .pending_transfer_cannot_post_or_void_another),
-        T(101, 1e1, 2e1, ud2, tr0, id0, 5e1, 6, 7, N, N, N, Y, p0, 16, t + 2, .timeout_reserved_for_pending_transfer),
-        T(101, 1e1, 2e1, ud2, tr0, id0, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_id_must_not_be_zero),
-        T(101, 1e1, 2e1, ud2, tr0, idZ, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_id_must_not_be_int_max),
-        T(101, 1e1, 2e1, ud2, tr0, 101, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_id_must_be_different),
-        T(101, 1e1, 2e1, ud2, tr0, 102, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_not_found),
-        T(101, 1e1, 2e1, ud2, tr0, id1, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_not_pending),
-        T(101, 1e1, 2e1, ud2, tr0, id2, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_debit_account_id),
-        T(101, id1, 2e1, ud2, tr0, id2, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_credit_account_id),
-        T(101, id1, id2, ud2, tr0, id2, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_ledger),
-        T(101, id1, id2, ud2, tr0, id2, to0, 1, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_code),
-        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, N, Y, p0, 16, t + 2, .exceeds_pending_transfer_amount),
-        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, N, Y, p0, 14, t + 2, .pending_transfer_has_different_amount),
-        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, N, Y, p0, 15, t + 2, .exists_with_different_flags),
-        T(101, id1, id2, ud2, tr0, id3, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_pending_id),
-        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_user_data),
-        T(101, id1, id2, ud0, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_user_data),
-        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_amount),
-        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 0, t + 2, .exists_with_different_amount),
-        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 13, t + 2, .exists),
-        T(102, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 13, t + 2, .pending_transfer_already_posted),
+        // Rollback all pending transfers.
+        \\ rollback_transfer 2
+        \\ balance A1 37 15  0  0
+        \\ balance A2  0  0 37 15
+        \\
+        \\ rollback_transfer 3
+        \\ balance A1 22 15  0  0
+        \\ balance A2  0  0 22 15
+        \\
+        \\ rollback_transfer 4
+        \\ balance A1  7 15  0  0
+        \\ balance A2  0  0  7 15
+        \\
+        \\ rollback_transfer 5
+        \\ balance A1  0 15  0  0
+        \\ balance A2  0  0  0 15
 
-        T(103, id1, id2, ud1, tr0, id3, to0, 1, 1, N, N, N, Y, p0, 15, t + 2, .ok),
-        T(102, id1, id2, ud1, tr0, id3, to0, 1, 1, N, N, Y, N, p0, 13, t + 3, .pending_transfer_already_voided),
-        T(102, id1, id2, ud1, tr0, id4, to0, 1, 1, N, N, N, Y, p0, 15, t + 3, .pending_transfer_expired),
-        T(105, id0, id0, ud0, tr0, id5, to0, 0, 0, N, N, Y, N, p0, 0, t + 3, .ok),
-    };
-
-    for (transfer_resolutions) |vector, i| {
-        try c.create_transfer(vector);
-        if (vector.result != .ok) continue;
-
-        // Test that posted values inherit from the pending or posting transfer:
-        const pending = c.state_machine.get_transfer(vector.object.pending_id).?.*;
-        const posted = c.state_machine.get_transfer(vector.object.id).?.*;
-
-        const user_data = if (vector.object.user_data == 0)
-            pending.user_data
-        else
-            vector.object.user_data;
-
-        const amount = if (vector.object.amount == 0)
-            pending.amount
-        else
-            vector.object.amount;
-
-        const expected = Transfer{
-            .id = vector.object.id,
-            .debit_account_id = pending.debit_account_id,
-            .credit_account_id = pending.credit_account_id,
-            .user_data = user_data,
-            .reserved = 0,
-            .pending_id = pending.id,
-            .timeout = 0,
-            .ledger = pending.ledger,
-            .code = pending.code,
-            .flags = vector.object.flags,
-            .amount = amount,
-            .timestamp = vector.object.timestamp,
-        };
-        expectEqual(expected, posted) catch |err| {
-            print_test_vector(i, expected, posted, vector.object, err);
-            return err;
-        };
-    }
-
-    // Balances after posting:
-    try test_account_balances(&c.state_machine, id1, 15, 35, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 15, 35);
-
-    // Rollback posting transfer (different amount):
-    assert(transfer_resolutions[0].result == .ok);
-    try test_transfer_rollback(&c.state_machine, &transfer_resolutions[0].object);
-    try test_account_balances(&c.state_machine, id1, 30, 22, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 30, 22);
-
-    // Rollback voiding transfer:
-    assert(transfer_resolutions[23].result == .ok);
-    try test_transfer_rollback(&c.state_machine, &transfer_resolutions[23].object);
-    try test_account_balances(&c.state_machine, id1, 45, 22, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 45, 22);
-
-    // Rollback posting transfer (zero amount):
-    assert(transfer_resolutions[26].result == .ok);
-    try test_transfer_rollback(&c.state_machine, &transfer_resolutions[26].object);
-    try test_account_balances(&c.state_machine, id1, 52, 15, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 52, 15);
-
-    // Rollback all pending transfers:
-    try test_transfer_rollback(&c.state_machine, &transfers_pending[1].object);
-    try test_account_balances(&c.state_machine, id1, 37, 15, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 37, 15);
-
-    try test_transfer_rollback(&c.state_machine, &transfers_pending[2].object);
-    try test_account_balances(&c.state_machine, id1, 22, 15, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 22, 15);
-
-    try test_transfer_rollback(&c.state_machine, &transfers_pending[3].object);
-    try test_account_balances(&c.state_machine, id1, 7, 15, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 7, 15);
-
-    try test_transfer_rollback(&c.state_machine, &transfers_pending[4].object);
-    try test_account_balances(&c.state_machine, id1, 0, 15, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 0, 15);
-
-    // Rollback transfer:
-    try test_transfer_rollback(&c.state_machine, &transfers_pending[0].object);
-    try test_account_balances(&c.state_machine, id1, 0, 0, 0, 0);
-    try test_account_balances(&c.state_machine, id2, 0, 0, 0, 0);
-}
-
-fn print_test_vector(
-    i: usize,
-    result_expect: anytype,
-    result_actual: anytype,
-    vector_object: anytype,
-    err: anyerror,
-) void {
-    std.debug.print("\nindex={}\n\nexpect: {}\n\nactual: {}\n\nobject: {}\n\nerr={}", .{
-        i,
-        result_expect,
-        result_actual,
-        vector_object,
-        err,
-    });
-}
-
-fn test_account_balances(
-    state_machine: *TestContext.StateMachine,
-    account_id: u128,
-    debits_pending: u64,
-    debits_posted: u64,
-    credits_pending: u64,
-    credits_posted: u64,
-) !void {
-    const account = state_machine.get_account(account_id).?.*;
-    try expectEqual(debits_pending, account.debits_pending);
-    try expectEqual(debits_posted, account.debits_posted);
-    try expectEqual(credits_pending, account.credits_pending);
-    try expectEqual(credits_posted, account.credits_posted);
-}
-
-fn test_transfer_rollback(state_machine: *TestContext.StateMachine, transfer: *const Transfer) !void {
-    assert(state_machine.get_transfer(transfer.id) != null);
-
-    state_machine.create_transfer_rollback(transfer);
-
-    try expect(state_machine.get_transfer(transfer.id) == null);
-    if (transfer.flags.post_pending_transfer or transfer.flags.void_pending_transfer) {
-        try expect(state_machine.get_posted(transfer.pending_id) == null);
-    }
+        // Rollback first transfer.
+        \\ rollback_transfer 1
+        \\ balance A1  0  0  0  0
+        \\ balance A2  0  0  0  0
+    );
 }
 
 test "zeroed_32_bytes" {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1278,6 +1278,10 @@ const TestCreateTransfer = struct {
 };
 
 fn check(comptime test_table: []const u8) !void {
+    // TODO(Zig): Disabled because of spurious failure (segfault) on MacOS at the
+    // `test_actions.constSlice()`. Most likely a comptime bug that will be resolved by 0.10.
+    if (@import("builtin").os.tag == .macos) return;
+
     const parse_table = @import("test/table.zig").parse;
     const allocator = std.testing.allocator;
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1298,7 +1298,8 @@ fn check(comptime test_table: []const u8) !void {
     defer reply.deinit();
 
     var operation: ?TestContext.StateMachine.Operation = null;
-    const test_actions = try parse_table(TestAction, test_table);
+
+    const test_actions = parse_table(TestAction, test_table);
     for (test_actions.constSlice()) |test_action| {
         switch (test_action) {
             .setup => |b| {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1284,9 +1284,6 @@ fn check(comptime test_table: []const u8) !void {
     try context.init(allocator);
     defer context.deinit(allocator);
 
-    const test_actions = try parse_table(allocator, TestAction, test_table);
-    defer test_actions.deinit();
-
     var accounts = std.AutoHashMap(u128, Account).init(allocator);
     defer accounts.deinit();
 
@@ -1300,7 +1297,8 @@ fn check(comptime test_table: []const u8) !void {
     defer reply.deinit();
 
     var operation: ?TestContext.StateMachine.Operation = null;
-    for (test_actions.items) |test_action| {
+    const test_actions = try parse_table(TestAction, test_table);
+    for (test_actions.constSlice()) |test_action| {
         switch (test_action) {
             .setup => |b| {
                 assert(operation == null);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1165,485 +1165,344 @@ const TestContext = struct {
         ctx.message_pool.deinit(allocator);
         ctx.* = undefined;
     }
-};
 
-test "create/lookup/rollback accounts" {
-    const Vector = struct { result: CreateAccountResult, object: Account };
+    fn ca(context: *TestContext, account_vector: AccountVector) !void {
+        const account = account_vector.object;
+        const result_actual = context.state_machine.create_account(&account);
+        try expectEqual(account_vector.result, result_actual);
 
-    const vectors = [_]Vector{
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 2,
-                .ledger = 3,
-                .code = 4,
-                .timestamp = 1,
-            }),
-        },
-        .{
-            .result = .reserved_flag,
-            .object = mem.zeroInit(Account, .{
-                .id = 0,
-                .user_data = 0,
-                .reserved = [_]u8{1} ** 48,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{
-                    .padding = 1,
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .reserved_field,
-            .object = mem.zeroInit(Account, .{
-                .id = 0,
-                .user_data = 0,
-                .reserved = [_]u8{1} ** 48,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{
-                    .padding = 0,
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .id_must_not_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 0,
-                .user_data = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{
-                    .padding = 0,
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .id_must_not_be_int_max,
-            .object = mem.zeroInit(Account, .{
-                .id = math.maxInt(u128),
-                .user_data = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{
-                    .padding = 0,
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .ledger_must_not_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{
-                    .padding = 0,
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .code_must_not_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 0,
-                .flags = .{
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .mutually_exclusive_flags,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .flags = .{
-                    .debits_must_not_exceed_credits = true,
-                    .credits_must_not_exceed_debits = true,
-                },
-                .debits_pending = math.maxInt(u64),
-                .debits_posted = math.maxInt(u64),
-                .credits_pending = math.maxInt(u64),
-                .credits_posted = math.maxInt(u64),
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .debits_pending_must_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .flags = .{
-                    .debits_must_not_exceed_credits = true,
-                },
-                .debits_pending = 1,
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .debits_posted_must_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .flags = .{
-                    .debits_must_not_exceed_credits = true,
-                },
-                .debits_posted = 1,
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .credits_pending_must_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .flags = .{
-                    .debits_must_not_exceed_credits = true,
-                },
-                .credits_pending = 1,
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .credits_posted_must_be_zero,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .flags = .{
-                    .debits_must_not_exceed_credits = true,
-                },
-                .credits_posted = 1,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_flags,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .flags = .{
-                    .credits_must_not_exceed_debits = true,
-                },
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_user_data,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 20,
-                .ledger = 30,
-                .code = 40,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_ledger,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 2,
-                .ledger = 30,
-                .code = 40,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_code,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 2,
-                .ledger = 3,
-                .code = 40,
-                .timestamp = 2,
-            }),
-        },
-        .{
-            .result = .exists,
-            .object = mem.zeroInit(Account, .{
-                .id = 1,
-                .user_data = 2,
-                .ledger = 3,
-                .code = 4,
-                .timestamp = 2,
-            }),
-        },
-    };
-
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    const state_machine = &context.state_machine;
-
-    for (vectors) |*vector, i| {
-        const result = state_machine.create_account(&vector.object);
-        expectEqual(vector.result, result) catch |err| {
-            print_test_vector(i, vector.result, result, vector.object, err);
-            return err;
-        };
-
-        if (vector.result == .ok) {
-            try expectEqual(vector.object, state_machine.get_account(vector.object.id).?.*);
+        if (account_vector.result == .ok) {
+            try expectEqual(account, context.state_machine.get_account(account.id).?.*);
         }
     }
 
-    state_machine.create_account_rollback(&vectors[0].object);
-    try expect(state_machine.get_account(vectors[0].object.id) == null);
+    fn put_account(context: *TestContext, account: Account) !void {
+        context.state_machine.forest.grooves.accounts.put(&account);
+        try expectEqual(account, context.state_machine.get_account(account.id).?.*);
+    }
+
+    fn create_transfer(context: *TestContext, transfer_vector: TransferVector) !void {
+        const transfer = transfer_vector.object;
+        const result_actual = context.state_machine.create_transfer(&transfer);
+        try expectEqual(transfer_vector.result, result_actual);
+    }
+
+    fn create_objects(
+        context: *TestContext,
+        comptime Object: type,
+        vectors: []const Vector(Object),
+    ) !void {
+        const operation = switch (Object) {
+            Account => .create_accounts,
+            Transfer => .create_transfers,
+            else => unreachable,
+        };
+
+        var objects = std.BoundedArray(Object, 32).init(0) catch unreachable;
+        for (vectors) |vector| {
+            objects.appendAssumeCapacity(vector.object);
+        }
+
+        const request = mem.sliceAsBytes(objects.slice());
+        const reply = try testing.allocator.alignedAlloc(u8, 16, 4096);
+        defer testing.allocator.free(reply);
+
+        _ = context.state_machine.prepare(operation, request);
+        const results_size = context.state_machine.commit(0, 1, operation, request, reply);
+        const results = mem.bytesAsSlice(StateMachine.Result(operation), reply[0..results_size]);
+
+        var results_index: usize = 0;
+        for (vectors) |vector, i| {
+            if (vector.result != .ok) {
+                try std.testing.expectEqual(results[results_index].index, @intCast(u32, i));
+                try std.testing.expectEqual(results[results_index].result, vector.result);
+                results_index += 1;
+            }
+        }
+        assert(results_index == results.len);
+
+        if (Object == Account) {
+            for (objects.slice()) |vector, i| {
+                if (vectors[i].result != .ok) continue;
+                try expectEqual(vector, context.state_machine.get_account(vector.id).?.*);
+            }
+        } else {
+            // The prior branch doesn't apply to Transfers because post/void tranfers' zero-fields
+            // are overwritten.
+        }
+    }
+};
+
+const N = false;
+const Y = true;
+
+// Account.id, Transfer.id
+const id0: u128 = 0;
+const id1: u128 = 1;
+const id2: u128 = 2;
+const id3: u128 = 3;
+const id4: u128 = 4;
+const id5: u128 = 5;
+const id6: u128 = 6;
+const id7: u128 = 7;
+const idZ: u128 = math.maxInt(u128);
+
+// Account.user_data, Transfer.user_data
+const ud0: u128 = id0;
+const ud1: u128 = id1;
+const ud2: u128 = id2;
+
+// Transfer.amount, Account.{debits,credits}_{pending,posted}
+const a0: u64 = 0;
+const a1: u64 = 1;
+const aZ: u64 = math.maxInt(u64);
+
+// Account.reserved
+const ar0 = [_]u8{0} ** 48;
+const ar1 = [_]u8{1} ** 48;
+
+// Account.flags.padding
+const afp0: u13 = 0;
+const afp1: u13 = 1;
+
+// Transfer.reserved
+const tr0: u128 = 0;
+const tr1: u128 = 1;
+
+// Transfer.timeout
+const to0: u64 = 0;
+
+// Transfer.flags.padding
+const p0: u12 = 0;
+const p1: u12 = 1;
+
+fn A(
+    id: u128,
+    user_data: u128,
+    reserved: [48]u8,
+    ledger: u32,
+    code: u16,
+    flags_linked: bool,
+    flags_debits_must_not_exceed_credits: bool,
+    flags_credits_must_not_exceed_debits: bool,
+    flags_padding: u13,
+    debits_pending: u64,
+    debits_posted: u64,
+    credits_pending: u64,
+    credits_posted: u64,
+    timestamp: u64,
+    result: CreateAccountResult,
+) AccountVector {
+    return .{
+        .object = Account{
+            .id = id,
+            .user_data = user_data,
+            .reserved = reserved,
+            .ledger = ledger,
+            .code = code,
+            .flags = .{
+                .linked = flags_linked,
+                .debits_must_not_exceed_credits = flags_debits_must_not_exceed_credits,
+                .credits_must_not_exceed_debits = flags_credits_must_not_exceed_debits,
+                .padding = flags_padding,
+            },
+            .debits_pending = debits_pending,
+            .debits_posted = debits_posted,
+            .credits_pending = credits_pending,
+            .credits_posted = credits_posted,
+            .timestamp = timestamp,
+        },
+        .result = result,
+    };
+}
+
+fn T(
+    id: u128,
+    debit_account_id: u128,
+    credit_account_id: u128,
+    user_data: u128,
+    reserved: u128,
+    pending_id: u128,
+    timeout: u64,
+    ledger: u32,
+    code: u16,
+    flags_linked: bool,
+    flags_pending: bool,
+    flags_post_pending_transfer: bool,
+    flags_void_pending_transfer: bool,
+    flags_padding: u12,
+    amount: u64,
+    timestamp: u64,
+    result: CreateTransferResult,
+) TransferVector {
+    return .{
+        .object = .{
+            .id = id,
+            .debit_account_id = debit_account_id,
+            .credit_account_id = credit_account_id,
+            .user_data = user_data,
+            .reserved = reserved,
+            .pending_id = pending_id,
+            .timeout = timeout,
+            .ledger = ledger,
+            .code = code,
+            .flags = .{
+                .linked = flags_linked,
+                .pending = flags_pending,
+                .post_pending_transfer = flags_post_pending_transfer,
+                .void_pending_transfer = flags_void_pending_transfer,
+                .padding = flags_padding,
+            },
+            .amount = amount,
+            .timestamp = timestamp,
+        },
+        .result = result,
+    };
+}
+
+fn Vector(comptime Object: type) type {
+    assert(Object == Account or Object == Transfer);
+    return struct {
+        object: Object,
+        result: switch (Object) {
+            Account => CreateAccountResult,
+            Transfer => CreateTransferResult,
+            else => unreachable,
+        },
+    };
+}
+
+const AccountVector = Vector(Account);
+const TransferVector = Vector(Transfer);
+
+test "create/lookup/rollback accounts" {
+    var c: TestContext = undefined;
+    try c.init(testing.allocator);
+    defer c.deinit(testing.allocator);
+
+    const account_vectors = [_]AccountVector{
+        A(id1, ud2, ar0, 3, 4, N, N, N, afp0, a0, a0, a0, a0, 1, .ok),
+        A(id0, ud0, ar1, 0, 0, N, Y, Y, afp1, a1, a1, a1, a1, 2, .reserved_flag),
+        A(id0, ud0, ar1, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .reserved_field),
+        A(id0, ud0, ar0, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .id_must_not_be_zero),
+        A(idZ, ud0, ar0, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .id_must_not_be_int_max),
+        A(id1, ud1, ar0, 0, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .ledger_must_not_be_zero),
+        A(id1, ud1, ar0, 9, 0, N, Y, Y, afp0, a1, a1, a1, a1, 2, .code_must_not_be_zero),
+        A(id1, ud1, ar0, 9, 9, N, Y, Y, afp0, aZ, aZ, aZ, aZ, 2, .mutually_exclusive_flags),
+        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a1, a1, a1, a1, 2, .debits_pending_must_be_zero),
+        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a1, a1, a1, 2, .debits_posted_must_be_zero),
+        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a0, a1, a1, 2, .credits_pending_must_be_zero),
+        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a0, a0, a1, 2, .credits_posted_must_be_zero),
+        A(id1, ud1, ar0, 9, 9, N, Y, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_flags),
+        A(id1, ud1, ar0, 9, 9, N, N, Y, afp0, a0, a0, a0, a0, 2, .exists_with_different_flags),
+        A(id1, ud1, ar0, 9, 9, N, N, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_user_data),
+        A(id1, ud2, ar0, 9, 9, N, N, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_ledger),
+        A(id1, ud2, ar0, 3, 9, N, N, N, afp0, a0, a0, a0, a0, 2, .exists_with_different_code),
+        A(id1, ud2, ar0, 3, 4, N, N, N, afp0, a0, a0, a0, a0, 2, .exists),
+    };
+
+    for (account_vectors[0..]) |account_vector| {
+        try c.ca(account_vector);
+    }
+
+    c.state_machine.create_account_rollback(&account_vectors[0].object);
+    try expect(c.state_machine.get_account(id1) == null);
+    try expect(c.state_machine.get_account(id2) == null);
 }
 
 test "linked accounts" {
-    var accounts = [_]Account{
-        // An individual event (successful):
-        mem.zeroInit(Account, .{ .id = 7, .code = 1, .ledger = 1 }),
-
-        // A chain of 4 events (the last event in the chain closes the chain with linked=false):
-        // Commit/rollback.
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        // Commit/rollback.
-        mem.zeroInit(Account, .{ .id = 2, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        // Fail with .exists.
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        // Fail without committing.
-        mem.zeroInit(Account, .{ .id = 3, .code = 1, .ledger = 1 }),
-
-        // An individual event (successful):
-        // This should not see any effect from the failed chain above.
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1 }),
-
-        // A chain of 2 events (the first event fails the chain):
-        mem.zeroInit(Account, .{ .id = 1, .code = 2, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 2, .code = 1, .ledger = 1 }),
-
-        // An individual event (successful):
-        mem.zeroInit(Account, .{ .id = 2, .code = 1, .ledger = 1 }),
-
-        // A chain of 2 events (the last event fails the chain):
-        mem.zeroInit(Account, .{ .id = 3, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 2 }),
-
-        // A chain of 2 events (successful):
-        mem.zeroInit(Account, .{ .id = 3, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 4, .code = 1, .ledger = 1 }),
-    };
-
     var context: TestContext = undefined;
     try context.init(testing.allocator);
     defer context.deinit(testing.allocator);
 
-    const state_machine = &context.state_machine;
+    try context.create_objects(Account, &.{
+        // An individual event (successful):
+        A(id7, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
 
-    const input = mem.asBytes(&accounts);
+        // A chain of 4 events (the last event in the chain closes the chain with linked=false):
+        // Commit/rollback.
+        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        // Commit/rollback.
+        A(id2, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        // Fail with .exists.
+        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .exists),
+        // Fail without committing.
+        A(id3, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
 
-    const output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(output);
+        // An individual event (successful):
+        // This does not see any effect from the failed chain above.
+        A(id1, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
 
-    _ = state_machine.prepare(.create_accounts, input);
-    const size = state_machine.commit(0, 1, .create_accounts, input, output);
-    const results = mem.bytesAsSlice(CreateAccountsResult, output[0..size]);
+        // A chain of 2 events (the first event fails the chain):
+        A(id1, ud0, ar0, 1, 2, Y, N, N, afp0, a0, a0, a0, a0, 0, .exists_with_different_flags),
+        A(id2, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
 
-    try expectEqualSlices(
-        CreateAccountsResult,
-        &[_]CreateAccountsResult{
-            .{ .index = 1, .result = .linked_event_failed },
-            .{ .index = 2, .result = .linked_event_failed },
-            .{ .index = 3, .result = .exists },
-            .{ .index = 4, .result = .linked_event_failed },
-            .{ .index = 6, .result = .exists_with_different_flags },
-            .{ .index = 7, .result = .linked_event_failed },
-            .{ .index = 9, .result = .linked_event_failed },
-            .{ .index = 10, .result = .exists_with_different_ledger },
-        },
-        results,
-    );
+        // An individual event (successful):
+        A(id2, ud1, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
 
-    try expectEqual(accounts[0], state_machine.get_account(accounts[0].id).?.*);
-    try expectEqual(accounts[5], state_machine.get_account(accounts[5].id).?.*);
-    try expectEqual(accounts[8], state_machine.get_account(accounts[8].id).?.*);
-    try expectEqual(accounts[11], state_machine.get_account(accounts[11].id).?.*);
-    try expectEqual(accounts[12], state_machine.get_account(accounts[12].id).?.*);
+        // A chain of 2 events (the last event fails the chain):
+        A(id3, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        A(id1, ud0, ar0, 2, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .exists_with_different_ledger),
+
+        // A chain of 2 events (successful):
+        A(id3, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        A(id4, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+    });
 
     // TODO How can we test that events were in fact rolled back in LIFO order?
     // All our rollback handlers appear to be commutative.
 }
 
 test "linked_event_chain_open" {
-    var accounts = [_]Account{
-        // A chain of 3 events (the last event in the chain closes the chain with linked=false):
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 2, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 3, .code = 1, .ledger = 1 }),
-
-        // An open chain of 2 events:
-        mem.zeroInit(Account, .{ .id = 4, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 5, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-    };
-
     var context: TestContext = undefined;
     try context.init(testing.allocator);
     defer context.deinit(testing.allocator);
 
-    const state_machine = &context.state_machine;
+    try context.create_objects(Account, &.{
+        // A chain of 3 events (the last event in the chain closes the chain with linked=false):
+        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        A(id2, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .ok),
+        A(id3, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
 
-    const input = mem.asBytes(&accounts);
+        // An open chain of 2 events:
+        A(id4, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        A(id5, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_chain_open),
+    });
 
-    const output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(output);
-
-    _ = state_machine.prepare(.create_accounts, input);
-    const size = state_machine.commit(0, 1, .create_accounts, input, output);
-    const results = mem.bytesAsSlice(CreateAccountsResult, output[0..size]);
-
-    try expectEqualSlices(
-        CreateAccountsResult,
-        &[_]CreateAccountsResult{
-            .{ .index = 3, .result = .linked_event_failed },
-            .{ .index = 4, .result = .linked_event_chain_open },
-        },
-        results,
-    );
-
-    try expectEqual(accounts[0], state_machine.get_account(accounts[0].id).?.*);
-    try expectEqual(accounts[1], state_machine.get_account(accounts[1].id).?.*);
-    try expectEqual(accounts[2], state_machine.get_account(accounts[2].id).?.*);
-
-    try expectEqual(@as(?*const Account, null), state_machine.get_account(accounts[3].id));
-    try expectEqual(@as(?*const Account, null), state_machine.get_account(accounts[4].id));
+    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id4));
+    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id5));
 }
 
 test "linked_event_chain_open for an already failed batch" {
-    var accounts = [_]Account{
-        // An individual event (successful):
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1 }),
-
-        // An open chain of 3 events (the second one fails):
-        mem.zeroInit(Account, .{ .id = 2, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-        mem.zeroInit(Account, .{ .id = 3, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-    };
-
     var context: TestContext = undefined;
     try context.init(testing.allocator);
     defer context.deinit(testing.allocator);
 
-    const state_machine = &context.state_machine;
+    try context.create_objects(Account, &.{
+        // An individual event (successful):
+        A(id1, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok),
 
-    const input = mem.asBytes(&accounts);
+        // An open chain of 3 events (the second one fails):
+        A(id2, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_failed),
+        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .exists_with_different_flags),
+        A(id3, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_chain_open),
+    });
 
-    const output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(output);
-
-    _ = state_machine.prepare(.create_accounts, input);
-    const size = state_machine.commit(0, 1, .create_accounts, input, output);
-    const results = mem.bytesAsSlice(CreateAccountsResult, output[0..size]);
-
-    try expectEqualSlices(
-        CreateAccountsResult,
-        &[_]CreateAccountsResult{
-            .{ .index = 1, .result = .linked_event_failed },
-            .{ .index = 2, .result = .exists_with_different_flags },
-            .{ .index = 3, .result = .linked_event_chain_open },
-        },
-        results,
-    );
-
-    try expectEqual(accounts[0], state_machine.get_account(accounts[0].id).?.*);
-
-    try expectEqual(@as(?*const Account, null), state_machine.get_account(accounts[1].id));
-    try expectEqual(@as(?*const Account, null), state_machine.get_account(accounts[3].id));
+    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id2));
+    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id3));
 }
 
 test "linked_event_chain_open for a batch of 1" {
-    var accounts = [_]Account{
-        // Just one event with linked = true
-        mem.zeroInit(Account, .{ .id = 1, .code = 1, .ledger = 1, .flags = .{ .linked = true } }),
-    };
-
     var context: TestContext = undefined;
     try context.init(testing.allocator);
     defer context.deinit(testing.allocator);
 
-    const state_machine = &context.state_machine;
+    try context.create_objects(Account, &.{
+        // Just one event with linked = true
+        A(id1, ud0, ar0, 1, 1, Y, N, N, afp0, a0, a0, a0, a0, 0, .linked_event_chain_open),
+    });
 
-    const input = mem.asBytes(&accounts);
-
-    const output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(output);
-
-    _ = state_machine.prepare(.create_accounts, input);
-    const size = state_machine.commit(0, 1, .create_accounts, input, output);
-    const results = mem.bytesAsSlice(CreateAccountsResult, output[0..size]);
-
-    try expectEqualSlices(
-        CreateAccountsResult,
-        &[_]CreateAccountsResult{
-            .{ .index = 0, .result = .linked_event_chain_open },
-        },
-        results,
-    );
-
-    try expectEqual(@as(?*const Account, null), state_machine.get_account(accounts[0].id));
+    try expectEqual(@as(?*const Account, null), context.state_machine.get_account(id1));
 }
 
 // The goal is to ensure that:
@@ -1651,1339 +1510,233 @@ test "linked_event_chain_open for a batch of 1" {
 // 2. enums tested in the order that they are defined, for easier auditing of coverage, and that
 // 3. state machine logic cannot be reordered in any way, breaking determinism.
 test "create/lookup/rollback transfers" {
-    var accounts = [_]Account{
-        mem.zeroInit(Account, .{
-            .id = 1,
-            .ledger = 1,
-            .code = 1,
-            .debits_pending = 100,
-            .debits_posted = 200,
-        }),
-        mem.zeroInit(Account, .{ .id = 2, .ledger = 2, .code = 2 }),
-        mem.zeroInit(Account, .{
-            .id = 3,
-            .ledger = 1,
-            .code = 1,
-            .credits_pending = 110,
-            .credits_posted = 210,
-        }),
-        mem.zeroInit(Account, .{
-            .id = 4,
-            .ledger = 1,
-            .code = 1,
-            .flags = .{ .debits_must_not_exceed_credits = true },
-            .debits_pending = 20,
-            .debits_posted = math.maxInt(u64) - 500 - 200,
-            .credits_pending = 0,
-            .credits_posted = math.maxInt(u64) - 500,
-        }),
-        mem.zeroInit(Account, .{
-            .id = 5,
-            .ledger = 1,
-            .code = 1,
-            .flags = .{ .credits_must_not_exceed_debits = true },
-            .debits_pending = 0,
-            .debits_posted = math.maxInt(u64) - 1000,
-            .credits_pending = 10,
-            .credits_posted = math.maxInt(u64) - 1000 - 100,
-        }),
+    var c: TestContext = undefined;
+    try c.init(testing.allocator);
+    defer c.deinit(testing.allocator);
+
+    const A1 = A(id1, ud0, ar0, 1, 1, N, N, N, afp0, 100, 200, a0, a0, 0, .ok).object;
+    const A2 = A(id2, ud0, ar0, 2, 2, N, N, N, afp0, a0, a0, a0, a0, 0, .ok).object;
+    const A3 = A(id3, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, 110, 210, 0, .ok).object;
+    const A4 = A(id4, ud0, ar0, 1, 1, N, Y, N, afp0, 20, aZ - 500 - 200, a0, aZ - 500, 0, .ok).object;
+    const A5 = A(id5, ud0, ar0, 1, 1, N, N, Y, afp0, a0, aZ - 1000, 10, aZ - 1000 - 100, 0, .ok).object;
+    for ([_]Account{ A1, A2, A3, A4, A5 }) |account| try c.put_account(account);
+
+    const t: u64 = c.state_machine.prepare_timestamp + 1;
+    const toZ: u64 = (std.math.maxInt(u64) - t) + 1;
+
+    const vectors = [_]TransferVector{
+        T(id0, id0, id0, ud0, tr1, id1, to0, 0, 0, N, Y, N, N, p1, 0, t, .reserved_flag),
+        T(id0, id0, id0, ud0, tr1, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .reserved_field),
+        T(id0, id0, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .id_must_not_be_zero),
+        T(idZ, id0, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .id_must_not_be_int_max),
+        T(id1, id0, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .debit_account_id_must_not_be_zero),
+        T(id1, idZ, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .debit_account_id_must_not_be_int_max),
+        T(id1, 100, id0, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .credit_account_id_must_not_be_zero),
+        T(id1, 100, idZ, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .credit_account_id_must_not_be_int_max),
+        T(id1, 100, 100, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .accounts_must_be_different),
+        T(id1, 100, 200, ud0, tr0, id1, to0, 0, 0, N, Y, N, N, p0, 0, t, .pending_id_must_be_zero),
+        T(id1, 100, 200, ud0, tr0, id0, to0, 0, 0, N, Y, N, N, p0, 0, t, .pending_transfer_must_timeout),
+        T(id1, 100, 200, ud0, tr0, id0, toZ, 0, 0, N, N, N, N, p0, 0, t, .timeout_reserved_for_pending_transfer),
+        T(id1, 100, 200, ud0, tr0, id0, toZ, 0, 0, N, Y, N, N, p0, 0, t, .ledger_must_not_be_zero),
+        T(id1, 100, 200, ud0, tr0, id0, toZ, 9, 0, N, Y, N, N, p0, 0, t, .code_must_not_be_zero),
+        T(id1, 100, 200, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 0, t, .amount_must_not_be_zero),
+        T(id1, 100, 200, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 9, t, .debit_account_not_found),
+        T(id1, id1, 200, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 9, t, .credit_account_not_found),
+        T(id1, id1, id2, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 1, t, .accounts_must_have_the_same_ledger),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 9, 1, N, Y, N, N, p0, 1, t, .transfer_must_have_the_same_ledger_as_accounts),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A1.debits_pending + 1, t, .overflows_debits_pending),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A3.credits_pending + 1, t, .overflows_credits_pending),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A1.debits_posted + 1, t, .overflows_debits_posted),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A3.credits_posted + 1, t, .overflows_credits_posted),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A1.debits_pending - A1.debits_posted + 1, t, .overflows_debits),
+        T(id1, id1, id3, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, aZ - A3.credits_pending - A3.credits_posted + 1, t, .overflows_credits),
+        T(id1, id4, id5, ud0, tr0, id0, toZ, 1, 1, N, Y, N, N, p0, A4.credits_posted - A4.debits_pending - A4.debits_posted + 1, t, .overflows_timeout),
+        T(id1, id4, id5, ud0, tr0, id0, to0, 1, 1, N, N, N, N, p0, A4.credits_posted - A4.debits_pending - A4.debits_posted + 1, t, .exceeds_credits),
+        T(id1, id4, id5, ud0, tr0, id0, to0, 1, 1, N, N, N, N, p0, A5.debits_posted - A5.credits_pending - A5.credits_posted + 1, t, .exceeds_debits),
+        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 1, N, Y, N, N, p0, 123, t, .ok),
+
+        // Ensure that idempotence is only checked after validation.
+        T(id1, id1, id3, ud0, tr0, id0, 1e4, 2, 1, N, Y, N, N, p0, 123, t + 1, .transfer_must_have_the_same_ledger_as_accounts),
+        T(id1, id1, id3, ud1, tr0, id0, to0, 1, 2, N, N, N, N, p0, aZ, t + 1, .exists_with_different_flags),
+        T(id1, id3, id1, ud1, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_debit_account_id),
+        T(id1, id1, id4, ud1, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_credit_account_id),
+        T(id1, id1, id3, ud1, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_user_data),
+        T(id1, id1, id3, ud0, tr0, id0, 2e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_timeout),
+        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 2, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_code),
+        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 1, N, Y, N, N, p0, aZ, t + 1, .exists_with_different_amount),
+        T(id1, id1, id3, ud0, tr0, id0, 1e4, 1, 1, N, Y, N, N, p0, 123, t + 1, .exists),
+        T(id2, id3, id1, ud0, tr0, id0, to0, 1, 2, N, N, N, N, p0, 7, t + 1, .ok),
+        T(id3, id1, id3, ud0, tr0, id0, to0, 1, 2, N, N, N, N, p0, 3, t + 2, .ok),
     };
 
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    const state_machine = &context.state_machine;
-
-    const input = mem.asBytes(&accounts);
-
-    const output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(output);
-
-    _ = state_machine.prepare(.create_accounts, input);
-
-    for (accounts) |account| {
-        state_machine.forest.grooves.accounts.put(&account);
-        try expectEqual(account, state_machine.get_account(account.id).?.*);
-    }
-
-    const Vector = struct { result: CreateTransferResult, object: Transfer };
-
-    const timestamp: u64 = state_machine.prepare_timestamp + 1;
-    const vectors = [_]Vector{
-        .{
-            .result = .reserved_flag,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 0,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .reserved = 1,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true, .padding = 1 },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .reserved_field,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 0,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .reserved = 1,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .id_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 0,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .id_must_not_be_int_max,
-            .object = mem.zeroInit(Transfer, .{
-                .id = math.maxInt(u128),
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .debit_account_id_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .debit_account_id_must_not_be_int_max,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = math.maxInt(u128),
-                .credit_account_id = 0,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .credit_account_id_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 0,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .credit_account_id_must_not_be_int_max,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = math.maxInt(u128),
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .accounts_must_be_different,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 100,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .pending_id_must_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .pending_id = 1,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .pending_transfer_must_timeout,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .timeout = 0,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .timeout_reserved_for_pending_transfer,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 0,
-                .code = 0,
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .ledger_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .code_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 100,
-                .code = 0,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .amount_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 100,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = 0,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .debit_account_not_found,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 100,
-                .credit_account_id = 200,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 100,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = 100,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .credit_account_not_found,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 200,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 100,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = 100,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .accounts_must_have_the_same_ledger,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 100,
-                .code = 1,
-                .amount = 1,
-                .flags = .{ .pending = true },
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .transfer_must_have_the_same_ledger_as_accounts,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 100,
-                .code = 1,
-                .amount = 1,
-                .flags = .{ .pending = true },
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_debits_pending,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64) - accounts[1 - 1].debits_pending + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_credits_pending,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64) - accounts[3 - 1].credits_pending + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_debits_posted,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64) - accounts[1 - 1].debits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_credits_posted,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64) - accounts[3 - 1].credits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_debits,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64) -
-                    accounts[1 - 1].debits_pending -
-                    accounts[1 - 1].debits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_credits,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64) -
-                    accounts[3 - 1].credits_pending -
-                    accounts[3 - 1].credits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .overflows_timeout,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 4,
-                .credit_account_id = 5,
-                .timeout = (std.math.maxInt(u64) - timestamp) + 1,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = accounts[4 - 1].credits_posted -
-                    accounts[4 - 1].debits_pending -
-                    accounts[4 - 1].debits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .exceeds_credits,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 4,
-                .credit_account_id = 5,
-                .ledger = 1,
-                .code = 1,
-                .amount = accounts[4 - 1].credits_posted -
-                    accounts[4 - 1].debits_pending -
-                    accounts[4 - 1].debits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .exceeds_debits,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 4,
-                .credit_account_id = 5,
-                .ledger = 1,
-                .code = 1,
-                .amount = accounts[5 - 1].debits_posted -
-                    accounts[5 - 1].credits_pending -
-                    accounts[5 - 1].credits_posted + 1,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = 123,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            // Ensure that idempotence is only checked after validation.
-            .result = .transfer_must_have_the_same_ledger_as_accounts,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = 10000,
-                .ledger = 2,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = 123,
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_flags,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .user_data = 1,
-                .ledger = 1,
-                .code = 2,
-                .flags = .{ .pending = false },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_debit_account_id,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 3,
-                .credit_account_id = 1,
-                .user_data = 1,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 2,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_credit_account_id,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 4,
-                .user_data = 1,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 2,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_user_data,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .user_data = 1,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 2,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_timeout,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = 10001,
-                .ledger = 1,
-                .code = 2,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_code,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 2,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists_with_different_amount,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = math.maxInt(u64),
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .exists,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 1,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .timeout = 10000,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .pending = true },
-                .amount = 123,
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 2,
-                .debit_account_id = 3,
-                .credit_account_id = 1,
-                .ledger = 1,
-                .code = 2,
-                .amount = 7,
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 3,
-                .debit_account_id = 1,
-                .credit_account_id = 3,
-                .ledger = 1,
-                .code = 2,
-                .amount = 3,
-                .timestamp = timestamp + 3,
-            }),
-        },
-    };
-
-    for (vectors) |vector, i| {
-        const result = state_machine.create_transfer(&vector.object);
-        expectEqual(vector.result, result) catch |err| {
-            print_test_vector(i, vector.result, result, vector.object, err);
-            return err;
-        };
+    for (vectors) |vector| {
+        try c.create_transfer(vector);
         if (vector.result == .ok) {
-            try expectEqual(vector.object, state_machine.get_transfer(vector.object.id).?.*);
+            try expectEqual(vector.object, c.state_machine.get_transfer(vector.object.id).?.*);
         }
     }
 
     // Transfer 3:
-    try test_account_balances(state_machine, 1, 100 + 123, 200 + 3, 0, 7);
-    try test_account_balances(state_machine, 3, 0, 7, 110 + 123, 210 + 3);
-    state_machine.create_transfer_rollback(state_machine.get_transfer(3).?);
-    try test_account_balances(state_machine, 1, 100 + 123, 200, 0, 7);
-    try test_account_balances(state_machine, 3, 0, 7, 110 + 123, 210);
-    try expect(state_machine.get_transfer(3) == null);
+    try test_account_balances(&c.state_machine, id1, 100 + 123, 200 + 3, 0, 7);
+    try test_account_balances(&c.state_machine, id3, 0, 7, 110 + 123, 210 + 3);
+    c.state_machine.create_transfer_rollback(c.state_machine.get_transfer(id3).?);
+    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 7);
+    try test_account_balances(&c.state_machine, id3, 0, 7, 110 + 123, 210);
+    try expect(c.state_machine.get_transfer(id3) == null);
 
     // Transfer 2:
-    try test_account_balances(state_machine, 1, 100 + 123, 200, 0, 7);
-    try test_account_balances(state_machine, 3, 0, 7, 110 + 123, 210);
-    state_machine.create_transfer_rollback(state_machine.get_transfer(2).?);
-    try test_account_balances(state_machine, 1, 100 + 123, 200, 0, 0);
-    try test_account_balances(state_machine, 3, 0, 0, 110 + 123, 210);
-    try expect(state_machine.get_transfer(2) == null);
+    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 7);
+    try test_account_balances(&c.state_machine, id3, 0, 7, 110 + 123, 210);
+    c.state_machine.create_transfer_rollback(c.state_machine.get_transfer(id2).?);
+    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 0);
+    try test_account_balances(&c.state_machine, id3, 0, 0, 110 + 123, 210);
+    try expect(c.state_machine.get_transfer(id2) == null);
 
     // Transfer 1:
-    try test_account_balances(state_machine, 1, 100 + 123, 200, 0, 0);
-    try test_account_balances(state_machine, 3, 0, 0, 110 + 123, 210);
-    state_machine.create_transfer_rollback(state_machine.get_transfer(1).?);
-    try test_account_balances(state_machine, 1, 100, 200, 0, 0);
-    try test_account_balances(state_machine, 3, 0, 0, 110, 210);
-    try expect(state_machine.get_transfer(1) == null);
+    try test_account_balances(&c.state_machine, id1, 100 + 123, 200, 0, 0);
+    try test_account_balances(&c.state_machine, id3, 0, 0, 110 + 123, 210);
+    c.state_machine.create_transfer_rollback(c.state_machine.get_transfer(id1).?);
+    try test_account_balances(&c.state_machine, id1, 100, 200, 0, 0);
+    try test_account_balances(&c.state_machine, id3, 0, 0, 110, 210);
+    try expect(c.state_machine.get_transfer(id1) == null);
 }
 
 test "create/lookup/rollback 2-phase transfers" {
-    var accounts = [_]Account{
-        mem.zeroInit(Account, .{ .id = 1, .ledger = 1, .code = 1 }),
-        mem.zeroInit(Account, .{ .id = 2, .ledger = 1, .code = 1 }),
+    var c: TestContext = undefined;
+    try c.init(testing.allocator);
+    defer c.deinit(testing.allocator);
+
+    const A1 = A(id1, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok).object;
+    const A2 = A(id2, ud0, ar0, 1, 1, N, N, N, afp0, a0, a0, a0, a0, 0, .ok).object;
+    for ([_]Account{ A1, A2 }) |account| try c.put_account(account);
+
+    const transfers_pending = [_]TransferVector{
+        T(id1, id1, id2, ud0, tr0, id0, to0, 1, 1, N, N, N, N, p0, 15, 0, .ok),
+        T(id2, id1, id2, ud0, tr0, id0, 1e3, 1, 1, N, Y, N, N, p0, 15, 0, .ok),
+        T(id3, id1, id2, ud0, tr0, id0, 5e0, 1, 1, N, Y, N, N, p0, 15, 0, .ok),
+        T(id4, id1, id2, ud0, tr0, id0, 1e0, 1, 1, N, Y, N, N, p0, 15, 0, .ok),
+        T(id5, id1, id2, 789, tr0, id0, 6e0, 1, 1, N, Y, N, N, p0, 7, 0, .ok),
     };
 
-    var transfers = [_]Transfer{
-        mem.zeroInit(Transfer, .{
-            .id = 1,
-            .debit_account_id = 1,
-            .credit_account_id = 2,
-            .ledger = 1,
-            .code = 1,
-            .amount = 15,
-        }),
-        mem.zeroInit(Transfer, .{
-            .id = 2,
-            .debit_account_id = 1,
-            .credit_account_id = 2,
-            .timeout = 1000,
-            .ledger = 1,
-            .code = 1,
-            .flags = .{ .pending = true },
-            .amount = 15,
-        }),
-        mem.zeroInit(Transfer, .{
-            .id = 3,
-            .debit_account_id = 1,
-            .credit_account_id = 2,
-            .timeout = 5,
-            .ledger = 1,
-            .code = 1,
-            .flags = .{ .pending = true },
-            .amount = 15,
-        }),
-        mem.zeroInit(Transfer, .{
-            .id = 4,
-            .debit_account_id = 1,
-            .credit_account_id = 2,
-            .timeout = 1,
-            .ledger = 1,
-            .code = 1,
-            .flags = .{ .pending = true },
-            .amount = 15,
-        }),
-        mem.zeroInit(Transfer, .{
-            .id = 5,
-            .debit_account_id = 1,
-            .credit_account_id = 2,
-            .user_data = 73,
-            .timeout = 6,
-            .ledger = 1,
-            .code = 1,
-            .flags = .{ .pending = true },
-            .amount = 7,
-        }),
-    };
-
-    var context: TestContext = undefined;
-    try context.init(testing.allocator);
-    defer context.deinit(testing.allocator);
-
-    const state_machine = &context.state_machine;
-
-    // Create accounts:
-    const accounts_input = mem.asBytes(&accounts);
-
-    const accounts_output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(accounts_output);
-
-    const accounts_timestamp = state_machine.prepare(.create_accounts, accounts_input);
-    {
-        const size = state_machine.commit(0, 1, .create_accounts, accounts_input, accounts_output);
-        const errors = mem.bytesAsSlice(CreateAccountsResult, accounts_output[0..size]);
-        try expectEqual(@as(usize, 0), errors.len);
-    }
-    for (accounts) |account| {
-        try expectEqual(account, state_machine.get_account(account.id).?.*);
-    }
-
-    // Create pending transfers:
-    const transfers_input = mem.asBytes(&transfers);
-
-    const transfers_output = try testing.allocator.alignedAlloc(u8, 16, 4096);
-    defer testing.allocator.free(transfers_output);
-
-    const transfers_timestamp = state_machine.prepare(.create_transfers, transfers_input);
-    try testing.expect(transfers_timestamp > accounts_timestamp);
-    {
-        const size = state_machine.commit(0, 2, .create_transfers, transfers_input, transfers_output);
-        const errors = mem.bytesAsSlice(CreateTransfersResult, transfers_output[0..size]);
-        try expectEqual(@as(usize, 0), errors.len);
-    }
-    for (transfers) |transfer| {
-        try expectEqual(transfer, state_machine.get_transfer(transfer.id).?.*);
-    }
+    try c.create_objects(Transfer, transfers_pending[0..]);
 
     // Test balances before posting:
-    try test_account_balances(state_machine, 1, 52, 15, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 52, 15);
+    try test_account_balances(&c.state_machine, id1, 52, 15, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 52, 15);
 
-    // Post pending transfers:
-    const Vector = struct { result: CreateTransferResult, object: Transfer };
-    const timestamp: u64 = (state_machine.commit_timestamp + 1);
+    const t: u64 = c.state_machine.commit_timestamp;
+    const transfer_resolutions = [_]TransferVector{
+        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 13, t + 1, .ok),
+        T(101, 1e1, 2e1, ud2, tr0, id0, 5e1, 6, 7, N, Y, Y, Y, p0, 16, t + 2, .cannot_post_and_void_pending_transfer),
+        T(101, 1e1, 2e1, ud2, tr0, id0, 5e1, 6, 7, N, Y, N, Y, p0, 16, t + 2, .pending_transfer_cannot_post_or_void_another),
+        T(101, 1e1, 2e1, ud2, tr0, id0, 5e1, 6, 7, N, N, N, Y, p0, 16, t + 2, .timeout_reserved_for_pending_transfer),
+        T(101, 1e1, 2e1, ud2, tr0, id0, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_id_must_not_be_zero),
+        T(101, 1e1, 2e1, ud2, tr0, idZ, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_id_must_not_be_int_max),
+        T(101, 1e1, 2e1, ud2, tr0, 101, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_id_must_be_different),
+        T(101, 1e1, 2e1, ud2, tr0, 102, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_not_found),
+        T(101, 1e1, 2e1, ud2, tr0, id1, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_not_pending),
+        T(101, 1e1, 2e1, ud2, tr0, id2, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_debit_account_id),
+        T(101, id1, 2e1, ud2, tr0, id2, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_credit_account_id),
+        T(101, id1, id2, ud2, tr0, id2, to0, 6, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_ledger),
+        T(101, id1, id2, ud2, tr0, id2, to0, 1, 7, N, N, N, Y, p0, 16, t + 2, .pending_transfer_has_different_code),
+        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, N, Y, p0, 16, t + 2, .exceeds_pending_transfer_amount),
+        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, N, Y, p0, 14, t + 2, .pending_transfer_has_different_amount),
+        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, N, Y, p0, 15, t + 2, .exists_with_different_flags),
+        T(101, id1, id2, ud2, tr0, id3, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_pending_id),
+        T(101, id1, id2, ud2, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_user_data),
+        T(101, id1, id2, ud0, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_user_data),
+        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 14, t + 2, .exists_with_different_amount),
+        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 0, t + 2, .exists_with_different_amount),
+        T(101, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 13, t + 2, .exists),
+        T(102, id1, id2, ud1, tr0, id2, to0, 1, 1, N, N, Y, N, p0, 13, t + 2, .pending_transfer_already_posted),
 
-    const vectors = [_]Vector{
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 1000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{ .post_pending_transfer = true },
-                .amount = 13,
-                .timestamp = timestamp,
-            }),
-        },
-        .{
-            .result = .cannot_post_and_void_pending_transfer,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 0,
-                .timeout = 50,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .pending = true,
-                    .post_pending_transfer = true,
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_cannot_post_or_void_another,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 0,
-                .timeout = 50,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .pending = true,
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .timeout_reserved_for_pending_transfer,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .timeout = 50,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_id_must_not_be_zero,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 0,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_id_must_not_be_int_max,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = math.maxInt(u128),
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_id_must_be_different,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 101,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_not_found,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 102,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_not_pending,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 1,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_has_different_debit_account_id,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 10,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 2,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_has_different_credit_account_id,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 20,
-                .user_data = 30,
-                .pending_id = 2,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_has_different_ledger,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 30,
-                .pending_id = 2,
-                .ledger = 60,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_has_different_code,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 30,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 70,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exceeds_pending_transfer_amount,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 7000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 80,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_has_different_amount,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 7000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 1,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists_with_different_flags,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .user_data = 7000,
-                .pending_id = 3,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 15,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists_with_different_pending_id,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 7000,
-                .pending_id = 3,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 14,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists_with_different_user_data,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 7000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 14,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists_with_different_user_data,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 0,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 14,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists_with_different_amount,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 1000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 14,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists_with_different_amount,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 1000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 0,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .exists,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 101,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 1000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 13,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_already_posted,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 102,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 1000,
-                .pending_id = 2,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 13,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 103,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .user_data = 0,
-                .pending_id = 3,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .void_pending_transfer = true },
-                .amount = 15,
-                .timestamp = timestamp + 1,
-            }),
-        },
-        .{
-            .result = .pending_transfer_already_voided,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 102,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 1000,
-                .pending_id = 3,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .post_pending_transfer = true,
-                },
-                .amount = 13,
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .pending_transfer_expired,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 102,
-                .debit_account_id = 1,
-                .credit_account_id = 2,
-                .user_data = 4000,
-                .pending_id = 4,
-                .ledger = 1,
-                .code = 1,
-                .flags = .{
-                    .void_pending_transfer = true,
-                },
-                .amount = 15,
-                .timestamp = timestamp + 2,
-            }),
-        },
-        .{
-            .result = .ok,
-            .object = mem.zeroInit(Transfer, .{
-                .id = 105,
-                .debit_account_id = 0,
-                .credit_account_id = 0,
-                .user_data = 0,
-                .pending_id = 5,
-                .ledger = 0,
-                .code = 0,
-                .flags = .{ .post_pending_transfer = true },
-                .amount = 0,
-                .timestamp = timestamp + 2,
-            }),
-        },
+        T(103, id1, id2, ud1, tr0, id3, to0, 1, 1, N, N, N, Y, p0, 15, t + 2, .ok),
+        T(102, id1, id2, ud1, tr0, id3, to0, 1, 1, N, N, Y, N, p0, 13, t + 3, .pending_transfer_already_voided),
+        T(102, id1, id2, ud1, tr0, id4, to0, 1, 1, N, N, N, Y, p0, 15, t + 3, .pending_transfer_expired),
+        T(105, id0, id0, ud0, tr0, id5, to0, 0, 0, N, N, Y, N, p0, 0, t + 3, .ok),
     };
 
-    for (vectors) |vector, i| {
-        const result = state_machine.create_transfer(&vector.object);
-        expectEqual(vector.result, result) catch |err| {
-            print_test_vector(i, vector.result, result, vector.object, err);
+    for (transfer_resolutions) |vector, i| {
+        try c.create_transfer(vector);
+        if (vector.result != .ok) continue;
+
+        // Test that posted values inherit from the pending or posting transfer:
+        const pending = c.state_machine.get_transfer(vector.object.pending_id).?.*;
+        const posted = c.state_machine.get_transfer(vector.object.id).?.*;
+
+        const user_data = if (vector.object.user_data == 0)
+            pending.user_data
+        else
+            vector.object.user_data;
+
+        const amount = if (vector.object.amount == 0)
+            pending.amount
+        else
+            vector.object.amount;
+
+        const expected = Transfer{
+            .id = vector.object.id,
+            .debit_account_id = pending.debit_account_id,
+            .credit_account_id = pending.credit_account_id,
+            .user_data = user_data,
+            .reserved = 0,
+            .pending_id = pending.id,
+            .timeout = 0,
+            .ledger = pending.ledger,
+            .code = pending.code,
+            .flags = vector.object.flags,
+            .amount = amount,
+            .timestamp = vector.object.timestamp,
+        };
+        expectEqual(expected, posted) catch |err| {
+            print_test_vector(i, expected, posted, vector.object, err);
             return err;
         };
-
-        if (vector.result == .ok) {
-            // Test that posted values inherit from the pending or posting transfer:
-            const pending = state_machine.get_transfer(vector.object.pending_id).?.*;
-            const posted = state_machine.get_transfer(vector.object.id).?.*;
-
-            const user_data = if (vector.object.user_data == 0)
-                pending.user_data
-            else
-                vector.object.user_data;
-
-            const amount = if (vector.object.amount == 0)
-                pending.amount
-            else
-                vector.object.amount;
-
-            const expected = Transfer{
-                .id = vector.object.id,
-                .debit_account_id = pending.debit_account_id,
-                .credit_account_id = pending.credit_account_id,
-                .user_data = user_data,
-                .reserved = 0,
-                .pending_id = pending.id,
-                .timeout = 0,
-                .ledger = pending.ledger,
-                .code = pending.code,
-                .flags = vector.object.flags,
-                .amount = amount,
-                .timestamp = vector.object.timestamp,
-            };
-            expectEqual(expected, posted) catch |err| {
-                print_test_vector(
-                    i,
-                    expected,
-                    posted,
-                    vector.object,
-                    err,
-                );
-                return err;
-            };
-        }
     }
 
     // Balances after posting:
-    try test_account_balances(state_machine, 1, 15, 35, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 15, 35);
+    try test_account_balances(&c.state_machine, id1, 15, 35, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 15, 35);
 
     // Rollback posting transfer (different amount):
-    assert(vectors[0].result == .ok);
-    try test_transfer_rollback(state_machine, &vectors[0].object);
-    try test_account_balances(state_machine, 1, 30, 22, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 30, 22);
+    assert(transfer_resolutions[0].result == .ok);
+    try test_transfer_rollback(&c.state_machine, &transfer_resolutions[0].object);
+    try test_account_balances(&c.state_machine, id1, 30, 22, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 30, 22);
 
     // Rollback voiding transfer:
-    assert(vectors[23].result == .ok);
-    try test_transfer_rollback(state_machine, &vectors[23].object);
-    try test_account_balances(state_machine, 1, 45, 22, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 45, 22);
+    assert(transfer_resolutions[23].result == .ok);
+    try test_transfer_rollback(&c.state_machine, &transfer_resolutions[23].object);
+    try test_account_balances(&c.state_machine, id1, 45, 22, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 45, 22);
 
     // Rollback posting transfer (zero amount):
-    assert(vectors[26].result == .ok);
-    try test_transfer_rollback(state_machine, &vectors[26].object);
-    try test_account_balances(state_machine, 1, 52, 15, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 52, 15);
+    assert(transfer_resolutions[26].result == .ok);
+    try test_transfer_rollback(&c.state_machine, &transfer_resolutions[26].object);
+    try test_account_balances(&c.state_machine, id1, 52, 15, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 52, 15);
 
     // Rollback all pending transfers:
-    try test_transfer_rollback(state_machine, &transfers[1]);
-    try test_account_balances(state_machine, 1, 37, 15, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 37, 15);
+    try test_transfer_rollback(&c.state_machine, &transfers_pending[1].object);
+    try test_account_balances(&c.state_machine, id1, 37, 15, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 37, 15);
 
-    try test_transfer_rollback(state_machine, &transfers[2]);
-    try test_account_balances(state_machine, 1, 22, 15, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 22, 15);
+    try test_transfer_rollback(&c.state_machine, &transfers_pending[2].object);
+    try test_account_balances(&c.state_machine, id1, 22, 15, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 22, 15);
 
-    try test_transfer_rollback(state_machine, &transfers[3]);
-    try test_account_balances(state_machine, 1, 7, 15, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 7, 15);
+    try test_transfer_rollback(&c.state_machine, &transfers_pending[3].object);
+    try test_account_balances(&c.state_machine, id1, 7, 15, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 7, 15);
 
-    try test_transfer_rollback(state_machine, &transfers[4]);
-    try test_account_balances(state_machine, 1, 0, 15, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 0, 15);
+    try test_transfer_rollback(&c.state_machine, &transfers_pending[4].object);
+    try test_account_balances(&c.state_machine, id1, 0, 15, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 0, 15);
 
     // Rollback transfer:
-    try test_transfer_rollback(state_machine, &transfers[0]);
-    try test_account_balances(state_machine, 1, 0, 0, 0, 0);
-    try test_account_balances(state_machine, 2, 0, 0, 0, 0);
+    try test_transfer_rollback(&c.state_machine, &transfers_pending[0].object);
+    try test_account_balances(&c.state_machine, id1, 0, 0, 0, 0);
+    try test_account_balances(&c.state_machine, id2, 0, 0, 0, 0);
 }
 
 fn print_test_vector(

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1165,104 +1165,35 @@ const TestContext = struct {
         ctx.message_pool.deinit(allocator);
         ctx.* = undefined;
     }
-
-    fn create_account(context: *TestContext, account: Account, result: CreateAccountResult) !void {
-        const result_actual = context.state_machine.create_account(&account);
-        try expectEqual(result, result_actual);
-
-        if (result == .ok) {
-            try expectEqual(account, context.state_machine.get_account(account.id).?.*);
-        }
-    }
-
-    fn create_transfer(
-        context: *TestContext,
-        transfer: Transfer,
-        result: CreateTransferResult,
-    ) !void {
-        const result_actual = context.state_machine.create_transfer(&transfer);
-        try expectEqual(result, result_actual);
-    }
-
-    fn create_objects(
-        context: *TestContext,
-        comptime Vector: type,
-        vectors: []const Vector,
-    ) !void {
-        const operation = switch (Vector) {
-            TestAccount => .create_accounts,
-            TestTransfer => .create_transfers,
-            else => unreachable,
-        };
-
-        var objects = std.BoundedArray(Vector.Object, 32).init(0) catch unreachable;
-        for (vectors) |vector| objects.appendAssumeCapacity(vector.object(0));
-
-        const request = mem.sliceAsBytes(objects.slice());
-        const reply = try testing.allocator.alignedAlloc(u8, 16, 4096);
-        defer testing.allocator.free(reply);
-
-        _ = context.state_machine.prepare(operation, request);
-        const results_size = context.state_machine.commit(0, 1, operation, request, reply);
-        const results = mem.bytesAsSlice(StateMachine.Result(operation), reply[0..results_size]);
-
-        var results_index: usize = 0;
-        for (vectors) |vector, i| {
-            if (vector.result != .ok) {
-                try std.testing.expectEqual(results[results_index].index, @intCast(u32, i));
-                try std.testing.expectEqual(results[results_index].result, vector.result);
-                results_index += 1;
-            }
-        }
-        assert(results_index == results.len);
-
-        if (Vector == TestAccount) {
-            for (objects.slice()) |vector, i| {
-                if (vectors[i].result != .ok) continue;
-                try expectEqual(vector, context.state_machine.get_account(vector.id).?.*);
-            }
-        } else {
-            // The prior branch doesn't apply to Transfers because post/void tranfers' zero-fields
-            // are overwritten.
-        }
-    }
 };
 
 const TestAction = union(enum) {
-    // Create an account and check the result.
-    account: TestAccount,
-
-    accounts_batch_start: void,
-    accounts_batch_end: void,
-    accounts: TestAccount,
-
-    account_exists: struct {
-        id: u128,
-        exists: bool,
-    },
-    // Create a transfer and check the result.
-    transfer: TestTransfer,
-    // Check an account's balance.
-    balance: struct {
-        account: u128,
-        debits_pending: u64,
-        debits_posted: u64,
-        credits_pending: u64,
-        credits_posted: u64,
-    },
     // Set the account's balance.
-    balance_set: struct {
+    setup: struct {
         account: u128,
         debits_pending: u64,
         debits_posted: u64,
         credits_pending: u64,
         credits_posted: u64,
     },
-    rollback_account: u128,
-    rollback_transfer: u128,
+
+    commit: TestContext.StateMachine.Operation,
+    account: TestCreateAccount,
+    transfer: TestCreateTransfer,
+
+    lookup_account: struct {
+        id: u128,
+        balance: ?struct {
+            debits_pending: u64,
+            debits_posted: u64,
+            credits_pending: u64,
+            credits_posted: u64,
+        } = null,
+    },
+    lookup_transfer: struct { id: u128, exists: bool },
 };
 
-const TestAccount = struct {
+const TestCreateAccount = struct {
     id: u128,
     user_data: u128 = 0,
     reserved: enum { @"0", @"1" } = .@"0",
@@ -1278,9 +1209,7 @@ const TestAccount = struct {
     credits_posted: u64 = 0,
     result: CreateAccountResult,
 
-    const Object = Account;
-
-    fn object(a: TestAccount, timestamp: u64) Object {
+    fn event(a: TestCreateAccount) Account {
         return .{
             .id = a.id,
             .user_data = a.user_data,
@@ -1300,12 +1229,12 @@ const TestAccount = struct {
             .debits_posted = a.debits_posted,
             .credits_pending = a.credits_pending,
             .credits_posted = a.credits_posted,
-            .timestamp = timestamp,
+            .timestamp = 0,
         };
     }
 };
 
-const TestTransfer = struct {
+const TestCreateTransfer = struct {
     id: u128,
     debit_account_id: u128,
     credit_account_id: u128,
@@ -1323,9 +1252,7 @@ const TestTransfer = struct {
     amount: u64 = 0,
     result: CreateTransferResult,
 
-    const Object = Transfer;
-
-    fn object(t: TestTransfer, timestamp: u64) Object {
+    fn event(t: TestCreateTransfer) Transfer {
         return .{
             .id = t.id,
             .debit_account_id = t.debit_account_id,
@@ -1344,20 +1271,20 @@ const TestTransfer = struct {
                 .padding = t.flags_padding,
             },
             .amount = t.amount,
-            .timestamp = timestamp,
+            .timestamp = 0,
         };
     }
 };
 
 fn check(comptime test_table: []const u8) !void {
-    const table = @import("test/table.zig").table;
+    const parse_table = @import("test/table.zig").parse;
     const allocator = std.testing.allocator;
 
     var context: TestContext = undefined;
     try context.init(allocator);
     defer context.deinit(allocator);
 
-    const test_actions = try table(allocator, TestAction, test_table);
+    const test_actions = try parse_table(allocator, TestAction, test_table);
     defer test_actions.deinit();
 
     var accounts = std.AutoHashMap(u128, Account).init(allocator);
@@ -1366,50 +1293,18 @@ fn check(comptime test_table: []const u8) !void {
     var transfers = std.AutoHashMap(u128, Transfer).init(allocator);
     defer transfers.deinit();
 
-    var batch_accounts: ?std.ArrayList(TestAccount) = null;
-    defer if (batch_accounts) |a| a.deinit();
+    var request = std.ArrayListAligned(u8, 16).init(allocator);
+    defer request.deinit();
 
-    const timestamp_base = context.state_machine.commit_timestamp + 1;
-    for (test_actions.items) |test_action, i| {
+    var reply = std.ArrayListAligned(u8, 16).init(allocator);
+    defer reply.deinit();
+
+    var operation: ?TestContext.StateMachine.Operation = null;
+    for (test_actions.items) |test_action| {
         switch (test_action) {
-            .account => |a| {
-                assert(batch_accounts == null);
+            .setup => |b| {
+                assert(operation == null);
 
-                const account = a.object(timestamp_base + i);
-                if (a.result == .ok) try accounts.putNoClobber(a.id, account);
-                try context.create_account(account, a.result);
-            },
-            .accounts_batch_start => {
-                assert(batch_accounts == null);
-                batch_accounts = std.ArrayList(TestAccount).init(allocator);
-            },
-            .accounts => |a| try batch_accounts.?.append(a),
-            .accounts_batch_end => {
-                try context.create_objects(TestAccount, batch_accounts.?.items);
-                batch_accounts.?.deinit();
-                batch_accounts = null;
-            },
-            .account_exists => |a| {
-                const account = context.state_machine.get_account(a.id);
-                if (a.exists) {
-                    try expectEqual(a.id, account.?.id);
-                } else {
-                    try expectEqual(@as(?*const Account, null), account);
-                }
-            },
-            .transfer => |t| {
-                const transfer = t.object(timestamp_base + i);
-                if (t.result == .ok) try transfers.putNoClobber(t.id, transfer);
-                try context.create_transfer(transfer, t.result);
-            },
-            .balance => |b| {
-                const account = context.state_machine.get_account(b.account).?.*;
-                try expectEqual(b.debits_pending, account.debits_pending);
-                try expectEqual(b.debits_posted, account.debits_posted);
-                try expectEqual(b.credits_pending, account.credits_pending);
-                try expectEqual(b.credits_posted, account.credits_posted);
-            },
-            .balance_set => |b| {
                 var account = context.state_machine.get_account(b.account).?.*;
                 account.debits_pending = b.debits_pending;
                 account.debits_posted = b.debits_posted;
@@ -1417,89 +1312,218 @@ fn check(comptime test_table: []const u8) !void {
                 account.credits_posted = b.credits_posted;
                 context.state_machine.forest.grooves.accounts.put(&account);
             },
-            .rollback_account => |id| {
-                const account = accounts.get(id).?;
-                context.state_machine.create_account_rollback(&account);
-            },
-            .rollback_transfer => |id| {
-                const transfer = transfers.get(id).?;
-                assert(context.state_machine.get_transfer(transfer.id) != null);
 
-                context.state_machine.create_transfer_rollback(&transfer);
-                try expect(context.state_machine.get_transfer(transfer.id) == null);
-                if (transfer.flags.post_pending_transfer or transfer.flags.void_pending_transfer) {
-                    try expect(context.state_machine.get_posted(transfer.pending_id) == null);
+            .account => |a| {
+                assert(operation == null or operation.? == .create_accounts);
+                operation = .create_accounts;
+
+                const event = a.event();
+                try request.appendSlice(std.mem.asBytes(&event));
+                if (a.result == .ok) {
+                    try accounts.put(a.id, event);
+                } else {
+                    const result = CreateAccountsResult{
+                        .index = @intCast(u32, @divExact(request.items.len, @sizeOf(Account)) - 1),
+                        .result = a.result,
+                    };
+                    try reply.appendSlice(std.mem.asBytes(&result));
                 }
+            },
+            .transfer => |t| {
+                assert(operation == null or operation.? == .create_transfers);
+                operation = .create_transfers;
+
+                const event = t.event();
+                try request.appendSlice(std.mem.asBytes(&event));
+                if (t.result == .ok) {
+                    try transfers.put(t.id, event);
+                } else {
+                    const result = CreateTransfersResult{
+                        .index = @intCast(u32, @divExact(request.items.len, @sizeOf(Transfer)) - 1),
+                        .result = t.result,
+                    };
+                    try reply.appendSlice(std.mem.asBytes(&result));
+                }
+            },
+            .lookup_account => |a| {
+                assert(operation == null or operation.? == .lookup_accounts);
+                operation = .lookup_accounts;
+
+                try request.appendSlice(std.mem.asBytes(&a.id));
+                if (a.balance) |b| {
+                    var account = accounts.get(a.id).?;
+                    account.debits_pending = b.debits_pending;
+                    account.debits_posted = b.debits_posted;
+                    account.credits_pending = b.credits_pending;
+                    account.credits_posted = b.credits_posted;
+                    try reply.appendSlice(std.mem.asBytes(&account));
+                }
+            },
+            .lookup_transfer => |t| {
+                assert(operation == null or operation.? == .lookup_transfers);
+                operation = .lookup_transfers;
+
+                try request.appendSlice(std.mem.asBytes(&t.id));
+                if (t.exists) {
+                    var transfer = transfers.get(t.id).?;
+                    try reply.appendSlice(std.mem.asBytes(&transfer));
+                }
+            },
+
+            .commit => |commit_operation| {
+                assert(operation == null or operation.? == commit_operation);
+                _ = context.state_machine.prepare(commit_operation, request.items);
+
+                const reply_actual_buffer = try allocator.alignedAlloc(u8, 16, 4096);
+                defer allocator.free(reply_actual_buffer);
+
+                const reply_actual_size = context.state_machine.commit(
+                    0,
+                    1,
+                    commit_operation,
+                    request.items,
+                    reply_actual_buffer,
+                );
+                var reply_actual = reply_actual_buffer[0..reply_actual_size];
+
+                if (commit_operation == .lookup_accounts) {
+                    for (std.mem.bytesAsSlice(Account, reply_actual)) |*a| a.timestamp = 0;
+                }
+
+                if (commit_operation == .lookup_transfers) {
+                    for (std.mem.bytesAsSlice(Transfer, reply_actual)) |*t| t.timestamp = 0;
+                }
+
+                // TODO(Zig): Use inline-switch to cast the replies to []Reply(operation), then
+                // change this to a simple "try".
+                testing.expectEqualSlices(u8, reply.items, reply_actual) catch |err| {
+                    print_results("expect", commit_operation, reply.items);
+                    print_results("actual", commit_operation, reply_actual);
+                    return err;
+                };
+
+                request.clearRetainingCapacity();
+                reply.clearRetainingCapacity();
+                operation = null;
             },
         }
     }
+
+    assert(operation == null);
+    assert(request.items.len == 0);
+    assert(reply.items.len == 0);
 }
 
-test "create/lookup/rollback accounts" {
+fn print_results(
+    label: []const u8,
+    operation: TestContext.StateMachine.Operation,
+    reply: []const u8,
+) void {
+    inline for (.{
+        .create_accounts,
+        .create_transfers,
+        .lookup_accounts,
+        .lookup_transfers,
+    }) |o| {
+        if (o == operation) {
+            const Result = TestContext.StateMachine.Result(o);
+            const results = std.mem.bytesAsSlice(Result, reply);
+            std.debug.print("{s}={any}\n", .{ label, results });
+            return;
+        }
+    }
+    unreachable;
+}
+
+test "create_accounts" {
     try check(
-        \\ account A1 U2 _ L3 C4 _   _   _  _  0  0  0  0 ok
-        \\ account A0  _ 1 L0 C0 _ D<C C<D P1  1  1  1  1 reserved_flag
-        \\ account A0  _ 1 L0 C0 _ D<C C<D  _  1  1  1  1 reserved_field
-        \\ account A0  _ _ L0 C0 _ D<C C<D  _  1  1  1  1 id_must_not_be_zero
-        \\ account -0  _ _ L0 C0 _ D<C C<D  _  1  1  1  1 id_must_not_be_int_max
-        \\ account A1 U1 _ L0 C0 _ D<C C<D  _  1  1  1  1 ledger_must_not_be_zero
-        \\ account A1 U1 _ L9 C0 _ D<C C<D  _  1  1  1  1 code_must_not_be_zero
-        \\ account A1 U1 _ L9 C9 _ D<C C<D  _ -0 -0 -0 -0 mutually_exclusive_flags
-        \\ account A1 U1 _ L9 C9 _ D<C   _  _  1  1  1  1 debits_pending_must_be_zero
-        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  1  1  1 debits_posted_must_be_zero
-        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  0  1  1 credits_pending_must_be_zero
-        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  0  0  1 credits_posted_must_be_zero
-        \\ account A1 U1 _ L9 C9 _ D<C   _  _  0  0  0  0 exists_with_different_flags
-        \\ account A1 U1 _ L9 C9 _   _ C<D  _  0  0  0  0 exists_with_different_flags
-        \\ account A1 U1 _ L9 C9 _   _   _  _  0  0  0  0 exists_with_different_user_data
-        \\ account A1 U2 _ L9 C9 _   _   _  _  0  0  0  0 exists_with_different_ledger
-        \\ account A1 U2 _ L3 C9 _   _   _  _  0  0  0  0 exists_with_different_code
-        \\ account A1 U2 _ L3 C4 _   _   _  _  0  0  0  0 exists
+        \\ account A1 U2 _ L3 C4 _   _   _ _  0  0  0  0 ok
+        \\ account A0  _ 1 L0 C0 _ D<C C<D 1  1  1  1  1 reserved_flag
+        \\ account A0  _ 1 L0 C0 _ D<C C<D _  1  1  1  1 reserved_field
+        \\ account A0  _ _ L0 C0 _ D<C C<D _  1  1  1  1 id_must_not_be_zero
+        \\ account -0  _ _ L0 C0 _ D<C C<D _  1  1  1  1 id_must_not_be_int_max
+        \\ account A1 U1 _ L0 C0 _ D<C C<D _  1  1  1  1 ledger_must_not_be_zero
+        \\ account A1 U1 _ L9 C0 _ D<C C<D _  1  1  1  1 code_must_not_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C C<D _ -0 -0 -0 -0 mutually_exclusive_flags
+        \\ account A1 U1 _ L9 C9 _ D<C   _ _  1  1  1  1 debits_pending_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _ _  0  1  1  1 debits_posted_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _ _  0  0  1  1 credits_pending_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _ _  0  0  0  1 credits_posted_must_be_zero
+        \\ account A1 U1 _ L9 C9 _ D<C   _ _  0  0  0  0 exists_with_different_flags
+        \\ account A1 U1 _ L9 C9 _   _ C<D _  0  0  0  0 exists_with_different_flags
+        \\ account A1 U1 _ L9 C9 _   _   _ _  0  0  0  0 exists_with_different_user_data
+        \\ account A1 U2 _ L9 C9 _   _   _ _  0  0  0  0 exists_with_different_ledger
+        \\ account A1 U2 _ L3 C9 _   _   _ _  0  0  0  0 exists_with_different_code
+        \\ account A1 U2 _ L3 C4 _   _   _ _  0  0  0  0 exists
+        \\ commit create_accounts
         \\
-        \\ account_exists A1 true
-        \\ account_exists A2 false
-        \\
-        \\ rollback_account A1
-        \\ account_exists A1 false
-        \\ account_exists A2 false
+        \\ lookup_account -0 _
+        \\ lookup_account A0 _
+        \\ lookup_account A1 0 0 0 0
+        \\ lookup_account A2 _
+        \\ commit lookup_accounts
+    );
+}
+
+test "create_accounts: empty" {
+    try check(
+        \\ commit create_transfers
     );
 }
 
 test "linked accounts" {
     try check(
-    // An individual event (successful):
-        \\ accounts_batch_start
-        \\   accounts A7 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+        \\ account A7 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok // An individual event (successful):
 
         // A chain of 4 events (the last event in the chain closes the chain with linked=false):
-        // Commit/rollback.
-        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
-        // Commit/rollback.
-        \\   accounts A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
-        // Fail with .exists.
-        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists
-        // Fail without committing.
-        \\   accounts A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed // Commit/rollback.
+        \\ account A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed // Commit/rollback.
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists              // Fail with .exists.
+        \\ account A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed // Fail without committing.
 
         // An individual event (successful):
         // This does not see any effect from the failed chain above.
-        \\   accounts A1 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+        \\ account A1 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // A chain of 2 events (the first event fails the chain):
-        \\   accounts A1 _ _ L1 C2 LNK _ _ _ 0 0 0 0 exists_with_different_flags
-        \\   accounts A2 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed
+        \\ account A1 _ _ L1 C2 LNK _ _ _ 0 0 0 0 exists_with_different_flags
+        \\ account A2 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed
 
         // An individual event (successful):
-        \\   accounts A2 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+        \\ account A2 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // A chain of 2 events (the last event fails the chain):
-        \\   accounts A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
-        \\   accounts A1 _ _ L2 C1   _ _ _ _ 0 0 0 0 exists_with_different_ledger
+        \\ account A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
+        \\ account A1 _ _ L2 C1   _ _ _ _ 0 0 0 0 exists_with_different_ledger
 
         // A chain of 2 events (successful):
-        \\   accounts A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
-        \\   accounts A4 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
-        \\ accounts_batch_end
+        \\ account A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
+        \\ account A4 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+        \\ commit create_accounts
+        \\
+        \\ lookup_account A7 0 0 0 0
+        \\ lookup_account A1 0 0 0 0
+        \\ lookup_account A2 0 0 0 0
+        \\ lookup_account A3 0 0 0 0
+        \\ lookup_account A4 0 0 0 0
+        \\ commit lookup_accounts
+    );
+
+    try check(
+        \\ account A7 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok // An individual event (successful):
+
+        // A chain of 4 events:
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed // Commit/rollback.
+        \\ account A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed // Commit/rollback.
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists              // Fail with .exists.
+        \\ account A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 linked_event_failed // Fail without committing.
+        \\ commit create_accounts
+        \\
+        \\ lookup_account A7 0 0 0 0
+        \\ lookup_account A1 _
+        \\ lookup_account A2 _
+        \\ lookup_account A3 _
+        \\ commit lookup_accounts
     );
 
     // TODO How can we test that events were in fact rolled back in LIFO order?
@@ -1508,49 +1532,50 @@ test "linked accounts" {
 
 test "linked_event_chain_open" {
     try check(
-        \\ accounts_batch_start
-        // A chain of 3 events (the last event in the chain closes the chain with linked=false):
-        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
-        \\   accounts A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
-        \\   accounts A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+    // A chain of 3 events (the last event in the chain closes the chain with linked=false):
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
+        \\ account A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 ok
+        \\ account A3 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // An open chain of 2 events:
-        \\   accounts A4 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
-        \\   accounts A5 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
-        \\ accounts_batch_end
+        \\ account A4 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
+        \\ account A5 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
+        \\ commit create_accounts
         \\
-        \\ account_exists A1 true
-        \\ account_exists A2 true
-        \\ account_exists A3 true
-        \\ account_exists A4 false
-        \\ account_exists A5 false
+        \\ lookup_account A1 0 0 0 0
+        \\ lookup_account A2 0 0 0 0
+        \\ lookup_account A3 0 0 0 0
+        \\ lookup_account A4 _
+        \\ lookup_account A5 _
+        \\ commit lookup_accounts
     );
 }
 
 test "linked_event_chain_open for an already failed batch" {
     try check(
-        \\ accounts_batch_start
-        // An individual event (successful):
-        \\   accounts A1 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
+    // An individual event (successful):
+        \\ account A1 _ _ L1 C1   _ _ _ _ 0 0 0 0 ok
 
         // An open chain of 3 events (the second one fails):
-        \\   accounts A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
-        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists_with_different_flags
-        \\   accounts A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
-        \\ accounts_batch_end
+        \\ account A2 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_failed
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 exists_with_different_flags
+        \\ account A3 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
+        \\ commit create_accounts
         \\
-        \\ account_exists A1 true
-        \\ account_exists A2 false
-        \\ account_exists A3 false
+        \\ lookup_account A1 0 0 0 0
+        \\ lookup_account A2 _
+        \\ lookup_account A3 _
+        \\ commit lookup_accounts
     );
 }
 
 test "linked_event_chain_open for a batch of 1" {
     try check(
-        \\ accounts_batch_start
-        \\   accounts A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
-        \\ accounts_batch_end
-        \\ account_exists A1 false
+        \\ account A1 _ _ L1 C1 LNK _ _ _ 0 0 0 0 linked_event_chain_open
+        \\ commit create_accounts
+        \\
+        \\ lookup_account A1 _
+        \\ commit lookup_accounts
     );
 }
 
@@ -1558,22 +1583,23 @@ test "linked_event_chain_open for a batch of 1" {
 // 1. all CreateTransferResult enums are covered, with
 // 2. enums tested in the order that they are defined, for easier auditing of coverage, and that
 // 3. state machine logic cannot be reordered in any way, breaking determinism.
-test "create/lookup/rollback transfers" {
+test "create_transfers/lookup_transfers" {
     try check(
-        \\ account  A1 _ _ L1 C1 _   _   _ _ 0 0 0 0 ok
-        \\ account  A2 _ _ L2 C2 _   _   _ _ 0 0 0 0 ok
-        \\ account  A3 _ _ L1 C1 _   _   _ _ 0 0 0 0 ok
-        \\ account  A4 _ _ L1 C1 _ D<C   _ _ 0 0 0 0 ok
-        \\ account  A5 _ _ L1 C1 _   _ C<D _ 0 0 0 0 ok
+        \\ account A1 _ _ L1 C1 _   _   _ _ 0 0 0 0 ok
+        \\ account A2 _ _ L2 C2 _   _   _ _ 0 0 0 0 ok
+        \\ account A3 _ _ L1 C1 _   _   _ _ 0 0 0 0 ok
+        \\ account A4 _ _ L1 C1 _ D<C   _ _ 0 0 0 0 ok
+        \\ account A5 _ _ L1 C1 _   _ C<D _ 0 0 0 0 ok
+        \\ commit create_accounts
 
         // Set up initial balances.
-        \\ balance_set A1  100   200    0     0
-        \\ balance_set A2    0     0    0     0
-        \\ balance_set A3    0     0  110   210
-        \\ balance_set A4   20  -700    0  -500
-        \\ balance_set A5    0 -1000   10 -1100
+        \\ setup A1  100   200    0     0
+        \\ setup A2    0     0    0     0
+        \\ setup A3    0     0  110   210
+        \\ setup A4   20  -700    0  -500
+        \\ setup A5    0 -1000   10 -1100
 
-        // Transfer.
+        // Test errors by descending precedence.
         \\ transfer T0 A0 A0  _ R1 T1   _ L0 C0 _ PEN _ _ P1    0 reserved_flag
         \\ transfer T0 A0 A0  _ R1 T1   _ L0 C0 _ PEN _ _  _    0 reserved_field
         \\ transfer T0 A0 A0  _  _ T1   _ L0 C0 _ PEN _ _  _    0 id_must_not_be_zero
@@ -1605,39 +1631,36 @@ test "create/lookup/rollback transfers" {
         \\ transfer T1 A1 A3  _  _  _ 999 L1 C1 _ PEN _ _  _  123 ok
 
         // Ensure that idempotence is only checked after validation.
-        \\ transfer  T1  A1  A3  _  _  _ 999 L2 C1 _ PEN _ _  _  123 transfer_must_have_the_same_ledger_as_accounts
-        \\ transfer  T1  A1  A3 U1  _  _   _ L1 C2 _   _ _ _  _   -0 exists_with_different_flags
-        \\ transfer  T1  A3  A1 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_debit_account_id
-        \\ transfer  T1  A1  A4 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_credit_account_id
-        \\ transfer  T1  A1  A3 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_user_data
-        \\ transfer  T1  A1  A3  _  _  _ 998 L1 C2 _ PEN _ _  _   -0 exists_with_different_timeout
-        \\ transfer  T1  A1  A3  _  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_code
-        \\ transfer  T1  A1  A3  _  _  _ 999 L1 C1 _ PEN _ _  _   -0 exists_with_different_amount
-        \\ transfer  T1  A1  A3  _  _  _ 999 L1 C1 _ PEN _ _  _  123 exists
-        \\ transfer  T2  A3  A1  _  _  _   _ L1 C2 _   _ _ _  _    7 ok
-        \\ transfer  T3  A1  A3  _  _  _   _ L1 C2 _   _ _ _  _    3 ok
+        \\ transfer T1 A1 A3  _  _  _ 999 L2 C1 _ PEN _ _  _  123 transfer_must_have_the_same_ledger_as_accounts
+        \\ transfer T1 A1 A3 U1  _  _   _ L1 C2 _   _ _ _  _   -0 exists_with_different_flags
+        \\ transfer T1 A3 A1 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_debit_account_id
+        \\ transfer T1 A1 A4 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_credit_account_id
+        \\ transfer T1 A1 A3 U1  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_user_data
+        \\ transfer T1 A1 A3  _  _  _ 998 L1 C2 _ PEN _ _  _   -0 exists_with_different_timeout
+        \\ transfer T1 A1 A3  _  _  _ 999 L1 C2 _ PEN _ _  _   -0 exists_with_different_code
+        \\ transfer T1 A1 A3  _  _  _ 999 L1 C1 _ PEN _ _  _   -0 exists_with_different_amount
+        \\ transfer T1 A1 A3  _  _  _ 999 L1 C1 _ PEN _ _  _  123 exists
+        \\ transfer T2 A3 A1  _  _  _   _ L1 C2 _   _ _ _  _    7 ok
+        \\ transfer T3 A1 A3  _  _  _   _ L1 C2 _   _ _ _  _    3 ok
+        \\ commit create_transfers
         \\
-        \\ balance A1 223 203   0   7
-        \\ balance A3   0   7 233 213
+        \\ lookup_account A1 223 203   0   7
+        \\ lookup_account A3   0   7 233 213
+        \\ commit lookup_accounts
         \\
-        \\ rollback_transfer T3
-        \\ balance A1 223 200   0   7
-        \\ balance A3   0   7 233 210
-        \\
-        \\ rollback_transfer T2
-        \\ balance A1 223 200   0   0
-        \\ balance A3   0   0 233 210
-        \\
-        \\ rollback_transfer T1
-        \\ balance A1 100 200   0   0
-        \\ balance A3   0   0 110 210
+        \\ lookup_transfer T1 true
+        \\ lookup_transfer T2 true
+        \\ lookup_transfer T3 true
+        \\ lookup_transfer -0 false
+        \\ commit lookup_transfers
     );
 }
 
-test "create/lookup/rollback 2-phase transfers" {
+test "create/lookup 2-phase transfers" {
     try check(
-        \\ account  A1 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
-        \\ account  A2 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ account A1 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ account A2 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ commit create_accounts
 
         // First phase.
         \\ transfer   T1 A1 A2  _ _   _    _ L1 C1 _   _   _   _ _ 15 ok // Not pending!
@@ -1645,10 +1668,12 @@ test "create/lookup/rollback 2-phase transfers" {
         \\ transfer   T3 A1 A2  _ _   _   50 L1 C1 _ PEN   _   _ _ 15 ok
         \\ transfer   T4 A1 A2  _ _   _    1 L1 C1 _ PEN   _   _ _ 15 ok
         \\ transfer   T5 A1 A2 U9 _   _   50 L1 C1 _ PEN   _   _ _  7 ok
+        \\ commit create_transfers
 
         // Check balances before resolving.
-        \\ balance  A1 52 15  0  0
-        \\ balance  A2  0  0 52 15
+        \\ lookup_account A1 52 15  0  0
+        \\ lookup_account A2  0  0 52 15
+        \\ commit lookup_accounts
 
         // Second phase.
         \\ transfer T101 A1 A2 U1 _  T2    _ L1 C1 _   _ POS   _ _ 13 ok
@@ -1678,41 +1703,64 @@ test "create/lookup/rollback 2-phase transfers" {
         \\ transfer T102 A1 A2 U1 _  T3    _ L1 C1 _   _ POS   _ _ 13 pending_transfer_already_voided
         \\ transfer T102 A1 A2 U1 _  T4    _ L1 C1 _   _   _ VOI _ 15 pending_transfer_expired
         \\ transfer T105 A0 A0 U0 _  T5    _ L0 C0 _   _ POS   _ _  _ ok
+        \\ commit create_transfers
 
         // Check balances after resolving.
-        \\ balance  A1 15 35  0  0
-        \\ balance  A2  0  0 15 35
-        \\ rollback_transfer 101 // Rollback posting transfer (different amount).
-        \\ balance A1 30 22  0  0
-        \\ balance A2  0  0 30 22
-        \\ rollback_transfer 103 // Rollback voiding transfer.
-        \\ balance A1 45 22  0  0
-        \\ balance A2  0  0 45 22
-        \\ rollback_transfer 105 // Rollback posting transfer (zero amount).
-        \\ balance A1 52 15  0  0
-        \\ balance A2  0  0 52 15
+        \\ lookup_account A1 15 35  0  0
+        \\ lookup_account A2  0  0 15 35
+        \\ commit lookup_accounts
+    );
+}
 
-        // Rollback all pending transfers.
-        \\ rollback_transfer 2
-        \\ balance A1 37 15  0  0
-        \\ balance A2  0  0 37 15
-        \\
-        \\ rollback_transfer 3
-        \\ balance A1 22 15  0  0
-        \\ balance A2  0  0 22 15
-        \\
-        \\ rollback_transfer 4
-        \\ balance A1  7 15  0  0
-        \\ balance A2  0  0  7 15
-        \\
-        \\ rollback_transfer 5
-        \\ balance A1  0 15  0  0
-        \\ balance A2  0  0  0 15
+test "create_transfers: empty" {
+    try check(
+        \\ commit create_transfers
+    );
+}
 
-        // Rollback first transfer.
-        \\ rollback_transfer 1
-        \\ balance A1  0  0  0  0
-        \\ balance A2  0  0  0  0
+test "create_transfers/lookup_transfers: failed transfer does not exist" {
+    try check(
+        \\ account A1 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ account A2 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ commit create_accounts
+        \\
+        \\ transfer T1 A1 A2  _ _   _ _ L1 C1 _ _ _ _ _ 15 ok
+        \\ transfer T2 A1 A2  _ _   _ _ L0 C1 _ _ _ _ _ 15 ledger_must_not_be_zero
+        \\ commit create_transfers
+        \\
+        \\ lookup_account A1 0 15 0  0
+        \\ lookup_account A2 0  0 0 15
+        \\ commit lookup_accounts
+        \\
+        \\ lookup_transfer T1 true
+        \\ lookup_transfer T2 false
+        \\ commit lookup_transfers
+    );
+}
+
+test "create_transfers/lookup_transfers: failed linked-chains are undone" {
+    try check(
+        \\ account A1 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ account A2 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
+        \\ commit create_accounts
+        \\
+        \\ transfer T1 A1 A2  _ _   _ _ L1 C1 LNK   _ _ _ _ 15 linked_event_failed
+        \\ transfer T2 A1 A2  _ _   _ _ L0 C1   _   _ _ _ _ 15 ledger_must_not_be_zero
+        \\ commit create_transfers
+        \\
+        \\ transfer T3 A1 A2  _ _   _ 1 L1 C1 LNK PEN _ _ _ 15 linked_event_failed
+        \\ transfer T4 A1 A2  _ _   _ _ L0 C1   _   _ _ _ _ 15 ledger_must_not_be_zero
+        \\ commit create_transfers
+        \\
+        \\ lookup_account A1 0 0 0 0
+        \\ lookup_account A2 0 0 0 0
+        \\ commit lookup_accounts
+        \\
+        \\ lookup_transfer T1 false
+        \\ lookup_transfer T2 false
+        \\ lookup_transfer T3 false
+        \\ lookup_transfer T4 false
+        \\ commit lookup_transfers
     );
 }
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1110,8 +1110,9 @@ const TestContext = struct {
     const StateMachine = StateMachineType(Storage, .{
         // Overestimate the batch size (in order to overprovision commit_entries_max)
         // because the test never compacts.
-        .message_body_size_max = 1000 * @sizeOf(Account),
+        .message_body_size_max = message_body_size_max,
     });
+    const message_body_size_max = 256 * @sizeOf(Account);
 
     storage: Storage,
     message_pool: MessagePool,
@@ -1290,10 +1291,10 @@ fn check(comptime test_table: []const u8) !void {
     var transfers = std.AutoHashMap(u128, Transfer).init(allocator);
     defer transfers.deinit();
 
-    var request = std.ArrayListAligned(u8, 16).init(allocator);
+    var request = std.ArrayListAligned(u8, TestContext.message_body_size_max).init(allocator);
     defer request.deinit();
 
-    var reply = std.ArrayListAligned(u8, 16).init(allocator);
+    var reply = std.ArrayListAligned(u8, TestContext.message_body_size_max).init(allocator);
     defer reply.deinit();
 
     var operation: ?TestContext.StateMachine.Operation = null;

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1736,7 +1736,7 @@ test "create_transfers/lookup_transfers: failed transfer does not exist" {
     );
 }
 
-test "create_transfers/lookup_transfers: failed linked-chains are undone" {
+test "create_transfers: failed linked-chains are undone" {
     try check(
         \\ account A1 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
         \\ account A2 _ _ L1 C1   _  _  _  _ 0 0 0 0 ok
@@ -1758,6 +1758,30 @@ test "create_transfers/lookup_transfers: failed linked-chains are undone" {
         \\ lookup_transfer T2 false
         \\ lookup_transfer T3 false
         \\ lookup_transfer T4 false
+        \\ commit lookup_transfers
+    );
+}
+
+test "create_transfers: failed linked-chains are undone within a commit" {
+    try check(
+        \\ account A1 _ _ L1 C1 _ D<C _ _ 0 0 0 0 ok
+        \\ account A2 _ _ L1 C1 _   _ _ _ 0 0 0 0 ok
+        \\ commit create_accounts
+        \\
+        \\ setup A1 0 0 0 20
+        \\
+        \\ transfer T1 A1 A2  _ _   _ _ L1 C1 LNK _ _ _ _ 15 linked_event_failed
+        \\ transfer T2 A1 A2  _ _   _ _ L0 C1   _ _ _ _ _  5 ledger_must_not_be_zero
+        \\ transfer T3 A1 A2  _ _   _ _ L1 C1   _ _ _ _ _ 15 ok
+        \\ commit create_transfers
+        \\
+        \\ lookup_account A1 0 15 0 20
+        \\ lookup_account A2 0  0 0 15
+        \\ commit lookup_accounts
+        \\
+        \\ lookup_transfer T1 false
+        \\ lookup_transfer T2 false
+        \\ lookup_transfer T3 true
         \\ commit lookup_transfers
     );
 }

--- a/src/test/table.zig
+++ b/src/test/table.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+/// Negative values for unsigned integers are interpreted as `maxInt(Int) - ...`.
+// TODO(Zig): Change this to a a purely comptime function (no allocator) returning a slice
+// once Zig's "runtime value cannot be passed to comptime arg" bugs are fixed.
+pub fn table(
+    allocator: std.mem.Allocator,
+    comptime Row: type,
+    comptime table_string: []const u8,
+) !std.ArrayList(Row) {
+    var rows = std.ArrayList(Row).init(allocator);
+    errdefer rows.deinit();
+
+    var row_strings = std.mem.tokenize(u8, table_string, "\n");
+    while (row_strings.next()) |row_string| {
+        // Ignore blank line.
+        if (row_string.len == 0) continue;
+
+        var columns = std.mem.tokenize(u8, row_string, " ");
+        try rows.append(parse(Row, &columns));
+
+        // Ignore trailing line comment.
+        if (columns.next()) |last| assert(std.mem.eql(u8, last, "//"));
+    }
+    return rows;
+}
+
+fn parse(comptime Data: type, tokens: *std.mem.TokenIterator(u8)) Data {
+    return switch (@typeInfo(Data)) {
+        .Optional => |info| parse(info.child, tokens),
+        .Enum => field(Data, tokens.next().?),
+        .Void => assert(tokens.next() == null),
+        .Bool => {
+            const token = tokens.next().?;
+            inline for (.{ "0", "false", "F", "N" }) |t| {
+                if (std.mem.eql(u8, token, t)) return false;
+            }
+            inline for (.{ "1", "true", "T", "Y" }) |t| {
+                if (std.mem.eql(u8, token, t)) return true;
+            }
+            std.debug.panic("Unknown boolean: {s}", .{token});
+        },
+        .Int => |info| {
+            const max = std.math.maxInt(Data);
+            const token = tokens.next().?;
+            //if (std.mem.eql(u8, token, "max")) return max;
+            const offset: usize = if (std.ascii.isAlpha(token[0])) 1 else 0;
+            if (info.signedness == .unsigned and token[offset] == '-') {
+                return max - (std.fmt.parseInt(Data, token[offset + 1 ..], 10) catch unreachable);
+            }
+            return std.fmt.parseInt(Data, token[offset..], 10) catch unreachable;
+        },
+        .Struct => {
+            var data: Data = undefined;
+            inline for (std.meta.fields(Data)) |value_field| {
+                // The repeated else branch seems to be necessary to keep Zig from complaining:
+                //   control flow attempts to use compile-time variable at runtime
+                if (value_field.default_value != null) {
+                    if (take(tokens, "_")) {
+                        @field(data, value_field.name) = value_field.default_value.?;
+                    } else {
+                        @field(data, value_field.name) = parse(value_field.field_type, tokens);
+                    }
+                } else {
+                    @field(data, value_field.name) = parse(value_field.field_type, tokens);
+                }
+            }
+            return data;
+        },
+        .Union => |info| {
+            const variant_string = tokens.next().?;
+            inline for (info.fields) |variant_field| {
+                if (std.mem.eql(u8, variant_field.name, variant_string)) {
+                    return @unionInit(
+                        Data,
+                        variant_field.name,
+                        parse(variant_field.field_type, tokens),
+                    );
+                }
+            }
+            std.debug.panic("Unknown union variant: {s}", .{variant_string});
+        },
+        else => @compileError("Unimplemented column type: " ++ @typeName(Data)),
+    };
+}
+
+fn take(tokens: *std.mem.TokenIterator(u8), token: []const u8) bool {
+    var index_before = tokens.index;
+    if (std.mem.eql(u8, tokens.next().?, token)) return true;
+    tokens.index = index_before;
+    return false;
+}
+
+/// TODO This function is a workaround for a comptime bug:
+///   error: unable to evaluate constant expression
+///   .Enum => @field(Column, column_string),
+fn field(comptime Enum: type, name: []const u8) Enum {
+    inline for (std.meta.fields(Enum)) |variant| {
+        if (std.mem.eql(u8, variant.name, name)) {
+            return @field(Enum, variant.name);
+        }
+    }
+    std.debug.panic("Unkown field name={s} for type={}", .{ name, Enum });
+}
+
+test "comment" {
+    const rows = try table(std.testing.allocator, struct {
+        a: u8,
+    },
+        \\
+        \\ 1 // Comment
+        \\
+    );
+    defer rows.deinit();
+
+    try std.testing.expectEqual(rows.items.len, 1);
+    try std.testing.expectEqual(rows.items[0], .{ .a = 1 });
+}
+
+test "int" {
+    const rows = try table(std.testing.allocator, struct { i: usize },
+        \\ 1
+        \\ 2
+        \\ -3
+        \\ A4
+        \\ a5
+        \\ -0
+    );
+    defer rows.deinit();
+
+    try std.testing.expectEqual(rows.items.len, 6);
+    try std.testing.expectEqual(rows.items[0], .{ .i = 1 });
+    try std.testing.expectEqual(rows.items[1], .{ .i = 2 });
+    try std.testing.expectEqual(rows.items[2], .{ .i = std.math.maxInt(usize) - 3 });
+    try std.testing.expectEqual(rows.items[3], .{ .i = 4 });
+    try std.testing.expectEqual(rows.items[4], .{ .i = 5 });
+    try std.testing.expectEqual(rows.items[5], .{ .i = std.math.maxInt(usize) });
+}
+
+test "bool" {
+    const rows = try table(std.testing.allocator, struct { i: bool },
+        \\ 0
+        \\ 1
+        \\ false
+        \\ true
+        \\ F
+        \\ T
+        \\ N
+        \\ Y
+    );
+    defer rows.deinit();
+
+    try std.testing.expectEqual(rows.items.len, 8);
+    try std.testing.expectEqual(rows.items[0], .{ .i = false });
+    try std.testing.expectEqual(rows.items[1], .{ .i = true });
+    try std.testing.expectEqual(rows.items[2], .{ .i = false });
+    try std.testing.expectEqual(rows.items[3], .{ .i = true });
+    try std.testing.expectEqual(rows.items[4], .{ .i = false });
+    try std.testing.expectEqual(rows.items[5], .{ .i = true });
+    try std.testing.expectEqual(rows.items[6], .{ .i = false });
+    try std.testing.expectEqual(rows.items[7], .{ .i = true });
+}
+
+test "struct" {
+    const rows = try table(std.testing.allocator, struct {
+        c1: enum { a, b, c, d },
+        c2: u8,
+        c3: u16 = 30,
+        c4: ?u32 = null,
+        c5: bool = false,
+    },
+        \\ a 1 10 1000 1
+        \\ b 2 20    _ T
+        \\ c 3  _    _ Y
+        \\ d 4  _    _ _
+    );
+    defer rows.deinit();
+
+    try std.testing.expectEqual(rows.items.len, 4);
+    try std.testing.expectEqual(rows.items[0], .{ .c1 = .a, .c2 = 1, .c3 = 10, .c4 = 1000, .c5 = true });
+    try std.testing.expectEqual(rows.items[1], .{ .c1 = .b, .c2 = 2, .c3 = 20, .c4 = null, .c5 = true });
+    try std.testing.expectEqual(rows.items[2], .{ .c1 = .c, .c2 = 3, .c3 = 30, .c4 = null, .c5 = true });
+    try std.testing.expectEqual(rows.items[3], .{ .c1 = .d, .c2 = 4, .c3 = 30, .c4 = null, .c5 = false });
+}
+
+test "struct (nested)" {
+    const rows = try table(std.testing.allocator, struct {
+        a: u32,
+        b: struct {
+            b1: u8,
+            b2: u8,
+        },
+        c: u32,
+    },
+        \\ 1 2 3 4
+        \\ 5 6 7 8
+    );
+    defer rows.deinit();
+
+    try std.testing.expectEqual(rows.items.len, 2);
+    try std.testing.expectEqual(rows.items[0], .{ .a = 1, .b = .{ .b1 = 2, .b2 = 3 }, .c = 4 });
+    try std.testing.expectEqual(rows.items[1], .{ .a = 5, .b = .{ .b1 = 6, .b2 = 7 }, .c = 8 });
+}
+
+test "union" {
+    const rows = try table(std.testing.allocator, union(enum) {
+        a: struct { b: u8, c: i8 },
+        d: u8,
+        e: void,
+    },
+        \\a 1 -2
+        \\d 3
+        \\e
+    );
+    defer rows.deinit();
+
+    try std.testing.expectEqual(rows.items.len, 3);
+    try std.testing.expectEqual(rows.items[0], .{ .a = .{ .b = 1, .c = -2 } });
+    try std.testing.expectEqual(rows.items[1], .{ .d = 3 });
+    try std.testing.expectEqual(rows.items[2], .{ .e = {} });
+}

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -33,4 +33,5 @@ test {
     _ = @import("test/accounting/auditor.zig");
     _ = @import("test/accounting/workload.zig");
     _ = @import("test/storage.zig");
+    _ = @import("test/table.zig");
 }


### PR DESCRIPTION
Refactor the state machine unit tests to a more compact form.

Rationale: The state machine tests were so verbose that they were hard to skim through or verify manually. This new layout makes it easy to check for e.g. missing test cases, and makes the organization more obvious (descending error precedence). In the process of this I found several missing tests (not missing codes, just multiple cases that could hit the code).