### PR TITLE
Fix differences between release and debug builds

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -151,6 +151,17 @@ jobs:
       - run: ./scripts/install_zig.sh
       - run: zig/zig build fuzz_vsr_superblock_quorums -- --seed 123
 
+  # This both checks that the hash_log builds and acts as a regression test for 
+  # https://github.com/tigerbeetledb/tigerbeetle/issues/404
+  fuzz_hash_log:
+    name: 'Fuzz LSM Forest with hash_log'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./scripts/install_zig.sh
+      - run: zig/zig build fuzz_lsm_forest -Dhash-log-mode=create -Drelease-safe -- --seed 16319736705930193193 --events-max 10000
+      - run: zig/zig build fuzz_lsm_forest -Dhash-log-mode=check -- --seed 16319736705930193193 --events-max 10000
+
   # This is just a canary to make sure that the simulator compiles
   # (and passes for at least a single seed).
   # simulator:
@@ -287,6 +298,7 @@ jobs:
       - fuzz_vsr_superblock
       - fuzz_vsr_superblock_free_set
       - fuzz_vsr_superblock_quorums
+      - fuzz_hash_log
       - build-tools
       - build-and-push
       - build-and-push-debug

--- a/build.zig
+++ b/build.zig
@@ -43,6 +43,13 @@ pub fn build(b: *std.build.Builder) void {
     ) orelse .none;
     options.addOption(config.TracerBackend, "tracer_backend", tracer_backend);
 
+    const hash_log_mode = b.option(
+        config.HashLogMode,
+        "hash-log-mode",
+        "Log hashes (used for debugging non-deterministic executions).",
+    ) orelse .none;
+    options.addOption(config.HashLogMode, "hash_log_mode", hash_log_mode);
+
     const vsr_package = std.build.Pkg{
         .name = "vsr",
         .path = .{ .path = "src/vsr.zig" },

--- a/src/config.zig
+++ b/src/config.zig
@@ -35,6 +35,7 @@ pub const Config = struct {
 const ConfigProcess = struct {
     log_level: std.log.Level = .info,
     tracer_backend: TracerBackend = .none,
+    hash_log_mode: HashLogMode = .none,
     verify: bool,
     port: u16 = 3001,
     address: []const u8 = "127.0.0.1",
@@ -127,6 +128,12 @@ pub const TracerBackend = enum {
     perfetto,
     // Sends data to https://github.com/wolfpld/tracy.
     tracy,
+};
+
+pub const HashLogMode = enum {
+    none,
+    create,
+    check,
 };
 
 pub const StateMachine = enum {
@@ -225,6 +232,13 @@ pub const configs = struct {
             // Zig's `addOptions` reuses the type, but redeclares it — identical structurally,
             // but a different type from a nominal typing perspective.
             @intToEnum(TracerBackend, @enumToInt(build_options.tracer_backend));
+
+        base.process.hash_log_mode = if (@hasDecl(root, "decode_events"))
+            // TODO(DJ) This is a hack to work around the absense of tigerbeetle_build_options.
+            // This should be removed once the node client is built using `zig build`.
+            .none
+        else
+            @intToEnum(HashLogMode, @enumToInt(build_options.hash_log_mode));
 
         break :current base;
     };

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -22,6 +22,9 @@ else
 // Default is `.none`.
 pub const tracer_backend = config.process.tracer_backend;
 
+// Which mode to use for ./test/hash_log.zig.
+pub const hash_log_mode = config.process.hash_log_mode;
+
 /// The maximum number of replicas allowed in a cluster.
 pub const replicas_max = 6;
 

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -29,6 +29,7 @@ pub const vsr_options = .{
     .config_base = vsr.config.ConfigBase.default,
     .config_cluster_state_machine = vsr.config.StateMachine.accounting,
     .tracer_backend = vsr.config.TracerBackend.none,
+    .hash_log_mode = vsr.config.HashLogMode.none,
 };
 
 pub fn request(

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -62,7 +62,12 @@ pub fn CompactionType(
         const BlockWrite = struct {
             write: Grid.Write = undefined,
             block: *BlockPtr = undefined,
-            writable: bool = false,
+            state: BlockState = .building,
+        };
+        const BlockState = enum {
+            building,
+            writable,
+            writing,
         };
 
         const Manifest = ManifestType(Table, Storage);
@@ -241,9 +246,9 @@ pub fn CompactionType(
                 .level_a_input = if (table_a) |table| table.* else null,
             };
 
-            assert(!compaction.index.writable);
-            assert(!compaction.filter.writable);
-            assert(!compaction.data.writable);
+            assert(compaction.index.state == .building);
+            assert(compaction.filter.state == .building);
+            assert(compaction.data.state == .building);
 
             // TODO Implement manifest.move_table() optimization if there's only range.table_count == 1.
             // This would do update_tables + insert_tables inline without going through the iterators.
@@ -342,6 +347,14 @@ pub fn CompactionType(
             const write_callback = struct {
                 fn callback(write: *Grid.Write) void {
                     const block_write = @fieldParentPtr(BlockWrite, "write", write);
+
+                    assert(block_write.state == .writing);
+                    block_write.state = .building;
+
+                    if (constants.verify) {
+                        // We've finished writing so the block should now be zeroed.
+                        assert(mem.allEqual(u8, block_write.block.*, 0));
+                    }
                     block_write.block = undefined;
 
                     const _compaction = @fieldParentPtr(Compaction, @tagName(field), block_write);
@@ -350,8 +363,8 @@ pub fn CompactionType(
             }.callback;
 
             const block_write: *BlockWrite = &@field(compaction, @tagName(field));
-            if (block_write.writable) {
-                block_write.writable = false;
+            if (block_write.state == .writable) {
+                block_write.state = .writing;
 
                 compaction.io_start();
                 compaction.grid.write_block(
@@ -405,9 +418,9 @@ pub fn CompactionType(
                 assert(!compaction.merge_iterator.?.empty());
             }
 
-            assert(!compaction.data.writable);
-            assert(!compaction.filter.writable);
-            assert(!compaction.index.writable);
+            assert(compaction.data.state == .building);
+            assert(compaction.filter.state == .building);
+            assert(compaction.index.state == .building);
 
             if (!compaction.merge_iterator.?.empty()) {
                 compaction.cpu_merge();
@@ -444,9 +457,9 @@ pub fn CompactionType(
             // Ensure there are values to merge and that is it safe to do so.
             const merge_iterator = &compaction.merge_iterator.?;
             assert(!merge_iterator.empty());
-            assert(!compaction.data.writable);
-            assert(!compaction.filter.writable);
-            assert(!compaction.index.writable);
+            assert(compaction.data.state == .building);
+            assert(compaction.filter.state == .building);
+            assert(compaction.index.state == .building);
 
             // Build up a data block with values merged from the read iterators.
             // This skips tombstone values if compaction was started with the intent to drop them.
@@ -470,8 +483,8 @@ pub fn CompactionType(
 
                 // Mark the finished data block as writable for the next compact_tick() call.
                 compaction.data.block = &compaction.table_builder.data_block;
-                assert(!compaction.data.writable);
-                compaction.data.writable = true;
+                assert(compaction.data.state == .building);
+                compaction.data.state = .writable;
             }
 
             // Finalize the filter block if it's full or if it contains pending data blocks
@@ -487,8 +500,8 @@ pub fn CompactionType(
 
                 // Mark the finished filter block as writable for the next compact_tick() call.
                 compaction.filter.block = &compaction.table_builder.filter_block;
-                assert(!compaction.filter.writable);
-                compaction.filter.writable = true;
+                assert(compaction.filter.state == .building);
+                compaction.filter.state = .writable;
             }
 
             // Finalize the index block if it's full or if it contains pending data blocks
@@ -507,8 +520,8 @@ pub fn CompactionType(
 
                 // Mark the finished index block as writable for the next compact_tick() call.
                 compaction.index.block = &compaction.table_builder.index_block;
-                assert(!compaction.index.writable);
-                compaction.index.writable = true;
+                assert(compaction.index.state == .building);
+                compaction.index.state = .writable;
 
                 compaction.tables_output_count += 1;
                 assert(compaction.tables_output_count <= compaction.range.table_count);
@@ -524,9 +537,9 @@ pub fn CompactionType(
 
             // Ensure merging is truly finished.
             assert(compaction.merge_iterator.?.empty());
-            assert(!compaction.data.writable);
-            assert(!compaction.filter.writable);
-            assert(!compaction.index.writable);
+            assert(compaction.data.state == .building);
+            assert(compaction.filter.state == .building);
+            assert(compaction.index.state == .building);
 
             // Double check the iterators are finished as well.
             const stream_empty = struct {

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -350,9 +350,7 @@ pub fn GridType(comptime Storage: type) type {
             const cache_index = grid.cache.insert_index(&completed_write.address);
             const cache_block = &grid.cache_blocks[cache_index];
             std.mem.swap(BlockPtr, cache_block, completed_write.block);
-            if (constants.verify) {
-                std.mem.set(u8, completed_write.block.*, undefined);
-            }
+            std.mem.set(u8, completed_write.block.*, 0);
 
             // Start a queued write if possible *before* calling the completed
             // write's callback. This ensures that if the callback calls

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -470,9 +470,7 @@ pub fn GridType(comptime Storage: type) type {
             const cache_index = grid.cache.insert_index(&read.address);
             const cache_block = &grid.cache_blocks[cache_index];
             std.mem.swap(BlockPtr, iop_block, cache_block);
-            if (constants.verify) {
-                std.mem.set(u8, iop_block.*, undefined);
-            }
+            std.mem.set(u8, iop_block.*, 0);
 
             // Handoff the iop to a pending read or release it before resolving the callbacks below.
             if (grid.read_pending_queue.pop()) |pending| {

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -36,6 +36,15 @@ pub const BlockType = enum(u8) {
     }
 };
 
+// Leave this outside GridType so we can call it from modules that don't know about Storage.
+pub fn alloc_block(
+    allocator: mem.Allocator,
+) !*align(constants.sector_size) [constants.block_size]u8 {
+    const block = try allocator.alignedAlloc(u8, constants.sector_size, constants.block_size);
+    mem.set(u8, block, 0);
+    return block[0..constants.block_size];
+}
+
 /// The Grid provides access to on-disk blocks (blobs of `block_size` bytes).
 /// Each block is identified by an "address" (`u64`, beginning at 1).
 ///
@@ -178,11 +187,6 @@ pub fn GridType(comptime Storage: type) type {
                 .cache = cache,
                 .read_iop_blocks = read_iop_blocks,
             };
-        }
-
-        pub fn alloc_block(allocator: mem.Allocator) !BlockPtr {
-            const block = try allocator.alignedAlloc(u8, constants.sector_size, block_size);
-            return block[0..block_size];
         }
 
         pub fn deinit(grid: *Grid, allocator: mem.Allocator) void {

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -33,6 +33,7 @@ const stdx = @import("../stdx.zig");
 const SuperBlockType = vsr.SuperBlockType;
 const GridType = @import("grid.zig").GridType;
 const BlockType = @import("grid.zig").BlockType;
+const alloc_block = @import("grid.zig").alloc_block;
 const tree = @import("tree.zig");
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
@@ -151,10 +152,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             var blocks: [blocks_count_max]BlockPtr = undefined;
             for (blocks) |*block, i| {
                 errdefer for (blocks[0..i]) |b| allocator.free(b);
-
-                const block_slice =
-                    try allocator.alignedAlloc(u8, constants.sector_size, constants.block_size);
-                block.* = block_slice[0..constants.block_size];
+                block.* = try alloc_block(allocator);
             }
             errdefer for (blocks) |b| allocator.free(b);
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -597,8 +597,6 @@ pub fn TableType(
 
                 const values_padding = mem.sliceAsBytes(values_max[builder.value..]);
                 const block_padding = block[data.padding_offset..][0..data.padding_size];
-                mem.set(u8, values_padding, 0);
-                mem.set(u8, block_padding, 0);
                 assert(compare_keys(key_from_value(&values[values.len - 1]), key_max) == .eq);
 
                 const header_bytes = block[0..@sizeOf(vsr.Header)];
@@ -661,8 +659,6 @@ pub fn TableType(
                 assert(builder.data_block_empty());
                 assert(options.address > 0);
 
-                mem.set(u8, builder.filter_block[filter.padding_offset..][0..filter.padding_size], 0);
-
                 const header_bytes = builder.filter_block[0..@sizeOf(vsr.Header)];
                 const header = mem.bytesAsValue(vsr.Header, header_bytes);
                 header.* = .{
@@ -714,17 +710,6 @@ pub fn TableType(
                 ));
 
                 const index_block = builder.index_block;
-
-                const index_data_keys_padding = index_data_keys(index_block)[builder.data_block_count..];
-                const index_data_keys_padding_bytes = mem.sliceAsBytes(index_data_keys_padding);
-                mem.set(u8, index_data_keys_padding_bytes, 0);
-                mem.set(u64, index_data_addresses(index_block)[builder.data_block_count..], 0);
-                mem.set(u128, index_data_checksums(index_block)[builder.data_block_count..], 0);
-
-                mem.set(u64, index_filter_addresses(index_block)[builder.filter_block_count..], 0);
-                mem.set(u128, index_filter_checksums(index_block)[builder.filter_block_count..], 0);
-
-                mem.set(u8, index_block[index.padding_offset..][0..index.padding_size], 0);
 
                 const header_bytes = index_block[0..@sizeOf(vsr.Header)];
                 const header = mem.bytesAsValue(vsr.Header, header_bytes);

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -14,6 +14,7 @@ const eytzinger = @import("eytzinger.zig").eytzinger;
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const BlockType = @import("grid.zig").BlockType;
+const alloc_block = @import("grid.zig").alloc_block;
 const TableInfoType = @import("manifest.zig").TableInfoType;
 
 pub const TableUsage = enum {
@@ -484,13 +485,13 @@ pub fn TableType(
             data_blocks_in_filter: u32 = 0,
 
             pub fn init(allocator: mem.Allocator) !Builder {
-                const index_block = try allocator.alignedAlloc(u8, constants.sector_size, block_size);
+                const index_block = try alloc_block(allocator);
                 errdefer allocator.free(index_block);
 
-                const filter_block = try allocator.alignedAlloc(u8, constants.sector_size, block_size);
+                const filter_block = try alloc_block(allocator);
                 errdefer allocator.free(filter_block);
 
-                const data_block = try allocator.alignedAlloc(u8, constants.sector_size, block_size);
+                const data_block = try alloc_block(allocator);
                 errdefer allocator.free(data_block);
 
                 return Builder{

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -661,6 +661,8 @@ pub fn TableType(
                 assert(builder.data_block_empty());
                 assert(options.address > 0);
 
+                mem.set(u8, builder.filter_block[filter.padding_offset..][0..filter.padding_size], 0);
+
                 const header_bytes = builder.filter_block[0..@sizeOf(vsr.Header)];
                 const header = mem.bytesAsValue(vsr.Header, header_bytes);
                 header.* = .{

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -148,7 +148,7 @@ pub const MessagePool = struct {
     pub fn unref(pool: *MessagePool, message: *Message) void {
         message.references -= 1;
         if (message.references == 0) {
-            if (builtin.mode == .Debug) mem.set(u8, message.buffer, undefined);
+            mem.set(u8, message.buffer, 0);
             message.next = pool.free_list;
             pool.free_list = message;
         }

--- a/src/test/hash_log.zig
+++ b/src/test/hash_log.zig
@@ -1,0 +1,55 @@
+//! A tool for narrowing down the point of divergence between two executions that should be identical.
+//! Sprinkle calls to `emit(some_hash)` throughout the code.
+//! With `-Dhash-log-mode=create`, all emitted hashes are written to ./hash_log.
+//! With `-Dhash-log-mode=check`, all emitted hashes are checked against the hashes in ./hash_log.
+//! Otherwise, calls to `emit` are noops.
+
+const std = @import("std");
+const assert = std.debug.assert;
+
+const constants = @import("../constants.zig");
+
+var file: ?std.fs.File = null;
+
+fn ensure_init() void {
+    if (file != null) return;
+    switch (constants.hash_log_mode) {
+        .none => unreachable,
+        .create => {
+            file = std.fs.cwd().createFile("./hash_log", .{ .truncate = true }) catch unreachable;
+        },
+        .check => {
+            file = std.fs.cwd().openFile("./hash_log", .{ .read = true }) catch unreachable;
+        },
+    }
+}
+
+pub fn emit(hash: u128) void {
+    @call(.{ .modifier = .never_inline }, emit_never_inline, .{hash});
+}
+
+// Don't inline because we want to be able to break on this function.
+fn emit_never_inline(hash: u128) void {
+    switch (constants.hash_log_mode) {
+        .none => {},
+        .create => {
+            ensure_init();
+            std.fmt.format(file.?.writer(), "{x:0>32}\n", .{hash}) catch unreachable;
+        },
+        .check => {
+            ensure_init();
+            var buffer: [33]u8 = undefined;
+            const bytes_read = file.?.readAll(&buffer) catch unreachable;
+            assert(bytes_read == 33);
+            const expected_hash = std.fmt.parseInt(u128, buffer[0..32], 16) catch unreachable;
+            assert(hash == expected_hash);
+        },
+    }
+}
+
+pub fn emit_autohash(hashable: anytype, comptime strategy: std.hash.Strategy) void {
+    if (constants.hash_log_mode == .none) return;
+    var hasher = std.hash.Wyhash.init(0);
+    std.hash.autoHashStrat(&hasher, hashable, strategy);
+    emit(hasher.final());
+}

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -33,6 +33,7 @@ const BlockType = @import("../lsm/grid.zig").BlockType;
 const stdx = @import("../stdx.zig");
 const PriorityQueue = @import("./priority_queue.zig").PriorityQueue;
 const fuzz = @import("./fuzz.zig");
+const hash_log = @import("./hash_log.zig");
 
 const log = std.log.scoped(.storage);
 
@@ -286,6 +287,8 @@ pub const Storage = struct {
         zone: vsr.Zone,
         offset_in_zone: u64,
     ) void {
+        hash_log.emit_autohash(.{ buffer, zone, offset_in_zone }, .DeepRecursive);
+
         verify_alignment(buffer);
 
         var sectors = SectorRange.from_zone(zone, offset_in_zone, buffer.len);
@@ -304,6 +307,8 @@ pub const Storage = struct {
     }
 
     fn read_sectors_finish(storage: *Storage, read: *Storage.Read) void {
+        hash_log.emit_autohash(.{ read.buffer, read.zone, read.offset }, .DeepRecursive);
+
         const offset_in_storage = read.zone.offset(read.offset);
         stdx.copy_disjoint(
             .exact,
@@ -340,6 +345,8 @@ pub const Storage = struct {
         zone: vsr.Zone,
         offset_in_zone: u64,
     ) void {
+        hash_log.emit_autohash(.{ buffer, zone, offset_in_zone }, .DeepRecursive);
+
         verify_alignment(buffer);
 
         // Verify that there are no concurrent overlapping writes.
@@ -363,6 +370,8 @@ pub const Storage = struct {
     }
 
     fn write_sectors_finish(storage: *Storage, write: *Storage.Write) void {
+        hash_log.emit_autohash(.{ write.buffer, write.zone, write.offset }, .DeepRecursive);
+
         const offset_in_storage = write.zone.offset(write.offset);
         stdx.copy_disjoint(
             .exact,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1666,12 +1666,10 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             const buffer = message.buffer[0..vsr.sector_ceil(message.header.size)];
             const offset = Ring.prepares.offset(slot);
 
-            if (builtin.mode == .Debug) {
-                // Assert that any sector padding has already been zeroed:
-                var sum_of_sector_padding_bytes: u8 = 0;
-                for (buffer[message.header.size..]) |byte| sum_of_sector_padding_bytes |= byte;
-                assert(sum_of_sector_padding_bytes == 0);
-            }
+            // Assert that any sector padding has already been zeroed:
+            var sum_of_sector_padding_bytes: u8 = 0;
+            for (buffer[message.header.size..]) |byte| sum_of_sector_padding_bytes |= byte;
+            assert(sum_of_sector_padding_bytes == 0);
 
             journal.prepare_inhabited[slot.index] = false;
             journal.prepare_checksums[slot.index] = 0;


### PR DESCRIPTION
## hash_log

From the module docs:

```
A tool for narrowing down the point of divergence between two executions that should be identical.
Sprinkle calls to `emit(some_hash)` throughout the code.
With `-Dhash-log-mode=create`, all emitted hashes are written to ./hash_log.
With `-Dhash-log-mode=check`, all emitted hashes are checked against the hashes in ./hash_log.
Otherwise, calls to `emit` are noops.
```

At the moment the only calls to `emit` are on read/write start/finish in test storage. This is pretty high leverage though, since most decisions end up being committed to disk at some point.

I added a single hash_log run with a low event count to CI to act as a regression test.

## Zero grid blocks

Zero grid blocks on init and before every point of reuse. 

This fixes several buffer bleeds, including https://github.com/tigerbeetledb/tigerbeetle/issues/404. 

We also weren't initializing filter blocks at all so they all converged towards being all set. I don't see any perf improvements from fixing this but our one benchmark atm only stresses compaction, not lookups.

In some places we used to set blocks to `undefined`, but this appears to have different behavior in debug vs release so I changed these all to zero too.

I also noticed https://github.com/tigerbeetledb/tigerbeetle/issues/419 while poking around in the grid.

## Zero filter padding

We explicitly set the padding to zero for index and data blocks, but not for filter blocks. Shouldn't actually be necessary to zero padding for any of them now, but better safe than sorry.

## Zero messages

These were set to undefined in debug builds. Given the issues above, I switched this to zero. I also switched an assert about zeroed padding that only ran in debug builds - it should pass in release builds now too. (If we're worried about perf we could put it behind `config.verify` instead - I mostly just wanted to remove debug vs release differences).