### PR TITLE
downgrade clock's log verbosity

### DIFF
--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -395,7 +395,7 @@ pub fn Clock(comptime Time: type) type {
             if (system == cluster) {} else if (system < lower) {
                 const delta = lower - system;
                 if (delta < std.time.ns_per_ms) {
-                    log.info("{}: system time is {} behind", .{
+                    log.debug("{}: system time is {} behind", .{
                         self.replica,
                         fmt.fmtDurationSigned(delta),
                     });
@@ -408,7 +408,7 @@ pub fn Clock(comptime Time: type) type {
             } else {
                 const delta = system - upper;
                 if (delta < std.time.ns_per_ms) {
-                    log.info("{}: system time is {} ahead", .{
+                    log.debug("{}: system time is {} ahead", .{
                         self.replica,
                         fmt.fmtDurationSigned(delta),
                     });


### PR DESCRIPTION
For an idle cluster, we get a stream of info messages from the clock. These probably should be just debug, as they don't carry that much useful info?

This is mostly an RFC, I don't know what our general stance towards logging verbosity is. The gut rule of thumb I am using is that, if nothing happens, nothing should be logged. 

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
