### PR TITLE
vsr: standby replicas

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -27,6 +27,10 @@ pub const hash_log_mode = config.process.hash_log_mode;
 
 /// The maximum number of replicas allowed in a cluster.
 pub const replicas_max = 6;
+/// The maximum number of standbys allowed in a cluster.
+pub const standbys_max = 6;
+/// The maximum number of nodes (either standbys or active replicas) allowed in a cluster.
+pub const nodes_max = replicas_max + standbys_max;
 
 /// The maximum number of clients allowed per cluster, where each client has a unique 128-bit ID.
 /// This impacts the amount of memory allocated at initialization by the server.
@@ -138,7 +142,7 @@ comptime {
 }
 
 /// The maximum number of connections that can be held open by the server at any time:
-pub const connections_max = replicas_max + clients_max;
+pub const connections_max = nodes_max + clients_max;
 
 /// The maximum size of a message in bytes:
 /// This is also the limit of all inflight data across multiple pipelined requests per connection.

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -343,6 +343,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 cluster.allocator,
                 .{
                     .replica_count = @intCast(u8, cluster.replicas.len),
+                    .standby_count = 0,
                     .storage = &cluster.storages[replica_index],
                     // TODO Test restarting with a higher storage limit.
                     .storage_size_limit = cluster.options.storage_size_limit,

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -37,7 +37,7 @@ pub const Failure = enum(u8) {
 
 /// Shift the id-generating index because the simulator network expects client ids to never collide
 /// with a replica index.
-const client_id_permutation_shift = constants.replicas_max;
+const client_id_permutation_shift = constants.nodes_max;
 
 pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, comptime constants: anytype) type) type {
     return struct {
@@ -55,6 +55,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
         pub const Options = struct {
             cluster_id: u32,
             replica_count: u8,
+            standby_count: u8,
             client_count: u8,
             storage_size_limit: u64,
             storage_fault_atlas: StorageFaultAtlas.Options,
@@ -77,9 +78,12 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
         network: *Network,
         storages: []Storage,
         storage_fault_atlas: *StorageFaultAtlas,
+        /// NB: includes both active replicas and standbys. 
         replicas: []Replica,
         replica_pools: []MessagePool,
         replica_health: []ReplicaHealth,
+        replica_count: u8,
+        standby_count: u8,
 
         clients: []Client,
         client_pools: []MessagePool,
@@ -109,6 +113,8 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             assert(options.storage.replica_index == null);
             assert(options.storage.fault_atlas == null);
 
+            const node_count = options.replica_count + options.standby_count;
+
             var prng = std.rand.DefaultPrng.init(options.seed);
             const random = prng.random();
 
@@ -119,7 +125,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
             network.* = try Network.init(
                 allocator,
-                options.replica_count,
+                node_count,
                 options.client_count,
                 options.network,
             );
@@ -135,7 +141,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 options.storage_fault_atlas,
             );
 
-            const storages = try allocator.alloc(Storage, options.replica_count);
+            const storages = try allocator.alloc(Storage, node_count);
             errdefer allocator.free(storages);
 
             for (storages) |*storage, replica_index| {
@@ -148,7 +154,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             }
             errdefer for (storages) |*storage| storage.deinit(allocator);
 
-            var replica_pools = try allocator.alloc(MessagePool, options.replica_count);
+            var replica_pools = try allocator.alloc(MessagePool, node_count);
             errdefer allocator.free(replica_pools);
 
             for (replica_pools) |*pool, i| {
@@ -157,10 +163,10 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             }
             errdefer for (replica_pools) |*pool| pool.deinit(allocator);
 
-            const replicas = try allocator.alloc(Replica, options.replica_count);
+            const replicas = try allocator.alloc(Replica, node_count);
             errdefer allocator.free(replicas);
 
-            const replica_health = try allocator.alloc(ReplicaHealth, options.replica_count);
+            const replica_health = try allocator.alloc(ReplicaHealth, node_count);
             errdefer allocator.free(replica_health);
             mem.set(ReplicaHealth, replica_health, .up);
 
@@ -232,6 +238,8 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 .replicas = replicas,
                 .replica_pools = replica_pools,
                 .replica_health = replica_health,
+                .replica_count = options.replica_count,
+                .standby_count = options.standby_count,
                 .clients = clients,
                 .client_pools = client_pools,
                 .client_id_permutation = client_id_permutation,
@@ -342,8 +350,8 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             try replica.open(
                 cluster.allocator,
                 .{
-                    .replica_count = @intCast(u8, cluster.replicas.len),
-                    .standby_count = 0,
+                    .replica_count = cluster.replica_count,
+                    .standby_count = cluster.standby_count,
                     .storage = &cluster.storages[replica_index],
                     // TODO Test restarting with a higher storage limit.
                     .storage_size_limit = cluster.options.storage_size_limit,
@@ -355,7 +363,8 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             );
             assert(replica.cluster == cluster.options.cluster_id);
             assert(replica.replica == replica_index);
-            assert(replica.replica_count == cluster.replicas.len);
+            assert(replica.replica_count == cluster.replica_count);
+            assert(replica.standby_count == cluster.standby_count);
 
             replica.context = cluster;
             replica.on_change_state = on_replica_change_state;

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -10,7 +10,7 @@ const message_pool = @import("../../message_pool.zig");
 const MessagePool = message_pool.MessagePool;
 const Message = MessagePool.Message;
 
-const ReplicaSet = std.StaticBitSet(constants.replicas_max);
+const ReplicaSet = std.StaticBitSet(constants.nodes_max);
 const Commits = std.ArrayList(struct {
     header: vsr.Header,
     replicas: ReplicaSet = ReplicaSet.initEmpty(),
@@ -25,7 +25,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
         replica_count: u8,
 
         commits: Commits,
-        commit_mins: [constants.replicas_max]u64 = [_]u64{0} ** constants.replicas_max,
+        commit_mins: [constants.nodes_max]u64 = [_]u64{0} ** constants.nodes_max,
 
         replicas: []const Replica,
         clients: []const Client,

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -615,8 +615,8 @@ pub const ClusterFaultAtlas = struct {
     options: Options,
     faulty_superblock_areas: FaultySuperBlockAreas =
         FaultySuperBlockAreas.initFill(CopySet.initEmpty()),
-    faulty_wal_header_sectors: [constants.replicas_max]FaultyWALHeaders =
-        [_]FaultyWALHeaders{FaultyWALHeaders.initEmpty()} ** constants.replicas_max,
+    faulty_wal_header_sectors: [constants.nodes_max]FaultyWALHeaders =
+        [_]FaultyWALHeaders{FaultyWALHeaders.initEmpty()} ** constants.nodes_max,
 
     pub fn init(replica_count: u8, random: std.rand.Random, options: Options) ClusterFaultAtlas {
         // If there is only one replica in the cluster, WAL/Grid faults are not recoverable.

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -140,7 +140,8 @@ const Command = struct {
 
         var replica: Replica = undefined;
         replica.open(allocator, .{
-            .replica_count = @intCast(u8, args.addresses.len),
+            .replica_count = @intCast(u8, args.addresses.len) - args.standby_count,
+            .standby_count = args.standby_count,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .message_pool = &command.message_pool,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1621,7 +1621,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(message.header.size <= message.buffer.len);
             assert(journal.has(message.header));
             assert(!journal.writing(message.header.op, message.header.checksum));
-            assert(replica.replica_count != 1 or journal.writes.executing() == 0);
+            if (replica.sole_replica()) assert(journal.writes.executing() == 0);
 
             // The underlying header memory must be owned by the buffer and not by journal.headers:
             // Otherwise, concurrent writes may modify the memory of the pointer while we write.

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -618,7 +618,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
         ) void {
             assert(!superblock.opened);
 
-            assert(options.replica < constants.replicas_max);
+            assert(options.replica < constants.nodes_max);
 
             // This working copy provides the parent checksum, and will not be written to disk.
             // We therefore use zero values to make this parent checksum as stable as possible.


### PR DESCRIPTION
Add ability to run a tigerbeetle cluster where some of the nodes are
standbys (the configuration is static).

This isn't particularly useful for any practical purposes (well, I'd
imagine you can already do a useful canary that way), but is a
reasonable stepping stone towards reconfig.

CLI wise, this looks like this:

```console
$ ./tigerbeetle format --cluster=0 --replica=0 0_0.tigerbeetle # active
$ ./tigerbeetle format --cluster=0 --replica=1 0_1.tigerbeetle # standby

$ ./tigerbeetle start --addresses=3001,3002 --standby-count=1 0_0.tigerbeetle # active
$ ./tigerbeetle start --addresses=3001,3002 --standby-count=1 0_1.tigerbeetle # standby
```

That is, we pass the number of standbys to start, the first
addresses.len - standby_count replicas are active, the rest are
standbys.

Internally, the numbering scheme is that replicas 0..<replica_count are
active, and replica_count..<replica_count + standby_count are standbys.
Keeping the numbers sequential helps with keeping stuff in arrays. I
expect our ID scheme to change in the future to accommodate dynamic
standbys, so I want to choose the simplest option for now.

Implementation wise, the strategy is for standbys to closely follow
active replicas, and skip sending messages almost at the last possible
moment. So, eg, standbys will still be computing DVC messages, and will
avoid sending them out. The motivation is two fold:

- to keep the amount of if (self.standby()) branches as small as
  possible, to simplify implementation.
- to keep runtime behavior of standbys close to active replicas, too
  make canaries more efficient.

The most interesting bit of actual new code here is fn replicate, where
I implement "interlinked rings" strategy of replication to the standbys.

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
