### PR TITLE
 Store tree_hash in keys for superblock_manifest.tables

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -181,7 +181,7 @@ pub const configs = struct {
             .pipeline_prepare_queue_max = 4,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(4),
-            .storage_size_max = 1024 * 1024 * 1024,
+            .storage_size_max = 4 * 1024 * 1024 * 1024,
 
             .block_size = sector_size,
             .lsm_growth_factor = 4,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -255,7 +255,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 const label = labels_used[entry];
                 const table = &tables_used[entry];
 
-                if (manifest.insert_table_extent(table.address, block_reference.address, entry)) {
+                if (manifest.insert_table_extent(manifest_log.tree_hash, table.address, block_reference.address, entry)) {
                     switch (label.event) {
                         .insert => manifest_log.open_event(manifest_log, label.level, table),
                         .remove => manifest.queue_for_compaction(block_reference.address),
@@ -332,7 +332,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
 
             const manifest: *SuperBlock.Manifest = &manifest_log.superblock.manifest;
             const address = Block.address(block);
-            if (manifest.update_table_extent(table.address, address, entry)) |previous_block| {
+            if (manifest.update_table_extent(manifest_log.tree_hash, table.address, address, entry)) |previous_block| {
                 manifest.queue_for_compaction(previous_block);
                 if (label.event == .remove) manifest.queue_for_compaction(address);
             } else {
@@ -547,7 +547,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 // Remove the extent if the table is the latest version.
                 // We must iterate entries in forward order to drop the extent here.
                 // Otherwise, stale versions earlier in the block may reappear.
-                if (manifest.remove_table_extent(table.address, block_reference.address, entry)) {
+                if (manifest.remove_table_extent(manifest_log.tree_hash, table.address, block_reference.address, entry)) {
                     switch (label.event) {
                         // Append the table, updating the table extent:
                         .insert => manifest_log.append(label, table),

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -615,7 +615,7 @@ fn verify_manifest(
     try std.testing.expect(std.mem.eql(u64, expect.addresses[0..c], actual.addresses[0..c]));
 
     try std.testing.expect(hash_map_equals(
-        u64,
+        SuperBlock.Manifest.TableExtentKey,
         SuperBlock.Manifest.TableExtent,
         &expect.tables,
         &actual.tables,

--- a/src/vsr/superblock_manifest.zig
+++ b/src/vsr/superblock_manifest.zig
@@ -29,13 +29,20 @@ pub const Manifest = struct {
     /// A map from table address to the manifest block and entry that is the latest extent version.
     /// Used to determine whether a table should be dropped in a compaction.
     /// Shared by all trees and sized to accommodate all possible tables.
-    tables: std.AutoHashMapUnmanaged(u64, TableExtent),
+    tables: Tables,
 
     /// A set of block addresses that have free entries.
     /// Used to determine whether a block should be compacted.
     /// Note: Some of these block addresses may yet to be appended to the manifest through a flush.
     /// This enables us to track fragmentation even in unflushed blocks.
     compaction_set: std.AutoHashMapUnmanaged(u64, void),
+
+    pub const Tables = std.AutoHashMapUnmanaged(TableExtentKey, TableExtent);
+
+    pub const TableExtentKey = struct {
+        tree_hash: u128,
+        table: u64,
+    };
 
     pub const TableExtent = struct {
         block: u64, // ManifestLog block address.
@@ -60,7 +67,7 @@ pub const Manifest = struct {
         const addresses = try allocator.alloc(u64, manifest_block_count_max);
         errdefer allocator.free(addresses);
 
-        var tables = std.AutoHashMapUnmanaged(u64, TableExtent){};
+        var tables = Tables{};
         try tables.ensureTotalCapacity(allocator, forest_table_count_max);
         errdefer tables.deinit(allocator);
 
@@ -293,11 +300,14 @@ pub const Manifest = struct {
 
     /// Inserts the table extent if it does not yet exist, and returns true.
     /// Otherwise, returns false.
-    pub fn insert_table_extent(manifest: *Manifest, table: u64, block: u64, entry: u32) bool {
+    pub fn insert_table_extent(manifest: *Manifest, tree_hash: u128, table: u64, block: u64, entry: u32) bool {
         assert(table > 0);
         assert(block > 0);
 
-        var extent = manifest.tables.getOrPutAssumeCapacity(table);
+        var extent = manifest.tables.getOrPutAssumeCapacity(.{
+            .tree_hash = tree_hash,
+            .table = table,
+        });
         if (extent.found_existing) return false;
 
         extent.value_ptr.* = .{
@@ -311,11 +321,14 @@ pub const Manifest = struct {
     /// Inserts or updates the table extent, and returns the previous block address if any.
     /// The table extent must be updated immediately when appending, without delay.
     /// Otherwise, ManifestLog.compact() may append a stale version over the latest.
-    pub fn update_table_extent(manifest: *Manifest, table: u64, block: u64, entry: u32) ?u64 {
+    pub fn update_table_extent(manifest: *Manifest, tree_hash: u128, table: u64, block: u64, entry: u32) ?u64 {
         assert(table > 0);
         assert(block > 0);
 
-        var extent = manifest.tables.getOrPutAssumeCapacity(table);
+        var extent = manifest.tables.getOrPutAssumeCapacity(.{
+            .tree_hash = tree_hash,
+            .table = table,
+        });
         const previous_block = if (extent.found_existing) extent.value_ptr.block else null;
 
         extent.value_ptr.* = .{
@@ -328,13 +341,19 @@ pub const Manifest = struct {
 
     /// Removes the table extent if { block, entry } is the latest version, and returns true.
     /// Otherwise, returns false.
-    pub fn remove_table_extent(manifest: *Manifest, table: u64, block: u64, entry: u32) bool {
+    pub fn remove_table_extent(manifest: *Manifest, tree_hash: u128, table: u64, block: u64, entry: u32) bool {
         assert(table > 0);
         assert(block > 0);
 
-        const extent = manifest.tables.getPtr(table).?;
+        const extent = manifest.tables.getPtr(.{
+            .tree_hash = tree_hash,
+            .table = table,
+        }).?;
         if (extent.block == block and extent.entry == entry) {
-            assert(manifest.tables.remove(table));
+            assert(manifest.tables.remove(.{
+                .tree_hash = tree_hash,
+                .table = table,
+            }));
 
             return true;
         } else {


### PR DESCRIPTION
This prevents manifest_logs from racing each other when a table address is reacquired by one log whilst still present in uncompacted stale entries of another.

Fixes https://github.com/tigerbeetledb/tigerbeetle/issues/403