### PR TITLE
Config: storage_size_max, storage_size_limit

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -11,8 +11,9 @@ const constants = @import("constants.zig");
 const tigerbeetle = @import("tigerbeetle.zig");
 const vsr = @import("vsr.zig");
 const IO = @import("io.zig").IO;
+const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
 
-// TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted
+// TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage
 const usage = fmt.comptimePrint(
     \\Usage:
     \\
@@ -77,20 +78,23 @@ const usage = fmt.comptimePrint(
 });
 
 pub const Command = union(enum) {
+    pub const Start = struct {
+        args_allocated: std.ArrayList([:0]const u8),
+        addresses: []net.Address,
+        cache_accounts: u32,
+        cache_transfers: u32,
+        cache_transfers_posted: u32,
+        size_limit: u64,
+        path: [:0]const u8,
+    };
+
     format: struct {
         args_allocated: std.ArrayList([:0]const u8),
         cluster: u32,
         replica: u8,
         path: [:0]const u8,
     },
-    start: struct {
-        args_allocated: std.ArrayList([:0]const u8),
-        addresses: []net.Address,
-        cache_accounts: u32,
-        cache_transfers: u32,
-        cache_transfers_posted: u32,
-        path: [:0]const u8,
-    },
+    start: Start,
     version: struct {
         verbose: bool,
     },
@@ -117,6 +121,7 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
     var cache_accounts: ?[]const u8 = null;
     var cache_transfers: ?[]const u8 = null;
     var cache_transfers_posted: ?[]const u8 = null;
+    var size_limit: ?[]const u8 = null;
     var verbose: ?bool = null;
 
     var args = try std.process.argsWithAllocator(allocator);
@@ -163,6 +168,9 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
         } else if (mem.startsWith(u8, arg, "--cache-transfers-posted")) {
             if (command != .start) fatal("--cache-transfers-posted: supported only by 'start' command", .{});
             cache_transfers_posted = parse_flag("--cache-transfers-posted", arg);
+        } else if (mem.startsWith(u8, arg, "--limit-storage")) {
+            if (command != .start) fatal("--limit-storage: supported only by 'start' command", .{});
+            size_limit = parse_flag("--limit-storage", arg);
         } else if (mem.eql(u8, arg, "--verbose")) {
             if (command != .version) fatal("--verbose: supported only by 'version' command", .{});
             verbose = true;
@@ -218,6 +226,7 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
                         cache_transfers_posted,
                         constants.cache_transfers_posted_max,
                     ),
+                    .size_limit = parse_storage_size(size_limit, constants.size_max),
                     .path = path orelse fatal("required: <path>", .{}),
                 },
             };
@@ -270,6 +279,20 @@ fn parse_addresses(allocator: std.mem.Allocator, raw_addresses: []const u8) []ne
         error.AddressInvalid => fatal("--addresses: invalid IPv4 address", .{}),
         error.OutOfMemory => fatal("out of memory", .{}),
     };
+}
+
+fn parse_storage_size(size_string: ?[]const u8, size_max: u64) u64 {
+    const size_min = data_file_size_min;
+    const size = if (size_string) |s| parse_size(s) else size_max;
+    if (size > size_max) fatal("size value {} exceeds maximum: {}", .{ size, size_max });
+    if (size < size_min) fatal("size value {} is below minimum: {}", .{ size, size_min });
+    if (size % constants.sector_size != 0) {
+        fatal("size value {} must be a multiple of sector size ({})", .{
+            size,
+            constants.sector_size,
+        });
+    }
+    return size;
 }
 
 fn parse_size(string: []const u8) u64 {

--- a/src/config.zig
+++ b/src/config.zig
@@ -72,7 +72,7 @@ const ConfigCluster = struct {
     journal_slot_count: usize = 1024,
     message_size_max: usize = 1 * 1024 * 1024,
     superblock_copies: comptime_int = 4,
-    size_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
+    storage_size_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
     block_size: comptime_int = 64 * 1024,
     lsm_levels: u7 = 7,
     lsm_growth_factor: u32 = 8,
@@ -169,7 +169,7 @@ pub const configs = struct {
             .clients_max = 4,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(2),
-            .size_max = 1024 * 1024 * 1024,
+            .storage_size_max = 1024 * 1024 * 1024,
 
             .block_size = sector_size,
             .lsm_growth_factor = 4,

--- a/src/config.zig
+++ b/src/config.zig
@@ -72,7 +72,7 @@ const ConfigCluster = struct {
     journal_slot_count: usize = 1024,
     message_size_max: usize = 1 * 1024 * 1024,
     superblock_copies: comptime_int = 4,
-    size_max: usize = 16 * 1024 * 1024 * 1024 * 1024,
+    size_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
     block_size: comptime_int = 64 * 1024,
     lsm_levels: u7 = 7,
     lsm_growth_factor: u32 = 8,
@@ -169,6 +169,7 @@ pub const configs = struct {
             .clients_max = 4,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(2),
+            .size_max = 1024 * 1024 * 1024,
 
             .block_size = sector_size,
             .lsm_growth_factor = 4,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -295,7 +295,6 @@ comptime {
 /// * replicated storage overhead, since all data files are mirrored,
 /// * the size of the superblock storage zone, and
 /// * the static memory allocation required for tracking LSM forest metadata in memory.
-// TODO Remove, now that we have block_count_max.
 pub const size_max = config.cluster.size_max;
 
 /// The unit of read/write access to LSM manifest and LSM table blocks in the block storage zone.
@@ -303,8 +302,6 @@ pub const size_max = config.cluster.size_max;
 /// - A lower block size increases the memory overhead of table metadata, due to smaller/more tables.
 /// - A higher block size increases space amplification due to partially-filled blocks.
 pub const block_size = config.cluster.block_size;
-
-pub const block_count_max = @divExact(16 * 1024 * 1024 * 1024 * 1024, block_size);
 
 comptime {
     assert(block_size % sector_size == 0);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -295,7 +295,7 @@ comptime {
 /// * replicated storage overhead, since all data files are mirrored,
 /// * the size of the superblock storage zone, and
 /// * the static memory allocation required for tracking LSM forest metadata in memory.
-pub const size_max = config.cluster.size_max;
+pub const storage_size_max = config.cluster.storage_size_max;
 
 /// The unit of read/write access to LSM manifest and LSM table blocks in the block storage zone.
 ///

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -147,7 +147,7 @@ const Environment = struct {
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
-            .size_max = constants.size_max,
+            .storage_size_max = constants.storage_size_max,
         });
         env.tick_until_state_change(.init, .formatted);
     }
@@ -287,7 +287,7 @@ const Environment = struct {
 
 pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) !void {
     // Init mocked storage.
-    var storage = try Storage.init(allocator, constants.size_max, storage_options);
+    var storage = try Storage.init(allocator, constants.storage_size_max, storage_options);
     defer storage.deinit(allocator);
 
     try Environment.format(&storage);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -41,11 +41,6 @@ const FuzzOpTag = std.meta.Tag(FuzzOp);
 const Environment = struct {
     const cluster = 32;
     const replica = 4;
-    // TODO Is this appropriate for the number of fuzz_ops we want to run?
-    const size_max = vsr.Zone.superblock.size().? +
-        vsr.Zone.wal_headers.size().? +
-        vsr.Zone.wal_prepares.size().? +
-        1024 * 1024 * 1024;
 
     const node_count = 1024;
     // This is the smallest size that set_associative_cache will allow us.
@@ -152,7 +147,7 @@ const Environment = struct {
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
-            .size_max = size_max,
+            .size_max = constants.size_max,
         });
         env.tick_until_state_change(.init, .formatted);
     }
@@ -292,7 +287,7 @@ const Environment = struct {
 
 pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) !void {
     // Init mocked storage.
-    var storage = try Storage.init(allocator, Environment.size_max, storage_options);
+    var storage = try Storage.init(allocator, constants.size_max, storage_options);
     defer storage.deinit(allocator);
 
     try Environment.format(&storage);

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -30,8 +30,6 @@ const fuzz = @import("../test/fuzz.zig");
 
 pub const tigerbeetle_config = @import("../config.zig").configs.test_min;
 
-const storage_size_max = data_file_size_min + constants.block_size * 1024;
-
 const entries_max_block = ManifestLog.Block.entry_count_max;
 const entries_max_buffered = entries_max_block *
     std.meta.fieldInfo(ManifestLog, .blocks).field_type.count_max;
@@ -66,20 +64,28 @@ fn run_fuzz(
         .write_latency_mean = 1 + random.uintLessThan(u64, 40),
     };
 
-    var storage = try Storage.init(allocator, storage_size_max, storage_options);
+    var storage = try Storage.init(allocator, constants.size_max, storage_options);
     defer storage.deinit(allocator);
 
-    var storage_verify = try Storage.init(allocator, storage_size_max, storage_options);
+    var storage_verify = try Storage.init(allocator, constants.size_max, storage_options);
     defer storage_verify.deinit(allocator);
 
     // The MessagePool is shared by both superblocks because they will not use it.
     var message_pool = try MessagePool.init(allocator, .replica);
     defer message_pool.deinit(allocator);
 
-    var superblock = try SuperBlock.init(allocator, &storage, &message_pool);
+    var superblock = try SuperBlock.init(allocator, .{
+        .storage = &storage,
+        .message_pool = &message_pool,
+        .size_limit = constants.size_max,
+    });
     defer superblock.deinit(allocator);
 
-    var superblock_verify = try SuperBlock.init(allocator, &storage_verify, &message_pool);
+    var superblock_verify = try SuperBlock.init(allocator, .{
+        .storage = &storage_verify,
+        .message_pool = &message_pool,
+        .size_limit = constants.size_max,
+    });
     defer superblock_verify.deinit(allocator);
 
     var grid = try Grid.init(allocator, &superblock);
@@ -324,7 +330,7 @@ const Environment = struct {
         env.manifest_log.superblock.format(format_superblock_callback, &env.superblock_context, .{
             .cluster = 0,
             .replica = 0,
-            .size_max = storage_size_max,
+            .size_max = constants.size_max,
         });
     }
 
@@ -453,8 +459,11 @@ const Environment = struct {
             test_superblock.deinit(env.allocator);
             test_superblock.* = try SuperBlock.init(
                 env.allocator,
-                test_storage,
-                env.manifest_log.superblock.client_table.message_pool,
+                .{
+                    .storage = test_storage,
+                    .message_pool = env.manifest_log.superblock.client_table.message_pool,
+                    .size_limit = constants.size_max,
+                },
             );
 
             test_grid.deinit(env.allocator);

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -64,10 +64,10 @@ fn run_fuzz(
         .write_latency_mean = 1 + random.uintLessThan(u64, 40),
     };
 
-    var storage = try Storage.init(allocator, constants.size_max, storage_options);
+    var storage = try Storage.init(allocator, constants.storage_size_max, storage_options);
     defer storage.deinit(allocator);
 
-    var storage_verify = try Storage.init(allocator, constants.size_max, storage_options);
+    var storage_verify = try Storage.init(allocator, constants.storage_size_max, storage_options);
     defer storage_verify.deinit(allocator);
 
     // The MessagePool is shared by both superblocks because they will not use it.
@@ -76,15 +76,15 @@ fn run_fuzz(
 
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
+        .storage_size_limit = constants.storage_size_max,
         .message_pool = &message_pool,
-        .size_limit = constants.size_max,
     });
     defer superblock.deinit(allocator);
 
     var superblock_verify = try SuperBlock.init(allocator, .{
         .storage = &storage_verify,
+        .storage_size_limit = constants.storage_size_max,
         .message_pool = &message_pool,
-        .size_limit = constants.size_max,
     });
     defer superblock_verify.deinit(allocator);
 
@@ -330,7 +330,6 @@ const Environment = struct {
         env.manifest_log.superblock.format(format_superblock_callback, &env.superblock_context, .{
             .cluster = 0,
             .replica = 0,
-            .size_max = constants.size_max,
         });
     }
 
@@ -461,8 +460,8 @@ const Environment = struct {
                 env.allocator,
                 .{
                     .storage = test_storage,
+                    .storage_size_limit = constants.storage_size_max,
                     .message_pool = env.manifest_log.superblock.client_table.message_pool,
-                    .size_limit = constants.size_max,
                 },
             );
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -27,7 +27,7 @@ const SuperBlock = vsr.SuperBlockType(Storage);
 const Environment = struct {
     const cluster = 32;
     const replica = 4;
-    const size_max = vsr.Zone.superblock.size().? +
+    const storage_size_max = vsr.Zone.superblock.size().? +
         vsr.Zone.wal_headers.size().? +
         vsr.Zone.wal_prepares.size().? +
         (512 + 64) * 1024 * 1024;
@@ -73,7 +73,7 @@ const Environment = struct {
         env.dir_fd = try IO.open_dir(dir_path);
         errdefer std.os.close(env.dir_fd);
 
-        env.fd = try IO.open_file(env.dir_fd, "test_forest", size_max, must_create);
+        env.fd = try IO.open_file(env.dir_fd, "test_forest", storage_size_max, must_create);
         errdefer std.os.close(env.fd);
 
         env.io = try IO.init(128, 0);
@@ -87,8 +87,8 @@ const Environment = struct {
 
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = &env.storage,
+            .storage_size_limit = constants.storage_size_max,
             .message_pool = &env.message_pool,
-            .size_limit = constants.size_max,
         });
         env.superblock_context = undefined;
         errdefer env.superblock.deinit(allocator);
@@ -136,7 +136,7 @@ const Environment = struct {
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
-            .size_max = size_max,
+            .storage_size_max = storage_size_max,
         });
 
         while (true) {

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -85,7 +85,11 @@ const Environment = struct {
         env.message_pool = try MessagePool.init(allocator, .replica);
         errdefer env.message_pool.deinit(allocator);
 
-        env.superblock = try SuperBlock.init(allocator, &env.storage, &env.message_pool);
+        env.superblock = try SuperBlock.init(allocator, .{
+            .storage = &env.storage,
+            .message_pool = &env.message_pool,
+            .size_limit = constants.size_max,
+        });
         env.superblock_context = undefined;
         errdefer env.superblock.deinit(allocator);
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -140,8 +140,8 @@ const Environment = struct {
 
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = env.storage,
+            .storage_size_limit = constants.storage_size_max,
             .message_pool = &env.message_pool,
-            .size_limit = constants.size_max,
         });
         errdefer env.superblock.deinit(allocator);
 
@@ -200,7 +200,6 @@ const Environment = struct {
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
-            .size_max = constants.size_max,
         });
         env.tick_until_state_change(.init, .formatted);
     }
@@ -345,7 +344,7 @@ const Environment = struct {
 
 pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) !void {
     // Init mocked storage.
-    var storage = try Storage.init(allocator, constants.size_max, storage_options);
+    var storage = try Storage.init(allocator, constants.storage_size_max, storage_options);
     defer storage.deinit(allocator);
 
     try Environment.format(&storage);

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,18 +45,7 @@ pub fn main() !void {
 
     switch (parse_args) {
         .format => |*args| try Command.format(allocator, args.cluster, args.replica, args.path),
-        .start => |*args| try Command.start(
-            &arena,
-            args.addresses,
-            .{
-                // TODO Tune lsm_forest_node_count better.
-                .lsm_forest_node_count = 4096,
-                .cache_entries_accounts = args.cache_accounts,
-                .cache_entries_transfers = args.cache_transfers,
-                .cache_entries_posted = args.cache_transfers_posted,
-            },
-            args.path,
-        ),
+        .start => |*args| try Command.start(&arena, args),
         .version => |*args| try Command.version(allocator, args.verbose),
     }
 }
@@ -113,24 +102,25 @@ const Command = struct {
 
         var superblock = try SuperBlock.init(
             allocator,
-            &command.storage,
-            &command.message_pool,
+            .{
+                .storage = &command.storage,
+                .message_pool = &command.message_pool,
+                .size_limit = data_file_size_min,
+            },
         );
         defer superblock.deinit(allocator);
 
         try vsr.format(Storage, allocator, cluster, replica, &command.storage, &superblock);
     }
 
-    pub fn start(
-        arena: *std.heap.ArenaAllocator,
-        addresses: []std.net.Address,
-        options: StateMachine.Options,
-        path: [:0]const u8,
-    ) !void {
+    pub fn start(arena: *std.heap.ArenaAllocator, args: *const cli.Command.Start) !void {
         var tracer_allocator = if (constants.tracer_backend == .tracy)
             tracer.TracerAllocator.init(arena.allocator())
         else
             arena;
+
+        // TODO Panic if the data file's size is larger that args.size_limit.
+        // (Here or in Replica.open()?).
 
         const allocator = tracer_allocator.allocator();
 
@@ -138,18 +128,25 @@ const Command = struct {
         defer tracer.deinit(allocator);
 
         var command: Command = undefined;
-        try command.init(allocator, path, false);
+        try command.init(allocator, args.path, false);
         defer command.deinit(allocator);
 
         var replica: Replica = undefined;
         replica.open(allocator, .{
-            .replica_count = @intCast(u8, addresses.len),
+            .replica_count = @intCast(u8, args.addresses.len),
+            .size_limit = args.size_limit,
             .storage = &command.storage,
             .message_pool = &command.message_pool,
             .time = .{},
-            .state_machine_options = options,
+            .state_machine_options = .{
+                // TODO Tune lsm_forest_node_count better.
+                .lsm_forest_node_count = 4096,
+                .cache_entries_accounts = args.cache_accounts,
+                .cache_entries_transfers = args.cache_transfers,
+                .cache_entries_posted = args.cache_transfers_posted,
+            },
             .message_bus_options = .{
-                .configuration = addresses,
+                .configuration = args.addresses,
                 .io = &command.io,
             },
         }) catch |err| switch (err) {
@@ -178,7 +175,7 @@ const Command = struct {
         log_main.info("{}: cluster={}: listening on {}", .{
             replica.replica,
             replica.cluster,
-            addresses[replica.replica],
+            args.addresses[replica.replica],
         });
 
         while (true) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -104,8 +104,8 @@ const Command = struct {
             allocator,
             .{
                 .storage = &command.storage,
+                .storage_size_limit = data_file_size_min,
                 .message_pool = &command.message_pool,
-                .size_limit = data_file_size_min,
             },
         );
         defer superblock.deinit(allocator);
@@ -119,7 +119,7 @@ const Command = struct {
         else
             arena;
 
-        // TODO Panic if the data file's size is larger that args.size_limit.
+        // TODO Panic if the data file's size is larger that args.storage_size_limit.
         // (Here or in Replica.open()?).
 
         const allocator = tracer_allocator.allocator();
@@ -134,7 +134,7 @@ const Command = struct {
         var replica: Replica = undefined;
         replica.open(allocator, .{
             .replica_count = @intCast(u8, args.addresses.len),
-            .size_limit = args.size_limit,
+            .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .message_pool = &command.message_pool,
             .time = .{},

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -94,8 +94,8 @@ pub fn main() !void {
         .cluster = cluster_id,
         .replica_count = replica_count,
         .client_count = client_count,
-        .size_limit = vsr.sector_floor(
-            constants.size_max - random.uintLessThan(u64, constants.size_max / 10),
+        .storage_size_limit = vsr.sector_floor(
+            constants.storage_size_max - random.uintLessThan(u64, constants.storage_size_max / 10),
         ),
         .seed = random.int(u64),
         .on_change_state = on_replica_change_state,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -94,8 +94,9 @@ pub fn main() !void {
         .cluster = cluster_id,
         .replica_count = replica_count,
         .client_count = client_count,
-        // TODO Compute an upper-bound for this based on requests_committed_max.
-        .grid_size_max = 1024 * 1024 * 256,
+        .size_limit = vsr.sector_floor(
+            constants.size_max - random.uintLessThan(u64, constants.size_max / 10),
+        ),
         .seed = random.int(u64),
         .on_change_state = on_replica_change_state,
         .on_compact = on_replica_compact,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1152,8 +1152,8 @@ const TestContext = struct {
 
         ctx.superblock = try SuperBlock.init(allocator, .{
             .storage = &ctx.storage,
+            .storage_size_limit = data_file_size_min,
             .message_pool = &ctx.message_pool,
-            .size_limit = data_file_size_min,
         });
         errdefer ctx.superblock.deinit(allocator);
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1115,6 +1115,7 @@ test "sum_overflows" {
 const TestContext = struct {
     const Storage = @import("test/storage.zig").Storage;
     const MessagePool = @import("message_pool.zig").MessagePool;
+    const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
     const SuperBlock = @import("vsr/superblock.zig").SuperBlockType(Storage);
     const Grid = @import("lsm/grid.zig").GridType(Storage);
     const StateMachine = StateMachineType(Storage, .{
@@ -1149,7 +1150,11 @@ const TestContext = struct {
         };
         errdefer ctx.message_pool.deinit(allocator);
 
-        ctx.superblock = try SuperBlock.init(allocator, &ctx.storage, &ctx.message_pool);
+        ctx.superblock = try SuperBlock.init(allocator, .{
+            .storage = &ctx.storage,
+            .message_pool = &ctx.message_pool,
+            .size_limit = data_file_size_min,
+        });
         errdefer ctx.superblock.deinit(allocator);
 
         // Pretend that the superblock is open so that the Forest can initialize.

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -29,7 +29,7 @@ pub const ClusterOptions = struct {
     cluster: u32,
     replica_count: u8,
     client_count: u8,
-    size_limit: u64,
+    storage_size_limit: u64,
 
     seed: u64,
     on_change_state: fn (replica: *const Replica) void,
@@ -76,8 +76,8 @@ pub const Cluster = struct {
     pub fn create(allocator: mem.Allocator, prng: std.rand.Random, options: ClusterOptions) !*Cluster {
         assert(options.replica_count > 0);
         assert(options.client_count > 0);
-        assert(options.size_limit % constants.sector_size == 0);
-        assert(options.size_limit <= constants.size_max);
+        assert(options.storage_size_limit % constants.sector_size == 0);
+        assert(options.storage_size_limit <= constants.storage_size_max);
         assert(options.health_options.crash_probability < 1.0);
         assert(options.health_options.crash_probability >= 0.0);
         assert(options.health_options.restart_probability < 1.0);
@@ -136,7 +136,7 @@ pub const Cluster = struct {
             var storage_options = options.storage_options;
             storage_options.replica_index = @intCast(u8, replica_index);
             storage_options.faulty_wal_areas = faulty_wal_areas[replica_index];
-            storage.* = try Storage.init(allocator, options.size_limit, storage_options);
+            storage.* = try Storage.init(allocator, options.storage_size_limit, storage_options);
         }
         errdefer for (cluster.storages) |*storage| storage.deinit(allocator);
 
@@ -145,7 +145,7 @@ pub const Cluster = struct {
             var superblock = try SuperBlock.init(allocator, .{
                 .storage = storage,
                 .message_pool = &cluster.pools[replica_index],
-                .size_limit = options.size_limit,
+                .storage_size_limit = options.storage_size_limit,
             });
             defer superblock.deinit(allocator);
 
@@ -330,7 +330,7 @@ pub const Cluster = struct {
             .{
                 .replica_count = @intCast(u8, cluster.replicas.len),
                 .storage = &cluster.storages[replica_index],
-                .size_limit = cluster.options.size_limit,
+                .storage_size_limit = cluster.options.storage_size_limit,
                 .message_pool = &cluster.pools[replica_index],
                 .time = time,
                 .state_machine_options = cluster.options.state_machine_options,

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -29,7 +29,7 @@ pub const ClusterOptions = struct {
     cluster: u32,
     replica_count: u8,
     client_count: u8,
-    grid_size_max: usize,
+    size_limit: u64,
 
     seed: u64,
     on_change_state: fn (replica: *const Replica) void,
@@ -76,8 +76,8 @@ pub const Cluster = struct {
     pub fn create(allocator: mem.Allocator, prng: std.rand.Random, options: ClusterOptions) !*Cluster {
         assert(options.replica_count > 0);
         assert(options.client_count > 0);
-        assert(options.grid_size_max > 0);
-        assert(options.grid_size_max % constants.sector_size == 0);
+        assert(options.size_limit % constants.sector_size == 0);
+        assert(options.size_limit <= constants.size_max);
         assert(options.health_options.crash_probability < 1.0);
         assert(options.health_options.crash_probability >= 0.0);
         assert(options.health_options.restart_probability < 1.0);
@@ -136,17 +136,17 @@ pub const Cluster = struct {
             var storage_options = options.storage_options;
             storage_options.replica_index = @intCast(u8, replica_index);
             storage_options.faulty_wal_areas = faulty_wal_areas[replica_index];
-            storage.* = try Storage.init(
-                allocator,
-                superblock_zone_size + constants.journal_size_max + options.grid_size_max,
-                storage_options,
-            );
+            storage.* = try Storage.init(allocator, options.size_limit, storage_options);
         }
         errdefer for (cluster.storages) |*storage| storage.deinit(allocator);
 
         // Format each replica's storage (equivalent to "tigerbeetle format ...").
         for (cluster.storages) |*storage, replica_index| {
-            var superblock = try SuperBlock.init(allocator, storage, &cluster.pools[replica_index]);
+            var superblock = try SuperBlock.init(allocator, .{
+                .storage = storage,
+                .message_pool = &cluster.pools[replica_index],
+                .size_limit = options.size_limit,
+            });
             defer superblock.deinit(allocator);
 
             try vsr.format(
@@ -330,6 +330,7 @@ pub const Cluster = struct {
             .{
                 .replica_count = @intCast(u8, cluster.replicas.len),
                 .storage = &cluster.storages[replica_index],
+                .size_limit = cluster.options.size_limit,
                 .message_pool = &cluster.pools[replica_index],
                 .time = time,
                 .state_machine_options = cluster.options.state_machine_options,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -291,7 +291,7 @@ pub fn ReplicaType(
 
         const OpenOptions = struct {
             replica_count: u8,
-            size_limit: u64,
+            storage_size_limit: u64,
             storage: *Storage,
             message_pool: *MessagePool,
             time: Time,
@@ -301,8 +301,8 @@ pub fn ReplicaType(
 
         /// Initializes and opens the provided replica using the options.
         pub fn open(self: *Self, parent_allocator: std.mem.Allocator, options: OpenOptions) !void {
-            assert(options.size_limit <= constants.size_max);
-            assert(options.size_limit % constants.sector_size == 0);
+            assert(options.storage_size_limit <= constants.storage_size_max);
+            assert(options.storage_size_limit % constants.sector_size == 0);
 
             self.static_allocator = StaticAllocator.init(parent_allocator);
             const allocator = self.static_allocator.allocator();
@@ -312,7 +312,7 @@ pub fn ReplicaType(
                 .{
                     .storage = options.storage,
                     .message_pool = options.message_pool,
-                    .size_limit = options.size_limit,
+                    .storage_size_limit = options.storage_size_limit,
                 },
             );
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -291,6 +291,7 @@ pub fn ReplicaType(
 
         const OpenOptions = struct {
             replica_count: u8,
+            size_limit: u64,
             storage: *Storage,
             message_pool: *MessagePool,
             time: Time,
@@ -300,13 +301,19 @@ pub fn ReplicaType(
 
         /// Initializes and opens the provided replica using the options.
         pub fn open(self: *Self, parent_allocator: std.mem.Allocator, options: OpenOptions) !void {
+            assert(options.size_limit <= constants.size_max);
+            assert(options.size_limit % constants.sector_size == 0);
+
             self.static_allocator = StaticAllocator.init(parent_allocator);
             const allocator = self.static_allocator.allocator();
 
             self.superblock = try SuperBlock.init(
                 allocator,
-                options.storage,
-                options.message_pool,
+                .{
+                    .storage = options.storage,
+                    .message_pool = options.message_pool,
+                    .size_limit = options.size_limit,
+                },
             );
 
             // Once initialzed, the replica is in charge of calling superblock.deinit()

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -151,6 +151,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
 
 test "format" {
     const superblock_zone_size = @import("./superblock.zig").superblock_zone_size;
+    const data_file_size_min = @import("./superblock.zig").data_file_size_min;
     const MessagePool = @import("../message_pool.zig").MessagePool;
     const Storage = @import("../test/storage.zig").Storage;
     const SuperBlock = vsr.SuperBlockType(Storage);
@@ -173,7 +174,11 @@ test "format" {
     var message_pool = try MessagePool.init(allocator, .replica);
     defer message_pool.deinit(allocator);
 
-    var superblock = try SuperBlock.init(allocator, &storage, &message_pool);
+    var superblock = try SuperBlock.init(allocator, .{
+        .storage = &storage,
+        .message_pool = &message_pool,
+        .size_limit = data_file_size_min,
+    });
     defer superblock.deinit(allocator);
 
     try format(Storage, allocator, cluster, replica, &storage, &superblock);

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -28,8 +28,6 @@ pub fn format(
         .{
             .cluster = cluster,
             .replica = replica,
-            // TODO Convert this to a runtime arg, to cap storage.
-            .size_max = constants.size_max,
         },
     );
 
@@ -176,8 +174,8 @@ test "format" {
 
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
+        .storage_size_limit = data_file_size_min,
         .message_pool = &message_pool,
-        .size_limit = data_file_size_min,
     });
     defer superblock.deinit(allocator);
 
@@ -191,7 +189,7 @@ test "format" {
         try std.testing.expectEqual(sector.copy, copy);
         try std.testing.expectEqual(sector.replica, replica);
         try std.testing.expectEqual(sector.cluster, cluster);
-        try std.testing.expectEqual(sector.size, storage.size);
+        try std.testing.expectEqual(sector.storage_size, storage.size);
         try std.testing.expectEqual(sector.sequence, 1);
         try std.testing.expectEqual(sector.vsr_state.commit_min, 0);
         try std.testing.expectEqual(sector.vsr_state.commit_max, 0);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -54,8 +54,9 @@ pub const SuperBlockSector = extern struct {
     /// The current size of the data file.
     size: u64,
 
-    /// The maximum size of the data file.
-    // TODO Actually limit the file to this size.
+    /// The maximum possible size of the data file.
+    /// The maximum allowed runtime size_limit.
+    /// The FreeSet's on-disk size is a function of size_max.
     size_max: u64,
 
     /// A monotonically increasing counter to locate the latest superblock at startup.
@@ -321,7 +322,7 @@ pub const superblock_trailer_manifest_size_max = blk: {
 };
 
 pub const superblock_trailer_free_set_size_max = blk: {
-    const encode_size_max = SuperBlockFreeSet.encode_size_max(constants.block_count_max);
+    const encode_size_max = SuperBlockFreeSet.encode_size_max(block_count_max);
     assert(encode_size_max > 0);
 
     // Round up to the nearest sector:
@@ -339,6 +340,33 @@ pub const superblock_trailer_client_table_size_max = blk: {
 pub const data_file_size_min = blk: {
     break :blk superblock_zone_size + constants.journal_size_max;
 };
+
+/// The maximum number of blocks in the grid.
+const block_count_max = blk: {
+    var size_max = constants.size_max;
+    size_max -= constants.superblock_copies * @sizeOf(SuperBlockSector);
+    size_max -= constants.superblock_copies * superblock_trailer_client_table_size_max;
+    size_max -= constants.superblock_copies * superblock_trailer_manifest_size_max;
+    size_max -= constants.journal_size_max;
+    // At this point, the remainder of size_max is split between the grid and the freeset copies.
+    // The size of a freeset is related to the number of blocks it must store.
+    // Maximize the number of grid blocks.
+
+    var shard_count = @divFloor(size_max, constants.block_size * SuperBlockFreeSet.shard_size);
+    while (true) : (shard_count -= 1) {
+        const block_count = shard_count * SuperBlockFreeSet.shard_size;
+        const grid_size = block_count * constants.block_size;
+        const free_set_size = vsr.sector_ceil(SuperBlockFreeSet.encode_size_max(block_count));
+        const free_sets_size = constants.superblock_copies * free_set_size;
+        if (free_sets_size + grid_size <= size_max) break;
+    }
+    break :blk shard_count * SuperBlockFreeSet.shard_size;
+};
+
+comptime {
+    assert(block_count_max > 0);
+    assert(block_count_max * constants.block_size + data_file_size_min <= constants.size_max);
+}
 
 /// This table shows the sequence number progression of the SuperBlock's sectors.
 ///
@@ -441,6 +469,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
         /// Whether the superblock has been opened. An open superblock may not be formatted.
         opened: bool = false,
+        block_count_limit: usize,
+        size_limit: u64,
 
         /// Beyond formatting and opening of the superblock, which are mutually exclusive of all
         /// other operations, only the following queue combinations are allowed:
@@ -452,11 +482,24 @@ pub fn SuperBlockType(comptime Storage: type) type {
         queue_head: ?*Context = null,
         queue_tail: ?*Context = null,
 
-        pub fn init(
-            allocator: mem.Allocator,
+        pub const Options = struct {
             storage: *Storage,
             message_pool: *MessagePool,
-        ) !SuperBlock {
+            size_limit: u64,
+        };
+
+        pub fn init(allocator: mem.Allocator, options: Options) !SuperBlock {
+            assert(options.size_limit >= data_file_size_min);
+            assert(options.size_limit <= constants.size_max);
+            assert(options.size_limit % constants.sector_size == 0);
+
+            const shard_count_limit = @intCast(usize, @divFloor(
+                options.size_limit - data_file_size_min,
+                constants.block_size * FreeSet.shard_size,
+            ));
+            const block_count_limit = shard_count_limit * FreeSet.shard_size;
+            assert(block_count_limit <= block_count_max);
+
             const a = try allocator.allocAdvanced(SuperBlockSector, constants.sector_size, 1, .exact);
             errdefer allocator.free(a);
 
@@ -481,10 +524,12 @@ pub fn SuperBlockType(comptime Storage: type) type {
             );
             errdefer manifest.deinit(allocator);
 
-            var free_set = try FreeSet.init(allocator, constants.block_count_max);
+            // TODO Allocate a FreeSet (and write buffer) when size_limit is small.
+            // Right now we can allocate blocks outside of the limit.
+            var free_set = try FreeSet.init(allocator, block_count_max);
             errdefer free_set.deinit(allocator);
 
-            var client_table = try ClientTable.init(allocator, message_pool);
+            var client_table = try ClientTable.init(allocator, options.message_pool);
             errdefer client_table.deinit(allocator);
 
             const manifest_buffer = try allocator.allocAdvanced(
@@ -512,7 +557,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             errdefer allocator.free(client_table_buffer);
 
             return SuperBlock{
-                .storage = storage,
+                .storage = options.storage,
                 .working = &a[0],
                 .staging = &b[0],
                 .reading = &reading[0],
@@ -522,6 +567,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .manifest_buffer = manifest_buffer,
                 .free_set_buffer = free_set_buffer,
                 .client_table_buffer = client_table_buffer,
+                .block_count_limit = block_count_limit,
+                .size_limit = options.size_limit,
             };
         }
 
@@ -757,7 +804,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
         fn write_staging_encode_free_set(superblock: *SuperBlock) void {
             const staging: *SuperBlockSector = superblock.staging;
-            const encode_size_max = FreeSet.encode_size_max(constants.block_count_max);
+            const encode_size_max = FreeSet.encode_size_max(block_count_max);
             const target = superblock.free_set_buffer[0..encode_size_max];
 
             superblock.free_set.include_staging();
@@ -772,6 +819,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             }
             assert(staging.size >= data_file_size_min);
             assert(staging.size <= staging.size_max);
+            assert(staging.size <= superblock.size_limit);
 
             staging.free_set_size = @intCast(u32, superblock.free_set.encode(target));
             staging.free_set_checksum = vsr.checksum(target[0..staging.free_set_size]);
@@ -1246,9 +1294,10 @@ pub fn SuperBlockType(comptime Storage: type) type {
             if (vsr.checksum(slice) == superblock.working.free_set_checksum) {
                 superblock.free_set.decode(slice);
 
-                log.debug("open: read_free_set: acquired blocks: {}/{}", .{
+                log.debug("open: read_free_set: acquired blocks: {}/{}/{}", .{
                     superblock.free_set.count_acquired(),
-                    constants.block_count_max,
+                    superblock.block_count_limit,
+                    block_count_max,
                 });
 
                 superblock.verify_manifest_blocks_are_acquired_in_free_set();

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -68,10 +68,18 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
     var message_pool = try MessagePool.init(allocator, .replica);
     defer message_pool.deinit(allocator);
 
-    var superblock = try SuperBlock.init(allocator, &storage, &message_pool);
+    var superblock = try SuperBlock.init(allocator, .{
+        .storage = &storage,
+        .message_pool = &message_pool,
+        .size_limit = constants.size_max,
+    });
     defer superblock.deinit(allocator);
 
-    var superblock_verify = try SuperBlock.init(allocator, &storage_verify, &message_pool);
+    var superblock_verify = try SuperBlock.init(allocator, .{
+        .storage = &storage_verify,
+        .message_pool = &message_pool,
+        .size_limit = constants.size_max,
+    });
     defer superblock_verify.deinit(allocator);
 
     var sequence_states = Environment.SequenceStates.init(allocator);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -70,15 +70,15 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
 
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
+        .storage_size_limit = constants.storage_size_max,
         .message_pool = &message_pool,
-        .size_limit = constants.size_max,
     });
     defer superblock.deinit(allocator);
 
     var superblock_verify = try SuperBlock.init(allocator, .{
         .storage = &storage_verify,
+        .storage_size_limit = constants.storage_size_max,
         .message_pool = &message_pool,
-        .size_limit = constants.size_max,
     });
     defer superblock_verify.deinit(allocator);
 
@@ -260,9 +260,6 @@ const Environment = struct {
         env.superblock.format(format_callback, &env.context_format, .{
             .cluster = cluster,
             .replica = 0,
-            // Include extra space (beyond what Storage actually needs) because SuperBlock will
-            // update the sector's size according to the highest FreeSet block allocated.
-            .size_max = data_file_size_min + 1000 * constants.block_size,
         });
 
         assert(env.sequence_states.items.len == 0);

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -123,7 +123,7 @@ fn test_quorums_working(
             .copy = @intCast(u8, i),
             .version = SuperBlockVersion,
             .replica = 1,
-            .size_max = superblock.data_file_size_min,
+            .storage_size_max = superblock.data_file_size_min,
             .sequence = copies[i].sequence,
             .parent = checksums[copies[i].sequence - 1],
         });
@@ -142,7 +142,7 @@ fn test_quorums_working(
                     checksum = random.int(u128);
                 }
             },
-            .invalid_fork => sector.size_max += 1, // Ensure we have a different checksum.
+            .invalid_fork => sector.storage_size_max += 1, // Ensure we have a different checksum.
             .invalid_parent => sector.parent += 1,
             .invalid_misdirect => {
                 if (misdirect) {
@@ -256,7 +256,7 @@ pub fn fuzz_quorum_repairs(
                 .copy = @intCast(u8, i),
                 .version = SuperBlockVersion,
                 .replica = 1,
-                .size_max = superblock.data_file_size_min,
+                .storage_size_max = superblock.data_file_size_min,
                 .sequence = 123,
             });
             sector.set_checksum();


### PR DESCRIPTION
### `size_limit`

We had a circular dependency in our comptime configuration, undetected because `blocks_count` was being computed incorrectly.
- We have a `size_max` config, from which we need to determine the grid's `block_count`.
  - `size_max` bounded the size of the data file.
- But the `block_count` determines the upper-bound size of the freeset... which in turn determines how much space is left for the grid.

To resolve this (and make data file sizing more flexible):
- `constants.size_max` is the absolute upper bound size of the data file
- `cli_arguments.size_limit` is the runtime upper bound size of the data file. (Must be ≤ `constants.size_max`).
- For layout purposes, `block_count` is computed from `constants.size_max`.
- For block allocation purposes, `block_count` _will be_ determined from `size_limit`, but this isn't implemented yet.

### `storage_`

s/size_max/storage_size_max
s/size_limit/storage_size_limit