### PR TITLE
Propagate GITHUB_TOKEN into environment when creating scheduled release

### DIFF
--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -12,3 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: hub release create --prerelease --message "Weekly automated build. Do not use in production." "$(date +%Y-%m-%d)-weekly"
+        # Propagate token into environment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dealing with https://github.com/tigerbeetledb/tigerbeetle/actions/runs/3517311509/jobs/5894934378.