### PR TITLE
Assert that blocks written to the grid are not already in use in cache or in-flight reads.

### DIFF
--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -292,6 +292,12 @@ pub fn GridType(comptime Storage: type) type {
             grid.assert_not_writing(address, block.*);
             grid.assert_not_reading(address, block.*);
 
+            if (constants.verify) {
+                for (grid.cache_blocks) |cache_block| {
+                    assert(cache_block != block.*);
+                }
+            }
+
             assert(grid.superblock.opened);
             assert(!grid.superblock.free_set.is_free(address));
 


### PR DESCRIPTION
I was worried about this when reading the manifest_log. Doesn't look like it can actually happen, but doesn't hurt to keep the assert around.