### PR TITLE
Statically size messages in MessagePool.

### DIFF
--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -64,7 +64,7 @@ pub const MessagePool = struct {
     pub const Message = struct {
         // TODO: replace this with a header() function to save memory
         header: *Header,
-        buffer: []align(constants.sector_size) u8,
+        buffer: *align(constants.sector_size) [constants.message_size_max]u8,
         references: u32 = 0,
         next: ?*Message,
 
@@ -108,7 +108,7 @@ pub const MessagePool = struct {
                 const message = try allocator.create(Message);
                 message.* = .{
                     .header = mem.bytesAsValue(Header, buffer[0..@sizeOf(Header)]),
-                    .buffer = buffer,
+                    .buffer = buffer[0..constants.message_size_max],
                     .next = pool.free_list,
                 };
                 pool.free_list = message;
@@ -123,7 +123,7 @@ pub const MessagePool = struct {
         var free_count: usize = 0;
         while (pool.free_list) |message| {
             pool.free_list = message.next;
-            allocator.free(message.buffer);
+            allocator.free(@as([]const u8, message.buffer));
             allocator.destroy(message);
             free_count += 1;
         }

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1629,7 +1629,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
             // The underlying header memory must be owned by the buffer and not by journal.headers:
             // Otherwise, concurrent writes may modify the memory of the pointer while we write.
-            assert(@ptrToInt(message.header) == @ptrToInt(message.buffer.ptr));
+            assert(@ptrToInt(message.header) == @ptrToInt(message.buffer));
 
             const slot = journal.slot_with_header(message.header).?;
 


### PR DESCRIPTION
Change message's buffer from []u8 to *[N] u8. The primary motivation is to make state-machine's interface clear. Currently, with  `output: []u8` a custom state machine has no idea how much memory is actually available.

A side benefit is that a message is now one pointer thinner. Indeed, given that message pool _requires_ all messages to be identical, it _is_ redundant to tag each message with unique buffer length at runtime.