### PR TITLE
Test/Cluster: Fix ping/register client race

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -248,6 +248,11 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             }
             errdefer for (cluster.replicas) |*replica| replica.deinit(allocator);
 
+            for (clients) |*client| {
+                client.on_reply_context = cluster;
+                client.on_reply_callback = client_on_reply;
+            }
+
             return cluster;
         }
 
@@ -364,11 +369,6 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             request_message: *Message,
             request_body_size: usize,
         ) void {
-            // TODO(Zig) Move these into init when `@returnAddress()` is available. They only needs to
-            // be set once, it just requires a stable pointer to the Cluster.
-            cluster.clients[client_index].on_reply_context = cluster;
-            cluster.clients[client_index].on_reply_callback = client_on_reply;
-
             cluster.clients[client_index].request(
                 undefined,
                 request_callback,


### PR DESCRIPTION
The cluster needs to set `on_reply_{callback,context}` before it receives its first reply. Normally that reply is a result of calling `client.request()` the first time, which triggers `operation=register`. But there's a race:

1. Client ping (before the client sends any request).
2. Client receives pong (still no requests from client)
3. Client triggers `register()` (still no requests from client).
4. Client receives `register`'s reply (still no requests from client).

As far as the client is concerned everything is fine, but the Simulator missed receiving it, so the `ReplySequencer` gets stuck and the test never finishes.

The client setup was always supposed to live in `init()`, but was moved (pending `@returnAddress()`) since `Cluster` used to be stack-allocated. (The context setup requires a stable pointer). But `Cluster` is heap allocated right now (pending `@returnAddress()`), so it is safe to do the setup in `Cluster.init()`.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
