### PR TITLE
Make codegen reproducible between unix and windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.zig text=auto eol=lf
+* text=auto eol=lf
 *.bat text=auto eol=crlf


### PR DESCRIPTION
We generated a bunch of source code via various scripts. To make sure that the result is always bytewise identical between windows and linux, force git to not mess up with line endings for all text files.