### PR TITLE
LSM: implement move table optimization for compaction

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -337,6 +337,7 @@ pub fn CompactionType(
                 const level_a = level_b - 1;
 
                 var table_a = compaction.level_a_input.?;
+                assert(table_a.snapshot_max >= snapshot_max);
                 compaction.manifest.move_table(level_a, level_b, snapshot_max, &table_a);
                 assert(table_a.snapshot_max == snapshot_max);
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -373,7 +373,7 @@ pub fn CompactionType(
                     assert(compaction.range.table_count == 1);
                     assert(compaction.grid_reservation == null);
 
-                    compaction.manifest.move_table(level_a, level_b, &table_a);
+                    compaction.manifest.move_table(level_a, level_b, table_a);
 
                     compaction.merge_done = true;
                     compaction.status = .done;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -337,7 +337,7 @@ pub fn CompactionType(
             switch (compaction.strategy) {
                 .merge => {
                     compaction.callback = callback;
-                    
+
                     tracer.start(
                         &compaction.tracer_slot,
                         .{ .tree_compaction_tick = .{

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -340,13 +340,12 @@ pub fn CompactionType(
                     const level_b = compaction.level_b;
                     const level_a = level_b - 1;
 
-                    var table_a = compaction.level_a_input.?;
+                    const table_a = compaction.level_a_input.?;
                     assert(table_a.snapshot_max >= snapshot_max);
                     assert(compaction.range.table_count == 1);
                     assert(compaction.grid_reservation == null);
 
-                    compaction.manifest.move_table(level_a, level_b, snapshot_max, &table_a);
-                    assert(table_a.snapshot_max == snapshot_max);
+                    compaction.manifest.move_table(level_a, level_b, &table_a);
 
                     compaction.merge_done = true;
                     compaction.status = .done;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -630,9 +630,12 @@ pub fn CompactionType(
 
             // TODO(Beat Pacing) This should really be where the compaction callback is invoked,
             // but currently that can occur multiple times per beat.
-            if (compaction.strategy == .table_merge) {
-                compaction.grid.forfeit(compaction.grid_reservation.?);
-                compaction.grid_reservation = null;
+            switch (compaction.strategy) {
+                .table_move => assert(compaction.grid_reservation == null),
+                .table_merge => {
+                    compaction.grid.forfeit(compaction.grid_reservation.?);
+                    compaction.grid_reservation = null;
+                },
             }
 
             compaction.status = .idle;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -337,11 +337,9 @@ pub fn CompactionType(
                 const level_a = level_b - 1;
 
                 var table_a = compaction.level_a_input.?;
-                compaction.manifest.update_table(level_a, snapshot_max, &table_a);
+                compaction.manifest.move_table(level_a, level_b, snapshot_max, &table_a);
                 assert(table_a.snapshot_max == snapshot_max);
-
-                table_a = compaction.level_a_input.?;
-                compaction.manifest.insert_table(level_b, &table_a);
+                assert(table_a.flags.moved);
 
                 compaction.merge_done = true;
                 compaction.status = .done;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -339,7 +339,6 @@ pub fn CompactionType(
                 var table_a = compaction.level_a_input.?;
                 compaction.manifest.move_table(level_a, level_b, snapshot_max, &table_a);
                 assert(table_a.snapshot_max == snapshot_max);
-                assert(table_a.flags.moved);
 
                 compaction.merge_done = true;
                 compaction.status = .done;

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -244,7 +244,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             }
 
             // First, remove the table from level A without appending changes to the manifest log.
-            const removed = manifest_level_a.remove_table(manifest.node_pool, table);
+            const removed = manifest_level_a.remove_table_visible(manifest.node_pool, table);
             assert(table.equal(removed));
 
             // Then, insert the table into the level B and append these changes to the manifest log.

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -247,7 +247,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             const removed = manifest_level_a.remove_table_visible(manifest.node_pool, table);
             assert(table.equal(removed));
 
-            // Then, insert the table into the level B and append these changes to the manifest log.
+            // Then, insert the table into level B and append these changes to the manifest log.
             // To move a table w.r.t manifest log, a "remove" change should NOT be appended for
             // the previous level A; When replaying the log from open(), inserts are processed in
             // LIFO order and duplicates are ignored. This means the table will only be replayed in

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -238,6 +238,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
             const manifest_level_a = &manifest.levels[level_a];
             const manifest_level_b = &manifest.levels[level_b];
+
             if (constants.verify) {
                 assert(manifest_level_a.contains(table));
                 assert(!manifest_level_b.contains(table));
@@ -254,6 +255,11 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             // level B instead of the old one in level A.
             manifest_level_b.insert_table(manifest.node_pool, table);
             manifest.manifest_log.insert(@intCast(u7, level_b), table);
+
+            if (constants.verify) {
+                assert(!manifest_level_a.contains(table));
+                assert(manifest_level_b.contains(table));
+            }
         }
 
         pub fn remove_invisible_tables(

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -162,7 +162,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
         pub fn deinit(manifest: *Manifest, allocator: mem.Allocator) void {
             for (manifest.levels) |*l| l.deinit(allocator, manifest.node_pool);
-            for (manifest.moved_table_addresses) |table_address| assert(table_address == null);
+
             manifest.manifest_log.deinit(allocator);
         }
 

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -259,7 +259,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             manifest_level_a.set_snapshot_max(snapshot, table);
             assert(table.snapshot_max == snapshot);
 
-            // Finally, the table address is recorded so that it will not be removed from the 
+            // Finally, the table address is recorded so that it will not be removed from the
             // manifest log during `remove_invisible_tables`.
             assert(manifest.moved_table_addresses[level_a] == null);
             manifest.moved_table_addresses[level_a] = table.address;
@@ -301,7 +301,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                 } else {
                     manifest.manifest_log.remove(@intCast(u7, level), table);
                 }
-                
+
                 manifest_level.remove_table(manifest.node_pool, &snapshots, table);
             }
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -81,12 +81,17 @@ pub fn ManifestLevelType(
             assert(level.keys.len() == level.tables.len());
         }
 
-        /// Set snapshot_max for the given table in the ManifestLevel.
+        /// Set snapshot_max and flags for the given table in the ManifestLevel.
         ///
         /// * The table is mutable so that this function can update its snapshot.
         /// * Asserts that the table currently has snapshot_max of math.maxInt(u64).
         /// * Asserts that the table exists in the manifest.
-        pub fn set_snapshot_max(level: *Self, snapshot: u64, table: *TableInfo) void {
+        pub fn set_snapshot_max(
+            level: *Self,
+            snapshot: u64,
+            flags: TableInfo.Flags,
+            table: *TableInfo,
+        ) void {
             assert(snapshot < lsm.snapshot_latest);
             assert(table.snapshot_max == math.maxInt(u64));
 
@@ -112,6 +117,9 @@ pub fn ManifestLevelType(
 
             level_table.snapshot_max = snapshot;
             table.snapshot_max = snapshot;
+
+            level_table.flags = flags;
+            table.flags = flags;
 
             assert(it.next() == null);
             level.table_count_visible -= 1;
@@ -658,7 +666,7 @@ pub fn TestContext(
             const snapshot = context.take_snapshot();
 
             for (context.reference.items[index..][0..count]) |*table| {
-                context.level.set_snapshot_max(snapshot, table);
+                context.level.set_snapshot_max(snapshot, .{}, table);
             }
 
             for (context.snapshot_tables.slice()) |tables| {

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -81,7 +81,7 @@ pub fn ManifestLevelType(
             assert(level.keys.len() == level.tables.len());
         }
 
-        /// Set snapshot_max and flags for the given table in the ManifestLevel.
+        /// Set snapshot_max for the given table in the ManifestLevel.
         ///
         /// * The table is mutable so that this function can update its snapshot.
         /// * Asserts that the table currently has snapshot_max of math.maxInt(u64).
@@ -89,7 +89,6 @@ pub fn ManifestLevelType(
         pub fn set_snapshot_max(
             level: *Self,
             snapshot: u64,
-            flags: TableInfo.Flags,
             table: *TableInfo,
         ) void {
             assert(snapshot < lsm.snapshot_latest);
@@ -117,9 +116,6 @@ pub fn ManifestLevelType(
 
             level_table.snapshot_max = snapshot;
             table.snapshot_max = snapshot;
-
-            level_table.flags = flags;
-            table.flags = flags;
 
             assert(it.next() == null);
             level.table_count_visible -= 1;
@@ -666,7 +662,7 @@ pub fn TestContext(
             const snapshot = context.take_snapshot();
 
             for (context.reference.items[index..][0..count]) |*table| {
-                context.level.set_snapshot_max(snapshot, .{}, table);
+                context.level.set_snapshot_max(snapshot, table);
             }
 
             for (context.snapshot_tables.slice()) |tables| {

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -120,13 +120,13 @@ pub fn ManifestLevelType(
         /// Remove the given table from the level assuming it's visible to `lsm.snapshot_latest`.
         /// Returns the same, unmodified table passed in to differentiate itself from 
         /// remove_table_invisible and guard against using the wrong function.
-        pub fn remove_table(
+        pub fn remove_table_visible(
             level: *Self,
             node_pool: *NodePool,
             table: *const TableInfo,
         ) *const TableInfo {
             assert(table.visible(lsm.snapshot_latest));
-            level.remove(node_pool, table);
+            level.remove_table(node_pool, table);
             level.table_count_visible -= 1;
             return table;
         }
@@ -140,10 +140,10 @@ pub fn ManifestLevelType(
             table: *const TableInfo,
         ) void {
             assert(table.invisible(snapshots));
-            level.remove(node_pool, table);
+            level.remove_table(node_pool, table);
         }
 
-        fn remove(level: *Self, node_pool: *NodePool, table: *const TableInfo) void {
+        fn remove_table(level: *Self, node_pool: *NodePool, table: *const TableInfo) void {
             assert(level.keys.len() == level.tables.len());
             assert(compare_keys(table.key_min, table.key_max) != .gt);
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -86,11 +86,7 @@ pub fn ManifestLevelType(
         /// * The table is mutable so that this function can update its snapshot.
         /// * Asserts that the table currently has snapshot_max of math.maxInt(u64).
         /// * Asserts that the table exists in the manifest.
-        pub fn set_snapshot_max(
-            level: *Self,
-            snapshot: u64,
-            table: *TableInfo,
-        ) void {
+        pub fn set_snapshot_max(level: *Self, snapshot: u64, table: *TableInfo) void {
             assert(snapshot < lsm.snapshot_latest);
             assert(table.snapshot_max == math.maxInt(u64));
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -672,7 +672,7 @@ pub fn TestContext(
 
             if (tables.items.len > 0) {
                 for (tables.items) |*table| {
-                    context.level.remove_table(&context.pool, snapshots, table);
+                    context.level.remove_table_invisible(&context.pool, snapshots, table);
                 }
             }
         }
@@ -733,7 +733,7 @@ pub fn TestContext(
 
                 if (to_remove.items.len > 0) {
                     for (to_remove.items) |*table| {
-                        context.level.remove_table(
+                        context.level.remove_table_invisible(
                             &context.pool,
                             context.snapshots.slice(),
                             table,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -860,14 +860,14 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                     .idle => assert(tree.table_immutable.free),
                     .processing => unreachable,
                     .done => {
-                        tree.compaction_table_immutable.reset();
-                        tree.table_immutable.clear();
                         tree.manifest.remove_invisible_tables(
                             tree.compaction_table_immutable.level_b,
                             tree.lookup_snapshot_max,
                             tree.compaction_table_immutable.range.key_min,
                             tree.compaction_table_immutable.range.key_max,
                         );
+                        tree.compaction_table_immutable.reset();
+                        tree.table_immutable.clear();
                     },
                 }
             }
@@ -880,7 +880,6 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                     .idle => {}, // The compaction wasn't started for this half bar.
                     .processing => unreachable,
                     .done => {
-                        context.compaction.reset();
                         tree.manifest.remove_invisible_tables(
                             context.compaction.level_b,
                             tree.lookup_snapshot_max,
@@ -895,6 +894,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                                 context.compaction.range.key_max,
                             );
                         }
+                        context.compaction.reset();
                     },
                 }
             }


### PR DESCRIPTION
When the table can be moved directly between levels without reading values from the iterators, do so and skip the rest of the compaction process.

This is currently a prototype. The benchmark ends up hitting this case quite frequently and not really doing any ~~Grid~~ disk reads.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1223 batches in 371.97 s
    load offered = 1000000 tx/s
    load accepted = 26883 tx/s
    batch latency p00 = 5 ms
    batch latency p10 = 37 ms
    batch latency p20 = 42 ms
    batch latency p30 = 46 ms
    batch latency p40 = 47 ms
    batch latency p50 = 47 ms
    batch latency p60 = 47 ms
    batch latency p70 = 52 ms
    batch latency p80 = 57 ms
    batch latency p90 = 58 ms
    batch latency p100 = 21847 ms
    transfer latency p00 = 5 ms
    transfer latency p10 = 4123 ms
    transfer latency p20 = 18843 ms
    transfer latency p30 = 41475 ms
    transfer latency p40 = 73113 ms
    transfer latency p50 = 118810 ms
    transfer latency p60 = 172811 ms
    transfer latency p70 = 220026 ms
    transfer latency p80 = 272064 ms
    transfer latency p90 = 321065 ms
    transfer latency p100 = 361967 ms
    
    # benchmark results after
    1223 batches in 318.06 s
    load offered = 1000000 tx/s
    load accepted = 31440 tx/s
    batch latency p00 = 5 ms
    batch latency p10 = 37 ms
    batch latency p20 = 42 ms
    batch latency p30 = 42 ms
    batch latency p40 = 47 ms
    batch latency p50 = 47 ms
    batch latency p60 = 47 ms
    batch latency p70 = 48 ms
    batch latency p80 = 52 ms
    batch latency p90 = 57 ms
    batch latency p100 = 18951 ms
    transfer latency p00 = 5 ms
    transfer latency p10 = 4206 ms
    transfer latency p20 = 19490 ms
    transfer latency p30 = 41898 ms
    transfer latency p40 = 72858 ms
    transfer latency p50 = 112216 ms
    transfer latency p60 = 153890 ms
    transfer latency p70 = 195212 ms
    transfer latency p80 = 234889 ms
    transfer latency p90 = 272316 ms
    transfer latency p100 = 308050 ms
    ```
