### PR TITLE
Make Cluster generic over StateMachine

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -9,9 +9,9 @@ const vsr = @import("vsr.zig");
 const Header = vsr.Header;
 
 const Client = @import("test/cluster.zig").Client;
-const Cluster = @import("test/cluster.zig").Cluster;
+const Cluster = @import("test/cluster.zig").ClusterType(constants.StateMachineType);
 const Replica = @import("test/cluster.zig").Replica;
-const StateMachine = @import("test/cluster.zig").StateMachine;
+const StateMachine = Cluster.StateMachine;
 const Failure = @import("test/cluster.zig").Failure;
 const PartitionMode = @import("test/packet_simulator.zig").PartitionMode;
 const ReplySequence = @import("test/reply_sequence.zig").ReplySequence;

--- a/src/test/cluster.zig
+++ b/src/test/cluster.zig
@@ -7,9 +7,6 @@ const message_pool = @import("../message_pool.zig");
 const MessagePool = message_pool.MessagePool;
 const Message = MessagePool.Message;
 
-pub const StateMachine = constants.StateMachineType(Storage, .{
-    .message_body_size_max = constants.message_body_size_max,
-});
 const Storage = @import("storage.zig").Storage;
 const StorageFaultAtlas = @import("storage.zig").ClusterFaultAtlas;
 const Time = @import("time.zig").Time;
@@ -18,28 +15,13 @@ const IdPermutation = @import("id.zig").IdPermutation;
 const MessageBus = @import("cluster/message_bus.zig").MessageBus;
 const Network = @import("cluster/network.zig").Network;
 const NetworkOptions = @import("cluster/network.zig").NetworkOptions;
-const StateChecker = @import("cluster/state_checker.zig").StateChecker;
-const StorageChecker = @import("cluster/storage_checker.zig").StorageChecker;
+const StateCheckerType = @import("cluster/state_checker.zig").StateCheckerType;
+const StorageCheckerType = @import("cluster/storage_checker.zig").StorageCheckerType;
 
 const vsr = @import("../vsr.zig");
-pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time);
 pub const ReplicaFormat = vsr.ReplicaFormatType(Storage);
-pub const Client = vsr.Client(StateMachine, MessageBus);
 const SuperBlock = vsr.SuperBlockType(Storage);
 const superblock_zone_size = @import("../vsr/superblock.zig").superblock_zone_size;
-
-const ClusterOptions = struct {
-    cluster_id: u32,
-    replica_count: u8,
-    client_count: u8,
-    storage_size_limit: u64,
-    storage_fault_atlas: StorageFaultAtlas.Options,
-    seed: u64,
-
-    network: NetworkOptions,
-    storage: Storage.Options,
-    state_machine: StateMachine.Options,
-};
 
 pub const ReplicaHealth = enum { up, down };
 
@@ -57,476 +39,499 @@ pub const Failure = enum(u8) {
 /// with a replica index.
 const client_id_permutation_shift = constants.replicas_max;
 
-pub const Cluster = struct {
-    pub const Options = ClusterOptions;
+pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, comptime constants: anytype) type) type {
+    return struct {
+        const Self = @This();
 
-    allocator: mem.Allocator,
-    options: ClusterOptions,
-    on_client_reply: fn (
-        cluster: *Cluster,
-        client: usize,
-        request: *Message,
-        reply: *Message,
-    ) void,
+        pub const StateMachine = StateMachineType(Storage, .{
+            .message_body_size_max = constants.message_body_size_max,
+        });
+        pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time);
+        pub const Client = vsr.Client(StateMachine, MessageBus);
+        pub const StateChecker = StateCheckerType(Client, Replica);
+        pub const StorageChecker = StorageCheckerType(Replica);
 
-    network: *Network,
-    storages: []Storage,
-    storage_fault_atlas: *StorageFaultAtlas,
-    replicas: []Replica,
-    replica_pools: []MessagePool,
-    replica_health: []ReplicaHealth,
+        pub const Options = struct {
+            cluster_id: u32,
+            replica_count: u8,
+            client_count: u8,
+            storage_size_limit: u64,
+            storage_fault_atlas: StorageFaultAtlas.Options,
+            seed: u64,
 
-    clients: []Client,
-    client_pools: []MessagePool,
-    client_id_permutation: IdPermutation,
+            network: NetworkOptions,
+            storage: Storage.Options,
+            state_machine: StateMachine.Options,
+        };
 
-    state_checker: StateChecker,
-    storage_checker: StorageChecker,
-
-    context: ?*anyopaque = null,
-
-    pub fn init(
         allocator: mem.Allocator,
-        /// Includes command=register messages.
+        options: Options,
         on_client_reply: fn (
-            cluster: *Cluster,
+            cluster: *Self,
             client: usize,
             request: *Message,
             reply: *Message,
         ) void,
-        options: ClusterOptions,
-    ) !*Cluster {
-        assert(options.replica_count >= 1);
-        assert(options.replica_count <= 6);
-        assert(options.client_count > 0);
-        assert(options.storage_size_limit % constants.sector_size == 0);
-        assert(options.storage_size_limit <= constants.storage_size_max);
-        assert(options.storage.replica_index == null);
-        assert(options.storage.fault_atlas == null);
 
-        var prng = std.rand.DefaultPrng.init(options.seed);
-        const random = prng.random();
+        network: *Network,
+        storages: []Storage,
+        storage_fault_atlas: *StorageFaultAtlas,
+        replicas: []Replica,
+        replica_pools: []MessagePool,
+        replica_health: []ReplicaHealth,
 
-        // TODO(Zig) Client.init()'s MessagePool.Options require a reference to the network — use
-        // @returnAddress() instead.
-        var network = try allocator.create(Network);
-        errdefer allocator.destroy(network);
+        clients: []Client,
+        client_pools: []MessagePool,
+        client_id_permutation: IdPermutation,
 
-        network.* = try Network.init(
-            allocator,
-            options.replica_count,
-            options.client_count,
-            options.network,
-        );
-        errdefer network.deinit();
+        state_checker: StateChecker,
+        storage_checker: StorageChecker,
 
-        // TODO(Zig) @returnAddress()
-        var storage_fault_atlas = try allocator.create(StorageFaultAtlas);
-        errdefer allocator.destroy(storage_fault_atlas);
+        context: ?*anyopaque = null,
 
-        storage_fault_atlas.* = StorageFaultAtlas.init(
-            options.replica_count,
-            random,
-            options.storage_fault_atlas,
-        );
+        pub fn init(
+            allocator: mem.Allocator,
+            /// Includes command=register messages.
+            on_client_reply: fn (
+                cluster: *Self,
+                client: usize,
+                request: *Message,
+                reply: *Message,
+            ) void,
+            options: Options,
+        ) !*Self {
+            assert(options.replica_count >= 1);
+            assert(options.replica_count <= 6);
+            assert(options.client_count > 0);
+            assert(options.storage_size_limit % constants.sector_size == 0);
+            assert(options.storage_size_limit <= constants.storage_size_max);
+            assert(options.storage.replica_index == null);
+            assert(options.storage.fault_atlas == null);
 
-        const storages = try allocator.alloc(Storage, options.replica_count);
-        errdefer allocator.free(storages);
+            var prng = std.rand.DefaultPrng.init(options.seed);
+            const random = prng.random();
 
-        for (storages) |*storage, replica_index| {
-            var storage_options = options.storage;
-            storage_options.replica_index = @intCast(u8, replica_index);
-            storage_options.fault_atlas = storage_fault_atlas;
-            storage.* = try Storage.init(allocator, options.storage_size_limit, storage_options);
-            // Disable most faults at startup, so that the replicas don't get stuck in recovery mode.
-            storage.faulty = replica_index >= vsr.quorums(options.replica_count).view_change;
-        }
-        errdefer for (storages) |*storage| storage.deinit(allocator);
+            // TODO(Zig) Client.init()'s MessagePool.Options require a reference to the network — use
+            // @returnAddress() instead.
+            var network = try allocator.create(Network);
+            errdefer allocator.destroy(network);
 
-        var replica_pools = try allocator.alloc(MessagePool, options.replica_count);
-        errdefer allocator.free(replica_pools);
-
-        for (replica_pools) |*pool, i| {
-            errdefer for (replica_pools[0..i]) |*p| p.deinit(allocator);
-            pool.* = try MessagePool.init(allocator, .replica);
-        }
-        errdefer for (replica_pools) |*pool| pool.deinit(allocator);
-
-        const replicas = try allocator.alloc(Replica, options.replica_count);
-        errdefer allocator.free(replicas);
-
-        const replica_health = try allocator.alloc(ReplicaHealth, options.replica_count);
-        errdefer allocator.free(replica_health);
-        mem.set(ReplicaHealth, replica_health, .up);
-
-        var client_pools = try allocator.alloc(MessagePool, options.client_count);
-        errdefer allocator.free(client_pools);
-
-        for (client_pools) |*pool, i| {
-            errdefer for (client_pools[0..i]) |*p| p.deinit(allocator);
-            pool.* = try MessagePool.init(allocator, .client);
-        }
-        errdefer for (replica_pools) |*pool| pool.deinit(allocator);
-
-        const client_id_permutation = IdPermutation.generate(random);
-        var clients = try allocator.alloc(Client, options.client_count);
-        errdefer allocator.free(clients);
-
-        for (clients) |*client, i| {
-            errdefer for (clients[0..i]) |*c| c.deinit(allocator);
-            client.* = try Client.init(
+            network.* = try Network.init(
                 allocator,
-                client_id_permutation.encode(i + client_id_permutation_shift),
-                options.cluster_id,
                 options.replica_count,
-                &client_pools[i],
-                .{ .network = network },
+                options.client_count,
+                options.network,
             );
-            network.link(client.message_bus.process, &client.message_bus);
-        }
-        errdefer for (clients) |*c| c.deinit(allocator);
+            errdefer network.deinit();
 
-        var state_checker =
-            try StateChecker.init(allocator, options.cluster_id, replicas, clients);
-        errdefer state_checker.deinit();
+            // TODO(Zig) @returnAddress()
+            var storage_fault_atlas = try allocator.create(StorageFaultAtlas);
+            errdefer allocator.destroy(storage_fault_atlas);
 
-        var storage_checker = StorageChecker.init(allocator);
-        errdefer storage_checker.deinit();
-
-        // Format each replica's storage (equivalent to "tigerbeetle format ...").
-        for (storages) |*storage, replica_index| {
-            var superblock = try SuperBlock.init(allocator, .{
-                .storage = storage,
-                .message_pool = &replica_pools[replica_index],
-                .storage_size_limit = options.storage_size_limit,
-            });
-            defer superblock.deinit(allocator);
-
-            try vsr.format(
-                Storage,
-                allocator,
-                options.cluster_id,
-                @intCast(u8, replica_index),
-                storage,
-                &superblock,
+            storage_fault_atlas.* = StorageFaultAtlas.init(
+                options.replica_count,
+                random,
+                options.storage_fault_atlas,
             );
-        }
 
-        // We must heap-allocate the cluster since its pointer will be attached to the replica.
-        // TODO(Zig) @returnAddress().
-        var cluster = try allocator.create(Cluster);
-        errdefer allocator.destroy(cluster);
+            const storages = try allocator.alloc(Storage, options.replica_count);
+            errdefer allocator.free(storages);
 
-        cluster.* = Cluster{
-            .allocator = allocator,
-            .options = options,
-            .on_client_reply = on_client_reply,
-            .network = network,
-            .storages = storages,
-            .storage_fault_atlas = storage_fault_atlas,
-            .replicas = replicas,
-            .replica_pools = replica_pools,
-            .replica_health = replica_health,
-            .clients = clients,
-            .client_pools = client_pools,
-            .client_id_permutation = client_id_permutation,
-            .state_checker = state_checker,
-            .storage_checker = storage_checker,
-        };
-
-        for (cluster.replicas) |_, replica_index| {
-            try cluster.open_replica(@intCast(u8, replica_index), .{
-                .resolution = constants.tick_ms * std.time.ns_per_ms,
-                .offset_type = .linear,
-                .offset_coefficient_A = 0,
-                .offset_coefficient_B = 0,
-            });
-        }
-        errdefer for (cluster.replicas) |*replica| replica.deinit(allocator);
-
-        return cluster;
-    }
-
-    pub fn deinit(cluster: *Cluster) void {
-        cluster.storage_checker.deinit();
-        cluster.state_checker.deinit();
-        cluster.network.deinit();
-        for (cluster.clients) |*client| client.deinit(cluster.allocator);
-        for (cluster.client_pools) |*pool| pool.deinit(cluster.allocator);
-        for (cluster.replicas) |*replica| replica.deinit(cluster.allocator);
-        for (cluster.replica_pools) |*pool| pool.deinit(cluster.allocator);
-        for (cluster.storages) |*storage| storage.deinit(cluster.allocator);
-
-        cluster.allocator.free(cluster.clients);
-        cluster.allocator.free(cluster.client_pools);
-        cluster.allocator.free(cluster.replicas);
-        cluster.allocator.free(cluster.replica_health);
-        cluster.allocator.free(cluster.replica_pools);
-        cluster.allocator.free(cluster.storages);
-        cluster.allocator.destroy(cluster.storage_fault_atlas);
-        cluster.allocator.destroy(cluster.network);
-        cluster.allocator.destroy(cluster);
-    }
-
-    pub fn tick(cluster: *Cluster) void {
-        cluster.network.tick();
-
-        for (cluster.clients) |*client| client.tick();
-        for (cluster.storages) |*storage| storage.tick();
-        for (cluster.replicas) |*replica, i| {
-            switch (cluster.replica_health[i]) {
-                .up => replica.tick(),
-                // Keep ticking the time so that it won't have diverged too far to synchronize
-                // when the replica restarts.
-                .down => replica.clock.time.tick(),
+            for (storages) |*storage, replica_index| {
+                var storage_options = options.storage;
+                storage_options.replica_index = @intCast(u8, replica_index);
+                storage_options.fault_atlas = storage_fault_atlas;
+                storage.* = try Storage.init(allocator, options.storage_size_limit, storage_options);
+                // Disable most faults at startup, so that the replicas don't get stuck in recovery mode.
+                storage.faulty = replica_index >= vsr.quorums(options.replica_count).view_change;
             }
-            on_replica_change_state(replica);
-        }
-    }
+            errdefer for (storages) |*storage| storage.deinit(allocator);
 
-    pub fn restart_replica(cluster: *Cluster, replica_index: u8) void {
-        assert(cluster.replica_health[replica_index] == .down);
+            var replica_pools = try allocator.alloc(MessagePool, options.replica_count);
+            errdefer allocator.free(replica_pools);
 
-        cluster.network.process_enable(.{ .replica = replica_index });
-        cluster.replica_health[replica_index] = .up;
-    }
-
-    /// Reset a replica to its initial state, simulating a random crash/panic.
-    /// Leave the persistent storage untouched, and leave any currently
-    /// inflight messages to/from the replica in the network.
-    ///
-    /// Returns whether the replica was crashed.
-    /// Returns an error when the replica was unable to recover (open).
-    pub fn crash_replica(cluster: *Cluster, replica_index: u8) !bool {
-        assert(cluster.replica_health[replica_index] == .up);
-
-        const replica = &cluster.replicas[replica_index];
-        if (replica.op == 0) {
-            // Only crash when `replica.op > 0` — an empty WAL would skip recovery after a crash.
-            return false;
-        }
-
-        // TODO Remove this workaround when VSR recovery protocol is disabled.
-        for (replica.journal.prepare_inhabited) |inhabited, i| {
-            if (i == 0) {
-                // Ignore the root header.
-            } else {
-                if (inhabited) break;
+            for (replica_pools) |*pool, i| {
+                errdefer for (replica_pools[0..i]) |*p| p.deinit(allocator);
+                pool.* = try MessagePool.init(allocator, .replica);
             }
-        } else {
-            // Only crash when at least one header has been written to the WAL.
-            // An empty WAL would skip recovery after a crash.
-            return false;
-        }
+            errdefer for (replica_pools) |*pool| pool.deinit(allocator);
 
-        // Ensure that the cluster can eventually recover without this replica.
-        // Verify that each op is recoverable by the current healthy cluster (minus the replica we
-        // are trying to crash).
-        // TODO Remove this workaround when VSR recovery protocol is disabled.
-        if (cluster.options.replica_count != 1) {
-            var parent: u128 = undefined;
-            const cluster_op_max = op_max: {
-                var v: ?u32 = null;
-                var op_max: ?u64 = null;
-                for (cluster.replicas) |other_replica, i| {
-                    if (cluster.replica_health[i] == .down) continue;
-                    if (other_replica.status == .recovering) continue;
+            const replicas = try allocator.alloc(Replica, options.replica_count);
+            errdefer allocator.free(replicas);
 
-                    if (v == null or other_replica.log_view > v.? or
-                        (other_replica.log_view == v.? and other_replica.op > op_max.?))
-                    {
-                        v = other_replica.log_view;
-                        op_max = other_replica.op;
-                        parent = other_replica.journal.header_with_op(op_max.?).?.checksum;
-                    }
-                }
-                break :op_max op_max.?;
+            const replica_health = try allocator.alloc(ReplicaHealth, options.replica_count);
+            errdefer allocator.free(replica_health);
+            mem.set(ReplicaHealth, replica_health, .up);
+
+            var client_pools = try allocator.alloc(MessagePool, options.client_count);
+            errdefer allocator.free(client_pools);
+
+            for (client_pools) |*pool, i| {
+                errdefer for (client_pools[0..i]) |*p| p.deinit(allocator);
+                pool.* = try MessagePool.init(allocator, .client);
+            }
+            errdefer for (replica_pools) |*pool| pool.deinit(allocator);
+
+            const client_id_permutation = IdPermutation.generate(random);
+            var clients = try allocator.alloc(Client, options.client_count);
+            errdefer allocator.free(clients);
+
+            for (clients) |*client, i| {
+                errdefer for (clients[0..i]) |*c| c.deinit(allocator);
+                client.* = try Client.init(
+                    allocator,
+                    client_id_permutation.encode(i + client_id_permutation_shift),
+                    options.cluster_id,
+                    options.replica_count,
+                    &client_pools[i],
+                    .{ .network = network },
+                );
+                network.link(client.message_bus.process, &client.message_bus);
+            }
+            errdefer for (clients) |*c| c.deinit(allocator);
+
+            var state_checker =
+                try StateChecker.init(allocator, options.cluster_id, replicas, clients);
+            errdefer state_checker.deinit();
+
+            var storage_checker = StorageChecker.init(allocator);
+            errdefer storage_checker.deinit();
+
+            // Format each replica's storage (equivalent to "tigerbeetle format ...").
+            for (storages) |*storage, replica_index| {
+                var superblock = try SuperBlock.init(allocator, .{
+                    .storage = storage,
+                    .message_pool = &replica_pools[replica_index],
+                    .storage_size_limit = options.storage_size_limit,
+                });
+                defer superblock.deinit(allocator);
+
+                try vsr.format(
+                    Storage,
+                    allocator,
+                    options.cluster_id,
+                    @intCast(u8, replica_index),
+                    storage,
+                    &superblock,
+                );
+            }
+
+            // We must heap-allocate the cluster since its pointer will be attached to the replica.
+            // TODO(Zig) @returnAddress().
+            var cluster = try allocator.create(Self);
+            errdefer allocator.destroy(cluster);
+
+            cluster.* = Self{
+                .allocator = allocator,
+                .options = options,
+                .on_client_reply = on_client_reply,
+                .network = network,
+                .storages = storages,
+                .storage_fault_atlas = storage_fault_atlas,
+                .replicas = replicas,
+                .replica_pools = replica_pools,
+                .replica_health = replica_health,
+                .clients = clients,
+                .client_pools = client_pools,
+                .client_id_permutation = client_id_permutation,
+                .state_checker = state_checker,
+                .storage_checker = storage_checker,
             };
 
-            // This whole workaround doesn't handle log wrapping correctly.
-            // If the log has wrapped, don't crash the replica.
-            if (cluster_op_max >= constants.journal_slot_count) {
+            for (cluster.replicas) |_, replica_index| {
+                try cluster.open_replica(@intCast(u8, replica_index), .{
+                    .resolution = constants.tick_ms * std.time.ns_per_ms,
+                    .offset_type = .linear,
+                    .offset_coefficient_A = 0,
+                    .offset_coefficient_B = 0,
+                });
+            }
+            errdefer for (cluster.replicas) |*replica| replica.deinit(allocator);
+
+            return cluster;
+        }
+
+        pub fn deinit(cluster: *Self) void {
+            cluster.storage_checker.deinit();
+            cluster.state_checker.deinit();
+            cluster.network.deinit();
+            for (cluster.clients) |*client| client.deinit(cluster.allocator);
+            for (cluster.client_pools) |*pool| pool.deinit(cluster.allocator);
+            for (cluster.replicas) |*replica| replica.deinit(cluster.allocator);
+            for (cluster.replica_pools) |*pool| pool.deinit(cluster.allocator);
+            for (cluster.storages) |*storage| storage.deinit(cluster.allocator);
+
+            cluster.allocator.free(cluster.clients);
+            cluster.allocator.free(cluster.client_pools);
+            cluster.allocator.free(cluster.replicas);
+            cluster.allocator.free(cluster.replica_health);
+            cluster.allocator.free(cluster.replica_pools);
+            cluster.allocator.free(cluster.storages);
+            cluster.allocator.destroy(cluster.storage_fault_atlas);
+            cluster.allocator.destroy(cluster.network);
+            cluster.allocator.destroy(cluster);
+        }
+
+        pub fn tick(cluster: *Self) void {
+            cluster.network.tick();
+
+            for (cluster.clients) |*client| client.tick();
+            for (cluster.storages) |*storage| storage.tick();
+            for (cluster.replicas) |*replica, i| {
+                switch (cluster.replica_health[i]) {
+                    .up => replica.tick(),
+                    // Keep ticking the time so that it won't have diverged too far to synchronize
+                    // when the replica restarts.
+                    .down => replica.clock.time.tick(),
+                }
+                on_replica_change_state(replica);
+            }
+        }
+
+        pub fn restart_replica(cluster: *Self, replica_index: u8) void {
+            assert(cluster.replica_health[replica_index] == .down);
+
+            cluster.network.process_enable(.{ .replica = replica_index });
+            cluster.replica_health[replica_index] = .up;
+        }
+
+        /// Reset a replica to its initial state, simulating a random crash/panic.
+        /// Leave the persistent storage untouched, and leave any currently
+        /// inflight messages to/from the replica in the network.
+        ///
+        /// Returns whether the replica was crashed.
+        /// Returns an error when the replica was unable to recover (open).
+        pub fn crash_replica(cluster: *Self, replica_index: u8) !bool {
+            assert(cluster.replica_health[replica_index] == .up);
+
+            const replica = &cluster.replicas[replica_index];
+            if (replica.op == 0) {
+                // Only crash when `replica.op > 0` — an empty WAL would skip recovery after a crash.
                 return false;
             }
 
-            var op: u64 = cluster_op_max + 1;
-            while (op > 0) {
-                op -= 1;
-
-                var cluster_op_known: bool = false;
-                for (cluster.replicas) |other_replica, i| {
-                    // Ignore replicas that are ineligible to assist recovery.
-                    if (replica_index == i) continue;
-                    if (cluster.replica_health[i] == .down) continue;
-                    if (other_replica.status == .recovering) continue;
-
-                    if (other_replica.journal.header_with_op_and_checksum(op, parent)) |header| {
-                        parent = header.parent;
-                        if (!other_replica.journal.dirty.bit(.{ .index = op })) {
-                            // The op is recoverable if this replica crashes.
-                            break;
-                        }
-                        cluster_op_known = true;
-                    }
+            // TODO Remove this workaround when VSR recovery protocol is disabled.
+            for (replica.journal.prepare_inhabited) |inhabited, i| {
+                if (i == 0) {
+                    // Ignore the root header.
                 } else {
-                    if (op == cluster_op_max and !cluster_op_known) {
-                        // The replica can crash; it will be able to truncate the last op.
-                    } else {
-                        // The op isn't recoverable if this replica is crashed.
-                        return false;
-                    }
+                    if (inhabited) break;
                 }
+            } else {
+                // Only crash when at least one header has been written to the WAL.
+                // An empty WAL would skip recovery after a crash.
+                return false;
             }
 
-            // We can't crash this replica because without it we won't be able to repair a broken
-            // hash chain.
-            if (parent != 0) return false;
+            // Ensure that the cluster can eventually recover without this replica.
+            // Verify that each op is recoverable by the current healthy cluster (minus the replica we
+            // are trying to crash).
+            // TODO Remove this workaround when VSR recovery protocol is disabled.
+            if (cluster.options.replica_count != 1) {
+                var parent: u128 = undefined;
+                const cluster_op_max = op_max: {
+                    var v: ?u32 = null;
+                    var op_max: ?u64 = null;
+                    for (cluster.replicas) |other_replica, i| {
+                        if (cluster.replica_health[i] == .down) continue;
+                        if (other_replica.status == .recovering) continue;
+
+                        if (v == null or other_replica.log_view > v.? or
+                            (other_replica.log_view == v.? and other_replica.op > op_max.?))
+                        {
+                            v = other_replica.log_view;
+                            op_max = other_replica.op;
+                            parent = other_replica.journal.header_with_op(op_max.?).?.checksum;
+                        }
+                    }
+                    break :op_max op_max.?;
+                };
+
+                // This whole workaround doesn't handle log wrapping correctly.
+                // If the log has wrapped, don't crash the replica.
+                if (cluster_op_max >= constants.journal_slot_count) {
+                    return false;
+                }
+
+                var op: u64 = cluster_op_max + 1;
+                while (op > 0) {
+                    op -= 1;
+
+                    var cluster_op_known: bool = false;
+                    for (cluster.replicas) |other_replica, i| {
+                        // Ignore replicas that are ineligible to assist recovery.
+                        if (replica_index == i) continue;
+                        if (cluster.replica_health[i] == .down) continue;
+                        if (other_replica.status == .recovering) continue;
+
+                        if (other_replica.journal.header_with_op_and_checksum(op, parent)) |header| {
+                            parent = header.parent;
+                            if (!other_replica.journal.dirty.bit(.{ .index = op })) {
+                                // The op is recoverable if this replica crashes.
+                                break;
+                            }
+                            cluster_op_known = true;
+                        }
+                    } else {
+                        if (op == cluster_op_max and !cluster_op_known) {
+                            // The replica can crash; it will be able to truncate the last op.
+                        } else {
+                            // The op isn't recoverable if this replica is crashed.
+                            return false;
+                        }
+                    }
+                }
+
+                // We can't crash this replica because without it we won't be able to repair a broken
+                // hash chain.
+                if (parent != 0) return false;
+            }
+
+            cluster.replica_health[replica_index] = .down;
+
+            // Reset the storage before the replica so that pending writes can (partially) finish.
+            cluster.storages[replica_index].reset();
+            const replica_time = replica.time;
+            replica.deinit(cluster.allocator);
+            cluster.network.process_disable(.{ .replica = replica_index });
+
+            // Ensure that none of the replica's messages leaked when it was deinitialized.
+            var messages_in_pool: usize = 0;
+            const message_bus = cluster.network.get_message_bus(.{ .replica = replica_index });
+            {
+                var it = message_bus.pool.free_list;
+                while (it) |message| : (it = message.next) messages_in_pool += 1;
+            }
+            assert(messages_in_pool == message_pool.messages_max_replica);
+
+            // Logically it would make more sense to run this during restart, not immediately following
+            // the crash. But having it here allows the replica's MessageBus to initialize and begin
+            // queueing packets.
+            //
+            // Pass the old replica's Time through to the new replica. It will continue to tick while
+            // the replica is crashed, to ensure the clocks don't desyncronize too far to recover.
+            try cluster.open_replica(replica_index, replica_time);
+
+            return true;
         }
 
-        cluster.replica_health[replica_index] = .down;
-
-        // Reset the storage before the replica so that pending writes can (partially) finish.
-        cluster.storages[replica_index].reset();
-        const replica_time = replica.time;
-        replica.deinit(cluster.allocator);
-        cluster.network.process_disable(.{ .replica = replica_index });
-
-        // Ensure that none of the replica's messages leaked when it was deinitialized.
-        var messages_in_pool: usize = 0;
-        const message_bus = cluster.network.get_message_bus(.{ .replica = replica_index });
-        {
-            var it = message_bus.pool.free_list;
-            while (it) |message| : (it = message.next) messages_in_pool += 1;
+        /// Returns the number of replicas capable of helping a crashed node recover (i.e. with
+        /// replica.status=normal).
+        pub fn replica_normal_count(cluster: *const Self) u8 {
+            var count: u8 = 0;
+            for (cluster.replicas) |*replica| {
+                if (replica.status == .normal) count += 1;
+            }
+            return count;
         }
-        assert(messages_in_pool == message_pool.messages_max_replica);
 
-        // Logically it would make more sense to run this during restart, not immediately following
-        // the crash. But having it here allows the replica's MessageBus to initialize and begin
-        // queueing packets.
-        //
-        // Pass the old replica's Time through to the new replica. It will continue to tick while
-        // the replica is crashed, to ensure the clocks don't desyncronize too far to recover.
-        try cluster.open_replica(replica_index, replica_time);
+        fn open_replica(cluster: *Self, replica_index: u8, time: Time) !void {
+            var replica = &cluster.replicas[replica_index];
+            try replica.open(
+                cluster.allocator,
+                .{
+                    .replica_count = @intCast(u8, cluster.replicas.len),
+                    .storage = &cluster.storages[replica_index],
+                    // TODO Test restarting with a higher storage limit.
+                    .storage_size_limit = cluster.options.storage_size_limit,
+                    .message_pool = &cluster.replica_pools[replica_index],
+                    .time = time,
+                    .state_machine_options = cluster.options.state_machine,
+                    .message_bus_options = .{ .network = cluster.network },
+                },
+            );
+            assert(replica.cluster == cluster.options.cluster_id);
+            assert(replica.replica == replica_index);
+            assert(replica.replica_count == cluster.replicas.len);
 
-        return true;
-    }
-
-    /// Returns the number of replicas capable of helping a crashed node recover (i.e. with
-    /// replica.status=normal).
-    pub fn replica_normal_count(cluster: *const Cluster) u8 {
-        var count: u8 = 0;
-        for (cluster.replicas) |*replica| {
-            if (replica.status == .normal) count += 1;
+            replica.context = cluster;
+            replica.on_change_state = on_replica_change_state;
+            replica.on_compact = on_replica_compact;
+            replica.on_checkpoint = on_replica_checkpoint;
+            cluster.network.link(replica.message_bus.process, &replica.message_bus);
         }
-        return count;
-    }
 
-    fn open_replica(cluster: *Cluster, replica_index: u8, time: Time) !void {
-        var replica = &cluster.replicas[replica_index];
-        try replica.open(
-            cluster.allocator,
-            .{
-                .replica_count = @intCast(u8, cluster.replicas.len),
-                .storage = &cluster.storages[replica_index],
-                // TODO Test restarting with a higher storage limit.
-                .storage_size_limit = cluster.options.storage_size_limit,
-                .message_pool = &cluster.replica_pools[replica_index],
-                .time = time,
-                .state_machine_options = cluster.options.state_machine,
-                .message_bus_options = .{ .network = cluster.network },
-            },
-        );
-        assert(replica.cluster == cluster.options.cluster_id);
-        assert(replica.replica == replica_index);
-        assert(replica.replica_count == cluster.replicas.len);
+        pub fn request(
+            cluster: *Self,
+            client_index: usize,
+            request_operation: StateMachine.Operation,
+            request_message: *Message,
+            request_body_size: usize,
+        ) void {
+            // TODO(Zig) Move these into init when `@returnAddress()` is available. They only needs to
+            // be set once, it just requires a stable pointer to the Cluster.
+            cluster.clients[client_index].on_reply_context = cluster;
+            cluster.clients[client_index].on_reply_callback = client_on_reply;
 
-        replica.context = cluster;
-        replica.on_change_state = on_replica_change_state;
-        replica.on_compact = on_replica_compact;
-        replica.on_checkpoint = on_replica_checkpoint;
-        cluster.network.link(replica.message_bus.process, &replica.message_bus);
-    }
+            cluster.clients[client_index].request(
+                undefined,
+                request_callback,
+                request_operation,
+                request_message,
+                request_body_size,
+            );
+        }
 
-    pub fn request(
-        cluster: *Cluster,
-        client_index: usize,
-        request_operation: StateMachine.Operation,
-        request_message: *Message,
-        request_body_size: usize,
-    ) void {
-        // TODO(Zig) Move these into init when `@returnAddress()` is available. They only needs to
-        // be set once, it just requires a stable pointer to the Cluster.
-        cluster.clients[client_index].on_reply_context = cluster;
-        cluster.clients[client_index].on_reply_callback = client_on_reply;
+        /// The `request_callback` is not used — Cluster uses `Client.on_reply_{context,callback}`
+        /// instead because:
+        /// - Cluster needs access to the request
+        /// - Cluster needs access to the reply message (not just the body)
+        /// - Cluster needs to know about command=register messages
+        ///
+        /// See `on_reply`.
+        fn request_callback(
+            user_data: u128,
+            operation: StateMachine.Operation,
+            result: Client.Error![]const u8,
+        ) void {
+            _ = user_data;
+            _ = operation;
+            _ = result catch |err| switch (err) {
+                error.TooManyOutstandingRequests => unreachable,
+            };
+        }
 
-        cluster.clients[client_index].request(
-            undefined,
-            request_callback,
-            request_operation,
-            request_message,
-            request_body_size,
-        );
-    }
+        fn client_on_reply(client: *Client, request_message: *Message, reply_message: *Message) void {
+            const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), client.on_reply_context.?));
+            assert(reply_message.header.cluster == cluster.options.cluster_id);
+            assert(reply_message.header.invalid() == null);
+            assert(reply_message.header.client == client.id);
+            assert(reply_message.header.request == request_message.header.request);
+            assert(reply_message.header.command == .reply);
+            assert(reply_message.header.operation == request_message.header.operation);
 
-    /// The `request_callback` is not used — Cluster uses `Client.on_reply_{context,callback}`
-    /// instead because:
-    /// - Cluster needs access to the request
-    /// - Cluster needs access to the reply message (not just the body)
-    /// - Cluster needs to know about command=register messages
-    ///
-    /// See `on_reply`.
-    fn request_callback(
-        user_data: u128,
-        operation: StateMachine.Operation,
-        result: Client.Error![]const u8,
-    ) void {
-        _ = user_data;
-        _ = operation;
-        _ = result catch |err| switch (err) {
-            error.TooManyOutstandingRequests => unreachable,
-        };
-    }
+            const client_index = for (cluster.clients) |*c, i| {
+                if (client == c) break i;
+            } else unreachable;
 
-    fn client_on_reply(client: *Client, request_message: *Message, reply_message: *Message) void {
-        const cluster = @ptrCast(*Cluster, @alignCast(@alignOf(Cluster), client.on_reply_context.?));
-        assert(reply_message.header.cluster == cluster.options.cluster_id);
-        assert(reply_message.header.invalid() == null);
-        assert(reply_message.header.client == client.id);
-        assert(reply_message.header.request == request_message.header.request);
-        assert(reply_message.header.command == .reply);
-        assert(reply_message.header.operation == request_message.header.operation);
+            cluster.on_client_reply(cluster, client_index, request_message, reply_message);
+        }
 
-        const client_index = for (cluster.clients) |*c, i| {
-            if (client == c) break i;
-        } else unreachable;
+        fn on_replica_change_state(replica: *const Replica) void {
+            const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            cluster.state_checker.check_state(replica.replica) catch |err| {
+                fatal(.correctness, "state checker error: {}", .{err});
+            };
+        }
 
-        cluster.on_client_reply(cluster, client_index, request_message, reply_message);
-    }
-};
+        fn on_replica_compact(replica: *const Replica) void {
+            const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            cluster.storage_checker.replica_compact(replica) catch |err| {
+                fatal(.correctness, "storage checker error: {}", .{err});
+            };
+        }
 
-fn on_replica_change_state(replica: *const Replica) void {
-    const cluster = @ptrCast(*Cluster, @alignCast(@alignOf(Cluster), replica.context.?));
-    cluster.state_checker.check_state(replica.replica) catch |err| {
-        fatal(.correctness, "state checker error: {}", .{err});
+        fn on_replica_checkpoint(replica: *const Replica) void {
+            const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            cluster.storage_checker.replica_checkpoint(replica) catch |err| {
+                fatal(.correctness, "storage checker error: {}", .{err});
+            };
+        }
+
+        /// Print an error message and then exit with an exit code.
+        fn fatal(failure: Failure, comptime fmt_string: []const u8, args: anytype) noreturn {
+            std.log.scoped(.state_checker).err(fmt_string, args);
+            std.os.exit(@enumToInt(failure));
+        }
     };
-}
-
-fn on_replica_compact(replica: *const Replica) void {
-    const cluster = @ptrCast(*Cluster, @alignCast(@alignOf(Cluster), replica.context.?));
-    cluster.storage_checker.replica_compact(replica) catch |err| {
-        fatal(.correctness, "storage checker error: {}", .{err});
-    };
-}
-
-fn on_replica_checkpoint(replica: *const Replica) void {
-    const cluster = @ptrCast(*Cluster, @alignCast(@alignOf(Cluster), replica.context.?));
-    cluster.storage_checker.replica_checkpoint(replica) catch |err| {
-        fatal(.correctness, "storage checker error: {}", .{err});
-    };
-}
-
-/// Print an error message and then exit with an exit code.
-fn fatal(failure: Failure, comptime fmt_string: []const u8, args: anytype) noreturn {
-    std.log.scoped(.state_checker).err(fmt_string, args);
-    std.os.exit(@enumToInt(failure));
 }

--- a/src/test/cluster/state_checker.zig
+++ b/src/test/cluster/state_checker.zig
@@ -6,8 +6,6 @@ const constants = @import("../../constants.zig");
 const vsr = @import("../../vsr.zig");
 const RingBuffer = @import("../../ring_buffer.zig").RingBuffer;
 
-const Client = @import("../cluster.zig").Client;
-const Replica = @import("../cluster.zig").Replica;
 const message_pool = @import("../../message_pool.zig");
 const MessagePool = message_pool.MessagePool;
 const Message = MessagePool.Message;
@@ -20,148 +18,152 @@ const Commits = std.ArrayList(struct {
 
 const log = std.log.scoped(.state_checker);
 
-pub const StateChecker = struct {
-    replica_count: u8,
+pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
+    return struct {
+        const Self = @This();
 
-    commits: Commits,
-    commit_mins: [constants.replicas_max]u64 = [_]u64{0} ** constants.replicas_max,
+        replica_count: u8,
 
-    replicas: []const Replica,
-    clients: []const Client,
+        commits: Commits,
+        commit_mins: [constants.replicas_max]u64 = [_]u64{0} ** constants.replicas_max,
 
-    /// The number of times the canonical state has been advanced.
-    requests_committed: u64 = 0,
-
-    pub fn init(
-        allocator: mem.Allocator,
-        cluster: u32,
         replicas: []const Replica,
         clients: []const Client,
-    ) !StateChecker {
-        const root_prepare = vsr.Header.root_prepare(cluster);
 
-        var commits = Commits.init(allocator);
-        errdefer commits.deinit();
+        /// The number of times the canonical state has been advanced.
+        requests_committed: u64 = 0,
 
-        var commit_replicas = ReplicaSet.initEmpty();
-        for (replicas) |_, i| commit_replicas.set(i);
-        try commits.append(.{
-            .header = root_prepare,
-            .replicas = commit_replicas,
-        });
+        pub fn init(
+            allocator: mem.Allocator,
+            cluster: u32,
+            replicas: []const Replica,
+            clients: []const Client,
+        ) !Self {
+            const root_prepare = vsr.Header.root_prepare(cluster);
 
-        return StateChecker{
-            .replica_count = @intCast(u8, replicas.len),
-            .commits = commits,
-            .replicas = replicas,
-            .clients = clients,
-        };
-    }
+            var commits = Commits.init(allocator);
+            errdefer commits.deinit();
 
-    pub fn deinit(state_checker: *StateChecker) void {
-        state_checker.commits.deinit();
-    }
+            var commit_replicas = ReplicaSet.initEmpty();
+            for (replicas) |_, i| commit_replicas.set(i);
+            try commits.append(.{
+                .header = root_prepare,
+                .replicas = commit_replicas,
+            });
 
-    pub fn check_state(state_checker: *StateChecker, replica_index: u8) !void {
-        const replica = &state_checker.replicas[replica_index];
+            return Self{
+                .replica_count = @intCast(u8, replicas.len),
+                .commits = commits,
+                .replicas = replicas,
+                .clients = clients,
+            };
+        }
 
-        const commit_root = replica.superblock.working.vsr_state.commit_min_checksum;
+        pub fn deinit(state_checker: *Self) void {
+            state_checker.commits.deinit();
+        }
 
-        const commit_a = state_checker.commit_mins[replica_index];
-        const commit_b = replica.commit_min;
+        pub fn check_state(state_checker: *Self, replica_index: u8) !void {
+            const replica = &state_checker.replicas[replica_index];
 
-        const header_b = replica.journal.header_with_op(replica.commit_min);
-        assert(header_b != null or replica.commit_min == replica.op_checkpoint);
-        assert(header_b == null or header_b.?.op == commit_b);
+            const commit_root = replica.superblock.working.vsr_state.commit_min_checksum;
 
-        const checksum_a = state_checker.commits.items[commit_a].header.checksum;
-        const checksum_b = if (header_b) |h| h.checksum else commit_root;
+            const commit_a = state_checker.commit_mins[replica_index];
+            const commit_b = replica.commit_min;
 
-        assert(checksum_b != commit_root or replica.commit_min == replica.superblock.working.vsr_state.commit_min);
-        assert((commit_a == commit_b) == (checksum_a == checksum_b));
+            const header_b = replica.journal.header_with_op(replica.commit_min);
+            assert(header_b != null or replica.commit_min == replica.op_checkpoint);
+            assert(header_b == null or header_b.?.op == commit_b);
 
-        if (checksum_a == checksum_b) return;
+            const checksum_a = state_checker.commits.items[commit_a].header.checksum;
+            const checksum_b = if (header_b) |h| h.checksum else commit_root;
 
-        assert(commit_b < commit_a or commit_a + 1 == commit_b);
-        state_checker.commit_mins[replica_index] = commit_b;
+            assert(checksum_b != commit_root or replica.commit_min == replica.superblock.working.vsr_state.commit_min);
+            assert((commit_a == commit_b) == (checksum_a == checksum_b));
 
-        // If some other replica has already reached this state, then it will be in the commit history:
-        if (replica.commit_min < state_checker.commits.items.len) {
-            state_checker.commits.items[replica.commit_min].replicas.set(replica_index);
+            if (checksum_a == checksum_b) return;
 
-            assert(replica.commit_min < state_checker.commits.items.len);
-            // A replica may transition more than once to the same state, for example, when
-            // restarting after a crash and replaying the log. The more important invariant is that
-            // the cluster as a whole may not transition to the same state more than once, and once
-            // transitioned may not regress.
-            log.info("{d:0>4}/{d:0>4} {x:0>32} > {x:0>32} {}", .{
-                replica.commit_min,
+            assert(commit_b < commit_a or commit_a + 1 == commit_b);
+            state_checker.commit_mins[replica_index] = commit_b;
+
+            // If some other replica has already reached this state, then it will be in the commit history:
+            if (replica.commit_min < state_checker.commits.items.len) {
+                state_checker.commits.items[replica.commit_min].replicas.set(replica_index);
+
+                assert(replica.commit_min < state_checker.commits.items.len);
+                // A replica may transition more than once to the same state, for example, when
+                // restarting after a crash and replaying the log. The more important invariant is that
+                // the cluster as a whole may not transition to the same state more than once, and once
+                // transitioned may not regress.
+                log.info("{d:0>4}/{d:0>4} {x:0>32} > {x:0>32} {}", .{
+                    replica.commit_min,
+                    state_checker.requests_committed,
+                    checksum_a,
+                    checksum_b,
+                    replica_index,
+                });
+                return;
+            }
+
+            if (header_b == null) return;
+            assert(header_b.?.parent == checksum_a);
+            assert(header_b.?.op > 0);
+            assert(header_b.?.command == .prepare);
+            assert(header_b.?.operation != .reserved);
+
+            // The replica has transitioned to state `b` that is not yet in the commit history.
+            // Check if this is a valid new state based on the originating client's inflight request.
+            const client = for (state_checker.clients) |*client| {
+                if (client.id == header_b.?.client) break client;
+            } else unreachable;
+
+            if (client.request_queue.empty()) {
+                return error.ReplicaTransitionedToInvalidState;
+            }
+
+            const request = client.request_queue.head_ptr_const().?;
+            assert(request.message.header.client == header_b.?.client);
+            assert(request.message.header.request == header_b.?.request);
+            assert(request.message.header.command == .request);
+            assert(request.message.header.operation == header_b.?.operation);
+            assert(request.message.header.size == header_b.?.size);
+            // `checksum_body` will not match; the leader's StateMachine updated the timestamps in the
+            // prepare body's accounts/transfers.
+
+            state_checker.requests_committed += 1;
+            assert(state_checker.requests_committed == header_b.?.op);
+
+            log.info("     {d:0>4} {x:0>32} > {x:0>32} {}", .{
                 state_checker.requests_committed,
                 checksum_a,
                 checksum_b,
                 replica_index,
             });
-            return;
+
+            assert(state_checker.commits.items.len == header_b.?.op);
+            state_checker.commits.append(.{ .header = header_b.?.* }) catch unreachable;
+            state_checker.commits.items[header_b.?.op].replicas.set(replica_index);
         }
 
-        if (header_b == null) return;
-        assert(header_b.?.parent == checksum_a);
-        assert(header_b.?.op > 0);
-        assert(header_b.?.command == .prepare);
-        assert(header_b.?.operation != .reserved);
-
-        // The replica has transitioned to state `b` that is not yet in the commit history.
-        // Check if this is a valid new state based on the originating client's inflight request.
-        const client = for (state_checker.clients) |*client| {
-            if (client.id == header_b.?.client) break client;
-        } else unreachable;
-
-        if (client.request_queue.empty()) {
-            return error.ReplicaTransitionedToInvalidState;
-        }
-
-        const request = client.request_queue.head_ptr_const().?;
-        assert(request.message.header.client == header_b.?.client);
-        assert(request.message.header.request == header_b.?.request);
-        assert(request.message.header.command == .request);
-        assert(request.message.header.operation == header_b.?.operation);
-        assert(request.message.header.size == header_b.?.size);
-        // `checksum_body` will not match; the leader's StateMachine updated the timestamps in the
-        // prepare body's accounts/transfers.
-
-        state_checker.requests_committed += 1;
-        assert(state_checker.requests_committed == header_b.?.op);
-
-        log.info("     {d:0>4} {x:0>32} > {x:0>32} {}", .{
-            state_checker.requests_committed,
-            checksum_a,
-            checksum_b,
-            replica_index,
-        });
-
-        assert(state_checker.commits.items.len == header_b.?.op);
-        state_checker.commits.append(.{ .header = header_b.?.* }) catch unreachable;
-        state_checker.commits.items[header_b.?.op].replicas.set(replica_index);
-    }
-
-    pub fn convergence(state_checker: *StateChecker) bool {
-        const a = state_checker.commits.items.len - 1;
-        for (state_checker.commit_mins[0..state_checker.replica_count]) |b| {
-            if (b != a) {
-                return false;
+        pub fn convergence(state_checker: *Self) bool {
+            const a = state_checker.commits.items.len - 1;
+            for (state_checker.commit_mins[0..state_checker.replica_count]) |b| {
+                if (b != a) {
+                    return false;
+                }
             }
-        }
 
-        for (state_checker.commits.items) |commit, i| {
-            assert(commit.replicas.count() == state_checker.replica_count);
-            assert(commit.header.command == .prepare);
-            assert(commit.header.op == i);
-            if (i > 0) {
-                const previous = state_checker.commits.items[i - 1].header;
-                assert(commit.header.parent == previous.checksum);
-                assert(commit.header.view >= previous.view);
+            for (state_checker.commits.items) |commit, i| {
+                assert(commit.replicas.count() == state_checker.replica_count);
+                assert(commit.header.command == .prepare);
+                assert(commit.header.op == i);
+                if (i > 0) {
+                    const previous = state_checker.commits.items[i - 1].header;
+                    assert(commit.header.parent == previous.checksum);
+                    assert(commit.header.view >= previous.view);
+                }
             }
+            return true;
         }
-        return true;
-    }
-};
+    };
+}

--- a/src/test/cluster/storage_checker.zig
+++ b/src/test/cluster/storage_checker.zig
@@ -26,7 +26,6 @@ const constants = @import("../../constants.zig");
 const vsr = @import("../../vsr.zig");
 const superblock = @import("../../vsr/superblock.zig");
 const SuperBlockSector = superblock.SuperBlockSector;
-const Replica = @import("../cluster.zig").Replica;
 const Storage = @import("../storage.zig").Storage;
 
 /// After each compaction half measure, save the cumulative hash of all acquired grid blocks.
@@ -53,147 +52,151 @@ const Checkpoint = struct {
     checksum_grid: u128,
 };
 
-pub const StorageChecker = struct {
-    allocator: std.mem.Allocator,
-    compactions: Compactions,
-    checkpoints: Checkpoints,
+pub fn StorageCheckerType(comptime Replica: type) type {
+    return struct {
+        const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator) StorageChecker {
-        var compactions = Compactions.init(allocator);
-        errdefer compactions.deinit();
+        allocator: std.mem.Allocator,
+        compactions: Compactions,
+        checkpoints: Checkpoints,
 
-        var checkpoints = Checkpoints.init(allocator);
-        errdefer checkpoints.deinit();
+        pub fn init(allocator: std.mem.Allocator) Self {
+            var compactions = Compactions.init(allocator);
+            errdefer compactions.deinit();
 
-        return StorageChecker{
-            .allocator = allocator,
-            .compactions = compactions,
-            .checkpoints = checkpoints,
-        };
-    }
+            var checkpoints = Checkpoints.init(allocator);
+            errdefer checkpoints.deinit();
 
-    pub fn deinit(checker: *StorageChecker) void {
-        checker.compactions.deinit();
-        checker.checkpoints.deinit();
-    }
-
-    pub fn replica_compact(checker: *StorageChecker, replica: *const Replica) !void {
-        // TODO(Beat Compaction) Remove when deterministic beat compaction is fixed.
-        // Until then this is too noisy.
-        if (1 == 1) return;
-
-        // If we are recovering from a crash, don't test the checksum until we are caught up.
-        // Until then our grid's checksum is too far ahead.
-        if (replica.superblock.working.vsr_state.op_compacted(replica.commit_min)) return;
-
-        // TODO(Beat Compaction) Remove when deterministic beat compaction is implemented.
-        const half_measure_beat_count = @divExact(constants.lsm_batch_multiple, 2);
-        if ((replica.commit_min + 1) % half_measure_beat_count != 0) return;
-
-        const checksum = checksum_grid(replica);
-        log.debug("{}: replica_compact: op={} area=grid checksum={}", .{
-            replica.replica,
-            replica.commit_min,
-            checksum,
-        });
-
-        // -1 since we never compact op=1.
-        const compactions_index = @divExact(replica.commit_min + 1, half_measure_beat_count) - 1;
-        if (compactions_index == checker.compactions.items.len) {
-            try checker.compactions.append(checksum);
-        } else {
-            const checksum_expect = checker.compactions.items[compactions_index];
-            if (checksum_expect != checksum) {
-                log.err("{}: replica_compact: mismatch area=grid expect={} actual={}", .{
-                    replica.replica,
-                    checksum_expect,
-                    checksum,
-                });
-                return error.StorageMismatch;
-            }
-        }
-    }
-
-    pub fn replica_checkpoint(checker: *StorageChecker, replica: *const Replica) !void {
-        const storage = replica.superblock.storage;
-        const working = replica.superblock.working;
-
-        // TODO(Beat Compaction) Remove when deterministic storage is fixed.
-        // Until then this is too noisy.
-        if (1 == 1) return;
-
-        var checkpoint = Checkpoint{
-            .checksum_superblock_manifest = 0,
-            .checksum_superblock_free_set = 0,
-            .checksum_superblock_client_table = 0,
-            .checksum_wal_prepares = checksum_wal_prepares(storage),
-            .checksum_grid = checksum_grid(replica),
-        };
-
-        inline for (.{ .manifest, .free_set, .client_table }) |trailer| {
-            const trailer_area = @field(superblock.areas, trailer);
-            const trailer_size = @field(working, @tagName(trailer) ++ "_size");
-            var copy: u8 = 0;
-            while (copy < constants.superblock_copies) : (copy += 1) {
-                @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer.field)) |=
-                    vsr.checksum(storage.memory[trailer_area.offset(copy)..][0..trailer_size]);
-            }
+            return Self{
+                .allocator = allocator,
+                .compactions = compactions,
+                .checkpoints = checkpoints,
+            };
         }
 
-        inline for (std.meta.fields(Checkpoint)) |field| {
-            log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={}", .{
+        pub fn deinit(checker: *Self) void {
+            checker.compactions.deinit();
+            checker.checkpoints.deinit();
+        }
+
+        pub fn replica_compact(checker: *Self, replica: *const Replica) !void {
+            // TODO(Beat Compaction) Remove when deterministic beat compaction is fixed.
+            // Until then this is too noisy.
+            if (1 == 1) return;
+
+            // If we are recovering from a crash, don't test the checksum until we are caught up.
+            // Until then our grid's checksum is too far ahead.
+            if (replica.superblock.working.vsr_state.op_compacted(replica.commit_min)) return;
+
+            // TODO(Beat Compaction) Remove when deterministic beat compaction is implemented.
+            const half_measure_beat_count = @divExact(constants.lsm_batch_multiple, 2);
+            if ((replica.commit_min + 1) % half_measure_beat_count != 0) return;
+
+            const checksum = checksum_grid(replica);
+            log.debug("{}: replica_compact: op={} area=grid checksum={}", .{
                 replica.replica,
-                replica.op_checkpoint,
-                field.name,
-                @field(checkpoint, field.name),
+                replica.commit_min,
+                checksum,
             });
+
+            // -1 since we never compact op=1.
+            const compactions_index = @divExact(replica.commit_min + 1, half_measure_beat_count) - 1;
+            if (compactions_index == checker.compactions.items.len) {
+                try checker.compactions.append(checksum);
+            } else {
+                const checksum_expect = checker.compactions.items[compactions_index];
+                if (checksum_expect != checksum) {
+                    log.err("{}: replica_compact: mismatch area=grid expect={} actual={}", .{
+                        replica.replica,
+                        checksum_expect,
+                        checksum,
+                    });
+                    return error.StorageMismatch;
+                }
+            }
         }
 
-        const checkpoint_expect = checker.checkpoints.get(replica.op_checkpoint) orelse {
-            // This replica is the first to reach op_checkpoint.
-            try checker.checkpoints.putNoClobber(replica.op_checkpoint, checkpoint);
-            return;
-        };
+        pub fn replica_checkpoint(checker: *Self, replica: *const Replica) !void {
+            const storage = replica.superblock.storage;
+            const working = replica.superblock.working;
 
-        var fail: bool = false;
-        inline for (std.meta.fields(Checkpoint)) |field| {
-            const field_actual = @field(checkpoint, field.name);
-            const field_expect = @field(checkpoint_expect, field.name);
-            if (!std.meta.eql(field_expect, field_actual)) {
-                fail = true;
-                log.debug("{}: replica_checkpoint: mismatch area={s} expect={} actual={}", .{
+            // TODO(Beat Compaction) Remove when deterministic storage is fixed.
+            // Until then this is too noisy.
+            if (1 == 1) return;
+
+            var checkpoint = Checkpoint{
+                .checksum_superblock_manifest = 0,
+                .checksum_superblock_free_set = 0,
+                .checksum_superblock_client_table = 0,
+                .checksum_wal_prepares = checksum_wal_prepares(storage),
+                .checksum_grid = checksum_grid(replica),
+            };
+
+            inline for (.{ .manifest, .free_set, .client_table }) |trailer| {
+                const trailer_area = @field(superblock.areas, trailer);
+                const trailer_size = @field(working, @tagName(trailer) ++ "_size");
+                var copy: u8 = 0;
+                while (copy < constants.superblock_copies) : (copy += 1) {
+                    @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer.field)) |=
+                        vsr.checksum(storage.memory[trailer_area.offset(copy)..][0..trailer_size]);
+                }
+            }
+
+            inline for (std.meta.fields(Checkpoint)) |field| {
+                log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={}", .{
                     replica.replica,
+                    replica.op_checkpoint,
                     field.name,
-                    @field(checkpoint_expect, field.name),
                     @field(checkpoint, field.name),
                 });
             }
-        }
-        if (fail) return error.StorageMismatch;
-    }
 
-    fn checksum_wal_prepares(storage: *const Storage) u128 {
-        var checksum: u128 = 0;
-        for (storage.wal_prepares()) |*prepare| {
-            assert(prepare.header.valid_checksum());
-            assert(prepare.header.command == .prepare);
+            const checkpoint_expect = checker.checkpoints.get(replica.op_checkpoint) orelse {
+                // This replica is the first to reach op_checkpoint.
+                try checker.checkpoints.putNoClobber(replica.op_checkpoint, checkpoint);
+                return;
+            };
 
-            // Only checksum the actual message header+body. Any leftover space is nondeterministic,
-            // because the current prepare may have overwritten a longer message.
-            checksum ^= vsr.checksum(std.mem.asBytes(prepare)[0..prepare.header.size]);
+            var fail: bool = false;
+            inline for (std.meta.fields(Checkpoint)) |field| {
+                const field_actual = @field(checkpoint, field.name);
+                const field_expect = @field(checkpoint_expect, field.name);
+                if (!std.meta.eql(field_expect, field_actual)) {
+                    fail = true;
+                    log.debug("{}: replica_checkpoint: mismatch area={s} expect={} actual={}", .{
+                        replica.replica,
+                        field.name,
+                        @field(checkpoint_expect, field.name),
+                        @field(checkpoint, field.name),
+                    });
+                }
+            }
+            if (fail) return error.StorageMismatch;
         }
-        return checksum;
-    }
 
-    fn checksum_grid(replica: *const Replica) u128 {
-        const storage = replica.superblock.storage;
-        var acquired = replica.superblock.free_set.blocks.iterator(.{ .kind = .unset });
-        var checksum: u128 = 0;
-        while (acquired.next()) |address_index| {
-            const block = storage.grid_block(address_index + 1);
-            const block_header = std.mem.bytesToValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
-            checksum ^= vsr.checksum(block[0..block_header.size]);
+        fn checksum_wal_prepares(storage: *const Storage) u128 {
+            var checksum: u128 = 0;
+            for (storage.wal_prepares()) |*prepare| {
+                assert(prepare.header.valid_checksum());
+                assert(prepare.header.command == .prepare);
+
+                // Only checksum the actual message header+body. Any leftover space is nondeterministic,
+                // because the current prepare may have overwritten a longer message.
+                checksum ^= vsr.checksum(std.mem.asBytes(prepare)[0..prepare.header.size]);
+            }
+            return checksum;
         }
-        return checksum;
-    }
-};
+
+        fn checksum_grid(replica: *const Replica) u128 {
+            const storage = replica.superblock.storage;
+            var acquired = replica.superblock.free_set.blocks.iterator(.{ .kind = .unset });
+            var checksum: u128 = 0;
+            while (acquired.next()) |address_index| {
+                const block = storage.grid_block(address_index + 1);
+                const block_header = std.mem.bytesToValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+                checksum ^= vsr.checksum(block[0..block_header.size]);
+            }
+            return checksum;
+        }
+    };
+}


### PR DESCRIPTION
Before, simualtor used `constants.StateMachineType` to select a fixed-at-a-build-time state machine type. Tough luck if you are not using one of the two state machine types supported!

So, let's rather make it generic over the type constructor here.

We inject StateMachineType rather than StateMachine, because Cluster wants to control the type of the storage.