### PR TITLE
LSM: Grid scheduling overhaul and adding Storage.on_next_tick

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -819,6 +819,14 @@ pub const IO = struct {
                 },
             },
         };
+
+        // Special case a zero timeout as a yield.
+        if (nanoseconds == 0) {
+            completion.result = -@intCast(i32, @enumToInt(std.os.E.TIME));
+            self.completed.push(completion);
+            return;
+        }
+
         self.enqueue(completion);
     }
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -121,7 +121,7 @@ const Environment = struct {
     }
 
     fn tick(env: *Environment) void {
-        env.grid.tick();
+        // env.grid.tick();
         env.storage.tick();
     }
 

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -103,7 +103,7 @@ pub fn GridType(comptime Storage: type) type {
         pub const BlockPtr = *align(constants.sector_size) [block_size]u8;
         pub const BlockPtrConst = *align(constants.sector_size) const [block_size]u8;
         pub const Reservation = free_set.Reservation;
-        
+
         // Grid just reuses the Storage's NextTick abstraction for simplicity.
         pub const NextTick = Storage.NextTick;
 
@@ -437,7 +437,7 @@ pub fn GridType(comptime Storage: type) type {
             // However, we do have to immediately set the cache key to uphold the
             // invariants of `SetAssociativeCache`.
             cache_interface.set_address(block, address);
-            
+
             iop.* = .{
                 .completion = undefined,
                 .read = read,
@@ -466,7 +466,7 @@ pub fn GridType(comptime Storage: type) type {
             const block = iop.block;
             const read = iop.read;
             const grid = read.grid;
-            
+
             // Either reoslve all reads on the address or send them all to recovery.
             if (read_block_valid(read, block)) {
                 grid.read_block_resolve(read, block);
@@ -490,7 +490,7 @@ pub fn GridType(comptime Storage: type) type {
 
             const header_bytes = block[0..@sizeOf(vsr.Header)];
             const header = mem.bytesAsValue(vsr.Header, header_bytes);
-            
+
             if (!header.valid_checksum()) {
                 log.err("invalid checksum at address {}", .{address});
                 return false;
@@ -536,7 +536,7 @@ pub fn GridType(comptime Storage: type) type {
                     pending_read.callback(pending_read, block);
                 }
             }
-            
+
             // Remove the "root" read so that the address is no longer actively reading / locked.
             // Then invoke the callback with the cache block (which is only valid until the the
             // next Grid.read_block/Grid.write_block which may be done inside callback).

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -467,19 +467,19 @@ pub fn GridType(comptime Storage: type) type {
             const read = iop.read;
             const grid = read.grid;
 
-            // Either reoslve all reads on the address or send them all to recovery.
-            if (read_block_valid(read, block)) {
-                grid.read_block_resolve(read, block);
-            } else {
-                grid.read_recovery_queue.push(read);
-            }
-
-            // Handoff the iop to a pending read or release it
+            // Handoff the iop to a pending read or release it before resolving the callbacks below.
             if (grid.read_pending_queue.pop()) |pending| {
                 const queued_read = @fieldParentPtr(Read, "pending", pending);
                 grid.read_block_with(iop, queued_read);
             } else {
                 grid.read_iops.release(iop);
+            }
+
+            // Either reoslve all reads on the address or send them all to recovery.
+            if (read_block_valid(read, block)) {
+                grid.read_block_resolve(read, block);
+            } else {
+                grid.read_recovery_queue.push(read);
             }
         }
 

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -432,8 +432,8 @@ pub fn GridType(comptime Storage: type) type {
             );
 
             // `block` will be initialized later when the read completes.
-            // This is safe because we will never attempt to lookup an address in the cache
-            // while a read is pending.
+             // This is safe because as long as `read` is in `grid.read_queue` or `grid.read_recovery_queue` 
+             // we will never attempt to read from or overwrite this cache entry.
             // However, we do have to immediately set the cache key to uphold the
             // invariants of `SetAssociativeCache`.
             cache_interface.set_address(block, address);

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -319,6 +319,9 @@ pub fn GridType(comptime Storage: type) type {
             const grid = iop.grid;
             const completed_write = iop.write;
 
+            // We can only update the cache if the Grid is not resolving callbacks with a cache block.
+            assert(!grid.read_resolving);
+
             const cached_block = grid.cache.insert_preserve_locked(
                 *Grid,
                 block_locked,

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -432,8 +432,8 @@ pub fn GridType(comptime Storage: type) type {
             );
 
             // `block` will be initialized later when the read completes.
-             // This is safe because as long as `read` is in `grid.read_queue` or `grid.read_recovery_queue` 
-             // we will never attempt to read from or overwrite this cache entry.
+            // This is safe because as long as `read` is in `grid.read_queue` or `grid.read_recovery_queue`
+            // we will never attempt to read from or overwrite this cache entry.
             // However, we do have to immediately set the cache key to uphold the
             // invariants of `SetAssociativeCache`.
             cache_interface.set_address(block, address);

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -319,7 +319,7 @@ const Environment = struct {
 
     fn wait(env: *Environment, manifest_log: *ManifestLog) void {
         while (env.pending > 0) {
-            manifest_log.grid.tick();
+            // manifest_log.grid.tick();
             manifest_log.superblock.storage.tick();
         }
     }

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -121,7 +121,7 @@ const Environment = struct {
     }
 
     fn tick(env: *Environment) !void {
-        env.grid.tick();
+        // env.grid.tick();
         try env.io.tick();
     }
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -181,7 +181,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         }
 
         fn tick(env: *Environment) void {
-            env.grid.tick();
+            // env.grid.tick();
             env.storage.tick();
         }
 

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -5,6 +5,7 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.storage);
 
 const IO = @import("io.zig").IO;
+const FIFO = @import("fifo.zig").FIFO;
 const constants = @import("constants.zig");
 const fatal = @import("cli.zig").fatal;
 const vsr = @import("vsr.zig");
@@ -68,8 +69,16 @@ pub const Storage = struct {
         offset: u64,
     };
 
+    pub const NextTick = struct {
+        next: ?*NextTick = null,
+        callback: fn (next_tick: *NextTick) void,
+    };
+
     io: *IO,
     fd: os.fd_t,
+
+    next_tick_queue: FIFO(NextTick) = .{},
+    next_tick_completion: IO.Completion = undefined, 
 
     pub fn init(io: *IO, fd: os.fd_t) !Storage {
         return Storage{
@@ -79,6 +88,7 @@ pub const Storage = struct {
     }
 
     pub fn deinit(storage: *Storage) void {
+        assert(storage.next_tick_queue.empty());
         assert(storage.fd != IO.INVALID_FILE);
         storage.fd = IO.INVALID_FILE;
     }
@@ -88,6 +98,43 @@ pub const Storage = struct {
             log.warn("tick: {}", .{err});
             std.debug.panic("io.tick(): {}", .{err});
         };
+    }
+
+    pub fn on_next_tick(
+        storage: *Storage,
+        callback: fn (next_tick: *Storage.NextTick) void,
+        next_tick: *Storage.NextTick,
+    ) void {
+        next_tick.* = .{ .callback = callback };
+
+        const was_empty = storage.next_tick_queue.empty();
+        storage.next_tick_queue.push(next_tick);
+
+        if (was_empty) {
+            storage.io.timeout(
+                *Storage,
+                storage,
+                timeout_callback,
+                &storage.next_tick_completion,
+                0, // 0ns timeout means to resolve as soon as possible - like a yield
+            );
+        } 
+    }
+
+    fn timeout_callback(
+        storage: *Storage,
+        completion: *IO.Completion,
+        result: IO.TimeoutError!void,
+    ) void {
+        assert(completion == &storage.next_tick_completion);
+        _ = result catch |e| switch (e) {
+            error.Canceled => unreachable,
+            error.Unexpected => unreachable,
+        };
+        
+        var queue = storage.next_tick_queue;
+        storage.next_tick_queue = .{};
+        while (queue.pop()) |next_tick| next_tick.callback(next_tick);
     }
 
     pub fn read_sectors(
@@ -113,18 +160,24 @@ pub const Storage = struct {
             .target_max = buffer.len,
         };
 
-        self.start_read(read, 0);
+        self.start_read(read, null);
         assert(read.target().len > 0);
     }
 
-    fn start_read(self: *Storage, read: *Storage.Read, bytes_read: usize) void {
-        assert(bytes_read <= read.target().len);
+    fn start_read(self: *Storage, read: *Storage.Read, bytes_read: ?usize) void {
+        const bytes = bytes_read orelse 0;
+        assert(bytes <= read.target().len);
 
-        read.offset += bytes_read;
-        read.buffer = read.buffer[bytes_read..];
+        read.offset += bytes;
+        read.buffer = read.buffer[bytes..];
 
         const target = read.target();
         if (target.len == 0) {
+            // Resolving the read inline means start_read() must not have been called from 
+            // read_sectors(). If it was, this is a synchronous callback resolution and should
+            // be reported.
+            assert(bytes_read != null);
+
             read.callback(read);
             return;
         }

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -78,7 +78,7 @@ pub const Storage = struct {
     fd: os.fd_t,
 
     next_tick_queue: FIFO(NextTick) = .{},
-    next_tick_completion: IO.Completion = undefined, 
+    next_tick_completion: IO.Completion = undefined,
 
     pub fn init(io: *IO, fd: os.fd_t) !Storage {
         return Storage{
@@ -118,7 +118,7 @@ pub const Storage = struct {
                 &storage.next_tick_completion,
                 0, // 0ns timeout means to resolve as soon as possible - like a yield
             );
-        } 
+        }
     }
 
     fn timeout_callback(
@@ -131,7 +131,7 @@ pub const Storage = struct {
             error.Canceled => unreachable,
             error.Unexpected => unreachable,
         };
-        
+
         var queue = storage.next_tick_queue;
         storage.next_tick_queue = .{};
         while (queue.pop()) |next_tick| next_tick.callback(next_tick);
@@ -173,7 +173,7 @@ pub const Storage = struct {
 
         const target = read.target();
         if (target.len == 0) {
-            // Resolving the read inline means start_read() must not have been called from 
+            // Resolving the read inline means start_read() must not have been called from
             // read_sectors(). If it was, this is a synchronous callback resolution and should
             // be reported.
             assert(bytes_read != null);

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -154,7 +154,7 @@ pub const Storage = struct {
     writes: std.PriorityQueue(*Storage.Write, void, Storage.Write.less_than),
 
     ticks: u64 = 0,
-    next_tick_queue: FIFO(NextTick) = .{}, 
+    next_tick_queue: FIFO(NextTick) = .{},
 
     pub fn init(allocator: mem.Allocator, size: u64, options: Storage.Options) !Storage {
         assert(options.write_latency_mean >= options.write_latency_min);
@@ -808,7 +808,7 @@ pub const Storage = struct {
     pub fn grid_block(
         storage: *const Storage,
         address: u64,
-    ) *align(constants.sector_size) const [constants.block_size]u8 {
+    ) *align(constants.sector_size) [constants.block_size]u8 {
         assert(address > 0);
 
         const block_offset = vsr.Zone.grid.offset((address - 1) * constants.block_size);

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -25,6 +25,7 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 
+const FIFO = @import("../fifo.zig").FIFO;
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const superblock = @import("../vsr/superblock.zig");
@@ -119,6 +120,11 @@ pub const Storage = struct {
         }
     };
 
+    pub const NextTick = struct {
+        next: ?*NextTick = null,
+        callback: fn (next_tick: *NextTick) void,
+    };
+
     /// Faulty areas are always sized to message_size_max
     /// If the faulty areas of all replicas are superimposed, the padding between them is always message_size_max.
     /// For a single replica, the padding between faulty areas depends on the number of other replicas.
@@ -148,6 +154,7 @@ pub const Storage = struct {
     writes: std.PriorityQueue(*Storage.Write, void, Storage.Write.less_than),
 
     ticks: u64 = 0,
+    next_tick_queue: FIFO(NextTick) = .{}, 
 
     pub fn init(allocator: mem.Allocator, size: u64, options: Storage.Options) !Storage {
         assert(options.write_latency_mean >= options.write_latency_min);
@@ -222,6 +229,7 @@ pub const Storage = struct {
     }
 
     pub fn deinit(storage: *Storage, allocator: mem.Allocator) void {
+        assert(storage.next_tick_queue.empty());
         allocator.free(storage.memory);
         storage.memory_written.deinit(allocator);
         storage.faults.deinit(allocator);
@@ -280,6 +288,19 @@ pub const Storage = struct {
             _ = storage.writes.remove();
             storage.write_sectors_finish(write);
         }
+
+        var queue = storage.next_tick_queue;
+        storage.next_tick_queue = .{};
+        while (queue.pop()) |next_tick| next_tick.callback(next_tick);
+    }
+
+    pub fn on_next_tick(
+        storage: *Storage,
+        callback: fn (next_tick: *Storage.NextTick) void,
+        next_tick: *Storage.NextTick,
+    ) void {
+        next_tick.* = .{ .callback = callback };
+        storage.next_tick_queue.push(next_tick);
     }
 
     /// * Verifies that the read fits within the target sector.
@@ -787,7 +808,7 @@ pub const Storage = struct {
     pub fn grid_block(
         storage: *const Storage,
         address: u64,
-    ) *align(constants.sector_size) [constants.block_size]u8 {
+    ) *align(constants.sector_size) const [constants.block_size]u8 {
         assert(address > 0);
 
         const block_offset = vsr.Zone.grid.offset((address - 1) * constants.block_size);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -356,7 +356,7 @@ pub fn ReplicaType(
             self.opened = false;
             self.state_machine.open(state_machine_open_callback);
             while (!self.opened) {
-                self.grid.tick();
+                // self.grid.tick();
                 self.superblock.storage.tick();
             }
 
@@ -629,7 +629,7 @@ pub fn ReplicaType(
 
             // TODO Replica owns Time; should it tick() here instead of Clock?
             self.clock.tick();
-            self.grid.tick();
+            // self.grid.tick();
             self.message_bus.tick();
 
             if (self.status == .recovering) {


### PR DESCRIPTION
There's a few places in the codebase where callbacks that are requested are resolved inline in the request. Without a guarantee from the compiler around tail-calls, this risks stack overflow and makes stack traces harder to follow. To ensure requests which take callbacks are completed asynchronously, we need a construct that can defer arbitrary execution for later.

The lowest level of scheduling exposed to TigerBeetle components is the `Storage` layer so this construct goes there. This PR implements `Storage.on_next_tick` as a way to defer callbacks until later. It uses `IO.timeout(0)` as a means of yielding, which is now special cased to avoid os/kernel calls and queue directly to its internal FIFO.

`Grid` also sees a reworking in its scheduling to allow more efficient Read merging, simpler cache access & control flow, and IOP handoff. Grid reads are now asynchronously driven by the Storage using `on_next_tick` so `Grid.tick()` no longer exists. These changes to grid should hopefully decrease worst case latency overall as cache reads are now being flushed/processed inside `Storage/IO.run_for_ns` instead of outside (with `Grid.tick()`).