### PR TITLE
VSR: Remove unnecessary commit

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1655,9 +1655,9 @@ pub fn ReplicaType(
             assert(prepare.message.header.op == self.commit_min + 1);
 
             if (prepare.ok_quorum_received) {
-                self.prepare_timeout.reset();
-
                 assert(self.committing);
+
+                self.prepare_timeout.reset();
                 return;
             }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1657,11 +1657,7 @@ pub fn ReplicaType(
             if (prepare.ok_quorum_received) {
                 self.prepare_timeout.reset();
 
-                // We were unable to commit at the time because we were waiting for a message.
-                log.debug("{}: on_prepare_timeout: quorum already received, retrying commit", .{
-                    self.replica,
-                });
-                self.commit_pipeline();
+                assert(self.committing);
                 return;
             }
 


### PR DESCRIPTION
This code is left over from ce554c2b9f56d7b3959b09e67e7bb539c58b8a2e, over a year ago! Since `MessagePool.get_message()` now succeeds unconditionally, the only way the head prepare's `prepare.ok_quorum_received` is `true` in `on_prepare()` is if we are already committing.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
