### PR TITLE
Scripts/pre-commit: Fix directory for worktrees

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -4,6 +4,6 @@
 # ln -s ../../scripts/pre-commit.sh .git/hooks/pre-commit
 
 set -euo pipefail
-cd "$(dirname "$0")/../.."
+cd "$(git rev-parse --show-toplevel)"
 
 zig fmt --check .


### PR DESCRIPTION
Git worktrees use many checkouts, with a shared `.git`. `dirname "$0"` finds the `.git`, but that might be in the wrong worktree.