### PR TITLE
Fix .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ dist/
 journal
 main
 simulator
-tigerbeetle
-tigerbeetle.exe
+/tigerbeetle
+/tigerbeetle.exe
 *_*.tigerbeetle
 zig/
 zig-cache/


### PR DESCRIPTION
Some weird wildcard rule was causing git to ignore files under folders named `tigerbeetle`, present in both the Java and Dotnet clients.