### PR TITLE
Use tabs in go docs

### DIFF
--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -30,7 +30,7 @@ import _ "github.com/tigerbeetledb/tigerbeetle-go"
 import "fmt"
 
 func main() {
-  fmt.Println("Import ok!")
+	fmt.Println("Import ok!")
 }
 ```
 

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -29,7 +29,7 @@ pub const GoDocs = Docs{
     \\import "fmt"
     \\
     \\func main() {
-    \\  fmt.Println("Import ok!")
+    \\	fmt.Println("Import ok!")
     \\}
     ,
 


### PR DESCRIPTION
Reported by Simon Klee on Slack.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
