### PR TITLE
Vary table size per tree.

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -163,7 +163,8 @@ pub fn main() !void {
             transfer_next_arrival_ns < batch_start_ns)
         {
             batch_transfers.appendAssumeCapacity(.{
-                .id = transfer_index + 1,
+                // Reverse the bits to stress non-append-only index for `id`.
+                .id = @bitReverse(u128, transfer_index + 1),
                 .debit_account_id = accounts[0].id,
                 .credit_account_id = accounts[1].id,
                 .user_data = 0,

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -14,6 +14,7 @@ const MessagePool = @import("message_pool.zig").MessagePool;
 const MessageBus = @import("message_bus.zig").MessageBusClient;
 const StateMachine = @import("state_machine.zig").StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 const RingBuffer = @import("ring_buffer.zig").RingBuffer;
 const vsr = @import("vsr.zig");

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -31,6 +31,7 @@ const Storage = @import("../../storage.zig").Storage;
 const MessageBus = @import("../../message_bus.zig").MessageBusClient;
 const StateMachine = @import("../../state_machine.zig").StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 
 const ContextType = @import("tb_client/context.zig").ContextType;

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -15,6 +15,7 @@ const CreateTransfersResult = tb.CreateTransfersResult;
 const Storage = @import("tigerbeetle/src/storage.zig").Storage;
 const StateMachine = @import("tigerbeetle/src/state_machine.zig").StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 const Operation = StateMachine.Operation;
 const MessageBus = @import("tigerbeetle/src/message_bus.zig").MessageBusClient;

--- a/src/config.zig
+++ b/src/config.zig
@@ -89,7 +89,6 @@ const ConfigCluster = struct {
     block_size: comptime_int = 64 * 1024,
     lsm_levels: u7 = 7,
     lsm_growth_factor: u32 = 8,
-    lsm_table_size_max: usize = 64 * 1024 * 1024,
     lsm_batch_multiple: comptime_int = 4,
     lsm_snapshots_max: usize = 32,
     lsm_value_to_key_layout_ratio_min: comptime_int = 16,
@@ -188,7 +187,6 @@ pub const configs = struct {
 
             .block_size = sector_size,
             .lsm_growth_factor = 4,
-            .lsm_table_size_max = 64 * 1024,
         },
     };
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -344,8 +344,6 @@ pub const block_size = config.cluster.block_size;
 
 comptime {
     assert(block_size % sector_size == 0);
-    assert(lsm_table_size_max % sector_size == 0);
-    assert(lsm_table_size_max % block_size == 0);
 }
 
 /// The number of levels in an LSM tree.
@@ -366,10 +364,6 @@ comptime {
 /// factor of 8 for lower write amplification rather than the more typical growth factor of 10.
 pub const lsm_growth_factor = config.cluster.lsm_growth_factor;
 
-/// The maximum cumulative size of a table — computed as the sum of the size of the index block,
-/// filter blocks, and data blocks.
-pub const lsm_table_size_max = config.cluster.lsm_table_size_max;
-
 /// Size of nodes used by the LSM tree manifest implementation.
 /// TODO Double-check this with our "LSM Manifest" spreadsheet.
 pub const lsm_manifest_node_size = config.process.lsm_manifest_node_size;
@@ -377,8 +371,6 @@ pub const lsm_manifest_node_size = config.process.lsm_manifest_node_size;
 /// A multiple of batch inserts that a mutable table can definitely accommodate before flushing.
 /// For example, if a message_size_max batch can contain at most 8181 transfers then a multiple of 4
 /// means that the transfer tree's mutable table will be sized to 8191 * 4 = 32764 transfers.
-/// TODO Assert this relative to lsm_table_size_max.
-/// We want to ensure that a mutable table can be converted to an immutable table without overflow.
 pub const lsm_batch_multiple = config.cluster.lsm_batch_multiple;
 
 comptime {

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -18,6 +18,7 @@ const MessagePool = vsr.message_pool.MessagePool;
 const MessageBus = vsr.message_bus.MessageBusClient;
 const StateMachine = vsr.state_machine.StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 
 const Header = vsr.Header;

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -67,6 +67,7 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
             open,
         };
 
+        pub const groove_config = groove_config;
         pub const GroovesOptions = _GroovesOptions;
 
         join_op: ?JoinOp = null,

--- a/src/lsm/level_iterator.zig
+++ b/src/lsm/level_iterator.zig
@@ -38,7 +38,7 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
             table_iterator: TableIterator,
         };
 
-        const ValuesRingBuffer = RingBuffer(Value, Table.data.value_count_max, .pointer);
+        const ValuesRingBuffer = RingBuffer(Value, Table.data.block_value_count_max, .pointer);
         const TablesRingBuffer = RingBuffer(TableIteratorScope, 2, .array);
 
         grid: *Grid,
@@ -280,7 +280,7 @@ pub fn LevelIteratorType(comptime Table: type, comptime Storage: type) type {
 
         fn buffered_enough_values(it: LevelIterator) bool {
             return it.buffered_all_values() or
-                it.buffered_value_count() >= Table.data.value_count_max;
+                it.buffered_value_count() >= Table.data.block_value_count_max;
         }
 
         /// Returns either:

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -417,6 +417,7 @@ pub fn TestContext(
             std.math.maxInt(Key),
             tombstone,
             tombstone_from_key,
+            1, // Doesn't matter for this test.
             .general,
         );
 

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -18,7 +18,7 @@ const compaction_snapshot_for_op = @import("tree.zig").compaction_snapshot_for_o
 /// TigerBeetle's state machine requires a map from u128 ID to posted boolean for transfers
 /// and this type implements that.
 /// TODO Make the LSM Forest library flexible enough to be able to get rid of this special case.
-pub fn PostedGrooveType(comptime Storage: type) type {
+pub fn PostedGrooveType(comptime Storage: type, value_count_max: usize) type {
     return struct {
         const PostedGroove = @This();
 
@@ -67,6 +67,7 @@ pub fn PostedGrooveType(comptime Storage: type) type {
             Value.sentinel_key,
             Value.tombstone,
             Value.tombstone_from_key,
+            value_count_max,
             .general,
         );
 
@@ -101,7 +102,6 @@ pub fn PostedGrooveType(comptime Storage: type) type {
         pub const Options = struct {
             cache_entries_max: u32,
             prefetch_entries_max: u32,
-            commit_entries_max: u32,
         };
 
         pub fn init(
@@ -116,7 +116,6 @@ pub fn PostedGrooveType(comptime Storage: type) type {
                 grid,
                 .{
                     .cache_entries_max = options.cache_entries_max,
-                    .commit_entries_max = options.commit_entries_max,
                 },
             );
             errdefer tree.deinit(allocator);
@@ -357,7 +356,11 @@ pub fn PostedGrooveType(comptime Storage: type) type {
 test "PostedGroove" {
     const Storage = @import("../storage.zig").Storage;
 
-    const PostedGroove = PostedGrooveType(Storage);
+    const PostedGroove = PostedGrooveType(
+        Storage,
+        // Doesn't matter for this test.
+        1,
+    );
 
     _ = PostedGroove.init;
     _ = PostedGroove.deinit;

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -1241,6 +1241,7 @@ pub fn run_tests(seed: u64, comptime options: Options) !void {
         Key.sentinel_key,
         Key.tombstone,
         Key.tombstone_from_key,
+        1, // Doesn't matter for this test.
         .general,
     ));
 

--- a/src/lsm/table_iterator.zig
+++ b/src/lsm/table_iterator.zig
@@ -17,7 +17,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
 
         const Grid = GridType(Storage);
         const Manifest = ManifestType(Table, Storage);
-        const ValuesRingBuffer = RingBuffer(Table.Value, Table.data.value_count_max, .pointer);
+        const ValuesRingBuffer = RingBuffer(Table.Value, Table.data.block_value_count_max, .pointer);
 
         const BlockPtrConst = *align(constants.sector_size) const [constants.block_size]u8;
         const IndexBlockCallback = fn (it: *TableIterator, index_block: BlockPtrConst) void;
@@ -278,7 +278,7 @@ pub fn TableIteratorType(comptime Table: type, comptime Storage: type) type {
             assert(!it.read_pending);
 
             return it.buffered_all_values() or
-                it.buffered_value_count() >= Table.data.value_count_max;
+                it.buffered_value_count() >= Table.data.block_value_count_max;
         }
 
         /// Returns either:

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -15,6 +15,7 @@ const Storage = @import("../storage.zig").Storage;
 const IO = @import("../io.zig").IO;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 
 const GridType = @import("grid.zig").GridType;

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -16,6 +16,7 @@ const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 
 const GridType = @import("grid.zig").GridType;
@@ -76,12 +77,12 @@ const FuzzOp = union(enum) {
 
 const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
 const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
+const value_count_max = constants.lsm_batch_multiple * commit_entries_max;
 
 const cluster = 32;
 const replica = 4;
 const node_count = 1024;
 const tree_options = .{
-    .commit_entries_max = commit_entries_max,
     // This is the smallest size that set_associative_cache will allow us.
     .cache_entries_max = 2048,
 };
@@ -106,6 +107,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             Key.sentinel_key,
             Key.tombstone,
             Key.tombstone_from_key,
+            value_count_max,
             table_usage,
         );
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -87,7 +87,10 @@ const tree_options = .{
     .cache_entries_max = 2048,
 };
 
-const puts_since_compact_max = commit_entries_max;
+// We must call compact after every 'batch'.
+// Every `lsm_batch_multiple` batches may put/remove `value_count_max` values.
+// Every `FuzzOp.put` issues one remove and one put.
+const puts_since_compact_max = @divTrunc(commit_entries_max, 2);
 const compacts_per_checkpoint = std.math.divCeil(
     usize,
     constants.journal_slot_count,

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -17,6 +17,7 @@ const PriorityQueue = @import("../testing/priority_queue.zig").PriorityQueue;
 const Storage = @import("../testing/storage.zig").Storage;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 
 pub const CreateAccountResultSet = std.enums.EnumSet(tb.CreateAccountResult);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -45,6 +45,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
         pub const StateMachine = StateMachineType(Storage, .{
             .message_body_size_max = constants.message_body_size_max,
+            .lsm_batch_multiple = constants.lsm_batch_multiple,
         });
         pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time);
         pub const Client = vsr.Client(StateMachine, MessageBus);

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -7,6 +7,7 @@ const log = std.log.scoped(.state_machine);
 
 pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
     message_body_size_max: usize,
+    lsm_batch_multiple: usize,
 }) type {
     _ = Storage;
     _ = constants_;

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -24,6 +24,7 @@ const MessageBus = vsr.message_bus.MessageBusReplica;
 const MessagePool = vsr.message_pool.MessagePool;
 const StateMachine = vsr.state_machine.StateMachineType(Storage, .{
     .message_body_size_max = constants.message_body_size_max,
+    .lsm_batch_multiple = constants.lsm_batch_multiple,
 });
 
 const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time);


### PR DESCRIPTION
Implements https://github.com/tigerbeetledb/tigerbeetle/issues/271.

The diff isn't as bad as it looks. The first commit passes `value_count_max` into table.zig rather than table_mutable.zig so that it can be used for layout, which requires a lot of trivial changes and renaming some conflicting variables. The second commit actually changes the layout - the math becomes much simpler. 

Has no effect on performance in the current benchmark because all the indexes stressed are append-only. Since we don't coalesce non-overlapping tables, append-only index tables were already accidentally batch-sized.

fuzz_lsm_forest and fuzz_lsm_tree pass (I fixed https://github.com/tigerbeetledb/tigerbeetle/issues/486 while I was in there).

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
``` sh
# benchmark results before
1223 batches in 79.35 s
load offered = 1000000 tx/s
load accepted = 126031 tx/s
batch latency p00 = 5 ms
batch latency p10 = 16 ms
batch latency p20 = 16 ms
batch latency p30 = 16 ms
batch latency p40 = 16 ms
batch latency p50 = 17 ms
batch latency p60 = 81 ms
batch latency p70 = 82 ms
batch latency p80 = 113 ms
batch latency p90 = 147 ms
batch latency p100 = 2286 ms
transfer latency p00 = 5 ms
transfer latency p10 = 5175 ms
transfer latency p20 = 11008 ms
transfer latency p30 = 17640 ms
transfer latency p40 = 24744 ms
transfer latency p50 = 31812 ms
transfer latency p60 = 38970 ms
transfer latency p70 = 46053 ms
transfer latency p80 = 53192 ms
transfer latency p90 = 62166 ms
transfer latency p100 = 69303 ms
    
# benchmark results after
1223 batches in 77.24 s
load offered = 1000000 tx/s
load accepted = 129471 tx/s
batch latency p00 = 5 ms
batch latency p10 = 16 ms
batch latency p20 = 16 ms
batch latency p30 = 16 ms
batch latency p40 = 16 ms
batch latency p50 = 17 ms
batch latency p60 = 77 ms
batch latency p70 = 82 ms
batch latency p80 = 112 ms
batch latency p90 = 147 ms
batch latency p100 = 467 ms
transfer latency p00 = 5 ms
transfer latency p10 = 5194 ms
transfer latency p20 = 10961 ms
transfer latency p30 = 17508 ms
transfer latency p40 = 24600 ms
transfer latency p50 = 31669 ms
transfer latency p60 = 38821 ms
transfer latency p70 = 45858 ms
transfer latency p80 = 52934 ms
transfer latency p90 = 60115 ms
transfer latency p100 = 67203 ms
```
OR
* [ ] I am very sure this PR could not affect performance.
