### PR TITLE
Drop redundant assert

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -473,7 +473,6 @@ pub fn ReplicaType(
             const quorum_view_change = quorums.view_change;
             assert(quorum_replication <= replica_count);
             assert(quorum_view_change <= replica_count);
-            assert(quorum_view_change + quorum_replication >= replica_count);
 
             if (replica_count <= 2) {
                 assert(quorum_replication == replica_count);


### PR DESCRIPTION
We assert a stronger version of this just after the if. I 

* [X] I am very sure this PR could not affect performance.
