### PR TITLE
Pass repo to docs build script, to fix validate_docs on forked PRs

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/validate_docs.sh
+    env:
+      SOURCE_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
 
   shellcheck_scripts:
     runs-on: ubuntu-latest

--- a/scripts/validate_docs.sh
+++ b/scripts/validate_docs.sh
@@ -13,5 +13,11 @@ if [[ -z "$BRANCH" ]]; then
     # Otherwise fall back to git rev-parse
     BRANCH=$(git rev-parse --abbrev-ref HEAD)
 fi
-( cd docs_website && npm install && ./scripts/build.sh "$BRANCH" )
+
+REPO="https://github.com/tigerbeetledb/tigerbeetle"
+if ! [[ -z "GITHUB_REPOSITORY" ]]; then
+    REPO="https://github.com/${GITHUB_REPOSITORY}"
+fi
+
+( cd docs_website && npm install && ./scripts/build.sh "$BRANCH" "$REPO" )
 rm -rf docs_website

--- a/scripts/validate_docs.sh
+++ b/scripts/validate_docs.sh
@@ -15,7 +15,7 @@ if [[ -z "$BRANCH" ]]; then
 fi
 
 REPO="https://github.com/tigerbeetledb/tigerbeetle"
-if ! [[ -z "GITHUB_REPOSITORY" ]]; then
+if [[ -n "$GITHUB_REPOSITORY" ]]; then
     REPO="https://github.com/${GITHUB_REPOSITORY}"
 fi
 

--- a/scripts/validate_docs.sh
+++ b/scripts/validate_docs.sh
@@ -15,8 +15,8 @@ if [[ -z "$BRANCH" ]]; then
 fi
 
 REPO="https://github.com/tigerbeetledb/tigerbeetle"
-if [[ -n "$GITHUB_REPOSITORY" ]]; then
-    REPO="https://github.com/${GITHUB_REPOSITORY}"
+if [[ -n "$SOURCE_REPO" ]]; then
+    REPO="${SOURCE_REPO}"
 fi
 
 ( cd docs_website && npm install && ./scripts/build.sh "$BRANCH" "$REPO" )


### PR DESCRIPTION
Currently CI will fail on forked repos, since the docs repo build script always tries to clone from `tigerbeetledb/tigerbeetle`. Pass in the repo from CI, if it's set, to fix this.

Requires a matching PR in the docs repo - https://github.com/tigerbeetledb/docs/pull/5