### PR TITLE
VSR: Don't request start_view from self

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5626,7 +5626,8 @@ pub fn ReplicaType(
                     .view_change => if (header.view == self.view) return,
                     else => unreachable,
                 },
-                .recovering_head => {},
+                // We need a start_view from any other replica — don't request it from ourselves.
+                .recovering_head => if (self.primary_index(header.view) == self.replica) return,
                 else => unreachable,
             }
 


### PR DESCRIPTION
`Replica.view_jump()` triggers a `request_start_view`. A replica in `status=recovering_head` is stuck until it can get a `start_view`, but it shouldn't ever request a `start_view` from itself.

## Pre-merge checklist

Performance:

* I am very sure this PR could not affect performance.
