### PR TITLE
Don't block pings on durable views

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -352,6 +352,11 @@ pub const Header = extern struct {
         if (self.request != 0) return "request != 0";
         if (self.commit != 0) return "commit != 0";
         if (self.timestamp != 0) return "timestamp != 0";
+        if (self.view != 0) return "view != 0";
+        if (self.client != 0) {
+            if (self.replica != 0) return "replica != 0";
+            if (self.op != 0) return "op != 0";
+        }
         if (self.operation != .reserved) return "operation != .reserved";
         return null;
     }
@@ -363,6 +368,9 @@ pub const Header = extern struct {
         if (self.context != 0) return "context != 0";
         if (self.request != 0) return "request != 0";
         if (self.commit != 0) return "commit != 0";
+        if (self.timestamp > 0) {
+            if (self.view != 0) return "view != 0";
+        }
         if (self.operation != .reserved) return "operation != .reserved";
         return null;
     }


### PR DESCRIPTION
We use pings to:

- exchange view info with the clients
- exchange time info with replicas

We also have a rule that no message with a view can be sent until that view is durably stored.

Together, this means we can't synchronize time while the view is not durable.

This commit fixes the issue by noticing that we never use pings for views and timestamps at the same time: views are for clients, timestamps are for other replicas.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1000 batches in 200513 ms
    40850 transfers per second
    max p100 latency per 8191 transfers = 524ms
    ...
    
    # benchmark results after
    1000 batches in 200402 ms
    40872 transfers per second
    max p100 latency per 8191 transfers = 541ms    
    ```
OR
* [ ] I am very sure this PR could not affect performance.
