### PR TITLE
sm: clarify that stored timeout for posts/voids is zero

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -785,7 +785,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 .ledger = p.ledger,
                 .code = p.code,
                 .pending_id = t.pending_id,
-                .timeout = t.timeout,
+                .timeout = 0,
                 .timestamp = t.timestamp,
                 .flags = t.flags,
                 .amount = amount,


### PR DESCRIPTION
We have an assert above that this is zero, so let's specify the zero. Though perhaps we should put `p.timeout + p.timestamp` here? It feels somewhat logical, as we do have a guarantee that that is < t.timestamp.