### PR TITLE
 Remove dead code

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const tigerbeetle = @import("tigerbeetle.zig");
 const vsr = @import("vsr.zig");
 
 const Environment = enum {


### PR DESCRIPTION
Everything else uses `const tb` rather than `const tigerbeetle`. Also, this isn't use in a file, should I just remove this perhaps? Or is this intentially incuded due to some zig peculiarity with respect to lazy compilation? 