### PR TITLE
Temporarily disable the windows benchmark.

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -80,12 +80,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./scripts/benchmark.sh
 
-  benchmark_on_windows:
-    name: Run benchmark on Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: ./scripts/benchmark.bat
+  # TODO Temporarily disabled. See https://github.com/tigerbeetledb/tigerbeetle/issues/473 
+  #benchmark_on_windows:
+  #  name: Run benchmark on Windows
+  #  runs-on: windows-latest
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - run: ./scripts/benchmark.bat
 
   fuzz_ewah:
     name: 'Fuzz EWAH codec'
@@ -329,7 +330,7 @@ jobs:
       - test_on_macos
       - benchmark_on_linux
       - benchmark_on_macos
-      - benchmark_on_windows
+      # - benchmark_on_windows
       - fuzz_ewah
       - fuzz_lsm_manifest_log
       - fuzz_lsm_segmented_array


### PR DESCRIPTION
We're currently debating whether to support windows at all, but in the meantime this CI failure is blocking everyone.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
