### PR TITLE
VSR: Misc cleanup

### DIFF
--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -72,7 +72,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             const commit_b = replica.commit_min;
 
             const header_b = replica.journal.header_with_op(replica.commit_min);
-            assert(header_b != null or replica.commit_min == replica.op_checkpoint);
+            assert(header_b != null or replica.commit_min == replica.op_checkpoint());
             assert(header_b == null or header_b.?.op == commit_b);
 
             const checksum_a = state_checker.commits.items[commit_a].header.checksum;

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -145,15 +145,15 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             inline for (std.meta.fields(Checkpoint)) |field| {
                 log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={}", .{
                     replica.replica,
-                    replica.op_checkpoint,
+                    replica.op_checkpoint(),
                     field.name,
                     @field(checkpoint, field.name),
                 });
             }
 
-            const checkpoint_expect = checker.checkpoints.get(replica.op_checkpoint) orelse {
+            const checkpoint_expect = checker.checkpoints.get(replica.op_checkpoint()) orelse {
                 // This replica is the first to reach op_checkpoint.
-                try checker.checkpoints.putNoClobber(replica.op_checkpoint, checkpoint);
+                try checker.checkpoints.putNoClobber(replica.op_checkpoint(), checkpoint);
                 return;
             };
 

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -14,7 +14,7 @@
 //! - Acquired Grid blocks
 //!
 //! Areas not verified:
-//! - SuperBlock sectors, which hold replica-specific state.
+//! - SuperBlock headers, which hold replica-specific state.
 //! - WAL headers, which may differ because the WAL writes deliberately corrupt redundant headers
 //!   to faulty slots to ensure recovery is consistent.
 //! - Non-allocated Grid blocks, which may differ due to state transfer.
@@ -25,7 +25,7 @@ const log = std.log.scoped(.storage_checker);
 const constants = @import("../../constants.zig");
 const vsr = @import("../../vsr.zig");
 const superblock = @import("../../vsr/superblock.zig");
-const SuperBlockSector = superblock.SuperBlockSector;
+const SuperBlockHeader = superblock.SuperBlockHeader;
 const Storage = @import("../storage.zig").Storage;
 
 /// After each compaction half measure, save the cumulative hash of all acquired grid blocks.
@@ -44,7 +44,7 @@ const Checkpoints = std.AutoHashMap(u64, Checkpoint);
 
 const Checkpoint = struct {
     // The superblock trailers are an XOR of all copies of all respective trailers, not the
-    // `SuperBlockSector.{trailer}_checksum`.
+    // `SuperBlockHeader.{trailer}_checksum`.
     checksum_superblock_manifest: u128,
     checksum_superblock_free_set: u128,
     checksum_superblock_client_table: u128,

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -625,20 +625,18 @@ pub const ClusterFaultAtlas = struct {
 
         var atlas = ClusterFaultAtlas{ .options = options };
 
-        {
-            for (&atlas.faulty_superblock_areas.values) |*copies, area| {
-                if (area == @enumToInt(superblock.Area.header)) {
-                    // Only inject read/write faults into trailers, not the header.
-                    // This prevents the quorum from being lost like so:
-                    // - copy₀: B (ok)
-                    // - copy₁: B (torn write)
-                    // - copy₂: A (corrupt)
-                    // - copy₃: A (ok)
-                } else {
-                    var area_faults: usize = 0;
-                    while (area_faults < superblock_trailer_faults_max) : (area_faults += 1) {
-                        copies.set(random.uintLessThan(usize, constants.superblock_copies));
-                    }
+        for (&atlas.faulty_superblock_areas.values) |*copies, area| {
+            if (area == @enumToInt(superblock.Area.header)) {
+                // Only inject read/write faults into trailers, not the header.
+                // This prevents the quorum from being lost like so:
+                // - copy₀: B (ok)
+                // - copy₁: B (torn write)
+                // - copy₂: A (corrupt)
+                // - copy₃: A (ok)
+            } else {
+                var area_faults: usize = 0;
+                while (area_faults < superblock_trailer_faults_max) : (area_faults += 1) {
+                    copies.set(random.uintLessThan(usize, constants.superblock_copies));
                 }
             }
         }

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -620,7 +620,6 @@ pub const ClusterFaultAtlas = struct {
 
     pub fn init(replica_count: u8, random: std.rand.Random, options: Options) ClusterFaultAtlas {
         // If there is only one replica in the cluster, WAL/Grid faults are not recoverable.
-        // TODO Can we allow Header faults only?
         assert(replica_count > 1 or options.faulty_wal_headers == false);
         assert(replica_count > 1 or options.faulty_wal_prepares == false);
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -112,6 +112,11 @@ const Command = struct {
         defer superblock.deinit(allocator);
 
         try vsr.format(Storage, allocator, cluster, replica, &command.storage, &superblock);
+
+        log_main.info("{}: formatted: cluster={}", .{
+            replica,
+            cluster,
+        });
     }
 
     pub fn start(arena: *std.heap.ArenaAllocator, args: *const cli.Command.Start) !void {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -38,7 +38,7 @@ pub const Clock = @import("vsr/clock.zig").Clock;
 pub const JournalType = @import("vsr/journal.zig").JournalType;
 pub const SlotRange = @import("vsr/journal.zig").SlotRange;
 pub const SuperBlockType = superblock.SuperBlockType;
-pub const VSRState = superblock.SuperBlockSector.VSRState;
+pub const VSRState = superblock.SuperBlockHeader.VSRState;
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1211,7 +1211,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             }
 
             const prepare_op_max = std.math.max(
-                replica.op_checkpoint,
+                replica.op_checkpoint(),
                 op_maximum_headers_untrusted(replica.cluster, journal.headers),
             );
 
@@ -1279,7 +1279,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
             const op_max = op_maximum_headers_untrusted(replica.cluster, journal.headers_redundant);
             if (op_max != op_maximum_headers_untrusted(replica.cluster, journal.headers)) return null;
-            if (op_max < replica.op_checkpoint) return null;
+            if (op_max < replica.op_checkpoint()) return null;
             // We can't assume that the header at `op_max` is a prepare — an empty journal with a
             // corrupt root prepare (op_max=0) will be repaired later.
 
@@ -1310,7 +1310,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 // unless the prepare header was lost, in which case this slot may also not be torn.
             }
 
-            const checkpoint_index = journal.slot_for_op(replica.op_checkpoint).index;
+            const checkpoint_index = journal.slot_for_op(replica.op_checkpoint()).index;
             const known_range = SlotRange{
                 .head = Slot{ .index = checkpoint_index },
                 .tail = torn_slot,
@@ -1333,8 +1333,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 // Do not use `faulty.bit()` because the decisions have not been processed yet.
                 if (case.decision(replica.replica_count) == .vsr) {
                     if (checkpoint_index == torn_slot.index) {
-                        assert(op_max >= replica.op_checkpoint);
-                        assert(torn_op > replica.op_checkpoint);
+                        assert(op_max >= replica.op_checkpoint());
+                        assert(torn_op > replica.op_checkpoint());
                         if (index != torn_slot.index) return null;
                     } else {
                         if (!known_range.contains(Slot{ .index = index })) return null;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -154,10 +154,6 @@ pub fn ReplicaType(
         // Also verify that a corresponding header exists in the WAL.
         op: u64,
 
-        /// The op of the highest checkpointed message.
-        // TODO Refuse to store/ack any op>op_checkpoint+journal_slot_count.
-        op_checkpoint: u64,
-
         /// The op number of the latest committed and executed operation (according to the replica):
         /// The replica may have to wait for repairs to complete before commit_min reaches commit_max.
         ///
@@ -551,7 +547,6 @@ pub fn ReplicaType(
                 .view = self.superblock.working.vsr_state.view,
                 .log_view = self.superblock.working.vsr_state.log_view,
                 .op = 0,
-                .op_checkpoint = self.superblock.working.vsr_state.commit_min,
                 .commit_min = self.superblock.working.vsr_state.commit_min,
                 .commit_max = self.superblock.working.vsr_state.commit_max,
                 .pipeline = .{ .cache = .{} },
@@ -909,7 +904,7 @@ pub fn ReplicaType(
                 log.debug("{}: on_prepare: ignoring op={} (too far ahead, checkpoint={})", .{
                     self.replica,
                     message.header.op,
-                    self.op_checkpoint,
+                    self.op_checkpoint(),
                 });
                 // When we are the primary, `on_request` enforces this invariant.
                 assert(self.backup());
@@ -920,7 +915,7 @@ pub fn ReplicaType(
             assert(message.header.view == self.view);
             assert(self.primary() or self.backup());
             assert(message.header.replica == self.primary_index(message.header.view));
-            assert(message.header.op > self.op_checkpoint);
+            assert(message.header.op > self.op_checkpoint());
             assert(message.header.op > self.op);
             assert(message.header.op > self.commit_min);
             assert(message.header.op <= self.op_checkpoint_trigger());
@@ -991,7 +986,7 @@ pub fn ReplicaType(
             // TODO: When Block recover & state transfer are implemented, this can be removed.
             const threshold =
                 if (prepare.message.header.op == self.op_checkpoint_trigger() or
-                prepare.message.header.op == self.op_checkpoint + constants.lsm_batch_multiple + 1)
+                prepare.message.header.op == self.op_checkpoint() + constants.lsm_batch_multiple + 1)
                 self.replica_count
             else
                 self.quorum_replication;
@@ -2285,8 +2280,8 @@ pub fn ReplicaType(
             const self = @fieldParentPtr(Self, "state_machine", state_machine);
             assert(self.committing);
             assert(self.commit_callback != null);
-            assert(self.op_checkpoint == self.superblock.staging.vsr_state.commit_min);
-            assert(self.op_checkpoint == self.superblock.working.vsr_state.commit_min);
+            assert(self.op_checkpoint() == self.superblock.staging.vsr_state.commit_min);
+            assert(self.op_checkpoint() == self.superblock.working.vsr_state.commit_min);
 
             const op = self.commit_prepare.?.header.op;
             assert(op == self.commit_min);
@@ -2301,7 +2296,7 @@ pub fn ReplicaType(
                     "(op={} current_checkpoint={} next_checkpoint={})", .{
                     self.replica,
                     self.op,
-                    self.op_checkpoint,
+                    self.op_checkpoint(),
                     self.op_checkpoint_next(),
                 });
                 tracer.start(
@@ -2354,15 +2349,14 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.op);
             assert(self.commit_prepare.?.header.op == self.commit_min);
 
-            self.op_checkpoint = self.op_checkpoint_next();
-            assert(self.op_checkpoint == self.commit_min - constants.lsm_batch_multiple);
-            assert(self.op_checkpoint == self.superblock.staging.vsr_state.commit_min);
-            assert(self.op_checkpoint == self.superblock.working.vsr_state.commit_min);
+            assert(self.op_checkpoint() == self.commit_min - constants.lsm_batch_multiple);
+            assert(self.op_checkpoint() == self.superblock.staging.vsr_state.commit_min);
+            assert(self.op_checkpoint() == self.superblock.working.vsr_state.commit_min);
 
             log.debug("{}: commit_op_compact_callback: checkpoint done (op={} new_checkpoint={})", .{
                 self.replica,
                 self.op,
-                self.op_checkpoint,
+                self.op_checkpoint(),
             });
             tracer.end(
                 &self.tracer_slot_checkpoint,
@@ -2413,7 +2407,7 @@ pub fn ReplicaType(
             // this commit.
 
             assert(self.journal.has(prepare.header));
-            if (self.op_checkpoint == self.commit_min) {
+            if (self.op_checkpoint() == self.commit_min) {
                 // op_checkpoint's slot may have been overwritten in the WAL — but we can
                 // always use the VSRState to anchor the hash chain.
                 assert(prepare.header.parent ==
@@ -2482,7 +2476,7 @@ pub fn ReplicaType(
             if (self.superblock.working.vsr_state.op_compacted(prepare.header.op)) {
                 // We are recovering from a checkpoint. Prior to the crash, the client table was
                 // updated with entries for one bar beyond the op_checkpoint.
-                assert(self.op_checkpoint == self.superblock.working.vsr_state.commit_min);
+                assert(self.op_checkpoint() == self.superblock.working.vsr_state.commit_min);
                 if (self.client_table().get(prepare.header.client)) |entry| {
                     assert(entry.reply.header.command == .reply);
                     assert(entry.reply.header.op >= prepare.header.op);
@@ -2493,7 +2487,7 @@ pub fn ReplicaType(
                 log.debug("{}: commit_op: skip client table update: prepare.op={} checkpoint={}", .{
                     self.replica,
                     prepare.header.op,
-                    self.op_checkpoint,
+                    self.op_checkpoint(),
                 });
             } else {
                 if (reply.header.operation == .register) {
@@ -3125,7 +3119,7 @@ pub fn ReplicaType(
                 log.debug("{}: on_request: ignoring op={} (too far ahead, checkpoint_trigger={})", .{
                     self.replica,
                     self.op + 1,
-                    self.op_checkpoint,
+                    self.op_checkpoint(),
                 });
                 return true;
             }
@@ -3432,9 +3426,9 @@ pub fn ReplicaType(
         ///              (`replica.op_checkpoint` == `replica.op`).
         fn op_head_certain(self: *const Self) bool {
             assert(self.status == .recovering);
-            assert(self.op_checkpoint <= self.op);
+            assert(self.op_checkpoint() <= self.op);
 
-            const slot_op_checkpoint = self.journal.slot_for_op(self.op_checkpoint);
+            const slot_op_checkpoint = self.journal.slot_for_op(self.op_checkpoint());
             const slot_op_head = self.journal.slot_with_op(self.op).?;
             const slot_known_range = vsr.SlotRange{
                 .head = slot_op_checkpoint,
@@ -3450,6 +3444,12 @@ pub fn ReplicaType(
                 }
             }
             return true;
+        }
+
+        /// The op of the highest checkpointed message.
+        // TODO Refuse to store/ack any op>op_checkpoint+journal_slot_count.
+        pub fn op_checkpoint(self: *const Self) u64 {
+            return self.superblock.working.vsr_state.commit_min;
         }
 
         /// Returns the op that will be `op_checkpoint` after the next checkpoint.
@@ -3476,21 +3476,21 @@ pub fn ReplicaType(
         ///     %  op_checkpoint_trigger
         ///
         fn op_checkpoint_next(self: *const Self) u64 {
-            assert(self.op_checkpoint <= self.commit_min);
-            assert(self.op_checkpoint <= self.op);
-            assert(self.op_checkpoint == 0 or
-                (self.op_checkpoint + 1) % constants.lsm_batch_multiple == 0);
+            assert(self.op_checkpoint() <= self.commit_min);
+            assert(self.op_checkpoint() <= self.op);
+            assert(self.op_checkpoint() == 0 or
+                (self.op_checkpoint() + 1) % constants.lsm_batch_multiple == 0);
 
-            const op = if (self.op_checkpoint == 0)
+            const op = if (self.op_checkpoint() == 0)
                 // First wrap: op_checkpoint_next = 8-2-1 = 5
                 constants.journal_slot_count - constants.lsm_batch_multiple - 1
             else
                 // Second wrap: op_checkpoint_next = 5+8-2 = 11
                 // Third wrap: op_checkpoint_next = 11+8-2 = 17
-                self.op_checkpoint + constants.journal_slot_count - constants.lsm_batch_multiple;
+                self.op_checkpoint() + constants.journal_slot_count - constants.lsm_batch_multiple;
             assert((op + 1) % constants.lsm_batch_multiple == 0);
             // The checkpoint always advances.
-            assert(op > self.op_checkpoint);
+            assert(op > self.op_checkpoint());
 
             return op;
         }
@@ -3649,8 +3649,8 @@ pub fn ReplicaType(
             assert(self.status == .normal or self.status == .view_change);
             assert(self.repairs_allowed());
 
-            assert(self.op_checkpoint <= self.op);
-            assert(self.op_checkpoint <= self.commit_min);
+            assert(self.op_checkpoint() <= self.op);
+            assert(self.op_checkpoint() <= self.commit_min);
             assert(self.commit_min <= self.op);
             assert(self.commit_min <= self.commit_max);
             assert(self.journal.header_with_op(self.op) != null);
@@ -3821,8 +3821,8 @@ pub fn ReplicaType(
                 return false;
             }
 
-            if (header.op <= self.op_checkpoint) {
-                if (header.op == 0 and self.op_checkpoint == 0) {
+            if (header.op <= self.op_checkpoint()) {
+                if (header.op == 0 and self.op_checkpoint() == 0) {
                     // Repairing the root op is allowed until the first checkpoint.
                 } else {
                     // It is critical that we do not repair checkpointed ops; their slots now belong
@@ -3830,7 +3830,7 @@ pub fn ReplicaType(
                     // correctness violation.
                     log.debug("{}: repair_header: false (precedes self.op_checkpoint={})", .{
                         self.replica,
-                        self.op_checkpoint,
+                        self.op_checkpoint(),
                     });
                     return false;
                 }
@@ -4180,7 +4180,7 @@ pub fn ReplicaType(
                         // belong) to a newer op, from the new WAL wrap. Additionally, we may not
                         // still have access to its surrounding commits to verify the hash chain.
                         assert(op <= self.commit_min);
-                        assert(op <= self.op_checkpoint);
+                        assert(op <= self.op_checkpoint());
                         assert(self.journal.faulty.bit(slot));
 
                         log.debug("{}: repair_prepares: remove slot={} " ++
@@ -4388,7 +4388,7 @@ pub fn ReplicaType(
         /// Replaces the header if the header is different and not already committed.
         /// The caller must ensure that the header is trustworthy.
         fn replace_header(self: *Self, header: *const Header) void {
-            assert(self.op_checkpoint <= self.commit_min);
+            assert(self.op_checkpoint() <= self.commit_min);
             assert(header.command == .prepare);
             assert(header.op <= self.op); // Never advance the op.
             assert(header.op <= self.op_checkpoint_trigger());
@@ -4398,7 +4398,7 @@ pub fn ReplicaType(
                     assert(existing_header.checksum == header.checksum);
                     return;
                 } else {
-                    if (header.op <= self.op_checkpoint) {
+                    if (header.op <= self.op_checkpoint()) {
                         // Never replace a checkpointed op — those slots are needed by the following
                         // WAL wrap.
                         return;
@@ -5138,7 +5138,7 @@ pub fn ReplicaType(
             const header_head = headers_canonical.next().?;
             assert(header_head.op == header_head.op);
             assert(header_head.op >= do_view_change_commit_min_max);
-            assert(header_head.op >= self.op_checkpoint);
+            assert(header_head.op >= self.op_checkpoint());
             assert(header_head.op >= self.commit_min);
             assert(header_head.op >= self.commit_max);
 
@@ -5273,7 +5273,7 @@ pub fn ReplicaType(
 
             log.warn("{}: transition_to_recovering_head: op_checkpoint={} op_head={}", .{
                 self.replica,
-                self.op_checkpoint,
+                self.op_checkpoint(),
                 self.op,
             });
         }
@@ -5521,7 +5521,7 @@ pub fn ReplicaType(
         fn valid_hash_chain_between(self: *const Self, op_min: u64, op_max: u64) bool {
             assert(op_min <= op_max);
             // Headers with ops preceding the checkpoint may be unavailable due to a WAL wrap.
-            assert(op_min >= self.op_checkpoint);
+            assert(op_min >= self.op_checkpoint());
 
             // If we use anything less than self.op then we may commit ops for a forked hash chain
             // that have since been reordered by a new primary.
@@ -5532,7 +5532,7 @@ pub fn ReplicaType(
             while (op > op_min) {
                 op -= 1;
 
-                if (self.op_checkpoint == op) {
+                if (self.op_checkpoint() == op) {
                     // op_checkpoint's slot may have been overwritten in the WAL — but we can
                     // always use the VSRState to anchor the hash chain.
                     assert(op == op_min);
@@ -5543,7 +5543,7 @@ pub fn ReplicaType(
                         log.debug("{}: valid_hash_chain_between: break A: {} (checkpoint={})", .{
                             self.replica,
                             self.superblock.working.vsr_state.commit_min_checksum,
-                            self.op_checkpoint,
+                            self.op_checkpoint(),
                         });
                         log.debug("{}: valid_hash_chain_between: break B: {}", .{
                             self.replica,
@@ -5656,10 +5656,10 @@ pub fn ReplicaType(
             assert(message.header.view <= self.view);
             assert(message.header.op <= self.op);
 
-            if (message.header.op == self.op_checkpoint) {
+            if (message.header.op == self.op_checkpoint()) {
                 assert(message.header.op == 0);
             } else {
-                assert(message.header.op > self.op_checkpoint);
+                assert(message.header.op > self.op_checkpoint());
             }
 
             if (!self.journal.has(message.header)) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5262,7 +5262,7 @@ pub fn ReplicaType(
 
         fn transition_to_recovering_head(self: *Self) void {
             assert(self.status == .recovering);
-            assert(self.view >= self.log_view);
+            assert(self.view == self.log_view);
             assert(self.op >= self.commit_min);
             assert(!self.committing);
             assert(self.replica_count > 1);

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -181,20 +181,20 @@ test "format" {
 
     try format(Storage, allocator, cluster, replica, &storage, &superblock);
 
-    // Verify the superblock sectors.
+    // Verify the superblock headers.
     var copy: u8 = 0;
     while (copy < constants.superblock_copies) : (copy += 1) {
-        const sector = storage.superblock_sector(copy);
+        const superblock_header = storage.superblock_header(copy);
 
-        try std.testing.expectEqual(sector.copy, copy);
-        try std.testing.expectEqual(sector.replica, replica);
-        try std.testing.expectEqual(sector.cluster, cluster);
-        try std.testing.expectEqual(sector.storage_size, storage.size);
-        try std.testing.expectEqual(sector.sequence, 1);
-        try std.testing.expectEqual(sector.vsr_state.commit_min, 0);
-        try std.testing.expectEqual(sector.vsr_state.commit_max, 0);
-        try std.testing.expectEqual(sector.vsr_state.view, 0);
-        try std.testing.expectEqual(sector.vsr_state.log_view, 0);
+        try std.testing.expectEqual(superblock_header.copy, copy);
+        try std.testing.expectEqual(superblock_header.replica, replica);
+        try std.testing.expectEqual(superblock_header.cluster, cluster);
+        try std.testing.expectEqual(superblock_header.storage_size, storage.size);
+        try std.testing.expectEqual(superblock_header.sequence, 1);
+        try std.testing.expectEqual(superblock_header.vsr_state.commit_min, 0);
+        try std.testing.expectEqual(superblock_header.vsr_state.commit_max, 0);
+        try std.testing.expectEqual(superblock_header.vsr_state.view, 0);
+        try std.testing.expectEqual(superblock_header.vsr_state.log_view, 0);
     }
 
     // Verify the WAL headers and prepares zones.

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1226,7 +1226,11 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     },
                 );
                 for (superblock.working.vsr_headers().slice) |*header| {
-                    log.debug("{s}: vsr_header: {}", .{ @tagName(context.caller), header.* });
+                    log.debug("{s}: vsr_header: op={} checksum={}", .{
+                        @tagName(context.caller),
+                        header.op,
+                        header.checksum,
+                    });
                 }
 
                 if (context.caller == .open) {

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -22,7 +22,7 @@ const StorageFaultAtlas = @import("../testing/storage.zig").ClusterFaultAtlas;
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const superblock_zone_size = @import("superblock.zig").superblock_zone_size;
 const data_file_size_min = @import("superblock.zig").data_file_size_min;
-const VSRState = @import("superblock.zig").SuperBlockSector.VSRState;
+const VSRState = @import("superblock.zig").SuperBlockHeader.VSRState;
 const SuperBlockType = @import("superblock.zig").SuperBlockType;
 const SuperBlock = SuperBlockType(Storage);
 const fuzz = @import("../testing/fuzz.zig");
@@ -154,7 +154,7 @@ const Environment = struct {
         vsr_headers: vsr.ViewChangeHeaders.BoundedArray,
         /// Track the expected `checksum(free_set)`.
         /// Note that this is a checksum of the decoded free set; it is not the same as
-        /// `SuperBlockSector.free_set_checksum`.
+        /// `SuperBlockHeader.free_set_checksum`.
         free_set: u128,
     });
 
@@ -233,7 +233,7 @@ const Environment = struct {
             if (env.latest_checksum != 0) {
                 if (env.latest_sequence + 1 == env.superblock_verify.working.sequence) {
                     // After a checkpoint() or view_change(), the parent points to the previous
-                    // working sector.
+                    // working header.
                     assert(env.superblock_verify.working.parent == env.latest_checksum);
                 }
             }

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.fuzz_vsr_superblock_quorums);
 
 const superblock = @import("./superblock.zig");
-const SuperBlockSector = superblock.SuperBlockSector;
+const SuperBlockHeader = superblock.SuperBlockHeader;
 const SuperBlockVersion = superblock.SuperBlockVersion;
 
 const fuzz = @import("../testing/fuzz.zig");
@@ -21,7 +21,7 @@ pub fn main() !void {
     try fuzz_quorums_working(prng.random());
 
     try fuzz_quorum_repairs(prng.random(), .{ .superblock_copies = 4 });
-    // TODO: Enable these once SuperBlockSector is generic over its Constants.
+    // TODO: Enable these once SuperBlockHeader is generic over its Constants.
     // try fuzz_quorum_repairs(prng.random(), .{ .superblock_copies = 6 });
     // try fuzz_quorum_repairs(prng.random(), .{ .superblock_copies = 8 });
 }
@@ -108,18 +108,18 @@ fn test_quorums_working(
     const Quorums = QuorumsType(.{ .superblock_copies = 4 });
     const misdirect = random.boolean(); // true:cluster false:replica
     var quorums: Quorums = undefined;
-    var sectors: [4]SuperBlockSector = undefined;
+    var headers: [4]SuperBlockHeader = undefined;
     // TODO(Zig): Ideally this would be a [6]?u128 and the access would be
     // "checksums[i] orelse random.int(u128)", but that currently causes the compiler to segfault
     // during code generation.
     var checksums: [6]u128 = undefined;
     for (checksums) |*c| c.* = random.int(u128);
 
-    // Create sectors in ascending-sequence order to build the checksum/parent hash chain.
+    // Create headers in ascending-sequence order to build the checksum/parent hash chain.
     std.sort.sort(CopyTemplate, copies, {}, CopyTemplate.less_than);
 
-    for (sectors) |*sector, i| {
-        sector.* = std.mem.zeroInit(SuperBlockSector, .{
+    for (headers) |*header, i| {
+        header.* = std.mem.zeroInit(SuperBlockHeader, .{
             .copy = @intCast(u8, i),
             .version = SuperBlockVersion,
             .replica = 1,
@@ -131,32 +131,32 @@ fn test_quorums_working(
         var checksum: ?u128 = null;
         switch (copies[i].variant) {
             .valid => {},
-            .valid_high_copy => sector.copy = 4,
+            .valid_high_copy => header.copy = 4,
             .invalid_broken => {
                 if (random.boolean() and i > 0) {
-                    // Error: duplicate sector (if available).
-                    sector.* = sectors[random.uintLessThanBiased(usize, i)];
+                    // Error: duplicate header (if available).
+                    header.* = headers[random.uintLessThanBiased(usize, i)];
                     checksum = random.int(u128);
                 } else {
                     // Error: invalid checksum.
                     checksum = random.int(u128);
                 }
             },
-            .invalid_fork => sector.storage_size_max += 1, // Ensure we have a different checksum.
-            .invalid_parent => sector.parent += 1,
+            .invalid_fork => header.storage_size_max += 1, // Ensure we have a different checksum.
+            .invalid_parent => header.parent += 1,
             .invalid_misdirect => {
                 if (misdirect) {
-                    sector.cluster += 1;
+                    header.cluster += 1;
                 } else {
-                    sector.replica += 1;
+                    header.replica += 1;
                 }
             },
-            .invalid_vsr_state => sector.vsr_state.view += 1,
+            .invalid_vsr_state => header.vsr_state.view += 1,
         }
-        sector.checksum = checksum orelse sector.calculate_checksum();
+        header.checksum = checksum orelse header.calculate_checksum();
 
         if (copies[i].variant == .valid or copies[i].variant == .invalid_vsr_state) {
-            checksums[sector.sequence] = sector.checksum;
+            checksums[header.sequence] = header.checksum;
         }
     }
 
@@ -165,7 +165,7 @@ fn test_quorums_working(
     } else {
         // Shuffling copies can only change the working quorum when we have a corrupt copy index,
         // because we guess that the true index is the slot.
-        random.shuffle(SuperBlockSector, &sectors);
+        random.shuffle(SuperBlockHeader, &headers);
     }
 
     const threshold = switch (threshold_count) {
@@ -175,8 +175,8 @@ fn test_quorums_working(
     };
     assert(threshold.count() == threshold_count);
 
-    if (quorums.working(&sectors, threshold)) |working| {
-        try std.testing.expectEqual(result, working.sector.sequence);
+    if (quorums.working(&headers, threshold)) |working| {
+        try std.testing.expectEqual(result, working.header.sequence);
     } else |err| {
         try std.testing.expectEqual(result, err);
     }
@@ -238,7 +238,7 @@ pub const CopyTemplate = struct {
     }
 };
 
-// Verify that a torn sector write during repair never compromises the existing quorum.
+// Verify that a torn header write during repair never compromises the existing quorum.
 pub fn fuzz_quorum_repairs(
     random: std.rand.Random,
     comptime options: superblock_quorums.Options,
@@ -249,66 +249,66 @@ pub fn fuzz_quorum_repairs(
     var q1: Quorums = undefined;
     var q2: Quorums = undefined;
 
-    const sectors_valid = blk: {
-        var sectors: [superblock_copies]SuperBlockSector = undefined;
-        for (&sectors) |*sector, i| {
-            sector.* = std.mem.zeroInit(SuperBlockSector, .{
+    const headers_valid = blk: {
+        var headers: [superblock_copies]SuperBlockHeader = undefined;
+        for (&headers) |*header, i| {
+            header.* = std.mem.zeroInit(SuperBlockHeader, .{
                 .copy = @intCast(u8, i),
                 .version = SuperBlockVersion,
                 .replica = 1,
                 .storage_size_max = superblock.data_file_size_min,
                 .sequence = 123,
             });
-            sector.set_checksum();
+            header.set_checksum();
         }
-        break :blk sectors;
+        break :blk headers;
     };
 
-    const sector_invalid = blk: {
-        var sector = sectors_valid[0];
-        sector.checksum = 456;
-        break :blk sector;
+    const header_invalid = blk: {
+        var header = headers_valid[0];
+        header.checksum = 456;
+        break :blk header;
     };
 
     // Generate a random valid 2/4 quorum.
-    // 1 bits indicate valid sectors.
-    // 0 bits indicate invalid sectors.
+    // 1 bits indicate valid headers.
+    // 0 bits indicate invalid headers.
     var valid = std.bit_set.IntegerBitSet(superblock_copies).initEmpty();
     while (valid.count() < Quorums.Threshold.open.count() or random.boolean()) {
         valid.set(random.uintLessThan(usize, superblock_copies));
     }
 
-    var working_sectors: [superblock_copies]SuperBlockSector = undefined;
-    for (&working_sectors) |*sector, i| {
-        sector.* = if (valid.isSet(i)) sectors_valid[i] else sector_invalid;
+    var working_headers: [superblock_copies]SuperBlockHeader = undefined;
+    for (&working_headers) |*header, i| {
+        header.* = if (valid.isSet(i)) headers_valid[i] else header_invalid;
     }
-    random.shuffle(SuperBlockSector, &working_sectors);
-    var repair_sectors = working_sectors;
+    random.shuffle(SuperBlockHeader, &working_headers);
+    var repair_headers = working_headers;
 
-    const working_quorum = q1.working(&working_sectors, .open) catch unreachable;
+    const working_quorum = q1.working(&working_headers, .open) catch unreachable;
     var quorum_repairs = working_quorum.repairs();
     while (quorum_repairs.next()) |repair_copy| {
         {
-            // Simulate a torn sector write, crash, recover sequence.
-            var damaged_sectors = repair_sectors;
-            damaged_sectors[repair_copy] = sector_invalid;
-            const damaged_quorum = q2.working(&damaged_sectors, .open) catch unreachable;
-            assert(damaged_quorum.sector.checksum == working_quorum.sector.checksum);
+            // Simulate a torn header write, crash, recover sequence.
+            var damaged_headers = repair_headers;
+            damaged_headers[repair_copy] = header_invalid;
+            const damaged_quorum = q2.working(&damaged_headers, .open) catch unreachable;
+            assert(damaged_quorum.header.checksum == working_quorum.header.checksum);
         }
 
         // "Finish" the write so that we can test the next repair.
-        repair_sectors[repair_copy] = sectors_valid[repair_copy];
+        repair_headers[repair_copy] = headers_valid[repair_copy];
 
-        const quorum_repaired = q2.working(&repair_sectors, .open) catch unreachable;
-        assert(quorum_repaired.sector.checksum == working_quorum.sector.checksum);
+        const quorum_repaired = q2.working(&repair_headers, .open) catch unreachable;
+        assert(quorum_repaired.header.checksum == working_quorum.header.checksum);
     }
 
     // At the end of all repairs, we expect to have every copy of the superblock.
     // They do not need to be in their home slot.
     var copies = Quorums.QuorumCount.initEmpty();
-    for (repair_sectors) |repair_sector| {
-        assert(repair_sector.checksum == working_quorum.sector.checksum);
-        copies.set(repair_sector.copy);
+    for (repair_headers) |repair_header| {
+        assert(repair_header.checksum == working_quorum.header.checksum);
+        copies.set(repair_header.copy);
     }
-    assert(repair_sectors.len == copies.count());
+    assert(repair_headers.len == copies.count());
 }


### PR DESCRIPTION
- Change `replica.op_checkpoint` from a field to a function.
- Improve assertions
- Cleanup logs
- Rename superblock "sector" to "header" (since it is >1 sector now)
- Fix storage fault injection to the superblock header. https://github.com/tigerbeetledb/tigerbeetle/pull/426 fixed a bug that was preventing some faults from being injected, but it turns out that it was _accidentally_ correct, and we can't inject read/write faults to the superblock header without losing the quorum.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
