### PR TITLE
don't leak accept socket

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -149,6 +149,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         pub fn deinit(bus: *Self, allocator: std.mem.Allocator) void {
             if (process_type == .replica) {
                 bus.process.clients.deinit(allocator);
+                os.closeSocket(bus.process.accept_fd);
             }
 
             for (bus.connections) |*connection| {


### PR DESCRIPTION
This is based solely on eyeballing the code, as it seems we just forgot to close this socket. Or is there some secret reason why we shouldn't be doing that? 


## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [X] I am very sure this PR could not affect performance.
