### PR TITLE
Split AccountsGrooves into mutable and immutable Grooves

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -203,7 +203,7 @@ const Environment = struct {
             _id: u128,
             _groove_mut: *GrooveMut,
             _groove_immut: *GrooveImmut,
-            
+
             finished: bool = false,
             prefetch_context_mut: GrooveMut.PrefetchContext = undefined,
             prefetch_context_immut: GrooveImmut.PrefetchContext = undefined,
@@ -223,7 +223,7 @@ const Environment = struct {
                 if (getter._groove_immut.get(getter._id)) |immut| {
                     groove.prefetch_enqueue(immut.timestamp);
                 }
-                
+
                 groove.prefetch(@This().prefetch_callback_mut, &getter.prefetch_context_mut);
             }
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -194,41 +194,41 @@ const Environment = struct {
     }
 
     fn prefetch_account(env: *Environment, id: u128) void {
-        const groove_immut = &env.forest.grooves.accounts_immutable;
-        const groove_mut = &env.forest.grooves.accounts_mutable;
+        const groove_immutable = &env.forest.grooves.accounts_immutable;
+        const groove_mutable = &env.forest.grooves.accounts_mutable;
 
-        const GrooveImmut = @TypeOf(groove_immut.*);
-        const GrooveMut = @TypeOf(groove_mut.*);
+        const GrooveImmutable = @TypeOf(groove_immutable.*);
+        const GrooveMutable = @TypeOf(groove_mutable.*);
         const Getter = struct {
             _id: u128,
-            _groove_mut: *GrooveMut,
-            _groove_immut: *GrooveImmut,
+            _groove_mutable: *GrooveMutable,
+            _groove_immutable: *GrooveImmutable,
 
             finished: bool = false,
-            prefetch_context_mut: GrooveMut.PrefetchContext = undefined,
-            prefetch_context_immut: GrooveImmut.PrefetchContext = undefined,
+            prefetch_context_mutable: GrooveMutable.PrefetchContext = undefined,
+            prefetch_context_immutable: GrooveImmutable.PrefetchContext = undefined,
 
             fn prefetch_start(getter: *@This()) void {
-                const groove = getter._groove_immut;
+                const groove = getter._groove_immutable;
                 groove.prefetch_setup(null);
                 groove.prefetch_enqueue(getter._id);
-                groove.prefetch(@This().prefetch_callback_immut, &getter.prefetch_context_immut);
+                groove.prefetch(@This().prefetch_callback_immuttable, &getter.prefetch_context_immutable);
             }
 
-            fn prefetch_callback_immut(prefetch_context: *GrooveImmut.PrefetchContext) void {
-                const getter = @fieldParentPtr(@This(), "prefetch_context_immut", prefetch_context);
-                const groove = getter._groove_mut;
+            fn prefetch_callback_immuttable(prefetch_context: *GrooveImmutable.PrefetchContext) void {
+                const getter = @fieldParentPtr(@This(), "prefetch_context_immutable", prefetch_context);
+                const groove = getter._groove_mutable;
                 groove.prefetch_setup(null);
 
-                if (getter._groove_immut.get(getter._id)) |immut| {
+                if (getter._groove_immutable.get(getter._id)) |immut| {
                     groove.prefetch_enqueue(immut.timestamp);
                 }
 
-                groove.prefetch(@This().prefetch_callback_mut, &getter.prefetch_context_mut);
+                groove.prefetch(@This().prefetch_callback_mutable, &getter.prefetch_context_mutable);
             }
 
-            fn prefetch_callback_mut(prefetch_context: *GrooveMut.PrefetchContext) void {
-                const getter = @fieldParentPtr(@This(), "prefetch_context_mut", prefetch_context);
+            fn prefetch_callback_mutable(prefetch_context: *GrooveMutable.PrefetchContext) void {
+                const getter = @fieldParentPtr(@This(), "prefetch_context_mutable", prefetch_context);
                 assert(!getter.finished);
                 getter.finished = true;
             }
@@ -236,8 +236,8 @@ const Environment = struct {
 
         var getter = Getter{
             ._id = id,
-            ._groove_mut = groove_mut,
-            ._groove_immut = groove_immut,
+            ._groove_mutable = groove_mutable,
+            ._groove_immutable = groove_immutable,
         };
         getter.prefetch_start();
         while (!getter.finished) env.storage.tick();

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -16,8 +16,6 @@ const snapshot_latest = @import("tree.zig").snapshot_latest;
 const compaction_snapshot_for_op = @import("tree.zig").compaction_snapshot_for_op;
 
 fn ObjectTreeHelpers(comptime Object: type) type {
-    assert(@hasField(Object, "id"));
-    assert(std.meta.fieldInfo(Object, .id).field_type == u128);
     assert(@hasField(Object, "timestamp"));
     assert(std.meta.fieldInfo(Object, .timestamp).field_type == u64);
 
@@ -157,8 +155,9 @@ pub fn GrooveType(
 ) type {
     @setEvalBranchQuota(64000);
 
-    assert(@hasField(Object, "id"));
-    assert(std.meta.fieldInfo(Object, .id).field_type == u128);
+    const use_id = @hasField(Object, "id");
+    if (use_id) assert(std.meta.fieldInfo(Object, .id).field_type == u128);
+
     assert(@hasField(Object, "timestamp"));
     assert(std.meta.fieldInfo(Object, .timestamp).field_type == u64);
 
@@ -170,7 +169,7 @@ pub fn GrooveType(
         //
         // By default, we ignore the "timestamp" field since it's a special identifier.
         // Since the "timestamp" is ignored by default, it shouldn't be provided in groove_options.ignored.
-        comptime var ignored = mem.eql(u8, field.name, "timestamp") or mem.eql(u8, field.name, "id");
+        comptime var ignored = mem.eql(u8, field.name, "timestamp") or (use_id and mem.eql(u8, field.name, "id"));
         for (groove_options.ignored) |ignored_field_name| {
             comptime assert(!std.mem.eql(u8, ignored_field_name, "timestamp"));
             comptime assert(!std.mem.eql(u8, ignored_field_name, "id"));
@@ -262,7 +261,7 @@ pub fn GrooveType(
         break :blk TreeType(Table, Storage, tree_name);
     };
 
-    const IdTree = blk: {
+    const IdTree = if (!use_id) void else blk: {
         const Table = TableType(
             u128,
             IdTreeValue,
@@ -310,8 +309,8 @@ pub fn GrooveType(
     const indexes_count_actual = std.meta.fields(IndexTrees).len;
     const indexes_count_expect = std.meta.fields(Object).len -
         groove_options.ignored.len -
-        // The id/timestamp field is implicitly ignored since it's the primary key for ObjectTree:
-        2 +
+        // The id/timestamp fields is implicitly ignored since it's the primary key for ObjectTree:
+        (1 + @boolToInt(use_id)) +
         std.meta.fields(@TypeOf(groove_options.derived)).len;
 
     assert(indexes_count_actual == indexes_count_expect);
@@ -381,24 +380,26 @@ pub fn GrooveType(
             open,
         };
 
-        const PrefetchIDs = std.AutoHashMapUnmanaged(u128, void);
+        const id_field = if (use_id) "id" else "timestamp";
+        const Id = @TypeOf(@field(@as(Object, undefined), id_field));
+        const PrefetchIDs = std.AutoHashMapUnmanaged(Id, void);
 
         const PrefetchObjectsContext = struct {
             pub fn hash(_: PrefetchObjectsContext, object: Object) u64 {
-                return std.hash.Wyhash.hash(0, mem.asBytes(&object.id));
+                return std.hash.Wyhash.hash(0, mem.asBytes(&@field(object, id_field)));
             }
 
             pub fn eql(_: PrefetchObjectsContext, a: Object, b: Object) bool {
-                return a.id == b.id;
+                return @field(a, id_field) == @field(b, id_field);
             }
         };
         const PrefetchObjectsAdapter = struct {
-            pub fn hash(_: PrefetchObjectsAdapter, id: u128) u64 {
+            pub fn hash(_: PrefetchObjectsAdapter, id: Id) u64 {
                 return std.hash.Wyhash.hash(0, mem.asBytes(&id));
             }
 
-            pub fn eql(_: PrefetchObjectsAdapter, a_id: u128, b_object: Object) bool {
-                return a_id == b_object.id;
+            pub fn eql(_: PrefetchObjectsAdapter, a_id: Id, b_object: Object) bool {
+                return a_id == @field(b_object, id_field);
             }
         };
         const PrefetchObjects = std.HashMapUnmanaged(Object, void, PrefetchObjectsContext, 70);
@@ -431,7 +432,7 @@ pub fn GrooveType(
             prefetch_entries_max: u32,
 
             tree_options_object: ObjectTree.Options,
-            tree_options_id: IdTree.Options,
+            tree_options_id: if (use_id) IdTree.Options else void,
             tree_options_index: IndexTreeOptions,
         };
 
@@ -450,13 +451,13 @@ pub fn GrooveType(
             );
             errdefer object_tree.deinit(allocator);
 
-            var id_tree = try IdTree.init(
+            var id_tree = if (!use_id) {} else (try IdTree.init(
                 allocator,
                 node_pool,
                 grid,
                 options.tree_options_id,
-            );
-            errdefer id_tree.deinit(allocator);
+            ));
+            errdefer if (use_id) id_tree.deinit(allocator);
 
             var index_trees_initialized: usize = 0;
             var index_trees: IndexTrees = undefined;
@@ -484,7 +485,7 @@ pub fn GrooveType(
 
             var prefetch_ids = PrefetchIDs{};
             try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_entries_max);
-            errdefer prefetch_ids.deinit(allocator);
+            errdefer if (use_id) prefetch_ids.deinit(allocator);
 
             var prefetch_objects = PrefetchObjects{};
             try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_entries_max);
@@ -507,7 +508,7 @@ pub fn GrooveType(
             }
 
             groove.objects.deinit(allocator);
-            groove.ids.deinit(allocator);
+            if (use_id) groove.ids.deinit(allocator);
 
             groove.prefetch_ids.deinit(allocator);
             groove.prefetch_objects.deinit(allocator);
@@ -515,7 +516,7 @@ pub fn GrooveType(
             groove.* = undefined;
         }
 
-        pub fn get(groove: *const Groove, id: u128) ?*const Object {
+        pub fn get(groove: *const Groove, id: Id) ?*const Object {
             return groove.prefetch_objects.getKeyPtrAdapted(id, PrefetchObjectsAdapter{});
         }
 
@@ -526,7 +527,7 @@ pub fn GrooveType(
             // output tables until the compaction is complete. (Until then, the output tables may
             // be in the manifest but not yet on disk).
             const snapshot_max = groove.objects.lookup_snapshot_max;
-            assert(snapshot_max == groove.ids.lookup_snapshot_max);
+            if (use_id) assert(snapshot_max == groove.ids.lookup_snapshot_max);
 
             const snapshot_target = snapshot orelse snapshot_max;
             assert(snapshot_target <= snapshot_max);
@@ -546,27 +547,31 @@ pub fn GrooveType(
         /// This must be called by the state machine for every key to be prefetched.
         /// We tolerate duplicate IDs enqueued by the state machine.
         /// For example, if all unique operations require the same two dependencies.
-        pub fn prefetch_enqueue(groove: *Groove, id: u128) void {
-            if (groove.ids.lookup_from_memory(groove.prefetch_snapshot.?, id)) |id_tree_value| {
-                if (id_tree_value.tombstone()) {
+        pub fn prefetch_enqueue(groove: *Groove, id: Id) void {
+            if (use_id) {
+                if (groove.ids.lookup_from_memory(groove.prefetch_snapshot.?, id)) |id_tree_value| {
                     // Do nothing; an explicit ID tombstone indicates that the object was deleted.
-                } else {
+                    if (id_tree_value.tombstone()) {
+                        return;
+                    }
+
+                    // Avoid going through prefetch if the object tree already contains it in memory.
                     if (groove.objects.lookup_from_memory(
                         groove.prefetch_snapshot.?,
                         id_tree_value.timestamp,
                     )) |object| {
                         assert(!ObjectTreeHelpers(Object).tombstone(object));
-                        assert(object.id == id);
+                        assert(@field(object, id_field) == id);
                         groove.prefetch_objects.putAssumeCapacity(object.*, {});
-                    } else {
-                        // The id was in the IdTree's value cache, but not in the ObjectTree's
-                        // value cache.
-                        groove.prefetch_ids.putAssumeCapacity(id, {});
+                        return;
                     }
+
+                    // Fallthrought: The id was in the IdTree's value cache, but not in the 
+                    // ObjectTree's value cache so it needs to be prefetched.
                 }
-            } else {
-                groove.prefetch_ids.putAssumeCapacity(id, {});
             }
+
+            groove.prefetch_ids.putAssumeCapacity(id, {});
         }
 
         /// Ensure the objects corresponding to all ids enqueued with prefetch_enqueue() are
@@ -642,7 +647,7 @@ pub fn GrooveType(
             // TODO(ifreund): use a union for these to save memory, likely an extern union
             // so that we can safetly @ptrCast() until @fieldParentPtr() is implemented
             // for unions. See: https://github.com/ziglang/zig/issues/6611
-            lookup_id: IdTree.LookupContext = undefined,
+            lookup_id: if (use_id) IdTree.LookupContext else void = undefined,
             lookup_object: ObjectTree.LookupContext = undefined,
 
             fn lookup_start_next(worker: *PrefetchWorker) void {
@@ -650,6 +655,11 @@ pub fn GrooveType(
                     worker.context.worker_finished();
                     return;
                 };
+
+                if (!use_id) {
+                    worker.lookup_with_timestamp(id.*);
+                    return;
+                }
 
                 if (worker.context.groove.ids.lookup_from_memory(
                     worker.context.snapshot,
@@ -699,32 +709,34 @@ pub fn GrooveType(
                         );
                     }
 
-                    if (id_tree_value.tombstone()) {
-                        worker.lookup_start_next();
+                    if (!id_tree_value.tombstone()) {
+                        worker.lookup_with_timestamp(id_tree_value.timestamp);
                         return;
                     }
-
-                    if (worker.context.groove.objects.lookup_from_memory(
-                        worker.context.snapshot,
-                        id_tree_value.timestamp,
-                    )) |object| {
-                        // The object is not a tombstone; the ID and Object trees are in sync.
-                        assert(!ObjectTreeHelpers(Object).tombstone(object));
-
-                        worker.context.groove.prefetch_objects.putAssumeCapacityNoClobber(object.*, {});
-                        worker.lookup_start_next();
-                        return;
-                    }
-
-                    worker.context.groove.objects.lookup_from_levels(
-                        lookup_object_callback,
-                        &worker.lookup_object,
-                        worker.context.snapshot,
-                        id_tree_value.timestamp,
-                    );
-                } else {
-                    worker.lookup_start_next();
                 }
+
+                worker.lookup_start_next();
+            }
+
+            fn lookup_with_timestamp(worker: *PrefetchWorker, timestamp: u64) void {
+                if (worker.context.groove.objects.lookup_from_memory(
+                    worker.context.snapshot,
+                    timestamp,
+                )) |object| {
+                    // The object is not a tombstone; the ID (if any) and Object trees are in sync.
+                    assert(!ObjectTreeHelpers(Object).tombstone(object));
+
+                    worker.context.groove.prefetch_objects.putAssumeCapacityNoClobber(object.*, {});
+                    worker.lookup_start_next();
+                    return;
+                }
+
+                worker.context.groove.objects.lookup_from_levels(
+                    lookup_object_callback,
+                    &worker.lookup_object,
+                    worker.context.snapshot,
+                    timestamp,
+                );
             }
 
             fn lookup_object_callback(
@@ -733,7 +745,7 @@ pub fn GrooveType(
             ) void {
                 const worker = @fieldParentPtr(PrefetchWorker, "lookup_object", completion);
 
-                // The result must be non-null as we keep the ID and Object trees in sync.
+                // The result must be non-null as we keep the ID (if any) and Object trees in sync.
                 const object = result.?;
                 assert(!ObjectTreeHelpers(Object).tombstone(object));
 
@@ -743,14 +755,14 @@ pub fn GrooveType(
         };
 
         pub fn put_no_clobber(groove: *Groove, object: *const Object) void {
-            const gop = groove.prefetch_objects.getOrPutAssumeCapacityAdapted(object.id, PrefetchObjectsAdapter{});
+            const gop = groove.prefetch_objects.getOrPutAssumeCapacityAdapted(@field(object, id_field), PrefetchObjectsAdapter{});
             assert(!gop.found_existing);
             groove.insert(object);
             gop.key_ptr.* = object.*;
         }
 
         pub fn put(groove: *Groove, object: *const Object) void {
-            const gop = groove.prefetch_objects.getOrPutAssumeCapacityAdapted(object.id, PrefetchObjectsAdapter{});
+            const gop = groove.prefetch_objects.getOrPutAssumeCapacityAdapted(@field(object, id_field), PrefetchObjectsAdapter{});
             if (gop.found_existing) {
                 groove.update(gop.key_ptr, object);
             } else {
@@ -762,7 +774,7 @@ pub fn GrooveType(
         /// Insert the value into the objects tree and its fields into the index trees.
         fn insert(groove: *Groove, object: *const Object) void {
             groove.objects.put(object);
-            groove.ids.put(&IdTreeValue{ .id = object.id, .timestamp = object.timestamp });
+            if (use_id) groove.ids.put(&IdTreeValue{ .id = @field(object, id_field), .timestamp = object.timestamp });
 
             inline for (std.meta.fields(IndexTrees)) |field| {
                 const Helper = IndexTreeFieldHelperType(field.name);
@@ -776,7 +788,7 @@ pub fn GrooveType(
 
         /// Update the object and index trees by diff'ing the old and new values.
         fn update(groove: *Groove, old: *const Object, new: *const Object) void {
-            assert(old.id == new.id);
+            assert(@field(old, id_field) == @field(new, id_field));
             assert(old.timestamp == new.timestamp);
 
             // Update the object tree entry if any of the fields (even ignored) are different.
@@ -807,11 +819,11 @@ pub fn GrooveType(
         }
 
         /// Asserts that the object with the given ID exists.
-        pub fn remove(groove: *Groove, id: u128) void {
+        pub fn remove(groove: *Groove, id: Id) void {
             const object = groove.prefetch_objects.getKeyPtrAdapted(id, PrefetchObjectsAdapter{}).?;
 
             groove.objects.remove(object);
-            groove.ids.remove(&IdTreeValue{ .id = object.id, .timestamp = object.timestamp });
+            if (use_id) groove.ids.remove(&IdTreeValue{ .id = @field(object, id_field), .timestamp = object.timestamp });
 
             inline for (std.meta.fields(IndexTrees)) |field| {
                 const Helper = IndexTreeFieldHelperType(field.name);
@@ -824,11 +836,11 @@ pub fn GrooveType(
 
             // TODO(zig) Replace this with a call to removeByPtr() after upgrading to 0.10.
             // removeByPtr() replaces an unnecessary lookup here with some pointer arithmetic.
-            assert(groove.prefetch_objects.removeAdapted(object.id, PrefetchObjectsAdapter{}));
+            assert(groove.prefetch_objects.removeAdapted(@field(object, id_field), PrefetchObjectsAdapter{}));
         }
 
         /// Maximum number of pending sync callbacks (ObjectTree + IdTree + IndexTrees).
-        const join_pending_max = 2 + std.meta.fields(IndexTrees).len;
+        const join_pending_max = 1 + @boolToInt(use_id) + std.meta.fields(IndexTrees).len;
 
         fn JoinType(comptime join_op: JoinOp) type {
             return struct {
@@ -897,7 +909,7 @@ pub fn GrooveType(
             const Join = JoinType(.open);
             Join.start(groove, callback);
 
-            groove.ids.open(Join.tree_callback(.ids));
+            if (use_id) groove.ids.open(Join.tree_callback(.ids));
             groove.objects.open(Join.tree_callback(.objects));
 
             inline for (std.meta.fields(IndexTrees)) |field| {
@@ -912,7 +924,7 @@ pub fn GrooveType(
             Join.start(groove, callback);
 
             // Compact the ObjectTree and IdTree
-            groove.ids.compact(Join.tree_callback(.ids), op);
+            if (use_id) groove.ids.compact(Join.tree_callback(.ids), op);
             groove.objects.compact(Join.tree_callback(.objects), op);
 
             // Compact the IndexTrees.
@@ -928,7 +940,7 @@ pub fn GrooveType(
             Join.start(groove, callback);
 
             // Checkpoint the IdTree and ObjectTree.
-            groove.ids.checkpoint(Join.tree_callback(.ids));
+            if (use_id) groove.ids.checkpoint(Join.tree_callback(.ids));
             groove.objects.checkpoint(Join.tree_callback(.objects));
 
             // Checkpoint the IndexTrees.

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -169,7 +169,7 @@ pub fn GrooveType(
         //
         // By default, we ignore the "timestamp" field since it's a special identifier.
         // Since the "timestamp" is ignored by default, it shouldn't be provided in groove_options.ignored.
-        comptime var ignored = mem.eql(u8, field.name, "timestamp") or (has_id and mem.eql(u8, field.name, "id"));
+        comptime var ignored = mem.eql(u8, field.name, "timestamp") or mem.eql(u8, field.name, "id");
         for (groove_options.ignored) |ignored_field_name| {
             comptime assert(!std.mem.eql(u8, ignored_field_name, "timestamp"));
             comptime assert(!std.mem.eql(u8, ignored_field_name, "id"));

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -485,7 +485,7 @@ pub fn GrooveType(
 
             var prefetch_ids = PrefetchIDs{};
             try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_entries_max);
-            errdefer if (use_id) prefetch_ids.deinit(allocator);
+            errdefer prefetch_ids.deinit(allocator);
 
             var prefetch_objects = PrefetchObjects{};
             try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_entries_max);

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -566,7 +566,7 @@ pub fn GrooveType(
                         return;
                     }
 
-                    // Fallthrought: The id was in the IdTree's value cache, but not in the 
+                    // Fallthrought: The id was in the IdTree's value cache, but not in the
                     // ObjectTree's value cache so it needs to be prefetched.
                 }
             }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -351,8 +351,14 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             );
         }
 
-        fn prefetch_create_accounts_immutable_callback(completion: *AccountsImmutableGroove.PrefetchContext) void {
-            const self = @fieldParentPtr(StateMachine, "prefetch_accounts_immutable_context", completion);
+        fn prefetch_create_accounts_immutable_callback(
+            completion: *AccountsImmutableGroove.PrefetchContext,
+        ) void {
+            const self = @fieldParentPtr(
+                StateMachine,
+                "prefetch_accounts_immutable_context",
+                completion,
+            );
 
             // Nothing to prefetch_enqueue() from accounts_mutable as accounts_immutable
             // is all that is needed to check for pre-existing accounts before creating one.
@@ -364,8 +370,14 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             );
         }
 
-        fn prefetch_create_accounts_mutable_callback(completion: *AccountsMutableGroove.PrefetchContext) void {
-            const self = @fieldParentPtr(StateMachine, "prefetch_accounts_mutable_context", completion);
+        fn prefetch_create_accounts_mutable_callback(
+            completion: *AccountsMutableGroove.PrefetchContext,
+        ) void {
+            const self = @fieldParentPtr(
+                StateMachine,
+                "prefetch_accounts_mutable_context",
+                completion,
+            );
 
             self.prefetch_finish();
         }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -318,13 +318,26 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 self.forest.grooves.accounts_immutable.prefetch_enqueue(a.id);
             }
             self.forest.grooves.accounts_immutable.prefetch(
-                prefetch_create_accounts_callback,
+                prefetch_create_accounts_immutable_callback,
                 &self.prefetch_accounts_immutable_context,
             );
         }
 
-        fn prefetch_create_accounts_callback(completion: *AccountsImmutableGroove.PrefetchContext) void {
+        fn prefetch_create_accounts_immutable_callback(completion: *AccountsImmutableGroove.PrefetchContext) void {
             const self = @fieldParentPtr(StateMachine, "prefetch_accounts_immutable_context", completion);
+
+            // Nothing to prefetch_enqueue() from accounts_mutable as accounts_immutable 
+            // is all that is needed to check for pre-existing accounts before creating one.
+            // We still call prefetch() anyway to keep a valid/expected Groove state for commit().
+
+            self.forest.grooves.accounts_mutable.prefetch(
+                prefetch_create_accounts_mutable_callback,
+                &self.prefetch_accounts_mutable_context,
+            );
+        }
+
+        fn prefetch_create_accounts_mutable_callback(completion: *AccountsMutableGroove.PrefetchContext) void {
+            const self = @fieldParentPtr(StateMachine, "prefetch_accounts_mutable_context", completion);
 
             self.prefetch_finish();
         }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -485,7 +485,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             for (ids) |id| {
                 if (self.forest.grooves.accounts_immutable.get(id)) |immut| {
                     self.forest.grooves.accounts_mutable.prefetch_enqueue(immut.timestamp);
-                }   
+                }
             }
 
             self.forest.grooves.accounts_mutable.prefetch(

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -84,7 +84,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             Storage,
             AccountMutable,
             .{
-                .ignored = &[_][]const u8{ "padding" },
+                .ignored = &[_][]const u8{"padding"},
                 .derived = .{},
             },
         );
@@ -326,7 +326,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
         fn prefetch_create_accounts_immutable_callback(completion: *AccountsImmutableGroove.PrefetchContext) void {
             const self = @fieldParentPtr(StateMachine, "prefetch_accounts_immutable_context", completion);
 
-            // Nothing to prefetch_enqueue() from accounts_mutable as accounts_immutable 
+            // Nothing to prefetch_enqueue() from accounts_mutable as accounts_immutable
             // is all that is needed to check for pre-existing accounts before creating one.
             // We still call prefetch() anyway to keep a valid/expected Groove state for commit().
 
@@ -451,7 +451,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
 
         fn prefetch_lookup_accounts_mutable_callback(completion: *AccountsMutableGroove.PrefetchContext) void {
             const self = @fieldParentPtr(StateMachine, "prefetch_accounts_mutable_context", completion);
-            
+
             self.prefetch_finish();
         }
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -766,8 +766,11 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
         }
 
         fn create_account_rollback(self: *StateMachine, a: *const Account) void {
+            // Need to get the timestamp from the inserted account rather than the one passed in.
+            const timestamp = self.forest.grooves.accounts_immutable.get(a.id).?.timestamp;
+
             self.forest.grooves.accounts_immutable.remove(a.id);
-            self.forest.grooves.accounts_mutable.remove(a.timestamp);
+            self.forest.grooves.accounts_mutable.remove(timestamp);
         }
 
         fn create_account_exists(a: *const Account, e: *const AccountImmutable) CreateAccountResult {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -429,16 +429,20 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
             for (transfers) |*t| {
                 if (t.flags.post_pending_transfer or t.flags.void_pending_transfer) {
                     if (self.forest.grooves.transfers.get(t.pending_id)) |p| {
-                        const dr_immut = self.forest.grooves.accounts_immutable.get(p.debit_account_id).?;
-                        const cr_immut = self.forest.grooves.accounts_immutable.get(p.credit_account_id).?;
-                        self.forest.grooves.accounts_mutable.prefetch_enqueue(dr_immut.timestamp);
-                        self.forest.grooves.accounts_mutable.prefetch_enqueue(cr_immut.timestamp);
+                        if (self.forest.grooves.accounts_immutable.get(p.debit_account_id)) |dr_immut| {
+                            self.forest.grooves.accounts_mutable.prefetch_enqueue(dr_immut.timestamp);
+                        }
+                        if (self.forest.grooves.accounts_immutable.get(p.credit_account_id)) |cr_immut| {
+                            self.forest.grooves.accounts_mutable.prefetch_enqueue(cr_immut.timestamp);
+                        }
                     }
                 } else {
-                    const dr_immut = self.forest.grooves.accounts_immutable.get(t.debit_account_id).?;
-                    const cr_immut = self.forest.grooves.accounts_immutable.get(t.credit_account_id).?;
-                    self.forest.grooves.accounts_mutable.prefetch_enqueue(dr_immut.timestamp);
-                    self.forest.grooves.accounts_mutable.prefetch_enqueue(cr_immut.timestamp);
+                    if (self.forest.grooves.accounts_immutable.get(t.debit_account_id)) |dr_immut| {
+                        self.forest.grooves.accounts_mutable.prefetch_enqueue(dr_immut.timestamp);
+                    }
+                    if (self.forest.grooves.accounts_immutable.get(t.credit_account_id)) |cr_immut| {
+                        self.forest.grooves.accounts_mutable.prefetch_enqueue(cr_immut.timestamp);
+                    }
                 }
             }
 
@@ -479,8 +483,9 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
 
             const ids = mem.bytesAsSlice(Event(.lookup_accounts), self.prefetch_input.?);
             for (ids) |id| {
-                const immut = self.forest.grooves.accounts_immutable.get(id) orelse continue;
-                self.forest.grooves.accounts_mutable.prefetch_enqueue(immut.timestamp);
+                if (self.forest.grooves.accounts_immutable.get(id)) |immut| {
+                    self.forest.grooves.accounts_mutable.prefetch_enqueue(immut.timestamp);
+                }   
             }
 
             self.forest.grooves.accounts_mutable.prefetch(

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -479,7 +479,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
 
             const ids = mem.bytesAsSlice(Event(.lookup_accounts), self.prefetch_input.?);
             for (ids) |id| {
-                const immut = self.forest.grooves.accounts_immutable.get(id).?;
+                const immut = self.forest.grooves.accounts_immutable.get(id) orelse continue;
                 self.forest.grooves.accounts_mutable.prefetch_enqueue(immut.timestamp);
             }
 


### PR DESCRIPTION
Splits out the immutable and mutable portions of the Account struct into their own Grooves to decrease write amplification overhead. `AccountImmutableGroove` contains all the non-balance fields with an IdTree while `AccountsMutableGroove` contains the balance fields updated frequently by `create_transfers`. Changes to Groove are made to conditionally opt-out of IdTree usage.

Closes #255 

## Pre-merge checklist

(TODO) Performance:

* ~~[ ] Compare `zig benchmark` on linux before and after this pr.~~
    ``` sh
    On my system, the standard deviation in req/s is too large to accurately tell if it introduces a regression or not :/
    ```
