### PR TITLE
Remove required_approvals and stick to using bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,3 @@
-required_approvals = 1
 status = [
   "bors/clients/dotnet",
   "bors/clients/go",


### PR DESCRIPTION
So we can implement the workflow @matklad suggested [here](https://github.com/tigerbeetledb/tigerbeetle/pull/385#discussion_r1066932594).