### PR TITLE
VSR: SuperBlock VSR recovery

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -80,6 +80,7 @@ const ConfigCluster = struct {
     cache_line_size: comptime_int = 64,
     clients_max: usize,
     pipeline_prepare_queue_max: usize = 8,
+    view_change_headers_max: usize = 8,
     quorum_replication_max: u8 = 3,
     journal_slot_count: usize = 1024,
     message_size_max: usize = 1 * 1024 * 1024,
@@ -180,6 +181,7 @@ pub const configs = struct {
         .cluster = .{
             .clients_max = 4 + 3,
             .pipeline_prepare_queue_max = 4,
+            .view_change_headers_max = 4,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(4),
             .storage_size_max = 4 * 1024 * 1024 * 1024,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -157,6 +157,9 @@ comptime {
     assert(message_size_max >= @sizeOf(vsr.Header));
     assert(message_size_max >= sector_size);
     assert(message_size_max >= Config.Cluster.message_size_max_min(clients_max));
+
+    // Ensure that DVC/SV messages can fit all necessary headers.
+    assert(message_body_size_max >= view_change_headers_max * @sizeOf(vsr.Header));
 }
 
 /// The maximum number of Viewstamped Replication prepare messages that can be inflight at a time.
@@ -182,6 +185,21 @@ comptime {
     assert(pipeline_prepare_queue_max + pipeline_request_queue_max <= clients_max);
     assert(pipeline_prepare_queue_max > 0);
     assert(pipeline_request_queue_max >= 0);
+}
+
+/// The number of prepare headers to include in the body of a DVC/SV.
+///
+/// CRITICAL:
+/// We must provide enough headers to cover all uncommitted headers so that the new
+/// primary (if we are in a view change) can decide whether to discard uncommitted headers
+/// that cannot be repaired because they are gaps. See DVCQuorum for more detail.
+pub const view_change_headers_max = config.cluster.view_change_headers_max;
+
+comptime {
+    assert(view_change_headers_max > 0);
+    assert(view_change_headers_max >= pipeline_prepare_queue_max);
+    assert(view_change_headers_max <= journal_slot_count);
+    assert(view_change_headers_max <= @divFloor(message_body_size_max, @sizeOf(vsr.Header)));
 }
 
 /// The minimum and maximum amount of time in milliseconds to wait before initiating a connection.

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -185,8 +185,6 @@ const Environment = struct {
             .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
             .commit_min = op,
             .commit_max = op + 1,
-            .log_view = 0,
-            .view = 0,
         });
     }
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -419,16 +419,17 @@ const Environment = struct {
         env.manifest_log.checkpoint(checkpoint_callback);
         env.wait(&env.manifest_log);
 
-        var vsr_state = env.manifest_log.superblock.working.vsr_state;
-        vsr_state.commit_min += 1;
-        vsr_state.commit_min_checksum += 1;
-        vsr_state.commit_max += 1;
+        const vsr_state = &env.manifest_log.superblock.working.vsr_state;
 
         env.pending += 1;
         env.manifest_log.superblock.checkpoint(
             checkpoint_superblock_callback,
             &env.superblock_context,
-            vsr_state,
+            .{
+                .commit_min_checksum = vsr_state.commit_min_checksum + 1,
+                .commit_min = vsr_state.commit_min + 1,
+                .commit_max = vsr_state.commit_max + 1,
+            },
         );
         env.wait(&env.manifest_log);
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -202,15 +202,16 @@ const Environment = struct {
 
         log.debug("forest checkpointing completed!", .{});
 
-        var vsr_state = env.superblock.staging.vsr_state;
-        vsr_state.commit_min += 1;
-        vsr_state.commit_min_checkpoint += 1;
+        const vsr_state = &env.superblock.staging.vsr_state;
 
         env.state = .superblock_checkpointing;
         env.superblock.checkpoint(
             superblock_checkpoint_callback,
             &env.superblock_context,
-            vsr_state,
+            .{
+                .commit_min_checkpoint += = vsr_state.commit_min_checkpoint + 1,
+                .commit_min = vsr_state.commit_min + 1,
+            },
         );
     }
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -209,7 +209,7 @@ const Environment = struct {
             superblock_checkpoint_callback,
             &env.superblock_context,
             .{
-                .commit_min_checkpoint += = vsr_state.commit_min_checkpoint + 1,
+                .commit_min_checkpoint = vsr_state.commit_min_checkpoint + 1,
                 .commit_min = vsr_state.commit_min + 1,
             },
         );

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -241,8 +241,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,
                 .commit_min = op,
                 .commit_max = op + 1,
-                .log_view = 0,
-                .view = 0,
             });
         }
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -143,7 +143,7 @@ pub fn main() !void {
     const simulator_options = Simulator.Options{
         .cluster = cluster_options,
         .workload = workload_options,
-        .replica_crash_probability = 0.000001,
+        .replica_crash_probability = 0.00002,
         .replica_crash_stability = random.uintLessThan(u32, 1_000),
         .replica_restart_probability = 0.0001,
         .replica_restart_stability = random.uintLessThan(u32, 1_000),
@@ -444,43 +444,11 @@ pub const Simulator = struct {
     }
 
     fn tick_crash(simulator: *Simulator) void {
-        // The maximum number of replicas that can crash, with the cluster still able to recover.
-        var crashes = blk: {
-            // The minimum number of healthy replicas required for a crashed replica to be able to
-            // recover. A cluster of 1 can crash safely (as long as there is no disk corruption)
-            // since it does not run the recovery protocol.
-            var replica_normal_min = if (simulator.options.cluster.replica_count == 1)
-                0
-            else
-                vsr.quorums(simulator.options.cluster.replica_count).view_change;
-            break :blk simulator.cluster.replica_normal_count() -| replica_normal_min;
-        };
-
-        for (simulator.cluster.storages) |*storage, replica| {
-            if (simulator.cluster.replicas[replica].journal.status == .recovered) {
-                // TODO Remove this workaround when VSR recovery protocol is disabled.
-                // When only the minimum number of replicas are healthy (no more crashes allowed),
-                // disable storage faults on all healthy replicas.
-                //
-                // This is a workaround to avoid the deadlock that occurs when (for example) in a
-                // cluster of 3 replicas, one is down, another has a corrupt prepare, and the last does
-                // not have the prepare. The two healthy replicas can never complete a view change,
-                // because two replicas are not enough to nack, and the unhealthy replica cannot
-                // complete the VSR recovery protocol either.
-                if (simulator.cluster.replica_health[replica] == .up and crashes == 0) {
-                    if (storage.faulty) {
-                        log_simulator.debug("{}: disable storage faults", .{replica});
-                        storage.faulty = false;
-                    }
-                } else {
-                    // When a journal recovers for the first time, enable its storage faults.
-                    // Future crashes will recover in the presence of faults.
-                    if (!storage.faulty) {
-                        log_simulator.debug("{}: enable storage faults", .{replica});
-                        storage.faulty = true;
-                    }
-                }
-            }
+        var recoverable_count_min =
+            vsr.quorums(simulator.options.cluster.replica_count).view_change;
+        var recoverable_count: usize = 0;
+        for (simulator.cluster.replicas) |*replica| {
+            recoverable_count += @boolToInt(replica.status != .recovering_head);
         }
 
         for (simulator.cluster.replicas) |*replica| {
@@ -490,28 +458,24 @@ pub const Simulator = struct {
 
             switch (simulator.cluster.replica_health[replica.replica]) {
                 .up => {
-                    if (crashes == 0) continue;
                     const replica_writes = simulator.cluster.storages[replica.replica].writes.count();
                     const crash_probability = simulator.options.replica_crash_probability *
                         @as(f64, if (replica_writes == 0) 1.0 else 10.0);
                     if (!chance_f64(simulator.random, crash_probability)) continue;
 
-                    const replica_crashed = simulator.cluster.crash_replica(replica.replica) catch |err| {
-                        log_simulator.err("{}: crash replica: unable to open after crash (err={})", .{
-                            replica.replica,
-                            err,
-                        });
-                        unreachable;
-                    };
-                    if (replica_crashed) {
-                        log_simulator.debug("{}: crash replica", .{replica.replica});
-                        crashes -= 1;
-                        simulator.replica_stability[replica.replica] =
-                            simulator.options.replica_crash_stability;
-                    }
+                    const fault = recoverable_count > recoverable_count_min;
+                    replica.superblock.storage.faulty = fault;
+                    recoverable_count -= @boolToInt(replica.status == .recovering_head);
+
+                    log_simulator.debug("{}: crash replica (faults={})", .{replica.replica, fault});
+                    simulator.cluster.crash_replica(replica.replica) catch unreachable;
+                    replica.superblock.storage.faulty = true;
+                    assert(replica.status != .recovering_head or fault);
+
+                    simulator.replica_stability[replica.replica] =
+                        simulator.options.replica_crash_stability;
                 },
                 .down => {
-                    assert(replica.status == .recovering);
                     if (chance_f64(simulator.random, simulator.options.replica_restart_probability)) {
                         simulator.cluster.restart_replica(replica.replica);
                         log_simulator.debug("{}: restart replica", .{replica.replica});

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -467,7 +467,7 @@ pub const Simulator = struct {
                     replica.superblock.storage.faulty = fault;
                     recoverable_count -= @boolToInt(replica.status == .recovering_head);
 
-                    log_simulator.debug("{}: crash replica (faults={})", .{replica.replica, fault});
+                    log_simulator.debug("{}: crash replica (faults={})", .{ replica.replica, fault });
                     simulator.cluster.crash_replica(replica.replica) catch unreachable;
                     replica.superblock.storage.faulty = true;
                     assert(replica.status != .recovering_head or fault);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -632,7 +632,7 @@ pub const ClusterFaultAtlas = struct {
         // - B₁ (corrupt), manifest (ok)
         // - A₂ (ok),      manifest (corrupt)
         // - A₃ (ok),      manifest (torn)
-        const sector_faults_max = random.uintLessThan(usize, superblock_area_faults_max);
+        const sector_faults_max = random.uintLessThan(usize, superblock_area_faults_max + 1);
         const trailer_faults_max = superblock_area_faults_max - sector_faults_max;
         for (&atlas.faulty_superblock_areas.values) |*copies, area| {
             const faults_max = if (area == @enumToInt(superblock.Area.sector))

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1021,6 +1021,7 @@ pub const ViewChangeHeaders = struct {
 
         var child: ?*const Header = null;
         for (slice) |*header| {
+            assert(header.valid_checksum());
             assert(header.command == .prepare);
 
             if (child) |child_header| {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -39,6 +39,7 @@ pub const JournalType = @import("vsr/journal.zig").JournalType;
 pub const SlotRange = @import("vsr/journal.zig").SlotRange;
 pub const SuperBlockType = superblock.SuperBlockType;
 pub const VSRState = superblock.SuperBlockSector.VSRState;
+pub const ViewChangeHeaders = std.BoundedArray(Header, constants.view_change_headers_max);
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -107,9 +107,6 @@ pub const Command = enum(u8) {
     do_view_change,
     start_view,
 
-    recovery,
-    recovery_response,
-
     request_start_view,
     request_headers,
     request_prepare,
@@ -324,8 +321,6 @@ pub const Header = extern struct {
             .start_view_change => self.invalid_start_view_change(),
             .do_view_change => self.invalid_do_view_change(),
             .start_view => self.invalid_start_view(),
-            .recovery => self.invalid_recovery(),
-            .recovery_response => self.invalid_recovery_response(),
             .request_start_view => self.invalid_request_start_view(),
             .request_headers => self.invalid_request_headers(),
             .request_prepare => self.invalid_request_prepare(),
@@ -522,29 +517,6 @@ pub const Header = extern struct {
         if (self.parent != 0) return "parent != 0";
         if (self.client != 0) return "client != 0";
         if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_recovery(self: *const Header) ?[]const u8 {
-        assert(self.command == .recovery);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_recovery_response(self: *const Header) ?[]const u8 {
-        assert(self.command == .recovery_response);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
         if (self.request != 0) return "request != 0";
         if (self.timestamp != 0) return "timestamp != 0";
         if (self.operation != .reserved) return "operation != .reserved";

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -65,7 +65,7 @@ comptime {
 const Slot = struct { index: usize };
 
 /// An inclusive, non-empty range of slots.
-const SlotRange = struct {
+pub const SlotRange = struct {
     head: Slot,
     tail: Slot,
 
@@ -76,7 +76,7 @@ const SlotRange = struct {
     /// * `head < tail` → `  head··tail  `
     /// * `head > tail` → `··tail  head··` (The range wraps around).
     /// * `head = tail` → panic            (Caller must handle this case separately).
-    fn contains(range: *const SlotRange, slot: Slot) bool {
+    pub fn contains(range: *const SlotRange, slot: Slot) bool {
         // To avoid confusion, the empty range must be checked separately by the caller.
         assert(range.head.index != range.tail.index);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4087,7 +4087,7 @@ pub fn ReplicaType(
             assert(self.repairs_allowed());
             assert(self.journal.dirty.count > 0);
             assert(self.op >= self.commit_min);
-            assert(self.op - self.commit_min + 1 <= constants.journal_slot_count);
+            assert(self.op - self.commit_min <= constants.journal_slot_count);
 
             // Request enough prepares to utilize our max IO depth:
             var budget = self.journal.writes.available();
@@ -5379,11 +5379,11 @@ pub fn ReplicaType(
                 self.status == .recovering or
                 self.status == .recovering_head);
 
-            const status_from = self.status;
+            const status_before = self.status;
             self.status = .view_change;
 
             if (self.view == view_new) {
-                assert(status_from == .recovering or self.status == .recovering_head);
+                assert(status_before == .recovering or status_before == .recovering_head);
             } else {
                 assert(view_new > self.view);
                 self.view = view_new;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1231,7 +1231,6 @@ pub fn ReplicaType(
             // headers of any other replica with the same log_view so that the next primary can
             // identify an unambiguous set of canonical headers.
             self.log_view = self.view;
-            self.view_durable_update();
 
             assert(self.op >= self.commit_max);
             assert(self.state_machine.prepare_timestamp >=
@@ -4905,11 +4904,15 @@ pub fn ReplicaType(
         /// `view_durable` and `log_view_durable` will update asynchronously, when their respective
         /// updates are durable.
         fn view_durable_update(self: *Self) void {
-            assert(self.status != .recovering);
+            assert(self.status == .normal or self.status == .view_change);
             assert(self.view >= self.log_view);
             assert(self.view >= self.view_durable());
             assert(self.log_view >= self.log_view_durable());
             assert(self.log_view > self.log_view_durable() or self.view > self.view_durable());
+            // The primary must only persist the SV headers after repairs are done.
+            // Otherwise headers could be nacked, truncated, then restored after a crash.
+            assert(self.log_view < self.view or self.replica != self.primary_index(self.view) or
+                self.status == .normal);
 
             if (self.view_durable_updating()) return;
 
@@ -4936,7 +4939,7 @@ pub fn ReplicaType(
 
         fn view_durable_update_callback(context: *SuperBlock.Context) void {
             const self = @fieldParentPtr(Self, "superblock_context_view_change", context);
-            assert(self.status != .recovering);
+            assert(self.status == .normal or self.status == .view_change);
             assert(!self.view_durable_updating());
             assert(self.superblock.working.vsr_state.view <= self.view);
             assert(self.superblock.working.vsr_state.log_view <= self.log_view);
@@ -4954,13 +4957,16 @@ pub fn ReplicaType(
             assert(self.log_view_durable() <= self.view_durable());
             assert(self.log_view_durable() <= self.log_view);
 
-            if (self.view_durable() != self.view or
-                self.log_view_durable() != self.log_view)
-            {
-                // The view/log_view incremented while the previous view-change update was
-                // being saved.
-                self.view_durable_update();
-            }
+            // The view/log_view incremented while the previous view-change update was being saved.
+            const update = self.log_view_durable() < self.log_view or
+                self.view_durable() < self.view;
+
+            const update_dvc = update and self.log_view < self.view;
+            const update_sv = update and self.log_view == self.view and
+                (self.replica != self.primary_index(self.view) or self.status == .normal);
+            assert(!(update_dvc and update_sv));
+
+            if (update_dvc or update_sv) self.view_durable_update();
         }
 
         fn set_op_and_commit_max(self: *Self, op: u64, commit_max: u64, method: []const u8) void {
@@ -5184,6 +5190,7 @@ pub fn ReplicaType(
         fn primary_start_view_as_the_new_primary(self: *Self) void {
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
+            assert(self.view == self.log_view);
             assert(self.do_view_change_quorum);
             assert(!self.pipeline_repairing);
             assert(self.primary_repair_pipeline() == .done);
@@ -5225,6 +5232,7 @@ pub fn ReplicaType(
             }
 
             self.transition_to_normal_from_view_change_status(self.view);
+            self.view_durable_update();
 
             assert(self.status == .normal);
             assert(self.primary());
@@ -5232,16 +5240,9 @@ pub fn ReplicaType(
             // Send prepare_ok messages to ourself to contribute to the pipeline.
             self.send_prepare_oks_after_view_change();
 
-            const start_view = self.create_view_change_message(.start_view);
-            defer self.message_bus.unref(start_view);
-
-            assert(start_view.references == 1);
-            assert(start_view.header.command == .start_view);
-            assert(start_view.header.view == self.view);
-            assert(start_view.header.op == self.op);
-            assert(start_view.header.commit == self.commit_max);
-
-            self.send_message_to_other_replicas(start_view);
+            // SVs will be sent out (via timeout) after the view_durable update completes.
+            assert(self.view_durable_updating());
+            assert(self.log_view > self.log_view_durable());
         }
 
         fn transition_to_recovering_head(self: *Self) void {
@@ -5333,8 +5334,7 @@ pub fn ReplicaType(
                 assert(self.pipeline == .queue);
                 assert(self.view == view_new);
                 assert(self.log_view == view_new);
-                assert(self.view_durable_updating() or self.view_durable() == view_new);
-                assert(self.view_durable_updating() or self.log_view_durable() == view_new);
+                assert(self.commit_min == self.commit_max);
 
                 self.ping_timeout.start();
                 self.commit_timeout.start();

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5120,9 +5120,6 @@ pub fn ReplicaType(
             assert(header_head.op >= self.op_checkpoint);
             assert(header_head.op >= self.commit_min);
             assert(header_head.op >= self.commit_max);
-            // At least one replica in the new quorum committed in the new replica.op's WAL wrap —
-            // wrapping implies a checkpoint (which implies a commit).
-            assert(header_head.op <= self.commit_max + constants.journal_slot_count);
 
             if (header_head.op > self.op_checkpoint_trigger()) {
                 // This replica is too far behind, i.e. the new `self.op` is too far ahead of the

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2799,18 +2799,33 @@ pub fn ReplicaType(
                 // Construct DVC message headers.
                 assert(self.view > self.log_view);
 
-                // Ensure that if we started a DVC before a crash, that we will resume sending the
-                // exact same DVC after recovery.
-                // (An alternative implementation would be to load the superblock's DVC headers
-                // (including gaps) into the journal during open(), but that is more complicated
-                // to implement correctly).
-                if (self.log_view_durable() == self.log_view and
-                    self.log_view_durable() < self.view_durable())
-                {
+                if (self.log_view_durable() == self.log_view) {
                     const headers_durable = self.superblock.working.vsr_headers().slice;
-                    assert(headers_durable[0].checksum == headers.get(0).checksum);
+                    assert(headers_durable[0].op <= self.op);
 
-                    for (headers_durable[1..]) |*header| headers.appendAssumeCapacity(header.*);
+                    if (self.log_view_durable() < self.view_durable()) {
+                        // Ensure that if we started a DVC before a crash, that we will resume
+                        // sending the exact same DVC after recovery.
+                        // (An alternative implementation would be to load the superblock's DVC
+                        // headers (including gaps) into the journal during open(), but that is more
+                        // complicated to implement correctly).
+                        assert(headers_durable[0].op == self.op);
+                        assert(headers_durable[0].checksum == headers.get(0).checksum);
+
+                        for (headers_durable[1..]) |*header| headers.appendAssumeCapacity(header.*);
+                    } else {
+                        // Durable SV anchor. See Example 4.
+                        assert(self.log_view_durable() == self.view_durable());
+
+                        var op = self.op;
+                        while (op > headers_durable[headers_durable.len - 1].op) : (op -= 1) {
+                            const header_prev = self.journal.header_with_op(op - 1) orelse continue;
+                            const header_next = self.journal.header_with_op(op);
+                            assert(header_next == null or header_prev.checksum == header_next.?.parent);
+
+                            headers.append(header_prev.*) catch break;
+                        }
+                    }
                     return headers;
                 }
 
@@ -5875,6 +5890,42 @@ pub fn ReplicaType(
 ///
 ///   replica   headers
 ///         1   1   2   3   4a  5   6   7a [8   9]         (retired primary)
+///
+///
+/// Example 4: Gap in retiring primary suffix after recovery
+///
+/// Suppose that replica 1 starts a view as the primary of view 4, with the suffix:
+///
+///  log_view   4
+///      view   4
+///   journal   1   2   3
+///      head   3
+///
+/// During this view, it prepares several ops:
+///
+///  log_view   4
+///      view   4
+///   journal   1   2   3   4   5   6   7
+///      head   7
+///
+/// However, the WAL writes are reordered — ops 4,5,7 writes finish before op=6's write has begun:
+///
+///  log_view   4
+///      view   4
+///   journal   1   2   3   4   5   6   7
+///       wal   1   2   3   4   5   _   7
+///      head   7
+///
+/// Replica 1 crashes and recovers, and immediately begins sending a DVC for view=5.
+/// Under normal circumstances, the retired primary cannot distinguish between a gap and a break
+/// due to the possibility that its did not complete repair (see Example 2a).
+/// In this instance though, the gap is safe to skip over because it is to the right of the durable
+/// SV's head (op=3).
+///
+///  log_view   4
+///      view   5
+///   journal   1   2   3  [4   5   _   7]
+///      head   7
 ///
 const DVCQuorum = struct {
     const DVCArray = std.BoundedArray(*const Message, constants.replicas_max);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6177,6 +6177,7 @@ fn message_body_as_headers(message: *const Message) []const Header {
 
     var child: ?*const Header = null;
     for (headers) |*header| {
+        assert(!constants.verify or header.valid_checksum());
         assert(header.cluster == message.header.cluster);
         assert(header.command == .prepare);
         assert(header.view <= message.header.view);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5256,16 +5256,13 @@ pub fn ReplicaType(
             assert(self.journal.header_with_op(self.op) != null);
             assert(self.pipeline == .cache);
 
+            self.status = .recovering_head;
+
             log.warn("{}: transition_to_recovering_head: op_checkpoint={} op_head={}", .{
                 self.replica,
                 self.op_checkpoint,
                 self.op,
             });
-
-            var view = self.view;
-            if (self.primary_index(view) == self.replica) view += 1;
-
-            self.status = .recovering_head;
         }
 
         fn transition_to_normal_from_recovering_status(self: *Self) void {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -214,6 +214,7 @@ pub const SuperBlockSector = extern struct {
     comptime {
         assert(@sizeOf(SuperBlockSector) % constants.sector_size == 0);
         assert(@divExact(@sizeOf(SuperBlockSector), constants.sector_size) >= 2);
+        assert(@offsetOf(SuperBlockSector, "vsr_headers_all") == constants.sector_size);
         // Assert that there is no implicit padding in the struct.
         assert(@bitSizeOf(SuperBlockSector) == @sizeOf(SuperBlockSector) * 8);
     }

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -107,6 +107,9 @@ pub const SuperBlockSector = extern struct {
 
     /// SV/DVC header suffix. Headers are ordered from high-to-low op.
     /// Unoccupied headers (after vsr_headers_count) are zeroed.
+    ///
+    /// When `vsr_state.log_view < vsr_state.view`, the headers are for a DVC.
+    /// When `vsr_state.log_view = vsr_state.view`, the headers are for a SV.
     vsr_headers_all: [constants.view_change_headers_max]vsr.Header,
     vsr_headers_reserved: [vsr_headers_reserved_size]u8 =
         [_]u8{0} ** vsr_headers_reserved_size,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -283,6 +283,7 @@ pub const SuperBlockSector = extern struct {
     }
 
     pub fn vsr_headers(superblock: *const SuperBlockSector) []const vsr.Header {
+        assert(superblock.vsr_headers_count > 0);
         return superblock.vsr_headers_all[0..superblock.vsr_headers_count];
     }
 };
@@ -751,7 +752,12 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 superblock.staging.vsr_state.view < update.view);
 
             assert(update.view >= update.log_view);
-            for (update.headers.constSlice()) |*h| assert(h.view <= update.view);
+            var op = update.headers.get(0).op + 1;
+            for (update.headers.constSlice()) |*h| {
+                assert(h.view <= update.view);
+                assert(h.op < op);
+                op = h.op;
+            }
 
             const vsr_state = SuperBlockSector.VSRState{
                 .commit_min_checksum = superblock.staging.vsr_state.commit_min_checksum,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1310,12 +1310,14 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 // We do not repair padding.
                 context.copy = 0;
                 superblock.read_free_set(context);
-            } else if (copy + 1 == constants.superblock_copies) {
-                @panic("superblock manifest lost");
             } else {
                 log.debug("open: read_manifest: corrupt copy={}", .{copy});
-                context.copy = copy + 1;
-                superblock.read_manifest(context);
+                if (copy + 1 == constants.superblock_copies) {
+                    @panic("superblock manifest lost");
+                } else {
+                    context.copy = copy + 1;
+                    superblock.read_manifest(context);
+                }
             }
         }
 

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -643,8 +643,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .free_set_size = 0,
                 .client_table_size = 0,
                 .vsr_headers_count = 0,
-                .vsr_headers_all = [_]vsr.Header{mem.zeroInit(vsr.Header, .{})} **
-                    constants.view_change_headers_max,
+                .vsr_headers_all = mem.zeroes([constants.view_change_headers_max]vsr.Header),
             };
 
             mem.set(SuperBlockSector.Snapshot, &superblock.working.snapshots, .{
@@ -834,7 +833,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 std.mem.set(
                     vsr.Header,
                     superblock.staging.vsr_headers_all[headers.len..],
-                    std.mem.zeroInit(vsr.Header, .{}),
+                    std.mem.zeroes(vsr.Header),
                 );
             } else {
                 assert(context.caller == .checkpoint);
@@ -1614,7 +1613,7 @@ pub const areas = struct {
 test "SuperBlockSector" {
     const expect = std.testing.expect;
 
-    var a = std.mem.zeroInit(SuperBlockSector, .{});
+    var a = std.mem.zeroes(SuperBlockSector);
     a.set_checksum();
 
     assert(a.copy == 0);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -334,8 +334,8 @@ const Environment = struct {
             .commit_min_checksum = env.superblock.staging.vsr_state.commit_min_checksum + 1,
             .commit_min = env.superblock.staging.vsr_state.commit_min + 1,
             .commit_max = env.superblock.staging.vsr_state.commit_max + 1,
-            .log_view = env.superblock.staging.vsr_state.log_view + 1,
-            .view = env.superblock.staging.vsr_state.view + 1,
+            .log_view = env.superblock.staging.vsr_state.log_view,
+            .view = env.superblock.staging.vsr_state.view,
         };
 
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -317,6 +317,7 @@ const Environment = struct {
 
         var vsr_headers = vsr.ViewChangeHeaders.BoundedArray{ .buffer = undefined };
         var vsr_head = std.mem.zeroInit(vsr.Header, .{
+            .command = .prepare,
             .op = env.superblock.staging.vsr_state.commit_min,
         });
         vsr_head.set_checksum_body(&.{});
@@ -361,7 +362,7 @@ const Environment = struct {
         try env.sequence_states.append(.{
             .vsr_state = vsr_state,
             .vsr_headers = vsr.ViewChangeHeaders.BoundedArray.fromSlice(
-                env.superblock.staging.vsr_headers(),
+                env.superblock.staging.vsr_headers().slice,
             ) catch unreachable,
             .free_set = checksum_free_set(env.superblock),
         });

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -167,7 +167,7 @@ const Environment = struct {
     latest_sequence: u64 = 0,
     latest_checksum: u128 = 0,
     latest_parent: u128 = 0,
-    latest_vsr_state: VSRState = std.mem.zeroInit(VSRState, .{}),
+    latest_vsr_state: VSRState = std.mem.zeroes(VSRState),
 
     context_format: SuperBlock.Context = undefined,
     context_open: SuperBlock.Context = undefined,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -360,8 +360,7 @@ const Environment = struct {
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);
         try env.sequence_states.append(.{
             .vsr_state = vsr_state,
-            .vsr_headers = vsr.ViewChangeHeaders.fromSlice(env.superblock.staging.vsr_headers())
-                catch unreachable,
+            .vsr_headers = vsr.ViewChangeHeaders.fromSlice(env.superblock.staging.vsr_headers()) catch unreachable,
             .free_set = checksum_free_set(env.superblock),
         });
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -151,7 +151,7 @@ const Environment = struct {
     /// Indexed by sequence.
     const SequenceStates = std.ArrayList(struct {
         vsr_state: VSRState,
-        vsr_headers: vsr.ViewChangeHeaders,
+        vsr_headers: vsr.ViewChangeHeaders.BoundedArray,
         /// Track the expected `checksum(free_set)`.
         /// Note that this is a checksum of the decoded free set; it is not the same as
         /// `SuperBlockSector.free_set_checksum`.
@@ -269,7 +269,7 @@ const Environment = struct {
             .replica = 0,
         });
 
-        var vsr_headers = vsr.ViewChangeHeaders{ .buffer = undefined };
+        var vsr_headers = vsr.ViewChangeHeaders.BoundedArray{ .buffer = undefined };
         vsr_headers.appendAssumeCapacity(vsr.Header.root_prepare(cluster));
 
         assert(env.sequence_states.items.len == 0);
@@ -315,7 +315,7 @@ const Environment = struct {
             .view = env.superblock.staging.vsr_state.view + 5,
         };
 
-        var vsr_headers = vsr.ViewChangeHeaders{ .buffer = undefined };
+        var vsr_headers = vsr.ViewChangeHeaders.BoundedArray{ .buffer = undefined };
         var vsr_head = std.mem.zeroInit(vsr.Header, .{
             .op = env.superblock.staging.vsr_state.commit_min,
         });
@@ -360,7 +360,9 @@ const Environment = struct {
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);
         try env.sequence_states.append(.{
             .vsr_state = vsr_state,
-            .vsr_headers = vsr.ViewChangeHeaders.fromSlice(env.superblock.staging.vsr_headers()) catch unreachable,
+            .vsr_headers = vsr.ViewChangeHeaders.BoundedArray.fromSlice(
+                env.superblock.staging.vsr_headers(),
+            ) catch unreachable,
             .free_set = checksum_free_set(env.superblock),
         });
 


### PR DESCRIPTION
### Summary

Replace recovery protocol with the superblock.

### Details

Currently when a replica recovers from a crash, it switches to `status=recovering` and starts "recovery protocol" (as described in [VRR](https://pmg.csail.mit.edu/papers/vr-revisited.pdf) §4.3). This allows the replica to safely rejoin the cluster's current (active) view. It has a major drawback though: for recovery protocol to complete, there must be a full view-change quorum (4/6 etc) of replicas in `status=normal`. Which means that if all replicas are restarted simultaneously, the cluster can never recover.

Instead of using recovery protocol:
- Before sending a message in a particular view, ensure that that view is persisted to the superblock.
- Before sending a DVC/SV, ensure that the DVC's/SV's headers are persisted to the superblock.

In combination, these guarantee that if a replica isolates an old primary, it remains isolated after the replica restarts. That is, it is impossible for a replica to participate in view _A_, then view _B_, then view _A_ again.

The "recovery" logic lives at the end of `Replica.open()`:

    if (self.replica_count == 1) {
        if (self.journal.faulty.count > 0) {
            @panic("journal is corrupt");
        }
        assert(self.op_head_certain());

        if (self.commit_min < self.op) {
            self.commit_journal(self.op);
        } else {
            self.transition_to_normal_from_recovering_status();
        }
    } else {
        if (self.op_head_certain()) {
            if (self.view == self.log_view) {
                if (self.primary_index(self.view) == self.replica) {
                    self.transition_to_view_change_status(self.view + 1);
                } else {
                    self.transition_to_normal_from_recovering_status();
                }
            } else {
                assert(self.view > self.log_view);
                self.transition_to_view_change_status(self.view);
            }
        } else {
            self.transition_to_recovering_head();
        }
    }


`recovering_head` is a new replica status for when the head op is "uncertain" (see `Replica.op_head_certain()`). In this status, the replica keeps requesting a `start_view` message, which will resolve its uncertainty.


## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
    * (This impacts view-change performance, but does not impact the prepare/commit path.)
