### PR TITLE
VSR/Correctness: Preserve Canonical Headers

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -131,7 +131,7 @@ comptime {
     assert(journal_slot_count >= Config.Cluster.journal_slot_count_min);
     assert(journal_slot_count >= lsm_batch_multiple * 2);
     assert(journal_slot_count % lsm_batch_multiple == 0);
-    assert(journal_size_max == journal_size_headers + journal_size_prepares);
+    assert(journal_slot_count > pipeline_max);
 
     assert(journal_size_max == journal_size_headers + journal_size_prepares);
 }

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -202,7 +202,7 @@ const Environment = struct {
             .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
             .commit_min = env.checkpoint_op.?,
             .commit_max = env.checkpoint_op.? + 1,
-            .view_normal = 0,
+            .log_view = 0,
             .view = 0,
         });
         env.checkpoint_op = null;

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -261,7 +261,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
                 .commit_min = env.checkpoint_op.?,
                 .commit_max = env.checkpoint_op.? + 1,
-                .view_normal = 0,
+                .log_view = 0,
                 .view = 0,
             });
             env.checkpoint_op = null;

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -227,10 +227,10 @@ pub const Cluster = struct {
                     if (cluster.health[i] == .down) continue;
                     if (other_replica.status == .recovering) continue;
 
-                    if (v == null or other_replica.view_normal > v.? or
-                        (other_replica.view_normal == v.? and other_replica.op > op_max.?))
+                    if (v == null or other_replica.log_view > v.? or
+                        (other_replica.log_view == v.? and other_replica.op > op_max.?))
                     {
-                        v = other_replica.view_normal;
+                        v = other_replica.log_view;
                         op_max = other_replica.op;
                         parent = other_replica.journal.header_with_op(op_max.?).?.checksum;
                     }

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -411,7 +411,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
         pub fn slot_with_header(journal: *const Journal, header: *const Header) ?Slot {
             assert(header.command == .prepare);
-            return journal.slot_with_op(header.op);
+            return journal.slot_with_op_and_checksum(header.op, header.checksum);
         }
 
         /// Returns any existing header at the location indicated by header.op.

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -586,20 +586,6 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             return copied;
         }
 
-        /// Returns the op of the last gap or hash-break in the headers.
-        /// Returns null when the hash chain is valid all the way back to op=0.
-        pub fn find_latest_headers_break_before(journal: *const Journal, op_max: u64) ?u64 {
-            assert(journal.status == .recovered);
-            assert(journal.header_with_op(op_max) != null);
-
-            var op: u64 = op_max;
-            while (op > 0) : (op -= 1) {
-                const header_next = journal.header_with_op(op).?;
-                const header_prev = journal.header_with_op(op - 1) orelse return op - 1;
-                if (header_prev.checksum != header_next.parent) return op - 1;
-            } else return null;
-        }
-
         const HeaderRange = struct { op_min: u64, op_max: u64 };
 
         /// Finds the latest break in headers between `op_min` and `op_max` (both inclusive).

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -586,6 +586,20 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             return copied;
         }
 
+        /// Returns the op of the last gap or hash-break in the headers.
+        /// Returns null when the hash chain is valid all the way back to op=0.
+        pub fn find_latest_headers_break_before(journal: *const Journal, op_max: u64) ?u64 {
+            assert(journal.status == .recovered);
+            assert(journal.header_with_op(op_max) != null);
+
+            var op: u64 = op_max;
+            while (op > 0) : (op -= 1) {
+                const header_next = journal.header_with_op(op).?;
+                const header_prev = journal.header_with_op(op - 1) orelse return op - 1;
+                if (header_prev.checksum != header_next.parent) return op - 1;
+            } else return null;
+        }
+
         const HeaderRange = struct { op_min: u64, op_max: u64 };
 
         /// Finds the latest break in headers between `op_min` and `op_max` (both inclusive).
@@ -605,6 +619,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             op_min: u64,
             op_max: u64,
         ) ?HeaderRange {
+            assert(journal.status == .recovered);
             assert(op_max >= op_min);
             assert(op_max - op_min + 1 <= slot_count);
             var range: ?HeaderRange = null;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1213,7 +1213,6 @@ pub fn ReplicaType(
 
             assert(self.status == .view_change);
             assert(message.header.view == self.view);
-            DVCQuorum.verify_message(message);
 
             // We may receive a `do_view_change` quorum from other replicas, which already have a
             // `start_view_change_quorum`, before we receive a `start_view_change_quorum`:
@@ -1237,6 +1236,7 @@ pub fn ReplicaType(
 
             assert(count == threshold);
             assert(self.do_view_change_from_all_replicas[self.replica] != null);
+            DVCQuorum.verify(self.do_view_change_from_all_replicas);
             log.debug("{}: on_do_view_change: view={} quorum received", .{
                 self.replica,
                 self.view,
@@ -3042,19 +3042,20 @@ pub fn ReplicaType(
                 .commit = if (command == .do_view_change) self.commit_min else self.commit_max,
             };
 
-            // The DVC anchor: Within the "suffix" (all ops following the anchor) we have additional
-            // guarantees about the state of the log headers, which allow us to tolerate certain
+            // The DVC anchor: Within the log suffix following the anchor, we have additional
+            // guarantees about the state of the log headers which allow us to tolerate certain
             // gaps (by locally guaranteeing that the gap does not hide a break).
+            // See Example 2/3 for more detail.
             const op_dvc_anchor = std.math.max(
                 self.commit_min,
                 // +1: We can have a full pipeline, but not yet have performed any repair.
                 // In such a case, we want to send those pipeline_max headers in the DVC, but not
                 // the preceding op (which may belong to a different chain).
                 // This satisfies the DVC invariant because the first op in the pipeline is
-                // "connected" to the canonical chain.
+                // "connected" to the canonical chain (via its "parent" checksum).
                 //
                 // For example, as a follower, we might have received pipeline_max headers in the SV
-                // message, but not done any repair yet.
+                // message, but not done any repair before the next view change.
                 1 + self.op -| constants.pipeline_max,
             );
 
@@ -5191,10 +5192,10 @@ pub fn ReplicaType(
             assert(self.start_view_change_quorum);
             assert(self.do_view_change_quorum);
             assert(self.do_view_change_from_all_replicas[self.replica] != null);
+            DVCQuorum.verify(self.do_view_change_from_all_replicas);
 
             const dvcs_all = DVCQuorum.dvcs_all(self.do_view_change_from_all_replicas);
             assert(dvcs_all.len == self.quorum_view_change);
-            for (dvcs_all.constSlice()) |message| DVCQuorum.verify_message(message);
 
             const dvcs_canonical = DVCQuorum.dvcs_canonical(self.do_view_change_from_all_replicas);
             assert(dvcs_canonical.len > 0);
@@ -5832,7 +5833,7 @@ pub fn ReplicaType(
 ///   This means that either:
 ///   - the DVC includes the op=C header, or
 ///   - the DVC includes the op=C+1 header (where C+1's parent is C).
-///   (Where `C = "DVC anchor" = max(replica.commit_min, replica.op + 1 -| pipeline_max)`).
+///   (Where `C = "DVC anchor" = max(replica.commit_min, replica.op -| pipeline_max)`).
 ///   - Reason: The new primary may truncate the entire pipeline (6-9) due to a gap (6),
 ///     but afterwards it still requires a head op to repair/chain backward from.
 ///     (According to the intersection property, a gap in the pipeline indicates an
@@ -5937,20 +5938,47 @@ pub fn ReplicaType(
 ///         1   1   2   3   4a  5  [6       8   9]         (retired follower)
 ///
 ///
-/// Example 4: Break in pipeline suffix
+/// Example 3: Break in pipeline suffix
 ///
 /// Consider a set of replicas performing a DVC:
 ///
 ///   replica   headers                              log_view
 ///         0   1  [2   3   4b]                      4     (new primary)
-///         1   1   2   3   4a  5a  6a  7a [8b  9b]  5
-///         2  (1   2   3   ?   ?   ?   ?   ?   ?)   5     (partitioned)
+///         1   1   2   3   4b  5a  6a  7a [8b  9b]  5
+///         2  (1   2   3   4b  5b  7b  7b  8b  9b)  5     (partitioned)
 ///
 /// (Note the chain break at replica 1's 7a/8b.)
-/// This situation is exactly analogous to Example 2, except that it can only occur on a retired
+/// This scenario is exactly analogous to Example 2, except that it can only occur on a retired
 /// primary, never a retired follower.
+///
+/// The retired primary sends a DVC with only the unbroken log suffix:
+///
+///   replica   headers
+///         1   1   2   3   4a  5   6   7a [8   9]         (retired primary)
+///
 const DVCQuorum = struct {
     const DVCArray = std.BoundedArray(*const Message, constants.replicas_max);
+
+    fn verify(dvc_quorum: QuorumMessages) void {
+        const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
+        assert(dvcs.len >= 2);
+        for (dvcs.constSlice()) |message| verify_message(message);
+
+        var log_views_all = std.BoundedArray(u32, constants.replicas_max){ .buffer = undefined };
+        for (dvcs.constSlice()) |message| {
+            const log_view = @intCast(u32, message.header.timestamp);
+            if (std.mem.count(u32, log_views_all.constSlice(), &.{log_view}) == 0) {
+                log_views_all.appendAssumeCapacity(log_view);
+            }
+        }
+
+        // Verify that DVCs with the same log_view do not conflict.
+        for (log_views_all.constSlice()) |log_view| {
+            const view_dvcs = dvcs_with_log_view(dvc_quorum, log_view);
+            var view_headers = HeaderIterator.init(view_dvcs, null);
+            while (view_headers.next()) |_| {}
+        }
+    }
 
     fn verify_message(message: *const Message) void {
         assert(message.header.command == .do_view_change);
@@ -5981,14 +6009,15 @@ const DVCQuorum = struct {
     }
 
     fn dvcs_canonical(dvc_quorum: QuorumMessages) DVCArray {
-        const log_view_max_ = DVCQuorum.log_view_max(dvc_quorum);
+        return dvcs_with_log_view(dvc_quorum, DVCQuorum.log_view_max(dvc_quorum));
+    }
+
+    fn dvcs_with_log_view(dvc_quorum: QuorumMessages, log_view: u32) DVCArray {
         var array = DVCArray{ .buffer = undefined };
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.constSlice()) |message| {
-            const log_view = @intCast(u32, message.header.timestamp);
-            assert(log_view <= log_view_max_);
-
-            if (log_view == log_view_max_) {
+            const message_log_view = @intCast(u32, message.header.timestamp);
+            if (message_log_view == log_view) {
                 array.appendAssumeCapacity(message);
             }
         }
@@ -6094,9 +6123,9 @@ const DVCQuorum = struct {
         return op_max.?;
     }
 
-    /// Iterate the headers from canonical DVCs, from high-to-low op.
-    /// The first header returned is the new head header.
-    fn headers_canonical(dvc_quorum: QuorumMessages) CanonicalHeaderIterator {
+    /// Return an iterator over the canonical DVC's headers, from high-to-low op.
+    /// The first header returned is the new head message.
+    fn headers_canonical(dvc_quorum: QuorumMessages) HeaderIterator {
         const dvcs = DVCQuorum.dvcs_canonical(dvc_quorum);
 
         const op_head_max = op_max_canonical(dvc_quorum);
@@ -6132,46 +6161,63 @@ const DVCQuorum = struct {
         assert(op_head >= op_head_min);
         assert(op_head <= op_head_max);
 
-        return CanonicalHeaderIterator.init(dvcs, op_head);
+        return HeaderIterator.init(dvcs, op_head);
     }
 
-    const CanonicalHeaderIterator = struct {
-        dvcs_canonical: DVCArray,
-        dvcs_canonical_offsets: std.BoundedArray(usize, constants.replicas_max),
+    /// Iterate the headers of a set of (same-log_view) DVCs, from high-to-low op.
+    const HeaderIterator = struct {
+        dvcs: DVCArray,
+        dvcs_offsets: std.BoundedArray(usize, constants.replicas_max),
 
         child: ?struct {
             op: u64,
             parent: u128,
         } = null,
 
-        fn init(dvcs: DVCArray, op_head: u64) CanonicalHeaderIterator {
+        fn init(dvcs: DVCArray, op_head: ?u64) HeaderIterator {
+            assert(dvcs.len > 0);
+
+            var dvcs_log_view: ?u32 = null;
+            for (dvcs.constSlice()) |message| {
+                const log_view = @intCast(u32, message.header.timestamp);
+                if (dvcs_log_view) |view| {
+                    assert(view == log_view);
+                } else {
+                    dvcs_log_view = log_view;
+                }
+            }
+
             var dvcs_offsets = std.BoundedArray(usize, constants.replicas_max){
                 .buffer = undefined,
             };
 
-            // Skip over discarded headers.
-            for (dvcs.constSlice()) |message| {
-                const offset = for (message_body_as_headers_chain_disjoint(message)) |header, i| {
-                    if (header.op <= op_head) break i;
-                } else 0;
-                dvcs_offsets.appendAssumeCapacity(offset);
+            if (op_head) |op_head_| {
+                // Skip over discarded headers.
+                for (dvcs.constSlice()) |message| {
+                    const offset = for (message_body_as_headers_chain_disjoint(message)) |header, i| {
+                        if (header.op <= op_head_) break i;
+                    } else 0;
+                    dvcs_offsets.appendAssumeCapacity(offset);
+                }
+            } else {
+                for (dvcs.constSlice()) |_| dvcs_offsets.appendAssumeCapacity(0);
             }
             assert(dvcs.len == dvcs_offsets.len);
 
             return .{
-                .dvcs_canonical = dvcs,
-                .dvcs_canonical_offsets = dvcs_offsets,
+                .dvcs = dvcs,
+                .dvcs_offsets = dvcs_offsets,
             };
         }
 
-        fn next(iterator: *CanonicalHeaderIterator) ?Header {
+        fn next(iterator: *HeaderIterator) ?Header {
             const ReplicaSet = std.StaticBitSet(constants.replicas_max);
             var next_header: ?*const Header = null;
-            var next_advance: ReplicaSet = ReplicaSet.initEmpty();
+            var next_advance = ReplicaSet.initEmpty();
 
-            for (iterator.dvcs_canonical.constSlice()) |message, i| {
+            for (iterator.dvcs.constSlice()) |message, i| {
                 const message_headers = message_body_as_headers_chain_disjoint(message);
-                const message_headers_offset = iterator.dvcs_canonical_offsets.get(i);
+                const message_headers_offset = iterator.dvcs_offsets.get(i);
                 if (message_headers_offset == message_headers.len) continue;
 
                 const header = &message_headers[message_headers_offset];
@@ -6192,7 +6238,7 @@ const DVCQuorum = struct {
 
             var next_advance_iterator = next_advance.iterator(.{});
             while (next_advance_iterator.next()) |i| {
-                iterator.dvcs_canonical_offsets.slice()[i] += 1;
+                iterator.dvcs_offsets.slice()[i] += 1;
             }
 
             if (next_header) |header| {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -140,7 +140,8 @@ pub fn ReplicaType(
 
         /// The latest view where
         /// - the replica was a primary and acquired a DVC quorum, or
-        /// - the replica was a backup and received a SV message.
+        /// - the replica was a backup and processed a SV message.
+        /// i.e. the latest view in which this replica changed its head message.
         log_view: u32,
 
         /// The current status, either normal, view_change, or recovering:

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -194,7 +194,7 @@ test "format" {
         try std.testing.expectEqual(sector.vsr_state.commit_min, 0);
         try std.testing.expectEqual(sector.vsr_state.commit_max, 0);
         try std.testing.expectEqual(sector.vsr_state.view, 0);
-        try std.testing.expectEqual(sector.vsr_state.view_normal, 0);
+        try std.testing.expectEqual(sector.vsr_state.log_view, 0);
     }
 
     // Verify the WAL headers and prepares zones.

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -298,7 +298,7 @@ const Environment = struct {
             .commit_min_checksum = env.superblock.staging.vsr_state.commit_min_checksum,
             .commit_min = env.superblock.staging.vsr_state.commit_min,
             .commit_max = env.superblock.staging.vsr_state.commit_max + 3,
-            .view_normal = env.superblock.staging.vsr_state.view_normal + 4,
+            .log_view = env.superblock.staging.vsr_state.log_view + 4,
             .view = env.superblock.staging.vsr_state.view + 5,
         };
 
@@ -326,7 +326,7 @@ const Environment = struct {
             .commit_min_checksum = env.superblock.staging.vsr_state.commit_min_checksum + 1,
             .commit_min = env.superblock.staging.vsr_state.commit_min + 1,
             .commit_max = env.superblock.staging.vsr_state.commit_max + 1,
-            .view_normal = env.superblock.staging.vsr_state.view_normal + 1,
+            .log_view = env.superblock.staging.vsr_state.log_view + 1,
             .view = env.superblock.staging.vsr_state.view + 1,
         };
 


### PR DESCRIPTION
(Includes https://github.com/tigerbeetledb/tigerbeetle/pull/359, to ensure `repair()` commits enough ops that the pipeline can't run out of space when the new primary has to play catch-up.)

Fixes 2 correctness bugs:
1. Don't Truncate Canonical DVC
2. Bump Primary view_normal Early

## Don't Truncate Canonical DVC

### Summary

Truncating a canonical DVC's headers can fork the log.

### VOPR Example

Consider a cluster with:

- Replica 2 is leading a view change (view=17).
- Replica 1 is participating in the view=17 view change.
- Replica 0 is partitioned.
- `pipeline_prepare_queue_max = 6`

The DVC quorum:

    2: on_do_view_change: replica=1 view_normal=15 op=38 commit_min=31
    2: on_do_view_change: replica=2 view_normal=14 op=33 commit_min=28

primary_set_log_from_do_view_change_messages():

  1. Replica 2's `op_canonical` is 28 (computed by `primary_op_canonical_max()`).
  3. Replica 1's DVC included headers 33,34,35,36,37,38. These were loaded into Replica 2's headers since Replica 1 has the canonical view.
  4. Near the end of `primary_set_log_from_do_view_change_messages()`, `do_view_change_op_max()` finds a hash break between op 32/33, and discards 33…38, forking the log.

It discarded the entire (canonical!) hash chain from replica 1! (In this case those ops were uncommitted, but that doesn't necessarily need to be true.) In any case, by discarding those ops we revert to our old (incorrect) op 29, which otherwise would have been repaired. We go on to commit the wrong op 29.

According to `do_view_change_op_max()`, the rationale for discarding those breaks (i.e. breaks which follow the primary's `op_canonical`) is:

    /// If there is a hash chain break, none of the headers from the canonical DVCs replaced
    /// the broken (leftover uncanonical) op.
    /// Removing these is necessary for correctness and liveness, to ensure that
    /// disconnected headers do not remain in place in lieu of gaps.

As the first sentence hints, passing more headers in the DVC would decrease the probability of this error, but that isn't an actual fix. (Aside: This bug was likely hidden until recently because it is becomes less probably for larger pipelines, and I have recently been heavily testing small pipelines.)

### Simplified Example

With `pipeline_prepare_queue_max=3`:

```
  replica  headers                    commit_min  view_normal
        0  (1a 2a 3a 4a 5a 6a 7a 8a)          8a            4 (partitioned)
        1   1a 2a 3a 4a 5a{6a 7a 8a}          5a            4
        2   1a 2a 3a 4b                       3a            2
```

Prior to the do_view_change_op_max() truncation, replica's 2 headers are:

```
        2   1a 2a 3a 4b 5a 6a 7a 8a
                      ↑ hash break
```

Per CTRL, we can only discard headers that are *definitely uncommitted*.
A gap/break in replica 1's 6a,7a,8a would be definitively uncommitted and this safe to discard.
A break before _any_ of the view_normal_canonical's DVC headers though _must_ be repaired.

## Bump Primary view_normal Early

### Background

The new primary picks (in `primary_set_log_from_do_view_change_messages()`) at least one "canonical view". This is the highest `view_normal` from any DVC in its quorum.
The canonical DVC(s) headers are called the view's "canonical headers". These headers help select the new log head.

If multiple replicas have the same `view_normal`, there may be multiple canonical DVCs.
However, canonical headers _must_ be unambiguous. More specifically:

  - Any particular DVC may have gaps (1a, 2a, 4a), but no hash breaks (1a, 2a, 4b).
  - DVCs with the same `view_normal` _must_ not conflict.

### Bug

*DVCs with the same `view_normal` _must_ not conflict.*

Currently they can conflict, though. The heart of this bug is that the `view_normal` updates at a different time than the headers, so there is an interval when do not correspond.

Consider the new primary during a view change:

  1. Primary (`R₀`) receives DVC quorum for view `V₀`. `R₀` replaces its log. `R₀` begins repair.
  2. (... primary repairs)
  3. `R₀` completes repair. `R₀` transitions to `status=normal`. `R₀` bumps `view_normal`. `R₀` sends out `start_view` messages.

If another view change occurs during step 2 (with new primary `R₁`), `R₀` will send a DVC with a `view_normal` from _before_ `V₀`, but with the headers from `V₀`. But another replica in the view change may _also_ send a DVC, with the same `view_normal`, but the actual (different) headers!

### Not So Normal

Possibly `view_normal` should be renamed.
- For backups, "view normal" is accurate.
- But for primaries that completed completed their DVC quorum but did _not_ complete repair, it is inaccurate. They never reach normal status, but still need to advertise as if they did, to match their headers.

Maybe `view_active`? `view_write`? `view_member`?

This issue isn't present in VRR because VRR's DVCs include the entire log, and assume that it can be replace atomically.