### PR TITLE
VSR: Refactor+fix DVC/SV header generation

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1008,7 +1008,7 @@ pub fn quorums(replica_count: u8) struct {
 }
 
 pub const Headers = struct {
-    pub const Array = std.BoundedArray(Header, constants.pipeline_prepare_queue_max);
+    pub const Array = std.BoundedArray(Header, constants.view_change_headers_max);
     /// The SuperBlock's persisted VSR headers.
     /// One of the following:
     ///

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1260,12 +1260,12 @@ const ViewChangeHeadersArray = struct {
 
             if (command_current == .start_view) {
                 // Primary: Collect headers for a start_view message.
-                // Follower: these headers are stored in the superblock's vsr_headers.
+                // Backup: these headers are stored in the superblock's vsr_headers.
                 switch (chain) {
                     .chain_sequence => {},
                     // Gaps are due to either:
                     // - entries before checkpoint, which are not repaired, or
-                    // - follower missed prepares and has not repaired headers. (Immediately after
+                    // - backup missed prepares and has not repaired headers. (Immediately after
                     //   receiving a start_view this is not a concern, but the view_durable_update()
                     //   may be delayed if another is in progress).
                     .chain_view, .chain_gap => {
@@ -1323,8 +1323,8 @@ const ViewChangeHeadersArray = struct {
             } else if (!current.log_view_primary and command_durable == .start_view) {
                 switch (chain) {
                     .chain_sequence => {},
-                    // Followers load a full suffix of headers from the view's SV message. If there
-                    // is now a gap in it the follower's suffix, this must be due to missed prepares.
+                    // Backups load a full suffix of headers from the view's SV message. If there
+                    // is now a gap in it the bcakup's suffix, this must be due to missed prepares.
                     .chain_view, .chain_gap => assert(op + 1 > op_head_durable),
                     // Breaks are impossible to the right of the durable SV — journal recovery uses
                     // the durable SV to prune bad headers by their view numbers.
@@ -1335,7 +1335,7 @@ const ViewChangeHeadersArray = struct {
                 switch (chain) {
                     .chain_sequence => {},
                     .chain_view => {},
-                    // Followers load a full suffix of headers from the view's SV message.
+                    // Backups load a full suffix of headers from the view's SV message.
                     // That SV isn't durable, but it is part of the journal, so any gaps to its
                     // right must be due to missed prepares.
                     .chain_gap => {},

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4647,7 +4647,7 @@ pub fn ReplicaType(
                     assert(message.header.replica == self.replica);
                     assert(message.header.op == self.op);
                     assert(message.header.commit == self.commit_min);
-                    assert(replica == self.primary_index(self.view));
+                    assert(message.header.timestamp == self.log_view);
                 },
                 .start_view => switch (self.status) {
                     .normal => {
@@ -4736,19 +4736,23 @@ pub fn ReplicaType(
                     return;
                 }
 
-                if (message.header.command == .do_view_change) {
-                    const message_log_view = message.header.timestamp;
-                    if (self.log_view_durable() < message_log_view) {
+                // For DVCs and SVCs we must wait for the log_view to be durable:
+                // - A DVC includes the log_view.
+                // - A SV implies the log_view.
+                if (message.header.command == .do_view_change or
+                    message.header.command == .start_view)
+                {
+                    if (self.log_view_durable() < self.log_view) {
                         log.debug("{}: send_message_to_replica: dropped {s} " ++
-                            "(log_view_durable={} message.log_view={})", .{
+                            "(log_view_durable={} log_view={})", .{
                             self.replica,
                             @tagName(message.header.command),
                             self.log_view_durable(),
-                            message_log_view,
+                            self.log_view,
                         });
                         return;
                     }
-                    assert(std.mem.eql(
+                    assert(message.header.command != .do_view_change or std.mem.eql(
                         u8,
                         message.body(),
                         std.mem.sliceAsBytes(self.superblock.working.vsr_headers().slice),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4891,13 +4891,27 @@ pub fn ReplicaType(
             // The view/log_view incremented while the previous view-change update was being saved.
             const update = self.log_view_durable() < self.log_view or
                 self.view_durable() < self.view;
-
             const update_dvc = update and self.log_view < self.view;
             const update_sv = update and self.log_view == self.view and
                 (self.replica != self.primary_index(self.view) or self.status == .normal);
             assert(!(update_dvc and update_sv));
 
             if (update_dvc or update_sv) self.view_durable_update();
+
+            // Reset SVC timeout in case the view-durable update took a long time.
+            if (self.view_change_status_timeout.ticking) self.view_change_status_timeout.reset();
+
+            // Trigger work that was deferred until after the view-change update.
+            if (self.status == .normal) {
+                if (self.primary_index(self.view) == self.replica) {
+                    const start_view = self.create_view_change_message(.start_view);
+                    defer self.message_bus.unref(start_view);
+
+                    self.send_message_to_other_replicas(start_view);
+                } else {
+                    self.send_prepare_oks_after_view_change();
+                }
+            }
         }
 
         fn set_op_and_commit_max(self: *Self, op: u64, commit_max: u64, method: []const u8) void {
@@ -5170,7 +5184,7 @@ pub fn ReplicaType(
             // Send prepare_ok messages to ourself to contribute to the pipeline.
             self.send_prepare_oks_after_view_change();
 
-            // SVs will be sent out (via timeout) after the view_durable update completes.
+            // SVs will be sent out after the view_durable update completes.
             assert(self.view_durable_updating());
             assert(self.log_view > self.log_view_durable());
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5317,15 +5317,20 @@ pub fn ReplicaType(
         /// based on its own timer, or because it receives a start_view_change or do_view_change
         /// message for a view with a larger number than its own view.
         fn transition_to_view_change_status(self: *Self, view_new: u32) void {
-            log.debug("{}: transition_to_view_change_status: view={}..{}", .{
-                self.replica,
-                self.view,
-                view_new,
-            });
             assert(self.status == .normal or
                 self.status == .view_change or
                 self.status == .recovering or
                 self.status == .recovering_head);
+            assert(view_new >= self.log_view);
+            assert(view_new >= self.view);
+
+            log.debug("{}: transition_to_view_change_status: view={}..{} status={}..{}", .{
+                self.replica,
+                self.view,
+                view_new,
+                self.status,
+                Status.view_change,
+            });
 
             const status_before = self.status;
             self.status = .view_change;
@@ -5333,7 +5338,6 @@ pub fn ReplicaType(
             if (self.view == view_new) {
                 assert(status_before == .recovering or status_before == .recovering_head);
             } else {
-                assert(view_new > self.view);
                 self.view = view_new;
                 self.view_durable_update();
             }
@@ -5365,7 +5369,11 @@ pub fn ReplicaType(
             assert(self.do_view_change_quorum == false);
             assert(self.nack_prepare_op == null);
 
-            self.send_start_view_change();
+            if (self.log_view == self.view) {
+                assert(status_before == .recovering_head);
+            } else {
+                self.send_start_view_change();
+            }
         }
 
         fn update_client_table_entry(self: *Self, reply: *Message) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2732,11 +2732,11 @@ pub fn ReplicaType(
             defer self.message_bus.unref(message);
 
             const headers = self.create_view_change_headers();
-            assert(headers.len > 0);
-            assert(headers.get(0).op == self.op);
+            assert(headers.array.len > 0);
+            assert(headers.array.get(0).op == self.op);
 
             message.header.* = .{
-                .size = @intCast(u32, @sizeOf(Header) * (1 + headers.len)),
+                .size = @intCast(u32, @sizeOf(Header) * (1 + headers.array.len)),
                 .command = command,
                 .cluster = self.cluster,
                 .replica = self.replica,
@@ -2755,7 +2755,7 @@ pub fn ReplicaType(
                 .exact,
                 Header,
                 std.mem.bytesAsSlice(Header, message.body()),
-                headers.constSlice(),
+                headers.array.constSlice(),
             );
             message.header.set_checksum_body(message.body());
             message.header.set_checksum();
@@ -2763,143 +2763,36 @@ pub fn ReplicaType(
             return message.ref();
         }
 
-        fn create_view_change_headers(self: *const Self) vsr.ViewChangeHeaders.BoundedArray {
+        fn create_view_change_headers(self: *const Self) vsr.Headers.ViewChangeArray {
             assert(self.status == .normal or self.status == .view_change);
             assert(self.view >= self.log_view);
             assert(self.view >= self.view_durable());
             assert(self.log_view >= self.log_view_durable());
 
-            var headers = vsr.ViewChangeHeaders.BoundedArray{ .buffer = undefined };
-
-            // Always include the head message.
-            headers.appendAssumeCapacity(self.journal.header_with_op(self.op).?.*);
-
-            if (self.view == self.log_view) {
-                // Construct SV message headers. (On the backup, these are only stored in the
-                // superblock).
-                if (self.primary_index(self.view) == self.replica and self.status == .normal) {
-                    assert(self.op >= self.commit_max);
-
-                    // The primary starting a new view has a pristine log suffix.
-                    //
-                    // +1 because commit_min may have been overwritten (and not repaired) if it
-                    // falls on a checkpoint boundary.
-                    var op = self.op;
-                    while (op > self.commit_min + 1) : (op -= 1) {
-                        const header_next = self.journal.header_with_op(op).?;
-                        const header_prev = self.journal.header_with_op(op - 1).?;
-                        assert(header_prev.checksum == header_next.parent);
-
-                        headers.append(header_prev.*) catch break;
-                    }
-                } else {
-                    // Either:
-                    // - The primary started a new view but has not finished repair.
-                    // - The backup joining a new view has a pristine log suffix — it just
-                    //   loaded a SV.
-                    //
-                    // In each case we send as much of a suffix as is available (fallthrough).
-                }
-            } else {
-                // Construct DVC message headers.
-                assert(self.view > self.log_view);
-
-                if (self.log_view_durable() == self.log_view) {
-                    const headers_durable = self.superblock.working.vsr_headers().slice;
-                    assert(headers_durable[0].op <= self.op);
-
-                    if (self.log_view_durable() < self.view_durable()) {
-                        // Ensure that if we started a DVC before a crash, that we will resume
-                        // sending the exact same DVC after recovery.
-                        // (An alternative implementation would be to load the superblock's DVC
-                        // headers (including gaps) into the journal during open(), but that is more
-                        // complicated to implement correctly).
-                        assert(headers_durable[0].op == self.op);
-                        assert(headers_durable[0].checksum == headers.get(0).checksum);
-
-                        for (headers_durable[1..]) |*header| headers.appendAssumeCapacity(header.*);
-                    } else {
-                        // Durable SV anchor. See Example 4.
-                        assert(self.log_view_durable() == self.view_durable());
-
-                        var op = self.op;
-                        while (op > headers_durable[headers_durable.len - 1].op) : (op -= 1) {
-                            const header_prev = self.journal.header_with_op(op - 1) orelse continue;
-                            const header_next = self.journal.header_with_op(op);
-                            assert(header_next == null or header_prev.checksum == header_next.?.parent);
-
-                            headers.append(header_prev.*) catch break;
-                        }
-                    }
-                    return headers;
-                }
-
-                // The DVC anchor: Within the log suffix following the anchor, we have additional
-                // guarantees about the state of the log headers which allow us to tolerate certain
-                // gaps (by locally guaranteeing that the gap does not hide a break).
-                // See Example 2/3 for more detail.
-                const op_dvc_anchor = std.math.max(
-                    self.commit_min,
-                    // +1: We can have a full pipeline, but not yet have performed any repair.
-                    // In such a case, we want to send those pipeline_prepare_queue_max headers in
-                    // the DVC, but not the preceding op (which may belong to a different chain).
-                    // This satisfies the DVC invariant because the first op in the pipeline is
-                    // "connected" to the canonical chain (via its "parent" checksum).
-                    //
-                    // For example, as a follower, we might have received pipeline_prepare_queue_max
-                    // headers in the SV message, but not done any repair before the next view
-                    // change.
-                    1 + self.op -| constants.pipeline_prepare_queue_max,
-                );
-
-                if (self.primary_index(self.log_view) == self.replica) {
-                    // Retired primary: see Example 2a.
-                    var op = self.op;
-                    while (op > op_dvc_anchor) : (op -= 1) {
-                        const header_next = self.journal.header_with_op(op).?;
-                        // Exclude gaps since we cannot distinguish the gap from a break.
-                        const header_prev = self.journal.header_with_op(op - 1) orelse break;
-                        if (header_prev.checksum != header_next.parent) break;
-
-                        headers.append(header_prev.*) catch break;
-                    }
-                } else {
-                    // Retired backup: see Example 2b.
-                    var op = self.op;
-                    while (op > self.commit_min) : (op -= 1) {
-                        const header_prev = self.journal.header_with_op(op - 1) orelse continue;
-                        const header_next = self.journal.header_with_op(op);
-                        assert(header_next == null or header_prev.checksum == header_next.?.parent);
-
-                        headers.append(header_prev.*) catch break;
-
-                        // Stop once we connect to the anchor.
-                        if (header_prev.op <= op_dvc_anchor + 1) break;
-                    } else {
-                        assert(self.commit_min == self.op);
-                    }
+            var journal_headers = vsr.Headers.Array{ .buffer = undefined };
+            var op = self.op + 1;
+            while (op > 0 and journal_headers.len < constants.view_change_headers_max) {
+                op -= 1;
+                if (self.journal.header_with_op(op)) |h| {
+                    journal_headers.appendAssumeCapacity(h.*);
                 }
             }
 
-            // Include as many extra headers as possible, but with no additional gaps (since they
-            // cannot be differentiated from breaks).
-            // - This reduces the number of headers that the new primary will need to repair.
-            // - More importantly, this ensures that a replica which re-sends its DVC does not
-            //   alter the DVC's headers, even if the replica finished a commit (updating
-            //   commit_min, possibly modifying the suffix anchor) in the mean time.
-            //   (This is not required for correctness, but enables additional verification
-            //   in on_do_view_change().)
-            var op = headers.get(headers.len - 1).op;
-            while (op > 0 and headers.len < constants.view_change_headers_max) : (op -= 1) {
-                const header_next = self.journal.header_with_op(op).?;
-                const header_prev = self.journal.header_with_op(op - 1) orelse break;
-                if (header_prev.checksum != header_next.parent) break;
-
-                headers.appendAssumeCapacity(header_prev.*);
-            }
-
-            vsr.ViewChangeHeaders.verify(headers.constSlice());
-            return headers;
+            return vsr.Headers.ViewChangeArray.build(.{
+                .op_checkpoint = self.op_checkpoint(),
+                .current = .{
+                    .headers = journal_headers,
+                    .view = self.view,
+                    .log_view = self.log_view,
+                    .log_view_primary = self.primary_index(self.log_view) == self.replica,
+                },
+                .durable = .{
+                    .headers = .{ .slice = self.superblock.working.vsr_headers().slice },
+                    .view = self.view_durable(),
+                    .log_view = self.log_view_durable(),
+                    .log_view_primary = self.primary_index(self.log_view_durable()) == self.replica,
+                },
+            });
         }
 
         /// The caller owns the returned message, if any, which has exactly 1 reference.
@@ -5020,7 +4913,6 @@ pub fn ReplicaType(
             // `commit_max` and not `self.op`. However, committed ops (`commit_max`) must survive:
             assert(op >= self.commit_max);
             assert(op >= commit_max);
-            // TODO: This assertion may fail until recovery protocol is removed.
             assert(op <= self.op_checkpoint_trigger());
 
             // We expect that our commit numbers may also be greater even than `commit_max` because
@@ -5738,7 +5630,7 @@ pub fn ReplicaType(
 }
 
 /// A do-view-change:
-/// - selects the view's head
+/// - selects the view's head (modulo nack+truncation during repair)
 /// - discards uncommitted ops (to maximize availability in the presence of storage faults)
 /// - retains all committed ops
 /// - retains all possibly-committed ops (because they might be committed — we can't tell)
@@ -5762,11 +5654,6 @@ pub fn ReplicaType(
 ///
 /// - *DVC* refers to a command=do_view_change message.
 /// - *SV* refers to a command=start_view message.
-/// - The *pipeline suffix* is the last pipeline_prepare_queue_max messages of the log (counting
-///   backwards from the head op). For example, when pipeline_prepare_queue_max=3,
-///
-///   - the pipeline suffix of log "1,2,3,4,5" is "3,4,5".
-///   - the pipeline suffix of log "1,2,3,5" is "3,5".
 ///
 ///
 /// Invariants:
@@ -5782,15 +5669,16 @@ pub fn ReplicaType(
 ///     - a DVC of 6a,8a is valid (6a/8a belong to the same chain).
 ///     - a DVC of 6b,8a is invalid (the gap at 7 conceal a chain break).
 ///     - a DVC of 6b,7b,8a is invalid (7b/8a is a chain break)..
+/// - All pipeline headers present on the replica must be included in the DVC headers.
 ///
-/// - The headers must connect to the cluster's committed ops (the "DVC anchor").
-///   This means that either:
-///   - the DVC includes the op=C header, or
-///   - the DVC includes the op=C+1 header (where C+1's parent is C).
-///   (Where `C = "DVC anchor" = max(replica.commit_min, replica.op -| pipeline_prepare_queue_max)`).
-///   - Reason: The new primary may truncate the entire pipeline (6-9) due to a gap (6),
+/// - If the replica does not possess the oldest known pipeline entry (the "DVC anchor")
+///   (usually 1 + op_head -| pipeline_prepare_queue_max, except it does not need to move backwards
+///   when op_head is truncated), then they should include `op_head -| pipeline_prepare_queue_max`
+///   if it is in the journal.
+///   (By the intersection property, at least one DVC will contain one or the other).
+///   - Reason: The new primary may truncate the entire pipeline (6,7,8,9) due to a gap (6),
 ///     but afterwards it still requires a head op to repair/chain backward from.
-///     (According to the intersection property, a gap in the pipeline indicates an
+///     (According to the intersection property, a gap in the unified pipeline indicates an
 ///     uncommitted op).
 ///   - For example, given pipeline_prepare_queue_max=3:
 ///     - a DVC of 7,8 is invalid if replica.commit_min=5.
@@ -5809,143 +5697,12 @@ pub fn ReplicaType(
 ///     loaded into the new primary with `replace_header()`, not `repair_header()`.
 ///
 /// Perhaps unintuitively, it is safe to advertise a header before its message is prepared
-/// (e.g. the write is still queued). The header is either:
+/// (e.g. the write is still queued, or the prepare has not arrived). The header is either:
 ///
 /// - committed — so another replica in the quorum must have a copy, according to the quorum
 ///   intersection property. Or,
 /// - uncommitted — if the header is chosen, but cannot be recovered from any replica, then
 ///   it will be discarded by the nack protocol.
-///
-///
-/// Examples
-///
-/// In these examples:
-/// - pipeline_prepare_queue_max=3
-/// - Brackets denote the suffix of the replica's log that is actually included in the DVC headers.
-/// - Parenthesis denote a replica that did not participate in the DVC (for example, because it is
-///   partitioned).
-///
-/// Example 1: No gap in canonical headers
-///
-/// Consider a view change with DVCs:
-///
-///   replica   headers                         log_view
-///         0   1  [2   3   4b]                 4          (new primary)
-///         1   1   2   3   4a  5   6  [7   8   9]   5
-///         2  (1   2   3   4a  5   6   7   8   9)   5     (partitioned)
-///
-/// Replica 1's headers are canonical, so replica 0 constructs the log:
-///
-///             1   2   3    4b         7   8   9
-///
-/// The 5/6 gap conceals a hash break — 4b should be 4a.
-/// The view must initially keeps all of these headers, and after the DVC quorum is handled, repairs
-/// backwards from 7. (If it instead discarded at the gap (5…9), the log would fork (4a→4b).)
-///
-///
-/// Example 2: Gap in pipeline suffix
-///
-/// Consider a set of replicas performing a DVC:
-///
-///   replica   headers                              log_view
-///         0   1  [2   3   4b]                      4     (new primary)
-///         1   1   2   3   4a  5   6       8   9    5
-///         2  (1   2   3   ?   ?   ?   ?   ?   ?)   5     (partitioned)
-///
-/// Which headers should replica 1 include in its DVC?
-/// The cases are be distinguished by `log_view % replica_count`.
-///
-/// (These examples are still applicable if the gap is not in the first op of the pipeline suffix).
-///
-///
-/// Example 2a: Gap in the pipeline suffix of a retired primary
-///
-/// The replica was a primary during its retired log_view.
-/// It may have gaps or breaks in its pipeline suffix iff:
-/// - it didn't finish repairs before the next view change, and
-/// - some uncommitted ops were truncated during the DVC (since this "moves" the suffix backwards).
-///
-/// We cannot send op 6 in the DVC because if repairs did not complete, it may be the wrong message.
-///
-/// However, even though we may not have a full unbroken suffix of pipeline_prepare_queue_max
-/// messages, we know that our unbroken suffix (however long it may be) includes all
-/// possibly-committed messages, since otherwise the retired log_view would not have started.
-///
-/// Therefore, the retired primary sends a DVC with only the unbroken log suffix:
-///
-///   replica   headers
-///         1   1   2   3   4a  5   6      [8   9]         (retired primary)
-///
-///
-/// Example 2b: Gap in the pipeline suffix of a retired follower
-///
-/// The replica was a follower during its retired log_view.
-/// Followers always load a full suffix of headers from the view's SV message.
-/// If there is now a gap in it the follower's suffix, this must be due to missed prepares.
-///
-/// Therefore, ops to the left of the gap (where the gap is within the suffix) are part of the
-/// suffix's hash chain, even though we cannot test this by chaining checksum/parent.
-///
-/// Therefore, the retired follower sends the DVC:
-///
-///   replica   headers
-///         1   1   2   3   4a  5  [6       8   9]         (retired follower)
-///
-///
-/// Example 3: Break in pipeline suffix
-///
-/// Consider a set of replicas performing a DVC:
-///
-///   replica   headers                              log_view
-///         0   1  [2   3   4b]                      4     (new primary)
-///         1   1   2   3   4b  5a  6a  7a [8b  9b]  5
-///         2  (1   2   3   4b  5b  7b  7b  8b  9b)  5     (partitioned)
-///
-/// (Note the chain break at replica 1's 7a/8b.)
-/// This scenario is exactly analogous to Example 2, except that it can only occur on a retired
-/// primary, never a retired follower.
-///
-/// The retired primary sends a DVC with only the unbroken log suffix:
-///
-///   replica   headers
-///         1   1   2   3   4a  5   6   7a [8   9]         (retired primary)
-///
-///
-/// Example 4: Gap in retiring primary suffix after recovery
-///
-/// Suppose that replica 1 starts a view as the primary of view 4, with the suffix:
-///
-///  log_view   4
-///      view   4
-///   journal   1   2   3
-///      head   3
-///
-/// During this view, it prepares several ops:
-///
-///  log_view   4
-///      view   4
-///   journal   1   2   3   4   5   6   7
-///      head   7
-///
-/// However, the WAL writes are reordered — ops 4,5,7 writes finish before op=6's write has begun:
-///
-///  log_view   4
-///      view   4
-///   journal   1   2   3   4   5   6   7
-///       wal   1   2   3   4   5   _   7
-///      head   7
-///
-/// Replica 1 crashes and recovers, and immediately begins sending a DVC for view=5.
-/// Under normal circumstances, the retired primary cannot distinguish between a gap and a break
-/// due to the possibility that its did not complete repair (see Example 2a).
-/// In this instance though, the gap is safe to skip over because it is to the right of the durable
-/// SV's head (op=3).
-///
-///  log_view   4
-///      view   5
-///   journal   1   2   3  [4   5   _   7]
-///      head   7
-///
 const DVCQuorum = struct {
     const DVCArray = std.BoundedArray(*const Message, constants.replicas_max);
 

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -730,7 +730,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             commit_max: u64,
             log_view: u32,
             view: u32,
-            headers: vsr.Headers.ViewChangeArray,
+            headers: *const vsr.Headers.ViewChangeArray,
         };
 
         /// The replica calls view_change() to persist its view/log_view — it cannot
@@ -784,7 +784,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .callback = callback,
                 .caller = .view_change,
                 .vsr_state = vsr_state,
-                .vsr_headers = update.headers,
+                .vsr_headers = update.headers.*,
             };
 
             superblock.acquire(context);
@@ -820,7 +820,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             superblock.staging.parent = superblock.staging.checksum;
             superblock.staging.vsr_state = context.vsr_state.?;
 
-            if (context.vsr_headers) |headers| {
+            if (context.vsr_headers) |*headers| {
                 assert(context.caller == .format or context.caller == .view_change);
 
                 superblock.staging.vsr_headers_count = @intCast(u32, headers.array.len);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -151,7 +151,7 @@ const Environment = struct {
     /// Indexed by sequence.
     const SequenceStates = std.ArrayList(struct {
         vsr_state: VSRState,
-        vsr_headers: vsr.ViewChangeHeaders.BoundedArray,
+        vsr_headers: vsr.Headers.Array,
         /// Track the expected `checksum(free_set)`.
         /// Note that this is a checksum of the decoded free set; it is not the same as
         /// `SuperBlockHeader.free_set_checksum`.
@@ -269,7 +269,7 @@ const Environment = struct {
             .replica = 0,
         });
 
-        var vsr_headers = vsr.ViewChangeHeaders.BoundedArray{ .buffer = undefined };
+        var vsr_headers = vsr.Headers.Array{ .buffer = undefined };
         vsr_headers.appendAssumeCapacity(vsr.Header.root_prepare(cluster));
 
         assert(env.sequence_states.items.len == 0);
@@ -315,7 +315,7 @@ const Environment = struct {
             .view = env.superblock.staging.vsr_state.view + 5,
         };
 
-        var vsr_headers = vsr.ViewChangeHeaders.BoundedArray{ .buffer = undefined };
+        var vsr_headers = vsr.Headers.Array{ .buffer = undefined };
         var vsr_head = std.mem.zeroInit(vsr.Header, .{
             .command = .prepare,
             .op = env.superblock.staging.vsr_state.commit_min,
@@ -336,7 +336,7 @@ const Environment = struct {
             .commit_max = vsr_state.commit_max,
             .log_view = vsr_state.log_view,
             .view = vsr_state.view,
-            .headers = vsr_headers,
+            .headers = .{ .array = vsr_headers },
         });
     }
 
@@ -361,7 +361,7 @@ const Environment = struct {
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);
         try env.sequence_states.append(.{
             .vsr_state = vsr_state,
-            .vsr_headers = vsr.ViewChangeHeaders.BoundedArray.fromSlice(
+            .vsr_headers = vsr.Headers.Array.fromSlice(
                 env.superblock.staging.vsr_headers().slice,
             ) catch unreachable,
             .free_set = checksum_free_set(env.superblock),

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -336,7 +336,7 @@ const Environment = struct {
             .commit_max = vsr_state.commit_max,
             .log_view = vsr_state.log_view,
             .view = vsr_state.view,
-            .headers = .{ .array = vsr_headers },
+            .headers = &.{ .array = vsr_headers },
         });
     }
 


### PR DESCRIPTION
## Refactor

Refactor DVC/SV header generation for greater clarity (at the cost of increased verbosity). Specifically, the critical logic for each different case (retired primary/follower, durable SV/DVC, etc) are made as clear as possible. The split cases also enable stricter assertions of chain states.

This new implementation also includes additional headers during the "suffix_done" phase by skipping over "same-view gaps". (That is, given `1,_,3`, if op=1 and op=3 have the same view, then if op=3 is included in the DVC then op=1 is guaranteed to be part of the same hash-chain, so it is safe to include as well).

## Fix

Cases with a durable SV now properly use that durable SV's head op in place of the DVC anchor.

## Pre-merge checklist

Performance:

* I am very sure this PR could not affect performance.
