### PR TITLE
remove incorrect comment

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -544,7 +544,6 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 bus.replicas_connect_attempts[connection.peer.replica] = 0;
 
                 connection.assert_recv_send_initial_state(bus);
-                // This will terminate the connection if there are no messages available:
                 connection.get_recv_message_and_recv(bus);
                 // A message may have been queued for sending while we were connecting:
                 // TODO Should we relax recv() and send() to return if `connection.state != .connected`?


### PR DESCRIPTION
As far as I can tell, "no messages available" is impossible -- we size our message pool such that there's _always_ a message.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [X] I am very sure this PR could not affect performance.
