### PR TITLE
Add script to compare debug and release builds

### DIFF
--- a/scripts/fuzz_loop_hash_log.sh
+++ b/scripts/fuzz_loop_hash_log.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+# Repeatedly runs some zig build command with different seeds and checks that release and debug builds have indentical behaviour.
+
+FUZZ_COMMAND=$1
+
+while true; do
+  SEED=$(od -A n -t u8 -N 8 /dev/urandom | xargs)
+  zig build "$FUZZ_COMMAND" -Dhash-log-mode=create -Drelease-safe -- --seed "$SEED" --events-max 100000;
+  zig build "$FUZZ_COMMAND" -Dhash-log-mode=check -- --seed "$SEED" --events-max 100000;
+done


### PR DESCRIPTION
I wrote this a while ago and forgot to commit it. When I ran it to check if it still works it immediately found multiple crashes.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
