### PR TITLE
Open loop benchmarks

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -232,18 +232,8 @@ pub fn main() !void {
             total_ns,
         ),
     });
-    try stdout.print("batch latency p100 = {} ms\n", .{
-        @divTrunc(
-            batch_latency_ns.items[batch_latency_ns.items.len - 1],
-            std.time.ns_per_ms,
-        ),
-    });
-    try stdout.print("transfer latency p100 = {} ms\n", .{
-        @divTrunc(
-            transfer_latency_ns.items[transfer_latency_ns.items.len - 1],
-            std.time.ns_per_ms,
-        ),
-    });
+    try print_deciles(stdout, "batch", batch_latency_ns.items);
+    try print_deciles(stdout, "transfer", transfer_latency_ns.items);
 }
 
 fn send(
@@ -312,4 +302,23 @@ fn send_complete(
 
     const result_ptr = @intToPtr(*?@TypeOf(result), @intCast(u64, user_data));
     result_ptr.* = result;
+}
+
+fn print_deciles(
+    stdout: anytype,
+    label: []const u8,
+    latencies: []const u64,
+) !void {
+    var decile: usize = 0;
+    while (decile <= 10) : (decile += 1) {
+        const index = @divTrunc(latencies.len * decile, 10) -| 1;
+        try stdout.print("{s} latency p{}0 = {} ms\n", .{
+            label,
+            decile,
+            @divTrunc(
+                latencies[index],
+                std.time.ns_per_ms,
+            ),
+        });
+    }
 }

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -219,7 +219,7 @@ pub fn main() !void {
     std.sort.sort(u64, batch_latency_ns.items, {}, less_than_ns);
     std.sort.sort(u64, transfer_latency_ns.items, {}, less_than_ns);
 
-    try stdout.print("{} batches in {d:2} s\n", .{
+    try stdout.print("{} batches in {d:.2} s\n", .{
         batch_index,
         @intToFloat(f64, total_ns) / std.time.ns_per_s,
     });

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -223,10 +223,10 @@ pub fn main() !void {
         batch_index,
         @intToFloat(f64, total_ns) / std.time.ns_per_s,
     });
-    try stdout.print("offered load = {} tx/s\n", .{
+    try stdout.print("load offered = {} tx/s\n", .{
         transfer_count_per_second,
     });
-    try stdout.print("accepted load = {} tx/s\n", .{
+    try stdout.print("load accepted = {} tx/s\n", .{
         @divTrunc(
             transfer_count * std.time.ns_per_s,
             total_ns,


### PR DESCRIPTION
This is the first part of https://github.com/tigerbeetledb/tigerbeetle/issues/428. Transfers arrive at the client according to a poisson process. Batches are filled as much as possible given the available transfers.

The offered load defaults to 1e6 tx/s:

```
> zig build benchmark -Drelease-safe
1223 batches in 80.67 s
load offered = 1000000 tx/s
load accepted = 123963 tx/s
batch latency p00 = 5 ms
batch latency p10 = 16 ms
batch latency p20 = 16 ms
batch latency p30 = 16 ms
batch latency p40 = 16 ms
batch latency p50 = 17 ms
batch latency p60 = 77 ms
batch latency p70 = 82 ms
batch latency p80 = 112 ms
batch latency p90 = 147 ms
batch latency p100 = 4727 ms
transfer latency p00 = 5 ms
transfer latency p10 = 5056 ms
transfer latency p20 = 10836 ms
transfer latency p30 = 17385 ms
transfer latency p40 = 24406 ms
transfer latency p50 = 31326 ms
transfer latency p60 = 38374 ms
transfer latency p70 = 45377 ms
transfer latency p80 = 52409 ms
transfer latency p90 = 63687 ms
transfer latency p100 = 70643 ms
```

The big difference between the batch latency and transfer latency shows that the server is overloaded. With less offered load:

```
> zig build benchmark -Drelease-safe -- --transfer-count-per-second 100_000
4451 batches in 100.05 s
load offered = 100000 tx/s
load accepted = 99947 tx/s
batch latency p00 = 5 ms
batch latency p10 = 5 ms
batch latency p20 = 5 ms
batch latency p30 = 10 ms
batch latency p40 = 10 ms
batch latency p50 = 15 ms
batch latency p60 = 16 ms
batch latency p70 = 25 ms
batch latency p80 = 35 ms
batch latency p90 = 51 ms
batch latency p100 = 591 ms
transfer latency p00 = 5 ms
transfer latency p10 = 12 ms
transfer latency p20 = 17 ms
transfer latency p30 = 21 ms
transfer latency p40 = 27 ms
transfer latency p50 = 33 ms
transfer latency p60 = 40 ms
transfer latency p70 = 48 ms
transfer latency p80 = 58 ms
transfer latency p90 = 75 ms
transfer latency p100 = 610 ms
```

There are more batches in total because they're not full when under lower load. The transfer latency matches batch latency closely because transfers aren't piling up behind an overloaded server.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    > zig build benchmark -Drelease-safe
    ============================================
    1000 batches in 59750 ms
    137087 transfers per second
    max p100 latency per 8191 transfers = 165ms
    
    # benchmark results after
    > zig build benchmark -Drelease-safe
    1223 batches in 75.807900442 s
    load offered = 1000000 tx/s
    load accepted = 131912 tx/s
    batch latency p100 = 479 ms
    transfer latency p100 = 65779 ms
    ```
OR
* [ ] I am very sure this PR could not affect performance.
