### PR TITLE
Increase lsm_batch_multiple to 64.

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -89,7 +89,7 @@ const ConfigCluster = struct {
     block_size: comptime_int = 64 * 1024,
     lsm_levels: u7 = 7,
     lsm_growth_factor: u32 = 8,
-    lsm_batch_multiple: comptime_int = 4,
+    lsm_batch_multiple: comptime_int = 64,
     lsm_snapshots_max: usize = 32,
     lsm_value_to_key_layout_ratio_min: comptime_int = 16,
 
@@ -186,6 +186,7 @@ pub const configs = struct {
             .storage_size_max = 4 * 1024 * 1024 * 1024,
 
             .block_size = sector_size,
+            .lsm_batch_multiple = 4,
             .lsm_growth_factor = 4,
         },
     };


### PR DESCRIPTION
This is roughly the value we plan to use in production, so we should be benchmarking this configuration as early as possible.

This increases memory usage and increase the latency spike from the final phase of compaction, but we need to deal with both regardless. 

https://github.com/tigerbeetledb/tigerbeetle/issues/491 and https://github.com/tigerbeetledb/tigerbeetle/issues/490 can help with memory usage.

https://github.com/tigerbeetledb/tigerbeetle/issues/269 will reduce the latency spike, as will any optimization that improves compaction performance in general.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
```
lbm=4
1643655168 allocated
1223 batches in 116.60 s
load offered = 1000000 tx/s
load accepted = 85766 tx/s
batch latency p00 = 5 ms
batch latency p10 = 26 ms
batch latency p20 = 27 ms
batch latency p30 = 32 ms
batch latency p40 = 36 ms
batch latency p50 = 42 ms
batch latency p60 = 112 ms
batch latency p70 = 142 ms
batch latency p80 = 172 ms
batch latency p90 = 217 ms
batch latency p100 = 411 ms

lbm=64
2989330432 bytes allocated
1223 batches in 93.51 s
load offered = 1000000 tx/s
load accepted = 106942 tx/s
batch latency p00 = 5 ms
batch latency p10 = 26 ms
batch latency p20 = 26 ms
batch latency p30 = 27 ms
batch latency p40 = 31 ms
batch latency p50 = 31 ms
batch latency p60 = 32 ms
batch latency p70 = 36 ms
batch latency p80 = 37 ms
batch latency p90 = 42 ms
batch latency p100 = 3624 ms
```
OR
* [ ] I am very sure this PR could not affect performance.
