### PR TITLE
Config: Rename "config" to "constants"

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
-const config = @import("constants.zig");
+const constants = @import("constants.zig");
 
 const log = std.log;
 pub const log_level: std.log.Level = .err;
@@ -14,7 +14,7 @@ const Storage = @import("storage.zig").Storage;
 const MessagePool = @import("message_pool.zig").MessagePool;
 const MessageBus = @import("message_bus.zig").MessageBusClient;
 const StateMachine = @import("state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 const RingBuffer = @import("ring_buffer.zig").RingBuffer;
 
@@ -26,7 +26,7 @@ const tb = @import("tigerbeetle.zig");
 const batches_count = 100;
 
 const transfers_per_batch: u32 = @divExact(
-    config.message_size_max - @sizeOf(vsr.Header),
+    constants.message_size_max - @sizeOf(vsr.Header),
     @sizeOf(tb.Transfer),
 );
 comptime {
@@ -78,7 +78,7 @@ pub fn main() !void {
 
     const client_id = std.crypto.random.int(u128);
     const cluster_id: u32 = 0;
-    var address = [_]std.net.Address{try std.net.Address.parseIp4("127.0.0.1", config.port)};
+    var address = [_]std.net.Address{try std.net.Address.parseIp4("127.0.0.1", constants.port)};
 
     var io = try IO.init(32, 0);
     defer io.deinit();

--- a/src/c/tb_client.zig
+++ b/src/c/tb_client.zig
@@ -26,11 +26,11 @@ pub const tb_completion_t = fn (
     result_len: u32,
 ) callconv(.C) void;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const Storage = @import("../storage.zig").Storage;
 const MessageBus = @import("../message_bus.zig").MessageBusClient;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 
 const ContextType = @import("tb_client/context.zig").ContextType;

--- a/src/c/tb_client/context.zig
+++ b/src/c/tb_client/context.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const os = std.os;
 const assert = std.debug.assert;
 
-const config = @import("../../constants.zig");
+const constants = @import("../../constants.zig");
 const log = std.log.scoped(.tb_client_context);
 
 const util = @import("../../util.zig");
@@ -122,7 +122,7 @@ pub fn ContextType(
             context.addresses = vsr.parse_addresses(
                 context.allocator,
                 addresses,
-                config.replicas_max,
+                constants.replicas_max,
             ) catch |err| return switch (err) {
                 error.AddressLimitExceeded => error.AddressLimitExceeded,
                 else => error.AddressInvalid,
@@ -165,7 +165,7 @@ pub fn ContextType(
             );
             errdefer context.client.deinit(context.allocator);
 
-            context.messages_available = config.client_request_queue_max;
+            context.messages_available = constants.client_request_queue_max;
             context.on_completion_ctx = on_completion_ctx;
             context.on_completion_fn = on_completion_fn;
             context.implementation = .{
@@ -199,7 +199,7 @@ pub fn ContextType(
         pub fn run(self: *Context) void {
             while (!self.thread.signal.is_shutdown()) {
                 self.tick();
-                self.io.run_for_ns(config.tick_ms * std.time.ns_per_ms) catch |err| {
+                self.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms) catch |err| {
                     log.err("{}: IO.run() failed: {s}", .{
                         self.client_id,
                         @errorName(err),
@@ -226,7 +226,7 @@ pub fn ContextType(
             }
 
             // Make sure the packet.data wouldn't overflow a message:
-            const writable = message.buffer[@sizeOf(Header)..][0..config.message_body_size_max];
+            const writable = message.buffer[@sizeOf(Header)..][0..constants.message_body_size_max];
             if (readable.len > writable.len) {
                 return self.on_complete(packet, error.TooMuchData);
             }
@@ -267,7 +267,7 @@ pub fn ContextType(
             result: PacketError![]const u8,
         ) void {
             self.messages_available += 1;
-            assert(self.messages_available <= config.client_request_queue_max);
+            assert(self.messages_available <= constants.client_request_queue_max);
 
             // Signal to resume sending requests that was waiting for available messages.
             if (self.messages_available == 1) self.thread.signal.notify();

--- a/src/c/tb_client/echo_client.zig
+++ b/src/c/tb_client/echo_client.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 
-const config = @import("../../constants.zig");
+const constants = @import("../../constants.zig");
 const vsr = @import("../../vsr.zig");
 const Header = vsr.Header;
 
@@ -24,7 +24,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
             };
         };
 
-        request_queue: RingBuffer(Self.Request, config.client_request_queue_max, .array) = .{},
+        request_queue: RingBuffer(Self.Request, constants.client_request_queue_max, .array) = .{},
         message_pool: *MessagePool,
 
         pub fn init(

--- a/src/c/tb_client/thread.zig
+++ b/src/c/tb_client/thread.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const config = @import("../../constants.zig");
 const log = std.log.scoped(.tb_client_thread);
 
 const Packet = @import("packet.zig").Packet;

--- a/src/c/test.zig
+++ b/src/c/test.zig
@@ -6,7 +6,7 @@ const testing = std.testing;
 const c = @cImport(@cInclude("tb_client.h"));
 
 const util = @import("../util.zig");
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const Packet = @import("tb_client/packet.zig").Packet;
 
 const Mutex = std.Thread.Mutex;
@@ -91,10 +91,10 @@ const Completion = struct {
 // 3. the data marshaling is correct, and exactly the same data sent was received back.
 test "c_client echo" {
     // Using the create_accounts operation for this test.
-    const RequestContext = RequestContextType(config.message_body_size_max);
+    const RequestContext = RequestContextType(constants.message_body_size_max);
     const create_accounts_operation: u8 = c.TB_OPERATION_CREATE_ACCOUNTS;
     const event_size = @sizeOf(c.tb_account_t);
-    const event_request_max = @divFloor(config.message_body_size_max, event_size);
+    const event_request_max = @divFloor(constants.message_body_size_max, event_size);
 
     // Initializing an echo client for testing purposes.
     // We ensure that the retry mechanism is being tested
@@ -103,7 +103,7 @@ test "c_client echo" {
     var tb_packet_list: c.tb_packet_list_t = undefined;
     const cluster_id = 0;
     const address = "3000";
-    const packets_count: u32 = config.client_request_queue_max * 2;
+    const packets_count: u32 = constants.client_request_queue_max * 2;
     const tb_context: usize = 42;
     const result = c.tb_client_init_echo(
         &tb_client,
@@ -221,7 +221,7 @@ test "c_client tb_status" {
     // More addresses thant "replicas_max" should return "TB_STATUS_ADDRESS_LIMIT_EXCEEDED":
     try assert_status(
         1,
-        ("3000," ** config.replicas_max) ++ "3001",
+        ("3000," ** constants.replicas_max) ++ "3001",
         c.TB_STATUS_ADDRESS_LIMIT_EXCEEDED,
     );
 
@@ -234,7 +234,7 @@ test "c_client tb_status" {
 
 // Asserts the validation rules associated with the "TB_PACKET_STATUS" enum.
 test "c_client tb_packet_status" {
-    const RequestContext = RequestContextType(config.message_body_size_max);
+    const RequestContext = RequestContextType(constants.message_body_size_max);
 
     var tb_client: c.tb_client_t = undefined;
     var tb_packet_list: c.tb_packet_list_t = undefined;
@@ -299,12 +299,12 @@ test "c_client tb_packet_status" {
 
     var packet_list = @ptrCast(*Packet.List, &tb_packet_list);
 
-    // Messages larger than config.message_body_size_max should return "too_much_data":
+    // Messages larger than constants.message_body_size_max should return "too_much_data":
     try assert_result(
         tb_client,
         packet_list,
         c.TB_OPERATION_CREATE_TRANSFERS,
-        config.message_body_size_max + @sizeOf(c.tb_transfer_t),
+        constants.message_body_size_max + @sizeOf(c.tb_transfer_t),
         c.TB_PACKET_TOO_MUCH_DATA,
     );
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -7,7 +7,7 @@ const meta = std.meta;
 const net = std.net;
 const os = std.os;
 
-const config = @import("constants.zig");
+const constants = @import("constants.zig");
 const tigerbeetle = @import("tigerbeetle.zig");
 const vsr = @import("vsr.zig");
 const IO = @import("io.zig").IO;
@@ -72,8 +72,8 @@ const usage = fmt.comptimePrint(
     \\  tigerbeetle version --verbose
     \\
 , .{
-    .default_address = config.address,
-    .default_port = config.port,
+    .default_address = constants.address,
+    .default_port = constants.port,
 });
 
 pub const Command = union(enum) {
@@ -206,17 +206,17 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
                     .cache_accounts = parse_size_to_count(
                         tigerbeetle.Account,
                         cache_accounts,
-                        config.cache_accounts_max,
+                        constants.cache_accounts_max,
                     ),
                     .cache_transfers = parse_size_to_count(
                         tigerbeetle.Transfer,
                         cache_transfers,
-                        config.cache_transfers_max,
+                        constants.cache_transfers_max,
                     ),
                     .cache_transfers_posted = parse_size_to_count(
                         u256, // TODO(#264): Use actual type here, once exposed.
                         cache_transfers_posted,
-                        config.cache_transfers_posted_max,
+                        constants.cache_transfers_posted_max,
                     ),
                     .path = path orelse fatal("required: <path>", .{}),
                 },
@@ -255,11 +255,11 @@ fn parse_cluster(raw_cluster: []const u8) u32 {
 
 /// Parse and allocate the addresses returning a slice into that array.
 fn parse_addresses(allocator: std.mem.Allocator, raw_addresses: []const u8) []net.Address {
-    return vsr.parse_addresses(allocator, raw_addresses, config.replicas_max) catch |err| switch (err) {
+    return vsr.parse_addresses(allocator, raw_addresses, constants.replicas_max) catch |err| switch (err) {
         error.AddressHasTrailingComma => fatal("--addresses: invalid trailing comma", .{}),
         error.AddressLimitExceeded => {
             fatal("--addresses: too many addresses, at most {d} are allowed", .{
-                config.replicas_max,
+                constants.replicas_max,
             });
         },
         error.AddressHasMoreThanOneColon => {
@@ -366,7 +366,7 @@ fn parse_size_to_count(comptime T: type, string_opt: ?[]const u8, comptime defau
 }
 
 fn parse_replica(raw_replica: []const u8) u8 {
-    comptime assert(config.replicas_max <= std.math.maxInt(u8));
+    comptime assert(constants.replicas_max <= std.math.maxInt(u8));
     const replica = fmt.parseUnsigned(u8, raw_replica, 10) catch |err| switch (err) {
         error.Overflow => fatal("--replica: value exceeds an 8-bit unsigned integer", .{}),
         error.InvalidCharacter => fatal("--replica: value contains an invalid character", .{}),

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -14,13 +14,13 @@ const CreateTransfersResult = tb.CreateTransfersResult;
 
 const Storage = @import("tigerbeetle/src/storage.zig").Storage;
 const StateMachine = @import("tigerbeetle/src/state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 const Operation = StateMachine.Operation;
 const MessageBus = @import("tigerbeetle/src/message_bus.zig").MessageBusClient;
 const MessagePool = @import("tigerbeetle/src/message_pool.zig").MessagePool;
 const IO = @import("tigerbeetle/src/io.zig").IO;
-const config = @import("tigerbeetle/src/constants.zig");
+const constants = @import("tigerbeetle/src/constants.zig");
 
 const vsr = @import("tigerbeetle/src/vsr.zig");
 const Header = vsr.Header;
@@ -46,7 +46,7 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
         env,
         exports,
         "tick_ms",
-        config.tick_ms,
+        constants.tick_ms,
         "failed to add tick_ms to exports",
     ) catch return null;
 
@@ -145,7 +145,7 @@ const Context = struct {
         context.message_pool = try MessagePool.init(allocator, .client);
         errdefer context.message_pool.deinit(allocator);
 
-        context.addresses = try vsr.parse_addresses(allocator, addresses_raw, config.replicas_max);
+        context.addresses = try vsr.parse_addresses(allocator, addresses_raw, constants.replicas_max);
         errdefer allocator.free(context.addresses);
         assert(context.addresses.len > 0);
 
@@ -242,7 +242,7 @@ fn decode_events_from_array(
     if (array_length < 1) return translate.throw(env, "Batch must contain at least one event.");
 
     const body_length = @sizeOf(T) * array_length;
-    if (@sizeOf(Header) + body_length > config.message_size_max) {
+    if (@sizeOf(Header) + body_length > constants.message_size_max) {
         return translate.throw(env, "Batch is larger than the maximum message size.");
     }
 

--- a/src/demo.zig
+++ b/src/demo.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const config = @import("constants.zig");
+const constants = @import("constants.zig");
 
 const tb = @import("tigerbeetle.zig");
 const Account = tb.Account;
@@ -16,7 +16,7 @@ const Storage = @import("storage.zig").Storage;
 const MessagePool = @import("message_pool.zig").MessagePool;
 const MessageBus = @import("message_bus.zig").MessageBusClient;
 const StateMachine = @import("state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 
 const vsr = @import("vsr.zig");
@@ -37,7 +37,7 @@ pub fn request(
     const allocator = std.heap.page_allocator;
     const client_id = std.crypto.random.int(u128);
     const cluster_id: u32 = 0;
-    var addresses = [_]std.net.Address{try std.net.Address.parseIp4("127.0.0.1", config.port)};
+    var addresses = [_]std.net.Address{try std.net.Address.parseIp4("127.0.0.1", constants.port)};
 
     var io = try IO.init(32, 0);
     defer io.deinit();
@@ -74,7 +74,7 @@ pub fn request(
 
     while (client.request_queue.count > 0) {
         client.tick();
-        try io.run_for_ns(config.tick_ms * std.time.ns_per_ms);
+        try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
 }
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -4,7 +4,7 @@ const mem = std.mem;
 const assert = std.debug.assert;
 const log = std.log.scoped(.io);
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const FIFO = @import("../fifo.zig").FIFO;
 const Time = @import("../time.zig").Time;
 const buffer_limit = @import("../io.zig").buffer_limit;
@@ -658,8 +658,8 @@ pub const IO = struct {
         must_create: bool,
     ) !os.fd_t {
         assert(relative_path.len > 0);
-        assert(size >= config.sector_size);
-        assert(size % config.sector_size == 0);
+        assert(size >= constants.sector_size);
+        assert(size % constants.sector_size == 0);
 
         // TODO Use O_EXCL when opening as a block device to obtain a mandatory exclusive lock.
         // This is much stronger than an advisory exclusive lock, and is required on some platforms.
@@ -694,7 +694,7 @@ pub const IO = struct {
 
         // On darwin assume that Direct I/O is always supported.
         // Use F_NOCACHE to disable the page cache as O_DIRECT doesn't exist.
-        if (config.direct_io) {
+        if (constants.direct_io) {
             _ = try os.fcntl(fd, os.F.NOCACHE, 1);
         }
 

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -7,7 +7,7 @@ const io_uring_cqe = linux.io_uring_cqe;
 const io_uring_sqe = linux.io_uring_sqe;
 const log = std.log.scoped(.io);
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const FIFO = @import("../fifo.zig").FIFO;
 const buffer_limit = @import("../io.zig").buffer_limit;
 
@@ -905,8 +905,8 @@ pub const IO = struct {
         must_create: bool,
     ) !os.fd_t {
         assert(relative_path.len > 0);
-        assert(size >= config.sector_size);
-        assert(size % config.sector_size == 0);
+        assert(size >= constants.sector_size);
+        assert(size % constants.sector_size == 0);
 
         // TODO Use O_EXCL when opening as a block device to obtain a mandatory exclusive lock.
         // This is much stronger than an advisory exclusive lock, and is required on some platforms.
@@ -918,11 +918,11 @@ pub const IO = struct {
         if (@hasDecl(os.O, "LARGEFILE")) flags |= os.O.LARGEFILE;
 
         var direct_io_supported = false;
-        if (config.direct_io) {
+        if (constants.direct_io) {
             direct_io_supported = try fs_supports_direct_io(dir_fd);
             if (direct_io_supported) {
                 flags |= os.O.DIRECT;
-            } else if (!config.direct_io_required) {
+            } else if (!constants.direct_io_required) {
                 log.warn("file system does not support Direct I/O", .{});
             } else {
                 // We require Direct I/O for safety to handle fsync failure correctly, and therefore
@@ -968,7 +968,7 @@ pub const IO = struct {
                     log.warn("file system does not support fallocate(), an ENOSPC will panic", .{});
                     log.info("allocating by writing to the last sector of the file instead...", .{});
 
-                    const sector_size = config.sector_size;
+                    const sector_size = constants.sector_size;
                     const sector: [sector_size]u8 align(sector_size) = [_]u8{0} ** sector_size;
 
                     // Handle partial writes where the physical sector is less than a logical sector:

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const os = std.os;
 const assert = std.debug.assert;
 const log = std.log.scoped(.io);
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const FIFO = @import("../fifo.zig").FIFO;
 const Time = @import("../time.zig").Time;
@@ -941,8 +941,8 @@ pub const IO = struct {
         must_create: bool,
     ) !os.fd_t {
         assert(relative_path.len > 0);
-        assert(size >= config.sector_size);
-        assert(size % config.sector_size == 0);
+        assert(size >= constants.sector_size);
+        assert(size % constants.sector_size == 0);
 
         const path_w = try os.windows.sliceToPrefixedFileW(relative_path);
 
@@ -1013,7 +1013,7 @@ pub const IO = struct {
                 log.warn("file system failed to preallocate the file memory", .{});
                 log.info("allocating by writing to the last sector of the file instead...", .{});
 
-                const sector_size = config.sector_size;
+                const sector_size = constants.sector_size;
                 const sector: [sector_size]u8 align(sector_size) = [_]u8{0} ** sector_size;
 
                 // Handle partial writes where the physical sector is less than a logical sector:

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -38,7 +38,7 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.compaction);
 const tracer = @import("../tracer.zig");
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const GridType = @import("grid.zig").GridType;
 const ManifestType = @import("manifest.zig").ManifestType;
@@ -226,17 +226,17 @@ pub fn CompactionType(
             assert(!compaction.merge_done and compaction.merge_iterator == null);
             assert(compaction.tracer_slot == null);
 
-            assert(op_min % @divExact(config.lsm_batch_multiple, 2) == 0);
+            assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
             assert(range.table_count > 0);
             if (table_a) |t| assert(t.visible(op_min));
 
-            assert(level_b < config.lsm_levels);
+            assert(level_b < constants.lsm_levels);
             assert((level_b == 0) == (table_a == null));
 
             // Levels may choose to drop tombstones if keys aren't included in the lower levels.
             // This invariant is always true for the last level as it doesn't have any lower ones.
             const drop_tombstones = manifest.compaction_must_drop_tombstones(level_b, range);
-            assert(drop_tombstones or level_b < config.lsm_levels - 1);
+            assert(drop_tombstones or level_b < constants.lsm_levels - 1);
 
             compaction.* = .{
                 .tree_name = compaction.tree_name,
@@ -625,11 +625,11 @@ pub fn CompactionType(
 }
 
 fn snapshot_max_for_table_input(op_min: u64) u64 {
-    assert(op_min % @divExact(config.lsm_batch_multiple, 2) == 0);
-    return op_min + @divExact(config.lsm_batch_multiple, 2) - 1;
+    assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
+    return op_min + @divExact(constants.lsm_batch_multiple, 2) - 1;
 }
 
 fn snapshot_min_for_table_output(op_min: u64) u64 {
-    assert(op_min % @divExact(config.lsm_batch_multiple, 2) == 0);
-    return op_min + @divExact(config.lsm_batch_multiple, 2);
+    assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
+    return op_min + @divExact(constants.lsm_batch_multiple, 2);
 }

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -4,11 +4,11 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 
 const GridType = @import("grid.zig").GridType;
-const NodePool = @import("node_pool.zig").NodePool(config.lsm_manifest_node_size, 16);
+const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 
 pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type {
     var groove_fields: []const std.builtin.TypeInfo.StructField = &.{};

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const free_set = @import("../vsr/superblock_free_set.zig");
 
@@ -41,7 +41,7 @@ pub const BlockType = enum(u8) {
 ///
 /// Recently/frequently-used blocks are transparently cached in memory.
 pub fn GridType(comptime Storage: type) type {
-    const block_size = config.block_size;
+    const block_size = constants.block_size;
     const SuperBlock = SuperBlockType(Storage);
 
     const cache_interface = struct {
@@ -72,7 +72,7 @@ pub fn GridType(comptime Storage: type) type {
         cache_interface.equal_addresses,
         .{
             .ways = set_associative_cache_ways,
-            .value_alignment = config.sector_size,
+            .value_alignment = constants.sector_size,
         },
     );
 
@@ -90,8 +90,8 @@ pub fn GridType(comptime Storage: type) type {
         // TODO put more thought into how low/high this limit should be.
         pub const write_iops_max = 16;
 
-        pub const BlockPtr = *align(config.sector_size) [block_size]u8;
-        pub const BlockPtrConst = *align(config.sector_size) const [block_size]u8;
+        pub const BlockPtr = *align(constants.sector_size) [block_size]u8;
+        pub const BlockPtrConst = *align(constants.sector_size) const [block_size]u8;
         pub const Reservation = free_set.Reservation;
 
         pub const Write = struct {

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -4,13 +4,13 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const TableType = @import("table.zig").TableType;
 const TreeType = @import("tree.zig").TreeType;
 const GridType = @import("grid.zig").GridType;
 const CompositeKey = @import("composite_key.zig").CompositeKey;
-const NodePool = @import("node_pool.zig").NodePool(config.lsm_manifest_node_size, 16);
+const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 const compaction_snapshot_for_op = @import("tree.zig").compaction_snapshot_for_op;
@@ -655,7 +655,7 @@ pub fn GrooveType(
                     assert(!id_tree_value.tombstone());
                     lookup_id_callback(&worker.lookup_id, id_tree_value);
 
-                    if (config.verify) {
+                    if (constants.verify) {
                         // If the id is cached, then we must be prefetching it because the object
                         // was not also cached.
                         assert(worker.context.groove.objects.lookup_from_memory(
@@ -682,7 +682,7 @@ pub fn GrooveType(
                 const worker = @fieldParentPtr(PrefetchWorker, "lookup_id", completion);
 
                 if (result) |id_tree_value| {
-                    if (config.verify) {
+                    if (constants.verify) {
                         // This was checked in prefetch_enqueue().
                         assert(
                             worker.context.groove.ids.lookup_from_memory(

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -3,7 +3,7 @@ const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const Direction = @import("direction.zig").Direction;
 const TableIteratorType = @import("table_iterator.zig").TableIteratorType;
@@ -24,7 +24,7 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
         const Grid = GridType(Storage);
         const Manifest = ManifestType(Table, Storage);
 
-        const BlockPtrConst = *align(config.sector_size) const [config.block_size]u8;
+        const BlockPtrConst = *align(constants.sector_size) const [constants.block_size]u8;
 
         const TableInfo = Manifest.TableInfo;
         const TableInfoCallback = fn (

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -4,7 +4,7 @@ const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const lsm = @import("tree.zig");
 const binary_search = @import("binary_search.zig");
 
@@ -360,7 +360,7 @@ pub fn ManifestLevelType(
 
         /// The function is only used for verification; it is not performance-critical.
         pub fn contains(level: Self, table: *const TableInfo) bool {
-            assert(config.verify);
+            assert(constants.verify);
 
             var level_tables = level.iterator(.visible, &.{
                 table.snapshot_min,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -26,7 +26,7 @@ const mem = std.mem;
 
 const log = std.log.scoped(.manifest_log);
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const util = @import("../util.zig");
 
@@ -66,7 +66,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
         comptime {
             // Bit 7 is reserved to indicate whether the event is an insert or remove.
-            assert(config.lsm_levels <= math.maxInt(u7) + 1);
+            assert(constants.lsm_levels <= math.maxInt(u7) + 1);
 
             assert(@sizeOf(Label) == @sizeOf(u8));
 
@@ -107,7 +107,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
         comptime {
             assert(blocks_count_max >= 3);
-            assert(blocks_count_max == 3 or config.block_size < 64 * 1024);
+            assert(blocks_count_max == 3 or constants.block_size < 64 * 1024);
         }
 
         superblock: *SuperBlock,
@@ -153,8 +153,8 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 errdefer for (blocks[0..i]) |b| allocator.free(b);
 
                 const block_slice =
-                    try allocator.alignedAlloc(u8, config.sector_size, config.block_size);
-                block.* = block_slice[0..config.block_size];
+                    try allocator.alignedAlloc(u8, constants.sector_size, constants.block_size);
+                block.* = block_slice[0..constants.block_size];
             }
             errdefer for (blocks) |b| allocator.free(b);
 
@@ -296,7 +296,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
         fn append(manifest_log: *ManifestLog, label: Label, table: *const TableInfo) void {
             assert(manifest_log.opened);
-            assert(label.level < config.lsm_levels);
+            assert(label.level < constants.lsm_levels);
             assert(table.address > 0);
             assert(table.snapshot_min > 0);
             assert(table.snapshot_max > table.snapshot_min);
@@ -673,7 +673,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
             assert(BlockType.from(header.operation) == .manifest);
 
-            if (config.verify) {
+            if (constants.verify) {
                 assert(header.valid_checksum());
                 assert(header.valid_checksum_body(block[@sizeOf(vsr.Header)..header.size]));
             }
@@ -695,7 +695,7 @@ fn ManifestLogBlockType(comptime Storage: type, comptime TableInfo: type) type {
         const BlockPtr = Grid.BlockPtr;
         const BlockPtrConst = Grid.BlockPtrConst;
 
-        const block_body_size = config.block_size - @sizeOf(vsr.Header);
+        const block_body_size = constants.block_size - @sizeOf(vsr.Header);
         const entry_size = @sizeOf(Label) + @sizeOf(TableInfo);
         const entry_count_max_unaligned = @divFloor(block_body_size, entry_size);
         pub const entry_count_max = @divFloor(

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -4,12 +4,12 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const TableType = @import("table.zig").TableType;
 const TreeType = @import("tree.zig").TreeType;
 const GridType = @import("grid.zig").GridType;
-const NodePool = @import("node_pool.zig").NodePool(config.lsm_manifest_node_size, 16);
+const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 const compaction_snapshot_for_op = @import("tree.zig").compaction_snapshot_for_op;
@@ -268,7 +268,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                     return;
                 };
 
-                if (config.verify) {
+                if (constants.verify) {
                     // This was checked in prefetch_enqueue().
                     assert(worker.context.groove.tree.lookup_from_memory(worker.context.snapshot, id.*) == null);
                 }

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const NodePoolType = @import("node_pool.zig").NodePool;
 const table_count_max_for_level = @import("tree.zig").table_count_max_for_level;
 const table_count_max_for_tree = @import("tree.zig").table_count_max_for_tree;
@@ -27,38 +27,38 @@ const configs = [_]Options{
     Options{
         .Key = u64,
         .value_size = 112,
-        .value_count = table_count_max_for_level(config.lsm_growth_factor, 1),
-        .node_size = config.lsm_manifest_node_size,
+        .value_count = table_count_max_for_level(constants.lsm_growth_factor, 1),
+        .node_size = constants.lsm_manifest_node_size,
     },
     Options{
         .Key = u64,
         .value_size = 112,
-        .value_count = table_count_max_for_level(config.lsm_growth_factor, 2),
-        .node_size = config.lsm_manifest_node_size,
+        .value_count = table_count_max_for_level(constants.lsm_growth_factor, 2),
+        .node_size = constants.lsm_manifest_node_size,
     },
     Options{
         .Key = u64,
         .value_size = 112,
-        .value_count = table_count_max_for_level(config.lsm_growth_factor, 3),
-        .node_size = config.lsm_manifest_node_size,
+        .value_count = table_count_max_for_level(constants.lsm_growth_factor, 3),
+        .node_size = constants.lsm_manifest_node_size,
     },
     Options{
         .Key = u64,
         .value_size = 112,
-        .value_count = table_count_max_for_level(config.lsm_growth_factor, 4),
-        .node_size = config.lsm_manifest_node_size,
+        .value_count = table_count_max_for_level(constants.lsm_growth_factor, 4),
+        .node_size = constants.lsm_manifest_node_size,
     },
     Options{
         .Key = u64,
         .value_size = 112,
-        .value_count = table_count_max_for_level(config.lsm_growth_factor, 5),
-        .node_size = config.lsm_manifest_node_size,
+        .value_count = table_count_max_for_level(constants.lsm_growth_factor, 5),
+        .node_size = constants.lsm_manifest_node_size,
     },
     Options{
         .Key = u64,
         .value_size = 112,
-        .value_count = table_count_max_for_level(config.lsm_growth_factor, 6),
-        .node_size = config.lsm_manifest_node_size,
+        .value_count = table_count_max_for_level(constants.lsm_growth_factor, 6),
+        .node_size = constants.lsm_manifest_node_size,
     },
 };
 

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -7,9 +7,9 @@ const mem = std.mem;
 const meta = std.meta;
 const Vector = meta.Vector;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const div_ceil = @import("../util.zig").div_ceil;
-const verify = config.verify;
+const verify = constants.verify;
 
 pub const Layout = struct {
     ways: u64 = 16,

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -3,7 +3,7 @@ const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const div_ceil = @import("../util.zig").div_ceil;
 const binary_search = @import("binary_search.zig");
 const snapshot_latest = @import("tree.zig").snapshot_latest;
@@ -27,7 +27,7 @@ pub fn TableImmutableType(comptime Table: type) type {
             assert(commit_entries_max > 0);
 
             // The in-memory immutable table is the same size as the mutable table:
-            const value_count_max = commit_entries_max * config.lsm_batch_multiple;
+            const value_count_max = commit_entries_max * constants.lsm_batch_multiple;
             const data_block_count = div_ceil(value_count_max, Table.data.value_count_max);
             assert(data_block_count <= Table.data_block_count_max);
 
@@ -95,7 +95,7 @@ pub fn TableImmutableType(comptime Table: type) type {
             assert(sorted_values.len <= table.value_count_max);
             assert(sorted_values.len <= Table.data.value_count_max * Table.data_block_count_max);
 
-            if (config.verify) {
+            if (constants.verify) {
                 var i: usize = 1;
                 while (i < sorted_values.len) : (i += 1) {
                     assert(i > 0);
@@ -128,7 +128,7 @@ pub fn TableImmutableType(comptime Table: type) type {
             );
             if (result.exact) {
                 const value = &table.values[result.index];
-                if (config.verify) assert(compare_keys(key, key_from_value(value)) == .eq);
+                if (constants.verify) assert(compare_keys(key, key_from_value(value)) == .eq);
                 return value;
             }
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -3,7 +3,7 @@ const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const util = @import("../util.zig");
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
@@ -19,7 +19,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
         const Manifest = ManifestType(Table, Storage);
         const ValuesRingBuffer = RingBuffer(Table.Value, Table.data.value_count_max, .pointer);
 
-        const BlockPtrConst = *align(config.sector_size) const [config.block_size]u8;
+        const BlockPtrConst = *align(constants.sector_size) const [constants.block_size]u8;
         const IndexBlockCallback = fn (it: *TableIterator, index_block: BlockPtrConst) void;
 
         grid: *Grid,
@@ -55,18 +55,26 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
         pub fn init(allocator: mem.Allocator) !TableIterator {
             const index_block = try allocator.alignedAlloc(
                 u8,
-                config.sector_size,
-                config.block_size,
+                constants.sector_size,
+                constants.block_size,
             );
             errdefer allocator.free(index_block);
 
             var values = try ValuesRingBuffer.init(allocator);
             errdefer values.deinit(allocator);
 
-            const block_a = try allocator.alignedAlloc(u8, config.sector_size, config.block_size);
+            const block_a = try allocator.alignedAlloc(
+                u8,
+                constants.sector_size,
+                constants.block_size,
+            );
             errdefer allocator.free(block_a);
 
-            const block_b = try allocator.alignedAlloc(u8, config.sector_size, config.block_size);
+            const block_b = try allocator.alignedAlloc(
+                u8,
+                constants.sector_size,
+                constants.block_size,
+            );
             errdefer allocator.free(block_b);
 
             return TableIterator{
@@ -76,14 +84,14 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
                 // Use 0 so that we can assert(address != 0) in tick().
                 .address = 0,
                 .checksum = undefined,
-                .index_block = index_block[0..config.block_size],
+                .index_block = index_block[0..constants.block_size],
                 .index_block_callback = null,
                 .data_block_index = undefined,
                 .values = values,
                 .data_blocks = .{
                     .buffer = .{
-                        block_a[0..config.block_size],
-                        block_b[0..config.block_size],
+                        block_a[0..constants.block_size],
+                        block_b[0..constants.block_size],
                     },
                 },
                 .value = undefined,

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -3,7 +3,7 @@ const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const div_ceil = @import("../util.zig").div_ceil;
 const SetAssociativeCache = @import("set_associative_cache.zig").SetAssociativeCache;
 
@@ -62,10 +62,10 @@ pub fn TableMutableType(comptime Table: type) type {
             values_cache: ?*ValuesCache,
             commit_entries_max: u32,
         ) !TableMutable {
-            comptime assert(config.lsm_batch_multiple > 0);
+            comptime assert(constants.lsm_batch_multiple > 0);
             assert(commit_entries_max > 0);
 
-            const value_count_max = commit_entries_max * config.lsm_batch_multiple;
+            const value_count_max = commit_entries_max * constants.lsm_batch_multiple;
             const data_block_count = div_ceil(value_count_max, Table.data.value_count_max);
             assert(data_block_count <= Table.data_block_count_max);
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -4,7 +4,7 @@ const allocator = testing.allocator;
 const assert = std.debug.assert;
 const os = std.os;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const log = std.log.scoped(.lsm_forest_test);
 
@@ -14,7 +14,7 @@ const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../storage.zig").Storage;
 const IO = @import("../io.zig").IO;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 
 const GridType = @import("grid.zig").GridType;
@@ -330,7 +330,7 @@ const Environment = struct {
         var crash_probability = std.rand.DefaultPrng.init(1337);
 
         var iter: usize = 0;
-        while (iter < (accounts_to_insert_per_op * config.lsm_batch_multiple * iterations)) : (iter += 1) {
+        while (iter < (accounts_to_insert_per_op * constants.lsm_batch_multiple * iterations)) : (iter += 1) {
             // Insert a bunch of accounts
 
             var i: u32 = 0;
@@ -373,8 +373,8 @@ const Environment = struct {
 
             // Checkpoint when the forest finishes compaction.
             // Don't repeat a checkpoint (commit_min must always advance).
-            const checkpoint_op = op -| config.lsm_batch_multiple;
-            if (checkpoint_op % config.lsm_batch_multiple == config.lsm_batch_multiple - 1 and
+            const checkpoint_op = op -| constants.lsm_batch_multiple;
+            if (checkpoint_op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
                 checkpoint_op != env.superblock.staging.vsr_state.commit_min)
             {
                 // Checkpoint the forest then superblock
@@ -385,7 +385,7 @@ const Environment = struct {
                 const checkpointed = inserted.items[0 .. checkpoint_op * accounts_to_insert_per_op];
                 const uncommitted = inserted.items[checkpointed.len..];
                 log.debug("checkpointed={d} uncommitted={d}", .{ checkpointed.len, uncommitted.len });
-                assert(uncommitted.len == config.lsm_batch_multiple * accounts_to_insert_per_op);
+                assert(uncommitted.len == constants.lsm_batch_multiple * accounts_to_insert_per_op);
 
                 // Randomly initiate a crash
                 if (crash_probability.random().uintLessThanBiased(u32, 100) >= 50) {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -4,7 +4,7 @@ const assert = std.debug.assert;
 const mem = std.mem;
 
 const tb = @import("tigerbeetle.zig");
-const config = @import("constants.zig");
+const constants = @import("constants.zig");
 const vsr = @import("vsr.zig");
 const Header = vsr.Header;
 
@@ -77,8 +77,8 @@ pub fn main() !void {
     var prng = std.rand.DefaultPrng.init(seed);
     const random = prng.random();
 
-    const replica_count = 1 + random.uintLessThan(u8, config.replicas_max);
-    const client_count = 1 + random.uintLessThan(u8, config.clients_max);
+    const replica_count = 1 + random.uintLessThan(u8, constants.replicas_max);
+    const client_count = 1 + random.uintLessThan(u8, constants.clients_max);
     const node_count = replica_count + client_count;
 
     const ticks_max = 50_000_000;
@@ -88,7 +88,7 @@ pub fn main() !void {
 
     // TODO: When block recovery and state transfer are implemented, remove this flag to allow
     // crashes to coexist with WAL wraps.
-    const requests_committed_max: usize = config.journal_slot_count * 3;
+    const requests_committed_max: usize = constants.journal_slot_count * 3;
 
     const cluster_options: ClusterOptions = .{
         .cluster = cluster_id,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -31,6 +31,8 @@ const log_state_transitions_only = builtin.mode != .Debug;
 
 const log_simulator = std.log.scoped(.simulator);
 
+pub const tigerbeetle_config = @import("config.zig").configs.test_min;
+
 /// You can fine tune your log levels even further (debug/info/warn/err):
 pub const log_level: std.log.Level = if (log_state_transitions_only) .info else .debug;
 

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -5,7 +5,7 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.storage);
 
 const IO = @import("io.zig").IO;
-const config = @import("constants.zig");
+const constants = @import("constants.zig");
 const fatal = @import("cli.zig").fatal;
 const vsr = @import("vsr.zig");
 
@@ -50,10 +50,10 @@ pub const Storage = struct {
             // that we need to subtract from `target_max` to get back onto the boundary.
             var max = read.target_max;
 
-            const partial_sector_read_remainder = read.buffer.len % config.sector_size;
+            const partial_sector_read_remainder = read.buffer.len % constants.sector_size;
             if (partial_sector_read_remainder != 0) {
                 // TODO log.debug() because this is interesting, and to ensure fuzz test coverage.
-                const partial_sector_read = config.sector_size - partial_sector_read_remainder;
+                const partial_sector_read = constants.sector_size - partial_sector_read_remainder;
                 max -= partial_sector_read;
             }
 
@@ -151,7 +151,7 @@ pub const Storage = struct {
                 // physical sectors than the logical sector size, so we cannot expect `target.len`
                 // to be an exact logical sector multiple.
                 const target = read.target();
-                if (target.len > config.sector_size) {
+                if (target.len > constants.sector_size) {
                     // We tried to read more than a logical sector and failed.
                     log.err("latent sector error: offset={}, subdividing read...", .{read.offset});
 
@@ -164,10 +164,10 @@ pub const Storage = struct {
                     // These lines both implement ceiling division e.g. `((3 - 1) / 2) + 1 == 2` and
                     // require that the numerator is always greater than zero:
                     assert(target.len > 0);
-                    const target_sectors = @divFloor(target.len - 1, config.sector_size) + 1;
+                    const target_sectors = @divFloor(target.len - 1, constants.sector_size) + 1;
                     assert(target_sectors > 0);
-                    read.target_max = (@divFloor(target_sectors - 1, 2) + 1) * config.sector_size;
-                    assert(read.target_max >= config.sector_size);
+                    read.target_max = (@divFloor(target_sectors - 1, 2) + 1) * constants.sector_size;
+                    assert(read.target_max >= constants.sector_size);
 
                     // Pass 0 for `bytes_read`, we want to retry the read with smaller `target_max`:
                     self.start_read(read, 0);
@@ -227,9 +227,9 @@ pub const Storage = struct {
         // then increase `target_max` according to AIMD now that we have read successfully and
         // hopefully cleared the faulty zone.
         // We assume that `target_max` may exceed `read.buffer.len` at any time.
-        if (read.target_max == config.sector_size) {
+        if (read.target_max == constants.sector_size) {
             // TODO Add log.debug because this is interesting.
-            read.target_max += config.sector_size;
+            read.target_max += constants.sector_size;
         }
 
         self.start_read(read, bytes_read);
@@ -319,9 +319,9 @@ pub const Storage = struct {
     /// We check this only at the start of a read or write because the physical sector size may be
     /// less than our logical sector size so that partial IOs then leave us no longer aligned.
     fn assert_alignment(buffer: []const u8, offset: u64) void {
-        assert(@ptrToInt(buffer.ptr) % config.sector_size == 0);
-        assert(buffer.len % config.sector_size == 0);
-        assert(offset % config.sector_size == 0);
+        assert(@ptrToInt(buffer.ptr) % constants.sector_size == 0);
+        assert(buffer.len % constants.sector_size == 0);
+        assert(offset % constants.sector_size == 0);
     }
 
     /// Ensures that the read or write is within bounds and intends to read or write some bytes.

--- a/src/test/accounting/auditor.zig
+++ b/src/test/accounting/auditor.zig
@@ -6,7 +6,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.test_auditor);
 
-const config = @import("../../constants.zig");
+const constants = @import("../../constants.zig");
 const tb = @import("../../tigerbeetle.zig");
 const vsr = @import("../../vsr.zig");
 const RingBuffer = @import("../../ring_buffer.zig").RingBuffer;
@@ -16,7 +16,7 @@ const IdPermutation = @import("../id.zig").IdPermutation;
 const PriorityQueue = @import("../priority_queue.zig").PriorityQueue;
 const Storage = @import("../storage.zig").Storage;
 const StateMachine = @import("../../state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 
 pub const CreateAccountResultSet = std.enums.EnumSet(tb.CreateAccountResult);

--- a/src/test/accounting/workload.zig
+++ b/src/test/accounting/workload.zig
@@ -21,7 +21,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.test_workload);
 
-const config = @import("../../constants.zig");
+const constants = @import("../../constants.zig");
 const tb = @import("../../tigerbeetle.zig");
 const vsr = @import("../../vsr.zig");
 const accounting_auditor = @import("./auditor.zig");
@@ -266,7 +266,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
             var transfers_delivered_recently = TransferBatchQueue.init(allocator, {});
             errdefer transfers_delivered_recently.deinit();
             try transfers_delivered_recently.ensureTotalCapacity(
-                options.auditor_options.client_count * config.client_request_queue_max,
+                options.auditor_options.client_count * constants.client_request_queue_max,
             );
 
             for (auditor.accounts) |*account, i| {
@@ -308,7 +308,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
             size: usize,
         } {
             assert(client_index < self.auditor.options.client_count);
-            assert(body.len == config.message_size_max - @sizeOf(vsr.Header));
+            assert(body.len == constants.message_size_max - @sizeOf(vsr.Header));
 
             const action = action: {
                 if (!self.accounts_sent and self.random.boolean()) {
@@ -353,8 +353,8 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
             reply_body: []align(@alignOf(vsr.Header)) const u8,
         ) void {
             assert(timestamp != 0);
-            assert(request_body.len <= config.message_size_max - @sizeOf(vsr.Header));
-            assert(reply_body.len <= config.message_size_max - @sizeOf(vsr.Header));
+            assert(request_body.len <= constants.message_size_max - @sizeOf(vsr.Header));
+            assert(reply_body.len <= constants.message_size_max - @sizeOf(vsr.Header));
 
             switch (operation.cast(AccountingStateMachine)) {
                 .create_accounts => self.auditor.on_create_accounts(

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const message_pool = @import("../message_pool.zig");
 const MessagePool = message_pool.MessagePool;
@@ -12,7 +12,7 @@ const Network = @import("network.zig").Network;
 const NetworkOptions = @import("network.zig").NetworkOptions;
 
 pub const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .{
-    .message_body_size_max = config.message_body_size_max,
+    .message_body_size_max = constants.message_body_size_max,
 });
 const MessageBus = @import("message_bus.zig").MessageBus;
 const Storage = @import("storage.zig").Storage;
@@ -77,7 +77,7 @@ pub const Cluster = struct {
         assert(options.replica_count > 0);
         assert(options.client_count > 0);
         assert(options.grid_size_max > 0);
-        assert(options.grid_size_max % config.sector_size == 0);
+        assert(options.grid_size_max % constants.sector_size == 0);
         assert(options.health_options.crash_probability < 1.0);
         assert(options.health_options.crash_probability >= 0.0);
         assert(options.health_options.restart_probability < 1.0);
@@ -123,10 +123,10 @@ pub const Cluster = struct {
             .network = network,
         };
 
-        var buffer: [config.replicas_max]Storage.FaultyAreas = undefined;
+        var buffer: [constants.replicas_max]Storage.FaultyAreas = undefined;
         const faulty_wal_areas = Storage.generate_faulty_wal_areas(
             prng,
-            config.journal_size_max,
+            constants.journal_size_max,
             options.replica_count,
             &buffer,
         );
@@ -138,7 +138,7 @@ pub const Cluster = struct {
             storage_options.faulty_wal_areas = faulty_wal_areas[replica_index];
             storage.* = try Storage.init(
                 allocator,
-                superblock_zone_size + config.journal_size_max + options.grid_size_max,
+                superblock_zone_size + constants.journal_size_max + options.grid_size_max,
                 storage_options,
             );
         }
@@ -161,7 +161,7 @@ pub const Cluster = struct {
 
         for (cluster.replicas) |_, replica_index| {
             try cluster.open_replica(@intCast(u8, replica_index), .{
-                .resolution = config.tick_ms * std.time.ns_per_ms,
+                .resolution = constants.tick_ms * std.time.ns_per_ms,
                 .offset_type = .linear,
                 .offset_coefficient_A = 0,
                 .offset_coefficient_B = 0,
@@ -238,7 +238,7 @@ pub const Cluster = struct {
 
             // This whole workaround doesn't handle log wrapping correctly.
             // If the log has wrapped, don't crash the replica.
-            if (cluster_op_max >= config.journal_slot_count) {
+            if (cluster_op_max >= constants.journal_slot_count) {
                 return false;
             }
 

--- a/src/test/conductor.zig
+++ b/src/test/conductor.zig
@@ -9,7 +9,7 @@ const log = std.log.scoped(.test_conductor);
 
 const vsr = @import("../vsr.zig");
 const util = @import("../util.zig");
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const IdPermutation = @import("id.zig").IdPermutation;
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Message = MessagePool.Message;
@@ -47,7 +47,8 @@ pub fn ConductorType(
         ///
         /// `Conduction.stalled_queue` hold replies (and corresponding requests) that are
         /// waiting to be processed.
-        pub const stalled_queue_capacity = config.clients_max * config.client_request_queue_max * 2;
+        pub const stalled_queue_capacity =
+            constants.clients_max * constants.client_request_queue_max * 2;
 
         random: std.rand.Random,
         workload: *Workload,
@@ -225,7 +226,7 @@ pub fn ConductorType(
             var client = &self.clients[client_index];
 
             // Check for space in the client's own request queue.
-            if (client.request_queue.count + 1 > config.client_request_queue_max) return;
+            if (client.request_queue.count + 1 > constants.client_request_queue_max) return;
 
             var request_message = client.get_message();
             defer client.unref(request_message);
@@ -234,10 +235,10 @@ pub fn ConductorType(
                 client_index,
                 @alignCast(
                     @alignOf(vsr.Header),
-                    request_message.buffer[@sizeOf(vsr.Header)..config.message_size_max],
+                    request_message.buffer[@sizeOf(vsr.Header)..constants.message_size_max],
                 ),
             );
-            assert(request_metadata.size <= config.message_size_max - @sizeOf(vsr.Header));
+            assert(request_metadata.size <= constants.message_size_max - @sizeOf(vsr.Header));
 
             client.request(
                 0,

--- a/src/test/message_bus.zig
+++ b/src/test/message_bus.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
-
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Message = MessagePool.Message;
 const Header = @import("../vsr.zig").Header;

--- a/src/test/network.zig
+++ b/src/test/network.zig
@@ -3,7 +3,7 @@ const math = std.math;
 const mem = std.mem;
 const assert = std.debug.assert;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const util = @import("../util.zig");
 
@@ -115,7 +115,7 @@ pub const Network = struct {
         const raw_process = switch (process) {
             .replica => |replica| replica,
             .client => |client| blk: {
-                assert(client >= config.replicas_max);
+                assert(client >= constants.replicas_max);
                 break :blk client;
             },
         };
@@ -194,7 +194,7 @@ pub const Network = struct {
             const sector_ceil = vsr.sector_ceil(target_message.header.size);
             if (target_message.header.size != sector_ceil) {
                 assert(target_message.header.size < sector_ceil);
-                assert(target_message.buffer.len == config.message_size_max + config.sector_size);
+                assert(target_message.buffer.len == constants.message_size_max + constants.sector_size);
                 mem.set(u8, target_message.buffer[target_message.header.size..sector_ceil], 0);
             }
         }
@@ -204,9 +204,9 @@ pub const Network = struct {
 
     fn raw_process_to_process(raw: u128) Process {
         switch (raw) {
-            0...(config.replicas_max - 1) => return .{ .replica = @intCast(u8, raw) },
+            0...(constants.replicas_max - 1) => return .{ .replica = @intCast(u8, raw) },
             else => {
-                assert(raw >= config.replicas_max);
+                assert(raw >= constants.replicas_max);
                 return .{ .client = raw };
             },
         }

--- a/src/test/state_checker.zig
+++ b/src/test/state_checker.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 
 const Cluster = @import("cluster.zig").Cluster;
@@ -23,7 +23,7 @@ const log = std.log.scoped(.state_checker);
 
 pub const StateChecker = struct {
     /// Indexed by replica index.
-    replica_states: [config.replicas_max]u128 = [_]u128{0} ** config.replicas_max,
+    replica_states: [constants.replicas_max]u128 = [_]u128{0} ** constants.replicas_max,
 
     /// Keyed by committed `message.header.checksum`.
     ///

--- a/src/test/storage_checker.zig
+++ b/src/test/storage_checker.zig
@@ -22,7 +22,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.storage_checker);
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const SuperBlockLayout = @import("../vsr/superblock.zig").Layout;
 const SuperBlockSector = @import("../vsr/superblock.zig").SuperBlockSector;
@@ -87,7 +87,7 @@ pub const StorageChecker = struct {
         if (replica.superblock.working.vsr_state.op_compacted(replica.commit_min)) return;
 
         // TODO(Beat Compaction) Remove when deterministic beat compaction is implemented.
-        const half_measure_beat_count = @divExact(config.lsm_batch_multiple, 2);
+        const half_measure_beat_count = @divExact(constants.lsm_batch_multiple, 2);
         if ((replica.commit_min + 1) % half_measure_beat_count != 0) return;
 
         const checksum = checksum_grid(replica);
@@ -138,7 +138,7 @@ pub const StorageChecker = struct {
             const trailer_size = @field(working, @tagName(trailer.field) ++ "_size");
 
             var copy: u8 = 0;
-            while (copy < config.superblock_copies) : (copy += 1) {
+            while (copy < constants.superblock_copies) : (copy += 1) {
                 const offset_in_storage = vsr.Zone.superblock.offset(trailer.offset(copy));
                 @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer.field)) |=
                     vsr.checksum(storage.memory[offset_in_storage..][0..trailer_size]);

--- a/src/time.zig
+++ b/src/time.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const config = @import("./constants.zig");
 
 const os = std.os;
 const assert = std.debug.assert;

--- a/src/tracer.zig
+++ b/src/tracer.zig
@@ -49,8 +49,8 @@
 //!     tracer.end(&a, group, ...);
 //!     tracer.end(&b, group, ...);
 //!
-//! The tracer itself will not object to non-tree spans,
-//! but some config.tracer_backends will either refuse to open the trace or will render it weirdly.
+//! The tracer itself will not object to non-tree spans, but
+//! some constants.tracer_backends will either refuse to open the trace or will render it weirdly.
 //!
 //! If you're having trouble making your spans form a tree, feel free to just add new groups.
 
@@ -59,7 +59,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.tracer);
 
-const config = @import("./constants.zig");
+const constants = @import("./constants.zig");
 const Time = @import("./time.zig").Time;
 const util = @import("util.zig");
 
@@ -134,7 +134,7 @@ pub const EventGroup = union(enum) {
     }
 };
 
-usingnamespace switch (config.tracer_backend) {
+usingnamespace switch (constants.tracer_backend) {
     .none => TracerNone,
     .perfetto => TracerPerfetto,
     .tracy => TracerTracy,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const Header = vsr.Header;
 
@@ -69,7 +69,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
 
         /// A client is allowed at most one inflight request at a time at the protocol layer.
         /// We therefore queue any further concurrent requests made by the application layer.
-        request_queue: RingBuffer(Request, config.client_request_queue_max, .array) = .{},
+        request_queue: RingBuffer(Request, constants.client_request_queue_max, .array) = .{},
 
         /// The number of ticks without a reply before the client resends the inflight request.
         /// Dynamically adjusted as a function of recent request round-trip time.
@@ -122,12 +122,12 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 .request_timeout = .{
                     .name = "request_timeout",
                     .id = id,
-                    .after = config.rtt_ticks * config.rtt_multiple,
+                    .after = constants.rtt_ticks * constants.rtt_multiple,
                 },
                 .ping_timeout = .{
                     .name = "ping_timeout",
                     .id = id,
-                    .after = 30000 / config.tick_ms,
+                    .after = 30000 / constants.tick_ms,
                 },
                 .prng = std.rand.DefaultPrng.init(@truncate(u64, id)),
             };
@@ -503,7 +503,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(message.header.context == 0);
             assert(message.header.request < self.request_number);
             assert(message.header.view == 0);
-            assert(message.header.size <= config.message_size_max);
+            assert(message.header.size <= constants.message_size_max);
 
             // We set the message checksums only when sending the request for the first time,
             // which is when we have the checksum of the latest reply available to set as `parent`,

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -3,12 +3,12 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.clock);
 const fmt = std.fmt;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
-const clock_offset_tolerance_max: u64 = config.clock_offset_tolerance_max_ms * std.time.ns_per_ms;
-const epoch_max: u64 = config.clock_epoch_max_ms * std.time.ns_per_ms;
-const window_min: u64 = config.clock_synchronization_window_min_ms * std.time.ns_per_ms;
-const window_max: u64 = config.clock_synchronization_window_max_ms * std.time.ns_per_ms;
+const clock_offset_tolerance_max: u64 = constants.clock_offset_tolerance_max_ms * std.time.ns_per_ms;
+const epoch_max: u64 = constants.clock_epoch_max_ms * std.time.ns_per_ms;
+const window_min: u64 = constants.clock_synchronization_window_min_ms * std.time.ns_per_ms;
+const window_max: u64 = constants.clock_synchronization_window_max_ms * std.time.ns_per_ms;
 
 const Marzullo = @import("marzullo.zig").Marzullo;
 
@@ -83,7 +83,8 @@ pub fn Clock(comptime Time: type) type {
         time: *Time,
 
         /// An epoch from which the clock can read synchronized clock timestamps within safe bounds.
-        /// At least `config.clock_synchronization_window_min_ms` is needed for this to be ready to use.
+        /// At least `constants.clock_synchronization_window_min_ms` is needed for this to be ready
+        /// to use.
         epoch: Epoch,
 
         /// The next epoch (collecting samples and being synchronized) to replace the current epoch.
@@ -156,8 +157,8 @@ pub fn Clock(comptime Time: type) type {
 
             // Our m0 and m2 readings should always be monotonically increasing if not equal.
             // Crucially, it is possible for a very fast network to have m0 == m2, especially where
-            // `config.tick_ms` is at a more course granularity. We must therefore tolerate RTT=0 or
-            // otherwise we would have a liveness bug simply because we would be throwing away
+            // `constants.tick_ms` is at a more course granularity. We must therefore tolerate RTT=0
+            // or otherwise we would have a liveness bug simply because we would be throwing away
             // perfectly good clock samples.
             // This condition should never be true. Reject this as a bad sample:
             if (m0 > m2) {

--- a/src/vsr/superblock_client_table.zig
+++ b/src/vsr/superblock_client_table.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const util = @import("../util.zig");
 
@@ -43,10 +43,10 @@ pub const ClientTable = struct {
         var entries: Entries = .{};
         errdefer entries.deinit(allocator);
 
-        try entries.ensureTotalCapacity(allocator, @intCast(u32, config.clients_max));
-        assert(entries.capacity() >= config.clients_max);
+        try entries.ensureTotalCapacity(allocator, @intCast(u32, constants.clients_max));
+        assert(entries.capacity() >= constants.clients_max);
 
-        const sorted = try allocator.alloc(*const Entry, config.clients_max);
+        const sorted = try allocator.alloc(*const Entry, constants.clients_max);
         errdefer allocator.free(sorted);
 
         return ClientTable{
@@ -84,15 +84,15 @@ pub const ClientTable = struct {
         // First goes the vsr headers for the entries.
         // This takes advantage of the buffer alignment to avoid adding padding for the headers.
         size_max = std.mem.alignForward(size_max, @alignOf(vsr.Header));
-        size_max += @sizeOf(vsr.Header) * config.clients_max;
+        size_max += @sizeOf(vsr.Header) * constants.clients_max;
 
         // Then follows the session values for the entries.
         size_max = std.mem.alignForward(size_max, @alignOf(u64));
-        size_max += @sizeOf(u64) * config.clients_max;
+        size_max += @sizeOf(u64) * constants.clients_max;
 
         // Followed by the message bodies for the entries.
         size_max = std.mem.alignForward(size_max, @alignOf(u8));
-        size_max += config.message_size_max * config.clients_max;
+        size_max += constants.message_size_max * constants.clients_max;
 
         // Finally the entry count at the end
         size_max = std.mem.alignForward(size_max, @alignOf(u32));
@@ -239,13 +239,13 @@ pub const ClientTable = struct {
         const client = entry.reply.header.client;
         client_table.entries.putAssumeCapacityNoClobber(client, entry.*);
 
-        if (config.verify) assert(client_table.entries.contains(client));
+        if (constants.verify) assert(client_table.entries.contains(client));
     }
 
     pub fn remove(client_table: *ClientTable, client: u128) void {
         assert(client_table.entries.remove(client));
 
-        if (config.verify) assert(!client_table.entries.contains(client));
+        if (constants.verify) assert(!client_table.entries.contains(client));
     }
 
     pub const Iterator = Entries.ValueIterator;

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -5,7 +5,7 @@ const mem = std.mem;
 const DynamicBitSetUnmanaged = std.bit_set.DynamicBitSetUnmanaged;
 const MaskInt = DynamicBitSetUnmanaged.MaskInt;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 
 const ewah = @import("../ewah.zig").ewah(usize);
 const div_ceil = @import("../util.zig").div_ceil;
@@ -74,7 +74,7 @@ pub const FreeSet = struct {
     //
     // e.g. 10TiB disk ÷ 64KiB/block ÷ 512*8 blocks/shard ÷ 8 shards/byte = 5120B index
     const shard_cache_lines = 8;
-    pub const shard_size = shard_cache_lines * config.cache_line_size * @bitSizeOf(u8);
+    pub const shard_size = shard_cache_lines * constants.cache_line_size * @bitSizeOf(u8);
     comptime {
         assert(shard_size == 4096);
         assert(@bitSizeOf(MaskInt) == 64);
@@ -404,8 +404,8 @@ fn bit_set_masks(bit_set: DynamicBitSetUnmanaged) []usize {
 }
 
 test "FreeSet block shard count" {
-    if (config.block_size != 64 * 1024) return;
-    const blocks_in_tb = @divExact(1 << 40, config.block_size);
+    if (constants.block_size != 64 * 1024) return;
+    const blocks_in_tb = @divExact(1 << 40, constants.block_size);
     try test_block_shards_count(5120 * 8, 10 * blocks_in_tb);
     try test_block_shards_count(5120 * 8 - 1, 10 * blocks_in_tb - FreeSet.shard_size);
     try test_block_shards_count(1, FreeSet.shard_size); // Must be at least one index bit.

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -14,7 +14,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.fuzz_vsr_superblock);
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const util = @import("../util.zig");
 const vsr = @import("../vsr.zig");
 const Storage = @import("../test/storage.zig").Storage;
@@ -254,7 +254,7 @@ const Environment = struct {
             .replica = 0,
             // Include extra space (beyond what Storage actually needs) because SuperBlock will
             // update the sector's size according to the highest FreeSet block allocated.
-            .size_max = data_file_size_min + 1000 * config.block_size,
+            .size_max = data_file_size_min + 1000 * constants.block_size,
         });
 
         assert(env.sequence_states.items.len == 0);

--- a/src/vsr/superblock_manifest.zig
+++ b/src/vsr/superblock_manifest.zig
@@ -5,7 +5,7 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.superblock_manifest);
 const mem = std.mem;
 
-const config = @import("../constants.zig");
+const constants = @import("../constants.zig");
 const util = @import("../util.zig");
 
 // TODO Compute & use the upper bound of manifest blocks (per tree) to size the trailer zone.
@@ -92,7 +92,7 @@ pub const Manifest = struct {
     }
 
     pub fn encode(manifest: *const Manifest, target: []align(@alignOf(u128)) u8) u64 {
-        if (config.verify) manifest.verify();
+        if (constants.verify) manifest.verify();
 
         assert(target.len > 0);
         assert(target.len % @sizeOf(u128) == 0);
@@ -177,7 +177,7 @@ pub const Manifest = struct {
         mem.set(u128, manifest.checksums[manifest.count..], 0);
         mem.set(u64, manifest.addresses[manifest.count..], 0);
 
-        if (config.verify) manifest.verify();
+        if (constants.verify) manifest.verify();
     }
 
     /// Addresses must be unique across all appends, or remove() must be called first.
@@ -208,7 +208,7 @@ pub const Manifest = struct {
             manifest.count_max,
         });
 
-        if (config.verify) {
+        if (constants.verify) {
             const index = manifest.index_for_address(address).?;
             assert(index == manifest.count - 1);
             manifest.verify_index_tree_checksum_address(index, tree, checksum, address);
@@ -243,7 +243,7 @@ pub const Manifest = struct {
             manifest.count_max,
         });
 
-        if (config.verify) {
+        if (constants.verify) {
             assert(manifest.index_for_address(address) == null);
             manifest.verify();
         }


### PR DESCRIPTION
Additionally, use `configs.test_min` in the VOPR — this was supposed to be included in https://github.com/tigerbeetledb/tigerbeetle/pull/301, but was missed because I changed how configs are injected by fuzzers at the last minute. :sweat_smile: