### PR TITLE
Avoid redundant tombstones in secondary indexes

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -131,6 +131,7 @@ fn IndexTreeType(
         Key.sentinel_key,
         Key.tombstone,
         Key.tombstone_from_key,
+        .secondary_index,
     );
 
     return TreeType(Table, Storage, tree_name);
@@ -254,6 +255,7 @@ pub fn GrooveType(
             ObjectTreeHelpers(Object).sentinel_key,
             ObjectTreeHelpers(Object).tombstone,
             ObjectTreeHelpers(Object).tombstone_from_key,
+            .general,
         );
 
         const tree_name = @typeName(Object);
@@ -269,6 +271,7 @@ pub fn GrooveType(
             IdTreeValue.sentinel_key,
             IdTreeValue.tombstone,
             IdTreeValue.tombstone_from_key,
+            .general,
         );
 
         const tree_name = @typeName(Object) ++ ".id";

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -417,6 +417,7 @@ pub fn TestContext(
             std.math.maxInt(Key),
             tombstone,
             tombstone_from_key,
+            .general,
         );
 
         const TableInfo = @import("manifest.zig").TableInfoType(Table);

--- a/src/lsm/merge_iterator.zig
+++ b/src/lsm/merge_iterator.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const math = std.math;
+const mem = std.mem;
+
+const Direction = @import("direction.zig").Direction;
+
+const k_max = 2;
+
+pub fn MergeIteratorType(
+    comptime Table: type,
+    comptime IteratorA: type,
+    comptime IteratorB: type,
+) type {
+    return struct {
+        const Self = @This();
+
+        iterator_a: *IteratorA,
+        iterator_b: *IteratorB,
+
+        empty_a: bool,
+        empty_b: bool,
+
+        previous_key_popped: ?Table.Key,
+
+        pub fn init(
+            iterator_a: *IteratorA,
+            iterator_b: *IteratorB,
+        ) Self {
+            return Self{
+                .iterator_a = iterator_a,
+                .iterator_b = iterator_b,
+                .empty_a = false,
+                .empty_b = false,
+                .previous_key_popped = null,
+            };
+        }
+
+        pub fn empty(it: Self) bool {
+            return it.empty_a and it.empty_b;
+        }
+
+        pub fn pop(it: *Self) ?Table.Value {
+            while (true) {
+                if (it.empty_a and it.empty_b) {
+                    return null;
+                }
+
+                if (it.empty_a) {
+                    _ = it.iterator_b.peek() catch |error_b| switch (error_b) {
+                        error.Drained => return null,
+                        error.Empty => {
+                            it.empty_b = true;
+                            continue;
+                        },
+                    };
+                    return it.iterator_b.pop();
+                }
+
+                if (it.empty_b) {
+                    _ = it.iterator_a.peek() catch |error_a| switch (error_a) {
+                        error.Drained => return null,
+                        error.Empty => {
+                            it.empty_a = true;
+                            continue;
+                        },
+                    };
+                    return it.iterator_a.pop();
+                }
+
+                const key_a = it.iterator_a.peek() catch |error_a| switch (error_a) {
+                    error.Drained => return null,
+                    error.Empty => {
+                        it.empty_a = true;
+                        continue;
+                    },
+                };
+                const key_b = it.iterator_b.peek() catch |error_b| switch (error_b) {
+                    error.Drained => return null,
+                    error.Empty => {
+                        it.empty_b = true;
+                        continue;
+                    },
+                };
+
+                switch (Table.compare_keys(key_a, key_b)) {
+                    .lt => return it.iterator_a.pop(),
+                    .gt => return it.iterator_b.pop(),
+                    .eq => {
+                        const value_a = it.iterator_a.pop();
+                        const value_b = it.iterator_b.pop();
+                        switch (Table.usage) {
+                            .general => return value_a,
+                            .secondary_index => {
+                                // In secondary indexes, puts and removes alternate and can be safely cancelled out.
+                                assert(Table.tombstone(&value_a) or Table.tombstone(&value_b));
+                                continue;
+                            },
+                        }
+                    },
+                }
+            }
+        }
+    };
+}

--- a/src/lsm/merge_iterator.zig
+++ b/src/lsm/merge_iterator.zig
@@ -34,10 +34,13 @@ pub fn MergeIteratorType(
             };
         }
 
+        /// Returns `true` once both `iterator_a` and `iterator_b` have raised `error.Empty`.
         pub fn empty(it: Self) bool {
             return it.empty_a and it.empty_b;
         }
 
+        /// Returns `null` if either `iterator_a` or `iterator_b` return `error.Empty` or `error.Drained`.
+        /// Check `it.empty()` to disambiguate.
         pub fn pop(it: *Self) ?Table.Value {
             while (true) {
                 if (it.empty_a and it.empty_b) {

--- a/src/lsm/merge_iterator.zig
+++ b/src/lsm/merge_iterator.zig
@@ -91,7 +91,7 @@ pub fn MergeIteratorType(
                             .general => return value_a,
                             .secondary_index => {
                                 // In secondary indexes, puts and removes alternate and can be safely cancelled out.
-                                assert(util.xor(Table.tombstone(&value_a), Table.tombstone(&value_b)));
+                                assert(Table.tombstone(&value_a) != Table.tombstone(&value_b));
                                 continue;
                             },
                         }

--- a/src/lsm/merge_iterator.zig
+++ b/src/lsm/merge_iterator.zig
@@ -1,9 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const math = std.math;
-const mem = std.mem;
 
-const Direction = @import("direction.zig").Direction;
+const util = @import("../util.zig");
 
 const k_max = 2;
 
@@ -93,7 +91,7 @@ pub fn MergeIteratorType(
                             .general => return value_a,
                             .secondary_index => {
                                 // In secondary indexes, puts and removes alternate and can be safely cancelled out.
-                                assert(Table.tombstone(&value_a) or Table.tombstone(&value_b));
+                                assert(util.xor(Table.tombstone(&value_a), Table.tombstone(&value_b)));
                                 continue;
                             },
                         }

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -67,6 +67,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             Value.sentinel_key,
             Value.tombstone,
             Value.tombstone_from_key,
+            .general,
         );
 
         const Tree = TreeType(Table, Storage, "posted_groove");

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -1241,6 +1241,7 @@ pub fn run_tests(seed: u64, comptime options: Options) !void {
         Key.sentinel_key,
         Key.tombstone,
         Key.tombstone_from_key,
+        .general,
     ));
 
     const CompareInt = struct {

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -69,6 +69,16 @@ pub fn TableType(
     comptime table_tombstone: fn (*const TableValue) callconv(.Inline) bool,
     /// Returns a tombstone value representation for a key.
     comptime table_tombstone_from_key: fn (TableKey) callconv(.Inline) TableValue,
+    comptime usage: enum {
+        /// General purpose table.
+        general,
+        /// If your usage fits this pattern:
+        /// * Only put keys which are not present.
+        /// * Only remove keys which are present.
+        /// * TableKey == TableValue (modulo padding, eg CompositeKey)
+        /// Then we can unlock additional optimizations.
+        secondary_index,
+    },
 ) type {
     return struct {
         const Table = @This();
@@ -81,6 +91,7 @@ pub fn TableType(
         pub const sentinel_key = table_sentinel_key;
         pub const tombstone = table_tombstone;
         pub const tombstone_from_key = table_tombstone_from_key;
+        pub const usage = usage;
 
         // Export hashmap context for Key and Value
         pub const HashMapContextValue = struct {
@@ -980,6 +991,7 @@ test "Table" {
         Key.sentinel_key,
         Key.tombstone,
         Key.tombstone_from_key,
+        .general,
     );
 
     _ = Table;

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -16,6 +16,17 @@ const snapshot_latest = @import("tree.zig").snapshot_latest;
 const BlockType = @import("grid.zig").BlockType;
 const TableInfoType = @import("manifest.zig").TableInfoType;
 
+pub const TableUsage = enum {
+    /// General purpose table.
+    general,
+    /// If your usage fits this pattern:
+    /// * Only put keys which are not present.
+    /// * Only remove keys which are present.
+    /// * TableKey == TableValue (modulo padding, eg CompositeKey)
+    /// Then we can unlock additional optimizations.
+    secondary_index,
+};
+
 /// A table is a set of blocks:
 ///
 /// * Index block (exactly 1)
@@ -69,16 +80,7 @@ pub fn TableType(
     comptime table_tombstone: fn (*const TableValue) callconv(.Inline) bool,
     /// Returns a tombstone value representation for a key.
     comptime table_tombstone_from_key: fn (TableKey) callconv(.Inline) TableValue,
-    comptime usage: enum {
-        /// General purpose table.
-        general,
-        /// If your usage fits this pattern:
-        /// * Only put keys which are not present.
-        /// * Only remove keys which are present.
-        /// * TableKey == TableValue (modulo padding, eg CompositeKey)
-        /// Then we can unlock additional optimizations.
-        secondary_index,
-    },
+    comptime usage: TableUsage,
 ) type {
     return struct {
         const Table = @This();

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -269,7 +269,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
         /// Returns either:
         /// - the next Key, if available.
         /// - error.Empty when there are no values remaining to iterate.
-        /// - error.Drained when the iterator isn't empty, but some values 
+        /// - error.Drained when the iterator isn't empty, but some values
         ///   still need to be buffered into memory via tick().
         pub fn peek(it: TableIterator) error{ Empty, Drained }!Table.Key {
             assert(!it.read_pending);
@@ -280,7 +280,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
             const block = it.data_blocks.head() orelse {
                 // NOTE: Even if there are no values to peek, some may be unbuffered.
                 // We call buffered_all_values() to distinguish between the iterator
-                // being empty and needing to tic() to refill values.
+                // being empty and needing to tick() to refill values.
                 if (!it.buffered_all_values()) return error.Drained;
                 return error.Empty;
             };

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -182,7 +182,13 @@ pub fn TableMutableType(comptime Table: type) type {
             while (it.next()) |value| : (i += 1) {
                 values_max[i] = value.*;
 
-                if (table.values_cache) |cache| cache.insert(key_from_value(value)).* = value.*;
+                if (table.values_cache) |cache| {
+                    if (tombstone(value)) {
+                        cache.remove(key_from_value(value));
+                    } else {
+                        cache.insert(key_from_value(value)).* = value.*;
+                    }
+                }
             }
 
             const values = values_max[0..i];

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -120,10 +120,6 @@ pub fn TableMutableType(comptime Table: type) type {
 
             // The hash map's load factor may allow for more capacity because of rounding:
             assert(table.values.count() <= table.value_count_max);
-
-            if (table.values_cache) |cache| {
-                cache.insert(key_from_value(value)).* = value.*;
-            }
         }
 
         pub fn remove(table: *TableMutable, value: *const Value) void {
@@ -150,11 +146,6 @@ pub fn TableMutableType(comptime Table: type) type {
             }
 
             assert(table.values.count() <= table.value_count_max);
-
-            if (table.values_cache) |cache| {
-                cache.insert(key_from_value(value)).* =
-                    tombstone_from_key(key_from_value(value));
-            }
         }
 
         /// This may return `false` even when committing would succeed — it pessimistically

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -129,7 +129,10 @@ pub fn TableMutableType(comptime Table: type) type {
 
             assert(table.values.count() <= table.value_count_max);
 
-            // TODO Should we remove value from cache?
+            if (table.values_cache) |cache| {
+                cache.insert(key_from_value(value)).* =
+                    tombstone_from_key(key_from_value(value));
+            }
         }
 
         /// This may return `false` even when committing would succeed — it pessimistically

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -98,16 +98,24 @@ pub fn TableMutableType(comptime Table: type) type {
         }
 
         pub fn put(table: *TableMutable, value: *const Value) void {
-            // If the key is already present in the hash map, the old key will not be overwritten
-            // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
-            // level getOrPut() API and manually overwrite the old key.
-            const upsert = table.values.getOrPutAssumeCapacity(value.*);
-            if (usage == .secondary_index and upsert.found_existing) {
-                // Put and remove cancel each other out.
-                assert(tombstone(upsert.key_ptr));
-                _ = table.values.remove(value.*);
-            } else {
-                upsert.key_ptr.* = value.*;
+            switch (usage) {
+                .secondary_index => {
+                    const existing = table.values.fetchRemove(value.*);
+                    if (existing) |kv| {
+                        // If there was a previous operation on this key then it must have been a remove.
+                        // The put and remove cancel out.
+                        assert(tombstone(&kv.key));
+                    } else {
+                        table.values.putAssumeCapacityNoClobber(value.*, {});
+                    }
+                },
+                .general => {
+                    // If the key is already present in the hash map, the old key will not be overwritten
+                    // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
+                    // level getOrPut() API and manually overwrite the old key.
+                    const upsert = table.values.getOrPutAssumeCapacity(value.*);
+                    upsert.key_ptr.* = value.*;
+                },
             }
 
             // The hash map's load factor may allow for more capacity because of rounding:
@@ -119,12 +127,26 @@ pub fn TableMutableType(comptime Table: type) type {
         }
 
         pub fn remove(table: *TableMutable, value: *const Value) void {
-            const existing = table.values.fetchRemove(value.*);
-            if (usage == .secondary_index and existing != null) {
-                // Put and remove cancel each other out.
-                assert(!tombstone(&existing.?.key));
-            } else {
-                table.values.putAssumeCapacityNoClobber(tombstone_from_key(key_from_value(value)), {});
+            switch (usage) {
+                .secondary_index => {
+                    const existing = table.values.fetchRemove(value.*);
+                    if (existing) |kv| {
+                        // The previous operation on this key then it must have been a put.
+                        // The put and remove cancel out.
+                        assert(!tombstone(&kv.key));
+                    } else {
+                        // If the put is already on-disk, then we need to follow it with a tombstone.
+                        // The put and the tombstone may cancel each other out later during compaction.
+                        table.values.putAssumeCapacityNoClobber(tombstone_from_key(key_from_value(value)), {});
+                    }
+                },
+                .general => {
+                    // If the key is already present in the hash map, the old key will not be overwritten
+                    // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
+                    // level getOrPut() API and manually overwrite the old key.
+                    const upsert = table.values.getOrPutAssumeCapacity(value.*);
+                    upsert.key_ptr.* = tombstone_from_key(key_from_value(value));
+                },
             }
 
             assert(table.values.count() <= table.value_count_max);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -28,6 +28,7 @@ const Table = @import("table.zig").TableType(
     Key.sentinel_key,
     Key.tombstone,
     Key.tombstone_from_key,
+    .general,
 );
 const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -20,17 +20,8 @@ const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .
 
 const GridType = @import("grid.zig").GridType;
 const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
-const Table = @import("table.zig").TableType(
-    Key,
-    Key.Value,
-    Key.compare_keys,
-    Key.key_from_value,
-    Key.sentinel_key,
-    Key.tombstone,
-    Key.tombstone_from_key,
-    .general,
-);
-const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
+const TableUsage = @import("table.zig").TableUsage;
+const TableType = @import("table.zig").TableType;
 
 const Grid = GridType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
@@ -83,275 +74,305 @@ const FuzzOp = union(enum) {
 };
 const FuzzOpTag = std.meta.Tag(FuzzOp);
 
-const Environment = struct {
-    const cluster = 32;
-    const replica = 4;
-    // TODO Is this appropriate for the number of fuzz_ops we want to run?
-    const size_max = vsr.Zone.superblock.size().? +
-        vsr.Zone.wal_headers.size().? +
-        vsr.Zone.wal_prepares.size().? +
-        1024 * 1024 * 1024;
+const cluster = 32;
+const replica = 4;
+// TODO Is this appropriate for the number of fuzz_ops we want to run?
+const size_max = vsr.Zone.superblock.size().? +
+    vsr.Zone.wal_headers.size().? +
+    vsr.Zone.wal_prepares.size().? +
+    1024 * 1024 * 1024;
 
-    const node_count = 1024;
-    const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
-    const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
-    const tree_options = Tree.Options{
-        .commit_entries_max = commit_entries_max,
-        // This is the smallest size that set_associative_cache will allow us.
-        .cache_entries_max = 2048,
-    };
+const node_count = 1024;
+const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
+const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
 
-    const puts_since_compact_max = commit_entries_max;
-
-    const compacts_per_checkpoint = std.math.divCeil(
-        usize,
-        constants.journal_slot_count,
-        constants.lsm_batch_multiple,
-    ) catch unreachable;
-
-    const State = enum {
-        uninit,
-        init,
-        formatted,
-        superblock_open,
-        tree_open,
-        tree_compacting,
-        tree_checkpointing,
-        superblock_checkpointing,
-        tree_lookup,
-    };
-
-    state: State,
-    storage: *Storage,
-    message_pool: MessagePool,
-    superblock: SuperBlock,
-    superblock_context: SuperBlock.Context = undefined,
-    grid: Grid,
-    node_pool: NodePool,
-    tree: Tree,
-    // We need @fieldParentPtr() of tree, so we can't use an optional Tree.
-    tree_exists: bool,
-    lookup_context: Tree.LookupContext = undefined,
-    lookup_value: ?*const Key.Value = null,
-    checkpoint_op: ?u64 = null,
-
-    fn init(env: *Environment, storage: *Storage) !void {
-        env.state = .uninit;
-
-        env.storage = storage;
-        errdefer env.storage.deinit(allocator);
-
-        env.message_pool = try MessagePool.init(allocator, .replica);
-        errdefer env.message_pool.deinit(allocator);
-
-        env.superblock = try SuperBlock.init(allocator, env.storage, &env.message_pool);
-        errdefer env.superblock.deinit(allocator);
-
-        env.grid = try Grid.init(allocator, &env.superblock);
-        errdefer env.grid.deinit(allocator);
-
-        env.node_pool = try NodePool.init(allocator, node_count);
-        errdefer env.node_pool.deinit(allocator);
-
-        // Tree must be initialized with an open superblock.
-        env.tree = undefined;
-        env.tree_exists = false;
-
-        env.state = .init;
-    }
-
-    fn deinit(env: *Environment) void {
-        assert(env.state != .uninit);
-
-        if (env.tree_exists) {
-            env.tree.deinit(allocator);
-            env.tree_exists = false;
-        }
-        env.node_pool.deinit(allocator);
-        env.grid.deinit(allocator);
-        env.superblock.deinit(allocator);
-        env.message_pool.deinit(allocator);
-
-        env.state = .uninit;
-    }
-
-    fn tick(env: *Environment) void {
-        env.grid.tick();
-        env.storage.tick();
-    }
-
-    fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
-        // Sometimes IO completes synchronously (eg if cached), so we might already be in next_state before ticking.
-        assert(env.state == current_state or env.state == next_state);
-        while (env.state == current_state) env.tick();
-        assert(env.state == next_state);
-    }
-
-    fn change_state(env: *Environment, current_state: State, next_state: State) void {
-        assert(env.state == current_state);
-        env.state = next_state;
-    }
-
-    pub fn format(storage: *Storage) !void {
-        var env: Environment = undefined;
-
-        try env.init(storage);
-        defer env.deinit();
-
-        assert(env.state == .init);
-        env.superblock.format(superblock_format_callback, &env.superblock_context, .{
-            .cluster = cluster,
-            .replica = replica,
-            .size_max = size_max,
-        });
-        env.tick_until_state_change(.init, .formatted);
-    }
-
-    fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
-        const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.init, .formatted);
-    }
-
-    pub fn open(env: *Environment) void {
-        assert(env.state == .init);
-        env.superblock.open(superblock_open_callback, &env.superblock_context);
-        env.tick_until_state_change(.init, .tree_open);
-    }
-
-    fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
-        const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.init, .superblock_open);
-        env.tree = Tree.init(allocator, &env.node_pool, &env.grid, tree_options) catch unreachable;
-        env.tree_exists = true;
-        env.tree.open(tree_open_callback);
-    }
-
-    fn tree_open_callback(tree: *Tree) void {
-        const env = @fieldParentPtr(@This(), "tree", tree);
-        env.change_state(.superblock_open, .tree_open);
-    }
-
-    pub fn compact(env: *Environment, op: u64) void {
-        env.change_state(.tree_open, .tree_compacting);
-        env.tree.compact(tree_compact_callback, op);
-        env.tick_until_state_change(.tree_compacting, .tree_open);
-    }
-
-    fn tree_compact_callback(tree: *Tree) void {
-        const env = @fieldParentPtr(@This(), "tree", tree);
-        env.change_state(.tree_compacting, .tree_open);
-    }
-
-    pub fn checkpoint(env: *Environment, op: u64) void {
-        env.checkpoint_op = op - constants.lsm_batch_multiple;
-        env.change_state(.tree_open, .tree_checkpointing);
-        env.tree.checkpoint(tree_checkpoint_callback);
-        env.tick_until_state_change(.tree_checkpointing, .superblock_checkpointing);
-        env.tick_until_state_change(.superblock_checkpointing, .tree_open);
-    }
-
-    fn tree_checkpoint_callback(tree: *Tree) void {
-        const env = @fieldParentPtr(@This(), "tree", tree);
-        env.change_state(.tree_checkpointing, .superblock_checkpointing);
-        env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
-            .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
-            .commit_min = env.checkpoint_op.?,
-            .commit_max = env.checkpoint_op.? + 1,
-            .view_normal = 0,
-            .view = 0,
-        });
-        env.checkpoint_op = null;
-    }
-
-    fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
-        const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.superblock_checkpointing, .tree_open);
-    }
-
-    fn get(env: *Environment, key: Key) ?*const Key.Value {
-        if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max, key)) |value| {
-            return Tree.unwrap_tombstone(value);
-        } else {
-            env.change_state(.tree_open, .tree_lookup);
-            env.lookup_context = undefined;
-            env.lookup_value = null;
-            env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
-            env.tick_until_state_change(.tree_lookup, .tree_open);
-            return env.lookup_value;
-        }
-    }
-
-    fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Key.Value) void {
-        const env = @fieldParentPtr(Environment, "lookup_context", lookup_context);
-        assert(env.lookup_value == null);
-        env.lookup_value = value;
-        env.change_state(.tree_lookup, .tree_open);
-    }
-
-    fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
-        var env: Environment = undefined;
-
-        try env.init(storage);
-        defer env.deinit();
-
-        // Open the superblock then tree.
-        env.open();
-
-        // The tree should behave like a simple key-value data-structure.
-        // We'll compare it to a hash map.
-        var model = std.hash_map.AutoHashMap(Key, Key.Value).init(allocator);
-        defer model.deinit();
-
-        for (fuzz_ops) |fuzz_op, fuzz_op_index| {
-            log.debug("Running fuzz_ops[{}/{}] == {}", .{ fuzz_op_index, fuzz_ops.len, fuzz_op });
-            const storage_size_used = storage.size_used();
-            log.debug("storage.size_used = {}/{}", .{ storage_size_used, storage.size });
-            const model_size = model.count() * @sizeOf(Key.Value);
-            log.debug("space_amplification = {d:.2}", .{
-                @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
-            });
-            // Apply fuzz_op to the tree and the model.
-            switch (fuzz_op) {
-                .compact => |compact| {
-                    env.compact(compact.op);
-                    if (compact.checkpoint) env.checkpoint(compact.op);
-                },
-                .put => |value| {
-                    env.tree.put(&value);
-                    try model.put(Key.key_from_value(&value), value);
-                },
-                .remove => |value| {
-                    env.tree.remove(&value);
-                    _ = model.remove(Key.key_from_value(&value));
-                },
-                .get => |key| {
-                    // Get account from lsm.
-                    const tree_value = env.get(key);
-
-                    // Compare result to model.
-                    const model_value = model.get(key);
-                    if (model_value == null) {
-                        assert(tree_value == null);
-                    } else {
-                        assert(std.mem.eql(
-                            u8,
-                            std.mem.asBytes(&model_value.?),
-                            std.mem.asBytes(tree_value.?),
-                        ));
-                    }
-                },
-            }
-        }
-    }
+const tree_options = .{
+    .commit_entries_max = commit_entries_max,
+    // This is the smallest size that set_associative_cache will allow us.
+    .cache_entries_max = 2048,
 };
 
-pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) !void {
-    // Init mocked storage.
-    var storage = try Storage.init(allocator, Environment.size_max, storage_options);
-    defer storage.deinit(allocator);
+const puts_since_compact_max = commit_entries_max;
 
-    try Environment.format(&storage);
-    try Environment.run(&storage, fuzz_ops);
+const compacts_per_checkpoint = std.math.divCeil(
+    usize,
+    constants.journal_slot_count,
+    constants.lsm_batch_multiple,
+) catch unreachable;
+
+fn EnvironmentType(comptime table_usage: TableUsage) type {
+    return struct {
+        const Environment = @This();
+
+        const Table = TableType(
+            Key,
+            Key.Value,
+            Key.compare_keys,
+            Key.key_from_value,
+            Key.sentinel_key,
+            Key.tombstone,
+            Key.tombstone_from_key,
+            table_usage,
+        );
+        const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
+
+        const State = enum {
+            uninit,
+            init,
+            formatted,
+            superblock_open,
+            tree_open,
+            tree_compacting,
+            tree_checkpointing,
+            superblock_checkpointing,
+            tree_lookup,
+        };
+
+        state: State,
+        storage: *Storage,
+        message_pool: MessagePool,
+        superblock: SuperBlock,
+        superblock_context: SuperBlock.Context = undefined,
+        grid: Grid,
+        node_pool: NodePool,
+        tree: Tree,
+        // We need @fieldParentPtr() of tree, so we can't use an optional Tree.
+        tree_exists: bool,
+        lookup_context: Tree.LookupContext = undefined,
+        lookup_value: ?*const Key.Value = null,
+        checkpoint_op: ?u64 = null,
+
+        fn init(env: *Environment, storage: *Storage) !void {
+            env.state = .uninit;
+
+            env.storage = storage;
+            errdefer env.storage.deinit(allocator);
+
+            env.message_pool = try MessagePool.init(allocator, .replica);
+            errdefer env.message_pool.deinit(allocator);
+
+            env.superblock = try SuperBlock.init(allocator, env.storage, &env.message_pool);
+            errdefer env.superblock.deinit(allocator);
+
+            env.grid = try Grid.init(allocator, &env.superblock);
+            errdefer env.grid.deinit(allocator);
+
+            env.node_pool = try NodePool.init(allocator, node_count);
+            errdefer env.node_pool.deinit(allocator);
+
+            // Tree must be initialized with an open superblock.
+            env.tree = undefined;
+            env.tree_exists = false;
+
+            env.state = .init;
+        }
+
+        fn deinit(env: *Environment) void {
+            assert(env.state != .uninit);
+
+            if (env.tree_exists) {
+                env.tree.deinit(allocator);
+                env.tree_exists = false;
+            }
+            env.node_pool.deinit(allocator);
+            env.grid.deinit(allocator);
+            env.superblock.deinit(allocator);
+            env.message_pool.deinit(allocator);
+
+            env.state = .uninit;
+        }
+
+        fn tick(env: *Environment) void {
+            env.grid.tick();
+            env.storage.tick();
+        }
+
+        fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
+            // Sometimes IO completes synchronously (eg if cached), so we might already be in next_state before ticking.
+            assert(env.state == current_state or env.state == next_state);
+            while (env.state == current_state) env.tick();
+            assert(env.state == next_state);
+        }
+
+        fn change_state(env: *Environment, current_state: State, next_state: State) void {
+            assert(env.state == current_state);
+            env.state = next_state;
+        }
+
+        pub fn format(storage: *Storage) !void {
+            var env: Environment = undefined;
+
+            try env.init(storage);
+            defer env.deinit();
+
+            assert(env.state == .init);
+            env.superblock.format(superblock_format_callback, &env.superblock_context, .{
+                .cluster = cluster,
+                .replica = replica,
+                .size_max = size_max,
+            });
+            env.tick_until_state_change(.init, .formatted);
+        }
+
+        fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
+            const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
+            env.change_state(.init, .formatted);
+        }
+
+        pub fn open(env: *Environment) void {
+            assert(env.state == .init);
+            env.superblock.open(superblock_open_callback, &env.superblock_context);
+            env.tick_until_state_change(.init, .tree_open);
+        }
+
+        fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
+            const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
+            env.change_state(.init, .superblock_open);
+            env.tree = Tree.init(allocator, &env.node_pool, &env.grid, tree_options) catch unreachable;
+            env.tree_exists = true;
+            env.tree.open(tree_open_callback);
+        }
+
+        fn tree_open_callback(tree: *Tree) void {
+            const env = @fieldParentPtr(@This(), "tree", tree);
+            env.change_state(.superblock_open, .tree_open);
+        }
+
+        pub fn compact(env: *Environment, op: u64) void {
+            env.change_state(.tree_open, .tree_compacting);
+            env.tree.compact(tree_compact_callback, op);
+            env.tick_until_state_change(.tree_compacting, .tree_open);
+        }
+
+        fn tree_compact_callback(tree: *Tree) void {
+            const env = @fieldParentPtr(@This(), "tree", tree);
+            env.change_state(.tree_compacting, .tree_open);
+        }
+
+        pub fn checkpoint(env: *Environment, op: u64) void {
+            env.checkpoint_op = op - constants.lsm_batch_multiple;
+            env.change_state(.tree_open, .tree_checkpointing);
+            env.tree.checkpoint(tree_checkpoint_callback);
+            env.tick_until_state_change(.tree_checkpointing, .superblock_checkpointing);
+            env.tick_until_state_change(.superblock_checkpointing, .tree_open);
+        }
+
+        fn tree_checkpoint_callback(tree: *Tree) void {
+            const env = @fieldParentPtr(@This(), "tree", tree);
+            env.change_state(.tree_checkpointing, .superblock_checkpointing);
+            env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
+                .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
+                .commit_min = env.checkpoint_op.?,
+                .commit_max = env.checkpoint_op.? + 1,
+                .view_normal = 0,
+                .view = 0,
+            });
+            env.checkpoint_op = null;
+        }
+
+        fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
+            const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
+            env.change_state(.superblock_checkpointing, .tree_open);
+        }
+
+        fn get(env: *Environment, key: Key) ?*const Key.Value {
+            if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max, key)) |value| {
+                return Tree.unwrap_tombstone(value);
+            } else {
+                env.change_state(.tree_open, .tree_lookup);
+                env.lookup_context = undefined;
+                env.lookup_value = null;
+                env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
+                env.tick_until_state_change(.tree_lookup, .tree_open);
+                return env.lookup_value;
+            }
+        }
+
+        fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Key.Value) void {
+            const env = @fieldParentPtr(Environment, "lookup_context", lookup_context);
+            assert(env.lookup_value == null);
+            env.lookup_value = value;
+            env.change_state(.tree_lookup, .tree_open);
+        }
+
+        fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
+            var env: Environment = undefined;
+
+            try env.init(storage);
+            defer env.deinit();
+
+            // Open the superblock then tree.
+            env.open();
+
+            // The tree should behave like a simple key-value data-structure.
+            // We'll compare it to a hash map.
+            var model = std.hash_map.AutoHashMap(Key, Key.Value).init(allocator);
+            defer model.deinit();
+
+            for (fuzz_ops) |fuzz_op, fuzz_op_index| {
+                log.debug("Running fuzz_ops[{}/{}] == {}", .{ fuzz_op_index, fuzz_ops.len, fuzz_op });
+                const storage_size_used = storage.size_used();
+                log.debug("storage.size_used = {}/{}", .{ storage_size_used, storage.size });
+                const model_size = model.count() * @sizeOf(Key.Value);
+                log.debug("space_amplification = {d:.2}", .{
+                    @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
+                });
+                // Apply fuzz_op to the tree and the model.
+                switch (fuzz_op) {
+                    .compact => |compact| {
+                        env.compact(compact.op);
+                        if (compact.checkpoint) env.checkpoint(compact.op);
+                    },
+                    .put => |value| {
+                        if (table_usage == .secondary_index) {
+                            if (model.get(Key.key_from_value(&value))) |old_value| {
+                                // Not allowed to put a present key without removing the old value first.
+                                env.tree.remove(&old_value);
+                            }
+                        }
+                        env.tree.put(&value);
+                        try model.put(Key.key_from_value(&value), value);
+                    },
+                    .remove => |value| {
+                        if (table_usage == .secondary_index and !model.contains((Key.key_from_value(&value)))) {
+                            // Not allowed to remove non-present keys
+                        } else {
+                            env.tree.remove(&value);
+                        }
+                        _ = model.remove(Key.key_from_value(&value));
+                    },
+                    .get => |key| {
+                        // Get account from lsm.
+                        const tree_value = env.get(key);
+
+                        // Compare result to model.
+                        const model_value = model.get(key);
+                        if (model_value == null) {
+                            assert(tree_value == null);
+                        } else {
+                            switch (table_usage) {
+                                .general => {
+                                    assert(std.mem.eql(
+                                        u8,
+                                        std.mem.asBytes(&model_value.?),
+                                        std.mem.asBytes(tree_value.?),
+                                    ));
+                                },
+                                .secondary_index => {
+                                    // secondary_index only preserves keys - may return old values
+                                    assert(std.mem.eql(
+                                        u8,
+                                        std.mem.asBytes(&Key.key_from_value(&model_value.?)),
+                                        std.mem.asBytes(&Key.key_from_value(tree_value.?)),
+                                    ));
+                                },
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    };
 }
 
 fn random_id(random: std.rand.Random, comptime Int: type) Int {
@@ -359,10 +380,10 @@ fn random_id(random: std.rand.Random, comptime Int: type) Int {
     const avg_int: Int = if (random.boolean())
         // 1. We want to cause many collisions.
         //8
-        100 * constants.lsm_growth_factor * Environment.tree_options.cache_entries_max
+        100 * constants.lsm_growth_factor * tree_options.cache_entries_max
     else
         // 2. We want to generate enough ids that the cache can't hold them all.
-        constants.lsm_growth_factor * Environment.tree_options.cache_entries_max;
+        constants.lsm_growth_factor * tree_options.cache_entries_max;
     return fuzz.random_int_exponential(random, Int, avg_int);
 }
 
@@ -384,13 +405,13 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
     };
     log.info("fuzz_op_distribution = {d:.2}", .{fuzz_op_distribution});
 
-    log.info("puts_since_compact_max = {}", .{Environment.puts_since_compact_max});
-    log.info("compacts_per_checkpoint = {}", .{Environment.compacts_per_checkpoint});
+    log.info("puts_since_compact_max = {}", .{puts_since_compact_max});
+    log.info("compacts_per_checkpoint = {}", .{compacts_per_checkpoint});
 
     var op: u64 = 1;
     var puts_since_compact: usize = 0;
     for (fuzz_ops) |*fuzz_op| {
-        const fuzz_op_tag = if (puts_since_compact >= Environment.puts_since_compact_max)
+        const fuzz_op_tag = if (puts_since_compact >= puts_since_compact_max)
             // We have to compact before doing any other operations.
             FuzzOpTag.compact
         else
@@ -400,16 +421,16 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
             .compact => compact: {
                 const compact_op = op;
                 op += 1;
-                const checkpoint =
+                const is_checkpoint =
                     // Can only checkpoint on the last beat of the bar.
                     compact_op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
                     compact_op > constants.lsm_batch_multiple and
                     // Checkpoint at roughly the same rate as log wraparound.
-                    random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
+                    random.uintLessThan(usize, compacts_per_checkpoint) == 0;
                 break :compact FuzzOp{
                     .compact = .{
                         .op = compact_op,
-                        .checkpoint = checkpoint,
+                        .checkpoint = is_checkpoint,
                     },
                 };
             },
@@ -441,16 +462,12 @@ pub fn main() !void {
     defer tracer.deinit(allocator);
 
     const fuzz_args = try fuzz.parse_fuzz_args(allocator);
+
     var rng = std.rand.DefaultPrng.init(fuzz_args.seed);
     const random = rng.random();
 
-    const fuzz_op_count = @minimum(
-        fuzz_args.events_max orelse @as(usize, 1E7),
-        fuzz.random_int_exponential(random, usize, 1E6),
-    );
-
-    const fuzz_ops = try generate_fuzz_ops(random, fuzz_op_count);
-    defer allocator.free(fuzz_ops);
+    const table_usage = random.enumValue(TableUsage);
+    log.info("table_usage={}", .{table_usage});
 
     const storage_options = .{
         .seed = random.int(u64),
@@ -460,7 +477,31 @@ pub fn main() !void {
         .write_latency_mean = 0 + fuzz.random_int_exponential(random, u64, 20),
     };
 
-    try run_fuzz_ops(storage_options, fuzz_ops);
+    const fuzz_op_count = @minimum(
+        fuzz_args.events_max orelse @as(usize, 1E7),
+        fuzz.random_int_exponential(random, usize, 1E6),
+    );
+
+    const fuzz_ops = try generate_fuzz_ops(random, fuzz_op_count);
+    defer allocator.free(fuzz_ops);
+
+    // Init mocked storage.
+    var storage = try Storage.init(allocator, size_max, storage_options);
+    defer storage.deinit(allocator);
+
+    // TODO Use inline switch after upgrading to zig 0.10
+    switch (table_usage) {
+        .general => {
+            const Environment = EnvironmentType(.general);
+            try Environment.format(&storage);
+            try Environment.run(&storage, fuzz_ops);
+        },
+        .secondary_index => {
+            const Environment = EnvironmentType(.secondary_index);
+            try Environment.format(&storage);
+            try Environment.run(&storage, fuzz_ops);
+        },
+    }
 
     log.info("Passed!", .{});
 }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -100,280 +100,280 @@ const compacts_per_checkpoint = std.math.divCeil(
     constants.lsm_batch_multiple,
 ) catch unreachable;
 
-fn EnvironmentType(comptime table_usage: TableUsage) type {
-    return struct {
-        const Environment = @This();
+//fn EnvironmentType(comptime table_usage: TableUsage) type {
+//return
+const EnvironmentType = struct {
+    const Environment = @This();
 
-        const Table = TableType(
-            Key,
-            Key.Value,
-            Key.compare_keys,
-            Key.key_from_value,
-            Key.sentinel_key,
-            Key.tombstone,
-            Key.tombstone_from_key,
-            table_usage,
-        );
-        const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
+    const Table = TableType(
+        Key,
+        Key.Value,
+        Key.compare_keys,
+        Key.key_from_value,
+        Key.sentinel_key,
+        Key.tombstone,
+        Key.tombstone_from_key,
+        table_usage,
+    );
+    const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
 
-        const State = enum {
-            uninit,
-            init,
-            formatted,
-            superblock_open,
-            tree_open,
-            tree_compacting,
-            tree_checkpointing,
-            superblock_checkpointing,
-            tree_lookup,
-        };
-
-        state: State,
-        storage: *Storage,
-        message_pool: MessagePool,
-        superblock: SuperBlock,
-        superblock_context: SuperBlock.Context = undefined,
-        grid: Grid,
-        node_pool: NodePool,
-        tree: Tree,
-        // We need @fieldParentPtr() of tree, so we can't use an optional Tree.
-        tree_exists: bool,
-        lookup_context: Tree.LookupContext = undefined,
-        lookup_value: ?*const Key.Value = null,
-        checkpoint_op: ?u64 = null,
-
-        fn init(env: *Environment, storage: *Storage) !void {
-            env.state = .uninit;
-
-            env.storage = storage;
-            errdefer env.storage.deinit(allocator);
-
-            env.message_pool = try MessagePool.init(allocator, .replica);
-            errdefer env.message_pool.deinit(allocator);
-
-            env.superblock = try SuperBlock.init(allocator, env.storage, &env.message_pool);
-            errdefer env.superblock.deinit(allocator);
-
-            env.grid = try Grid.init(allocator, &env.superblock);
-            errdefer env.grid.deinit(allocator);
-
-            env.node_pool = try NodePool.init(allocator, node_count);
-            errdefer env.node_pool.deinit(allocator);
-
-            // Tree must be initialized with an open superblock.
-            env.tree = undefined;
-            env.tree_exists = false;
-
-            env.state = .init;
-        }
-
-        fn deinit(env: *Environment) void {
-            assert(env.state != .uninit);
-
-            if (env.tree_exists) {
-                env.tree.deinit(allocator);
-                env.tree_exists = false;
-            }
-            env.node_pool.deinit(allocator);
-            env.grid.deinit(allocator);
-            env.superblock.deinit(allocator);
-            env.message_pool.deinit(allocator);
-
-            env.state = .uninit;
-        }
-
-        fn tick(env: *Environment) void {
-            env.grid.tick();
-            env.storage.tick();
-        }
-
-        fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
-            // Sometimes IO completes synchronously (eg if cached), so we might already be in next_state before ticking.
-            assert(env.state == current_state or env.state == next_state);
-            while (env.state == current_state) env.tick();
-            assert(env.state == next_state);
-        }
-
-        fn change_state(env: *Environment, current_state: State, next_state: State) void {
-            assert(env.state == current_state);
-            env.state = next_state;
-        }
-
-        pub fn format(storage: *Storage) !void {
-            var env: Environment = undefined;
-
-            try env.init(storage);
-            defer env.deinit();
-
-            assert(env.state == .init);
-            env.superblock.format(superblock_format_callback, &env.superblock_context, .{
-                .cluster = cluster,
-                .replica = replica,
-                .size_max = size_max,
-            });
-            env.tick_until_state_change(.init, .formatted);
-        }
-
-        fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
-            const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-            env.change_state(.init, .formatted);
-        }
-
-        pub fn open(env: *Environment) void {
-            assert(env.state == .init);
-            env.superblock.open(superblock_open_callback, &env.superblock_context);
-            env.tick_until_state_change(.init, .tree_open);
-        }
-
-        fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
-            const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-            env.change_state(.init, .superblock_open);
-            env.tree = Tree.init(allocator, &env.node_pool, &env.grid, tree_options) catch unreachable;
-            env.tree_exists = true;
-            env.tree.open(tree_open_callback);
-        }
-
-        fn tree_open_callback(tree: *Tree) void {
-            const env = @fieldParentPtr(@This(), "tree", tree);
-            env.change_state(.superblock_open, .tree_open);
-        }
-
-        pub fn compact(env: *Environment, op: u64) void {
-            env.change_state(.tree_open, .tree_compacting);
-            env.tree.compact(tree_compact_callback, op);
-            env.tick_until_state_change(.tree_compacting, .tree_open);
-        }
-
-        fn tree_compact_callback(tree: *Tree) void {
-            const env = @fieldParentPtr(@This(), "tree", tree);
-            env.change_state(.tree_compacting, .tree_open);
-        }
-
-        pub fn checkpoint(env: *Environment, op: u64) void {
-            env.checkpoint_op = op - constants.lsm_batch_multiple;
-            env.change_state(.tree_open, .tree_checkpointing);
-            env.tree.checkpoint(tree_checkpoint_callback);
-            env.tick_until_state_change(.tree_checkpointing, .superblock_checkpointing);
-            env.tick_until_state_change(.superblock_checkpointing, .tree_open);
-        }
-
-        fn tree_checkpoint_callback(tree: *Tree) void {
-            const env = @fieldParentPtr(@This(), "tree", tree);
-            env.change_state(.tree_checkpointing, .superblock_checkpointing);
-            env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
-                .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
-                .commit_min = env.checkpoint_op.?,
-                .commit_max = env.checkpoint_op.? + 1,
-                .view_normal = 0,
-                .view = 0,
-            });
-            env.checkpoint_op = null;
-        }
-
-        fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
-            const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-            env.change_state(.superblock_checkpointing, .tree_open);
-        }
-
-        fn get(env: *Environment, key: Key) ?*const Key.Value {
-            if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max, key)) |value| {
-                return Tree.unwrap_tombstone(value);
-            } else {
-                env.change_state(.tree_open, .tree_lookup);
-                env.lookup_context = undefined;
-                env.lookup_value = null;
-                env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
-                env.tick_until_state_change(.tree_lookup, .tree_open);
-                return env.lookup_value;
-            }
-        }
-
-        fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Key.Value) void {
-            const env = @fieldParentPtr(Environment, "lookup_context", lookup_context);
-            assert(env.lookup_value == null);
-            env.lookup_value = value;
-            env.change_state(.tree_lookup, .tree_open);
-        }
-
-        fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
-            var env: Environment = undefined;
-
-            try env.init(storage);
-            defer env.deinit();
-
-            // Open the superblock then tree.
-            env.open();
-
-            // The tree should behave like a simple key-value data-structure.
-            // We'll compare it to a hash map.
-            var model = std.hash_map.AutoHashMap(Key, Key.Value).init(allocator);
-            defer model.deinit();
-
-            for (fuzz_ops) |fuzz_op, fuzz_op_index| {
-                log.debug("Running fuzz_ops[{}/{}] == {}", .{ fuzz_op_index, fuzz_ops.len, fuzz_op });
-                const storage_size_used = storage.size_used();
-                log.debug("storage.size_used = {}/{}", .{ storage_size_used, storage.size });
-                const model_size = model.count() * @sizeOf(Key.Value);
-                log.debug("space_amplification = {d:.2}", .{
-                    @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
-                });
-                // Apply fuzz_op to the tree and the model.
-                switch (fuzz_op) {
-                    .compact => |compact| {
-                        env.compact(compact.op);
-                        if (compact.checkpoint) env.checkpoint(compact.op);
-                    },
-                    .put => |value| {
-                        if (table_usage == .secondary_index) {
-                            if (model.get(Key.key_from_value(&value))) |old_value| {
-                                // Not allowed to put a present key without removing the old value first.
-                                env.tree.remove(&old_value);
-                            }
-                        }
-                        env.tree.put(&value);
-                        try model.put(Key.key_from_value(&value), value);
-                    },
-                    .remove => |value| {
-                        if (table_usage == .secondary_index and !model.contains((Key.key_from_value(&value)))) {
-                            // Not allowed to remove non-present keys
-                        } else {
-                            env.tree.remove(&value);
-                        }
-                        _ = model.remove(Key.key_from_value(&value));
-                    },
-                    .get => |key| {
-                        // Get account from lsm.
-                        const tree_value = env.get(key);
-
-                        // Compare result to model.
-                        const model_value = model.get(key);
-                        if (model_value == null) {
-                            assert(tree_value == null);
-                        } else {
-                            switch (table_usage) {
-                                .general => {
-                                    assert(std.mem.eql(
-                                        u8,
-                                        std.mem.asBytes(&model_value.?),
-                                        std.mem.asBytes(tree_value.?),
-                                    ));
-                                },
-                                .secondary_index => {
-                                    // secondary_index only preserves keys - may return old values
-                                    assert(std.mem.eql(
-                                        u8,
-                                        std.mem.asBytes(&Key.key_from_value(&model_value.?)),
-                                        std.mem.asBytes(&Key.key_from_value(tree_value.?)),
-                                    ));
-                                },
-                            }
-                        }
-                    },
-                }
-            }
-        }
+    const State = enum {
+        uninit,
+        init,
+        formatted,
+        superblock_open,
+        tree_open,
+        tree_compacting,
+        tree_checkpointing,
+        superblock_checkpointing,
+        tree_lookup,
     };
-}
+
+    state: State,
+    storage: *Storage,
+    message_pool: MessagePool,
+    superblock: SuperBlock,
+    superblock_context: SuperBlock.Context = undefined,
+    grid: Grid,
+    node_pool: NodePool,
+    tree: Tree,
+    // We need @fieldParentPtr() of tree, so we can't use an optional Tree.
+    tree_exists: bool,
+    lookup_context: Tree.LookupContext = undefined,
+    lookup_value: ?*const Key.Value = null,
+    checkpoint_op: ?u64 = null,
+
+    fn init(env: *Environment, storage: *Storage) !void {
+        env.state = .uninit;
+
+        env.storage = storage;
+        errdefer env.storage.deinit(allocator);
+
+        env.message_pool = try MessagePool.init(allocator, .replica);
+        errdefer env.message_pool.deinit(allocator);
+
+        env.superblock = try SuperBlock.init(allocator, env.storage, &env.message_pool);
+        errdefer env.superblock.deinit(allocator);
+
+        env.grid = try Grid.init(allocator, &env.superblock);
+        errdefer env.grid.deinit(allocator);
+
+        env.node_pool = try NodePool.init(allocator, node_count);
+        errdefer env.node_pool.deinit(allocator);
+
+        // Tree must be initialized with an open superblock.
+        env.tree = undefined;
+        env.tree_exists = false;
+
+        env.state = .init;
+    }
+
+    fn deinit(env: *Environment) void {
+        assert(env.state != .uninit);
+
+        if (env.tree_exists) {
+            env.tree.deinit(allocator);
+            env.tree_exists = false;
+        }
+        env.node_pool.deinit(allocator);
+        env.grid.deinit(allocator);
+        env.superblock.deinit(allocator);
+        env.message_pool.deinit(allocator);
+
+        env.state = .uninit;
+    }
+
+    fn tick(env: *Environment) void {
+        env.grid.tick();
+        env.storage.tick();
+    }
+
+    fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
+        // Sometimes IO completes synchronously (eg if cached), so we might already be in next_state before ticking.
+        assert(env.state == current_state or env.state == next_state);
+        while (env.state == current_state) env.tick();
+        assert(env.state == next_state);
+    }
+
+    fn change_state(env: *Environment, current_state: State, next_state: State) void {
+        assert(env.state == current_state);
+        env.state = next_state;
+    }
+
+    pub fn format(storage: *Storage) !void {
+        var env: Environment = undefined;
+
+        try env.init(storage);
+        defer env.deinit();
+
+        assert(env.state == .init);
+        env.superblock.format(superblock_format_callback, &env.superblock_context, .{
+            .cluster = cluster,
+            .replica = replica,
+            .size_max = size_max,
+        });
+        env.tick_until_state_change(.init, .formatted);
+    }
+
+    fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
+        const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
+        env.change_state(.init, .formatted);
+    }
+
+    pub fn open(env: *Environment) void {
+        assert(env.state == .init);
+        env.superblock.open(superblock_open_callback, &env.superblock_context);
+        env.tick_until_state_change(.init, .tree_open);
+    }
+
+    fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
+        const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
+        env.change_state(.init, .superblock_open);
+        env.tree = Tree.init(allocator, &env.node_pool, &env.grid, tree_options) catch unreachable;
+        env.tree_exists = true;
+        env.tree.open(tree_open_callback);
+    }
+
+    fn tree_open_callback(tree: *Tree) void {
+        const env = @fieldParentPtr(@This(), "tree", tree);
+        env.change_state(.superblock_open, .tree_open);
+    }
+
+    pub fn compact(env: *Environment, op: u64) void {
+        env.change_state(.tree_open, .tree_compacting);
+        env.tree.compact(tree_compact_callback, op);
+        env.tick_until_state_change(.tree_compacting, .tree_open);
+    }
+
+    fn tree_compact_callback(tree: *Tree) void {
+        const env = @fieldParentPtr(@This(), "tree", tree);
+        env.change_state(.tree_compacting, .tree_open);
+    }
+
+    pub fn checkpoint(env: *Environment, op: u64) void {
+        env.checkpoint_op = op - constants.lsm_batch_multiple;
+        env.change_state(.tree_open, .tree_checkpointing);
+        env.tree.checkpoint(tree_checkpoint_callback);
+        env.tick_until_state_change(.tree_checkpointing, .superblock_checkpointing);
+        env.tick_until_state_change(.superblock_checkpointing, .tree_open);
+    }
+
+    fn tree_checkpoint_callback(tree: *Tree) void {
+        const env = @fieldParentPtr(@This(), "tree", tree);
+        env.change_state(.tree_checkpointing, .superblock_checkpointing);
+        env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
+            .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
+            .commit_min = env.checkpoint_op.?,
+            .commit_max = env.checkpoint_op.? + 1,
+            .view_normal = 0,
+            .view = 0,
+        });
+        env.checkpoint_op = null;
+    }
+
+    fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
+        const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
+        env.change_state(.superblock_checkpointing, .tree_open);
+    }
+
+    fn get(env: *Environment, key: Key) ?*const Key.Value {
+        if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max, key)) |value| {
+            return Tree.unwrap_tombstone(value);
+        } else {
+            env.change_state(.tree_open, .tree_lookup);
+            env.lookup_context = undefined;
+            env.lookup_value = null;
+            env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
+            env.tick_until_state_change(.tree_lookup, .tree_open);
+            return env.lookup_value;
+        }
+    }
+
+    fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Key.Value) void {
+        const env = @fieldParentPtr(Environment, "lookup_context", lookup_context);
+        assert(env.lookup_value == null);
+        env.lookup_value = value;
+        env.change_state(.tree_lookup, .tree_open);
+    }
+
+    fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
+        var env: Environment = undefined;
+
+        try env.init(storage);
+        defer env.deinit();
+
+        // Open the superblock then tree.
+        env.open();
+
+        // The tree should behave like a simple key-value data-structure.
+        // We'll compare it to a hash map.
+        var model = std.hash_map.AutoHashMap(Key, Key.Value).init(allocator);
+        defer model.deinit();
+
+        for (fuzz_ops) |fuzz_op, fuzz_op_index| {
+            log.debug("Running fuzz_ops[{}/{}] == {}", .{ fuzz_op_index, fuzz_ops.len, fuzz_op });
+            const storage_size_used = storage.size_used();
+            log.debug("storage.size_used = {}/{}", .{ storage_size_used, storage.size });
+            const model_size = model.count() * @sizeOf(Key.Value);
+            log.debug("space_amplification = {d:.2}", .{
+                @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
+            });
+            // Apply fuzz_op to the tree and the model.
+            switch (fuzz_op) {
+                .compact => |compact| {
+                    env.compact(compact.op);
+                    if (compact.checkpoint) env.checkpoint(compact.op);
+                },
+                .put => |value| {
+                    if (table_usage == .secondary_index) {
+                        if (model.get(Key.key_from_value(&value))) |old_value| {
+                            // Not allowed to put a present key without removing the old value first.
+                            env.tree.remove(&old_value);
+                        }
+                    }
+                    env.tree.put(&value);
+                    try model.put(Key.key_from_value(&value), value);
+                },
+                .remove => |value| {
+                    if (table_usage == .secondary_index and !model.contains((Key.key_from_value(&value)))) {
+                        // Not allowed to remove non-present keys
+                    } else {
+                        env.tree.remove(&value);
+                    }
+                    _ = model.remove(Key.key_from_value(&value));
+                },
+                .get => |key| {
+                    // Get account from lsm.
+                    const tree_value = env.get(key);
+
+                    // Compare result to model.
+                    const model_value = model.get(key);
+                    if (model_value == null) {
+                        assert(tree_value == null);
+                    } else {
+                        switch (table_usage) {
+                            .general => {
+                                assert(std.mem.eql(
+                                    u8,
+                                    std.mem.asBytes(&model_value.?),
+                                    std.mem.asBytes(tree_value.?),
+                                ));
+                            },
+                            .secondary_index => {
+                                // secondary_index only preserves keys - may return old values
+                                assert(std.mem.eql(
+                                    u8,
+                                    std.mem.asBytes(&Key.key_from_value(&model_value.?)),
+                                    std.mem.asBytes(&Key.key_from_value(tree_value.?)),
+                                ));
+                            },
+                        }
+                    }
+                },
+            }
+        }
+    }
+};
 
 fn random_id(random: std.rand.Random, comptime Int: type) Int {
     // We have two opposing desires for random ids:

--- a/src/util.zig
+++ b/src/util.zig
@@ -135,7 +135,3 @@ test "disjoint_slices" {
     try std.testing.expectEqual(false, disjoint_slices(u8, u32, a, std.mem.bytesAsSlice(u32, a)));
     try std.testing.expectEqual(false, disjoint_slices(u32, u8, b, std.mem.sliceAsBytes(b)));
 }
-
-pub fn xor(a: bool, b: bool) bool {
-    return (a or b) and !(a and b);
-}

--- a/src/util.zig
+++ b/src/util.zig
@@ -135,3 +135,7 @@ test "disjoint_slices" {
     try std.testing.expectEqual(false, disjoint_slices(u8, u32, a, std.mem.bytesAsSlice(u32, a)));
     try std.testing.expectEqual(false, disjoint_slices(u32, u8, b, std.mem.sliceAsBytes(b)));
 }
+
+pub fn xor(a: bool, b: bool) bool {
+    return (a or b) and !(a and b);
+}


### PR DESCRIPTION
I [noticed](https://github.com/tigerbeetledb/tigerbeetle/issues/262#issuecomment-1341623199) that a simple workload of transfers between two accounts was spending most of it's time compacting the balance trees. The reason is that updating the balance generates a slew of useless tombstones which are written to the tree and fill up level 0.

It's safe to drop these tombstones in the secondary indexes, but not in general. So let's add a parameter to `TableType`: `usage: enum {general, secondary_index}`.

Setting `usage == .secondary_index` promises:
* Only put a key if it doesn't exist.
* Only remove a key if it exists.
* Never look at `TableValue`, only `TableKey`. 

This is true for all of our index trees.

What we gain from this is that we know that for a given key the sequence of operations alternates puts and removes, and whenever we see a put and a remove together we can cancel them out.

This change increases throughput on the 2 account benchmark from `44523` tx/s to `159744` tx/s.

It was difficult to put the put/remove cancel into KWayMergeIterator, so I made a MergeIterator that is specialized for compaction. This cuts merge time a little (before/after below). We'd probably have to rework the TableIterator interface to do better (it forces a lot of repeated computation) but it's not nearly a priority yet.

![image](https://user-images.githubusercontent.com/340884/206802292-c0af0403-b8f4-4fb4-8203-58a8e5644ace.png)
