### PR TITLE
CI: Re-enable benchmark on Windows

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -87,13 +87,19 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./scripts/benchmark.sh
 
-  # TODO Temporarily disabled. See https://github.com/tigerbeetledb/tigerbeetle/issues/473 
-  #benchmark_on_windows:
-  #  name: Run benchmark on Windows
-  #  runs-on: windows-latest
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - run: ./scripts/benchmark.bat
+  benchmark_on_windows:
+    name: Run benchmark on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Copy repository to C:\ path
+        ## Limited disk space on D:\ partition causes the benchmark to fail on Windows.
+        ## Unfortunately, actions/checkout@v2 does not allow cloning outside GITHUB_WORKSPACE,
+        ## so, copying to C:\ is simpler than customizing git clone command.
+        run: |
+          xcopy /E /I /Y . C:\tigerbeetle\
+      - run: ./scripts/benchmark.bat
+        working-directory: c:\tigerbeetle
 
   fuzz_ewah:
     name: 'Fuzz EWAH codec'

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: ./scripts/benchmark.sh
+      - run: ./scripts/benchmark.sh --account-count 10 --transfer-count 100_000
 
   benchmark_on_macos:
     name: Run benchmark on macOS
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - run: ./scripts/benchmark.sh
+      - run: ./scripts/benchmark.sh --account-count 10 --transfer-count 100_000
 
   benchmark_on_windows:
     name: Run benchmark on Windows

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -92,14 +92,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Copy repository to C:\ path
-        ## Limited disk space on D:\ partition causes the benchmark to fail on Windows.
-        ## Unfortunately, actions/checkout@v2 does not allow cloning outside GITHUB_WORKSPACE,
-        ## so, copying to C:\ is simpler than customizing git clone command.
-        run: |
-          xcopy /E /I /Y . C:\tigerbeetle\
-      - run: ./scripts/benchmark.bat
-        working-directory: c:\tigerbeetle
+      - run: ./scripts/benchmark.bat --account-count 10 --transfer-count 100_000
 
   fuzz_ewah:
     name: 'Fuzz EWAH codec'

--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -44,5 +44,12 @@ for /l %%i in (0, 1, 0) do (
 
 echo.
 echo Benchmarking...
-zig\zig.exe build benchmark -Drelease-safe
+
+set ARGS=
+for %%a in (%*) do (
+    if not "%%a"==":main" (
+        SET ARGS=!ARGS! %%a
+    )
+)
+zig\zig.exe build benchmark -Drelease-safe -- %ARGS%
 exit /b %errorlevel%

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -54,7 +54,7 @@ done
 
 echo ""
 echo "Benchmarking..."
-zig/zig build benchmark -Drelease-safe
+zig/zig build benchmark -Drelease-safe -- "$@"
 echo ""
 
 for I in $REPLICAS


### PR DESCRIPTION
This PR re-enables Windows benchmark during CI, which was failing due to insufficient disk space on GH runner. See #473 for more details.

Although the benchmark completes successfully on Windows now, it took **30 minutes to run, so feel free to reject this PR, since it may not be a good idea to re-enable this job anyways**.
See the execution log: https://github.com/tigerbeetledb/tigerbeetle/actions/runs/4261985816/jobs/7416950272

## Additional info:

- This PR does not solve the `@panic` issue related to #473.

- The data file grows about ~12.8GB during the benchmark both on Linux and Windows.

- GitHub [offers larger runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners) for demanding workloads.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
