### PR TITLE
Clients/Node: Bump version

### DIFF
--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
When merging the node client into this repo, the package hash changed, so CI is complaining.
When this merges it will publish a new version to resolve the CI failure.