### PR TITLE
SuperBlock/FreeSet: Allocate FreeSet based on block limit

### DIFF
--- a/src/ewah_fuzz.zig
+++ b/src/ewah_fuzz.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
         const random = prng.random();
 
         const decoded_size_max = @divExact(1024 * 1024, @sizeOf(Word));
-        const decoded_size = 1 + random.uintLessThan(usize, decoded_size_max);
+        const decoded_size = random.uintLessThan(usize, 1 + decoded_size_max);
         const decoded = try allocator.alloc(Word, decoded_size);
         defer allocator.free(decoded);
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -635,7 +635,7 @@ fn verify_manifest_compaction_set(
     var compact_blocks_checked: u32 = 0;
 
     // This test doesn't include any actual table blocks, so all blocks are manifest blocks.
-    var blocks = superblock.free_set.blocks.iterator(.{ .kind = .unset });
+    var blocks = superblock.free_set.blocks.iterator(.{ .kind = .set });
     while (blocks.next()) |block_index| {
         const block_address = block_index + 1;
         const block = superblock.storage.grid_block(block_address);

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -330,6 +330,7 @@ pub const Cluster = struct {
             .{
                 .replica_count = @intCast(u8, cluster.replicas.len),
                 .storage = &cluster.storages[replica_index],
+                // TODO Test restarting with a higher storage limit.
                 .storage_size_limit = cluster.options.storage_size_limit,
                 .message_pool = &cluster.pools[replica_index],
                 .time = time,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -352,15 +352,15 @@ const block_count_max = blk: {
     // The size of a freeset is related to the number of blocks it must store.
     // Maximize the number of grid blocks.
 
-    var shard_count = @divFloor(size, constants.block_size * SuperBlockFreeSet.shard_size);
+    var shard_count = @divFloor(size, constants.block_size * SuperBlockFreeSet.shard_bits);
     while (true) : (shard_count -= 1) {
-        const block_count = shard_count * SuperBlockFreeSet.shard_size;
+        const block_count = shard_count * SuperBlockFreeSet.shard_bits;
         const grid_size = block_count * constants.block_size;
         const free_set_size = vsr.sector_ceil(SuperBlockFreeSet.encode_size_max(block_count));
         const free_sets_size = constants.superblock_copies * free_set_size;
         if (free_sets_size + grid_size <= size) break;
     }
-    break :blk shard_count * SuperBlockFreeSet.shard_size;
+    break :blk shard_count * SuperBlockFreeSet.shard_bits;
 };
 
 comptime {
@@ -495,9 +495,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
             const shard_count_limit = @intCast(usize, @divFloor(
                 options.storage_size_limit - data_file_size_min,
-                constants.block_size * FreeSet.shard_size,
+                constants.block_size * FreeSet.shard_bits,
             ));
-            const block_count_limit = shard_count_limit * FreeSet.shard_size;
+            const block_count_limit = shard_count_limit * FreeSet.shard_bits;
             assert(block_count_limit <= block_count_max);
 
             const a = try allocator.allocAdvanced(SuperBlockSector, constants.sector_size, 1, .exact);

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -83,7 +83,6 @@ pub const FreeSet = struct {
     }
 
     pub fn init(allocator: mem.Allocator, blocks_count: usize) !FreeSet {
-        assert(shard_bits <= blocks_count);
         assert(blocks_count % shard_bits == 0);
         assert(blocks_count % @bitSizeOf(usize) == 0);
 
@@ -372,7 +371,6 @@ pub const FreeSet = struct {
 
     /// Returns the maximum number of bytes that `blocks_count` blocks need to be encoded.
     pub fn encode_size_max(blocks_count: usize) usize {
-        assert(shard_bits <= blocks_count);
         assert(blocks_count % shard_bits == 0);
         assert(blocks_count % @bitSizeOf(usize) == 0);
 

--- a/src/vsr/superblock_free_set_fuzz.zig
+++ b/src/vsr/superblock_free_set_fuzz.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
 
     var prng = std.rand.DefaultPrng.init(args.seed);
 
-    const blocks_count = FreeSet.shard_size * (1 + prng.random().uintLessThan(usize, 10));
+    const blocks_count = FreeSet.shard_bits * (1 + prng.random().uintLessThan(usize, 10));
     const events = try generate_events(allocator, prng.random(), blocks_count);
     defer allocator.free(events);
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -196,9 +196,7 @@ const Environment = struct {
         {
             // Reset `superblock_verify` so that it can be reused.
             env.superblock_verify.opened = false;
-            var free_set_iterator = env.superblock_verify.free_set.blocks.iterator(.{
-                .kind = .unset,
-            });
+            var free_set_iterator = env.superblock_verify.free_set.blocks.iterator(.{});
             while (free_set_iterator.next()) |block_bit| {
                 const block_address = block_bit + 1;
                 env.superblock_verify.free_set.release(block_address);


### PR DESCRIPTION
Fixes https://github.com/tigerbeetledb/tigerbeetle/issues/341

Use the block count *limit* to compute the number of blocks in the FreeSet, instead of the block count *max*.
This means running TB with a lower `--limit-storage` also reduces its memory usage.
(Though this is currently masked by the arena allocator's fragmentation).

As part of this: Previously the FreeSet used "1" to indicate _free_ blocks, now "1" indicates _acquired_ blocks.