### PR TITLE
chore: update node client repository to new location

### DIFF
--- a/src/clients/node/package-lock.json
+++ b/src/clients/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tigerbeetle-node",
-      "version": "0.11.12",
+      "version": "0.11.13",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -6,7 +6,8 @@
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tigerbeetledb/tigerbeetle-node.git"
+    "url": "git+https://github.com/tigerbeetledb/tigerbeetle.git",
+    "directory": "src/clients/node"
   },
   "preferUnplugged": true,
   "files": [

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbeetle-node",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "TigerBeetle Node.js client",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Fixes a minor issue where https://www.npmjs.com/package/tigerbeetle-node still points to the old git location.

@eatonphil does this require a version bump? Or will that happen on the next release?

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
