### PR TITLE
Journal: Repair local redundant headers for decision=fix

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -130,11 +130,7 @@ pub fn main() !void {
             .write_latency_mean = 3 + random.uintLessThan(u16, 100),
             .read_fault_probability = random.uintLessThan(u8, 10),
             .write_fault_probability = random.uintLessThan(u8, 10),
-            // TODO Allow WAL faults on crash when replica_count=1 when redundant-header-repair
-            // is implemented after recovering with decision=fix. Otherwise we can end up with
-            // multiple crashes faulting first a redundant headers, then a prepare, upgrading
-            // a decision=fix to decision=vsr.
-            .crash_fault_probability = if (replica_count == 1) 0 else 80 + random.uintLessThan(u8, 21),
+            .crash_fault_probability = 80 + random.uintLessThan(u8, 21),
             .faulty_superblock = true,
         },
         .health_options = .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5989,6 +5989,7 @@ pub fn ReplicaType(
                 // This is an optimization to eliminate waiting until the next repair timeout.
                 .repair => self.repair(),
                 .pipeline => self.repair(),
+                .fix => unreachable,
             }
         }
     };


### PR DESCRIPTION
When recovering the WAL, `decision=fix` indicates that there is a intact, trusted prepare — but the corresponding redundant header is damaged.

Previously we would use remote repair for this. Instead, repair it locally using the trusted prepare's header.

- When `replica_count>1`, this is more efficient than requesting the prepare (which we already have) and then rewriting it.
- When `replica_count=1`, we can't request a prepare. The VOPR previously had to disable "corrupt in-flight writes on crash" for `replica_count=1` to avoid a scenario where 2 crashes resulted in all redundant headers being corrupted, which a solo replica cannot recover from.