### PR TITLE
Add a tracing api.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,25 +1,41 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const TracerBackend = enum {
+    none,
+    // Writes to a file (./tracer.json) which can be uploaded to https://ui.perfetto.dev/
+    perfetto,
+};
+
 pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
 
+    const options = b.addOptions();
+
+    // The "tigerbeetle version" command includes the build-time commit hash.
+    if (git_commit(allocator)) |commit| {
+        options.addOption(?[]const u8, "git_commit", commit[0..]);
+    } else {
+        options.addOption(?[]const u8, "git_commit", null);
+    }
+
+    const tracer_backend = b.option(
+        TracerBackend,
+        "tracer-backend",
+        "Which backend to use for tracing. One of: none, perfetto.",
+    ) orelse TracerBackend.none;
+    options.addOption(TracerBackend, "tracer_backend", tracer_backend);
+
     {
         const tigerbeetle = b.addExecutable("tigerbeetle", "src/main.zig");
         tigerbeetle.setTarget(target);
         tigerbeetle.setBuildMode(mode);
         tigerbeetle.install();
-
-        // The "tigerbeetle version" command includes the build-time commit hash.
-        const options = b.addOptions();
-        if (git_commit(allocator)) |commit| {
-            options.addOption(?[]const u8, "git_commit", commit[0..]);
-        } else {
-            options.addOption(?[]const u8, "git_commit", null);
-        }
+        // Ensure that we get stack traces even in release builds.
+        tigerbeetle.omit_frame_pointer = false;
         tigerbeetle.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = tigerbeetle.run();
@@ -49,6 +65,7 @@ pub fn build(b: *std.build.Builder) void {
         const unit_tests = b.addTest("src/unit_tests.zig");
         unit_tests.setTarget(target);
         unit_tests.setBuildMode(mode);
+        unit_tests.addOptions("tigerbeetle_build_options", options);
 
         // for src/c/tb_client_header_test.zig to use cImport on tb_client.h
         unit_tests.linkLibC();
@@ -79,8 +96,7 @@ pub fn build(b: *std.build.Builder) void {
     {
         const simulator = b.addExecutable("simulator", "src/simulator.zig");
         simulator.setTarget(target);
-        // Ensure that we get stack traces even in release builds.
-        simulator.omit_frame_pointer = false;
+        simulator.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = simulator.run();
 
@@ -100,6 +116,7 @@ pub fn build(b: *std.build.Builder) void {
         vopr.setTarget(target);
         // Ensure that we get stack traces even in release builds.
         vopr.omit_frame_pointer = false;
+        vopr.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = vopr.run();
 
@@ -121,6 +138,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_lsm_forest.setBuildMode(mode);
         // Ensure that we get stack traces even in release builds.
         fuzz_lsm_forest.omit_frame_pointer = false;
+        fuzz_lsm_forest.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_lsm_forest.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -138,6 +156,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_lsm_manifest_log.setTarget(target);
         fuzz_lsm_manifest_log.setBuildMode(mode);
         fuzz_lsm_manifest_log.omit_frame_pointer = false;
+        fuzz_lsm_manifest_log.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_lsm_manifest_log.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -153,6 +172,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_lsm_tree.setBuildMode(mode);
         // Ensure that we get stack traces even in release builds.
         fuzz_lsm_tree.omit_frame_pointer = false;
+        fuzz_lsm_tree.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_lsm_tree.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -171,6 +191,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_lsm_segmented_array.setBuildMode(mode);
         // Ensure that we get stack traces even in release builds.
         fuzz_lsm_segmented_array.omit_frame_pointer = false;
+        fuzz_lsm_segmented_array.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_lsm_segmented_array.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -188,6 +209,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_vsr_superblock.setTarget(target);
         fuzz_vsr_superblock.setBuildMode(mode);
         fuzz_vsr_superblock.omit_frame_pointer = false;
+        fuzz_vsr_superblock.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_vsr_superblock.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -205,6 +227,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_vsr_superblock_free_set.setTarget(target);
         fuzz_vsr_superblock_free_set.setBuildMode(mode);
         fuzz_vsr_superblock_free_set.omit_frame_pointer = false;
+        fuzz_vsr_superblock_free_set.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_vsr_superblock_free_set.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -225,6 +248,7 @@ pub fn build(b: *std.build.Builder) void {
         fuzz_vsr_superblock_quorums.setTarget(target);
         fuzz_vsr_superblock_quorums.setBuildMode(mode);
         fuzz_vsr_superblock_quorums.omit_frame_pointer = false;
+        fuzz_vsr_superblock_quorums.addOptions("tigerbeetle_build_options", options);
 
         const run_cmd = fuzz_vsr_superblock_quorums.run();
         if (b.args) |args| run_cmd.addArgs(args);
@@ -257,6 +281,7 @@ pub fn build(b: *std.build.Builder) void {
         exe.setTarget(target);
         exe.setBuildMode(.ReleaseSafe);
         exe.setMainPkgPath("src");
+        exe.addOptions("tigerbeetle_build_options", options);
 
         const build_step = b.step("build_" ++ benchmark.name, "Build " ++ benchmark.description ++ " benchmark");
         build_step.dependOn(&exe.step);

--- a/src/config.zig
+++ b/src/config.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const assert = std.debug.assert;
 const vsr = @import("vsr.zig");
 
+const build_options = @import("tigerbeetle_build_options");
+
 const Environment = enum {
     development,
     production,
@@ -329,6 +331,10 @@ pub const verify = true;
 // TODO Move these to a separate "internal computed constants" file.
 pub const journal_size_headers = journal_slot_count * @sizeOf(vsr.Header);
 pub const journal_size_prepares = journal_slot_count * message_size_max;
+
+// Which backend to use for ./tracer.zig.
+// Default is `.none`.
+pub const tracer_backend = build_options.tracer_backend;
 
 // TODO Move these into a separate `config_valid.zig` which we import here:
 comptime {

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -6,7 +6,9 @@ const assert = std.debug.assert;
 const config = @import("../config.zig");
 const fuzz = @import("../test/fuzz.zig");
 const vsr = @import("../vsr.zig");
+
 const log = std.log.scoped(.lsm_forest_fuzz);
+const tracer = @import("../tracer.zig");
 
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Transfer = @import("../tigerbeetle.zig").Transfer;
@@ -395,6 +397,9 @@ pub fn generate_fuzz_ops(random: std.rand.Random) ![]const FuzzOp {
 }
 
 pub fn main() !void {
+    try tracer.init(allocator);
+    defer tracer.deinit(allocator);
+
     const fuzz_args = try fuzz.parse_fuzz_args(allocator);
     var rng = std.rand.DefaultPrng.init(fuzz_args.seed);
     const random = rng.random();

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -6,7 +6,9 @@ const assert = std.debug.assert;
 const config = @import("../config.zig");
 const fuzz = @import("../test/fuzz.zig");
 const vsr = @import("../vsr.zig");
+
 const log = std.log.scoped(.lsm_tree_fuzz);
+const tracer = @import("../tracer.zig");
 
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Transfer = @import("../tigerbeetle.zig").Transfer;
@@ -27,7 +29,7 @@ const Table = @import("table.zig").TableType(
     Key.tombstone,
     Key.tombstone_from_key,
 );
-const Tree = @import("tree.zig").TreeType(Table, Storage, @typeName(Table) ++ "_test");
+const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
 
 const Grid = GridType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
@@ -440,6 +442,9 @@ pub fn generate_fuzz_ops(random: std.rand.Random) ![]const FuzzOp {
 }
 
 pub fn main() !void {
+    try tracer.init(allocator);
+    defer tracer.deinit(allocator);
+
     const fuzz_args = try fuzz.parse_fuzz_args(allocator);
     var rng = std.rand.DefaultPrng.init(fuzz_args.seed);
     const random = rng.random();

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,7 @@ const log = std.log.scoped(.main);
 const build_options = @import("tigerbeetle_build_options");
 const config = @import("config.zig");
 pub const log_level: std.log.Level = @intToEnum(std.log.Level, config.log_level);
+const tracer = @import("tracer.zig");
 
 const cli = @import("cli.zig");
 const fatal = cli.fatal;
@@ -129,6 +130,9 @@ const Command = struct {
         path: [:0]const u8,
     ) !void {
         const allocator = arena.allocator();
+
+        try tracer.init(allocator);
+        defer tracer.deinit(allocator);
 
         var command: Command = undefined;
         try command.init(allocator, path, false);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
+
 const log = std.log.scoped(.state_machine);
+const tracer = @import("tracer.zig");
 
 const tb = @import("tigerbeetle.zig");
 const snapshot_latest = @import("lsm/tree.zig").snapshot_latest;
@@ -114,6 +116,8 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
         compact_callback: ?fn (*StateMachine) void = null,
         checkpoint_callback: ?fn (*StateMachine) void = null,
 
+        tracer_slot: ?tracer.SpanStart,
+
         pub fn init(allocator: mem.Allocator, grid: *Grid, options: Options) !StateMachine {
             var forest = try Forest.init(
                 allocator,
@@ -127,10 +131,13 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 .prepare_timestamp = 0,
                 .commit_timestamp = 0,
                 .forest = forest,
+                .tracer_slot = null,
             };
         }
 
         pub fn deinit(self: *StateMachine, allocator: mem.Allocator) void {
+            assert(self.tracer_slot == null);
+
             self.forest.deinit(allocator);
         }
 
@@ -218,6 +225,12 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 return;
             }
 
+            tracer.start(
+                &self.tracer_slot,
+                .main,
+                .state_machine_prefetch,
+            );
+
             self.prefetch_input = input;
             self.prefetch_callback = callback;
 
@@ -248,6 +261,13 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             const callback = self.prefetch_callback.?;
             self.prefetch_input = null;
             self.prefetch_callback = null;
+
+            tracer.end(
+                &self.tracer_slot,
+                .main,
+                .state_machine_prefetch,
+            );
+
             callback(self);
         }
 
@@ -367,6 +387,12 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             _ = client;
             assert(op != 0);
 
+            tracer.start(
+                &self.tracer_slot,
+                .main,
+                .state_machine_commit,
+            );
+
             const result = switch (operation) {
                 .root => unreachable,
                 .register => 0,
@@ -377,12 +403,24 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 else => unreachable,
             };
 
+            tracer.end(
+                &self.tracer_slot,
+                .main,
+                .state_machine_commit,
+            );
+
             return result;
         }
 
         pub fn compact(self: *StateMachine, callback: fn (*StateMachine) void, op: u64) void {
             assert(self.compact_callback == null);
             assert(self.checkpoint_callback == null);
+
+            tracer.start(
+                &self.tracer_slot,
+                .main,
+                .state_machine_compact,
+            );
 
             self.compact_callback = callback;
             self.forest.compact(compact_finish, op);
@@ -392,6 +430,13 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             const self = @fieldParentPtr(StateMachine, "forest", forest);
             const callback = self.compact_callback.?;
             self.compact_callback = null;
+
+            tracer.end(
+                &self.tracer_slot,
+                .main,
+                .state_machine_compact,
+            );
+
             callback(self);
         }
 

--- a/src/tracer.zig
+++ b/src/tracer.zig
@@ -1,0 +1,319 @@
+//! The tracer records a tree of event spans.
+//!
+//! In order to create event spans, you need somewhere to store the `SpanStart`.
+//!
+//!     var slot: ?SpanStart = null;
+//!     tracer.start(&slot, group, event);
+//!     ... do stuff ...
+//!     tracer.end(&slot, group, event);
+//!
+//! Each slot can be used as many times as you like,
+//! but you must alternate calls to start and end,
+//! and you must end every event.
+//!
+//!     // good
+//!     tracer.start(&slot, group_a, event_a);
+//!     tracer.end(&slot, group_a, event_a);
+//!     tracer.start(&slot, group_b, event_b);
+//!     tracer.end(&slot, group_b, event_b);
+//!
+//!     // bad
+//!     tracer.start(&slot, group_a, event_a);
+//!     tracer.start(&slot, group_b, event_b);
+//!     tracer.end(&slot, group_b, event_b);
+//!     tracer.end(&slot, group_a, event_a);
+//!
+//!     // bad
+//!     tracer.end(&slot, group_a, event_a);
+//!     tracer.start(&slot, group_a, event_a);
+//!
+//!     // bad
+//!     tracer.start(&slot, group_a, event_a);
+//!     std.os.exit(0);
+//!
+//! Before freeing a slot, you should `assert(slot == null)`
+//! to ensure that you didn't forget to end an event.
+//!
+//! Each `Event` has an `EventGroup`.
+//! Within each group, event spans should form a tree.
+//!
+//!     // good
+//!     tracer.start(&a, group, ...);
+//!     tracer.start(&b, group, ...);
+//!     tracer.end(&b, group, ...);
+//!     tracer.end(&a, group, ...);
+//!
+//!     // bad
+//!     tracer.start(&a, group, ...);
+//!     tracer.start(&b, group, ...);
+//!     tracer.end(&a, group, ...);
+//!     tracer.end(&b, group, ...);
+//!
+//! The tracer itself will not object to non-tree spans,
+//! but some config.tracer_backends will either refuse to open the trace or will render it weirdly.
+//!
+//! If you're having trouble making your spans form a tree, feel free to just add new groups.
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const log = std.log.scoped(.tracer);
+
+const config = @import("./config.zig");
+const Time = @import("./time.zig").Time;
+
+var is_initialized = false;
+var timer = Time{};
+var span_id_next: u64 = 0;
+var spans: std.ArrayList(Span) = undefined;
+var flush_slot: ?SpanStart = null;
+var log_file: std.fs.File = undefined;
+
+const span_count_max = 1 << 20;
+const log_path = "./tracer.json";
+
+/// All strings in Event must be comptime constants to ensure that they live until after `tracer.deinit` is called.
+pub const Event = union(enum) {
+    tracer_flush,
+    commit: struct {
+        op: u64,
+    },
+    checkpoint,
+    state_machine_prefetch,
+    state_machine_commit,
+    state_machine_compact,
+    tree_compaction_beat: struct {
+        tree_name: []const u8,
+    },
+    tree_compaction_tick: struct {
+        tree_name: []const u8,
+        level_b: u8,
+    },
+    tree_compaction_merge: struct {
+        tree_name: []const u8,
+        level_b: u8,
+    },
+};
+
+/// All strings in EventGroup must be comptime constants to ensure that they live until after `tracer.deinit` is called.
+pub const EventGroup = union(enum) {
+    main,
+    tracer,
+    tree: struct {
+        tree_name: []const u8,
+    },
+};
+
+const SpanId = u64;
+
+pub const SpanStart = struct {
+    id: SpanId,
+    start_time_ns: u64,
+    group: EventGroup,
+    event: Event,
+};
+
+const Span = struct {
+    id: SpanId,
+    start_time_ns: u64,
+    end_time_ns: u64,
+    group: EventGroup,
+    event: Event,
+};
+
+pub fn init(allocator: Allocator) !void {
+    if (config.tracer_backend == .none) return;
+    assert(!is_initialized);
+
+    spans = try std.ArrayList(Span).initCapacity(allocator, span_count_max);
+    errdefer spans.deinit();
+
+    switch (config.tracer_backend) {
+        .none => unreachable,
+        .perfetto => {
+            log_file = try std.fs.cwd().createFile(log_path, .{ .truncate = true });
+            errdefer log_file.close();
+
+            try log_file.writeAll(
+                \\{"traceEvents":[
+                \\
+            );
+        },
+    }
+
+    is_initialized = true;
+}
+
+pub fn deinit(allocator: Allocator) void {
+    _ = allocator;
+
+    if (config.tracer_backend == .none) return;
+    assert(is_initialized);
+
+    flush();
+    log_file.close();
+    assert(flush_slot == null);
+    spans.deinit();
+    is_initialized = false;
+}
+
+pub fn start(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
+    if (config.tracer_backend == .none) return;
+    assert(is_initialized);
+
+    // The event must not have already been started.
+    assert(slot.* == null);
+
+    slot.* = .{
+        .id = span_id_next,
+        .start_time_ns = timer.monotonic(),
+        .group = event_group,
+        .event = event,
+    };
+    span_id_next += 1;
+}
+
+pub fn end(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
+    if (config.tracer_backend == .none) return;
+    assert(is_initialized);
+
+    // The event must have already been started.
+    const span_start = &slot.*.?;
+    assert(std.meta.eql(span_start.group, event_group));
+    assert(std.meta.eql(span_start.event, event));
+
+    // Make sure we have room in spans.
+    if (spans.items.len >= span_count_max) flush();
+    assert(spans.items.len < span_count_max);
+
+    spans.appendAssumeCapacity(.{
+        .id = span_start.id,
+        .start_time_ns = span_start.start_time_ns,
+        .end_time_ns = timer.monotonic(),
+        .group = span_start.group,
+        .event = span_start.event,
+    });
+    slot.* = null;
+}
+
+pub fn flush() void {
+    if (config.tracer_backend == .none) return;
+    assert(is_initialized);
+
+    if (spans.items.len == 0) return;
+
+    start(&flush_slot, .tracer, .tracer_flush);
+    flush_or_err() catch |err| {
+        log.err("Could not flush tracer log, discarding instead: {}", .{err});
+    };
+    spans.shrinkRetainingCapacity(0);
+    end(&flush_slot, .tracer, .tracer_flush);
+}
+
+fn flush_or_err() !void {
+    switch (config.tracer_backend) {
+        .none => unreachable,
+        .perfetto => {
+            for (spans.items) |span| {
+                // Perfetto requires this json format:
+                // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+                const NameJson = struct {
+                    event: Event,
+
+                    pub fn jsonStringify(
+                        name_json: @This(),
+                        options: std.json.StringifyOptions,
+                        writer: anytype,
+                    ) @TypeOf(writer).Error!void {
+                        _ = options;
+                        try writer.writeAll("\"");
+                        switch (name_json.event) {
+                            .tracer_flush => try writer.print("tracer_flush", .{}),
+                            .commit => |commit| try writer.print(
+                                "commit({})",
+                                .{commit.op},
+                            ),
+                            .checkpoint => try writer.print("checkpoint", .{}),
+                            .state_machine_prefetch => try writer.print("state_machine_prefetch", .{}),
+                            .state_machine_commit => try writer.print("state_machine_commit", .{}),
+                            .state_machine_compact => try writer.print("state_machine_compact", .{}),
+                            .tree_compaction_beat => |tree_compaction_tick| try writer.print(
+                                "tree_compaction_beat({s})",
+                                .{tree_compaction_tick.tree_name},
+                            ),
+                            .tree_compaction_tick => |tree_compaction_tick| try writer.print(
+                                "tree_compaction_tick({s}, {})",
+                                .{ tree_compaction_tick.tree_name, tree_compaction_tick.level_b },
+                            ),
+                            .tree_compaction_merge => |tree_compaction_merge| try writer.print(
+                                "tree_compaction_merge({s}, {})",
+                                .{ tree_compaction_merge.tree_name, tree_compaction_merge.level_b },
+                            ),
+                        }
+                        try writer.writeAll("\"");
+                    }
+                };
+                const SpanJson = struct {
+                    name: NameJson,
+                    cat: []const u8 = "default",
+                    ph: []const u8 = "X",
+                    ts: f64,
+                    dur: f64,
+                    pid: u64 = 0,
+                    tid: u64,
+                };
+                const MetaJson = struct {
+                    name: []const u8,
+                    ph: []const u8 = "M",
+                    pid: u64 = 0,
+                    tid: u64,
+                    args: struct {
+                        name: []const u8,
+                    },
+                };
+
+                const group_name = switch (span.group) {
+                    .main => "main",
+                    .tracer => "tracer",
+                    .tree => |tree| tree.tree_name,
+                };
+
+                const tid_64 = switch (span.group) {
+                    .main => 0,
+                    .tracer => 1,
+                    .tree => |tree| std.hash_map.hashString(tree.tree_name),
+                };
+                const tid = @truncate(u32, tid_64) ^ @truncate(u32, tid_64 >> 32);
+
+                var buffered_writer = std.io.bufferedWriter(log_file.writer());
+                const writer = buffered_writer.writer();
+
+                try std.json.stringify(
+                    SpanJson{
+                        .name = .{ .event = span.event },
+                        .ts = @intToFloat(f64, span.start_time_ns) / 1000,
+                        .dur = @intToFloat(f64, span.end_time_ns - span.start_time_ns) / 1000,
+                        .tid = tid,
+                    },
+                    .{},
+                    writer,
+                );
+                try writer.writeAll(",\n");
+
+                // TODO Only emit metadata once per group name.
+                try std.json.stringify(
+                    MetaJson{
+                        .name = "thread_name",
+                        .tid = tid,
+                        .args = .{ .name = group_name },
+                    },
+                    .{},
+                    writer,
+                );
+                try writer.writeAll(",\n");
+
+                try buffered_writer.flush();
+            }
+        },
+    }
+}


### PR DESCRIPTION
Much revised since the previous attempt. See the module-level docs in `src/tracer.zig` for usage.

* Current backends are: none, perfetto. But we should also be able to support eg Tracy without changing the user-facing api.
* The default backend is none, in which case tracing is compiled away.
* Change the backend by passing eg `-Dtracer-backend=perfetto` to zig build.
* No dynamic allocation. The caller allocates space for the event span while the span is running. Completed spans are stored in a fixed-size buffer and flushed to the disk when the buffer is full.
* Rather than try to track structure dynamically, which doesn't play well with our non-structured async, the caller is responsible for assigning the span to an `EventGroup` and assuring that within each event group the spans form a tree. So far this hasn't been difficult. There is a main group for the state machine, a per-tree group for compaction etc, and a tracer group that measure the overhead of the tracer itself.

https://user-images.githubusercontent.com/340884/204163450-21dccfd3-9ff9-4c1e-aac8-e9cde81e05c9.mp4