### PR TITLE
temporary paper over nodejes build failures.

### DIFF
--- a/src/clients/node/scripts/build.sh
+++ b/src/clients/node/scripts/build.sh
@@ -2,7 +2,7 @@
 
  set -e
 
-docker run -v "$(pwd)/../../..":/wrk -w /wrk/src/clients/node --entrypoint bash node -c "
+docker run -v "$(pwd)/../../..":/wrk -w /wrk/src/clients/node --entrypoint bash node:lts -c "
 npm config set cache /tmp --global
 npm install
 npm pack


### PR DESCRIPTION
`npm pack` does not work for us correctly under latest npm 9. Paper over this by sticking to an older npm version for packaging.

Note that newer npm versions should install the package just fine -- its just the creation of package which is buggy (npm changed its behavior around symlinks)


Note sure if we should do this, but, given that this have been failing for a while, we might? 