### PR TITLE
Java client: Add CI for publishing to Maven Central

### DIFF
--- a/.github/workflows/clients-java-build.yml
+++ b/.github/workflows/clients-java-build.yml
@@ -1,13 +1,10 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+# This workflow will build a package using Maven and then publish it to Maven Central when a release is created
 
 name: "clients/java: Build"
 
 on:
   push:
     branches: [ main, staging, trying ]
-    # paths:
-    #   - src/clients/java/**
   pull_request:
     branches: [ main ]
     paths:
@@ -22,12 +19,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0    
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'
-        server-id: github
+        server-id: ossrh 
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_CENTRAL_TOKEN
+        gpg-private-key: ${{ secrets.MAVEN_GPG_SECRET_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE        
         settings-path: ${{ github.workspace }}
 
     - name: Format linter
@@ -46,25 +49,29 @@ jobs:
       run: mvn compile
 
     - name: Build
-      if: ${{ github.ref != 'refs/heads/main' }}
       working-directory: src/clients/java
       run: mvn -B package --file pom.xml
 
     - name: Save local package
       uses: actions/upload-artifact@v3
-      if: ${{ github.ref != 'refs/heads/main' }}
       with:
         name: jar-artifact
         path: |
           src/clients/java/target/*.jar
           !src/clients/java/target/*javadoc.jar
+          !src/clients/java/target/*sources.jar
 
-    - name: Build and publish
+    - name: Publish to the Maven Central Repository
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       working-directory: src/clients/java
-      run: mvn -B deploy --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
+      run: |
+        mvn -B versions:set -DnewVersion=$BASE_VERSION-$(git rev-list --count HEAD) --file pom.xml
+        mvn -B clean deploy -Dmaven.test.skip --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BASE_VERSION: 0.0.1
+        MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}        
 
   prepare_validation_tests:
     needs: build
@@ -79,26 +86,11 @@ jobs:
         server-id: github
         settings-path: ${{ github.workspace }}
 
-    ## If it's not on main, the package wasn't uploaded, so we use a local version:
     - name: Restore local package
-      if: ${{ github.ref != 'refs/heads/main' }}
       uses: actions/download-artifact@v3
       with:
         name: jar-artifact
         path: test/
-
-    ## If it's a push, we can download the package from Maven's registry:
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: whelk-io/maven-settings-xml-action@v4
-      with:
-        repositories: '[{ "id": "github", "url": "https://maven.pkg.github.com/tigerbeetledb/tigerbeetle", "snapshots": { "enabled": "true" } }]'
-        servers: '[{ "id": "github", "username": "${{github.actor}}", "password": "${{ github.token }}" }]'
-    - name: Download tigerbeetle-java package
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      run: |
-        mvn dependency:copy -Dartifact=com.tigerbeetle:tigerbeetle-java:0.0.1-SNAPSHOT -DoutputDirectory=. -DrepositoryId=github
-        mkdir -p test
-        mv *.jar test/
    
     - name: Create a simple test program
       run: |

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -2,12 +2,15 @@
 
 [TigerBeetle](https://github.com/tigerbeetledb/tigerbeetle) client for Java.
 
+[![javadoc](https://javadoc.io/badge2/com.tigerbeetle/tigerbeetle-java/javadoc.svg)](https://javadoc.io/doc/com.tigerbeetle/tigerbeetle-java)
+
+[![maven-central](https://img.shields.io/maven-central/v/com.tigerbeetle/tigerbeetle-java)](https://central.sonatype.com/namespace/com.tigerbeetle)
 
 ## Pre-built package
 
-Available at [GitHub Packages Registry](https://github.com/orgs/tigerbeetledb/packages?repo_name=tigerbeetle) as a `jar` package.
+Available at [Maven Central](https://central.sonatype.com/namespace/com.tigerbeetle).
 
-You can install it by just downloading and placing the `jar` package directly in your `classpath` or by using a package management system such as [Maven](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) or [Gradle](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
+Can be installed by a package management system such as [Maven](https://central.sonatype.org/consume/consume-apache-maven/) or [Gradle](https://central.sonatype.org/consume/consume-gradle/).
 
 ## Examples
 

--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -7,6 +7,17 @@
   <artifactId>tigerbeetle-java</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>TigerBeetle Java client</name>
+  <description>The distributed financial accounting database designed for mission critical safety and performance.</description>
+  <developers>
+    <developer>
+      <name>The TigerBeetle contributors</name>
+      <email>hi@tigerbeetle.com</email>
+    </developer>
+  </developers>
+  <organization>
+    <name>TigerBeetle, Inc.</name>
+    <url>https://www.tigerbeetle.com</url>
+  </organization>
   <url>https://www.tigerbeetle.com</url>
   <scm>
     <url>https://github.com/tigerbeetledb/tigerbeetle</url>
@@ -94,6 +105,16 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.4.1</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>                 
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
@@ -249,7 +270,42 @@
         </executions>
       </plugin>
 
-      <!-- Javadoc -->
+      <!-- Sign artifacts -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>sign</goal>
+                </goals>
+                <configuration>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>      
+
+      <!-- Source code jar -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>attach-sources</id>
+                <goals>
+                    <goal>jar</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>      
+
+      <!-- Javadoc jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -263,6 +319,7 @@
         </executions>
       </plugin>
 
+      <!-- PMD -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
@@ -280,14 +337,30 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- Maven central -->
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.13</version>
+        <extensions>true</extensions>
+        <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   
   <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
     <repository>
-      <id>github</id>
-      <name>TigerBeetle Java client</name>
-      <url>https://maven.pkg.github.com/tigerbeetledb/tigerbeetle</url>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
-  </distributionManagement>
+  </distributionManagement>  
 </project>


### PR DESCRIPTION
This PR adds a Maven Central publish step, replacing the GitHub registry.
The version number must be unique and incremental, it's composed by a fixed version `0.0.1` dash `git commit count`.

Also adds badges for `javadocs` and `maven-central` on the Java client's ReadMe.md:

[![javadoc](https://javadoc.io/badge2/com.tigerbeetle/tigerbeetle-java/javadoc.svg)](https://javadoc.io/doc/com.tigerbeetle/tigerbeetle-java)

[![maven-central](https://img.shields.io/maven-central/v/com.tigerbeetle/tigerbeetle-java)](https://central.sonatype.com/namespace/com.tigerbeetle)

**IMPORTANT¹**: The following SECRETS must be created on this repository before merging this PR:

`MAVEN_CENTRAL_TOKEN`
`MAVEN_CENTRAL_USERNAME`
`MAVEN_GPG_SECRET_KEY`
`MAVEN_GPG_SECRET_KEY_PASSWORD`

Please contact me on private to obtain the values to be configured.
More info about setting up github secrets can be found [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets)

**IMPORTANT²**: We can delete the old [GitHub's registry package](https://github.com/tigerbeetledb/tigerbeetle/packages/1734273) after merging this PR.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
