### PR TITLE
IO: ensure `get_sqe()` fairness for unqueued

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -120,6 +120,10 @@ pub const IO = struct {
             self.completed = .{};
             while (copy.pop()) |completion| completion.complete();
         }
+
+        // At this point, unqueued could have completions either by 1) those who didn't get an SQE
+        // during the popping of unqueued or 2) completion.complete() which start new IO. These
+        // unqueued completions will get priority to acquiring SQEs on the next flush().
     }
 
     fn flush_completions(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -102,9 +102,9 @@ pub const IO = struct {
         try self.flush_completions(0, timeouts, etime);
 
         // The SQE array is empty from flush_submissions(). Fill it up with unqueued completions.
-        // This runs before `self.completed` is flushed below to prevent new IO from reserving SQE 
+        // This runs before `self.completed` is flushed below to prevent new IO from reserving SQE
         // slots and potentially starving those in `self.unqueued`.
-        // Loop over a copy to avoid an infinite loop of `enqueue()` re-adding to `self.unqueued`. 
+        // Loop over a copy to avoid an infinite loop of `enqueue()` re-adding to `self.unqueued`.
         {
             var copy = self.unqueued;
             self.unqueued = .{};


### PR DESCRIPTION
Right after `flush_submissions()`, the `completed` FIFO is ran before the `unqueued` FIFO is. New completions could do IO and reserve `ring.get_sqe()` slots ahead of those in `unqueued` which can ruin IO fairness. Instead, run `unqueued` before `completed` to ensure those waiting for SQEs have a chance at them ahead of new IO.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1223 batches in 383.96 s
    load offered = 1000000 tx/s
    load accepted = 26044 tx/s
    batch latency p00 = 5 ms
    batch latency p10 = 41 ms
    batch latency p20 = 43 ms
    batch latency p30 = 47 ms
    batch latency p40 = 47 ms
    batch latency p50 = 47 ms
    batch latency p60 = 52 ms
    batch latency p70 = 52 ms
    batch latency p80 = 57 ms
    batch latency p90 = 62 ms
    batch latency p100 = 21958 ms
    transfer latency p00 = 5 ms
    transfer latency p10 = 4240 ms
    transfer latency p20 = 19428 ms
    transfer latency p30 = 42431 ms
    transfer latency p40 = 73692 ms
    transfer latency p50 = 120617 ms
    transfer latency p60 = 176922 ms
    transfer latency p70 = 225502 ms
    transfer latency p80 = 279721 ms
    transfer latency p90 = 330106 ms
    transfer latency p100 = 373948 ms
    
    # benchmark results after
    1223 batches in 378.04 s
    load offered = 1000000 tx/s
    load accepted = 26452 tx/s
    batch latency p00 = 5 ms
    batch latency p10 = 37 ms
    batch latency p20 = 42 ms
    batch latency p30 = 47 ms
    batch latency p40 = 47 ms
    batch latency p50 = 47 ms
    batch latency p60 = 48 ms
    batch latency p70 = 52 ms
    batch latency p80 = 57 ms
    batch latency p90 = 62 ms
    batch latency p100 = 19841 ms
    transfer latency p00 = 5 ms
    transfer latency p10 = 4166 ms
    transfer latency p20 = 19472 ms
    transfer latency p30 = 42533 ms
    transfer latency p40 = 74927 ms
    transfer latency p50 = 120267 ms
    transfer latency p60 = 174774 ms
    transfer latency p70 = 223592 ms
    transfer latency p80 = 275487 ms
    transfer latency p90 = 323550 ms
    transfer latency p100 = 368033 ms
    ```
