### PR TITLE
Java Client: Echo tests

### DIFF
--- a/src/clients/java/src/tigerbeetle-java/exclude-pmd.properties
+++ b/src/clients/java/src/tigerbeetle-java/exclude-pmd.properties
@@ -2,9 +2,6 @@
 # https://pmd.github.io/
 # Exclusion rules
 
-# UnusedPrivateField: some private fields are used from the JNI side.
-com.tigerbeetle.Client=UnusedPrivateField
-
 # DoNotExtendJavaLangError: this class has "System Error" semantics,
 # the application must not try to recover from them.
 #

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/AsyncRequest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/AsyncRequest.java
@@ -18,32 +18,46 @@ final class AsyncRequest<TResponse extends Batch> extends Request<TResponse> {
 
     private final CompletableFuture<TResponse> future;
 
-    AsyncRequest(final Client client, final byte operation, final Batch batch) {
-        super(client, operation, batch);
+    AsyncRequest(final NativeClient nativeClient, final Operations operation, final Batch batch) {
+        super(nativeClient, operation, batch);
 
         future = new CompletableFuture<TResponse>();
     }
 
-    public static AsyncRequest<CreateAccountResultBatch> createAccounts(final Client client,
-            final AccountBatch batch) {
-        return new AsyncRequest<CreateAccountResultBatch>(client,
+    public static AsyncRequest<CreateAccountResultBatch> createAccounts(
+            final NativeClient nativeClient, final AccountBatch batch) {
+        return new AsyncRequest<CreateAccountResultBatch>(nativeClient,
                 Request.Operations.CREATE_ACCOUNTS, batch);
     }
 
-    public static AsyncRequest<AccountBatch> lookupAccounts(final Client client,
+    public static AsyncRequest<AccountBatch> lookupAccounts(final NativeClient nativeClient,
             final IdBatch batch) {
-        return new AsyncRequest<AccountBatch>(client, Request.Operations.LOOKUP_ACCOUNTS, batch);
+        return new AsyncRequest<AccountBatch>(nativeClient, Request.Operations.LOOKUP_ACCOUNTS,
+                batch);
     }
 
-    public static AsyncRequest<CreateTransferResultBatch> createTransfers(final Client client,
-            final TransferBatch batch) {
-        return new AsyncRequest<CreateTransferResultBatch>(client,
+    public static AsyncRequest<CreateTransferResultBatch> createTransfers(
+            final NativeClient nativeClient, final TransferBatch batch) {
+        return new AsyncRequest<CreateTransferResultBatch>(nativeClient,
                 Request.Operations.CREATE_TRANSFERS, batch);
     }
 
-    public static AsyncRequest<TransferBatch> lookupTransfers(final Client client,
+    public static AsyncRequest<TransferBatch> lookupTransfers(final NativeClient nativeClient,
             final IdBatch batch) {
-        return new AsyncRequest<TransferBatch>(client, Request.Operations.LOOKUP_TRANSFERS, batch);
+        return new AsyncRequest<TransferBatch>(nativeClient, Request.Operations.LOOKUP_TRANSFERS,
+                batch);
+    }
+
+    public static AsyncRequest<AccountBatch> echo(final NativeClient nativeClient,
+            final AccountBatch batch) {
+        return new AsyncRequest<AccountBatch>(nativeClient, Request.Operations.ECHO_ACCOUNTS,
+                batch);
+    }
+
+    public static AsyncRequest<TransferBatch> echo(final NativeClient nativeClient,
+            final TransferBatch batch) {
+        return new AsyncRequest<TransferBatch>(nativeClient, Request.Operations.ECHO_TRANSFERS,
+                batch);
     }
 
     public CompletableFuture<TResponse> getFuture() {

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/BlockingRequest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/BlockingRequest.java
@@ -31,33 +31,47 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
     private TResponse result;
     private Throwable exception;
 
-    BlockingRequest(final Client client, final byte operation, final Batch batch) {
-        super(client, operation, batch);
+    BlockingRequest(final NativeClient nativeClient, final Operations operation,
+            final Batch batch) {
+        super(nativeClient, operation, batch);
 
         result = null;
         exception = null;
     }
 
-    public static BlockingRequest<CreateAccountResultBatch> createAccounts(final Client client,
-            final AccountBatch batch) {
-        return new BlockingRequest<CreateAccountResultBatch>(client,
+    public static BlockingRequest<CreateAccountResultBatch> createAccounts(
+            final NativeClient nativeClient, final AccountBatch batch) {
+        return new BlockingRequest<CreateAccountResultBatch>(nativeClient,
                 Request.Operations.CREATE_ACCOUNTS, batch);
     }
 
-    public static BlockingRequest<AccountBatch> lookupAccounts(final Client client,
+    public static BlockingRequest<AccountBatch> lookupAccounts(final NativeClient nativeClient,
             final IdBatch batch) {
-        return new BlockingRequest<AccountBatch>(client, Request.Operations.LOOKUP_ACCOUNTS, batch);
+        return new BlockingRequest<AccountBatch>(nativeClient, Request.Operations.LOOKUP_ACCOUNTS,
+                batch);
     }
 
-    public static BlockingRequest<CreateTransferResultBatch> createTransfers(final Client client,
-            final TransferBatch batch) {
-        return new BlockingRequest<CreateTransferResultBatch>(client,
+    public static BlockingRequest<CreateTransferResultBatch> createTransfers(
+            final NativeClient nativeClient, final TransferBatch batch) {
+        return new BlockingRequest<CreateTransferResultBatch>(nativeClient,
                 Request.Operations.CREATE_TRANSFERS, batch);
     }
 
-    public static BlockingRequest<TransferBatch> lookupTransfers(final Client client,
+    public static BlockingRequest<TransferBatch> lookupTransfers(final NativeClient nativeClient,
             final IdBatch batch) {
-        return new BlockingRequest<TransferBatch>(client, Request.Operations.LOOKUP_TRANSFERS,
+        return new BlockingRequest<TransferBatch>(nativeClient, Request.Operations.LOOKUP_TRANSFERS,
+                batch);
+    }
+
+    public static BlockingRequest<AccountBatch> echo(final NativeClient nativeClient,
+            final AccountBatch batch) {
+        return new BlockingRequest<AccountBatch>(nativeClient, Request.Operations.ECHO_ACCOUNTS,
+                batch);
+    }
+
+    public static BlockingRequest<TransferBatch> echo(final NativeClient nativeClient,
+            final TransferBatch batch) {
+        return new BlockingRequest<TransferBatch>(nativeClient, Request.Operations.ECHO_TRANSFERS,
                 batch);
     }
 

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/EchoClient.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/EchoClient.java
@@ -1,0 +1,41 @@
+package com.tigerbeetle;
+
+import java.util.concurrent.CompletableFuture;
+
+public final class EchoClient implements AutoCloseable {
+
+    private final NativeClient nativeClient;
+
+    public EchoClient(final int clusterID, final String replicaAddresses,
+            final int maxConcurrency) {
+        this.nativeClient = NativeClient.initEcho(clusterID, replicaAddresses, maxConcurrency);
+    }
+
+    public AccountBatch echo(final AccountBatch batch) throws RequestException {
+        final var request = BlockingRequest.echo(this.nativeClient, batch);
+        request.beginRequest();
+        return request.waitForResult();
+    }
+
+    public TransferBatch echo(final TransferBatch batch) throws RequestException {
+        final var request = BlockingRequest.echo(this.nativeClient, batch);
+        request.beginRequest();
+        return request.waitForResult();
+    }
+
+    public CompletableFuture<AccountBatch> echoAsync(final AccountBatch batch) {
+        final var request = AsyncRequest.echo(this.nativeClient, batch);
+        request.beginRequest();
+        return request.getFuture();
+    }
+
+    public CompletableFuture<TransferBatch> echoAsync(final TransferBatch batch) {
+        final var request = AsyncRequest.echo(this.nativeClient, batch);
+        request.beginRequest();
+        return request.getFuture();
+    }
+
+    public void close() throws Exception {
+        nativeClient.close();
+    }
+}

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/InitializationException.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/InitializationException.java
@@ -38,15 +38,21 @@ public final class InitializationException extends RuntimeException {
             case Status.OUT_OF_MEMORY:
                 return "Internal client ran out of memory";
 
+            case Status.ADDRESS_INVALID:
+                return "Replica addresses format is invalid";
+
+            case Status.ADDRESS_LIMIT_EXCEEDED:
+                return "Replica addresses limit exceeded";
+
+            case Status.PACKETS_COUNT_INVALID:
+                return "Invalid maxConcurrency";
+
             case Status.SYSTEM_RESOURCES:
                 return "Internal client ran out of system resources";
 
             case Status.NETWORK_SUBSYSTEM:
                 return "Internal client had unexpected networking issues";
 
-            case Status.ADDRESS_INVALID:
-            case Status.ADDRESS_LIMIT_EXCEEDED:
-            case Status.PACKETS_COUNT_INVALID:
             default:
                 return "Error status " + status;
         }

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/InitializationException.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/InitializationException.java
@@ -6,9 +6,11 @@ public final class InitializationException extends RuntimeException {
         int SUCCESS = 0;
         int UNEXPECTED = 1;
         int OUT_OF_MEMORY = 2;
-        int INVALID_ADDRESS = 3;
-        int SYSTEM_RESOURCES = 4;
-        int NETWORK_SUBSYSTEM = 5;
+        int ADDRESS_INVALID = 3;
+        int ADDRESS_LIMIT_EXCEEDED = 4;
+        int PACKETS_COUNT_INVALID = 5;
+        int SYSTEM_RESOURCES = 6;
+        int NETWORK_SUBSYSTEM = 7;
     }
 
     private final int status;
@@ -31,22 +33,22 @@ public final class InitializationException extends RuntimeException {
         switch (status) {
 
             case Status.UNEXPECTED:
-                return "Unexpected error";
+                return "Unexpected internal error";
 
             case Status.OUT_OF_MEMORY:
-                return "Out of memory";
-
-            case Status.INVALID_ADDRESS:
-                return "Invalid addresses";
+                return "Internal client ran out of memory";
 
             case Status.SYSTEM_RESOURCES:
-                return "System Resources";
+                return "Internal client ran out of system resources";
 
             case Status.NETWORK_SUBSYSTEM:
-                return "Network subsystem";
+                return "Internal client had unexpected networking issues";
 
+            case Status.ADDRESS_INVALID:
+            case Status.ADDRESS_LIMIT_EXCEEDED:
+            case Status.PACKETS_COUNT_INVALID:
             default:
-                return "Unknown error status " + status;
+                return "Error status " + status;
         }
     }
 

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/NativeClient.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/NativeClient.java
@@ -1,0 +1,103 @@
+package com.tigerbeetle;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import static com.tigerbeetle.AssertionError.assertTrue;
+
+final class NativeClient {
+    static {
+        JNILoader.loadFromJar();
+    }
+
+    private final int maxConcurrency;
+    private final Semaphore maxConcurrencySemaphore;
+    private volatile long contextHandle;
+
+    public static NativeClient init(final int clusterID, final String addresses,
+            final int maxConcurrency) {
+        assertArgs(clusterID, addresses, maxConcurrency);
+        final long contextHandle = clientInit(clusterID, addresses, maxConcurrency);
+        return new NativeClient(maxConcurrency, contextHandle);
+    }
+
+    public static NativeClient initEcho(final int clusterID, final String addresses,
+            final int maxConcurrency) {
+        assertArgs(clusterID, addresses, maxConcurrency);
+        final long contextHandle = clientInitEcho(clusterID, addresses, maxConcurrency);
+        return new NativeClient(maxConcurrency, contextHandle);
+    }
+
+    private static void assertArgs(final int clusterID, final String addresses,
+            final int maxConcurrency) {
+        assertTrue(clusterID >= 0, "ClusterID must be positive");
+        assertTrue(addresses != null, "Replica addresses cannot be null");
+        assertTrue(maxConcurrency > 0, "Invalid maxConcurrency");
+    }
+
+    private NativeClient(final int maxConcurrency, final long contextHandle) {
+        this.contextHandle = contextHandle;
+        this.maxConcurrency = maxConcurrency;
+        this.maxConcurrencySemaphore = new Semaphore(maxConcurrency, false);
+    }
+
+    public void submit(final Request<?> request) {
+        acquirePermit();
+        submit(contextHandle, request);
+    }
+
+    private void acquirePermit() {
+
+        // Assure that only the max number of concurrent requests can acquire a packet
+        // It forces other threads to wait until a packet became available
+        // We also assure that the clientHandle will be zeroed only after all permits
+        // have been released
+        final int TIMEOUT = 5;
+        boolean acquired = false;
+        do {
+
+            if (contextHandle == 0)
+                throw new IllegalStateException("Client is closed");
+
+            try {
+                acquired = maxConcurrencySemaphore.tryAcquire(TIMEOUT, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException interruptedException) {
+
+                // This exception should never exposed by the API to be handled by the user
+                throw new AssertionError(interruptedException,
+                        "Unexpected thread interruption on acquiring a packet.");
+            }
+
+        } while (!acquired);
+    }
+
+    public void releasePermit() {
+        // Releasing the packet to be used by another thread
+        maxConcurrencySemaphore.release();
+    }
+
+    public void close() throws Exception {
+
+        if (contextHandle != 0) {
+
+            // Acquire all permits, forcing to wait for any processing thread to release
+            // Note that "acquireUninterruptibly(maxConcurrency)" atomically acquires the
+            // permits
+            // all at once, causing this operation to take longer.
+            for (int i = 0; i < maxConcurrency; i++) {
+                this.maxConcurrencySemaphore.acquireUninterruptibly();
+            }
+
+            // Deinit and signalize that this client is closed by setting the handles to 0
+            clientDeinit(contextHandle);
+            contextHandle = 0;
+        }
+    }
+
+    private static native void submit(long contextHandle, Request<?> request);
+
+    private static native long clientInit(int clusterID, String addresses, int maxConcurrency);
+
+    private static native long clientInitEcho(int clusterID, String addresses, int maxConcurrency);
+
+    private static native void clientDeinit(long contextHandle);
+}

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/Request.java
@@ -132,8 +132,6 @@ abstract class Request<TResponse extends Batch> {
             }
         }
 
-        client.returnPacket(packet);
-
         if (exception != null) {
             setException(exception);
         } else {
@@ -149,6 +147,10 @@ abstract class Request<TResponse extends Batch> {
         }
     }
 
+    void releasePermit() {
+        // Releasing the packet to be used by another thread
+        client.releasePermit();
+    }
 
     /**
      * Copies the message buffer memory to managed memory.

--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/Request.java
@@ -27,11 +27,20 @@ abstract class Request<TResponse extends Batch> {
      */
     // @formatter:on
 
-    interface Operations {
-        byte CREATE_ACCOUNTS = 3;
-        byte CREATE_TRANSFERS = 4;
-        byte LOOKUP_ACCOUNTS = 5;
-        byte LOOKUP_TRANSFERS = 6;
+    enum Operations {
+        CREATE_ACCOUNTS(3),
+        CREATE_TRANSFERS(4),
+        LOOKUP_ACCOUNTS(5),
+        LOOKUP_TRANSFERS(6),
+
+        ECHO_ACCOUNTS(3),
+        ECHO_TRANSFERS(4);
+
+        byte value;
+
+        Operations(int value) {
+            this.value = (byte) value;
+        }
     }
 
     // Used ony by the JNI side
@@ -41,15 +50,16 @@ abstract class Request<TResponse extends Batch> {
     @Native
     private final long bufferLen;
 
-    private final Client client;
-    private final byte operation;
+    private final NativeClient nativeClient;
+    private final Operations operation;
     private final int requestLen;
 
-    protected Request(final Client client, final byte operation, final Batch batch) {
-        Objects.requireNonNull(client, "Id cannot be null");
+    protected Request(final NativeClient nativeClient, final Operations operation,
+            final Batch batch) {
+        Objects.requireNonNull(nativeClient, "Client cannot be null");
         Objects.requireNonNull(batch, "Batch cannot be null");
 
-        this.client = client;
+        this.nativeClient = nativeClient;
         this.operation = operation;
         this.requestLen = batch.getLength();
         this.buffer = batch.getBuffer();
@@ -60,7 +70,7 @@ abstract class Request<TResponse extends Batch> {
     }
 
     public void beginRequest() {
-        client.submit(this);
+        nativeClient.submit(this);
     }
 
     // Unchecked: Since we just support a limited set of operations, it is safe to cast the
@@ -76,46 +86,50 @@ abstract class Request<TResponse extends Batch> {
         Batch result = null;
         Throwable exception = null;
 
-        if (receivedOperation != operation) {
+        try {
 
-            exception = new AssertionError("Unexpected callback operation: expected=%d, actual=%d",
-                    operation, receivedOperation);
+            if (receivedOperation != operation.value) {
 
-        } else if (packet == 0) {
+                exception =
+                        new AssertionError("Unexpected callback operation: expected=%d, actual=%d",
+                                operation.value, receivedOperation);
 
-            exception = new AssertionError("Unexpected callback packet: packet=null");
+            } else if (packet == 0) {
 
-        } else if (status != RequestException.Status.OK) {
+                exception = new AssertionError("Unexpected callback packet: packet=null");
 
-            exception = new RequestException(status);
+            } else if (status != RequestException.Status.OK) {
 
-        } else if (buffer == null) {
+                exception = new RequestException(status);
 
-            exception = new AssertionError("Unexpected callback buffer: buffer=null");
+            } else if (buffer == null) {
 
-        } else {
+                exception = new AssertionError("Unexpected callback buffer: buffer=null");
 
-            try {
+            } else {
+
                 switch (operation) {
-                    case Operations.CREATE_ACCOUNTS: {
+                    case CREATE_ACCOUNTS: {
                         result = buffer.capacity() == 0 ? CreateAccountResultBatch.EMPTY
                                 : new CreateAccountResultBatch(memcpy(buffer));
                         break;
                     }
 
-                    case Operations.CREATE_TRANSFERS: {
+                    case CREATE_TRANSFERS: {
                         result = buffer.capacity() == 0 ? CreateTransferResultBatch.EMPTY
                                 : new CreateTransferResultBatch(memcpy(buffer));
                         break;
                     }
 
-                    case Operations.LOOKUP_ACCOUNTS: {
+                    case ECHO_ACCOUNTS:
+                    case LOOKUP_ACCOUNTS: {
                         result = buffer.capacity() == 0 ? AccountBatch.EMPTY
                                 : new AccountBatch(memcpy(buffer));
                         break;
                     }
 
-                    case Operations.LOOKUP_TRANSFERS: {
+                    case ECHO_TRANSFERS:
+                    case LOOKUP_TRANSFERS: {
                         result = buffer.capacity() == 0 ? TransferBatch.EMPTY
                                 : new TransferBatch(memcpy(buffer));
                         break;
@@ -126,10 +140,9 @@ abstract class Request<TResponse extends Batch> {
                         break;
                     }
                 }
-            } catch (Throwable any) {
-
-                exception = any;
             }
+        } catch (Throwable any) {
+            exception = any;
         }
 
         if (exception != null) {
@@ -147,9 +160,13 @@ abstract class Request<TResponse extends Batch> {
         }
     }
 
+    byte getOperation() {
+        return this.operation.value;
+    }
+
     void releasePermit() {
         // Releasing the packet to be used by another thread
-        client.releasePermit();
+        nativeClient.releasePermit();
     }
 
     /**

--- a/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -6,13 +6,14 @@ import static org.junit.Assert.assertTrue;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.junit.Test;
+import com.tigerbeetle.Request.Operations;
 
 public class BlockingRequestTest {
 
     @Test
     public void testCreateAccountsRequestConstructor() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new AccountBatch(1);
         batch.add();
 
@@ -23,7 +24,7 @@ public class BlockingRequestTest {
     @Test
     public void testCreateTransfersRequestConstructor() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -34,7 +35,7 @@ public class BlockingRequestTest {
     @Test
     public void testLookupAccountsRequestConstructor() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new IdBatch(1);
         batch.add();
 
@@ -45,7 +46,7 @@ public class BlockingRequestTest {
     @Test
     public void testLookupTransfersRequestConstructor() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new IdBatch(1);
         batch.add();
 
@@ -66,7 +67,7 @@ public class BlockingRequestTest {
     @Test(expected = NullPointerException.class)
     public void testConstructorWithBatchNull() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         BlockingRequest.createAccounts(client, null);
         assert false;
     }
@@ -74,7 +75,7 @@ public class BlockingRequestTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroCapacityBatch() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new AccountBatch(0);
 
         BlockingRequest.createAccounts(client, batch);
@@ -84,7 +85,7 @@ public class BlockingRequestTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroItemsBatch() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new AccountBatch(1);
 
         BlockingRequest.createAccounts(client, batch);
@@ -94,7 +95,7 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidOperation() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -105,7 +106,7 @@ public class BlockingRequestTest {
         assertFalse(request.isDone());
 
         // Invalid operation, should be CREATE_TRANSFERS
-        request.endRequest(Request.Operations.LOOKUP_ACCOUNTS, dummyBuffer, 1,
+        request.endRequest(Request.Operations.LOOKUP_ACCOUNTS.value, dummyBuffer, 1,
                 RequestException.Status.OK);
 
         assertTrue(request.isDone());
@@ -117,12 +118,13 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testEndRequestWithUnknownOperation() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
         final byte UNKNOWN = 99;
-        var request = new BlockingRequest<CreateTransferResultBatch>(client, UNKNOWN, batch);
+        var request = new BlockingRequest<CreateTransferResultBatch>(client,
+                Operations.CREATE_TRANSFERS, batch);
         var dummyBuffer = ByteBuffer.allocateDirect(CreateTransferResultBatch.Struct.SIZE);
 
         assertFalse(request.isDone());
@@ -139,7 +141,7 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testEndRequestWithNullBuffer() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -147,7 +149,7 @@ public class BlockingRequestTest {
 
         assertFalse(request.isDone());
 
-        request.endRequest(Request.Operations.CREATE_TRANSFERS, null, 1,
+        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, null, 1,
                 RequestException.Status.OK);
 
         assertTrue(request.isDone());
@@ -159,7 +161,7 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidBufferSize() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -169,7 +171,7 @@ public class BlockingRequestTest {
 
         assertFalse(request.isDone());
 
-        request.endRequest(Request.Operations.CREATE_TRANSFERS, invalidBuffer, 1,
+        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, invalidBuffer, 1,
                 RequestException.Status.OK);
 
         assertTrue(request.isDone());
@@ -181,7 +183,7 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidPacket() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -192,7 +194,7 @@ public class BlockingRequestTest {
         final long NULL = 0;
 
         assertFalse(request.isDone());
-        request.endRequest(Request.Operations.CREATE_TRANSFERS, dummyBuffer, NULL,
+        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, dummyBuffer, NULL,
                 RequestException.Status.OK);
 
         assertTrue(request.isDone());
@@ -204,7 +206,7 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testGetResultBeforeEndRequest() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -219,7 +221,7 @@ public class BlockingRequestTest {
     @Test
     public void testEndRequestWithRequestException() {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(1);
         batch.add();
 
@@ -228,7 +230,7 @@ public class BlockingRequestTest {
         assertFalse(request.isDone());
 
         var dummyBuffer = ByteBuffer.allocateDirect(CreateTransferResultBatch.Struct.SIZE);
-        request.endRequest(Request.Operations.CREATE_TRANSFERS, dummyBuffer, 1,
+        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, dummyBuffer, 1,
                 RequestException.Status.TOO_MUCH_DATA);
 
 
@@ -245,7 +247,7 @@ public class BlockingRequestTest {
     @Test(expected = AssertionError.class)
     public void testEndRequestWithAmountOfResultsGreaterThanAmountOfRequests()
             throws RequestException {
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
 
         // A batch with only 1 item
         var batch = new AccountBatch(1);
@@ -256,8 +258,8 @@ public class BlockingRequestTest {
                 .order(ByteOrder.LITTLE_ENDIAN);
 
         var request = BlockingRequest.createAccounts(client, batch);
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
         request.waitForResult();
@@ -265,7 +267,7 @@ public class BlockingRequestTest {
 
     @Test(expected = AssertionError.class)
     public void testEndRequestTwice() throws RequestException {
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
 
         // A batch with only 1 item
         var batch = new AccountBatch(1);
@@ -278,15 +280,15 @@ public class BlockingRequestTest {
         var request = BlockingRequest.createAccounts(client, batch);
         assertFalse(request.isDone());
 
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
         var result = request.waitForResult();
         assertEquals(1, result.getLength());
 
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
 
@@ -296,7 +298,7 @@ public class BlockingRequestTest {
 
     @Test
     public void testCreateAccountEndRequest() throws RequestException {
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new AccountBatch(2);
         batch.add();
         batch.add();
@@ -311,8 +313,8 @@ public class BlockingRequestTest {
         dummyReplyBuffer.putInt(1);
         dummyReplyBuffer.putInt(CreateAccountResult.Exists.ordinal());
 
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
         var result = request.waitForResult();
@@ -329,7 +331,7 @@ public class BlockingRequestTest {
 
     @Test
     public void testCreateTransferEndRequest() throws RequestException {
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new TransferBatch(2);
         batch.add();
         batch.add();
@@ -344,8 +346,8 @@ public class BlockingRequestTest {
         dummyReplyBuffer.putInt(1);
         dummyReplyBuffer.putInt(CreateTransferResult.Exists.ordinal());
 
-        request.endRequest(Request.Operations.CREATE_TRANSFERS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
         var result = request.waitForResult();
@@ -362,7 +364,7 @@ public class BlockingRequestTest {
 
     @Test
     public void testLookupAccountEndRequest() throws RequestException {
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new IdBatch(2);
         batch.add();
         batch.add();
@@ -375,8 +377,8 @@ public class BlockingRequestTest {
         dummyReplyBuffer.putLong(100).putLong(1000);
         dummyReplyBuffer.position(AccountBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        request.endRequest(Request.Operations.LOOKUP_ACCOUNTS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.LOOKUP_ACCOUNTS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
         var result = request.waitForResult();
@@ -393,7 +395,7 @@ public class BlockingRequestTest {
 
     @Test
     public void testLookupTransferEndRequest() throws RequestException {
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new IdBatch(2);
         batch.add();
         batch.add();
@@ -406,8 +408,8 @@ public class BlockingRequestTest {
         dummyReplyBuffer.putLong(100).putLong(1000);
         dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        request.endRequest(Request.Operations.LOOKUP_TRANSFERS, dummyReplyBuffer.position(0), 1,
-                RequestException.Status.OK);
+        request.endRequest(Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer.position(0),
+                1, RequestException.Status.OK);
 
         assertTrue(request.isDone());
         var result = request.waitForResult();
@@ -425,7 +427,7 @@ public class BlockingRequestTest {
     @Test
     public void testSuccessCompletion() throws RequestException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new IdBatch(2);
         batch.add();
         batch.add();
@@ -437,9 +439,10 @@ public class BlockingRequestTest {
         dummyReplyBuffer.putLong(100).putLong(1000);
         dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        var callback = new CallbackSimulator<TransferBatch>(
-                BlockingRequest.lookupTransfers(client, batch), Request.Operations.LOOKUP_TRANSFERS,
-                dummyReplyBuffer.position(0), 1, RequestException.Status.OK, 500);
+        var callback =
+                new CallbackSimulator<TransferBatch>(BlockingRequest.lookupTransfers(client, batch),
+                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer.position(0), 1,
+                        RequestException.Status.OK, 500);
 
         callback.start();
 
@@ -459,16 +462,17 @@ public class BlockingRequestTest {
     @Test
     public void testFailedCompletion() throws InterruptedException {
 
-        var client = new Client(0, 1);
+        var client = NativeClient.initEcho(0, "3000", 1);
         var batch = new IdBatch(1);
         batch.add();
 
         // A dummy ByteBuffer simulating some simple reply
         var dummyReplyBuffer = ByteBuffer.allocateDirect(0);
 
-        var callback = new CallbackSimulator<TransferBatch>(
-                BlockingRequest.lookupTransfers(client, batch), Request.Operations.LOOKUP_TRANSFERS,
-                dummyReplyBuffer.position(0), 1, RequestException.Status.TOO_MUCH_DATA, 250);
+        var callback =
+                new CallbackSimulator<TransferBatch>(BlockingRequest.lookupTransfers(client, batch),
+                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer.position(0), 1,
+                        RequestException.Status.TOO_MUCH_DATA, 250);
 
         callback.start();
 

--- a/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/EchoTest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/EchoTest.java
@@ -1,0 +1,196 @@
+package com.tigerbeetle;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class EchoTest {
+
+    static final int HEADER_SIZE = 128; // @sizeOf(vsr.Header)
+    static final int TRANSFER_SIZE = 128; // @sizeOf(Transfer)
+    static final int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
+    static final int ITEMS_PER_BATCH = (MESSAGE_SIZE_MAX - HEADER_SIZE) / TRANSFER_SIZE;
+
+    @Test(expected = AssertionError.class)
+    public void testConstructorNullReplicaAddresses() throws Throwable {
+
+        try (var client = new EchoClient(0, null, 1)) {
+
+        } catch (Throwable any) {
+            throw any;
+        }
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testConstructorNegativeCluster() throws Throwable {
+        try (var client = new EchoClient(-1, "3000", 1)) {
+
+        } catch (Throwable any) {
+            throw any;
+        }
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testConstructorNegativeMaxConcurrency() throws Throwable {
+        try (var client = new EchoClient(0, "3000", -1)) {
+
+        } catch (Throwable any) {
+            throw any;
+        }
+    }
+
+    @Test
+    public void testEchoAccounts() throws Throwable {
+        final Random rnd = new Random(1);
+
+        try (var client = new EchoClient(0, "3000", 32)) {
+            final var batch = new AccountBatch(getRandomData(rnd, AccountBatch.Struct.SIZE));
+            final var reply = client.echo(batch);
+            assertBatchesEqual(batch, reply);
+        }
+    }
+
+    @Test
+    public void testEchoTransfers() throws Throwable {
+        final Random rnd = new Random(2);
+
+        try (var client = new EchoClient(0, "3000", 32)) {
+            final var batch = new TransferBatch(getRandomData(rnd, TransferBatch.Struct.SIZE));
+            final var future = client.echoAsync(batch);
+            final var reply = future.join();
+            assertBatchesEqual(batch, reply);
+        }
+    }
+
+    @Test
+    public void testEchoAccountsAsync() throws Throwable {
+
+        final class AsyncContext {
+            public AccountBatch batch;
+            public CompletableFuture<AccountBatch> future;
+        };
+
+        final Random rnd = new Random(3);
+        final int maxConcurrency = 64;
+        try (var client = new EchoClient(0, "3000", maxConcurrency)) {
+
+            // Repeating the same test multiple times to stress the
+            // cycle of message exhaustion followed by completions.
+            final int repetitionsMax = 100;
+            for (int repetition = 0; repetition < repetitionsMax; repetition++) {
+
+                final var list = new ArrayList<AsyncContext>();
+                for (int i = 0; i < maxConcurrency; i++) {
+
+                    // Submitting some random data to be echoed back:
+                    final var batch =
+                            new AccountBatch(getRandomData(rnd, AccountBatch.Struct.SIZE));
+
+                    var context = new AsyncContext();
+                    context.batch = batch;
+                    context.future = client.echoAsync(batch);
+
+                    list.add(context);
+                }
+
+                for (var context : list) {
+                    final var batch = context.batch;
+                    final var reply = context.future.get();
+                    assertBatchesEqual(batch, reply);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testEchoTransfersConcurrent() throws Throwable {
+
+        final class ThreadContext extends Thread {
+
+            public final TransferBatch batch;
+            private final EchoClient client;
+            private TransferBatch reply;
+            private Throwable exception;
+
+            public ThreadContext(EchoClient client, TransferBatch batch) {
+                this.client = client;
+                this.batch = batch;
+                this.reply = null;
+                this.exception = null;
+            }
+
+            public TransferBatch getReply() {
+                if (exception != null)
+                    throw new RuntimeException(exception);
+                return reply;
+            }
+
+            @Override
+            public synchronized void run() {
+                try {
+                    reply = client.echo(batch);
+                } catch (Throwable e) {
+                    exception = e;
+                }
+            }
+        }
+
+        final Random rnd = new Random(4);
+        final int maxConcurrency = 64;
+        try (var client = new EchoClient(0, "3000", maxConcurrency)) {
+
+            // Repeating the same test multiple times to stress the
+            // cycle of message exhaustion followed by completions.
+            final int repetitionsMax = 100;
+            for (int repetition = 0; repetition < repetitionsMax; repetition++) {
+
+                final var list = new ArrayList<ThreadContext>();
+                for (int i = 0; i < maxConcurrency; i++) {
+
+                    // Submitting some random data to be echoed back:
+                    final var batch =
+                            new TransferBatch(getRandomData(rnd, TransferBatch.Struct.SIZE));
+
+                    var context = new ThreadContext(client, batch);
+                    context.start();
+
+                    list.add(context);
+                }
+
+                for (var context : list) {
+                    context.join();
+                    final var batch = context.batch;
+                    final var reply = context.getReply();
+                    assertBatchesEqual(batch, reply);
+                }
+            }
+        }
+    }
+
+    private ByteBuffer getRandomData(final Random rnd, final int SIZE) {
+        final var length = rnd.nextInt(ITEMS_PER_BATCH - 1) + 1;
+        var buffer = ByteBuffer.allocateDirect(length * SIZE);
+        for (int i = 0; i < length; i++) {
+            var item = new byte[SIZE];
+            rnd.nextBytes(item);
+            buffer.put(item);
+        }
+        return buffer.position(0);
+    }
+
+    private void assertBatchesEqual(Batch batch, Batch reply) {
+        final var capacity = batch.getCapacity();
+        assertEquals(capacity, reply.getCapacity());
+
+        final var length = batch.getLength();
+        assertEquals(length, reply.getLength());
+
+        var buffer = batch.getBuffer();
+        var replyBuffer = reply.getBuffer();
+
+        assertEquals(buffer, replyBuffer);
+    }
+}

--- a/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Array;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;

--- a/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Array;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -93,25 +94,37 @@ public class IntegrationTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructorEmptyStringReplicaAddresses() throws Throwable {
+    public void testConstructorReplicaAddressesLimitExceeded() throws Throwable {
+        var replicaAddresses = new String[100];
+        for (int i = 0; i < replicaAddresses.length; i++)
+            replicaAddresses[i] = "3000";
 
-        var replicaAddresses = new String[] {"", "", ""};
         try (var client = new Client(0, replicaAddresses)) {
-
-        } catch (Throwable any) {
-            throw any;
+            assert false;
+        } catch (InitializationException initializationException) {
+            assertEquals(InitializationException.Status.ADDRESS_LIMIT_EXCEEDED,
+                    initializationException.getStatus());
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorEmptyStringReplicaAddresses() throws Throwable {
+        var replicaAddresses = new String[] {"", "", ""};
+        try (var client = new Client(0, replicaAddresses)) {
+            assert false;
+        } catch (InitializationException initializationException) {
+            assertEquals(InitializationException.Status.ADDRESS_INVALID,
+                    initializationException.getStatus());
+        }
+    }
+
     public void testConstructorInvalidReplicaAddresses() throws Throwable {
 
         var replicaAddresses = new String[] {"127.0.0.1:99999"};
         try (var client = new Client(0, replicaAddresses)) {
-
-        } catch (Throwable any) {
-            throw any;
+            assert false;
+        } catch (InitializationException initializationException) {
+            assertEquals(InitializationException.Status.ADDRESS_INVALID,
+                    initializationException.getStatus());
         }
     }
 

--- a/src/clients/java/src/zig/build.zig
+++ b/src/clients/java/src/zig/build.zig
@@ -25,7 +25,6 @@ pub fn build(b: *std.build.Builder) void {
         lib.setBuildMode(mode);
 
         if (cross_target.os_tag.? == .windows) {
-
             // The linker cannot resolve these dependencies from tb_client
             // So we have to insert them manually here, or we are going to receive a "lld-link: error: undefined symbol"
             lib.linkSystemLibrary("ws2_32");

--- a/src/clients/java/src/zig/src/client.zig
+++ b/src/clients/java/src/zig/src/client.zig
@@ -134,8 +134,14 @@ const ReflectionHelper = struct {
         assert(this_obj != null);
         assert(request_operation_method_id != null);
 
-        const value = env.callNonVirtualMethod(.byte, this_obj, request_class, request_operation_method_id, null,) catch |err| {
-            log.err("Method getOperation failed {}", .{ err });
+        const value = env.callNonVirtualMethod(
+            .byte,
+            this_obj,
+            request_class,
+            request_operation_method_id,
+            null,
+        ) catch |err| {
+            log.err("Method getOperation failed {}", .{err});
             @panic("JNI: Method getOperation failed");
         };
 
@@ -276,7 +282,7 @@ const NativeClient = struct {
         };
         const addresses_len = @intCast(usize, env.getStringUTFLength(addresses_obj));
         var addresses_chars = std.meta.assumeSentinel(addresses_return.chars[0..addresses_len], 0);
-        defer env.releaseStringUTFChars(addresses_obj, addresses_chars);
+        defer env.releaseStringUTFChars(addresses_obj, addresses_return.chars);
 
         var context = global_allocator.create(JNIContext) catch {
             ReflectionHelper.throwInitializationException(env, tb.tb_status_t.out_of_memory);

--- a/src/clients/java/src/zig/src/client.zig
+++ b/src/clients/java/src/zig/src/client.zig
@@ -381,7 +381,7 @@ const NativeClient = struct {
 
         var context = @intToPtr(*JNIContext, context_ptr);
         var env = context.jvm.attachCurrentThreadAsDaemon() catch |err| {
-            log.err("Unexpected error attaching the native thread as daemon {s}", .{err});
+            log.err("Unexpected error attaching the native thread as daemon {}", .{err});
             @panic("JNI: Unexpected error attaching the native thread as daemon");
         };
 

--- a/src/clients/java/src/zig/src/client.zig
+++ b/src/clients/java/src/zig/src/client.zig
@@ -132,6 +132,7 @@ const ReflectionHelper = struct {
 
     pub fn operation(env: *jui.JNIEnv, this_obj: jui.jobject) u8 {
         assert(this_obj != null);
+        assert(request_class != null);
         assert(request_operation_method_id != null);
 
         const value = env.callNonVirtualMethod(
@@ -151,6 +152,7 @@ const ReflectionHelper = struct {
 
     pub fn end_request(env: *jui.JNIEnv, this_obj: jui.jobject, result: ?[]const u8, packet: *tb.tb_packet_t) void {
         assert(this_obj != null);
+        assert(request_class != null);
         assert(request_end_request_method_id != null);
 
         var buffer_obj: jui.jobject = if (result) |value| blk: {
@@ -191,6 +193,7 @@ const ReflectionHelper = struct {
 
     pub fn release_permit(env: *jui.JNIEnv, this_obj: jui.jobject) void {
         assert(this_obj != null);
+        assert(request_class != null);
         assert(request_release_permit_method_id != null);
 
         env.callNonVirtualMethod(


### PR DESCRIPTION
This PR is related to the work started at #231, implementing the base "Conformance test suite" for the Java Client.

- Added [new validations](https://github.com/tigerbeetledb/tigerbeetle/blob/bbd540349cb6f24c12dfb1c8ee9e0ec1bbb8d06b/src/c/tb_client.zig#L13-L15) introduced at #231 

- Major refactory on the JNI side, reducing the number of JNI calls and improving how the packet list is handled  (see commit message for more details).

- Java EchoClient, a minor refactory decoupling the JNI interface from the Client implementation, allowing both the `Client` and `EchoClient` to share the same logic by composition, without dynamic dispatch (see commit messages for more details).

- New `EchoClient` test suite, asserting the correct data marshaling and callback handling between the JVM and the Zig client. This test was based on the C client tests.

- Submodule `jui` updated.