### PR TITLE
Fix compaction_must_drop_tombstones

### DIFF
--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -531,7 +531,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                     .ascending,
                     KeyRange{ .key_min = range.key_min, .key_max = range.key_max },
                 );
-                if (it.next() == null) {
+                if (it.next() != null) {
                     // If the range is being compacted into the last level then this is unreachable,
                     // as the last level has no subsequent levels and must always drop tombstones.
                     assert(level_b != constants.lsm_levels - 1);


### PR DESCRIPTION
compaction_must_drop_tombstones should be false only if there exists a lower table with overlap.

The current code will never return true until every level is full, at which point it will drop tombstones in every level.