### PR TITLE
VOPR: Open with partially-faulty storage

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -269,11 +269,6 @@ pub fn main() !void {
         }
     };
 
-    // Disable most faults at startup, so that the replicas don't get stuck in recovery mode.
-    for (cluster.storages) |*storage, i| {
-        storage.faulty = replica_normal_min <= i;
-    }
-
     var tick: u64 = 0;
     while (tick < ticks_max) : (tick += 1) {
         const health_options = &cluster.options.health_options;

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -137,6 +137,8 @@ pub const Cluster = struct {
             storage_options.replica_index = @intCast(u8, replica_index);
             storage_options.faulty_wal_areas = faulty_wal_areas[replica_index];
             storage.* = try Storage.init(allocator, options.storage_size_limit, storage_options);
+            // Disable most faults at startup, so that the replicas don't get stuck in recovery mode.
+            storage.faulty = replica_index >= vsr.quorums(options.replica_count).view_change;
         }
         errdefer for (cluster.storages) |*storage| storage.deinit(allocator);
 


### PR DESCRIPTION
Observed bug: Start the cluster, but several replicas see `decision=vsr` (due to a corrupt prepare) in their WALs. The cluster stalls because there are not enough healthy replicas to complete recovery protocol.

There are two components to this fix:

`replica_normal_min ≤ i` was backwards — it should have been `replica_normal_min ≥ i`. This ensures that during the (simulated) cluster initialization, there are enough replicas able to start without resorting to recovery protocol (no corruption in their WALs).

But this first bug was mostly masked (though not completely — it was just extremely improbable) until "Journal: Recover the WAL within Replica.open()" (https://github.com/tigerbeetledb/tigerbeetle/pull/335). Including journal recovery in `Replica.open()` meant that journal recovery was taking place while the test storage had its default value of `faulty == true` for all replicas.