### PR TITLE
No target on linux, except RHEL

### DIFF
--- a/src/clients/node/package-lock.json
+++ b/src/clients/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.8",
+  "version": "0.11.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tigerbeetle-node",
-      "version": "0.11.8",
+      "version": "0.11.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/node/scripts/build_lib.sh
+++ b/src/clients/node/scripts/build_lib.sh
@@ -5,25 +5,37 @@ set -e
 # macOS 13 Ventura is not supported on Zig 0.9.x.
 # Overriding -target is one workaround Andrew suggests.
 # https://github.com/ziglang/zig/issues/10478#issuecomment-1294313967
-# Cut everything after the first `.` in the target query result
-# because the rest of it doesn't always seem to be valid when passed
-# back in to `-target`.
-target="$(./zig/zig targets | grep triple |cut -d '"' -f 4 | cut -d '.' -f 1)"
+target=""
 if [ "$(./zig/zig targets | grep triple |cut -d '"' -f 4 | cut -d '.' -f 1,2)" = "aarch64-macos.13" ]; then
-    target="native-macos.11"
+    target="-target native-macos.11"
 fi
 
-echo "Building for $target"
+# Zig picks musl libc on RHEL instead of glibc, incorrectly
+# https://github.com/ziglang/zig/issues/12156
+if [ -f "/etc/redhat-release" ]; then
+   if ! grep Fedora /etc/redhat-release; then
+       target="-target native-native-gnu"
+   fi
+fi
+
+if [ "$target" = "" ]; then
+    echo "Building default target"
+else
+    echo "Building for '$target'"
+fi
 
 mkdir -p dist
 
-./zig/zig build-lib \
+# Need to do string eval-ing because of shellcheck's strict string
+# interpolation rules.
+cmd="./zig/zig build-lib \
 	-mcpu=baseline \
 	-OReleaseSafe \
 	-dynamic \
 	-lc \
-	-isystem build/node-"$(node --version)"/include/node \
+	-isystem build/node-$(node --version)/include/node \
 	-fallow-shlib-undefined \
 	-femit-bin=dist/client.node \
-	-target "$target" \
-	src/node.zig 
+        $target src/node.zig"
+
+eval "$cmd"

--- a/src/clients/node/scripts/test_install_on_amazonlinux.sh
+++ b/src/clients/node/scripts/test_install_on_amazonlinux.sh
@@ -16,6 +16,5 @@ yum install -y xz wget git glibc tar
 wget -O- -q https://rpm.nodesource.com/setup_16.x | bash -
 yum install -y nodejs
 npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
-ln -s /lib64/libc.so.6 /lib64/libc.so
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_debian.sh
+++ b/src/clients/node/scripts/test_install_on_debian.sh
@@ -14,6 +14,5 @@ apt-get install -y xz-utils wget git
 wget -O- -q https://deb.nodesource.com/setup_18.x | bash -
 apt-get install -y nodejs
 npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
-ln -s /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_fedora.sh
+++ b/src/clients/node/scripts/test_install_on_fedora.sh
@@ -14,6 +14,5 @@ dnf install -y xz wget git
 wget -O- -q https://rpm.nodesource.com/setup_18.x | bash -
 dnf install -y nodejs
 npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
-ln -s /lib64/libc.so.6 /lib64/libc.so
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_rhelubi.sh
+++ b/src/clients/node/scripts/test_install_on_rhelubi.sh
@@ -15,7 +15,6 @@ yum update -y
 yum install -y xz wget git glibc tar
 wget -O- -q https://rpm.nodesource.com/setup_18.x | bash -
 yum install -y nodejs
-ln -s /lib64/libc.so.6 /lib64/libc.so
 npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "

--- a/src/clients/node/scripts/test_install_on_ubuntu.sh
+++ b/src/clients/node/scripts/test_install_on_ubuntu.sh
@@ -14,6 +14,5 @@ apt-get install -y xz-utils wget git
 wget -O- -q https://deb.nodesource.com/setup_18.x | bash -
 apt-get install -y nodejs
 npm install /wrk/src/clients/node/tigerbeetle-node-*.tgz
-ln -s /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so
 node -e 'require(\"tigerbeetle-node\"); console.log(\"SUCCESS!\")'
 "


### PR DESCRIPTION
`zig targets` doesn't seem to produce a target that can be safely fed back into `zig build -target X`. Or at least not in a way I can find.

So rather than even trying, we'll just completely omit `-target X` like we used to do. And we'll only override the target in the macOS case. And also RHEL given https://github.com/ziglang/zig/issues/12156.

Closes https://github.com/tigerbeetledb/tigerbeetle/issues/433