### PR TITLE
Journal: recovering/recovered flags → Status (Refactor)

### DIFF
--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -333,7 +333,7 @@ pub fn main() !void {
         var crashes = cluster.replica_normal_count() -| replica_normal_min;
 
         for (cluster.storages) |*storage, replica| {
-            if (cluster.replicas[replica].journal.recovered) {
+            if (cluster.replicas[replica].journal.status == .recovered) {
                 // TODO Remove this workaround when VSR recovery protocol is disabled.
                 // When only the minimum number of replicas are healthy (no more crashes allowed),
                 // disable storage faults on all healthy replicas.

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -72,7 +72,7 @@ pub const StateChecker = struct {
     pub fn check_state(state_checker: *StateChecker, replica_index: u8) !void {
         const replica = state_checker.replicas[replica_index];
         const commit_header = header: {
-            if (replica.journal.recovered) {
+            if (replica.journal.status == .recovered) {
                 const commit_header = replica.journal.header_with_op(replica.commit_min);
                 assert(commit_header != null or replica.commit_min == replica.op_checkpoint);
                 break :header replica.journal.header_with_op(replica.commit_min);

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -88,6 +88,12 @@ const SlotRange = struct {
     }
 };
 
+const Status = enum {
+    init,
+    recovering,
+    recovered,
+};
+
 const slot_count = config.journal_slot_count;
 const headers_size = config.journal_size_headers;
 const prepares_size = config.journal_size_prepares;
@@ -254,8 +260,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         /// (`undefined` would may more sense than `0`, but `0` allows it to be asserted).
         prepare_inhabited: []bool,
 
-        recovered: bool = false,
-        recovering: bool = false,
+        status: Status = .init,
 
         pub fn init(allocator: Allocator, storage: *Storage, replica: u8) !Self {
             // TODO Fix this assertion:
@@ -365,8 +370,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         /// Called by the replica immediately after WAL recovery completes, but before the replica
         /// issues any I/O from handling messages.
         pub fn is_empty(self: *const Self) bool {
-            assert(!self.recovering);
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(self.writes.executing() == 0);
 
             if (!self.headers[0].valid_checksum()) return false;
@@ -486,7 +490,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
 
         /// Returns the highest op number prepared, in any slot without reference to the checkpoint.
         pub fn op_maximum(self: *const Self) u64 {
-            assert(self.recovered);
+            assert(self.status == .recovered);
 
             var op: u64 = 0;
             for (self.headers) |*header| {
@@ -516,7 +520,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         }
 
         pub fn has(self: *const Self, header: *const Header) bool {
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(header.command == .prepare);
 
             const slot = self.slot_for_op(header.op);
@@ -562,7 +566,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             op_max: u64,
             dest: []Header,
         ) usize {
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(op_min <= op_max);
             assert(dest.len > 0);
 
@@ -721,7 +725,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             checksum: u128,
             destination_replica: ?u8,
         ) void {
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(checksum != 0);
 
             const replica = @fieldParentPtr(Replica, "journal", self);
@@ -757,7 +761,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         ) void {
             const replica = @fieldParentPtr(Replica, "journal", self);
             const slot = self.slot_for_op(op);
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(self.prepare_inhabited[slot.index]);
             assert(self.prepare_checksums[slot.index] == checksum);
 
@@ -820,7 +824,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             const replica = @fieldParentPtr(Replica, "journal", self);
             const op = read.op;
             const checksum = read.checksum;
-            assert(self.recovered);
+            assert(self.status == .recovered);
 
             defer {
                 replica.message_bus.unref(read.message);
@@ -923,12 +927,11 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         }
 
         pub fn recover(self: *Self) void {
-            assert(!self.recovered);
-            assert(!self.recovering);
+            assert(self.status == .init);
             assert(self.dirty.count == slot_count);
             assert(self.faulty.count == slot_count);
 
-            self.recovering = true;
+            self.status = .recovering;
 
             log.debug("{}: recover: recovering", .{self.replica});
 
@@ -938,8 +941,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         fn recover_headers(self: *Self, offset: u64) void {
             const replica = @fieldParentPtr(Replica, "journal", self);
 
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(self.dirty.count == slot_count);
             assert(self.faulty.count == slot_count);
 
@@ -1000,8 +1002,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
                 buffer.len,
             });
 
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(offset % @sizeOf(Header) == 0);
             assert(buffer.len >= @sizeOf(Header));
             assert(buffer.len % @sizeOf(Header) == 0);
@@ -1038,8 +1039,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
 
         fn recover_prepares(self: *Self, slot: Slot) void {
             const replica = @fieldParentPtr(Replica, "journal", self);
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(self.dirty.count == slot_count);
             assert(self.faulty.count == slot_count);
             // We expect that no other process is issuing reads while we are recovering.
@@ -1086,8 +1086,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             const self = read.self;
             const replica = @fieldParentPtr(Replica, "journal", self);
 
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(self.dirty.count == slot_count);
             assert(self.faulty.count == slot_count);
             assert(read.destination_replica == null);
@@ -1179,8 +1178,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         fn recover_slots(self: *Self) void {
             const replica = @fieldParentPtr(Replica, "journal", self);
 
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(self.reads.executing() == 0);
             assert(self.writes.executing() == 0);
             assert(self.dirty.count == slot_count);
@@ -1233,8 +1231,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
                 self.faulty.count,
             });
 
-            self.recovered = true;
-            self.recovering = false;
+            self.status = .recovered;
             self.assert_recovered();
             // From here it's over to the Recovery protocol from VRR 2012.
         }
@@ -1252,8 +1249,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         fn recover_torn_prepare(self: *const Self, cases: []const *const Case) ?Slot {
             const replica = @fieldParentPtr(Replica, "journal", self);
 
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(self.dirty.count == slot_count);
             assert(self.faulty.count == slot_count);
 
@@ -1333,8 +1329,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
             const replica = @fieldParentPtr(Replica, "journal", self);
             const cluster = replica.cluster;
 
-            assert(!self.recovered);
-            assert(self.recovering);
+            assert(self.status == .recovering);
             assert(self.dirty.bit(slot));
             assert(self.faulty.bit(slot));
 
@@ -1418,8 +1413,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         fn assert_recovered(self: *const Self) void {
             const replica = @fieldParentPtr(Replica, "journal", self);
 
-            assert(self.recovered);
-            assert(!self.recovering);
+            assert(self.status == .recovered);
 
             assert(self.dirty.count <= slot_count);
             assert(self.faulty.count <= slot_count);
@@ -1453,7 +1447,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         /// Removes entries from `op_min` (inclusive) onwards.
         /// Used after a view change to remove uncommitted entries discarded by the new leader.
         pub fn remove_entries_from(self: *Self, op_min: u64) void {
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(op_min > 0);
 
             log.debug("{}: remove_entries_from: op_min={}", .{ self.replica, op_min });
@@ -1497,7 +1491,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         }
 
         pub fn set_header_as_dirty(self: *Self, header: *const Header) void {
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(header.command == .prepare);
 
             log.debug("{}: set_header_as_dirty: op={} checksum={}", .{
@@ -1533,7 +1527,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         ) void {
             const replica = @fieldParentPtr(Replica, "journal", self);
 
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(message.header.command == .prepare);
             assert(message.header.size >= @sizeOf(Header));
             assert(message.header.size <= message.buffer.len);
@@ -1597,7 +1591,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         fn write_prepare_header(write: *Self.Write) void {
             const self = write.self;
             const message = write.message;
-            assert(self.recovered);
+            assert(self.status == .recovered);
 
             {
                 // `prepare_inhabited[slot.index]` is usually false here, but may be true if two
@@ -1641,7 +1635,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         }
 
         fn write_prepare_on_lock_header_sector(self: *Self, write: *Write) void {
-            assert(self.recovered);
+            assert(self.status == .recovered);
             assert(write.header_sector_locked);
 
             // TODO It's possible within this section that the header has since been replaced but we


### PR DESCRIPTION
- The invalid state `recovering && recovered` is no longer representable.
- This condenses two state checks to one.
- It corresponds better to Replica's own Status.