### PR TITLE
VSR: Fix head after recovery from primary repair

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -363,9 +363,23 @@ pub fn ReplicaType(
             for (self.journal.headers) |*header| {
                 if (header.command == .prepare and header.op > op_head) {
                     assert(self.log_view >= header.view);
-                    assert(self.log_view == self.view);
+                    // Typically if there is an op in the WAL higher than the durable headers'
+                    // head op, we must have crashed with a durable SV, not a durable DVC.
+                    //
+                    // There is one exception:
+                    // 1. New-primary sends (and persists) a DVC: 5,6,7.
+                    // 2. New-primary receives DVC quorum. Suffix is 6,7,8.
+                    //    It already has 6,7. op=8 is new to us, but part of our prior log_view.
+                    // 3. New-primary repairs 8 (writes it to the WAL).
+                    // 4. New-primary crashes/recovers — op=8 was part of the same log_view, so the
+                    //    journal doesn't truncate it, and the primary recovers with a new head.
+                    // To avoid special-casing this all over, we pretend this higher op doesn't
+                    // exist. This is safe because the prior view-change didn't complete.
+                    assert(self.log_view <= self.view);
+                    assert(self.log_view == self.view or
+                        self.replica == self.primary_index(self.view));
 
-                    op_head = header.op;
+                    if (self.log_view == self.view) op_head = header.op;
                 }
             }
 


### PR DESCRIPTION
This is a tricky one. A replica that crashes while it was starting a new view, after receiving a DVC quorum, but before persisting the SV, may have a "new" head op. Ignoring it is safe, and the simplest solution.

(An alternative would be to bump up the `op_head`, but that would confuse all of the DVC generation logic since our DVC would have changed from the durable one, which normally isn't allowed.)

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
