### PR TITLE
Java client: Minor benchmark adjustments

### DIFF
--- a/src/clients/java/src/main/java/benchmark/Benchmark.java
+++ b/src/clients/java/src/main/java/benchmark/Benchmark.java
@@ -43,7 +43,7 @@ public class Benchmark {
             final int TRANSFER_SIZE = 128; // @sizeOf(Transfer)
             final int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
 
-            final int BATCHES_COUNT = 5;
+            final int BATCHES_COUNT = 100;
             final int TRANSFERS_PER_BATCH = (MESSAGE_SIZE_MAX - HEADER_SIZE) / TRANSFER_SIZE;
             final int MAX_TRANSFERS = BATCHES_COUNT * TRANSFERS_PER_BATCH;
 
@@ -53,7 +53,7 @@ public class Benchmark {
                 for (int j = 0; j < TRANSFERS_PER_BATCH; j++) {
 
                     transfersBatch.add();
-                    transfersBatch.setId(i + 1, j + 1);
+                    transfersBatch.setId(j + 1, i);
                     transfersBatch.setCreditAccountId(100, 1000);
                     transfersBatch.setDebitAccountId(200, 2000);
                     transfersBatch.setCode((short) 1);
@@ -74,7 +74,7 @@ public class Benchmark {
                 var transfersErrors = client.createTransfers(batch);
                 if (transfersErrors.getLength() > 0) {
 
-                    while (accountErrors.next()) {
+                    while (transfersErrors.next()) {
                         System.err.printf("Error creating transfer #%d -> %s%n",
                                 transfersErrors.getIndex(), transfersErrors.getResult());
                     }


### PR DESCRIPTION
- Fix the endianness of the transfer's Id in the benchmark program.
It's the same problem fixed by #334, but in this case it has affected only the benchmark program which had the order of the parameters inverted: Java's convention asks for the most significant bytes first, and the least significant later. But internally it's correctly represented as little endian.

- Fix a minor typo when checking for errors using the wrong result object.

- Bumps this benchmark to perform 100 batches, just like the Zig benchmark program.