### PR TITLE
introduce vsr package

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -43,9 +43,16 @@ pub fn build(b: *std.build.Builder) void {
     ) orelse .none;
     options.addOption(config.TracerBackend, "tracer_backend", tracer_backend);
 
-    const tigerbeetle = b.addExecutable("tigerbeetle", "src/main.zig");
+    const vsr_package = std.build.Pkg{
+        .name = "vsr",
+        .path = .{ .path = "src/vsr.zig" },
+        .dependencies = &.{ options.getPackage("tigerbeetle_build_options") },
+    };
+
+    const tigerbeetle = b.addExecutable("tigerbeetle", "src/tigerbeetle/main.zig");
     tigerbeetle.setTarget(target);
     tigerbeetle.setBuildMode(mode);
+    tigerbeetle.addPackage(vsr_package);
     tigerbeetle.install();
     // Ensure that we get stack traces even in release builds.
     tigerbeetle.omit_frame_pointer = false;
@@ -73,6 +80,7 @@ pub fn build(b: *std.build.Builder) void {
         const benchmark = b.addExecutable("benchmark", "src/benchmark.zig");
         benchmark.setTarget(target);
         benchmark.setBuildMode(mode);
+        benchmark.addPackage(vsr_package);
         benchmark.install();
         benchmark.addOptions("tigerbeetle_build_options", options);
         link_tracer_backend(benchmark, tracer_backend, target);

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -6,7 +6,6 @@ const constants = @import("constants.zig");
 const log = std.log;
 pub const log_level: std.log.Level = .err;
 
-const cli = @import("cli.zig");
 const IO = @import("io.zig").IO;
 
 const util = @import("util.zig");

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -7,7 +7,6 @@ const log = std.log.scoped(.storage);
 const IO = @import("io.zig").IO;
 const FIFO = @import("fifo.zig").FIFO;
 const constants = @import("constants.zig");
-const fatal = @import("cli.zig").fatal;
 const vsr = @import("vsr.zig");
 
 pub const Storage = struct {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -7,11 +7,11 @@ const meta = std.meta;
 const net = std.net;
 const os = std.os;
 
-const constants = @import("constants.zig");
-const tigerbeetle = @import("tigerbeetle.zig");
-const vsr = @import("vsr.zig");
-const IO = @import("io.zig").IO;
-const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
+const vsr = @import("vsr");
+const constants = vsr.constants;
+const tigerbeetle = vsr.tigerbeetle;
+const IO = vsr.io.IO;
+const data_file_size_min = vsr.superblock.data_file_size_min;
 
 // TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage
 const usage = fmt.comptimePrint(

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -7,29 +7,30 @@ const os = std.os;
 const log_main = std.log.scoped(.main);
 
 const build_options = @import("tigerbeetle_build_options");
-const constants = @import("constants.zig");
-const config = @import("config.zig").configs.current;
-const tracer = @import("tracer.zig");
+
+const vsr = @import("vsr");
+const constants = vsr.constants;
+const config = vsr.config.configs.current;
+const tracer = vsr.tracer;
 
 const cli = @import("cli.zig");
 const fatal = cli.fatal;
 
-const IO = @import("io.zig").IO;
-const Time = @import("time.zig").Time;
-const Storage = @import("storage.zig").Storage;
+const IO = vsr.io.IO;
+const Time = vsr.time.Time;
+const Storage = vsr.storage.Storage;
 
-const MessageBus = @import("message_bus.zig").MessageBusReplica;
-const MessagePool = @import("message_pool.zig").MessagePool;
-const StateMachine = @import("state_machine.zig").StateMachineType(Storage, .{
+const MessageBus = vsr.message_bus.MessageBusReplica;
+const MessagePool = vsr.message_pool.MessagePool;
+const StateMachine = vsr.state_machine.StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
 });
 
-const vsr = @import("vsr.zig");
 const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time);
 
 const SuperBlock = vsr.SuperBlockType(Storage);
-const superblock_zone_size = @import("vsr/superblock.zig").superblock_zone_size;
-const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
+const superblock_zone_size = vsr.superblock.superblock_zone_size;
+const data_file_size_min = vsr.superblock.data_file_size_min;
 
 pub const log_level: std.log.Level = constants.log_level;
 pub const log = constants.log;

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -18,8 +18,6 @@ test {
     _ = @import("ring_buffer.zig");
 
     _ = @import("io.zig");
-
-    _ = @import("cli.zig");
     _ = @import("ewah.zig");
     _ = @import("util.zig");
 
@@ -37,4 +35,7 @@ test {
 
     _ = @import("clients/go/go_bindings_test.zig");
     _ = @import("clients/dotnet/dotnet_bindings_test.zig");
+
+    // This one is a bit sketchy: we rely on tests not actually using the `vsr` package.
+    _ = @import("tigerbeetle/cli.zig");
 }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -4,11 +4,27 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const log = std.log.scoped(.vsr);
 
-const constants = @import("constants.zig");
-
-/// The version of our Viewstamped Replication protocol in use, including customizations.
-/// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).
-pub const Version: u8 = 0;
+// vsr.zig is the root of a zig package, reexport all public APIs.
+//
+// Note that we don't promise any stability of these interfaces yet.
+pub const constants = @import("constants.zig");
+pub const io = @import("io.zig");
+pub const message_bus = @import("message_bus.zig");
+pub const message_pool = @import("message_pool.zig");
+pub const state_machine = @import("state_machine.zig");
+pub const storage = @import("storage.zig");
+pub const tigerbeetle = @import("tigerbeetle.zig");
+pub const time = @import("time.zig");
+pub const tracer = @import("tracer.zig");
+pub const config = @import("config.zig");
+pub const superblock = @import("vsr/superblock.zig");
+pub const lsm = .{
+    .tree = @import("lsm/tree.zig"),
+    .grid = @import("lsm/grid.zig"),
+    .groove = @import("lsm/groove.zig"),
+    .forest = @import("lsm/forest.zig"),
+    .posted_groove = @import("lsm/posted_groove.zig"),
+};
 
 pub const ReplicaType = @import("vsr/replica.zig").ReplicaType;
 pub const format = @import("vsr/replica_format.zig").format;
@@ -17,8 +33,12 @@ pub const Client = @import("vsr/client.zig").Client;
 pub const Clock = @import("vsr/clock.zig").Clock;
 pub const JournalType = @import("vsr/journal.zig").JournalType;
 pub const SlotRange = @import("vsr/journal.zig").SlotRange;
-pub const SuperBlockType = @import("vsr/superblock.zig").SuperBlockType;
-pub const VSRState = @import("vsr/superblock.zig").SuperBlockSector.VSRState;
+pub const SuperBlockType = superblock.SuperBlockType;
+pub const VSRState = superblock.SuperBlockSector.VSRState;
+
+/// The version of our Viewstamped Replication protocol in use, including customizations.
+/// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).
+pub const Version: u8 = 0;
 
 pub const ProcessType = enum { replica, client };
 
@@ -28,7 +48,7 @@ pub const Zone = enum {
     wal_prepares,
     grid,
 
-    const size_superblock = @import("vsr/superblock.zig").superblock_zone_size;
+    const size_superblock = superblock.superblock_zone_size;
     const size_wal_headers = constants.journal_size_headers;
     const size_wal_prepares = constants.journal_size_prepares;
 


### PR DESCRIPTION
This is the start of "using tigerbeetle as a library". What is done in this PR:

- make `vsr.zig` file the root of the package, re-export everything there
- move `src/main.zig` into `src/tigerbeetle/main.zig`, make that use the vsr "package" via build.zig

What is _not_ done in this PR:

- fixing demos -- they are broken already, so I'd rather look into that separately
- making the vsr package "reasonable". Instead, we package basically everything there is. In particular, accounting state_machine _should_ be outside of vsr package, but it is curretnly there. Fixing that would require some extra untangling of code.
- stable APIs -- these are pretty far away at this point.