### PR TITLE
Misc improvements

### DIFF
--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -433,6 +433,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 block,
                 address,
             );
+            manifest_log.blocks.advance_head();
         }
 
         fn write_block_callback(write: *Grid.Write) void {
@@ -441,7 +442,6 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             assert(manifest_log.writing);
 
             manifest_log.blocks_closed -= 1;
-            manifest_log.blocks.advance_head();
             assert(manifest_log.blocks_closed <= manifest_log.blocks.count);
 
             manifest_log.write_block();

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -198,7 +198,7 @@ fn generate_events(
         event.* = switch (event_type) {
             .insert_new => insert: {
                 const level = random.uintLessThan(u7, constants.lsm_levels);
-                const table = .{
+                const table = TableInfo{
                     .checksum = 0,
                     .address = i + 1,
                     .snapshot_min = 1,
@@ -210,10 +210,11 @@ fn generate_events(
                     .level = level,
                     .table = table,
                 });
-                break :insert ManifestEvent{ .insert = .{
+                const insert = ManifestEvent{ .insert = .{
                     .level = level,
                     .table = table,
                 } };
+                break :insert insert;
             },
 
             .insert_change_level => insert: {
@@ -223,27 +224,30 @@ fn generate_events(
                 }
 
                 table.level += 1;
-                break :insert ManifestEvent{ .insert = .{
+                const insert = ManifestEvent{ .insert = .{
                     .level = table.level,
                     .table = table.table,
                 } };
+                break :insert insert;
             },
 
             .insert_change_snapshot => insert: {
                 const table = &tables.items[random.uintLessThan(usize, tables.items.len)];
                 table.table.snapshot_max += 1;
-                break :insert ManifestEvent{ .insert = .{
+                const insert = ManifestEvent{ .insert = .{
                     .level = table.level,
                     .table = table.table,
                 } };
+                break :insert insert;
             },
 
             .remove => remove: {
                 const table = tables.swapRemove(random.uintLessThan(usize, tables.items.len));
-                break :remove ManifestEvent{ .remove = .{
+                const remove = ManifestEvent{ .remove = .{
                     .level = table.level,
                     .table = table.table,
                 } };
+                break :remove remove;
             },
 
             .compact => ManifestEvent{ .compact = {} },

--- a/src/test/packet_simulator.zig
+++ b/src/test/packet_simulator.zig
@@ -5,6 +5,7 @@ const math = std.math;
 const log = std.log.scoped(.packet_simulator);
 const vsr = @import("../vsr.zig");
 const PriorityQueue = @import("./priority_queue.zig").PriorityQueue;
+const fuzz = @import("./fuzz.zig");
 
 pub const PacketSimulatorOptions = struct {
     replica_count: u8,
@@ -206,7 +207,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
         fn one_way_delay(self: *Self) u64 {
             const min = self.options.one_way_delay_min;
             const mean = self.options.one_way_delay_mean;
-            return min + @floatToInt(u64, @intToFloat(f64, mean - min) * self.prng.random().floatExp(f64));
+            return min + fuzz.random_int_exponential(self.prng.random(), u64, mean - min);
         }
 
         /// Partitions the network. Guaranteed to isolate at least one replica.
@@ -326,7 +327,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
                     if (self.should_clog(reverse_path)) {
                         log.debug("reverse path clogged", .{});
                         const mean = @intToFloat(f64, self.options.path_clog_duration_mean);
-                        const ticks = @floatToInt(u64, mean * self.prng.random().floatExp(f64));
+                        const ticks = fuzz.random_int_exponential(self.prng.random(), u64, mean);
                         self.clog_for(reverse_path, ticks);
                     }
                 }

--- a/src/test/packet_simulator.zig
+++ b/src/test/packet_simulator.zig
@@ -4,6 +4,7 @@ const math = std.math;
 
 const log = std.log.scoped(.packet_simulator);
 const vsr = @import("../vsr.zig");
+const PriorityQueue = @import("./priority_queue.zig").PriorityQueue;
 
 pub const PacketSimulatorOptions = struct {
     replica_count: u8,
@@ -77,7 +78,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
         };
 
         const Link = struct {
-            queue: std.PriorityQueue(LinkPacket, void, Self.order_packets),
+            queue: PriorityQueue(LinkPacket, void, Self.order_packets),
             /// When false, packets sent on the path are not delivered.
             enabled: bool = true,
             /// We can arbitrary clog a path until a tick.
@@ -110,7 +111,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             for (links) |*link, i| {
                 errdefer for (links[0..i]) |l| l.queue.deinit();
 
-                const queue = std.PriorityQueue(LinkPacket, void, Self.order_packets).init(allocator, {});
+                const queue = PriorityQueue(LinkPacket, void, Self.order_packets).init(allocator, {});
                 try link.queue.ensureTotalCapacity(options.path_maximum_capacity);
                 link.* = .{ .queue = queue };
             }

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -31,6 +31,7 @@ const vsr = @import("../vsr.zig");
 const superblock = @import("../vsr/superblock.zig");
 const BlockType = @import("../lsm/grid.zig").BlockType;
 const stdx = @import("../stdx.zig");
+const PriorityQueue = @import("./priority_queue.zig").PriorityQueue;
 
 const log = std.log.scoped(.storage);
 
@@ -137,8 +138,8 @@ pub const Storage = struct {
     /// This is used to disable faults during the replica's first startup.
     faulty: bool = true,
 
-    reads: std.PriorityQueue(*Storage.Read, void, Storage.Read.less_than),
-    writes: std.PriorityQueue(*Storage.Write, void, Storage.Write.less_than),
+    reads: PriorityQueue(*Storage.Read, void, Storage.Read.less_than),
+    writes: PriorityQueue(*Storage.Write, void, Storage.Write.less_than),
 
     ticks: u64 = 0,
     next_tick_queue: FIFO(NextTick) = .{},
@@ -161,11 +162,11 @@ pub const Storage = struct {
         var faults = try std.DynamicBitSetUnmanaged.initEmpty(allocator, sector_count);
         errdefer faults.deinit(allocator);
 
-        var reads = std.PriorityQueue(*Storage.Read, void, Storage.Read.less_than).init(allocator, {});
+        var reads = PriorityQueue(*Storage.Read, void, Storage.Read.less_than).init(allocator, {});
         errdefer reads.deinit();
         try reads.ensureTotalCapacity(constants.iops_read_max);
 
-        var writes = std.PriorityQueue(*Storage.Write, void, Storage.Write.less_than).init(allocator, {});
+        var writes = PriorityQueue(*Storage.Write, void, Storage.Write.less_than).init(allocator, {});
         errdefer writes.deinit();
         try writes.ensureTotalCapacity(constants.iops_write_max);
 

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -32,6 +32,7 @@ const superblock = @import("../vsr/superblock.zig");
 const BlockType = @import("../lsm/grid.zig").BlockType;
 const stdx = @import("../stdx.zig");
 const PriorityQueue = @import("./priority_queue.zig").PriorityQueue;
+const fuzz = @import("./fuzz.zig");
 
 const log = std.log.scoped(.storage);
 
@@ -392,7 +393,7 @@ pub const Storage = struct {
     }
 
     fn latency(storage: *Storage, min: u64, mean: u64) u64 {
-        return min + @floatToInt(u64, @intToFloat(f64, mean - min) * storage.prng.random().floatExp(f64));
+        return min + fuzz.random_int_exponential(storage.prng.random(), u64, mean - min);
     }
 
     /// Return true with probability x/100.


### PR DESCRIPTION
* Reduce visibility of uninitialized blocks in manifest_log.
* Work around a miscompilation in manifest_log_fuzz.
* Use test/priority_queue instead of std.PriorityQueue.
* Use fuzz.random_int_exponential instead of manual casts.