### PR TITLE
LSM: Ensure callbacks are asynchronous where practical

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -124,7 +124,7 @@ const Environment = struct {
             .cluster = cluster,
             .replica = replica,
         });
-        
+
         env.tick_until_state_change(.superblock_format, .superblock_open);
         env.superblock.open(superblock_open_callback, &env.superblock_context);
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -62,77 +62,48 @@ const Environment = struct {
     ) catch unreachable;
 
     const State = enum {
-        uninit,
         init,
-        formatted,
+        superblock_format,
         superblock_open,
+        forest_init,
         forest_open,
-        forest_compacting,
-        forest_checkpointing,
-        superblock_checkpointing,
+        fuzzing,
+        forest_compact,
+        forest_checkpoint,
+        superblock_checkpoint,
     };
 
     state: State,
     storage: *Storage,
     message_pool: MessagePool,
     superblock: SuperBlock,
-    superblock_context: SuperBlock.Context = undefined,
+    superblock_context: SuperBlock.Context,
     grid: Grid,
     forest: Forest,
-    // We need @fieldParentPtr() of forest, so we can't use an optional Forest.
-    forest_exists: bool,
-    checkpoint_op: ?u64 = null,
+    checkpoint_op: ?u64,
 
-    fn init(env: *Environment, storage: *Storage) !void {
-        env.state = .uninit;
-
+    pub fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
+        var env: Environment = undefined;
+        env.state = .init;
         env.storage = storage;
-        errdefer env.storage.deinit(allocator);
 
         env.message_pool = try MessagePool.init(allocator, .replica);
-        errdefer env.message_pool.deinit(allocator);
+        defer env.message_pool.deinit(allocator);
 
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = env.storage,
             .storage_size_limit = constants.storage_size_max,
             .message_pool = &env.message_pool,
         });
-        errdefer env.superblock.deinit(allocator);
+        defer env.superblock.deinit(allocator);
 
         env.grid = try Grid.init(allocator, &env.superblock);
-        errdefer env.grid.deinit(allocator);
+        defer env.grid.deinit(allocator);
 
-        // Forest must be initialized with an open superblock.
         env.forest = undefined;
-        env.forest_exists = false;
+        env.checkpoint_op = null;
 
-        env.state = .init;
-    }
-
-    fn deinit(env: *Environment) void {
-        assert(env.state != .uninit);
-
-        if (env.forest_exists) {
-            env.forest.deinit(allocator);
-            env.forest_exists = false;
-        }
-        env.grid.deinit(allocator);
-        env.superblock.deinit(allocator);
-        env.message_pool.deinit(allocator);
-
-        env.state = .uninit;
-    }
-
-    fn tick(env: *Environment) void {
-        // env.grid.tick();
-        env.storage.tick();
-    }
-
-    fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
-        // Sometimes IO completes synchronously (eg if cached), so we might already be in next_state before ticking.
-        assert(env.state == current_state or env.state == next_state);
-        while (env.state == current_state) env.tick();
-        assert(env.state == next_state);
+        try env.open_then_apply(fuzz_ops);
     }
 
     fn change_state(env: *Environment, current_state: State, next_state: State) void {
@@ -140,79 +111,88 @@ const Environment = struct {
         env.state = next_state;
     }
 
-    pub fn format(storage: *Storage) !void {
-        var env: Environment = undefined;
+    fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
+        // Sometimes operations complete synchronously so we might already be in next_state before ticking.
+        //assert(env.state == current_state or env.state == next_state);
+        while (env.state == current_state) env.storage.tick();
+        assert(env.state == next_state);
+    }
 
-        try env.init(storage);
-        defer env.deinit();
-
-        assert(env.state == .init);
+    pub fn open_then_apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
+        env.change_state(.init, .superblock_format);
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
         });
-        env.tick_until_state_change(.init, .formatted);
+        
+        env.tick_until_state_change(.superblock_format, .superblock_open);
+        env.superblock.open(superblock_open_callback, &env.superblock_context);
+
+        env.tick_until_state_change(.superblock_open, .forest_init);
+        env.forest = try Forest.init(allocator, &env.grid, node_count, forest_options);
+        defer env.forest.deinit(allocator);
+
+        env.change_state(.forest_init, .forest_open);
+        env.forest.open(forest_open_callback);
+
+        env.tick_until_state_change(.forest_open, .fuzzing);
+        try env.apply(fuzz_ops);
     }
 
     fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
         const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.init, .formatted);
-    }
-
-    pub fn open(env: *Environment) void {
-        assert(env.state == .init);
-        env.superblock.open(superblock_open_callback, &env.superblock_context);
-        env.tick_until_state_change(.init, .forest_open);
+        env.change_state(.superblock_format, .superblock_open);
     }
 
     fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
         const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.init, .superblock_open);
-        env.forest = Forest.init(allocator, &env.grid, node_count, forest_options) catch unreachable;
-        env.forest_exists = true;
-        env.forest.open(forest_open_callback);
+        env.change_state(.superblock_open, .forest_init);
     }
 
     fn forest_open_callback(forest: *Forest) void {
         const env = @fieldParentPtr(@This(), "forest", forest);
-        env.change_state(.superblock_open, .forest_open);
+        env.change_state(.forest_open, .fuzzing);
     }
 
     pub fn compact(env: *Environment, op: u64) void {
-        env.change_state(.forest_open, .forest_compacting);
+        env.change_state(.fuzzing, .forest_compact);
         env.forest.compact(forest_compact_callback, op);
-        env.tick_until_state_change(.forest_compacting, .forest_open);
+        env.tick_until_state_change(.forest_compact, .fuzzing);
     }
 
     fn forest_compact_callback(forest: *Forest) void {
         const env = @fieldParentPtr(@This(), "forest", forest);
-        env.change_state(.forest_compacting, .forest_open);
+        env.change_state(.forest_compact, .fuzzing);
     }
 
     pub fn checkpoint(env: *Environment, op: u64) void {
+        assert(env.checkpoint_op == null);
         env.checkpoint_op = op - constants.lsm_batch_multiple;
-        env.change_state(.forest_open, .forest_checkpointing);
+
+        env.change_state(.fuzzing, .forest_checkpoint);
         env.forest.checkpoint(forest_checkpoint_callback);
-        env.tick_until_state_change(.forest_checkpointing, .superblock_checkpointing);
-        env.tick_until_state_change(.superblock_checkpointing, .forest_open);
+        env.tick_until_state_change(.forest_checkpoint, .superblock_checkpoint);
+        env.tick_until_state_change(.superblock_checkpoint, .fuzzing);
     }
 
     fn forest_checkpoint_callback(forest: *Forest) void {
         const env = @fieldParentPtr(@This(), "forest", forest);
-        env.change_state(.forest_checkpointing, .superblock_checkpointing);
+        const op = env.checkpoint_op.?;
+        env.checkpoint_op = null;
+
+        env.change_state(.forest_checkpoint, .superblock_checkpoint);
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
             .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
-            .commit_min = env.checkpoint_op.?,
-            .commit_max = env.checkpoint_op.? + 1,
+            .commit_min = op,
+            .commit_max = op + 1,
             .log_view = 0,
             .view = 0,
         });
-        env.checkpoint_op = null;
     }
 
     fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
         const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.superblock_checkpointing, .forest_open);
+        env.change_state(.superblock_checkpoint, .fuzzing);
     }
 
     fn prefetch_account(env: *Environment, id: u128) void {
@@ -230,31 +210,27 @@ const Environment = struct {
         groove.prefetch_setup(null);
         groove.prefetch_enqueue(id);
         groove.prefetch(Getter.prefetch_callback, &getter.prefetch_context);
-        while (!getter.finished) env.tick();
+        while (!getter.finished) env.storage.tick();
     }
 
-    fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
-        var env: Environment = undefined;
-
-        try env.init(storage);
-        defer env.deinit();
-
-        // Open the superblock then forest.
-        env.open();
-
+    fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
         // The forest should behave like a simple key-value data-structure.
         // We'll compare it to a hash map.
         var model = std.hash_map.AutoHashMap(u128, Account).init(allocator);
         defer model.deinit();
 
         for (fuzz_ops) |fuzz_op, fuzz_op_index| {
+            assert(env.state == .fuzzing);
             log.debug("Running fuzz_ops[{}/{}] == {}", .{ fuzz_op_index, fuzz_ops.len, fuzz_op });
-            const storage_size_used = storage.size_used();
-            log.debug("storage.size_used = {}/{}", .{ storage_size_used, storage.size });
+
+            const storage_size_used = env.storage.size_used();
+            log.debug("storage.size_used = {}/{}", .{ storage_size_used, env.storage.size });
+
             const model_size = model.count() * @sizeOf(Account);
             log.debug("space_amplification = {d:.2}", .{
                 @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
             });
+
             // Apply fuzz_op to the forest and the model.
             switch (fuzz_op) {
                 .compact => |compact| {
@@ -294,7 +270,6 @@ pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) 
     var storage = try Storage.init(allocator, constants.storage_size_max, storage_options);
     defer storage.deinit(allocator);
 
-    try Environment.format(&storage);
     try Environment.run(&storage, fuzz_ops);
 }
 

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -145,6 +145,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
 
         compaction_io_pending: usize,
         compaction_callback: ?fn (*Tree) void,
+        compaction_next_tick: Grid.NextTick = undefined,
 
         checkpoint_callback: ?fn (*Tree) void,
         open_callback: ?fn (*Tree) void,
@@ -568,8 +569,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                     tree.compact_mutable_table_into_immutable();
                 }
 
-                // TODO Defer this callback until tick() to avoid stack growth.
-                callback(tree);
+                tree.compaction_callback = callback;
+                tree.grid.on_next_tick(compact_skip_tick_callback, &tree.compaction_next_tick);
                 return;
             }
 
@@ -595,6 +596,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
 
             tree.compact_start(callback);
             tree.compact_drive();
+        }
+
+        fn compact_skip_tick_callback(next_tick: *Grid.NextTick) void {
+            const tree = @fieldParentPtr(Tree, "compaction_next_tick", next_tick);
+            const callback = tree.compaction_callback.?;
+            tree.compaction_callback = null;
+            callback(tree);
         }
 
         fn compact_start(tree: *Tree, callback: fn (*Tree) void) void {
@@ -866,7 +874,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 // We are at the end of a half-bar, but the compactions have not finished.
                 // We keep ticking them until they finish.
                 log.debug(tree_name ++ ": compact_done: driving outstanding compactions", .{});
-                tree.compact_drive();
+                tree.grid.on_next_tick(compact_drive_tick_callback, &tree.compaction_next_tick);
                 return;
             }
 
@@ -942,6 +950,16 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             // At the end of the second/fourth beat:
             // - Compact the manifest before invoking the compact() callback.
             tree.manifest.compact(compact_manifest_callback);
+        }
+
+        /// Asynchronously continue to drive the compactions when they haven't finished at the time
+        /// they were supposed to at the end of a half-bar.
+        fn compact_drive_tick_callback(next_tick: *Grid.NextTick) void {
+            const tree = @fieldParentPtr(Tree, "compaction_next_tick", next_tick);
+            assert(tree.compaction_io_pending == 0);
+            assert(tree.compaction_callback != null);
+            assert(tree.compaction_op == tree.lookup_snapshot_max);
+            tree.compact_drive();
         }
 
         /// Called after the last beat of a full compaction bar.

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -336,7 +336,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             }
 
             if (index_block_count == 0) {
-                callback(context, null);
+                context.callback = callback;
+                tree.grid.on_next_tick(lookup_invalid_tick_callback, &context.next_tick);
                 return;
             }
 
@@ -346,6 +347,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             context.* = .{
                 .tree = tree,
                 .completion = undefined,
+                .next_tick = undefined,
 
                 .key = key,
                 .fingerprint = fingerprint,
@@ -360,12 +362,18 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             context.read_index_block();
         }
 
+        fn lookup_invalid_tick_callback(next_tick: *Grid.NextTick) void {
+            const context = @fieldParentPtr(LookupContext, "next_tick", next_tick);
+            context.callback(context, null);
+        }
+
         pub const LookupContext = struct {
             const Read = Grid.Read;
             const BlockPtrConst = Grid.BlockPtrConst;
 
             tree: *Tree,
             completion: Read,
+            next_tick: Grid.NextTick,
 
             key: Key,
             fingerprint: bloom_filter.Fingerprint,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -108,7 +108,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             Key.tombstone_from_key,
             table_usage,
         );
-        
+
         const State = enum {
             init,
             superblock_format,
@@ -180,7 +180,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 .cluster = cluster,
                 .replica = replica,
             });
-            
+
             env.tick_until_state_change(.superblock_format, .superblock_open);
             env.superblock.open(superblock_open_callback, &env.superblock_context);
 
@@ -253,12 +253,12 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         pub fn get(env: *Environment, key: Key) ?*const Key.Value {
             env.change_state(.fuzzing, .tree_lookup);
-            
+
             if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max, key)) |value| {
                 env.change_state(.tree_lookup, .fuzzing);
                 return Tree.unwrap_tombstone(value);
             }
-            
+
             env.lookup_value = null;
             env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
             env.tick_until_state_change(.tree_lookup, .fuzzing);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -62,6 +62,7 @@ const Key = packed struct {
     }
 };
 
+const FuzzOpTag = std.meta.Tag(FuzzOp);
 const FuzzOp = union(enum) {
     // TODO Test range queries.
     compact: struct {
@@ -72,14 +73,13 @@ const FuzzOp = union(enum) {
     remove: Key.Value,
     get: Key,
 };
-const FuzzOpTag = std.meta.Tag(FuzzOp);
+
+const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
+const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
 
 const cluster = 32;
 const replica = 4;
 const node_count = 1024;
-const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
-const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
-
 const tree_options = .{
     .commit_entries_max = commit_entries_max,
     // This is the smallest size that set_associative_cache will allow us.
@@ -87,7 +87,6 @@ const tree_options = .{
 };
 
 const puts_since_compact_max = commit_entries_max;
-
 const compacts_per_checkpoint = std.math.divCeil(
     usize,
     constants.journal_slot_count,
@@ -98,6 +97,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
     return struct {
         const Environment = @This();
 
+        const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
         const Table = TableType(
             Key,
             Key.Value,
@@ -108,17 +108,17 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             Key.tombstone_from_key,
             table_usage,
         );
-        const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
-
+        
         const State = enum {
-            uninit,
             init,
-            formatted,
+            superblock_format,
             superblock_open,
+            tree_init,
             tree_open,
-            tree_compacting,
-            tree_checkpointing,
-            superblock_checkpointing,
+            fuzzing,
+            tree_compact,
+            tree_checkpoint,
+            superblock_checkpoint,
             tree_lookup,
         };
 
@@ -126,70 +126,40 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         storage: *Storage,
         message_pool: MessagePool,
         superblock: SuperBlock,
-        superblock_context: SuperBlock.Context = undefined,
+        superblock_context: SuperBlock.Context,
         grid: Grid,
         node_pool: NodePool,
         tree: Tree,
-        // We need @fieldParentPtr() of tree, so we can't use an optional Tree.
-        tree_exists: bool,
-        lookup_context: Tree.LookupContext = undefined,
-        lookup_value: ?*const Key.Value = null,
-        checkpoint_op: ?u64 = null,
+        lookup_context: Tree.LookupContext,
+        lookup_value: ?*const Key.Value,
+        checkpoint_op: ?u64,
 
-        fn init(env: *Environment, storage: *Storage) !void {
-            env.state = .uninit;
-
+        pub fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
+            var env: Environment = undefined;
+            env.state = .init;
             env.storage = storage;
-            errdefer env.storage.deinit(allocator);
 
             env.message_pool = try MessagePool.init(allocator, .replica);
-            errdefer env.message_pool.deinit(allocator);
+            defer env.message_pool.deinit(allocator);
 
             env.superblock = try SuperBlock.init(allocator, .{
                 .storage = env.storage,
                 .storage_size_limit = constants.storage_size_max,
                 .message_pool = &env.message_pool,
             });
-            errdefer env.superblock.deinit(allocator);
+            defer env.superblock.deinit(allocator);
 
             env.grid = try Grid.init(allocator, &env.superblock);
-            errdefer env.grid.deinit(allocator);
+            defer env.grid.deinit(allocator);
 
             env.node_pool = try NodePool.init(allocator, node_count);
-            errdefer env.node_pool.deinit(allocator);
+            defer env.node_pool.deinit(allocator);
 
-            // Tree must be initialized with an open superblock.
             env.tree = undefined;
-            env.tree_exists = false;
+            env.lookup_value = null;
+            env.checkpoint_op = null;
 
-            env.state = .init;
-        }
-
-        fn deinit(env: *Environment) void {
-            assert(env.state != .uninit);
-
-            if (env.tree_exists) {
-                env.tree.deinit(allocator);
-                env.tree_exists = false;
-            }
-            env.node_pool.deinit(allocator);
-            env.grid.deinit(allocator);
-            env.superblock.deinit(allocator);
-            env.message_pool.deinit(allocator);
-
-            env.state = .uninit;
-        }
-
-        fn tick(env: *Environment) void {
-            // env.grid.tick();
-            env.storage.tick();
-        }
-
-        fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
-            // Sometimes IO completes synchronously (eg if cached), so we might already be in next_state before ticking.
-            assert(env.state == current_state or env.state == next_state);
-            while (env.state == current_state) env.tick();
-            assert(env.state == next_state);
+            try env.open_then_apply(fuzz_ops);
         }
 
         fn change_state(env: *Environment, current_state: State, next_state: State) void {
@@ -197,123 +167,129 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.state = next_state;
         }
 
-        pub fn format(storage: *Storage) !void {
-            var env: Environment = undefined;
+        fn tick_until_state_change(env: *Environment, current_state: State, next_state: State) void {
+            // Sometimes operations complete synchronously so we might already be in next_state before ticking.
+            //assert(env.state == current_state or env.state == next_state);
+            while (env.state == current_state) env.storage.tick();
+            assert(env.state == next_state);
+        }
 
-            try env.init(storage);
-            defer env.deinit();
-
-            assert(env.state == .init);
+        pub fn open_then_apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
+            env.change_state(.init, .superblock_format);
             env.superblock.format(superblock_format_callback, &env.superblock_context, .{
                 .cluster = cluster,
                 .replica = replica,
             });
-            env.tick_until_state_change(.init, .formatted);
+            
+            env.tick_until_state_change(.superblock_format, .superblock_open);
+            env.superblock.open(superblock_open_callback, &env.superblock_context);
+
+            env.tick_until_state_change(.superblock_open, .tree_init);
+            env.tree = try Tree.init(allocator, &env.node_pool, &env.grid, tree_options);
+            defer env.tree.deinit(allocator);
+
+            env.change_state(.tree_init, .tree_open);
+            env.tree.open(tree_open_callback);
+
+            env.tick_until_state_change(.tree_open, .fuzzing);
+            try env.apply(fuzz_ops);
         }
 
         fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
             const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-            env.change_state(.init, .formatted);
-        }
-
-        pub fn open(env: *Environment) void {
-            assert(env.state == .init);
-            env.superblock.open(superblock_open_callback, &env.superblock_context);
-            env.tick_until_state_change(.init, .tree_open);
+            env.change_state(.superblock_format, .superblock_open);
         }
 
         fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
             const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-            env.change_state(.init, .superblock_open);
-            env.tree = Tree.init(allocator, &env.node_pool, &env.grid, tree_options) catch unreachable;
-            env.tree_exists = true;
-            env.tree.open(tree_open_callback);
+            env.change_state(.superblock_open, .tree_init);
         }
 
         fn tree_open_callback(tree: *Tree) void {
             const env = @fieldParentPtr(@This(), "tree", tree);
-            env.change_state(.superblock_open, .tree_open);
+            env.change_state(.tree_open, .fuzzing);
         }
 
         pub fn compact(env: *Environment, op: u64) void {
-            env.change_state(.tree_open, .tree_compacting);
+            env.change_state(.fuzzing, .tree_compact);
             env.tree.compact(tree_compact_callback, op);
-            env.tick_until_state_change(.tree_compacting, .tree_open);
+            env.tick_until_state_change(.tree_compact, .fuzzing);
         }
 
         fn tree_compact_callback(tree: *Tree) void {
             const env = @fieldParentPtr(@This(), "tree", tree);
-            env.change_state(.tree_compacting, .tree_open);
+            env.change_state(.tree_compact, .fuzzing);
         }
 
         pub fn checkpoint(env: *Environment, op: u64) void {
+            assert(env.checkpoint_op == null);
             env.checkpoint_op = op - constants.lsm_batch_multiple;
-            env.change_state(.tree_open, .tree_checkpointing);
+
+            env.change_state(.fuzzing, .tree_checkpoint);
             env.tree.checkpoint(tree_checkpoint_callback);
-            env.tick_until_state_change(.tree_checkpointing, .superblock_checkpointing);
-            env.tick_until_state_change(.superblock_checkpointing, .tree_open);
+            env.tick_until_state_change(.tree_checkpoint, .superblock_checkpoint);
+            env.tick_until_state_change(.superblock_checkpoint, .fuzzing);
         }
 
         fn tree_checkpoint_callback(tree: *Tree) void {
             const env = @fieldParentPtr(@This(), "tree", tree);
-            env.change_state(.tree_checkpointing, .superblock_checkpointing);
+            const op = env.checkpoint_op.?;
+            env.checkpoint_op = null;
+
+            env.change_state(.tree_checkpoint, .superblock_checkpoint);
             env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
                 .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
-                .commit_min = env.checkpoint_op.?,
-                .commit_max = env.checkpoint_op.? + 1,
+                .commit_min = op,
+                .commit_max = op + 1,
                 .log_view = 0,
                 .view = 0,
             });
-            env.checkpoint_op = null;
         }
 
         fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
             const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-            env.change_state(.superblock_checkpointing, .tree_open);
+            env.change_state(.superblock_checkpoint, .fuzzing);
         }
 
-        fn get(env: *Environment, key: Key) ?*const Key.Value {
+        pub fn get(env: *Environment, key: Key) ?*const Key.Value {
+            env.change_state(.fuzzing, .tree_lookup);
+            
             if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max, key)) |value| {
+                env.change_state(.tree_lookup, .fuzzing);
                 return Tree.unwrap_tombstone(value);
-            } else {
-                env.change_state(.tree_open, .tree_lookup);
-                env.lookup_context = undefined;
-                env.lookup_value = null;
-                env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
-                env.tick_until_state_change(.tree_lookup, .tree_open);
-                return env.lookup_value;
             }
+            
+            env.lookup_value = null;
+            env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max, key);
+            env.tick_until_state_change(.tree_lookup, .fuzzing);
+            return env.lookup_value;
         }
 
         fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Key.Value) void {
             const env = @fieldParentPtr(Environment, "lookup_context", lookup_context);
             assert(env.lookup_value == null);
             env.lookup_value = value;
-            env.change_state(.tree_lookup, .tree_open);
+            env.change_state(.tree_lookup, .fuzzing);
         }
 
-        fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
-            var env: Environment = undefined;
-
-            try env.init(storage);
-            defer env.deinit();
-
-            // Open the superblock then tree.
-            env.open();
-
+        pub fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
             // The tree should behave like a simple key-value data-structure.
             // We'll compare it to a hash map.
             var model = std.hash_map.AutoHashMap(Key, Key.Value).init(allocator);
             defer model.deinit();
 
             for (fuzz_ops) |fuzz_op, fuzz_op_index| {
+                assert(env.state == .fuzzing);
                 log.debug("Running fuzz_ops[{}/{}] == {}", .{ fuzz_op_index, fuzz_ops.len, fuzz_op });
-                const storage_size_used = storage.size_used();
-                log.debug("storage.size_used = {}/{}", .{ storage_size_used, storage.size });
+
+                const storage_size_used = env.storage.size_used();
+                log.debug("storage.size_used = {}/{}", .{ storage_size_used, env.storage.size });
+
                 const model_size = model.count() * @sizeOf(Key.Value);
                 log.debug("space_amplification = {d:.2}", .{
                     @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
                 });
+
                 // Apply fuzz_op to the tree and the model.
                 switch (fuzz_op) {
                     .compact => |compact| {
@@ -489,14 +465,10 @@ pub fn main() !void {
     // TODO Use inline switch after upgrading to zig 0.10
     switch (table_usage) {
         .general => {
-            const Environment = EnvironmentType(.general);
-            try Environment.format(&storage);
-            try Environment.run(&storage, fuzz_ops);
+            try EnvironmentType(.general).run(&storage, fuzz_ops);
         },
         .secondary_index => {
-            const Environment = EnvironmentType(.secondary_index);
-            try Environment.format(&storage);
-            try Environment.run(&storage, fuzz_ops);
+            try EnvironmentType(.secondary_index).run(&storage, fuzz_ops);
         },
     }
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -206,6 +206,8 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             assert(self.prefetch_input == null);
             assert(self.prefetch_callback == null);
 
+            // NOTE: prefetch(.register)'s callback should end up calling commit()
+            // (which is always async) instead of recursing, so this inline callback is fine.
             if (operation == .register) {
                 callback(self);
                 return;

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -131,9 +131,9 @@ pub const Storage = struct {
             error.Unexpected => unreachable,
         };
 
-        var queue = storage.next_tick_queue;
-        storage.next_tick_queue = .{};
-        while (queue.pop()) |next_tick| next_tick.callback(next_tick);
+        while (storage.next_tick_queue.pop()) |next_tick| {
+            next_tick.callback(next_tick);
+        }
     }
 
     pub fn read_sectors(

--- a/src/test/storage.zig
+++ b/src/test/storage.zig
@@ -263,9 +263,9 @@ pub const Storage = struct {
             storage.write_sectors_finish(write);
         }
 
-        var queue = storage.next_tick_queue;
-        storage.next_tick_queue = .{};
-        while (queue.pop()) |next_tick| next_tick.callback(next_tick);
+        while (storage.next_tick_queue.pop()) |next_tick| {
+            next_tick.callback(next_tick);
+        }
     }
 
     pub fn on_next_tick(


### PR DESCRIPTION
Around the codebase, some functions which take a callback may resolve them immediately. Resolving them like this can cause issues for the caller if it expected them to be resolved asynchronously to it. It could also result in a stack overflow if the callback re-invokes the caller. This PR enforces enforces callbacks to be resolved asynchronously to the callers for Tree compact drive and Tree lookup by utilizing `Grid/Storage.on_next_tick`.

Asynchronous callbacks were NOT added to the following:
- `StateMachine.prefetch` as the comment notes that the callback should always end up doing something asynchronous and never recursing into itself.
- `Journal.read/write_prepare*` as they take no Context to store the `Storage.NextTick` node and it becomes complicated to dynamically allocate and free them out of band to the functions.

Also took the opportunity to cleanup `forest/tree_fuzz.zig` with regards to Environment state transitions and resource init/free.

Also *also* made Storage next_tick queues get drained instead of processing only existing nodes. This seems to decrease benchmark latency from going through the IO path less often.