### PR TITLE
Java client: Improve fragile tests

### DIFF
--- a/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
@@ -899,7 +899,9 @@ public class BatchTest {
         // Mimic the the binary response
         dummyCreateAccountResultsStream = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
         dummyCreateAccountResultsStream.putInt(0).putInt(0); // Item 0 - OK
-        dummyCreateAccountResultsStream.putInt(1).putInt(18); // Item 1 - Exists
+        dummyCreateAccountResultsStream.putInt(1).putInt(CreateAccountResult.Exists.value); // Item
+                                                                                            // 1 -
+                                                                                            // Exists
 
         createTransferResult1 = CreateTransferResult.Ok;
         createTransferResult2 = CreateTransferResult.ExceedsDebits;
@@ -907,7 +909,8 @@ public class BatchTest {
         // Mimic the the binary response
         dummyCreateTransfersResultsStream = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
         dummyCreateTransfersResultsStream.putInt(0).putInt(0); // Item 0 - OK
-        dummyCreateTransfersResultsStream.putInt(1).putInt(37); // Item 1 - ExceedsDebits
+        dummyCreateTransfersResultsStream.putInt(1)
+                .putInt(CreateTransferResult.ExceedsDebits.value); // Item 1 - ExceedsDebits
 
         id1 = new byte[] {10, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0};
         id1LeastSignificant = 10;

--- a/src/clients/java/src/test/java/com/tigerbeetle/CreateAccountResultTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/CreateAccountResultTest.java
@@ -7,13 +7,13 @@ public class CreateAccountResultTest {
 
     @Test
     public void testFromValue() {
-        var value = 18;
+        final var value = CreateAccountResult.Exists.value;
         Assert.assertEquals(CreateAccountResult.Exists, CreateAccountResult.fromValue(value));
     }
 
     @Test
     public void testOrdinal() {
-        var value = 18;
+        final var value = CreateAccountResult.Exists.value;
         Assert.assertEquals(CreateAccountResult.Exists.ordinal(), value);
     }
 

--- a/src/clients/java/src/test/java/com/tigerbeetle/CreateTransferResultTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/CreateTransferResultTest.java
@@ -7,7 +7,7 @@ public class CreateTransferResultTest {
 
     @Test
     public void testFromValue() {
-        var value = 8;
+        var value = CreateTransferResult.DebitAccountIdMustNotBeIntMax.value;
         Assert.assertEquals(CreateTransferResult.DebitAccountIdMustNotBeIntMax,
                 CreateTransferResult.fromValue(value));
     }


### PR DESCRIPTION
Some tests were using constants instead of the generated bindings.