### PR TITLE
Journal: concurrent recovery

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -93,7 +93,11 @@ const Environment = struct {
         env.message_pool = try MessagePool.init(allocator, .replica);
         errdefer env.message_pool.deinit(allocator);
 
-        env.superblock = try SuperBlock.init(allocator, env.storage, &env.message_pool);
+        env.superblock = try SuperBlock.init(allocator, .{
+            .storage = env.storage,
+            .storage_size_limit = constants.storage_size_max,
+            .message_pool = &env.message_pool,
+        });
         errdefer env.superblock.deinit(allocator);
 
         env.grid = try Grid.init(allocator, &env.superblock);
@@ -147,7 +151,6 @@ const Environment = struct {
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
-            .storage_size_max = constants.storage_size_max,
         });
         env.tick_until_state_change(.init, .formatted);
     }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -311,8 +311,8 @@ pub fn ReplicaType(
                 allocator,
                 .{
                     .storage = options.storage,
-                    .message_pool = options.message_pool,
                     .storage_size_limit = options.storage_size_limit,
+                    .message_pool = options.message_pool,
                 },
             );
 


### PR DESCRIPTION
During recovery, read the WAL concurrently (redundant headers, then prepares).
The redundant headers and prepares are read in two stages, both for implementation simplicity and to deter temporally-correlated faults.

I expected this to improve TB's cold-start time, but it didn't make a difference on my laptop. My guess is this is because of some combination of:
- my SSD's latency is either too low (so sequential IO isn't a bottleneck), and
- its throughput too low (so concurrency doesn't help).

I'm pushing the code anyway since it isn't complex and it will let a replica recover more quickly on higher latency/throughput disks, e.g. EBS.