### PR TITLE
Checkout repo and temporarily more frequent runs of scheduled releases

### DIFF
--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -1,10 +1,12 @@
 on:
   schedule:
     # Every Monday at 14:00
-    - cron: "0 14 * * 1"
+    # TODO: temporarily once per hour until I get this correct
+    - cron: "0 * * * 1"
 
 jobs:
   scheduled_release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - run: hub release create --prerelease --message "Weekly automated build. Do not use in production." "$(date +%Y-%m-%d)-weekly"


### PR DESCRIPTION
Based on the failure today: https://github.com/tigerbeetledb/tigerbeetle/actions/runs/3515081241/jobs/5889892982.