### PR TITLE
Remove timeout.exe - crashes in CI

### DIFF
--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -42,9 +42,6 @@ for /l %%i in (0, 1, 0) do (
     start /B "tigerbeetle_%%i" .\tigerbeetle.exe start --addresses=3001 !ZIG_FILE! > benchmark.log 2>&1
 )
 
-rem Wait for replicas to start, listen and connect:
-timeout /t 2
-
 echo.
 echo Benchmarking...
 zig\zig.exe build benchmark -Drelease-safe

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -52,9 +52,6 @@ do
     ./tigerbeetle start --addresses=3001 "$FILE" >> benchmark.log 2>&1 &
 done
 
-# Wait for replicas to start, listen and connect:
-sleep 1
-
 echo ""
 echo "Benchmarking..."
 zig/zig build benchmark -Drelease-safe


### PR DESCRIPTION
See https://www.ibm.com/support/pages/timeout-command-run-batch-job-exits-immediately-and-returns-error-input-redirection-not-supported-exiting-process-immediately

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
