### PR TITLE
VSR: replica_count=4 replication_quorum=3→2

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -38,14 +38,14 @@ comptime {
     assert(clients_max >= Config.Cluster.clients_max_min);
 }
 
-/// The minimum number of nodes required to form a quorum for replication:
+/// The maximum number of nodes required to form a quorum for replication.
 /// Majority quorums are only required across view change and replication phases (not within).
 /// As per Flexible Paxos, provided `quorum_replication + quorum_view_change > replicas`:
 /// 1. you may increase `quorum_view_change` above a majority, so that
 /// 2. you can decrease `quorum_replication` below a majority, to optimize the common case.
 /// This improves latency by reducing the number of nodes required for synchronous replication.
 /// This reduces redundancy only in the short term, asynchronous replication will still continue.
-/// The size of the replication quorum is limited to the minimum of this value and actual majority.
+/// The size of the replication quorum is limited to the minimum of this value and ⌈replicas/2⌉.
 /// The size of the view change quorum will then be automatically inferred from quorum_replication.
 pub const quorum_replication_max = config.cluster.quorum_replication_max;
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -984,22 +984,29 @@ pub fn quorums(replica_count: u8) struct {
     replication: u8,
     view_change: u8,
 } {
+    assert(constants.quorum_replication_max >= 2);
+    // For replica_count=2, set quorum_replication=2 even though =1 would intersect. This improves
+    // durability and avoids special cases for a single-replica view-change in Replica.
+    const quorum_replication = if (replica_count == 2) 2 else std.math.min(
+        constants.quorum_replication_max,
+        stdx.div_ceil(replica_count, 2),
+    );
+    assert(quorum_replication >= 2 or quorum_replication == replica_count);
+
     const majority = @divFloor(replica_count, 2) + 1;
     assert(majority <= replica_count);
 
-    assert(constants.quorum_replication_max >= 2);
-    const quorum_replication = std.math.min(constants.quorum_replication_max, majority);
-    assert(quorum_replication >= 2 or quorum_replication == replica_count);
-
+    const quorum_view_change = std.math.max(
+        replica_count - quorum_replication + 1,
+        majority,
+    );
     // The view change quorum may be more expensive to make the replication quorum cheaper.
     // The insight is that the replication phase is by far more common than the view change.
     // This trade-off allows us to optimize for the common case.
     // See the comments in `constants.zig` for further explanation.
-    //
-    // For replica_count=2, set quorum_view_change=2 even though 1 would intersect.
-    // This avoids creating special cases for a single-replica view-change in Replica.
-    const quorum_view_change =
-        if (replica_count == 2) 2 else replica_count - quorum_replication + 1;
+    assert(quorum_view_change >= 2 or quorum_view_change == replica_count);
+    assert(quorum_view_change >= majority);
+    assert(quorum_view_change + quorum_replication > replica_count);
 
     return .{
         .replication = quorum_replication,
@@ -1010,8 +1017,8 @@ pub fn quorums(replica_count: u8) struct {
 test "quorums" {
     if (constants.quorum_replication_max != 3) return;
 
-    const expect_replication = [_]u8{ 1, 2, 2, 3, 3, 3 };
-    const expect_view_change = [_]u8{ 1, 2, 2, 2, 3, 4 };
+    const expect_replication = [_]u8{ 1, 2, 2, 2, 3, 3 };
+    const expect_view_change = [_]u8{ 1, 2, 2, 3, 3, 4 };
 
     for (expect_replication[0..]) |_, i| {
         const actual = quorums(@intCast(u8, i) + 1);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -984,28 +984,29 @@ pub fn quorums(replica_count: u8) struct {
     replication: u8,
     view_change: u8,
 } {
+    assert(replica_count > 0);
+
     assert(constants.quorum_replication_max >= 2);
-    // For replica_count=2, set quorum_replication=2 even though =1 would intersect. This improves
-    // durability and avoids special cases for a single-replica view-change in Replica.
+    // For replica_count=2, set quorum_replication=2 even though =1 would intersect.
+    // This improves durability of small clusters.
     const quorum_replication = if (replica_count == 2) 2 else std.math.min(
         constants.quorum_replication_max,
         stdx.div_ceil(replica_count, 2),
     );
+    assert(quorum_replication <= replica_count);
     assert(quorum_replication >= 2 or quorum_replication == replica_count);
 
-    const majority = @divFloor(replica_count, 2) + 1;
-    assert(majority <= replica_count);
-
-    const quorum_view_change = std.math.max(
-        replica_count - quorum_replication + 1,
-        majority,
-    );
+    // For replica_count=2, set quorum_view_change=2 even though =1 would intersect.
+    // This avoids special cases for a single-replica view-change in Replica.
+    const quorum_view_change =
+        if (replica_count == 2) 2 else replica_count - quorum_replication + 1;
     // The view change quorum may be more expensive to make the replication quorum cheaper.
     // The insight is that the replication phase is by far more common than the view change.
     // This trade-off allows us to optimize for the common case.
     // See the comments in `constants.zig` for further explanation.
+    assert(quorum_view_change <= replica_count);
     assert(quorum_view_change >= 2 or quorum_view_change == replica_count);
-    assert(quorum_view_change >= majority);
+    assert(quorum_view_change >= @divFloor(replica_count, 2) + 1);
     assert(quorum_view_change + quorum_replication > replica_count);
 
     return .{
@@ -1015,10 +1016,10 @@ pub fn quorums(replica_count: u8) struct {
 }
 
 test "quorums" {
-    if (constants.quorum_replication_max != 3) return;
+    if (constants.quorum_replication_max != 3) return error.SkipZigTest;
 
-    const expect_replication = [_]u8{ 1, 2, 2, 2, 3, 3 };
-    const expect_view_change = [_]u8{ 1, 2, 2, 3, 3, 4 };
+    const expect_replication = [_]u8{ 1, 2, 2, 2, 3, 3, 3, 3 };
+    const expect_view_change = [_]u8{ 1, 2, 2, 3, 3, 4, 5, 6 };
 
     for (expect_replication[0..]) |_, i| {
         const actual = quorums(@intCast(u8, i) + 1);

--- a/src/vsr/README.md
+++ b/src/vsr/README.md
@@ -201,7 +201,7 @@ With the default configuration:
 |      **Replica Count** |   1 |  2 |  3 |  4 |  5 |  6 |
 | ---------------------: | --: | -: | -: | -: | -: | -: |
 | **Replication Quorum** |   1 |  2 |  2 |  3 |  3 |  3 |
-| **View-Change Quorum** |   1 |  2 |  2 |  3 |  3 |  4 |
+| **View-Change Quorum** |   1 |  2 |  2 |  2 |  3 |  4 |
 
 See also:
 

--- a/src/vsr/README.md
+++ b/src/vsr/README.md
@@ -200,8 +200,8 @@ With the default configuration:
 
 |      **Replica Count** |   1 |  2 |  3 |  4 |  5 |  6 |
 | ---------------------: | --: | -: | -: | -: | -: | -: |
-| **Replication Quorum** |   1 |  2 |  2 |  3 |  3 |  3 |
-| **View-Change Quorum** |   1 |  2 |  2 |  2 |  3 |  4 |
+| **Replication Quorum** |   1 |  2 |  2 |  2 |  3 |  3 |
+| **View-Change Quorum** |   1 |  2 |  2 |  3 |  3 |  4 |
 
 See also:
 


### PR DESCRIPTION
`replication=2 + view-change=3 = 5 > replica-count=3`, so the quorums still intersect.


## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
