### PR TITLE
Specify that we should benchmark on linux, in light of linux-only regressions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Performance:
 
-* [ ] Compare `zig benchmark` before and after this pr.
+* [ ] Compare `zig benchmark` on linux before and after this pr.
     ``` sh
     # benchmark results before
     ...


### PR DESCRIPTION
This isn't great dx, but until we have continuous benchmarking on a reference machine I don't see how to avoid it.