### PR TITLE
Node client: Fix incorrect defer statement

### DIFF
--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -161,7 +161,7 @@ const Context = struct {
                 .io = context.io,
             },
         );
-        defer context.client.deinit(allocator);
+        errdefer context.client.deinit(allocator);
 
         return try translate.create_external(env, context);
     }


### PR DESCRIPTION
It should be `errdefer` instead of `defer`
Closes #420

In a next PR I'll change CI tests to catch this kind of problem.