### PR TITLE
Correct endianness of u128 in go client

### DIFF
--- a/src/clients/go/pkg/types/main.go
+++ b/src/clients/go/pkg/types/main.go
@@ -25,6 +25,12 @@ func (value Uint128) Bytes() [16]byte {
 
 func (value Uint128) String() string {
 	bytes := value.Bytes()
+
+	// Convert little-endian number to big-endian string
+	for i, j := 0, len(bytes)-1; i < j; i, j = i+1, j-1 {
+		bytes[i], bytes[j] = bytes[j], bytes[i]
+	}
+
 	s := hex.EncodeToString(bytes[:16])
 
 	// Prettier to drop preceeding zeros so you get "0" instead of "0000000000000000"
@@ -40,17 +46,6 @@ func BytesToUint128(value [16]byte) Uint128 {
 	return *(*Uint128)(unsafe.Pointer(&value[0]))
 }
 
-// HexBytesToUint128 converts a hex-encoded integer to a Uint128.
-func HexBytesToUint128(value [32]byte) (Uint128, error) {
-	decoded := [16]byte{}
-	_, err := hex.Decode(decoded[:], value[:])
-	if err != nil {
-		return Uint128{}, err
-	}
-
-	return BytesToUint128(decoded), nil
-}
-
 // HexStringToUint128 converts a hex-encoded integer to a Uint128.
 func HexStringToUint128(value string) (Uint128, error) {
 	if len(value) > 32 {
@@ -59,16 +54,20 @@ func HexStringToUint128(value string) (Uint128, error) {
 	if len(value)%2 == 1 {
 		value = "0" + value
 	}
-	// Pad with zeroes
-	bytes := [32]byte{}
-	for i := range bytes {
-		if i < 32-len(value) {
-			bytes[i] = '0'
-		} else {
-			bytes[i] = value[i-(32-len(value))]
-		}
+
+	bytes := [16]byte{}
+	nonZeroLen, err := hex.Decode(bytes[:], []byte(value))
+	if err != nil {
+		return Uint128{}, err
 	}
-	return HexBytesToUint128(bytes)
+
+	// Convert big-endian string to little endian number
+	for i := 0; i < nonZeroLen / 2; i += 1 {
+		j := nonZeroLen - 1 - i
+		bytes[i], bytes[j] = bytes[j], bytes[i]
+	}
+
+	return BytesToUint128(bytes), nil;
 }
 
 // EventResult is returned from TB only when an error occurred processing it.

--- a/src/clients/go/pkg/types/main_test.go
+++ b/src/clients/go/pkg/types/main_test.go
@@ -9,6 +9,7 @@ func Test_HexStringToUint128(t *testing.T) {
 		"400",
 		"203",
 		"ffffffffffffffffffffffffffffffff",
+		"123456",
 	}
 
 	for _, test := range tests {
@@ -20,5 +21,21 @@ func Test_HexStringToUint128(t *testing.T) {
 		if thereAndBack != test {
 			t.Errorf("Expected %s to be %s, got %s", test, test, thereAndBack)
 		}
+	}
+}
+
+func Test_HexStringToUint128_LittleEndian(t *testing.T) {
+
+	test := "123456"
+
+	res, err := HexStringToUint128(test)
+	if err != nil {
+		t.Errorf("Expected %s to be a valid hex string, got: %s", test, err)
+	}
+
+	expected := [16]byte{86,52,18,0,0,0,0,0,0,0,0,0,0,0,0,0}
+
+	if res.Bytes() != expected {
+		t.Errorf("Expected %s to produce bytes %v, got bytes %v", test, expected, res.Bytes())
 	}
 }


### PR DESCRIPTION
Both encode and decode were wrong, so the round-trip tests didn't catch the bug. Adds a test that explicitly checks the bytes. 