### PR TITLE
LSM/Manifest: Don't assert table precedence

### DIFF
--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -279,8 +279,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             key: Key,
             level: u8 = 0,
             inner: ?Level.Iterator = null,
-            // Verifies that we never check a newer table after an older one.
-            precedence: ?u64 = null,
 
             pub fn next(it: *LookupIterator) ?*const TableInfo {
                 while (it.level < config.lsm_levels) : (it.level += 1) {
@@ -294,9 +292,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                     );
 
                     if (inner.next()) |table| {
-                        if (it.precedence) |p| assert(p > table.snapshot_min);
-                        it.precedence = table.snapshot_min;
-
                         assert(table.visible(it.snapshot));
                         assert(compare_keys(it.key, table.key_min) != .lt);
                         assert(compare_keys(it.key, table.key_max) != .gt);


### PR DESCRIPTION
Fixes https://github.com/tigerbeetledb/tigerbeetle/issues/240

This fixes a safety-check failure in the [manifest](https://github.com/tigerbeetledb/tigerbeetle/blob/a95201d8522605a932c472b806c2792ea4206c39/src/lsm/manifest.zig#L295) by removing the assertion:

    if (it.precedence) |p| assert(p > table.snapshot_min);

(For context, during a point-lookup we first check level 0. If it misses, check level 1. (Then repeat down the tree until a key-hit or the bottom of the tree).) This check verifies that we check level `A` then level `A+1`, then the table on level `A+1` must be older.

But a TableInfo's snapshot doesn't reflect the "age" of the values in the table (when the value was inserted into the tree) — tables are rewritten by compaction, and each rewrite increases the `snapshot_min`. Consider this example:

  1. At level 0 we have 2 tables: `T₀` covers key `a`, and `T₁` covers key `b`.
  2. At level 1 we have 1 table, covering keys `a` and `b`.
  3. Compact `T₀` into level 1.
  4. Now query key `b`. Assuming it doesn't exist in `T₁`, we query the new table on level-1. This violates the precedence rule, but I think is the correct behavior.

More generally, if `X.snapshot_min < Y.snapshot_min`, the updates in `X` are not necessarily older than the updates in `Y`.