### PR TITLE
VSR: s/leader/primary; s/follower/backup

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -386,7 +386,7 @@ pub const clock_epoch_max_ms = config.process.clock_epoch_max_ms;
 
 /// The amount of time to wait for enough accurate samples before synchronizing the clock.
 /// The more samples we can take per remote clock source, the more accurate our estimation becomes.
-/// This impacts cluster startup time as the leader must first wait for synchronization to complete.
+/// This impacts cluster startup time as the primary must first wait for synchronization to complete.
 pub const clock_synchronization_window_min_ms = config.process.clock_synchronization_window_min_ms;
 
 /// The amount of time without agreement before the clock window is expired and a new window opened.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -135,8 +135,8 @@ pub const Operation = enum(u8) {
 };
 
 /// Network message and journal entry header:
-/// We reuse the same header for both so that prepare messages from the leader can simply be
-/// journalled as is by the followers without requiring any further modification.
+/// We reuse the same header for both so that prepare messages from the primary can simply be
+/// journalled as is by the backups without requiring any further modification.
 pub const Header = extern struct {
     comptime {
         assert(@sizeOf(Header) == 128);
@@ -156,7 +156,7 @@ pub const Header = extern struct {
     /// 1. across our distributed log of prepares, and
     /// 2. across a client's requests and our replies.
     /// This may also be used as the initialization vector for AEAD encryption at rest, provided
-    /// that the leader ratchets the encryption key every view change to ensure that prepares
+    /// that the primary ratchets the encryption key every view change to ensure that prepares
     /// reordered through a view change never repeat the same IV for the same encryption key.
     parent: u128 = 0,
 
@@ -221,7 +221,7 @@ pub const Header = extern struct {
 
     /// This field is used in various ways:
     ///
-    /// * A `prepare` sets this to the leader's state machine `prepare_timestamp`.
+    /// * A `prepare` sets this to the primary's state machine `prepare_timestamp`.
     ///   For `create_accounts` and `create_transfers` this is the batch's highest timestamp.
     /// * A `reply` sets this to the corresponding `prepare`'s timestamp.
     ///   This allows the test workload to verify transfer timeouts.

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -247,8 +247,8 @@ pub fn Clock(comptime Time: type) type {
             return self.time.realtime();
         }
 
-        /// Called by `StateMachine.prepare_timestamp()` when the leader wants to timestamp a batch.
-        /// If the leader's clock is not synchronized with the cluster, it must wait until it is.
+        /// Called by `StateMachine.prepare_timestamp()` when the primary wants to timestamp a batch.
+        /// If the primary's clock is not synchronized with the cluster, it must wait until it is.
         /// Returns the system time clamped to be within our synchronized lower and upper bounds.
         /// This is complementary to NTP and allows clusters with very accurate time to make use of it,
         /// while providing guard rails for when NTP is partitioned or unable to correct quickly enough.

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -882,7 +882,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
                 // * The prepare was rewritten since the read began.
                 // * Misdirected read/write.
                 // * The combination of:
-                //   * The leader is responding to a `request_prepare`.
+                //   * The primary is responding to a `request_prepare`.
                 //   * The `request_prepare` did not include a checksum.
                 //   * The requested op's slot is faulty, but the prepare is valid. Since the
                 //     prepare is valid, WAL recovery set `prepare_checksums[slot]`. But on reading
@@ -1445,7 +1445,7 @@ pub fn Journal(comptime Replica: type, comptime Storage: type) type {
         }
 
         /// Removes entries from `op_min` (inclusive) onwards.
-        /// Used after a view change to remove uncommitted entries discarded by the new leader.
+        /// Used after a view change to remove uncommitted entries discarded by the new primary.
         pub fn remove_entries_from(self: *Self, op_min: u64) void {
             assert(self.status == .recovered);
             assert(op_min > 0);


### PR DESCRIPTION
Rename primary-only methods to make invariant clear.