### PR TITLE
Test: Unit test reorg

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -130,8 +130,11 @@ pub fn build(b: *std.build.Builder) void {
         unit_tests.linkLibC();
         unit_tests.addIncludeDir("src/clients/c/");
 
-        const test_step = b.step("test", "Run the unit tests");
+        const unit_tests_step = b.step("test:unit", "Run the unit tests");
+        unit_tests_step.dependOn(&unit_tests.step);
 
+        const test_step = b.step("test", "Run the unit tests");
+        test_step.dependOn(&unit_tests.step);
         // Test that our demos compile, but don't run them.
         inline for (.{
             "demo_01_create_accounts",
@@ -146,7 +149,6 @@ pub fn build(b: *std.build.Builder) void {
             demo_exe.addPackage(vsr_package);
             test_step.dependOn(&demo_exe.step);
         }
-        test_step.dependOn(&unit_tests.step);
     }
 
     // Clients build:

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -1,6 +1,36 @@
 // zig fmt: off
 
+test "src/ewah.zig" { _ = @import("ewah.zig"); }
+test "src/fifo.zig" { _ = @import("fifo.zig"); }
+test "src/io.zig" { _ = @import("io.zig"); }
+test "src/ring_buffer.zig" { _ = @import("ring_buffer.zig"); }
+test "src/stdx.zig" { _ = @import("stdx.zig"); }
+
+test "src/clients/c/test.zig" { _ = @import("clients/c/test.zig"); }
+test "src/clients/c/tb_client_header_test.zig" { _ = @import("clients/c/tb_client_header_test.zig"); }
+test "src/clients/dotnet/dotnet_bindings_test.zig" { _ = @import("clients/dotnet/dotnet_bindings_test.zig"); }
+test "src/clients/go/go_bindings_test.zig" { _ = @import("clients/go/go_bindings_test.zig"); }
+test "src/clients/java/java_bindings.zig" { _ = @import("clients/java/java_bindings.zig"); }
+
+// TODO Add remaining unit tests from lsm namespace.
+test "src/lsm/forest.zig" { _ = @import("lsm/forest.zig"); }
+test "src/lsm/manifest_level.zig" { _ = @import("lsm/manifest_level.zig"); }
+test "src/lsm/segmented_array.zig" { _ = @import("lsm/segmented_array.zig"); }
+
+test "src/state_machine.zig" { _ = @import("state_machine.zig"); }
+test "src/state_machine/auditor.zig" { _ = @import("state_machine/auditor.zig"); }
+test "src/state_machine/workload.zig" { _ = @import("state_machine/workload.zig"); }
+
+test "src/testing/id.zig" { _ = @import("testing/id.zig"); }
+test "src/testing/storage.zig" { _ = @import("testing/storage.zig"); }
+test "src/testing/table.zig" { _ = @import("testing/table.zig"); }
+
+// This one is a bit sketchy: we rely on tests not actually using the `vsr` package.
+test "src/tigerbeetle/cli.zig" { _ = @import("tigerbeetle/cli.zig"); }
+
 test "src/vsr.zig" { _ = @import("vsr.zig"); }
+// TODO: clean up logging of clock test and enable it here.
+//test "src/vsr/clock.zig" { _ = @import("vsr/clock.zig"); }
 test "src/vsr/journal.zig" { _ = @import("vsr/journal.zig"); }
 test "src/vsr/marzullo.zig" { _ = @import("vsr/marzullo.zig"); }
 test "src/vsr/replica_format.zig" { _ = @import("vsr/replica_format.zig"); }
@@ -8,35 +38,3 @@ test "src/vsr/superblock.zig" { _ = @import("vsr/superblock.zig"); }
 test "src/vsr/superblock_free_set.zig" { _ = @import("vsr/superblock_free_set.zig"); }
 test "src/vsr/superblock_manifest.zig" { _ = @import("vsr/superblock_manifest.zig"); }
 test "src/vsr/superblock_quorums.zig" { _ = @import("vsr/superblock_quorums.zig"); }
-// TODO: clean up logging of clock test and enable it here.
-//test "src/vsr/clock.zig" { _ = @import("vsr/clock.zig"); }
-
-test "src/state_machine.zig" { _ = @import("state_machine.zig"); }
-test "src/state_machine/auditor.zig" { _ = @import("state_machine/auditor.zig"); }
-test "src/state_machine/workload.zig" { _ = @import("state_machine/workload.zig"); }
-
-test "src/fifo.zig" { _ = @import("fifo.zig"); }
-test "src/ring_buffer.zig" { _ = @import("ring_buffer.zig"); }
-
-test "src/io.zig" { _ = @import("io.zig"); }
-test "src/ewah.zig" { _ = @import("ewah.zig"); }
-test "src/stdx.zig" { _ = @import("stdx.zig"); }
-
-test "src/clients/c/test.zig" { _ = @import("clients/c/test.zig"); }
-test "src/clients/c/tb_client_header_test.zig" { _ = @import("clients/c/tb_client_header_test.zig"); }
-
-// TODO Add remaining unit tests from lsm namespace.
-test "src/lsm/forest.zig" { _ = @import("lsm/forest.zig"); }
-test "src/lsm/manifest_level.zig" { _ = @import("lsm/manifest_level.zig"); }
-test "src/lsm/segmented_array.zig" { _ = @import("lsm/segmented_array.zig"); }
-
-test "src/testing/id.zig" { _ = @import("testing/id.zig"); }
-test "src/testing/storage.zig" { _ = @import("testing/storage.zig"); }
-test "src/testing/table.zig" { _ = @import("testing/table.zig"); }
-
-test "src/clients/go/go_bindings_test.zig" { _ = @import("clients/go/go_bindings_test.zig"); }
-test "src/clients/dotnet/dotnet_bindings_test.zig" { _ = @import("clients/dotnet/dotnet_bindings_test.zig"); }
-test "src/clients/java/java_bindings.zig" { _ = @import("clients/java/java_bindings.zig"); }
-
-// This one is a bit sketchy: we rely on tests not actually using the `vsr` package.
-test "src/tigerbeetle/cli.zig" { _ = @import("tigerbeetle/cli.zig"); }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -1,42 +1,42 @@
-test {
-    _ = @import("vsr.zig");
-    _ = @import("vsr/journal.zig");
-    _ = @import("vsr/marzullo.zig");
-    _ = @import("vsr/replica_format.zig");
-    _ = @import("vsr/superblock.zig");
-    _ = @import("vsr/superblock_free_set.zig");
-    _ = @import("vsr/superblock_manifest.zig");
-    _ = @import("vsr/superblock_quorums.zig");
-    // TODO: clean up logging of clock test and enable it here.
-    //_ = @import("vsr/clock.zig");
+// zig fmt: off
 
-    _ = @import("state_machine.zig");
-    _ = @import("state_machine/auditor.zig");
-    _ = @import("state_machine/workload.zig");
+test "src/vsr.zig" { _ = @import("vsr.zig"); }
+test "src/vsr/journal.zig" { _ = @import("vsr/journal.zig"); }
+test "src/vsr/marzullo.zig" { _ = @import("vsr/marzullo.zig"); }
+test "src/vsr/replica_format.zig" { _ = @import("vsr/replica_format.zig"); }
+test "src/vsr/superblock.zig" { _ = @import("vsr/superblock.zig"); }
+test "src/vsr/superblock_free_set.zig" { _ = @import("vsr/superblock_free_set.zig"); }
+test "src/vsr/superblock_manifest.zig" { _ = @import("vsr/superblock_manifest.zig"); }
+test "src/vsr/superblock_quorums.zig" { _ = @import("vsr/superblock_quorums.zig"); }
+// TODO: clean up logging of clock test and enable it here.
+//test "src/vsr/clock.zig" { _ = @import("vsr/clock.zig"); }
 
-    _ = @import("fifo.zig");
-    _ = @import("ring_buffer.zig");
+test "src/state_machine.zig" { _ = @import("state_machine.zig"); }
+test "src/state_machine/auditor.zig" { _ = @import("state_machine/auditor.zig"); }
+test "src/state_machine/workload.zig" { _ = @import("state_machine/workload.zig"); }
 
-    _ = @import("io.zig");
-    _ = @import("ewah.zig");
-    _ = @import("stdx.zig");
+test "src/fifo.zig" { _ = @import("fifo.zig"); }
+test "src/ring_buffer.zig" { _ = @import("ring_buffer.zig"); }
 
-    _ = @import("clients/c/test.zig");
-    _ = @import("clients/c/tb_client_header_test.zig");
+test "src/io.zig" { _ = @import("io.zig"); }
+test "src/ewah.zig" { _ = @import("ewah.zig"); }
+test "src/stdx.zig" { _ = @import("stdx.zig"); }
 
-    // TODO Add remaining unit tests from lsm namespace.
-    _ = @import("lsm/forest.zig");
-    _ = @import("lsm/manifest_level.zig");
-    _ = @import("lsm/segmented_array.zig");
+test "src/clients/c/test.zig" { _ = @import("clients/c/test.zig"); }
+test "src/clients/c/tb_client_header_test.zig" { _ = @import("clients/c/tb_client_header_test.zig"); }
 
-    _ = @import("testing/id.zig");
-    _ = @import("testing/storage.zig");
-    _ = @import("testing/table.zig");
+// TODO Add remaining unit tests from lsm namespace.
+test "src/lsm/forest.zig" { _ = @import("lsm/forest.zig"); }
+test "src/lsm/manifest_level.zig" { _ = @import("lsm/manifest_level.zig"); }
+test "src/lsm/segmented_array.zig" { _ = @import("lsm/segmented_array.zig"); }
 
-    _ = @import("clients/go/go_bindings_test.zig");
-    _ = @import("clients/dotnet/dotnet_bindings_test.zig");
-    _ = @import("clients/java/java_bindings.zig");
+test "src/testing/id.zig" { _ = @import("testing/id.zig"); }
+test "src/testing/storage.zig" { _ = @import("testing/storage.zig"); }
+test "src/testing/table.zig" { _ = @import("testing/table.zig"); }
 
-    // This one is a bit sketchy: we rely on tests not actually using the `vsr` package.
-    _ = @import("tigerbeetle/cli.zig");
-}
+test "src/clients/go/go_bindings_test.zig" { _ = @import("clients/go/go_bindings_test.zig"); }
+test "src/clients/dotnet/dotnet_bindings_test.zig" { _ = @import("clients/dotnet/dotnet_bindings_test.zig"); }
+test "src/clients/java/java_bindings.zig" { _ = @import("clients/java/java_bindings.zig"); }
+
+// This one is a bit sketchy: we rely on tests not actually using the `vsr` package.
+test "src/tigerbeetle/cli.zig" { _ = @import("tigerbeetle/cli.zig"); }


### PR DESCRIPTION
Add `zig build test:unit`, which runs just the unit tests. (`zig build test` additionally compiles e.g. the demos).

Change

```zig
test {
    _ = @import("vsr.zig");
    _ = @import("vsr/journal.zig");
    _ = @import("vsr/marzullo.zig");
...
```

to something like

```zig
test "src/vsr.zig" { _ = @import("vsr.zig"); }
test "src/vsr/journal.zig" { _ = @import("vsr/journal.zig"); }
test "src/vsr/marzullo.zig" { _ = @import("vsr/marzullo.zig"); }
```

So a file's tests can be run with e.g. `zig build test:unit -Dtest-filter=vsr.zig`.

## Pre-merge checklist

Performance:

OR
* [x] I am very sure this PR could not affect performance.
