### PR TITLE
Be more strict about capping the number of operations on table_mutable.

### DIFF
--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -43,6 +43,13 @@ pub fn TableMutableType(comptime Table: type) type {
         value_count_max: u32,
         values: Values = .{},
 
+        /// Rather than using values.count(), we count how many values we could have had if every
+        /// operation had been on a different key. This means that mistakes in calculating
+        /// commit_entries_max are much easier to catch when fuzzing, rather than requiring very
+        /// specific workloads.
+        /// Invariant: value_count_worst_case <= value_count_max
+        value_count_worst_case: u32 = 0,
+
         /// This is used to accelerate point lookups and is not used for range queries.
         /// Secondary index trees used only for range queries can therefore set this to null.
         ///
@@ -98,6 +105,8 @@ pub fn TableMutableType(comptime Table: type) type {
         }
 
         pub fn put(table: *TableMutable, value: *const Value) void {
+            assert(table.value_count_worst_case < table.value_count_max);
+            table.value_count_worst_case += 1;
             switch (usage) {
                 .secondary_index => {
                     const existing = table.values.fetchRemove(value.*);
@@ -123,6 +132,8 @@ pub fn TableMutableType(comptime Table: type) type {
         }
 
         pub fn remove(table: *TableMutable, value: *const Value) void {
+            assert(table.value_count_worst_case < table.value_count_max);
+            table.value_count_worst_case += 1;
             switch (usage) {
                 .secondary_index => {
                     const existing = table.values.fetchRemove(value.*);
@@ -152,11 +163,12 @@ pub fn TableMutableType(comptime Table: type) type {
         /// assumes that none of the batch's keys are already in `table.values`.
         pub fn can_commit_batch(table: *TableMutable, batch_count: u32) bool {
             assert(batch_count <= table.value_count_max);
-            return (table.count() + batch_count) <= table.value_count_max;
+            return (table.value_count_worst_case + batch_count) <= table.value_count_max;
         }
 
         pub fn clear(table: *TableMutable) void {
             assert(table.values.count() > 0);
+            table.value_count_worst_case = 0;
             table.values.clearRetainingCapacity();
             assert(table.values.count() == 0);
         }


### PR DESCRIPTION
This would have caught the mutating-immutable-fields bug in forest_fuzz immediately.