### PR TITLE
Fix stale grid cache reads caused by uninitialized blocks.

### DIFF
--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -53,6 +53,16 @@ pub fn GridType(comptime Storage: type) type {
             return address;
         }
 
+        inline fn set_address(block: *[block_size]u8, address: u64) void {
+            const header = mem.toBytes(vsr.Header{
+                .op = address,
+                .cluster = undefined,
+                .command = undefined,
+            });
+            const header_bytes = block[0..@sizeOf(vsr.Header)];
+            header_bytes.* = header;
+        }
+
         inline fn hash_address(address: u64) u64 {
             assert(address > 0);
             return std.hash.Wyhash.hash(0, mem.asBytes(&address));
@@ -428,7 +438,8 @@ pub fn GridType(comptime Storage: type) type {
             // If the block is already in the cache, queue up the read to be resolved
             // from the cache on the next tick. This keeps start_read() asynchronous.
             // Note that this must be called after we have checked for an in
-            // progress read targeting the same address.
+            // progress read targeting the same address, otherwise we may read an
+            // unininitialized block.
             if (grid.cache.exists(read.address)) {
                 grid.read_cached_queue.push(read);
                 return;
@@ -445,6 +456,12 @@ pub fn GridType(comptime Storage: type) type {
                 grid,
                 read.address,
             );
+            // `block` will be initialized later when the read completes.
+            // This is safe because we will never attempt to lookup an address in the cache
+            // while a read is pending.
+            // However, we do have to immediately set the cache key to uphold the
+            // invariants of `SetAssociativeCache`.
+            cache_interface.set_address(block, read.address);
 
             iop.* = .{
                 .grid = grid,

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -603,31 +603,13 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                     assert(compare_keys(table_info.key_min, table_info.key_max) != .gt);
                     key_max_prev = table_info.key_max;
 
-                    if (Storage == @import("../test/storage.zig").Storage) {
-                        const storage = manifest.manifest_log.grid.superblock.storage;
-                        const index_block = storage.grid_block(table_info.address);
-                        const addresses = Table.index_data_addresses(index_block);
-                        const data_blocks_used = Table.index_data_blocks_used(index_block);
-                        var data_block_index: usize = 0;
-                        while (data_block_index < data_blocks_used) : (data_block_index += 1) {
-                            const address = addresses[data_block_index];
-                            const data_block = storage.grid_block(address);
-                            const values = Table.data_block_values_used(data_block);
-                            if (values.len > 0) {
-                                if (data_block_index == 0) {
-                                    assert(Table.compare_keys(table_info.key_min, Table.key_from_value(&values[0])) == .eq);
-                                }
-                                if (data_block_index == data_blocks_used - 1) {
-                                    assert(Table.compare_keys(Table.key_from_value(&values[values.len - 1]), table_info.key_max) == .eq);
-                                }
-                                var a = &values[0];
-                                for (values[1..]) |*b| {
-                                    assert(Table.compare_keys(Table.key_from_value(a), Table.key_from_value(b)) == .lt);
-                                    a = b;
-                                }
-                            }
-                        }
-                    }
+                    Table.verify(
+                        Storage,
+                        manifest.manifest_log.grid.superblock.storage,
+                        table_info.address,
+                        table_info.key_min,
+                        table_info.key_max,
+                    );
                 }
             }
         }

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -188,7 +188,7 @@ pub fn SetAssociativeCache(
             mem.set(u64, self.clocks.words, 0);
         }
 
-        /// Returns whether an entry with the given key is cached, 
+        /// Returns whether an entry with the given key is cached,
         /// without modifying the entry's counter.
         pub fn exists(self: *Self, key: Key) bool {
             const set = self.associate(key);
@@ -262,6 +262,7 @@ pub fn SetAssociativeCache(
         }
 
         /// Add a key, evicting an older entry if needed, and return a pointer to the value.
+        /// The caller must immediately initialize the value such that `equal(key_from_value(value), key)`.
         /// The key must not already be in the cache.
         /// Never evicts keys for which locked() returns true.
         /// The caller must guarantee that locked() returns true for less than layout.ways keys.

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -629,6 +629,11 @@ pub fn TableType(
                     assert(compare_keys(builder.key_min, builder.key_max) == .lt);
                 }
 
+                if (current > 0) {
+                    const key_max_prev = index_data_keys(builder.index_block)[current - 1];
+                    assert(compare_keys(key_max_prev, key_from_value(&values[0])) == .lt);
+                }
+
                 builder.data_block_count += 1;
                 builder.value = 0;
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -52,6 +52,9 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
         /// This field is only used for safety checks, it does not affect the behavior.
         read_pending: bool = false,
 
+        // Used for verifying key order when constants.verify == true.
+        key_prev: ?Table.Key,
+
         pub fn init(allocator: mem.Allocator) !TableIterator {
             const index_block = try allocator.alignedAlloc(
                 u8,
@@ -95,6 +98,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
                     },
                 },
                 .value = undefined,
+                .key_prev = null,
             };
         }
 
@@ -132,6 +136,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
                 .values = .{ .buffer = it.values.buffer },
                 .data_blocks = .{ .buffer = it.data_blocks.buffer },
                 .value = 0,
+                .key_prev = null,
             };
 
             assert(it.values.empty());
@@ -291,6 +296,18 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
 
         /// This may only be called after peek() returns a Key (and not Empty or Drained)
         pub fn pop(it: *TableIterator) Table.Value {
+            const value = it.pop_internal();
+
+            if (constants.verify) {
+                const key = Table.key_from_value(&value);
+                if (it.key_prev) |k| assert(Table.compare_keys(k, key) == .lt);
+                it.key_prev = key;
+            }
+
+            return value;
+        }
+
+        fn pop_internal(it: *TableIterator) Table.Value {
             assert(!it.read_pending);
             assert(!it.read_table_index);
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -141,6 +141,16 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
 
             assert(it.values.empty());
             assert(it.data_blocks.empty());
+
+            if (constants.verify) {
+                Table.verify(
+                    Storage,
+                    context.grid.superblock.storage,
+                    context.address,
+                    null,
+                    null,
+                );
+            }
         }
 
         /// Try to buffer at least a full block of values to be peek()'d.

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -593,6 +593,10 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             assert(tree.compaction_io_pending == 0);
             assert(tree.compaction_callback == null);
 
+            if (constants.verify) {
+                tree.manifest.verify(tree.compaction_op);
+            }
+
             tracer.start(
                 &tree.tracer_slot,
                 .{ .tree = .{ .tree_name = tree_name } },
@@ -974,6 +978,10 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 .{ .tree = .{ .tree_name = tree_name } },
                 .tree_compaction_beat,
             );
+
+            if (constants.verify) {
+                tree.manifest.verify(tree.compaction_op);
+            }
 
             // Invoke the compact() callback after the manifest compacts at the end of the beat.
             const callback = tree.compaction_callback.?;

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -787,7 +787,7 @@ pub const Storage = struct {
     pub fn grid_block(
         storage: *const Storage,
         address: u64,
-    ) *align(constants.sector_size) const [constants.block_size]u8 {
+    ) *align(constants.sector_size) [constants.block_size]u8 {
         assert(address > 0);
 
         const block_offset = vsr.Zone.grid.offset((address - 1) * constants.block_size);


### PR DESCRIPTION
Contains an immediate fix for https://github.com/tigerbeetledb/tigerbeetle/issues/345, along with many additional asserts which helped track down the bug.