### PR TITLE
LSM/Compaction: Sync block flushes at filter/index

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -502,6 +502,8 @@ pub fn CompactionType(
             // Finalize the data block if it's full or if it contains pending values when there's
             // no more left to merge.
             if (compaction.table_builder.data_block_full() or
+                compaction.table_builder.filter_block_full() or
+                compaction.table_builder.index_block_full() or
                 (merge_iterator.empty() and !compaction.table_builder.data_block_empty()))
             {
                 compaction.table_builder.data_block_finish(.{
@@ -518,6 +520,7 @@ pub fn CompactionType(
             // Finalize the filter block if it's full or if it contains pending data blocks
             // when there's no more merged values to fill them.
             if (compaction.table_builder.filter_block_full() or
+                compaction.table_builder.index_block_full() or
                 (merge_iterator.empty() and !compaction.table_builder.filter_block_empty()))
             {
                 compaction.table_builder.filter_block_finish(.{

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -638,6 +638,7 @@ pub fn TableType(
 
             pub fn filter_block_finish(builder: *Builder, options: FilterFinishOptions) void {
                 assert(!builder.filter_block_empty());
+                assert(builder.data_block_empty());
                 assert(options.address > 0);
 
                 const header_bytes = builder.filter_block[0..@sizeOf(vsr.Header)];
@@ -680,6 +681,8 @@ pub fn TableType(
 
             pub fn index_block_finish(builder: *Builder, options: IndexFinishOptions) TableInfo {
                 assert(options.address > 0);
+                assert(builder.filter_block_empty());
+                assert(builder.data_block_empty());
                 assert(builder.data_block_count > 0);
                 assert(builder.value == 0);
                 assert(builder.data_blocks_in_filter == 0);


### PR DESCRIPTION
A data block cannot span multiple filter blocks (or index blocks!), so when the filter block is flushed, there cannot be a partial data block.

A filter block cannot span multiple index blocks, so when the index block is flushed, there cannot be a partial filter block.