### PR TITLE
Add support for Tracy 0.9 as a tracing backend.

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -139,6 +139,10 @@ jobs:
       - run: zig/zig build build_benchmark_ewah
       - run: zig/zig build build_benchmark_eytzinger
       - run: zig/zig build build_benchmark_segmented_array
+      - run: zig/zig build -Dtracer-backend=perfetto
+      - run: git submodule init -- tools/tracy
+      - run: git submodule update -- tools/tracy
+      - run: zig/zig build -Dtracer-backend=tracy
 
   build-and-push:
     name: 'Build and push Docker image'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/clients/java/src/zig/lib/jui"]
 	path = src/clients/java/src/zig/lib/jui
 	url = https://github.com/zig-java/jui.git
+[submodule "tools/tracy"]
+	path = tools/tracy
+	url = https://github.com/wolfpld/tracy.git

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -26,6 +26,11 @@ const vsr = @import("tigerbeetle/src/vsr.zig");
 const Header = vsr.Header;
 const Client = vsr.Client(StateMachine, MessageBus);
 
+// TODO(jamii)
+// This is a hack used to work around the absence of tigerbeetle_build_options.
+// This should be removed once the node client is built using `zig build`.
+pub const tracer_backend: enum { none, perfetto, tracy } = .none;
+
 // Since this is running in application space, log only critical messages to reduce noise.
 pub const log_level: std.log.Level = .err;
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -122,7 +122,7 @@ pub fn CompactionType(
             done,
         };
 
-        tree_name: []const u8,
+        tree_name: [:0]const u8,
 
         grid: *Grid,
         grid_reservation: Grid.Reservation,
@@ -161,7 +161,7 @@ pub fn CompactionType(
 
         tracer_slot: ?tracer.SpanStart = null,
 
-        pub fn init(allocator: mem.Allocator, tree_name: []const u8) !Compaction {
+        pub fn init(allocator: mem.Allocator, tree_name: [:0]const u8) !Compaction {
             var iterator_a = try IteratorA.init(allocator);
             errdefer iterator_a.deinit(allocator);
 
@@ -355,6 +355,7 @@ pub fn CompactionType(
                     .tree_name = compaction.tree_name,
                     .level_b = compaction.level_b,
                 } },
+                @src(),
             );
 
             // Generate fake IO to make sure io_pending doesn't reach zero multiple times from
@@ -433,6 +434,7 @@ pub fn CompactionType(
                     .tree_name = compaction.tree_name,
                     .level_b = compaction.level_b,
                 } },
+                @src(),
             );
 
             // Create the merge iterator only when we can peek() from the read iterators.

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -120,7 +120,7 @@ comptime {
 fn IndexTreeType(
     comptime Storage: type,
     comptime Field: type,
-    comptime tree_name: []const u8,
+    comptime tree_name: [:0]const u8,
 ) type {
     const Key = CompositeKey(IndexCompositeKeyType(Field));
     const Table = TableType(

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -67,7 +67,7 @@ pub const compaction_tables_output_max = compaction_tables_input_max;
 /// The maximum number of concurrent compactions (per tree).
 pub const compactions_max = div_ceil(config.lsm_levels, 2);
 
-pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_name: []const u8) type {
+pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_name: [:0]const u8) type {
     const Key = TreeTable.Key;
     const Value = TreeTable.Value;
     const compare_keys = TreeTable.compare_keys;
@@ -557,6 +557,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 &tree.tracer_slot,
                 .{ .tree = .{ .tree_name = tree_name } },
                 .{ .tree_compaction_beat = .{ .tree_name = tree_name } },
+                @src(),
             );
 
             tree.compaction_callback = callback;

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -229,6 +229,8 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 &self.tracer_slot,
                 .main,
                 .state_machine_prefetch,
+
+                @src(),
             );
 
             self.prefetch_input = input;
@@ -391,6 +393,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 &self.tracer_slot,
                 .main,
                 .state_machine_commit,
+                @src(),
             );
 
             const result = switch (operation) {
@@ -420,6 +423,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 &self.tracer_slot,
                 .main,
                 .state_machine_compact,
+                @src(),
             );
 
             self.compact_callback = callback;

--- a/src/tracer.zig
+++ b/src/tracer.zig
@@ -3,7 +3,7 @@
 //! In order to create event spans, you need somewhere to store the `SpanStart`.
 //!
 //!     var slot: ?SpanStart = null;
-//!     tracer.start(&slot, group, event);
+//!     tracer.start(&slot, group, event, @src());
 //!     ... do stuff ...
 //!     tracer.end(&slot, group, event);
 //!
@@ -12,23 +12,23 @@
 //! and you must end every event.
 //!
 //!     // good
-//!     tracer.start(&slot, group_a, event_a);
+//!     tracer.start(&slot, group_a, event_a, @src());
 //!     tracer.end(&slot, group_a, event_a);
-//!     tracer.start(&slot, group_b, event_b);
+//!     tracer.start(&slot, group_b, event_b, @src());
 //!     tracer.end(&slot, group_b, event_b);
 //!
 //!     // bad
-//!     tracer.start(&slot, group_a, event_a);
-//!     tracer.start(&slot, group_b, event_b);
+//!     tracer.start(&slot, group_a, event_a, @src());
+//!     tracer.start(&slot, group_b, event_b, @src());
 //!     tracer.end(&slot, group_b, event_b);
 //!     tracer.end(&slot, group_a, event_a);
 //!
 //!     // bad
 //!     tracer.end(&slot, group_a, event_a);
-//!     tracer.start(&slot, group_a, event_a);
+//!     tracer.start(&slot, group_a, event_a, @src());
 //!
 //!     // bad
-//!     tracer.start(&slot, group_a, event_a);
+//!     tracer.start(&slot, group_a, event_a, @src());
 //!     std.os.exit(0);
 //!
 //! Before freeing a slot, you should `assert(slot == null)`
@@ -61,16 +61,7 @@ const log = std.log.scoped(.tracer);
 
 const config = @import("./config.zig");
 const Time = @import("./time.zig").Time;
-
-var is_initialized = false;
-var timer = Time{};
-var span_id_next: u64 = 0;
-var spans: std.ArrayList(Span) = undefined;
-var flush_slot: ?SpanStart = null;
-var log_file: std.fs.File = undefined;
-
-const span_count_max = 1 << 20;
-const log_path = "./tracer.json";
+const util = @import("util.zig");
 
 /// All strings in Event must be comptime constants to ensure that they live until after `tracer.deinit` is called.
 pub const Event = union(enum) {
@@ -93,6 +84,37 @@ pub const Event = union(enum) {
         tree_name: []const u8,
         level_b: u8,
     },
+
+    pub fn format(
+        event: Event,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+
+        switch (event) {
+            .tracer_flush => try writer.print("tracer_flush", .{}),
+            .commit => |commit| try writer.print("commit({})", .{commit.op}),
+            .checkpoint => try writer.print("checkpoint", .{}),
+            .state_machine_prefetch => try writer.print("state_machine_prefetch", .{}),
+            .state_machine_commit => try writer.print("state_machine_commit", .{}),
+            .state_machine_compact => try writer.print("state_machine_compact", .{}),
+            .tree_compaction_beat => |tree_compaction_tick| try writer.print(
+                "tree_compaction_beat({s})",
+                .{tree_compaction_tick.tree_name},
+            ),
+            .tree_compaction_tick => |tree_compaction_tick| try writer.print(
+                "tree_compaction_tick({s}, {})",
+                .{ tree_compaction_tick.tree_name, tree_compaction_tick.level_b },
+            ),
+            .tree_compaction_merge => |tree_compaction_merge| try writer.print(
+                "tree_compaction_merge({s}, {})",
+                .{ tree_compaction_merge.tree_name, tree_compaction_merge.level_b },
+            ),
+        }
+    }
 };
 
 /// All strings in EventGroup must be comptime constants to ensure that they live until after `tracer.deinit` is called.
@@ -100,220 +122,386 @@ pub const EventGroup = union(enum) {
     main,
     tracer,
     tree: struct {
-        tree_name: []const u8,
+        tree_name: [:0]const u8,
     },
+
+    fn name(event_group: EventGroup) [:0]const u8 {
+        return switch (event_group) {
+            .main => "main",
+            .tracer => "tracer",
+            .tree => |tree| tree.tree_name,
+        };
+    }
 };
 
-const SpanId = u64;
-
-pub const SpanStart = struct {
-    id: SpanId,
-    start_time_ns: u64,
-    group: EventGroup,
-    event: Event,
+usingnamespace switch (config.tracer_backend) {
+    .none => TracerNone,
+    .perfetto => TracerPerfetto,
+    .tracy => TracerTracy,
 };
 
-const Span = struct {
-    id: SpanId,
-    start_time_ns: u64,
-    end_time_ns: u64,
-    group: EventGroup,
-    event: Event,
+pub const TracerNone = struct {
+    pub const SpanStart = void;
+    pub fn init(allocator: Allocator) !void {
+        _ = allocator;
+    }
+    pub fn deinit(allocator: Allocator) void {
+        _ = allocator;
+    }
+    pub fn start(
+        slot: *?SpanStart,
+        event_group: EventGroup,
+        event: Event,
+        src: std.builtin.SourceLocation,
+    ) void {
+        _ = src;
+        _ = slot;
+        _ = event_group;
+        _ = event;
+    }
+    pub fn end(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
+        _ = slot;
+        _ = event_group;
+        _ = event;
+    }
+    pub fn flush() void {}
 };
 
-pub fn init(allocator: Allocator) !void {
-    if (config.tracer_backend == .none) return;
-    assert(!is_initialized);
+pub const TracerPerfetto = struct {
+    var is_initialized = false;
+    var timer = Time{};
+    var span_id_next: u64 = 0;
+    var spans: std.ArrayList(Span) = undefined;
+    var flush_slot: ?SpanStart = null;
+    var log_file: std.fs.File = undefined;
 
-    spans = try std.ArrayList(Span).initCapacity(allocator, span_count_max);
-    errdefer spans.deinit();
+    const span_count_max = 1 << 20;
+    const log_path = "./tracer.json";
 
-    switch (config.tracer_backend) {
-        .none => unreachable,
-        .perfetto => {
-            log_file = try std.fs.cwd().createFile(log_path, .{ .truncate = true });
-            errdefer log_file.close();
+    const SpanId = u64;
 
-            try log_file.writeAll(
-                \\{"traceEvents":[
-                \\
-            );
-        },
+    pub const SpanStart = struct {
+        id: SpanId,
+        start_time_ns: u64,
+        group: EventGroup,
+        event: Event,
+    };
+
+    const Span = struct {
+        id: SpanId,
+        start_time_ns: u64,
+        end_time_ns: u64,
+        group: EventGroup,
+        event: Event,
+    };
+
+    pub fn init(allocator: Allocator) !void {
+        assert(!is_initialized);
+
+        spans = try std.ArrayList(Span).initCapacity(allocator, span_count_max);
+        errdefer spans.deinit();
+
+        log_file = try std.fs.cwd().createFile(log_path, .{ .truncate = true });
+        errdefer log_file.close();
+
+        try log_file.writeAll(
+            \\{"traceEvents":[
+            \\
+        );
+
+        is_initialized = true;
     }
 
-    is_initialized = true;
-}
+    pub fn deinit(allocator: Allocator) void {
+        _ = allocator;
 
-pub fn deinit(allocator: Allocator) void {
-    _ = allocator;
+        assert(is_initialized);
 
-    if (config.tracer_backend == .none) return;
-    assert(is_initialized);
+        flush();
+        log_file.close();
+        assert(flush_slot == null);
+        spans.deinit();
+        is_initialized = false;
+    }
 
-    flush();
-    log_file.close();
-    assert(flush_slot == null);
-    spans.deinit();
-    is_initialized = false;
-}
+    pub fn start(
+        slot: *?SpanStart,
+        event_group: EventGroup,
+        event: Event,
+        src: std.builtin.SourceLocation,
+    ) void {
+        _ = src;
+        assert(is_initialized);
 
-pub fn start(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
-    if (config.tracer_backend == .none) return;
-    assert(is_initialized);
+        // The event must not have already been started.
+        assert(slot.* == null);
 
-    // The event must not have already been started.
-    assert(slot.* == null);
+        slot.* = .{
+            .id = span_id_next,
+            .start_time_ns = timer.monotonic(),
+            .group = event_group,
+            .event = event,
+        };
+        span_id_next += 1;
+    }
 
-    slot.* = .{
-        .id = span_id_next,
-        .start_time_ns = timer.monotonic(),
-        .group = event_group,
-        .event = event,
-    };
-    span_id_next += 1;
-}
+    pub fn end(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
+        assert(is_initialized);
 
-pub fn end(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
-    if (config.tracer_backend == .none) return;
-    assert(is_initialized);
+        // The event must have already been started.
+        const span_start = &slot.*.?;
+        assert(std.meta.eql(span_start.group, event_group));
+        assert(std.meta.eql(span_start.event, event));
 
-    // The event must have already been started.
-    const span_start = &slot.*.?;
-    assert(std.meta.eql(span_start.group, event_group));
-    assert(std.meta.eql(span_start.event, event));
+        // Make sure we have room in spans.
+        if (spans.items.len >= span_count_max) flush();
+        assert(spans.items.len < span_count_max);
 
-    // Make sure we have room in spans.
-    if (spans.items.len >= span_count_max) flush();
-    assert(spans.items.len < span_count_max);
+        spans.appendAssumeCapacity(.{
+            .id = span_start.id,
+            .start_time_ns = span_start.start_time_ns,
+            .end_time_ns = timer.monotonic(),
+            .group = span_start.group,
+            .event = span_start.event,
+        });
+        slot.* = null;
+    }
 
-    spans.appendAssumeCapacity(.{
-        .id = span_start.id,
-        .start_time_ns = span_start.start_time_ns,
-        .end_time_ns = timer.monotonic(),
-        .group = span_start.group,
-        .event = span_start.event,
-    });
-    slot.* = null;
-}
+    pub fn flush() void {
+        assert(is_initialized);
 
-pub fn flush() void {
-    if (config.tracer_backend == .none) return;
-    assert(is_initialized);
+        if (spans.items.len == 0) return;
 
-    if (spans.items.len == 0) return;
+        start(&flush_slot, .tracer, .tracer_flush, @src());
+        flush_or_err() catch |err| {
+            log.err("Could not flush tracer log, discarding instead: {}", .{err});
+        };
+        spans.shrinkRetainingCapacity(0);
+        end(&flush_slot, .tracer, .tracer_flush);
+    }
 
-    start(&flush_slot, .tracer, .tracer_flush);
-    flush_or_err() catch |err| {
-        log.err("Could not flush tracer log, discarding instead: {}", .{err});
-    };
-    spans.shrinkRetainingCapacity(0);
-    end(&flush_slot, .tracer, .tracer_flush);
-}
+    fn flush_or_err() !void {
+        for (spans.items) |span| {
+            // Perfetto requires this json format:
+            // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+            const NameJson = struct {
+                event: Event,
 
-fn flush_or_err() !void {
-    switch (config.tracer_backend) {
-        .none => unreachable,
-        .perfetto => {
-            for (spans.items) |span| {
-                // Perfetto requires this json format:
-                // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-                const NameJson = struct {
-                    event: Event,
-
-                    pub fn jsonStringify(
-                        name_json: @This(),
-                        options: std.json.StringifyOptions,
-                        writer: anytype,
-                    ) @TypeOf(writer).Error!void {
-                        _ = options;
-                        try writer.writeAll("\"");
-                        switch (name_json.event) {
-                            .tracer_flush => try writer.print("tracer_flush", .{}),
-                            .commit => |commit| try writer.print(
-                                "commit({})",
-                                .{commit.op},
-                            ),
-                            .checkpoint => try writer.print("checkpoint", .{}),
-                            .state_machine_prefetch => try writer.print("state_machine_prefetch", .{}),
-                            .state_machine_commit => try writer.print("state_machine_commit", .{}),
-                            .state_machine_compact => try writer.print("state_machine_compact", .{}),
-                            .tree_compaction_beat => |tree_compaction_tick| try writer.print(
-                                "tree_compaction_beat({s})",
-                                .{tree_compaction_tick.tree_name},
-                            ),
-                            .tree_compaction_tick => |tree_compaction_tick| try writer.print(
-                                "tree_compaction_tick({s}, {})",
-                                .{ tree_compaction_tick.tree_name, tree_compaction_tick.level_b },
-                            ),
-                            .tree_compaction_merge => |tree_compaction_merge| try writer.print(
-                                "tree_compaction_merge({s}, {})",
-                                .{ tree_compaction_merge.tree_name, tree_compaction_merge.level_b },
-                            ),
-                        }
-                        try writer.writeAll("\"");
-                    }
-                };
-                const SpanJson = struct {
-                    name: NameJson,
-                    cat: []const u8 = "default",
-                    ph: []const u8 = "X",
-                    ts: f64,
-                    dur: f64,
-                    pid: u64 = 0,
-                    tid: u64,
-                };
-                const MetaJson = struct {
+                pub fn jsonStringify(
+                    name_json: @This(),
+                    options: std.json.StringifyOptions,
+                    writer: anytype,
+                ) @TypeOf(writer).Error!void {
+                    _ = options;
+                    try writer.writeAll("\"");
+                    try writer.print("{}", .{name_json.event});
+                    try writer.writeAll("\"");
+                }
+            };
+            const SpanJson = struct {
+                name: NameJson,
+                cat: []const u8 = "default",
+                ph: []const u8 = "X",
+                ts: f64,
+                dur: f64,
+                pid: u64 = 0,
+                tid: u64,
+            };
+            const MetaJson = struct {
+                name: []const u8,
+                ph: []const u8 = "M",
+                pid: u64 = 0,
+                tid: u64,
+                args: struct {
                     name: []const u8,
-                    ph: []const u8 = "M",
-                    pid: u64 = 0,
-                    tid: u64,
-                    args: struct {
-                        name: []const u8,
-                    },
-                };
+                },
+            };
 
-                const group_name = switch (span.group) {
-                    .main => "main",
-                    .tracer => "tracer",
-                    .tree => |tree| tree.tree_name,
-                };
+            const tid_64 = switch (span.group) {
+                .main => 0,
+                .tracer => 1,
+                .tree => |tree| std.hash_map.hashString(tree.tree_name),
+            };
+            const tid = @truncate(u32, tid_64) ^ @truncate(u32, tid_64 >> 32);
 
-                const tid_64 = switch (span.group) {
-                    .main => 0,
-                    .tracer => 1,
-                    .tree => |tree| std.hash_map.hashString(tree.tree_name),
-                };
-                const tid = @truncate(u32, tid_64) ^ @truncate(u32, tid_64 >> 32);
+            var buffered_writer = std.io.bufferedWriter(log_file.writer());
+            const writer = buffered_writer.writer();
 
-                var buffered_writer = std.io.bufferedWriter(log_file.writer());
-                const writer = buffered_writer.writer();
+            try std.json.stringify(
+                SpanJson{
+                    .name = .{ .event = span.event },
+                    .ts = @intToFloat(f64, span.start_time_ns) / 1000,
+                    .dur = @intToFloat(f64, span.end_time_ns - span.start_time_ns) / 1000,
+                    .tid = tid,
+                },
+                .{},
+                writer,
+            );
+            try writer.writeAll(",\n");
 
-                try std.json.stringify(
-                    SpanJson{
-                        .name = .{ .event = span.event },
-                        .ts = @intToFloat(f64, span.start_time_ns) / 1000,
-                        .dur = @intToFloat(f64, span.end_time_ns - span.start_time_ns) / 1000,
-                        .tid = tid,
-                    },
-                    .{},
-                    writer,
-                );
-                try writer.writeAll(",\n");
+            // TODO Only emit metadata once per group name.
+            try std.json.stringify(
+                MetaJson{
+                    .name = "thread_name",
+                    .tid = tid,
+                    .args = .{ .name = span.group.name() },
+                },
+                .{},
+                writer,
+            );
+            try writer.writeAll(",\n");
 
-                // TODO Only emit metadata once per group name.
-                try std.json.stringify(
-                    MetaJson{
-                        .name = "thread_name",
-                        .tid = tid,
-                        .args = .{ .name = group_name },
-                    },
-                    .{},
-                    writer,
-                );
-                try writer.writeAll(",\n");
-
-                try buffered_writer.flush();
-            }
-        },
+            try buffered_writer.flush();
+        }
     }
-}
+};
+
+const TracerTracy = struct {
+    const c = @cImport({
+        @cDefine("TRACY_ENABLE", "1");
+        @cDefine("TRACY_FIBERS", "1");
+        @cInclude("TracyC.h");
+    });
+
+    // TODO Ask config.zig for a static bound on callstack depth.
+    const callstack_depth = 64;
+
+    pub const SpanStart = c.___tracy_c_zone_context;
+
+    var print_buffer: [1024]u8 = undefined;
+
+    pub fn init(allocator: Allocator) !void {
+        _ = allocator;
+    }
+
+    pub fn deinit(allocator: Allocator) void {
+        _ = allocator;
+    }
+
+    pub fn start(
+        slot: *?SpanStart,
+        event_group: EventGroup,
+        event: Event,
+        src: std.builtin.SourceLocation,
+    ) void {
+        // The event must not already have been started.
+        assert(slot.* == null);
+        c.___tracy_fiber_enter(event_group.name());
+        const name = std.fmt.bufPrint(&print_buffer, "{}", .{event}) catch name: {
+            const dots = "...";
+            util.copy_disjoint(.exact, u8, print_buffer[print_buffer.len - dots.len ..], dots);
+            break :name &print_buffer;
+        };
+        // TODO The alloc_srcloc here is not free and should be unnecessary,
+        //      but the alloc-free version currently crashes:
+        //      https://github.com/ziglang/zig/issues/13315#issuecomment-1331099909.
+        slot.* = c.___tracy_emit_zone_begin_alloc_callstack(c.___tracy_alloc_srcloc_name(
+            src.line,
+            src.file.ptr,
+            src.file.len,
+            src.fn_name.ptr,
+            src.fn_name.len,
+            name.ptr,
+            name.len,
+        ), callstack_depth, 1);
+    }
+
+    pub fn end(slot: *?SpanStart, event_group: EventGroup, event: Event) void {
+        _ = event;
+
+        // The event must already have been started.
+        const tracy_context = slot.*.?;
+        c.___tracy_fiber_enter(event_group.name());
+        c.___tracy_emit_zone_end(tracy_context);
+        slot.* = null;
+    }
+
+    pub fn flush() void {}
+
+    pub fn log_fn(
+        comptime level: std.log.Level,
+        comptime scope: @TypeOf(.EnumLiteral),
+        comptime format: []const u8,
+        args: anytype,
+    ) void {
+        const level_text = comptime level.asText();
+        const prefix = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+        const message = std.fmt.bufPrint(
+            &print_buffer,
+            level_text ++ prefix ++ format,
+            args,
+        ) catch message: {
+            const dots = "...";
+            util.copy_disjoint(.exact, u8, print_buffer[print_buffer.len - dots.len ..], dots);
+            break :message &print_buffer;
+        };
+        c.___tracy_fiber_enter((EventGroup{ .main = {} }).name());
+        c.___tracy_emit_message(message.ptr, message.len, callstack_depth);
+    }
+
+    // Copied from zig/src/tracy.zig
+    pub const TracerAllocator = struct {
+        parent_allocator: std.mem.Allocator,
+
+        pub fn init(parent_allocator: std.mem.Allocator) TracerAllocator {
+            return .{
+                .parent_allocator = parent_allocator,
+            };
+        }
+
+        pub fn allocator(self: *TracerAllocator) std.mem.Allocator {
+            return std.mem.Allocator.init(self, allocFn, resizeFn, freeFn);
+        }
+
+        fn allocFn(
+            self: *TracerAllocator,
+            len: usize,
+            ptr_align: u29,
+            len_align: u29,
+            ret_addr: usize,
+        ) std.mem.Allocator.Error![]u8 {
+            const result = self.parent_allocator.rawAlloc(len, ptr_align, len_align, ret_addr);
+            if (result) |data| {
+                if (data.len != 0) {
+                    c.___tracy_emit_memory_alloc_callstack(data.ptr, data.len, callstack_depth, 0);
+                }
+            } else |_| {}
+            return result;
+        }
+
+        fn resizeFn(
+            self: *TracerAllocator,
+            buf: []u8,
+            buf_align: u29,
+            new_len: usize,
+            len_align: u29,
+            ret_addr: usize,
+        ) ?usize {
+            if (self.parent_allocator.rawResize(
+                buf,
+                buf_align,
+                new_len,
+                len_align,
+                ret_addr,
+            )) |resized_len| {
+                c.___tracy_emit_memory_free_callstack(buf.ptr, callstack_depth, 0);
+                c.___tracy_emit_memory_alloc_callstack(buf.ptr, resized_len, callstack_depth, 0);
+
+                return resized_len;
+            }
+
+            // during normal operation the compiler hits this case thousands of times due to this
+            // emitting messages for it is both slow and causes clutter
+            return null;
+        }
+
+        fn freeFn(self: *TracerAllocator, buf: []u8, buf_align: u29, ret_addr: usize) void {
+            self.parent_allocator.rawFree(buf, buf_align, ret_addr);
+            // this condition is to handle free being called on an empty slice that was never even allocated
+            // example case: `std.process.getSelfExeSharedLibPaths` can return `&[_][:0]u8{}`
+            if (buf.len != 0) {
+                c.___tracy_emit_memory_free_callstack(buf.ptr, callstack_depth, 0);
+            }
+        }
+    };
+};

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2524,6 +2524,7 @@ pub fn ReplicaType(
                 &self.tracer_slot_commit,
                 .main,
                 .{ .commit = .{ .op = prepare.header.op } },
+                @src(),
             );
 
             self.commit_prepare = prepare.ref();
@@ -2608,6 +2609,7 @@ pub fn ReplicaType(
                     &self.tracer_slot_checkpoint,
                     .main,
                     .checkpoint,
+                    @src(),
                 );
                 self.state_machine.checkpoint(commit_op_checkpoint_state_machine_callback);
             } else {


### PR DESCRIPTION
* Add a new tracer backend for https://github.com/wolfpld/tracy. The client is only linked when tb is built with `-Dtracer-backend=tracy`.
* If the tracy backend is enabled, divert logging and allocation statistics to tracy.
* Build the tracer backends in CI, to prevent accidental breakage.

https://user-images.githubusercontent.com/340884/204653140-da12df47-bd1a-481e-9715-d25428ab5b3d.mp4
