### PR TITLE
Fix Java client on Windows

### DIFF
--- a/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/JNILoader.java
+++ b/src/clients/java/src/tigerbeetle-java/src/main/java/com/tigerbeetle/JNILoader.java
@@ -11,14 +11,14 @@ import java.nio.file.StandardCopyOption;
 final class JNILoader {
 
     enum OS {
-        win,
+        windows,
         linux,
         macos;
 
         public static OS getOS() {
             String osName = System.getProperty("os.name").toLowerCase();
             if (osName.startsWith("win")) {
-                return OS.win;
+                return OS.windows;
             } else if (osName.startsWith("mac") || osName.startsWith("darwin")) {
                 return OS.macos;
             } else if (osName.startsWith("linux")) {
@@ -136,7 +136,7 @@ final class JNILoader {
 
                 return String.format("%s/lib%s.dylib", jniResources, libName);
 
-            case win:
+            case windows:
 
                 if (arch == Arch.x86_64)
                     return String.format("%s/%s.dll", jniResources, libName);

--- a/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1227,7 +1227,7 @@ public class IntegrationTest {
 
             String exe;
             switch (JNILoader.OS.getOS()) {
-                case win:
+                case windows:
                     exe = TB_SERVER + ".exe";
                     break;
                 default:

--- a/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/JNILoaderTest.java
+++ b/src/clients/java/src/tigerbeetle-java/src/test/java/com/tigerbeetle/JNILoaderTest.java
@@ -26,13 +26,14 @@ public class JNILoaderTest {
         assertEquals("/lib/aarch64-macos/libtb_jniclient.dylib", JNILoader
                 .getResourcesPath(JNILoader.Arch.aarch64, JNILoader.OS.macos, JNILoader.Abi.none));
 
-        assertEquals("/lib/x86_64-win/tb_jniclient.dll", JNILoader
-                .getResourcesPath(JNILoader.Arch.x86_64, JNILoader.OS.win, JNILoader.Abi.none));
+        assertEquals("/lib/x86_64-windows/tb_jniclient.dll", JNILoader
+                .getResourcesPath(JNILoader.Arch.x86_64, JNILoader.OS.windows, JNILoader.Abi.none));
     }
 
     @Test(expected = AssertionError.class)
     public void testUnsupportedPlatform() {
-        JNILoader.getResourcesPath(JNILoader.Arch.aarch64, JNILoader.OS.win, JNILoader.Abi.none);
+        JNILoader.getResourcesPath(JNILoader.Arch.aarch64, JNILoader.OS.windows,
+                JNILoader.Abi.none);
     }
 
 }

--- a/src/clients/java/src/zig/build.zig
+++ b/src/clients/java/src/zig/build.zig
@@ -44,14 +44,13 @@ pub fn build(b: *std.build.Builder) void {
         lib.setOutputDir("../tigerbeetle-java/src/main/resources/lib/" ++ platform);
         lib.setTarget(cross_target);
         lib.setBuildMode(mode);
+        lib.linkLibC();
 
         if (cross_target.os_tag.? == .windows) {
             // The linker cannot resolve these dependencies from tb_client
             // So we have to insert them manually here, or we are going to receive a "lld-link: error: undefined symbol"
             lib.linkSystemLibrary("ws2_32");
             lib.linkSystemLibrary("advapi32");
-        } else {
-            lib.linkLibC();
         }
 
         // Hit some issue with the build cache between cross compilations:


### PR DESCRIPTION
- Link libC to export functions.

- Fix native lib path to match zig triple os-arch-abi.