### PR TITLE
Fix Tracy's complaints about concurrent transaction traces.

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -122,7 +122,8 @@ pub fn CompactionType(
             done,
         };
 
-        tree_name: [:0]const u8,
+        /// Used only for debugging/tracing.
+        name: [:0]const u8,
 
         grid: *Grid,
         grid_reservation: Grid.Reservation,
@@ -161,7 +162,7 @@ pub fn CompactionType(
 
         tracer_slot: ?tracer.SpanStart = null,
 
-        pub fn init(allocator: mem.Allocator, tree_name: [:0]const u8) !Compaction {
+        pub fn init(allocator: mem.Allocator, name: [:0]const u8) !Compaction {
             var iterator_a = try IteratorA.init(allocator);
             errdefer iterator_a.deinit(allocator);
 
@@ -172,7 +173,7 @@ pub fn CompactionType(
             errdefer table_builder.deinit(allocator);
 
             return Compaction{
-                .tree_name = tree_name,
+                .name = name,
 
                 // Assigned by start()
                 .grid = undefined,
@@ -239,7 +240,7 @@ pub fn CompactionType(
             assert(drop_tombstones or level_b < constants.lsm_levels - 1);
 
             compaction.* = .{
-                .tree_name = compaction.tree_name,
+                .name = compaction.name,
 
                 .grid = grid,
                 // Reserve enough blocks to write our output tables in the worst case, where:
@@ -350,11 +351,8 @@ pub fn CompactionType(
 
             tracer.start(
                 &compaction.tracer_slot,
-                .{ .tree = .{ .tree_name = compaction.tree_name } },
-                .{ .tree_compaction_tick = .{
-                    .tree_name = compaction.tree_name,
-                    .level_b = compaction.level_b,
-                } },
+                .{ .tree_compaction = .{ .compaction_name = compaction.name } },
+                .{ .tree_compaction_tick = .{ .level_b = compaction.level_b } },
                 @src(),
             );
 
@@ -429,11 +427,8 @@ pub fn CompactionType(
             var tracer_slot: ?tracer.SpanStart = null;
             tracer.start(
                 &tracer_slot,
-                .{ .tree = .{ .tree_name = compaction.tree_name } },
-                .{ .tree_compaction_merge = .{
-                    .tree_name = compaction.tree_name,
-                    .level_b = compaction.level_b,
-                } },
+                .{ .tree_compaction = .{ .compaction_name = compaction.name } },
+                .{ .tree_compaction_merge = .{ .level_b = compaction.level_b } },
                 @src(),
             );
 
@@ -456,19 +451,13 @@ pub fn CompactionType(
 
             tracer.end(
                 &tracer_slot,
-                .{ .tree = .{ .tree_name = compaction.tree_name } },
-                .{ .tree_compaction_merge = .{
-                    .tree_name = compaction.tree_name,
-                    .level_b = compaction.level_b,
-                } },
+                .{ .tree_compaction = .{ .compaction_name = compaction.name } },
+                .{ .tree_compaction_merge = .{ .level_b = compaction.level_b } },
             );
             tracer.end(
                 &compaction.tracer_slot,
-                .{ .tree = .{ .tree_name = compaction.tree_name } },
-                .{ .tree_compaction_tick = .{
-                    .tree_name = compaction.tree_name,
-                    .level_b = compaction.level_b,
-                } },
+                .{ .tree_compaction = .{ .compaction_name = compaction.name } },
+                .{ .tree_compaction_tick = .{ .level_b = compaction.level_b } },
             );
 
             // TODO Implement pacing here by deciding if we should do another compact_tick()


### PR DESCRIPTION
* Use a different EventGroup for each compaction slot in each tree.
* Generate the compaction_name for each compaction EventGroup at comptime, to fulfill Tracy's requirement that fiber names have static lifetime.
* Remove redundant information from Event.

This makes the tracing output a little less pleasant to read, but I don't see an alternative given Tracy's requirement that spans always form a tree. The output will look very different after https://github.com/tigerbeetledb/tigerbeetle/issues/269 anyway.