### PR TITLE
Client: Don't increment request number on error

### DIFF
--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -97,7 +97,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
             while (self.request_queue.pop()) |inflight| {
                 defer self.unref(inflight.message);
 
-                inflight.callback(
+                inflight.callback.?(
                     inflight.user_data,
                     inflight.message.header.operation.cast(Self.StateMachine),
                     inflight.message.body(),

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -29,7 +29,8 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 results: Error![]const u8,
             ) void;
             user_data: u128,
-            callback: Callback,
+            // Null iff operation=register.
+            callback: ?Callback,
             message: *Message,
         };
 
@@ -370,7 +371,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             }
 
             if (inflight.message.header.operation != .register) {
-                inflight.callback(
+                inflight.callback.?(
                     inflight.user_data,
                     inflight.message.header.operation.cast(StateMachine),
                     reply.body(),
@@ -454,7 +455,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
 
             self.request_queue.push_assume_capacity(.{
                 .user_data = 0,
-                .callback = undefined,
+                .callback = null,
                 .message = message.ref(),
             });
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -370,12 +370,16 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 on_reply_callback(self.on_reply_context, self, inflight.message, reply);
             }
 
-            if (inflight.message.header.operation != .register) {
-                inflight.callback.?(
+            if (inflight.callback) |callback| {
+                assert(inflight.message.header.operation != .register);
+
+                callback(
                     inflight.user_data,
                     inflight.message.header.operation.cast(StateMachine),
                     reply.body(),
                 );
+            } else {
+                assert(inflight.message.header.operation == .register);
             }
         }
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -194,6 +194,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             message_body_size: usize,
         ) void {
             self.register();
+            assert(self.request_number > 0);
 
             // We will set parent, context, view and checksums only when sending for the first time:
             message.header.* = .{
@@ -204,9 +205,6 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @intCast(u32, @sizeOf(Header) + message_body_size),
             };
-
-            assert(self.request_number > 0);
-            self.request_number += 1;
 
             log.debug("{}: request: user_data={} request={} size={} {s}", .{
                 self.id,
@@ -223,6 +221,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
 
             const was_empty = self.request_queue.empty();
 
+            self.request_number += 1;
             self.request_queue.push_assume_capacity(.{
                 .user_data = user_data,
                 .callback = callback,


### PR DESCRIPTION
If the request is just going to be discarded, don't increment the `request_number`.