### PR TITLE
Separate cache blocks from cache entries.

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -23,7 +23,7 @@ const Client = vsr.Client(StateMachine, MessageBus);
 
 const tb = @import("tigerbeetle.zig");
 
-const batches_count = 100;
+const batches_count = 1000;
 
 const transfers_per_batch: u32 = @divExact(
     constants.message_size_max - @sizeOf(vsr.Header),
@@ -151,7 +151,8 @@ pub fn main() !void {
 
     const result: i64 = @divFloor(@intCast(i64, transfers.len * 1000), ms);
     try stdout.print("============================================\n", .{});
-    try stdout.print("{} transfers per second\n\n", .{result});
+    try stdout.print("{} batches in {} ms\n", .{ batches_count, ms });
+    try stdout.print("{} transfers per second\n", .{result});
     try stdout.print("max p100 latency per {} transfers = {}ms\n", .{
         transfers_per_batch,
         queue.transfers_latency_max,

--- a/src/iops.zig
+++ b/src/iops.zig
@@ -19,9 +19,15 @@ pub fn IOPS(comptime T: type, comptime size: u6) type {
 
         pub fn release(self: *Self, item: *T) void {
             item.* = undefined;
-            const i = (@ptrToInt(item) - @ptrToInt(&self.items)) / @sizeOf(T);
+            const i = self.index(item);
             assert(!self.free.isSet(i));
             self.free.set(i);
+        }
+
+        pub fn index(self: *Self, item: *T) usize {
+            const i = (@ptrToInt(item) - @ptrToInt(&self.items)) / @sizeOf(T);
+            assert(i < size);
+            return i;
         }
 
         /// Returns the count of IOPs available.

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -61,7 +61,7 @@ pub fn CompactionType(
         const BlockPtrConst = Grid.BlockPtrConst;
         const BlockWrite = struct {
             write: Grid.Write = undefined,
-            block: BlockPtr = undefined,
+            block: *BlockPtr = undefined,
             writable: bool = false,
         };
 
@@ -358,7 +358,7 @@ pub fn CompactionType(
                     write_callback,
                     &block_write.write,
                     block_write.block,
-                    Table.block_address(block_write.block),
+                    Table.block_address(block_write.block.*),
                 );
             }
         }
@@ -469,7 +469,7 @@ pub fn CompactionType(
                 });
 
                 // Mark the finished data block as writable for the next compact_tick() call.
-                compaction.data.block = compaction.table_builder.data_block;
+                compaction.data.block = &compaction.table_builder.data_block;
                 assert(!compaction.data.writable);
                 compaction.data.writable = true;
             }
@@ -486,7 +486,7 @@ pub fn CompactionType(
                 });
 
                 // Mark the finished filter block as writable for the next compact_tick() call.
-                compaction.filter.block = compaction.table_builder.filter_block;
+                compaction.filter.block = &compaction.table_builder.filter_block;
                 assert(!compaction.filter.writable);
                 compaction.filter.writable = true;
             }
@@ -506,7 +506,7 @@ pub fn CompactionType(
                 compaction.manifest.insert_table(compaction.level_b, &table);
 
                 // Mark the finished index block as writable for the next compact_tick() call.
-                compaction.index.block = compaction.table_builder.index_block;
+                compaction.index.block = &compaction.table_builder.index_block;
                 assert(!compaction.index.writable);
                 compaction.index.writable = true;
 

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -47,15 +47,8 @@ pub fn GridType(comptime Storage: type) type {
     return struct {
         const Grid = @This();
 
-        pub const read_iops_max = 15;
-        comptime {
-            // This + 1 ensures that it is always possible for writes to add the written block
-            // to the cache on completion, even if the maximum number of concurrent reads are in
-            // progress and have locked all but one way in the target set.
-            assert(read_iops_max + 1 <= set_associative_cache_ways);
-        }
-
-        // TODO put more thought into how low/high this limit should be.
+        // TODO put more thought into how low/high these limits should be.
+        pub const read_iops_max = 16;
         pub const write_iops_max = 16;
 
         pub const BlockPtr = *align(constants.sector_size) [block_size]u8;

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -44,48 +44,6 @@ pub fn GridType(comptime Storage: type) type {
     const block_size = constants.block_size;
     const SuperBlock = SuperBlockType(Storage);
 
-    const cache_interface = struct {
-        inline fn address_from_block(block: *const [block_size]u8) u64 {
-            const header_bytes = block[0..@sizeOf(vsr.Header)];
-            const header = mem.bytesAsValue(vsr.Header, header_bytes);
-            const address = header.op;
-            assert(address > 0);
-            return address;
-        }
-
-        inline fn set_address(block: *[block_size]u8, address: u64) void {
-            const header = mem.toBytes(vsr.Header{
-                .op = address,
-                .cluster = undefined,
-                .command = undefined,
-            });
-            const header_bytes = block[0..@sizeOf(vsr.Header)];
-            header_bytes.* = header;
-        }
-
-        inline fn hash_address(address: u64) u64 {
-            assert(address > 0);
-            return std.hash.Wyhash.hash(0, mem.asBytes(&address));
-        }
-
-        inline fn equal_addresses(a: u64, b: u64) bool {
-            return a == b;
-        }
-    };
-
-    const set_associative_cache_ways = 16;
-    const Cache = SetAssociativeCache(
-        u64,
-        [block_size]u8,
-        cache_interface.address_from_block,
-        cache_interface.hash_address,
-        cache_interface.equal_addresses,
-        .{
-            .ways = set_associative_cache_ways,
-            .value_alignment = constants.sector_size,
-        },
-    );
-
     return struct {
         const Grid = @This();
 
@@ -110,7 +68,7 @@ pub fn GridType(comptime Storage: type) type {
         pub const Write = struct {
             callback: fn (*Grid.Write) void,
             address: u64,
-            block: BlockPtrConst,
+            block: *BlockPtr,
 
             /// Link for the Grid.write_queue linked list.
             next: ?*Write = null,
@@ -146,15 +104,48 @@ pub fn GridType(comptime Storage: type) type {
         const ReadIOP = struct {
             completion: Storage.Read,
             read: *Read,
-            block: BlockPtr,
         };
 
+        const cache_interface = struct {
+            inline fn address_from_address(address: *const u64) u64 {
+                return address.*;
+            }
+
+            inline fn hash_address(address: u64) u64 {
+                assert(address > 0);
+                return std.hash.Wyhash.hash(0, mem.asBytes(&address));
+            }
+
+            inline fn equal_addresses(a: u64, b: u64) bool {
+                return a == b;
+            }
+        };
+
+        const set_associative_cache_ways = 16;
+
+        const Cache = SetAssociativeCache(
+            u64,
+            u64,
+            cache_interface.address_from_address,
+            cache_interface.hash_address,
+            cache_interface.equal_addresses,
+            .{
+                .ways = set_associative_cache_ways,
+                .value_alignment = @alignOf(u64),
+            },
+        );
+
         superblock: *SuperBlock,
+
+        // Each entry in cache has a corresponding block.
+        cache_blocks: []BlockPtr,
         cache: Cache,
 
         write_iops: IOPS(WriteIOP, write_iops_max) = .{},
         write_queue: FIFO(Write) = .{},
 
+        // Each read_iops has a corresponding block.
+        read_iop_blocks: [read_iops_max]BlockPtr,
         read_iops: IOPS(ReadIOP, read_iops_max) = .{},
         read_queue: FIFO(Read) = .{},
 
@@ -168,19 +159,47 @@ pub fn GridType(comptime Storage: type) type {
         pub fn init(allocator: mem.Allocator, superblock: *SuperBlock) !Grid {
             // TODO Determine this at runtime based on runtime configured maximum
             // memory usage of tigerbeetle.
-            const blocks_in_cache = 2048;
+            const cache_blocks_count = 2048;
 
-            var cache = try Cache.init(allocator, blocks_in_cache);
+            const cache_blocks = try allocator.alloc(BlockPtr, cache_blocks_count);
+            errdefer allocator.free(cache_blocks);
+
+            for (cache_blocks) |*cache_block, i| {
+                errdefer for (cache_blocks[0..i]) |block| allocator.free(block);
+                cache_block.* = try alloc_block(allocator);
+            }
+
+            var cache = try Cache.init(allocator, cache_blocks_count);
             errdefer cache.deinit(allocator);
+
+            var read_iop_blocks: [read_iops_max]BlockPtr = undefined;
+
+            for (&read_iop_blocks) |*read_iop_block, i| {
+                errdefer for (read_iop_blocks[0..i]) |block| allocator.free(block);
+                read_iop_block.* = try alloc_block(allocator);
+            }
 
             return Grid{
                 .superblock = superblock,
+                .cache_blocks = cache_blocks,
                 .cache = cache,
+                .read_iop_blocks = read_iop_blocks,
             };
         }
 
+        pub fn alloc_block(allocator: mem.Allocator) !BlockPtr {
+            const block = try allocator.alignedAlloc(u8, constants.sector_size, block_size);
+            return block[0..block_size];
+        }
+
         pub fn deinit(grid: *Grid, allocator: mem.Allocator) void {
+            for (&grid.read_iop_blocks) |block| allocator.free(block);
+
             grid.cache.deinit(allocator);
+
+            for (grid.cache_blocks) |block| allocator.free(block);
+            allocator.free(grid.cache_blocks);
+
             grid.* = undefined;
         }
 
@@ -233,14 +252,14 @@ pub fn GridType(comptime Storage: type) type {
                 var it = grid.write_queue.peek();
                 while (it) |queued_write| : (it = queued_write.next) {
                     assert(address != queued_write.address);
-                    assert(block != queued_write.block);
+                    assert(block != queued_write.block.*);
                 }
             }
             {
                 var it = grid.write_iops.iterate();
                 while (it.next()) |iop| {
                     assert(address != iop.write.address);
-                    assert(block != iop.write.block);
+                    assert(block != iop.write.block.*);
                 }
             }
         }
@@ -262,21 +281,23 @@ pub fn GridType(comptime Storage: type) type {
                 var it = grid.read_iops.iterate();
                 while (it.next()) |iop| {
                     assert(address != iop.read.address);
-                    assert(block != iop.block);
+                    const iop_block = grid.read_iop_blocks[grid.read_iops.index(iop)];
+                    assert(block != iop_block);
                 }
             }
         }
 
+        /// NOTE: This will consume `block` and replace it with a fresh block.
         pub fn write_block(
             grid: *Grid,
             callback: fn (*Grid.Write) void,
             write: *Grid.Write,
-            block: BlockPtrConst,
+            block: *BlockPtr,
             address: u64,
         ) void {
             assert(address > 0);
-            grid.assert_not_writing(address, block);
-            grid.assert_not_reading(address, block);
+            grid.assert_not_writing(address, block.*);
+            grid.assert_not_reading(address, block.*);
 
             assert(grid.superblock.opened);
             assert(!grid.superblock.free_set.is_free(address));
@@ -305,7 +326,7 @@ pub fn GridType(comptime Storage: type) type {
             grid.superblock.storage.write_sectors(
                 write_block_callback,
                 &iop.completion,
-                write.block,
+                write.block.*,
                 .grid,
                 block_offset(write.address),
             );
@@ -322,13 +343,10 @@ pub fn GridType(comptime Storage: type) type {
             // We can only update the cache if the Grid is not resolving callbacks with a cache block.
             assert(!grid.read_resolving);
 
-            const cached_block = grid.cache.insert_preserve_locked(
-                *Grid,
-                block_locked,
-                grid,
-                completed_write.address,
-            );
-            util.copy_disjoint(.exact, u8, cached_block, completed_write.block);
+            // Insert the write block into the cache, and give the evicted block to the writer.
+            const cache_index = grid.cache.insert_index(&completed_write.address);
+            const cache_block = &grid.cache_blocks[cache_index];
+            std.mem.swap(BlockPtr, cache_block, completed_write.block);
 
             // Start a queued write if possible *before* calling the completed
             // write's callback. This ensures that if the callback calls
@@ -399,9 +417,10 @@ pub fn GridType(comptime Storage: type) type {
             const grid = read.grid;
 
             // Try to resolve the read from the cache.
-            if (grid.cache.get(read.address)) |block| {
-                if (constants.verify) grid.verify_cached_read(read.address, block);
-                grid.read_block_resolve(read, block);
+            if (grid.cache.get_index(read.address)) |cache_index| {
+                const cache_block = grid.cache_blocks[cache_index];
+                if (constants.verify) grid.verify_cached_read(read.address, cache_block);
+                grid.read_block_resolve(read, cache_block);
                 return;
             }
 
@@ -422,50 +441,31 @@ pub fn GridType(comptime Storage: type) type {
             // We can only update the cache if the Grid is not resolving callbacks with a cache block.
             assert(!grid.read_resolving);
 
-            // Grab a block from the cache to read with.
-            // This also inserts the block into the cache at the address.
-            const block = grid.cache.insert_preserve_locked(
-                *Grid,
-                block_locked,
-                grid,
-                address,
-            );
-
-            // `block` will be initialized later when the read completes.
-            // This is safe because as long as `read` is in `grid.read_queue` or `grid.read_recovery_queue`
-            // we will never attempt to read from or overwrite this cache entry.
-            // However, we do have to immediately set the cache key to uphold the
-            // invariants of `SetAssociativeCache`.
-            cache_interface.set_address(block, address);
-
             iop.* = .{
                 .completion = undefined,
                 .read = read,
-                .block = block,
             };
+            const iop_block = grid.read_iop_blocks[grid.read_iops.index(iop)];
 
             grid.superblock.storage.read_sectors(
                 read_block_callback,
                 &iop.completion,
-                block,
+                iop_block,
                 .grid,
                 block_offset(address),
             );
         }
 
-        inline fn block_locked(grid: *Grid, block: BlockPtrConst) bool {
-            var it = grid.read_iops.iterate();
-            while (it.next()) |iop| {
-                if (block == iop.block) return true;
-            }
-            return false;
-        }
-
         fn read_block_callback(completion: *Storage.Read) void {
             const iop = @fieldParentPtr(ReadIOP, "completion", completion);
-            const block = iop.block;
             const read = iop.read;
             const grid = read.grid;
+            const iop_block = &grid.read_iop_blocks[grid.read_iops.index(iop)];
+
+            // Insert the block into the cache, and give the evicted block to `iop`.
+            const cache_index = grid.cache.insert_index(&read.address);
+            const cache_block = &grid.cache_blocks[cache_index];
+            std.mem.swap(BlockPtr, iop_block, cache_block);
 
             // Handoff the iop to a pending read or release it before resolving the callbacks below.
             if (grid.read_pending_queue.pop()) |pending| {
@@ -476,8 +476,8 @@ pub fn GridType(comptime Storage: type) type {
             }
 
             // A valid block filled by storage means the reads for the address can be resolved
-            if (read_block_valid(read, block)) {
-                grid.read_block_resolve(read, block);
+            if (read_block_valid(read, cache_block.*)) {
+                grid.read_block_resolve(read, cache_block.*);
                 return;
             }
 
@@ -536,6 +536,9 @@ pub fn GridType(comptime Storage: type) type {
                 grid.read_resolving = false;
             }
 
+            // Remove the "root" read so that the address is no longer actively reading / locked.
+            grid.read_queue.remove(read);
+
             // Resolve all reads queued to the address with the block.
             // Callbacks may queue more to read.resolves so it must drain any new/existing pendings.
             while (read.resolves.pop()) |pending| {
@@ -543,10 +546,8 @@ pub fn GridType(comptime Storage: type) type {
                 pending_read.callback(pending_read, block);
             }
 
-            // Remove the "root" read so that the address is no longer actively reading / locked.
             // Then invoke the callback with the cache block (which should be valid for the duration
             // of the callback as any nested Grid calls cannot synchronously update the cache).
-            grid.read_queue.remove(read);
             read.callback(read, block);
         }
 

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -347,6 +347,9 @@ pub fn GridType(comptime Storage: type) type {
             const cache_index = grid.cache.insert_index(&completed_write.address);
             const cache_block = &grid.cache_blocks[cache_index];
             std.mem.swap(BlockPtr, cache_block, completed_write.block);
+            if (constants.verify) {
+                std.mem.set(u8, completed_write.block.*, undefined);
+            }
 
             // Start a queued write if possible *before* calling the completed
             // write's callback. This ensures that if the callback calls
@@ -466,6 +469,9 @@ pub fn GridType(comptime Storage: type) type {
             const cache_index = grid.cache.insert_index(&read.address);
             const cache_block = &grid.cache_blocks[cache_index];
             std.mem.swap(BlockPtr, iop_block, cache_block);
+            if (constants.verify) {
+                std.mem.set(u8, iop_block.*, undefined);
+            }
 
             // Handoff the iop to a pending read or release it before resolving the callbacks below.
             if (grid.read_pending_queue.pop()) |pending| {

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -546,7 +546,6 @@ pub fn GridType(comptime Storage: type) type {
             grid.read_queue.remove(read);
 
             // Resolve all reads queued to the address with the block.
-            // Callbacks may queue more to read.resolves so it must drain any new/existing pendings.
             while (read.resolves.pop()) |pending| {
                 const pending_read = @fieldParentPtr(Read, "pending", pending);
                 pending_read.callback(pending_read, block);

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -404,14 +404,14 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 return;
             }
 
-            const block = manifest_log.blocks.head().?;
-            verify_block(block, null, null);
+            const block = manifest_log.blocks.head_ptr().?;
+            verify_block(block.*, null, null);
 
-            const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
-            const address = Block.address(block);
+            const header = mem.bytesAsValue(vsr.Header, block.*[0..@sizeOf(vsr.Header)]);
+            const address = Block.address(block.*);
             assert(address > 0);
 
-            const entry_count = Block.entry_count(block);
+            const entry_count = Block.entry_count(block.*);
 
             if (manifest_log.blocks_closed == 1 and manifest_log.blocks.count == 1) {
                 // This might be the last block of a checkpoint, which can be a partial block.

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -216,6 +216,7 @@ pub fn SetAssociativeCache(
             const way = self.search(set, key) orelse return;
 
             self.counts.set(set.offset + way, 0);
+            set.values[way] = undefined;
         }
 
         /// Hint that the key is less likely to be accessed in the future, without actually removing

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -195,14 +195,19 @@ pub fn SetAssociativeCache(
             return self.search(set, key) != null;
         }
 
-        pub fn get(self: *Self, key: Key) ?*align(value_alignment) Value {
+        pub fn get_index(self: *Self, key: Key) ?usize {
             const set = self.associate(key);
             const way = self.search(set, key) orelse return null;
 
             const count = self.counts.get(set.offset + way);
             self.counts.set(set.offset + way, count +| 1);
 
-            return @alignCast(value_alignment, &set.values[way]);
+            return set.offset + way;
+        }
+
+        pub fn get(self: *Self, key: Key) ?*align(value_alignment) Value {
+            const index = self.get_index(key) orelse return null;
+            return @alignCast(value_alignment, &self.values[index]);
         }
 
         /// Remove a key from the set associative cache if present.
@@ -248,40 +253,21 @@ pub fn SetAssociativeCache(
             return @ptrCast(*const Ways, &result).*;
         }
 
-        pub fn insert(self: *Self, key: Key) *align(value_alignment) Value {
-            return self.insert_preserve_locked(
-                void,
-                struct {
-                    inline fn locked(_: void, _: *const Value) bool {
-                        return false;
-                    }
-                }.locked,
-                {},
-                key,
-            );
+        /// Insert a value, evicting an older entry if needed.
+        pub fn insert(self: *Self, value: *const Value) void {
+            _ = self.insert_index(value);
         }
 
-        /// Add a key, evicting an older entry if needed, and return a pointer to the value.
-        /// The caller must immediately initialize the value such that `equal(key_from_value(value), key)`.
-        /// The key must not already be in the cache.
-        /// Never evicts keys for which locked() returns true.
-        /// The caller must guarantee that locked() returns true for less than layout.ways keys.
-        pub fn insert_preserve_locked(
-            self: *Self,
-            comptime Context: type,
-            comptime locked: fn (
-                Context,
-                *align(value_alignment) const Value,
-            ) callconv(.Inline) bool,
-            context: Context,
-            key: Key,
-        ) *align(value_alignment) Value {
+        /// Insert a value, evicting an older entry if needed.
+        /// Return the index at which the value was inserted.
+        pub fn insert_index(self: *Self, value: *const Value) usize {
+            const key = key_from_value(value);
             const set = self.associate(key);
             if (self.search(set, key)) |way| {
-                // Remove the old entry for this key.
-                // It should be a different value, but since we are returning a value pointer we
-                // can't check against the new one.
-                self.counts.set(set.offset + way, 0);
+                // Overwrite the old entry for this key.
+                self.counts.set(set.offset + way, 1);
+                set.values[way] = value.*;
+                return set.offset + way;
             }
 
             const clock_index = @divExact(set.offset, layout.ways);
@@ -300,11 +286,6 @@ pub fn SetAssociativeCache(
                 safety_count += 1;
                 way +%= 1;
             }) {
-                // We pass a value pointer to the callback here so that a cache miss
-                // can be avoided if the caller is able to determine if the value is
-                // locked by comparing pointers directly.
-                if (locked(context, @alignCast(value_alignment, &set.values[way]))) continue;
-
                 var count = self.counts.get(set.offset + way);
                 if (count == 0) break; // Way is already free.
 
@@ -317,10 +298,11 @@ pub fn SetAssociativeCache(
             assert(self.counts.get(set.offset + way) == 0);
 
             set.tags[way] = set.tag;
+            set.values[way] = value.*;
             self.counts.set(set.offset + way, 1);
             self.clocks.set(clock_index, way +% 1);
 
-            return @alignCast(value_alignment, &set.values[way]);
+            return set.offset + way;
         }
 
         const Set = struct {
@@ -431,7 +413,7 @@ fn set_associative_cache_test(
                     try expectEqual(i, sac.clocks.get(0));
 
                     const key = i * sac.sets;
-                    sac.insert(key).* = key;
+                    sac.insert(&key);
                     try expect(sac.counts.get(i) == 1);
                     try expectEqual(key, sac.get(key).?.*);
                     try expect(sac.counts.get(i) == 2);
@@ -444,7 +426,7 @@ fn set_associative_cache_test(
             // Insert another element into the first set, causing key 0 to be evicted.
             {
                 const key = layout.ways * sac.sets;
-                sac.insert(key).* = key;
+                sac.insert(&key);
                 try expect(sac.counts.get(0) == 1);
                 try expectEqual(key, sac.get(key).?.*);
                 try expect(sac.counts.get(0) == 2);
@@ -457,34 +439,6 @@ fn set_associative_cache_test(
                         try expect(sac.counts.get(i) == 1);
                     }
                 }
-            }
-
-            if (log) sac.associate(0).inspect(sac);
-
-            // Lock all other slots, causing key layout.ways * sac.sets to be evicted despite having the
-            // highest count.
-            {
-                {
-                    assert(sac.counts.get(0) == 2);
-                    var i: usize = 1;
-                    while (i < layout.ways) : (i += 1) assert(sac.counts.get(i) == 1);
-                }
-
-                const key = (layout.ways + 1) * sac.sets;
-                const expect_evicted = layout.ways * sac.sets;
-
-                sac.insert_preserve_locked(
-                    u64,
-                    struct {
-                        inline fn locked(only_unlocked: u64, value: *const Value) bool {
-                            return value.* != only_unlocked;
-                        }
-                    }.locked,
-                    expect_evicted,
-                    key,
-                ).* = key;
-
-                try expectEqual(@as(?*Value, null), sac.get(expect_evicted));
             }
 
             if (log) sac.associate(0).inspect(sac);
@@ -513,7 +467,7 @@ fn set_associative_cache_test(
                     try expectEqual(i, sac.clocks.get(0));
 
                     const key = i * sac.sets;
-                    sac.insert(key).* = key;
+                    sac.insert(&key);
                     try expect(sac.counts.get(i) == 1);
                     var j: usize = 2;
                     while (j <= math.maxInt(SAC.Count)) : (j += 1) {
@@ -531,7 +485,7 @@ fn set_associative_cache_test(
             // Insert another element into the first set, causing key 0 to be evicted.
             {
                 const key = layout.ways * sac.sets;
-                sac.insert(key).* = key;
+                sac.insert(&key);
                 try expect(sac.counts.get(0) == 1);
                 try expectEqual(key, sac.get(key).?.*);
                 try expect(sac.counts.get(0) == 2);

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -186,7 +186,7 @@ pub fn TableMutableType(comptime Table: type) type {
                     if (tombstone(value)) {
                         cache.remove(key_from_value(value));
                     } else {
-                        cache.insert(key_from_value(value)).* = value.*;
+                        cache.insert(value);
                     }
                 }
             }


### PR DESCRIPTION
Rather than storing cache blocks in set_associative_cache itself, allocate them separately and just store a pointer in the cache.

This allows:
* Removing the `locked` interface and never having uninitialized blocks in the cache. Instead, each read_iop owns a block and swaps with a cache block when the read finishes.
* Removing the `memcpy` on grid block write. Instead, the writer passes a `*BlockPtr` and then grid swaps it with a cache block when the write finishes. (This means writers have to be aware that writing a block consumes that data.)

Also, it was previously possible for inserting a key into the cache to cause two evictions. In some workloads (notably src/lsm/tree_fuzz, but not src/benchmark) this led to cache occupancy dropping to ~40%. We can avoid this by overwriting the existing entry if there is one, at the expense of muddling the fifo order of the cache.