### PR TITLE
Tests improvements

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -809,7 +809,7 @@ namespace TigerBeetle.Tests
             // Waiting for just one task
             list.First().Wait();
 
-            // Disposes the client, forcing all tasks to finish if already submited a message, or fail
+            // Disposes the client, forcing all tasks to finish if already submitted a message, or fail
             client.Dispose();
 
             try
@@ -820,7 +820,8 @@ namespace TigerBeetle.Tests
             catch { }
 
             // Asserting that either the task failed or succeeded
-            Assert.IsTrue(list.Any(x => x.IsFaulted) && list.Any(x => x.Result == CreateTransferResult.Ok));
+            Assert.IsTrue(list.Any(x => x.Result == CreateTransferResult.Ok));
+            Assert.IsTrue(list.All(x => x.IsFaulted || x.Result == CreateTransferResult.Ok));
         }
 
         private static void AssertAccounts(Account[] lookupAccounts)

--- a/src/clients/java/scripts/install.bat
+++ b/src/clients/java/scripts/install.bat
@@ -8,4 +8,4 @@ cd ..\..\..
 call .\scripts\install.bat
 
 echo "Building TigerBeetle Java Client..."
-mvn -B package --quiet
+mvn -B package -Dmaven.test.skip -Djacoco.skip --quiet

--- a/src/clients/java/scripts/install.sh
+++ b/src/clients/java/scripts/install.sh
@@ -8,4 +8,4 @@ echo "Installing TigerBeetle..."
 (cd ../../.. && ./scripts/install.sh)
 
 echo "Building TigerBeetle Java Client..."
-mvn -B package --quiet
+mvn -B package -Dmaven.test.skip -Djacoco.skip --quiet

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1062,7 +1062,6 @@ public class IntegrationTest {
                     }
                 }
 
-                assertTrue(failedCount > 0);
                 assertTrue(succeededCount > 0);
                 assertTrue(succeededCount + failedCount == tasks_qty);
 


### PR DESCRIPTION
- False-negative during integration tests for concurrent threads. 
C# ConcurrentTasksDispose and ConcurrentTasksDisposeAsync tests and Java testCloseWithConcurrentTasks test.
At some conditions, all tasks may complete before the client closes, triggering the Assert.
Related https://github.com/tigerbeetledb/tigerbeetle/actions/runs/4234496668/jobs/7356863570

- Avoid running tests twice during the Java build process.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
