### PR TITLE
Provisory workaround for .net CI failures.

### DIFF
--- a/.github/workflows/clients-dotnet-build.yml
+++ b/.github/workflows/clients-dotnet-build.yml
@@ -75,8 +75,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet: [ 6.0.x, 3.1.x]
+        os: [ macos-latest, windows-latest]
+        dotnet: [ 7.0.x, 6.0.x, 3.1.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-dotnet@v3

--- a/.github/workflows/clients-dotnet-build.yml
+++ b/.github/workflows/clients-dotnet-build.yml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet: [ 7.0.x, 6.0.x, 3.1.x]
+        dotnet: [ 6.0.x, 3.1.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-dotnet@v3


### PR DESCRIPTION
Just disabling one combination of builds to reduce the number of tests.

~It may confirm my suspicion of the issue being caused by  `actions/upload-artifact@v3` and `actions/download-artifact@v3`. actions.~

~To avoid false positives, note that I removed the runtime `7.0` from the build matrix, which never failed during CI (all logs failed on ubuntu + runtime 3.1 or 6.0).
If after this fix we still have this problem, it may point to another cause, probably that combination of OS and runtime. Otherwise, I'll open a new PR replacing those actions with `actions/cache@v3`.~