### PR TITLE
Don't release index block addresses until they are dropped from the manifest_log.

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -181,7 +181,7 @@ pub const configs = struct {
             .pipeline_prepare_queue_max = 4,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(4),
-            .storage_size_max = 1024 * 1024 * 1024,
+            .storage_size_max = 4 * 1024 * 1024 * 1024,
 
             .block_size = sector_size,
             .lsm_growth_factor = 4,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -301,7 +301,7 @@ pub fn CompactionType(
             for (Table.index_filter_addresses_used(index_block)) |address| {
                 grid.release(address);
             }
-            grid.release(Table.index_block_address(index_block));
+            // The index block itself will be released later by manifest_log during compaction.
         }
 
         pub fn compact_tick(compaction: *Compaction, callback: Callback) void {

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -17,7 +17,7 @@
 //! 6. Compaction must compact partially full blocks, even where it must rewrite all entries to the
 //!    tail end of the log.
 //!
-//! 7.  If a remove is dropped from the log, then all prior inserts must already have been dropped.
+//! 7. If a remove is dropped from the log, then all prior inserts must already have been dropped.
 //!
 //! 8. A `table_info.address` is never released from the grid until all references in the log have
 //!    been dropped. Otherwise it's possible for the address to be reused in a different log,

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -457,6 +457,12 @@ pub const Storage = struct {
         return mem.bytesAsSlice(MessageRaw, storage.memory[offset..][0..size]);
     }
 
+    pub fn grid_block_written(storage: *const Storage, address: u64) bool {
+        assert(address > 0);
+        const block_offset = vsr.Zone.grid.offset((address - 1) * constants.block_size);
+        return storage.memory_written.isSet(@divExact(block_offset, constants.sector_size));
+    }
+
     pub fn grid_block(
         storage: *const Storage,
         address: u64,


### PR DESCRIPTION
Don't release index block addresses until they are dropped from the manifest_log.

Otherwise the address can be reused in another manifest_log, leading to non-deterministic updates to superblock_manifest during open, compaction or append.

Fixes https://github.com/tigerbeetledb/tigerbeetle/issues/403.

With this fix we can also pass many forest_fuzz seeds, so long as we increase the storage size a little to avoid exhausting the grid.