### PR TITLE
Client CI fixups

### DIFF
--- a/.github/workflows/clients-node-build.yml
+++ b/.github/workflows/clients-node-build.yml
@@ -47,4 +47,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.TIGERBEETLE_NODE_PUBLISH_KEY }}" > ~/.npmrc
-      - run: PACKAGE_JSON_VERSION=$(jq -r '.version' package.json) && npm show "tigerbeetle-node@${PACKAGE_JSON_VERSION}" --json 2>/dev/null && echo "Package tigerbeetle-node@${PACKAGE_JSON_VERSION} already exists - not publishing" || (npm install && npm publish)
+      - run: PACKAGE_JSON_VERSION=$(jq -r '.version' package.json) && npm show "tigerbeetle-node@${PACKAGE_JSON_VERSION}" --json 2>/dev/null && echo "Package tigerbeetle-node@${PACKAGE_JSON_VERSION} already exists - not publishing" || (npm install && sha256sum dist/client.node > dist/.client.node.sha256 && npm publish)

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -5,7 +5,7 @@
 
 ## Pre-built package
 
-Available at [GitHub Packages Registry](https://github.com/orgs/tigerbeetledb/packages?repo_name=tigerbeetle-java) as a `jar` package.
+Available at [GitHub Packages Registry](https://github.com/orgs/tigerbeetledb/packages?repo_name=tigerbeetle) as a `jar` package.
 
 You can install it by just downloading and placing the `jar` package directly in your `classpath` or by using a package management system such as [Maven](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) or [Gradle](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
 

--- a/src/clients/java/src/tigerbeetle-java/pom.xml
+++ b/src/clients/java/src/tigerbeetle-java/pom.xml
@@ -9,7 +9,7 @@
   <name>TigerBeetle Java client</name>
   <url>https://www.tigerbeetle.com</url>
   <scm>
-    <url>https://github.com/tigerbeetledb/tigerbeetle-java</url>
+    <url>https://github.com/tigerbeetledb/tigerbeetle</url>
   </scm>
 
   <licenses>
@@ -269,7 +269,7 @@
     <repository>
       <id>github</id>
       <name>TigerBeetle Java client</name>
-      <url>https://maven.pkg.github.com/tigerbeetledb/tigerbeetle-java</url>
+      <url>https://maven.pkg.github.com/tigerbeetledb/tigerbeetle</url>
     </repository>
   </distributionManagement>
 </project>

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -13,6 +13,7 @@
     "LICENSE",
     "README.md",
     "dist",
+    "dist/.client.node.sha256",
     "!dist/client.node",
     "package.json",
     "package-lock.json",

--- a/src/clients/node/scripts/test_install_on_alpine.sh
+++ b/src/clients/node/scripts/test_install_on_alpine.sh
@@ -13,6 +13,6 @@ docker run -w /test "$id" sh -c "
 set -e
 apk add --update nodejs npm git
 
-npm install /wrk/src/clients/node
+npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_amazonlinux.sh
+++ b/src/clients/node/scripts/test_install_on_amazonlinux.sh
@@ -15,6 +15,6 @@ yum update -y
 yum install -y xz wget git glibc tar
 wget -O- -q https://rpm.nodesource.com/setup_16.x | bash -
 yum install -y nodejs
-npm install /wrk/src/clients/node
+npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_debian.sh
+++ b/src/clients/node/scripts/test_install_on_debian.sh
@@ -13,6 +13,6 @@ apt-get update -y
 apt-get install -y xz-utils wget git
 wget -O- -q https://deb.nodesource.com/setup_18.x | bash -
 apt-get install -y nodejs
-npm install /wrk/src/clients/node
+npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_fedora.sh
+++ b/src/clients/node/scripts/test_install_on_fedora.sh
@@ -13,6 +13,6 @@ dnf update -y
 dnf install -y xz wget git
 wget -O- -q https://rpm.nodesource.com/setup_18.x | bash -
 dnf install -y nodejs
-npm install /wrk/src/clients/node
+npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_rhelubi.sh
+++ b/src/clients/node/scripts/test_install_on_rhelubi.sh
@@ -16,6 +16,6 @@ yum install -y xz wget git glibc tar
 wget -O- -q https://rpm.nodesource.com/setup_18.x | bash -
 yum install -y nodejs
 ln -s /lib64/libc.so.6 /lib64/libc.so
-npm install /wrk/src/clients/node
+npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_ubuntu.sh
+++ b/src/clients/node/scripts/test_install_on_ubuntu.sh
@@ -13,6 +13,6 @@ apt-get update -y
 apt-get install -y xz-utils wget git
 wget -O- -q https://deb.nodesource.com/setup_18.x | bash -
 apt-get install -y nodejs
-npm install /wrk/src/clients/node
+npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/version_check.sh
+++ b/src/clients/node/scripts/version_check.sh
@@ -1,28 +1,47 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
+shopt -s dotglob
 
 PACKAGE_JSON_VERSION=$(jq -r '.version' package.json)
 NPM_SHOW_OUTPUT=$(npm show "tigerbeetle-node@${PACKAGE_JSON_VERSION}" --json 2>/dev/null || echo -n "")
 NPM_VERSION_EXISTS=$(test -z "${NPM_SHOW_OUTPUT}" && echo "false" || echo "true")
+TMP_DIR=$(mktemp -d)
 
-NPM_INTEGRITY=$(echo "${NPM_SHOW_OUTPUT}" | jq -r '.dist.integrity')
-
-CURRENT_INTEGRITY=$(npm --json pack --pack-destination /tmp/ | grep -v -E '^>' | jq -r '.[0].integrity')
+function cleanup {
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
 
 echo "Version in package.json: ${PACKAGE_JSON_VERSION}"
 echo "Does it exist on NPM?    ${NPM_VERSION_EXISTS}"
-echo "Integrity of current build: ${CURRENT_INTEGRITY}"
-echo "Integrity of NPM version:   ${NPM_INTEGRITY}"
-echo
 
 if [ "${NPM_VERSION_EXISTS}" != "false" ]; then
+    mkdir "${TMP_DIR}/current"
+
+    NPM_TARBALL=$(echo "${NPM_SHOW_OUTPUT}" | jq -r '.dist.tarball')
+    curl "${NPM_TARBALL}" 2>/dev/null | tar -xzf - -C "${TMP_DIR}"
+
+    npm --json pack --pack-destination "${TMP_DIR}/current" &> /dev/null
+    tar -xzf "${TMP_DIR}/current/tigerbeetle-node"*.tgz -C "${TMP_DIR}/current"
+
+    # We pull in src/io/darwin.zig and src/io/windows.zig explicitly here: the hash of our binary will only
+    # include src/io/linux.zig due to a comptime switch.
+    NPM_DIST_INTEGRITY=$(cat "${TMP_DIR}/package/dist/"* "${TMP_DIR}/package/src/tigerbeetle/src/io/"{darwin.zig,windows.zig} | sha256sum | awk '{print $1}')
+    CURRENT_DIST_INTEGRITY=$(cat "${TMP_DIR}/current/package/dist/"* "${TMP_DIR}/current/package/src/tigerbeetle/src/io/"{darwin.zig,windows.zig} | sha256sum | awk '{print $1}')
+
+    echo "Integrity of current build: ${CURRENT_DIST_INTEGRITY}"
+    echo "Integrity of NPM version:   ${NPM_DIST_INTEGRITY}"
+
+    echo
     echo "package.json version matches NPM version"
-    if [ "${NPM_INTEGRITY}" != "${CURRENT_INTEGRITY}" ]; then
+
+    if [ "${NPM_DIST_INTEGRITY}" != "${CURRENT_DIST_INTEGRITY}" ]; then
         echo "NPM integrity differs from current integrity for the same version number. You'll need to increment the version under package.json to cut a new release. Bailing out."
         exit 1
     else
         echo "NPM integrity and current integrity match."
     fi
 else
+    echo
     echo "package.json version differs from NPM version - a new release will be created"
 fi


### PR DESCRIPTION
This PR addresses 3 problems with the client CI:

- Java client not pushing to the right Maven repo.
- Node client tests failing on Alpine due to them landing npm 9 and https://github.com/npm/cli/issues/5844
- Node version check being over eager - instead, we now store a hash of the CI compiled client binary in the dist folder, and hash that up for comparison. 
    - Since we only pull in `src/io/linux.zig` in this CI build (until we do full cross compilation for binary shipping), include the checksums of `src/io/darwin.zig`  and `src/io/windows.zig` to ensure changes to those aren't missed.