### PR TITLE
VSR: Prepare queue

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -78,6 +78,7 @@ const ConfigProcess = struct {
 const ConfigCluster = struct {
     cache_line_size: comptime_int = 64,
     clients_max: usize,
+    pipeline_prepare_queue_max: usize = 8,
     quorum_replication_max: u8 = 3,
     journal_slot_count: usize = 1024,
     message_size_max: usize = 1 * 1024 * 1024,
@@ -101,7 +102,7 @@ const ConfigCluster = struct {
     pub const clients_max_min = 1;
 
     /// The smallest possible message_size_max (for use in the simulator to improve performance).
-    /// The message body must have room for pipeline_max headers in the DVC.
+    /// The message body must have room for pipeline_prepare_queue_max headers in the DVC.
     pub fn message_size_max_min(clients_max: usize) usize {
         return std.math.max(
             sector_size,
@@ -176,7 +177,8 @@ pub const configs = struct {
             .verify = true,
         },
         .cluster = .{
-            .clients_max = 4,
+            .clients_max = 4 + 3,
+            .pipeline_prepare_queue_max = 4,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(4),
             .storage_size_max = 1024 * 1024 * 1024,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -135,7 +135,7 @@ comptime {
     assert(journal_slot_count >= Config.Cluster.journal_slot_count_min);
     assert(journal_slot_count >= lsm_batch_multiple * 2);
     assert(journal_slot_count % lsm_batch_multiple == 0);
-    assert(journal_slot_count > pipeline_max);
+    assert(journal_slot_count > pipeline_prepare_queue_max);
 
     assert(journal_size_max == journal_size_headers + journal_size_prepares);
 }
@@ -165,7 +165,27 @@ comptime {
 /// The maximum number of Viewstamped Replication prepare messages that can be inflight at a time.
 /// This is immutable once assigned per cluster, as replicas need to know how many operations might
 /// possibly be uncommitted during a view change, and this must be constant for all replicas.
-pub const pipeline_max = clients_max;
+pub const pipeline_prepare_queue_max = config.cluster.pipeline_prepare_queue_max;
+
+/// The maximum number of Viewstamped Replication request messages that can be queued at a primary,
+/// waiting to prepare.
+// TODO(Zig): After 0.10, change this to simply "clients_max -| pipeline_prepare_queue_max".
+// In Zig 0.9 compilation fails with "operation caused overflow" despite the saturating subtraction.
+// See: https://github.com/ziglang/zig/issues/10870
+pub const pipeline_request_queue_max =
+    if (clients_max < pipeline_prepare_queue_max)
+    0
+else
+    clients_max - pipeline_prepare_queue_max;
+
+comptime {
+    // A prepare-queue capacity larger than clients_max is wasted.
+    assert(pipeline_prepare_queue_max <= clients_max);
+    // A total queue capacity larger than clients_max is wasted.
+    assert(pipeline_prepare_queue_max + pipeline_request_queue_max <= clients_max);
+    assert(pipeline_prepare_queue_max > 0);
+    assert(pipeline_request_queue_max >= 0);
+}
 
 /// The minimum and maximum amount of time in milliseconds to wait before initiating a connection.
 /// Exponential backoff and jitter are applied within this range.
@@ -267,7 +287,7 @@ pub const iops_write_max = journal_iops_write_max;
 /// The maximum number of concurrent WAL read I/O operations to allow at once.
 pub const journal_iops_read_max = config.process.journal_iops_read_max;
 /// The maximum number of concurrent WAL write I/O operations to allow at once.
-/// Ideally this is at least as high as pipeline_max, but it is safe to be lower.
+/// Ideally this is at least as high as pipeline_prepare_queue_max, but it is safe to be lower.
 pub const journal_iops_write_max = config.process.journal_iops_write_max;
 
 /// The number of redundant copies of the superblock in the superblock storage zone.

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -26,7 +26,8 @@ pub const messages_max_replica = messages_max: {
     sum += constants.journal_iops_write_max; // Journal writes
     sum += constants.clients_max; // SuperBlock.client_table
     sum += 1; // Replica.loopback_queue
-    sum += constants.pipeline_max; // Replica.pipeline
+    sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
+    sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}
     sum += 1; // Replica.commit_prepare
     // Replica.do_view_change_from_all_replicas quorum:
     // Replica.recovery_response_quorum is only used for recovery and does not increase the limit.

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -103,7 +103,7 @@ comptime {
     assert(slot_count >= headers_per_sector);
     // The length of the prepare pipeline is the upper bound on how many ops can be
     // reordered during a view change. See `recover_prepares_callback()` for more detail.
-    assert(slot_count > constants.pipeline_max);
+    assert(slot_count > constants.pipeline_prepare_queue_max);
 
     assert(headers_size > 0);
     assert(headers_size % constants.sector_size == 0);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -59,6 +59,11 @@ const Prepare = struct {
     ok_quorum_received: bool = false,
 };
 
+const Request = struct {
+    message: *Message, // header.command == .request
+    realtime: i64,
+};
+
 const QuorumMessages = [constants.replicas_max]?*Message;
 const quorum_messages_null = [_]?*Message{null} ** constants.replicas_max;
 
@@ -71,11 +76,11 @@ const quorum_counter_null = QuorumCounter.initEmpty();
 // that cannot be repaired because they are gaps, and this must be relative to the
 // cluster as a whole (not relative to the difference between our op and commit number)
 // as otherwise we would break correctness.
-const view_change_headers_count = constants.pipeline_max;
+const view_change_headers_count = constants.pipeline_prepare_queue_max;
 
 comptime {
     assert(view_change_headers_count > 0);
-    assert(view_change_headers_count >= constants.pipeline_max);
+    assert(view_change_headers_count >= constants.pipeline_prepare_queue_max);
     assert(view_change_headers_count <=
         @divFloor(constants.message_size_max - @sizeOf(Header), @sizeOf(Header)));
 }
@@ -197,12 +202,17 @@ pub fn ReplicaType(
         /// Whether we are reading a prepare from storage in order to push to the pipeline.
         repairing_pipeline: bool = false,
 
-        /// The primary's pipeline of inflight prepares waiting to commit in FIFO order.
-        /// This allows us to pipeline without the complexity of out-of-order commits.
-        ///
-        /// After a view change, the old primary's pipeline is left untouched so that it is able to
-        /// help the new primary repair, even in the face of local storage faults.
-        pipeline: RingBuffer(Prepare, constants.pipeline_max, .array) = .{},
+        /// The pipeline is a queue for a replica which is the primary and in status=normal.
+        /// At all other times the pipeline is a cache.
+        pipeline: union(enum) {
+            /// The primary's pipeline of inflight prepares waiting to commit in FIFO order,
+            /// with a tail of pending requests which have not begun to prepare.
+            /// This allows us to pipeline without the complexity of out-of-order commits.
+            queue: PipelineQueue,
+            /// Prepares in the cache may be committed or uncommitted, and may not belong to the
+            /// current view.
+            cache: PipelineCache,
+        },
 
         /// In some cases, a replica may send a message to itself. We do not submit these messages
         /// to the message bus but rather queue them here for guaranteed immediate delivery, which
@@ -514,6 +524,7 @@ pub fn ReplicaType(
                 .op_checkpoint = self.superblock.working.vsr_state.commit_min,
                 .commit_min = self.superblock.working.vsr_state.commit_min,
                 .commit_max = self.superblock.working.vsr_state.commit_max,
+                .pipeline = .{ .cache = .{} },
                 .ping_timeout = Timeout{
                     .name = "ping_timeout",
                     .id = replica_index,
@@ -591,7 +602,11 @@ pub fn ReplicaType(
             self.grid.deinit(allocator);
             defer self.message_bus.deinit(allocator);
 
-            while (self.pipeline.pop()) |prepare| self.message_bus.unref(prepare.message);
+            // TODO(Zig) 0.10: inline-switch.
+            switch (self.pipeline) {
+                .queue => |*pipeline| pipeline.deinit(self.message_bus.pool),
+                .cache => |*pipeline| pipeline.deinit(self.message_bus.pool),
+            }
 
             if (self.loopback_queue) |loopback_message| {
                 assert(loopback_message.next == null);
@@ -812,18 +827,22 @@ pub fn ReplicaType(
             self.clock.learn(message.header.replica, m0, t1, m2);
         }
 
-        /// The primary advances op-number, adds the request to the end of the log, and updates the
-        /// information for this client in the client-table to contain the new request number, s.
-        /// Then it sends a ⟨PREPARE v, m, n, k⟩ message to the other replicas, where v is the
-        /// current view-number, m is the message it received from the client, n is the op-number
-        /// it assigned to the request, and k is the commit-number.
+        /// When there is free space in the pipeline's prepare queue:
+        ///   The primary advances op-number, adds the request to the end of the log, and updates the
+        ///   information for this client in the client-table to contain the new request number, s.
+        ///   Then it sends a ⟨PREPARE v, m, n, k⟩ message to the other replicas, where v is the
+        ///   current view-number, m is the message it received from the client, n is the op-number
+        ///   it assigned to the request, and k is the commit-number.
+        /// Otherwise, when there is room in the pipeline's request queue:
+        ///   The request is queued, and will be dequeued & prepared when the pipeline head commits.
+        /// Otherwise, drop the request.
         fn on_request(self: *Self, message: *Message) void {
             if (self.ignore_request_message(message)) return;
 
             assert(self.status == .normal);
             assert(self.primary());
             assert(self.commit_min == self.commit_max);
-            assert(self.commit_max + self.pipeline.count == self.op);
+            assert(self.commit_max + self.pipeline.queue.prepare_queue.count == self.op);
 
             assert(message.header.command == .request);
             assert(message.header.view <= self.view); // The client's view may be behind ours.
@@ -833,59 +852,16 @@ pub fn ReplicaType(
                 return;
             };
 
-            log.debug("{}: on_request: request {}", .{ self.replica, message.header.checksum });
+            const request = .{
+                .message = message.ref(),
+                .realtime = realtime,
+            };
 
-            // Guard against the wall clock going backwards by taking the max with timestamps issued:
-            self.state_machine.prepare_timestamp = std.math.max(
-                // The cluster `commit_timestamp` may be ahead of our `prepare_timestamp` because this
-                // may be our first prepare as a recently elected primary:
-                std.math.max(
-                    self.state_machine.prepare_timestamp,
-                    self.state_machine.commit_timestamp,
-                ) + 1,
-                @intCast(u64, realtime),
-            );
-            assert(self.state_machine.prepare_timestamp > self.state_machine.commit_timestamp);
-
-            const prepare_timestamp = self.state_machine.prepare(
-                message.header.operation.cast(StateMachine),
-                message.body(),
-            );
-
-            const latest_entry = self.journal.header_with_op(self.op).?;
-            message.header.parent = latest_entry.checksum;
-            message.header.context = message.header.checksum;
-            message.header.view = self.view;
-            message.header.op = self.op + 1;
-            message.header.commit = self.commit_max;
-            message.header.timestamp = prepare_timestamp;
-            message.header.replica = self.replica;
-            message.header.command = .prepare;
-
-            message.header.set_checksum_body(message.body());
-            message.header.set_checksum();
-
-            log.debug("{}: on_request: prepare {}", .{ self.replica, message.header.checksum });
-
-            self.pipeline.push_assume_capacity(.{ .message = message.ref() });
-            assert(self.pipeline.count >= 1);
-
-            if (self.pipeline.count == 1) {
-                // This is the only prepare in the pipeline, start the timeout:
-                assert(!self.prepare_timeout.ticking);
-                self.prepare_timeout.start();
+            if (self.pipeline.queue.prepare_queue.full()) {
+                self.pipeline.queue.push_request(request);
             } else {
-                // Do not restart the prepare timeout as it is already ticking for another prepare.
-                assert(self.prepare_timeout.ticking);
-                const previous = self.pipeline.get_ptr(self.pipeline.count - 2).?;
-                assert(previous.message.header.checksum == message.header.parent);
+                self.primary_pipeline_prepare(request);
             }
-
-            self.on_prepare(message);
-
-            // We expect `on_prepare()` to increment `self.op` to match the primary's latest prepare:
-            // This is critical to ensure that pipelined prepares do not receive the same op number.
-            assert(self.op == message.header.op);
         }
 
         /// Replication is simple, with a single code path for the primary and backups.
@@ -1003,11 +979,20 @@ pub fn ReplicaType(
             assert(message.header.view == self.view);
             assert(self.primary());
 
-            const prepare = self.pipeline_prepare_for_prepare_ok(message) orelse return;
+            const prepare = self.pipeline.queue.prepare_by_prepare_ok(message) orelse {
+                // This can be normal, for example, if an old prepare_ok is replayed.
+                log.debug("{}: on_prepare_ok: not preparing ok={} checksum={}", .{
+                    self.replica,
+                    message.header.op,
+                    message.header.context,
+                });
+                return;
+            };
 
             assert(prepare.message.header.checksum == message.header.context);
             assert(prepare.message.header.op >= self.commit_max + 1);
-            assert(prepare.message.header.op <= self.commit_max + self.pipeline.count);
+            assert(prepare.message.header.op <= self.commit_max +
+                self.pipeline.queue.prepare_queue.count);
             assert(prepare.message.header.op <= self.op);
 
             // Wait until we have `f + 1` prepare_ok messages (including ourself) for quorum:
@@ -1376,7 +1361,7 @@ pub fn ReplicaType(
             // To understand why, consider this scenario, where:
             //
             //                   replica_count   3
-            //      do_view_change.headers.len   3 (= pipeline_max)
+            //      do_view_change.headers.len   3 (= pipeline_prepare_queue_max)
             //   recovery_response.headers.len   2 (!)
             //                   replica 0 log   3, 4a, 5a, 6a, 7a, 8a  (status=normal, primary)
             //                   replica 1 log   3, 4a, 5a, --, --, --  (status=normal, backup)
@@ -1671,13 +1656,13 @@ pub fn ReplicaType(
             // Try to serve the message directly from the pipeline.
             // This saves us from going to disk. And we don't need to worry that the WAL's copy
             // of an uncommitted prepare is lost/corrupted.
-            if (self.pipeline_prepare_for_op_and_checksum(op, checksum)) |prepare| {
+            if (self.pipeline_prepare_by_op_and_checksum(op, checksum)) |prepare| {
                 log.debug("{}: on_request_prepare: op={} checksum={} reply from pipeline", .{
                     self.replica,
                     op,
                     checksum,
                 });
-                self.send_message_to_replica(message.header.replica, prepare.message);
+                self.send_message_to_replica(message.header.replica, prepare);
                 return;
             }
 
@@ -1964,8 +1949,9 @@ pub fn ReplicaType(
             assert(self.status == .normal);
             assert(self.primary());
 
-            const prepare = self.pipeline.head_ptr().?;
+            const prepare = self.pipeline.queue.prepare_queue.head_ptr().?;
             assert(prepare.message.header.command == .prepare);
+            assert(prepare.message.header.op == self.commit_min + 1);
 
             if (prepare.ok_quorum_received) {
                 self.prepare_timeout.reset();
@@ -2011,10 +1997,10 @@ pub fn ReplicaType(
                 // We may be slow and waiting for the write to complete.
                 //
                 // We may even have maxed out our IO depth and been unable to initiate the write,
-                // which can happen if `constants.pipeline_max` exceeds `constants.journal_iops_write_max`.
-                // This can lead to deadlock for a cluster of one or two (if we do not retry here),
-                // since there is no other way for the primary to repair the dirty op because no
-                // other replica has it.
+                // which can happen if `constants.pipeline_prepare_queue_max` exceeds
+                // `constants.journal_iops_write_max`. This can lead to deadlock for a cluster of
+                // one or two (if we do not retry here), since there is no other way for the primary
+                // to repair the dirty op because no other replica has it.
                 //
                 // Retry the write through `on_repair()` which will work out which is which.
                 // We do expect that the op would have been run through `on_prepare()` already.
@@ -2295,7 +2281,7 @@ pub fn ReplicaType(
             assert(message.header.view == self.view);
             assert(message.header.op == self.op);
 
-            if (self.replica_count == 1 and self.pipeline.count > 1) {
+            if (self.replica_count == 1 and self.pipeline.queue.prepare_queue.count > 1) {
                 // In a cluster-of-one, the prepares must always be written to the WAL sequentially
                 // (never concurrently). This ensures that there will be no gaps in the WAL during
                 // crash recovery.
@@ -2545,8 +2531,14 @@ pub fn ReplicaType(
             assert(self.commit_min <= self.commit_max);
 
             if (self.status == .normal and self.primary()) {
-                const prepare = self.pipeline.pop().?;
+                const prepare = self.pipeline.queue.pop_prepare().?;
+                if (self.pipeline.queue.pop_request()) |request| {
+                    // Start preparing the next request in the queue (if any).
+                    self.primary_pipeline_prepare(request);
+                }
+
                 assert(self.commit_min == self.commit_max);
+                assert(prepare.message.header.command == .prepare);
                 assert(prepare.message.header.checksum == self.commit_prepare.?.header.checksum);
                 assert(prepare.message.header.op == self.commit_min);
                 assert(prepare.message.header.op == self.commit_max);
@@ -2554,7 +2546,7 @@ pub fn ReplicaType(
 
                 self.message_bus.unref(prepare.message);
 
-                if (self.pipeline.head_ptr()) |next| {
+                if (self.pipeline.queue.prepare_queue.head_ptr()) |next| {
                     assert(next.message.header.op == self.commit_min + 1);
                     assert(next.message.header.op == self.commit_prepare.?.header.op + 1);
 
@@ -2815,7 +2807,7 @@ pub fn ReplicaType(
         fn commit_pipeline(self: *Self) void {
             assert(self.status == .normal);
             assert(self.primary());
-            assert(self.pipeline.count > 0);
+            assert(self.pipeline.queue.prepare_queue.count > 0);
 
             // Guard against multiple concurrent invocations of commit_journal()/commit_pipeline():
             if (self.committing) {
@@ -2832,10 +2824,10 @@ pub fn ReplicaType(
             assert(self.status == .normal);
             assert(self.primary());
 
-            if (self.pipeline.head_ptr()) |prepare| {
+            if (self.pipeline.queue.prepare_queue.head_ptr()) |prepare| {
                 assert(self.commit_min == self.commit_max);
                 assert(self.commit_min + 1 == prepare.message.header.op);
-                assert(self.commit_min + self.pipeline.count == self.op);
+                assert(self.commit_min + self.pipeline.queue.prepare_queue.count == self.op);
                 assert(self.journal.has(prepare.message.header));
 
                 if (!prepare.ok_quorum_received) {
@@ -2861,7 +2853,7 @@ pub fn ReplicaType(
             assert(self.commit_min <= self.op);
 
             if (self.status == .normal and self.primary()) {
-                if (self.pipeline.head_ptr()) |pipeline_head| {
+                if (self.pipeline.queue.prepare_queue.head_ptr()) |pipeline_head| {
                     assert(pipeline_head.message.header.op == self.commit_min + 1);
                 }
                 self.commit_pipeline_next();
@@ -3051,14 +3043,14 @@ pub fn ReplicaType(
             const op_dvc_anchor = std.math.max(
                 self.commit_min,
                 // +1: We can have a full pipeline, but not yet have performed any repair.
-                // In such a case, we want to send those pipeline_max headers in the DVC, but not
-                // the preceding op (which may belong to a different chain).
+                // In such a case, we want to send those pipeline_prepare_queue_max headers in the
+                // DVC, but not the preceding op (which may belong to a different chain).
                 // This satisfies the DVC invariant because the first op in the pipeline is
                 // "connected" to the canonical chain (via its "parent" checksum).
                 //
-                // For example, as a follower, we might have received pipeline_max headers in the SV
-                // message, but not done any repair before the next view change.
-                1 + self.op -| constants.pipeline_max,
+                // For example, as a follower, we might have received pipeline_prepare_queue_max
+                // headers in the SV message, but not done any repair before the next view change.
+                1 + self.op -| constants.pipeline_prepare_queue_max,
             );
 
             // How many headers should we send in the DVC?
@@ -3362,9 +3354,10 @@ pub fn ReplicaType(
             if (self.ignore_request_message_duplicate(message)) return true;
             if (self.ignore_request_message_preparing(message)) return true;
 
-            // Verify that the new request will fit in the WAL.
-            // The message's op hasn't been assigned yet, but it will be `self.op + 1`.
-            if (self.op == self.op_checkpoint_trigger()) {
+            // Don't accept more requests than will fit in the current checkpoint.
+            // (The request's op hasn't been assigned yet, but it will be `self.op + 1`
+            // when primary_pipeline_next() converts the request to a prepare.)
+            if (self.op + self.pipeline.queue.request_queue.count == self.op_checkpoint_trigger()) {
                 log.debug("{}: on_request: ignoring op={} (too far ahead, checkpoint_trigger={})", .{
                     self.replica,
                     self.op + 1,
@@ -3437,7 +3430,7 @@ pub fn ReplicaType(
             } else if (message.header.operation == .register) {
                 log.debug("{}: on_request: new session", .{self.replica});
                 return false;
-            } else if (self.pipeline_prepare_for_client(message.header.client)) |_| {
+            } else if (self.pipeline.queue.message_by_client(message.header.client)) |_| {
                 // The client registered with the previous primary, which committed and replied back
                 // to the client before the view change, after which the register operation was
                 // reloaded into the pipeline to be driven to completion by the new primary, which
@@ -3509,21 +3502,31 @@ pub fn ReplicaType(
             assert(message.header.client > 0);
             assert(message.header.view <= self.view); // See ignore_request_message_backup().
 
-            if (self.pipeline_prepare_for_client(message.header.client)) |prepare| {
-                assert(prepare.message.header.command == .prepare);
-                assert(prepare.message.header.client == message.header.client);
-                assert(prepare.message.header.op > self.commit_max);
+            if (self.pipeline.queue.message_by_client(message.header.client)) |pipeline_message| {
+                assert(pipeline_message.header.client == message.header.client);
+                assert(pipeline_message.header.command == .request or
+                    pipeline_message.header.command == .prepare);
 
-                if (message.header.checksum == prepare.message.header.context) {
-                    log.debug("{}: on_request: ignoring (already preparing)", .{self.replica});
-                    return true;
-                } else {
-                    log.err("{}: on_request: ignoring (client forked)", .{self.replica});
+                if (pipeline_message.header.command == .request and
+                    pipeline_message.header.checksum == message.header.checksum)
+                {
+                    log.debug("{}: on_request: ignoring (already queued)", .{self.replica});
                     return true;
                 }
+
+                if (pipeline_message.header.command == .prepare and
+                    pipeline_message.header.context == message.header.checksum)
+                {
+                    assert(pipeline_message.header.op > self.commit_max);
+                    log.debug("{}: on_request: ignoring (already preparing)", .{self.replica});
+                    return true;
+                }
+
+                log.err("{}: on_request: ignoring (client forked)", .{self.replica});
+                return true;
             }
 
-            if (self.pipeline.full()) {
+            if (self.pipeline.queue.full()) {
                 log.debug("{}: on_request: ignoring (pipeline full)", .{self.replica});
                 return true;
             }
@@ -3787,93 +3790,80 @@ pub fn ReplicaType(
             }
         }
 
-        /// Searches the pipeline for a prepare for a given op and checksum.
-        /// When `checksum` is `null`, match any checksum.
-        fn pipeline_prepare_for_op_and_checksum(self: *Self, op: u64, checksum: ?u128) ?*Prepare {
-            assert(self.status == .normal or self.status == .view_change);
-
-            // To optimize the search, we can leverage the fact that the pipeline is ordered and
-            // continuous.
-            if (self.pipeline.count == 0) return null;
-            const head_op = self.pipeline.head_ptr().?.message.header.op;
-            const tail_op = self.pipeline.tail_ptr().?.message.header.op;
-            if (op < head_op) return null;
-            if (op > tail_op) return null;
-
-            const pipeline_prepare = self.pipeline.get_ptr(op - head_op).?;
-            assert(pipeline_prepare.message.header.op == op);
-
-            if (checksum == null or pipeline_prepare.message.header.checksum == checksum.?) {
-                return pipeline_prepare;
-            } else {
-                return null;
-            }
-        }
-
-        /// Searches the pipeline for a prepare for a given client.
-        fn pipeline_prepare_for_client(self: *Self, client: u128) ?*Prepare {
+        fn primary_pipeline_prepare(self: *Self, request: Request) void {
             assert(self.status == .normal);
             assert(self.primary());
             assert(self.commit_min == self.commit_max);
+            assert(self.commit_max + self.pipeline.queue.prepare_queue.count == self.op);
+            assert(!self.pipeline.queue.prepare_queue.full());
+            self.pipeline.queue.verify();
 
-            var op = self.commit_max + 1;
-            var parent = self.journal.header_with_op(self.commit_max).?.checksum;
-            var iterator = self.pipeline.iterator_mutable();
-            while (iterator.next_ptr()) |prepare| {
-                assert(prepare.message.header.command == .prepare);
-                assert(prepare.message.header.op == op);
-                assert(prepare.message.header.parent == parent);
+            const message = request.message;
+            assert(!self.ignore_request_message(message));
 
-                // A client may have multiple requests in the pipeline if these were committed by
-                // the previous primary and were reloaded into the pipeline after a view change.
-                if (prepare.message.header.client == client) return prepare;
+            log.debug("{}: primary_pipeline_next: request checksum={} client={}", .{
+                self.replica,
+                message.header.checksum,
+                message.header.client,
+            });
 
-                parent = prepare.message.header.checksum;
-                op += 1;
+            // Guard against the wall clock going backwards by taking the max with timestamps issued:
+            self.state_machine.prepare_timestamp = std.math.max(
+                // The cluster `commit_timestamp` may be ahead of our `prepare_timestamp` because this
+                // may be our first prepare as a recently elected primary:
+                std.math.max(
+                    self.state_machine.prepare_timestamp,
+                    self.state_machine.commit_timestamp,
+                ) + 1,
+                @intCast(u64, request.realtime),
+            );
+            assert(self.state_machine.prepare_timestamp > self.state_machine.commit_timestamp);
+
+            const prepare_timestamp = self.state_machine.prepare(
+                message.header.operation.cast(StateMachine),
+                message.body(),
+            );
+
+            const latest_entry = self.journal.header_with_op(self.op).?;
+            message.header.parent = latest_entry.checksum;
+            message.header.context = message.header.checksum;
+            message.header.view = self.view;
+            message.header.op = self.op + 1;
+            message.header.commit = self.commit_max;
+            message.header.timestamp = prepare_timestamp;
+            message.header.replica = self.replica;
+            message.header.command = .prepare;
+
+            message.header.set_checksum_body(message.body());
+            message.header.set_checksum();
+
+            log.debug("{}: primary_pipeline_next: prepare {}", .{ self.replica, message.header.checksum });
+
+            if (self.pipeline.queue.prepare_queue.tail_ptr()) |previous| {
+                // Do not restart the prepare timeout as it is already ticking for another prepare.
+                assert(self.prepare_timeout.ticking);
+                assert(previous.message.header.checksum == message.header.parent);
+            } else {
+                // We are about to add the first prepare to the pipeline, so start the timeout.
+                assert(!self.prepare_timeout.ticking);
+                self.prepare_timeout.start();
             }
+            self.pipeline.queue.push_prepare(message);
+            self.on_prepare(message);
 
-            assert(self.pipeline.count <= constants.pipeline_max);
-            assert(self.commit_max + self.pipeline.count == op - 1);
-            assert(self.commit_max + self.pipeline.count == self.op);
-
-            return null;
+            // We expect `on_prepare()` to increment `self.op` to match the primary's latest prepare:
+            // This is critical to ensure that pipelined prepares do not receive the same op number.
+            assert(self.op == message.header.op);
         }
 
-        /// Searches the pipeline for a prepare for a given client and checksum.
-        /// Passing the prepare_ok message prevents these u128s from being accidentally swapped.
-        /// Asserts that the returned prepare, if any, exactly matches the prepare_ok.
-        fn pipeline_prepare_for_prepare_ok(self: *Self, ok: *const Message) ?*Prepare {
-            assert(ok.header.command == .prepare_ok);
-
-            assert(self.status == .normal);
-            assert(self.primary());
-
-            const prepare = self.pipeline_prepare_for_client(ok.header.client) orelse {
-                log.debug("{}: pipeline_prepare_for_prepare_ok: not preparing", .{self.replica});
-                return null;
+        fn pipeline_prepare_by_op_and_checksum(self: *Self, op: u64, checksum: ?u128) ?*Message {
+            return switch (self.pipeline) {
+                .queue => |*pipeline| if (pipeline.prepare_by_op_and_checksum(op, checksum)) |prepare|
+                    prepare.message
+                else
+                    null,
+                .cache => |*pipeline| pipeline.prepare_by_op_and_checksum(op, checksum),
             };
-
-            if (ok.header.context != prepare.message.header.checksum) {
-                // This can be normal, for example, if an old prepare_ok is replayed.
-                log.debug("{}: pipeline_prepare_for_prepare_ok: preparing a different client op", .{
-                    self.replica,
-                });
-                return null;
-            }
-
-            assert(prepare.message.header.parent == ok.header.parent);
-            assert(prepare.message.header.client == ok.header.client);
-            assert(prepare.message.header.request == ok.header.request);
-            assert(prepare.message.header.cluster == ok.header.cluster);
-            assert(prepare.message.header.epoch == ok.header.epoch);
-            // A prepare may be committed in the same view or in a newer view:
-            assert(prepare.message.header.view <= ok.header.view);
-            assert(prepare.message.header.op == ok.header.op);
-            assert(prepare.message.header.commit == ok.header.commit);
-            assert(prepare.message.header.timestamp == ok.header.timestamp);
-            assert(prepare.message.header.operation == ok.header.operation);
-
-            return prepare;
         }
 
         fn recover(self: *Self) void {
@@ -4000,9 +3990,12 @@ pub fn ReplicaType(
             }
 
             if (self.status == .view_change and self.primary_index(self.view) == self.replica) {
-                if (self.primary_repair_pipeline_op() != null) return self.primary_repair_pipeline();
-                // Start the view as the new primary:
-                self.primary_start_view_as_the_new_primary();
+                // Repair the pipeline, which may discover faulty prepares and drive more repairs.
+                switch (self.primary_repair_pipeline()) {
+                    // primary_repair_pipeline() is already working.
+                    .busy => {},
+                    .done => self.primary_start_view_as_the_new_primary(),
+                }
             }
         }
 
@@ -4197,110 +4190,107 @@ pub fn ReplicaType(
         }
 
         /// Reads prepares into the pipeline (before we start the view as the new primary).
-        fn primary_repair_pipeline(self: *Self) void {
+        fn primary_repair_pipeline(self: *Self) enum { done, busy } {
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
             assert(self.commit_max < self.op);
+            assert(self.commit_max == self.commit_min);
+            assert(self.commit_max <= self.op);
             assert(self.journal.dirty.count == 0);
+            assert(self.pipeline == .cache);
 
             if (self.repairing_pipeline) {
                 log.debug("{}: primary_repair_pipeline: already repairing...", .{self.replica});
-                return;
+                return .busy;
             }
 
-            log.debug("{}: primary_repair_pipeline: repairing", .{self.replica});
+            if (self.primary_repair_pipeline_op()) |_| {
+                log.debug("{}: primary_repair_pipeline: repairing", .{self.replica});
+                assert(!self.repairing_pipeline);
+                self.repairing_pipeline = true;
+                self.primary_repair_pipeline_read();
+                return .busy;
+            }
 
-            assert(!self.repairing_pipeline);
-            self.repairing_pipeline = true;
-
-            self.primary_repair_pipeline_read();
+            // All prepares needed to reconstruct the pipeline queue are now available in the cache.
+            return .done;
         }
 
-        /// Discard messages from the prepare pipeline.
-        /// Retain uncommitted messages that belong in the current view to maximize durability.
-        fn primary_repair_pipeline_diff(self: *Self) void {
+        fn primary_repair_pipeline_done(self: *Self) PipelineQueue {
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
+            assert(self.commit_max == self.commit_min);
+            assert(self.commit_max <= self.op);
+            assert(self.journal.dirty.count == 0);
+            assert(self.valid_hash_chain_between(self.commit_min, self.op));
+            assert(self.pipeline == .cache);
+            assert(!self.repairing_pipeline);
+            assert(self.primary_repair_pipeline() == .done);
+            assert(self.commit_max + constants.pipeline_prepare_queue_max >= self.op);
 
-            // Discard messages from the front of the pipeline that committed since we were primary.
-            while (self.pipeline.head_ptr()) |prepare| {
-                if (prepare.message.header.op > self.commit_max) break;
+            var pipeline_queue = PipelineQueue{};
+            var op = self.commit_max + 1;
+            var parent = self.journal.header_with_op(self.commit_max).?.checksum;
+            while (op <= self.op) : (op += 1) {
+                const journal_header = self.journal.header_with_op(op).?;
+                assert(journal_header.op == op);
+                assert(journal_header.parent == parent);
 
-                self.message_bus.unref(self.pipeline.pop().?.message);
+                const prepare =
+                    self.pipeline.cache.prepare_by_op_and_checksum(op, journal_header.checksum).?;
+                assert(prepare.header.op == op);
+                assert(prepare.header.op <= self.op);
+                assert(prepare.header.checksum == journal_header.checksum);
+                assert(prepare.header.parent == parent);
+                assert(self.journal.has(prepare.header));
+
+                pipeline_queue.push_prepare(prepare.ref());
+                parent = prepare.header.checksum;
             }
+            assert(self.commit_max + pipeline_queue.prepare_queue.count == self.op);
 
-            // Discard the whole pipeline if it is now disconnected from the WAL's hash chain.
-            if (self.pipeline.head_ptr()) |pipeline_head| {
-                const parent = self.journal.header_with_op_and_checksum(
-                    pipeline_head.message.header.op - 1,
-                    pipeline_head.message.header.parent,
-                );
-                if (parent == null) {
-                    while (self.pipeline.pop()) |prepare| self.message_bus.unref(prepare.message);
-                    assert(self.pipeline.count == 0);
-                }
-            }
-
-            // Discard messages from the back of the pipeline that are not part of this view.
-            while (self.pipeline.tail_ptr()) |prepare| {
-                if (self.journal.has(prepare.message.header)) break;
-
-                self.message_bus.unref(self.pipeline.pop_tail().?.message);
-            }
-
-            log.debug("{}: primary_repair_pipeline_diff: {} prepare(s)", .{
-                self.replica,
-                self.pipeline.count,
-            });
-
-            self.verify_pipeline();
-
-            // Do not reset `repairing_pipeline` here as this must be reset by the read callback.
-            // Otherwise, we would be making `primary_repair_pipeline()` reentrant.
+            pipeline_queue.verify();
+            return pipeline_queue;
         }
 
         /// Returns the next `op` number that needs to be read into the pipeline.
-        fn primary_repair_pipeline_op(self: *Self) ?u64 {
+        /// Returns null when all necessary prepares are in the pipeline cache.
+        fn primary_repair_pipeline_op(self: *const Self) ?u64 {
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
+            assert(self.commit_max == self.commit_min);
+            assert(self.commit_max <= self.op);
+            assert(self.pipeline == .cache);
 
-            // We cannot rely on `pipeline.count` below unless the pipeline has first been diffed.
-            self.primary_repair_pipeline_diff();
-
-            const op = self.commit_max + self.pipeline.count + 1;
-            if (op <= self.op) return op;
-
-            assert(self.commit_max + self.pipeline.count == self.op);
+            var op = self.commit_max + 1;
+            while (op <= self.op) : (op += 1) {
+                const op_header = self.journal.header_with_op(op).?;
+                if (!self.pipeline.cache.contains_header(op_header)) {
+                    return op;
+                }
+            }
             return null;
         }
 
         fn primary_repair_pipeline_read(self: *Self) void {
-            assert(self.repairing_pipeline);
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
+            assert(self.commit_max == self.commit_min);
+            assert(self.commit_max <= self.op);
+            assert(self.pipeline == .cache);
+            assert(self.repairing_pipeline);
 
-            if (self.primary_repair_pipeline_op()) |op| {
-                assert(op > self.commit_max);
-                assert(op <= self.op);
-                assert(self.commit_max + self.pipeline.count + 1 == op);
-
-                const checksum = self.journal.header_with_op(op).?.checksum;
-
-                log.debug("{}: primary_repair_pipeline_read: op={} checksum={}", .{
-                    self.replica,
-                    op,
-                    checksum,
-                });
-
-                self.journal.read_prepare(repair_pipeline_push, op, checksum, null);
-            } else {
-                log.debug("{}: primary_repair_pipeline_read: repaired", .{self.replica});
-                self.repairing_pipeline = false;
-                self.repair();
-            }
+            const op = self.primary_repair_pipeline_op().?;
+            const op_checksum = self.journal.header_with_op(op).?.checksum;
+            log.debug("{}: primary_repair_pipeline_read: op={} checksum={}", .{
+                self.replica,
+                op,
+                op_checksum,
+            });
+            self.journal.read_prepare(repair_pipeline_read_callback, op, op_checksum, null);
         }
 
-        fn repair_pipeline_push(
+        fn repair_pipeline_read_callback(
             self: *Self,
             prepare: ?*Message,
             destination_replica: ?u8,
@@ -4311,61 +4301,63 @@ pub fn ReplicaType(
             self.repairing_pipeline = false;
 
             if (prepare == null) {
-                log.debug("{}: repair_pipeline_push: prepare == null", .{self.replica});
+                log.debug("{}: repair_pipeline_read_callback: prepare == null", .{self.replica});
                 return;
             }
 
             // Our state may have advanced significantly while we were reading from disk.
             if (self.status != .view_change) {
-                log.debug("{}: repair_pipeline_push: no longer in view change status", .{
+                assert(self.primary_index(self.view) != self.replica);
+
+                log.debug("{}: repair_pipeline_read_callback: no longer in view change status", .{
                     self.replica,
                 });
                 return;
             }
 
             if (self.primary_index(self.view) != self.replica) {
-                log.debug("{}: repair_pipeline_push: no longer primary", .{self.replica});
+                log.debug("{}: repair_pipeline_read_callback: no longer primary", .{self.replica});
                 return;
             }
 
             // We may even be several views ahead and may now have a completely different pipeline.
             const op = self.primary_repair_pipeline_op() orelse {
-                log.debug("{}: repair_pipeline_push: pipeline changed", .{self.replica});
+                log.debug("{}: repair_pipeline_read_callback: pipeline changed", .{self.replica});
                 return;
             };
 
             assert(op > self.commit_max);
             assert(op <= self.op);
-            assert(self.commit_max + self.pipeline.count + 1 == op);
 
             if (prepare.?.header.op != op) {
-                log.debug("{}: repair_pipeline_push: op changed", .{self.replica});
+                log.debug("{}: repair_pipeline_read_callback: op changed", .{self.replica});
                 return;
             }
 
             if (prepare.?.header.checksum != self.journal.header_with_op(op).?.checksum) {
-                log.debug("{}: repair_pipeline_push: checksum changed", .{self.replica});
+                log.debug("{}: repair_pipeline_read_callback: checksum changed", .{self.replica});
                 return;
             }
 
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
 
-            log.debug("{}: repair_pipeline_push: op={} checksum={}", .{
+            log.debug("{}: repair_pipeline_read_callback: op={} checksum={}", .{
                 self.replica,
                 prepare.?.header.op,
                 prepare.?.header.checksum,
             });
 
-            if (self.pipeline.tail_ptr()) |parent| {
-                assert(prepare.?.header.parent == parent.message.header.checksum);
+            const prepare_old = self.pipeline.cache.insert(prepare.?.ref());
+            if (prepare_old) |message_old| self.message_bus.unref(message_old);
+
+            if (self.primary_repair_pipeline_op()) |_| {
+                assert(!self.repairing_pipeline);
+                self.repairing_pipeline = true;
+                self.primary_repair_pipeline_read();
+            } else {
+                self.repair();
             }
-
-            self.pipeline.push_assume_capacity(.{ .message = prepare.?.ref() });
-            assert(self.pipeline.count >= 1);
-
-            self.repairing_pipeline = true;
-            self.primary_repair_pipeline_read();
         }
 
         fn repair_prepares(self: *Self) void {
@@ -4513,9 +4505,9 @@ pub fn ReplicaType(
             //
             // Using the pipeline to repair is faster than a `request_prepare`.
             // Also, messages in the pipeline are never corrupt.
-            if (self.pipeline_prepare_for_op_and_checksum(op, checksum)) |prepare| {
-                assert(prepare.message.header.op == op);
-                assert(prepare.message.header.checksum == checksum);
+            if (self.pipeline_prepare_by_op_and_checksum(op, checksum)) |prepare| {
+                assert(prepare.header.op == op);
+                assert(prepare.header.checksum == checksum);
 
                 if (self.replica_count == 1) {
                     // This op won't start writing until all ops in the pipeline preceding it have
@@ -4525,7 +4517,8 @@ pub fn ReplicaType(
                         op,
                         checksum,
                     });
-                    assert(op > self.pipeline.head_ptr().?.message.header.op);
+                    const pipeline_head = self.pipeline.queue.prepare_queue.head_ptr().?;
+                    assert(pipeline_head.message.header.op < op);
                     return false;
                 }
 
@@ -4534,7 +4527,7 @@ pub fn ReplicaType(
                     op,
                     checksum,
                 });
-                self.write_prepare(prepare.message, .pipeline);
+                self.write_prepare(prepare, .pipeline);
                 return true;
             }
 
@@ -4745,20 +4738,6 @@ pub fn ReplicaType(
         fn reset_quorum_nack_prepare(self: *Self) void {
             self.reset_quorum_counter(&self.nack_prepare_from_other_replicas);
             self.nack_prepare_op = null;
-        }
-
-        fn reset_quorum_prepare_ok(self: *Self) void {
-            // "prepare_ok"s from previous views are not valid, even if the pipeline entry is reused
-            // after a cycle of view changes. In other words, when a view change cycles around, so
-            // that the original primary becomes a primary of a new view, pipeline entries may be
-            // reused. However, the pipeline's prepare_ok quorums must not be reused, since the
-            // replicas that sent them may have swapped them out during a previous view change.
-            var iterator = self.pipeline.iterator_mutable();
-            while (iterator.next_ptr()) |prepare| {
-                prepare.ok_quorum_received = false;
-                prepare.ok_from_all_replicas = quorum_counter_null;
-                assert(prepare.ok_from_all_replicas.count() == 0);
-            }
         }
 
         fn reset_quorum_start_view_change(self: *Self) void {
@@ -5135,9 +5114,7 @@ pub fn ReplicaType(
                 });
             }
 
-            assert(commit_max >=
-                self.commit_max - std.math.min(constants.pipeline_max, self.commit_max));
-
+            assert(commit_max >= self.commit_max -| constants.pipeline_prepare_queue_max);
             assert(self.commit_min <= self.commit_max);
             assert(self.op >= self.commit_max or self.op < self.commit_max);
 
@@ -5281,7 +5258,7 @@ pub fn ReplicaType(
                         // An op cannot be uncommitted if it is definitely outside the pipeline.
                         // Use `do_view_change_op_head` instead of `replica.op` since the former is
                         // about to become the new `replica.op`.
-                        header_head.op -| constants.pipeline_max,
+                        header_head.op -| constants.pipeline_prepare_queue_max,
                     ),
                 ),
                 "on_do_view_change",
@@ -5325,20 +5302,45 @@ pub fn ReplicaType(
             assert(self.primary_index(self.view) == self.replica);
             assert(self.do_view_change_quorum);
             assert(!self.repairing_pipeline);
+            assert(self.primary_repair_pipeline() == .done);
 
             assert(self.commit_min == self.commit_max);
-            assert(self.primary_repair_pipeline_op() == null);
-            self.verify_pipeline();
-            assert(self.commit_max + self.pipeline.count == self.op);
-            assert(self.valid_hash_chain_between(self.commit_min, self.op));
-
             assert(self.journal.dirty.count == 0);
             assert(self.journal.faulty.count == 0);
             assert(self.nack_prepare_op == null);
+            assert(self.valid_hash_chain_between(self.commit_min, self.op));
+
+            {
+                const pipeline_queue = self.primary_repair_pipeline_done();
+                assert(pipeline_queue.request_queue.empty());
+                assert(pipeline_queue.prepare_queue.count + self.commit_max == self.op);
+                if (!pipeline_queue.prepare_queue.empty()) {
+                    const prepares = &pipeline_queue.prepare_queue;
+                    assert(prepares.head_ptr_const().?.message.header.op == self.commit_max + 1);
+                    assert(prepares.tail_ptr_const().?.message.header.op == self.op);
+                }
+
+                var pipeline_prepares = pipeline_queue.prepare_queue.iterator();
+                while (pipeline_prepares.next()) |prepare| {
+                    assert(self.journal.has(prepare.message.header));
+                    assert(!prepare.ok_quorum_received);
+                    assert(prepare.ok_from_all_replicas.count() == 0);
+
+                    log.debug("{}: start_view_as_the_new_primary: pipeline " ++
+                        "(op={} checksum={x} parent={x})", .{
+                        self.replica,
+                        prepare.message.header.op,
+                        prepare.message.header.checksum,
+                        prepare.message.header.parent,
+                    });
+                }
+
+                self.pipeline.cache.deinit(self.message_bus.pool);
+                self.pipeline = .{ .queue = pipeline_queue };
+                self.pipeline.queue.verify();
+            }
 
             self.transition_to_normal_from_view_change_status(self.view);
-            // Detect if the transition to normal status above accidentally resets the pipeline:
-            assert(self.commit_max + self.pipeline.count == self.op);
 
             assert(self.status == .normal);
             assert(self.primary());
@@ -5364,6 +5366,7 @@ pub fn ReplicaType(
             assert(!self.committing);
             assert(self.replica_count > 1 or new_view == 0);
             assert(self.journal.header_with_op(self.op) != null);
+            assert(self.pipeline == .cache);
             self.view = new_view;
             self.log_view = new_view;
             self.status = .normal;
@@ -5387,6 +5390,9 @@ pub fn ReplicaType(
                 self.commit_timeout.start();
                 self.repair_timeout.start();
                 self.recovery_timeout.stop();
+
+                self.pipeline.cache.deinit(self.message_bus.pool);
+                self.pipeline = .{ .queue = .{} };
             } else {
                 log.debug(
                     "{}: transition_to_normal_from_recovering_status: view={} backup",
@@ -5428,6 +5434,8 @@ pub fn ReplicaType(
 
                 assert(!self.prepare_timeout.ticking);
                 assert(!self.recovery_timeout.ticking);
+                assert(!self.repairing_pipeline);
+                assert(self.pipeline == .queue);
                 assert(self.log_view == new_view);
 
                 self.ping_timeout.start();
@@ -5438,7 +5446,7 @@ pub fn ReplicaType(
                 self.repair_timeout.start();
 
                 // Do not reset the pipeline as there may be uncommitted ops to drive to completion.
-                if (self.pipeline.count > 0) self.prepare_timeout.start();
+                if (self.pipeline.queue.prepare_queue.count > 0) self.prepare_timeout.start();
             } else {
                 log.debug("{}: transition_to_normal_from_view_change_status: view={} backup", .{
                     self.replica,
@@ -5447,6 +5455,7 @@ pub fn ReplicaType(
 
                 assert(!self.prepare_timeout.ticking);
                 assert(!self.recovery_timeout.ticking);
+                assert(self.pipeline == .cache);
 
                 self.log_view = new_view;
                 self.ping_timeout.start();
@@ -5460,7 +5469,6 @@ pub fn ReplicaType(
             self.reset_quorum_start_view_change();
             self.reset_quorum_do_view_change();
             self.reset_quorum_nack_prepare();
-            self.reset_quorum_prepare_ok();
 
             assert(self.start_view_change_quorum == false);
             assert(self.do_view_change_quorum == false);
@@ -5482,6 +5490,11 @@ pub fn ReplicaType(
             assert(new_view > self.view);
             self.view = new_view;
             self.status = .view_change;
+            if (self.pipeline == .queue) {
+                var queue = self.pipeline.queue;
+                self.pipeline = .{ .cache = PipelineCache.init_from_queue(&queue) };
+                queue.deinit(self.message_bus.pool);
+            }
 
             self.ping_timeout.stop();
             self.commit_timeout.stop();
@@ -5500,7 +5513,6 @@ pub fn ReplicaType(
             self.reset_quorum_start_view_change();
             self.reset_quorum_do_view_change();
             self.reset_quorum_nack_prepare();
-            self.reset_quorum_prepare_ok();
 
             assert(self.start_view_change_quorum == false);
             assert(self.do_view_change_quorum == false);
@@ -5626,37 +5638,6 @@ pub fn ReplicaType(
             }
             assert(b.op == op_min);
             return true;
-        }
-
-        fn verify_pipeline(self: *Self) void {
-            assert(self.status == .view_change);
-
-            var op = self.commit_max + 1;
-            var parent = self.journal.header_with_op(self.commit_max).?.checksum;
-
-            var iterator = self.pipeline.iterator();
-            while (iterator.next_ptr()) |prepare| {
-                assert(prepare.message.header.command == .prepare);
-                assert(!prepare.ok_quorum_received);
-                assert(prepare.ok_from_all_replicas.count() == 0);
-
-                log.debug("{}: verify_pipeline: op={} checksum={x} parent={x}", .{
-                    self.replica,
-                    prepare.message.header.op,
-                    prepare.message.header.checksum,
-                    prepare.message.header.parent,
-                });
-
-                assert(self.journal.has(prepare.message.header));
-                assert(prepare.message.header.op == op);
-                assert(prepare.message.header.op <= self.op);
-                assert(prepare.message.header.parent == parent);
-
-                parent = prepare.message.header.checksum;
-                op += 1;
-            }
-            assert(self.pipeline.count <= constants.pipeline_max);
-            assert(self.commit_max + self.pipeline.count == op - 1);
         }
 
         fn view_jump(self: *Self, header: *const Header) void {
@@ -5811,8 +5792,9 @@ pub fn ReplicaType(
 ///
 /// - *DVC* refers to a command=do_view_change message.
 /// - *SV* refers to a command=start_view message.
-/// - The *pipeline suffix* is the last pipeline_max messages of the log (counting backwards from
-///   the head op). For example, when pipeline_max=3,
+/// - The *pipeline suffix* is the last pipeline_prepare_queue_max messages of the log (counting
+///   backwards from the head op). For example, when pipeline_prepare_queue_max=3,
+///
 ///   - the pipeline suffix of log "1,2,3,4,5" is "3,4,5".
 ///   - the pipeline suffix of log "1,2,3,5" is "3,5".
 ///
@@ -5835,12 +5817,12 @@ pub fn ReplicaType(
 ///   This means that either:
 ///   - the DVC includes the op=C header, or
 ///   - the DVC includes the op=C+1 header (where C+1's parent is C).
-///   (Where `C = "DVC anchor" = max(replica.commit_min, replica.op -| pipeline_max)`).
+///   (Where `C = "DVC anchor" = max(replica.commit_min, replica.op -| pipeline_prepare_queue_max)`).
 ///   - Reason: The new primary may truncate the entire pipeline (6-9) due to a gap (6),
 ///     but afterwards it still requires a head op to repair/chain backward from.
 ///     (According to the intersection property, a gap in the pipeline indicates an
 ///     uncommitted op).
-///   - For example, given pipeline_max=3:
+///   - For example, given pipeline_prepare_queue_max=3:
 ///     - a DVC of 7,8 is invalid if replica.commit_min=5.
 ///     - a DVC of 7,8 is valid if replica.commit_min=6.
 ///     - a DVC of 5,7,8 is valid. (5,_,7,8)
@@ -5868,7 +5850,7 @@ pub fn ReplicaType(
 /// Examples
 ///
 /// In these examples:
-/// - pipeline_max=3
+/// - pipeline_prepare_queue_max=3
 /// - Brackets denote the suffix of the replica's log that is actually included in the DVC headers.
 /// - Parenthesis denote a replica that did not participate in the DVC (for example, because it is
 ///   partitioned).
@@ -5915,9 +5897,9 @@ pub fn ReplicaType(
 ///
 /// We cannot send op 6 in the DVC because if repairs did not complete, it may be the wrong message.
 ///
-/// However, even though we may not have a full unbroken suffix of pipeline_max messages, we know
-/// that our unbroken suffix (however long it may be) includes all possibly-committed messages,
-/// since otherwise the retired log_view would not have started.
+/// However, even though we may not have a full unbroken suffix of pipeline_prepare_queue_max
+/// messages, we know that our unbroken suffix (however long it may be) includes all
+/// possibly-committed messages, since otherwise the retired log_view would not have started.
 ///
 /// Therefore, the retired primary sends a DVC with only the unbroken log suffix:
 ///
@@ -6132,11 +6114,11 @@ const DVCQuorum = struct {
 
         const op_head_max = op_max_canonical(dvc_quorum);
         // The number of uncommitted ops cannot be more than the length of the pipeline.
-        const op_suffix_min = op_head_max -| constants.pipeline_max;
+        const op_suffix_min = op_head_max -| constants.pipeline_prepare_queue_max;
         assert(op_suffix_min <= op_head_max);
 
         var op_head_min = op_suffix_min;
-        var ops_in_suffix = std.StaticBitSet(constants.pipeline_max).initEmpty();
+        var ops_in_suffix = std.StaticBitSet(constants.pipeline_prepare_queue_max).initEmpty();
         for (dvcs.constSlice()) |message| {
             const message_headers = message_body_as_headers_chain_disjoint(message);
             for (message_headers) |header| {
@@ -6329,3 +6311,258 @@ fn message_body_as_headers_chain_consecutive(message: *const Message) []const He
     }
     return message_headers;
 }
+
+/// The PipelineQueue belongs to a normal-status primary. It consists of two queues:
+/// - A prepare queue, containing all messages currently being prepared.
+/// - A request queue, containing all messages which are waiting to begin preparing.
+///
+/// Invariants:
+/// - prepare_queue contains only messages with command=prepare.
+/// - prepare_queue's messages have sequential, increasing ops.
+/// - prepare_queue's messages are hash-chained.
+/// - request_queue contains only messages with command=request.
+/// - If request_queue is not empty, then prepare_queue is full OR 1-less than full.
+///   (The caller is responsible for maintaining this invariant. If the caller removes an entry
+///   from `prepare_queue`, an entry from request_queue should be moved over promptly.)
+///
+/// Note: The prepare queue may contain multiple prepares from a single client, but the request
+/// queue may not (see message_by_client()).
+const PipelineQueue = struct {
+    const PrepareQueue = RingBuffer(Prepare, constants.pipeline_prepare_queue_max, .array);
+    const RequestQueue = RingBuffer(Request, constants.pipeline_request_queue_max, .array);
+
+    /// Messages that are preparing (uncommitted, being written to the WAL (may already be written
+    /// to the WAL) and replicated (may just be waiting for acks)).
+    prepare_queue: PrepareQueue = .{},
+    /// Messages that are accepted from the client, but not yet preparing.
+    /// When `pipeline_prepare_queue_max + pipeline_request_queue_max = clients_max`, the request
+    /// queue guards against clients starving one another.
+    request_queue: RequestQueue = .{},
+
+    fn deinit(pipeline: *PipelineQueue, message_pool: *MessagePool) void {
+        while (pipeline.request_queue.pop()) |r| message_pool.unref(r.message);
+        while (pipeline.prepare_queue.pop()) |p| message_pool.unref(p.message);
+    }
+
+    fn verify(pipeline: PipelineQueue) void {
+        assert(pipeline.request_queue.count <= constants.pipeline_request_queue_max);
+        assert(pipeline.prepare_queue.count <= constants.pipeline_prepare_queue_max);
+        assert(pipeline.request_queue.empty() or
+            constants.pipeline_prepare_queue_max == pipeline.prepare_queue.count or
+            constants.pipeline_prepare_queue_max == pipeline.prepare_queue.count + 1);
+
+        if (pipeline.prepare_queue.head_ptr_const()) |head| {
+            var op = head.message.header.op;
+            var parent = head.message.header.parent;
+            var prepare_iterator = pipeline.prepare_queue.iterator();
+            while (prepare_iterator.next_ptr()) |prepare| {
+                assert(prepare.message.header.command == .prepare);
+                assert(prepare.message.header.op == op);
+                assert(prepare.message.header.parent == parent);
+
+                parent = prepare.message.header.checksum;
+                op += 1;
+            }
+        }
+
+        var request_iterator = pipeline.request_queue.iterator();
+        while (request_iterator.next()) |request| {
+            assert(request.message.header.command == .request);
+        }
+    }
+
+    fn full(pipeline: PipelineQueue) bool {
+        if (pipeline.prepare_queue.full()) {
+            return pipeline.request_queue.full();
+        } else {
+            assert(pipeline.request_queue.empty() or
+                pipeline.prepare_queue.count + 1 == constants.pipeline_prepare_queue_max);
+            return false;
+        }
+    }
+
+    /// Searches the pipeline for a prepare for a given op and checksum.
+    /// When `checksum` is `null`, match any checksum.
+    fn prepare_by_op_and_checksum(pipeline: *PipelineQueue, op: u64, checksum: ?u128) ?*Prepare {
+        if (pipeline.prepare_queue.empty()) return null;
+
+        // To optimize the search, we can leverage the fact that the pipeline's entries are
+        // ordered and consecutive.
+        const head_op = pipeline.prepare_queue.head_ptr().?.message.header.op;
+        const tail_op = pipeline.prepare_queue.tail_ptr().?.message.header.op;
+        if (op < head_op) return null;
+        if (op > tail_op) return null;
+
+        const prepare = pipeline.prepare_queue.get_ptr(op - head_op).?;
+        assert(prepare.message.header.op == op);
+
+        if (checksum == null) return prepare;
+        if (checksum.? == prepare.message.header.checksum) return prepare;
+        return null;
+    }
+
+    /// Searches the pipeline for a prepare matching the given ack.
+    /// Asserts that the returned prepare corresponds to the prepare_ok.
+    fn prepare_by_prepare_ok(pipeline: *PipelineQueue, ok: *const Message) ?*Prepare {
+        assert(ok.header.command == .prepare_ok);
+
+        const prepare = pipeline.prepare_by_op_and_checksum(
+            ok.header.op,
+            ok.header.context,
+        ) orelse return null;
+        assert(prepare.message.header.command == .prepare);
+        assert(prepare.message.header.parent == ok.header.parent);
+        assert(prepare.message.header.client == ok.header.client);
+        assert(prepare.message.header.request == ok.header.request);
+        assert(prepare.message.header.cluster == ok.header.cluster);
+        assert(prepare.message.header.epoch == ok.header.epoch);
+        // A prepare may be committed in the same view or in a newer view:
+        assert(prepare.message.header.view <= ok.header.view);
+        assert(prepare.message.header.op == ok.header.op);
+        assert(prepare.message.header.commit == ok.header.commit);
+        assert(prepare.message.header.timestamp == ok.header.timestamp);
+        assert(prepare.message.header.operation == ok.header.operation);
+
+        return prepare;
+    }
+
+    /// Search the pipeline (both request & prepare queues) for a message from the given client.
+    /// - A client may have multiple prepares in the pipeline if these were committed by the
+    ///   previous primary and were reloaded into the pipeline after a view change.
+    /// - A client may have at most one request in the pipeline.
+    /// If there are multiple messages in the pipeline from the client, the *latest* message is
+    /// returned (to help the caller identify bad client behavior).
+    fn message_by_client(pipeline: PipelineQueue, client_id: u128) ?*const Message {
+        var message: ?*const Message = null;
+        var prepare_iterator = pipeline.prepare_queue.iterator();
+        while (prepare_iterator.next_ptr()) |prepare| {
+            if (prepare.message.header.client == client_id) message = prepare.message;
+        }
+
+        var request_iterator = pipeline.request_queue.iterator();
+        while (request_iterator.next()) |request| {
+            if (request.message.header.client == client_id) message = request.message;
+        }
+        return message;
+    }
+
+    /// Warning: This temporarily violates the prepare/request queue count invariant.
+    /// After invocation, call pop_request→push_prepare to begin preparing the next request.
+    fn pop_prepare(pipeline: *PipelineQueue) ?Prepare {
+        if (pipeline.prepare_queue.pop()) |prepare| {
+            assert(pipeline.request_queue.empty() or
+                pipeline.prepare_queue.count + 1 == constants.pipeline_prepare_queue_max);
+            return prepare;
+        } else {
+            assert(pipeline.request_queue.empty());
+            return null;
+        }
+    }
+
+    fn pop_request(pipeline: *PipelineQueue) ?Request {
+        return pipeline.request_queue.pop();
+    }
+
+    fn push_request(pipeline: *PipelineQueue, request: Request) void {
+        assert(request.message.header.command == .request);
+        var queue_iterator = pipeline.request_queue.iterator();
+        while (queue_iterator.next()) |queue_request| {
+            assert(queue_request.message.header.client != request.message.header.client);
+        }
+
+        pipeline.request_queue.push_assume_capacity(request);
+        if (constants.verify) pipeline.verify();
+    }
+
+    fn push_prepare(pipeline: *PipelineQueue, message: *Message) void {
+        assert(message.header.command == .prepare);
+        if (pipeline.prepare_queue.tail()) |tail| {
+            assert(message.header.op == tail.message.header.op + 1);
+            assert(message.header.parent == tail.message.header.checksum);
+            assert(message.header.view >= tail.message.header.view);
+        } else {
+            assert(pipeline.request_queue.empty());
+        }
+
+        pipeline.prepare_queue.push_assume_capacity(.{ .message = message });
+        if (constants.verify) pipeline.verify();
+    }
+};
+
+/// Prepares in the cache may be committed or uncommitted, and may not belong to the current view.
+///
+/// Invariants:
+/// - The cache contains only messages with command=prepare.
+/// - If a message with op X is in the cache, it is in `prepares[X % prepares.len]`.
+const PipelineCache = struct {
+    const prepares_max =
+        constants.pipeline_prepare_queue_max +
+        constants.pipeline_request_queue_max;
+
+    prepares: [prepares_max]?*Message = [_]?*Message{null} ** prepares_max,
+
+    /// Converting a PipelineQueue to a PipelineCache discards all accumulated acks.
+    /// "prepare_ok"s from previous views are not valid, even if the pipeline entry is reused
+    /// after a cycle of view changes. In other words, when a view change cycles around, so
+    /// that the original primary becomes a primary of a new view, pipeline entries may be
+    /// reused. However, the pipeline's prepare_ok quorums must not be reused, since the
+    /// replicas that sent them may have swapped them out during a previous view change.
+    fn init_from_queue(queue: *PipelineQueue) PipelineCache {
+        var cache = PipelineCache{};
+        var prepares = queue.prepare_queue.iterator();
+        while (prepares.next()) |prepare| {
+            const prepare_old = cache.insert(prepare.message.ref());
+            assert(prepare_old == null);
+            assert(prepare.message.header.command == .prepare);
+        }
+        return cache;
+    }
+
+    fn deinit(pipeline: *PipelineCache, message_pool: *MessagePool) void {
+        for (pipeline.prepares) |*entry| {
+            if (entry.*) |m| {
+                message_pool.unref(m);
+                entry.* = null;
+            }
+        }
+    }
+
+    fn empty(pipeline: *const PipelineCache) bool {
+        for (pipeline.prepares) |*entry| {
+            if (entry) |_| return true;
+        }
+        return false;
+    }
+
+    fn contains_header(pipeline: *const PipelineCache, header: *const Header) bool {
+        assert(header.command == .prepare);
+
+        const slot = header.op % prepares_max;
+        const prepare = pipeline.prepares[slot] orelse return false;
+        return prepare.header.op == header.op and prepare.header.checksum == header.checksum;
+    }
+
+    fn prepare_by_op(pipeline: *PipelineCache, op: u64) ?*Message {
+        const slot = op % prepares_max;
+        const prepare = pipeline.prepares[slot] orelse return null;
+        if (prepare.header.op != op) return null;
+        return prepare;
+    }
+
+    fn prepare_by_op_and_checksum(pipeline: *PipelineCache, op: u64, checksum: ?u128) ?*Message {
+        const prepare = pipeline.prepare_by_op(op) orelse return null;
+        if (checksum == null) return prepare;
+        if (checksum.? == prepare.header.checksum) return prepare;
+        return null;
+    }
+
+    /// Returns the message evicted from the cache, if any.
+    fn insert(pipeline: *PipelineCache, prepare: *Message) ?*Message {
+        assert(prepare.header.command == .prepare);
+
+        const slot = prepare.header.op % prepares_max;
+        const prepare_old = pipeline.prepares[slot];
+        pipeline.prepares[slot] = prepare;
+        return prepare_old;
+    }
+};

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4348,8 +4348,8 @@ pub fn ReplicaType(
                 prepare.?.header.checksum,
             });
 
-            const prepare_old = self.pipeline.cache.insert(prepare.?.ref());
-            if (prepare_old) |message_old| self.message_bus.unref(message_old);
+            const prepare_evicted = self.pipeline.cache.insert(prepare.?.ref());
+            if (prepare_evicted) |message_evicted| self.message_bus.unref(message_evicted);
 
             if (self.primary_repair_pipeline_op()) |_| {
                 assert(!self.pipeline_repairing);
@@ -5741,6 +5741,18 @@ pub fn ReplicaType(
                 return;
             }
 
+            // Criteria for caching:
+            // - The primary does not update the cache since it is (or will be) reconstructing its
+            //   pipeline.
+            // - Cache uncommitted ops, since it will avoid a WAL read in the common case.
+            if (self.pipeline == .cache and
+                self.replica != self.primary_index(self.view) and
+                self.commit_min < message.header.op)
+            {
+                const prepare_evicted = self.pipeline.cache.insert(message.ref());
+                if (prepare_evicted) |m| self.message_bus.unref(m);
+            }
+
             self.journal.write_prepare(write_prepare_callback, message, trigger);
         }
 
@@ -6511,8 +6523,8 @@ const PipelineCache = struct {
         var cache = PipelineCache{};
         var prepares = queue.prepare_queue.iterator();
         while (prepares.next()) |prepare| {
-            const prepare_old = cache.insert(prepare.message.ref());
-            assert(prepare_old == null);
+            const prepare_evicted = cache.insert(prepare.message.ref());
+            assert(prepare_evicted == null);
             assert(prepare.message.header.command == .prepare);
         }
         return cache;
@@ -6561,8 +6573,8 @@ const PipelineCache = struct {
         assert(prepare.header.command == .prepare);
 
         const slot = prepare.header.op % prepares_max;
-        const prepare_old = pipeline.prepares[slot];
+        const prepare_evicted = pipeline.prepares[slot];
         pipeline.prepares[slot] = prepare;
-        return prepare_old;
+        return prepare_evicted;
     }
 };


### PR DESCRIPTION
## Background

Split the FIFO pipeline (with capacity `pipeline_max`) into a _prepare queue_ and a _request queue_.

This is a good change on its own — it decouples the number of messages to prepare concurrently (which should be tuned according to IO throughput/latency) from the number of clients. But the original impetus is to give a tighter bound on the number if pipelined prepares, so that we can fit the full DVC/SV headers in the superblock.

## Config

The _prepare queue_'s capacity is `constants.pipeline_prepare_queue_max`.
The _request queue_'s capacity is `constants.pipeline_request_queue_max`.

#### Relative Values

- `pipeline_prepare_queue_max + pipeline_request_queue_max = clients_max`: This is the typical case — no client can starve others.
- `pipeline_prepare_queue_max + pipeline_request_queue_max < clients_max`: Also allowed, but if clients are sending requests often they may starve one another.
- `pipeline_prepare_queue_max + pipeline_request_queue_max > clients_max`: Not allowed, since the extra pipeline messages aren't useful.

## Flow

#### Request → Prepare:

Previously, when a request arrives that the primary:
1. Convert the request to a prepare (sequence it, etc).
2. Queue the prepare in the FIFO pipeline.
3. Replicate the prepare.
4. Write the prepare to the WAL.
5. etc
6. After a prepare commits, it is popped from the pipeline.

#### Now:
1. If there is free space in the prepare queue, convert the request to a prepare and begin replication/etc. Otherwise, queue the request as-is.
2. After a prepare commits, it is popped from the pipeline. If there is a request waiting, pop it from the request queue and push it to the prepare queue, and start replication/etc of the new prepare.

(Aside: We acquire the realtime when the request arrives, not when the request is converted to a prepare. Because reading the realtime can fail (if the clock synchronization is lost) this simplifies the queueing logic.)

## Prepare Cache
### Background

The message pool statically allocates all messages that the replica will require. The pipeline contains `pipeline_prepare_queue_max + pipeline_request_queue_max` (typically equal to `clients_max`). But those queues are only used by the primary.

The primary commits from its pipeline (prepares in memory) — the follower commits from the journal (prepares on disk), requiring an extra read.

### Cache

This change adds and additional "mode" to the pipeline — a follower's pipeline serves as a cache of recent messages. The replica currently uses the cache to help repair itself or other replicas, and to skip a WAL read in the commit path.