### PR TITLE
Drop hourly release

### DIFF
--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -3,8 +3,7 @@ name: "Release (weekly)"
 on:
   schedule:
     # Every Monday at 14:00
-    # TODO: temporarily once per hour until I get this correct
-    - cron: "0 * * * 1"
+    - cron: "0 14 * * 1"
 
 jobs:
   scheduled_release:


### PR DESCRIPTION
The scheduled releases seem to be working! So I'm dropping the hourly part of it because I no longer need that for debugging.