### PR TITLE
Fix latent build error in Java client build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -443,7 +443,7 @@ fn java_client(
     }
 
     const bindings = b.addExecutable("java_bindings", "src/clients/java/java_bindings.zig");
-    bindings.addOptions("tigerbeetle_build_options", options);
+    bindings.addOptions("vsr_options", options);
     bindings.setMainPkgPath("src");
     const bindings_step = bindings.run();
 


### PR DESCRIPTION
We renamed the options package from tigerbeetle_build_optioins to vsr_options, to follow the suite of std_options.

As zig is super lazy, and the java_binding.zig doesn't _actually_ use options, the current code compiles, though it is quite wrong.