### PR TITLE
LSM: pipeline IO between `Compaction.compact_tick`s

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -454,7 +454,7 @@ pub fn CompactionType(
             compaction.callback = null;
             defer callback(compaction); // Invoke the callback *after* running io_tick() down below
 
-            // Start IO for the compact_tick() after invoking the callback. It will wait for this 
+            // Start IO for the compact_tick() after invoking the callback. It will wait for this
             // pending IO to complete before running its cpu_merge_start().
             if (!compaction.merge_done) compaction.io_tick();
         }


### PR DESCRIPTION
Currently, `compact_tick` starts IO, waits for it to finish, does `cpu_merge`, and invokes the tick callback. Each tick (until the callback) only does a portion of the compaction work which is expected to be spread out across a half beat of `lsm_batch_multiple`. There's potentially an artificial dependency where the `compact_tick` of one `Compaction` has to wait for all other's ticks to complete before starting its own again.

This moves the "all other ticks must finish" dependency from both the IO + CPU work in a Compaction, to only the CPU portion. The first tick will start IO as usual, with cpu_merge waiting for said IO to complete. However once a cpu_merge completes, it starts the IO for the next tick then invokes the callback. The next tick will wait for that previous IO to complete (instead of starting its own), then cpu_merge and so on.

Since IO now has the potential to run outside of compact_tick (when `compaction.callback == null`) it has to be accounted for in the various asynchronous IO callbacks in `Compaction`. Assumption is that this results in lower
overall `tree.compact()` latency and/or higher disk IO utilization.

## Pre-merge checklist

(TODO) Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1222 batches in 172.11 s
    load offered = 1000000 tx/s
    load accepted = 58100 tx/s
    batch latency p00 = 16 ms
    batch latency p10 = 34 ms
    batch latency p20 = 36 ms
    batch latency p30 = 37 ms
    batch latency p40 = 38 ms
    batch latency p50 = 40 ms
    batch latency p60 = 42 ms
    batch latency p70 = 52 ms
    batch latency p80 = 64 ms
    batch latency p90 = 79 ms
    batch latency p100 = 10886 ms
    transfer latency p00 = 16 ms
    transfer latency p10 = 4086 ms
    transfer latency p20 = 12795 ms
    transfer latency p30 = 22808 ms
    transfer latency p40 = 35144 ms
    transfer latency p50 = 51297 ms
    transfer latency p60 = 72389 ms
    transfer latency p70 = 93951 ms
    transfer latency p80 = 117359 ms
    transfer latency p90 = 143818 ms
    transfer latency p100 = 162083 ms
    
    # benchmark results after
    1222 batches in 172.37 s
    load offered = 1000000 tx/s
    load accepted = 58014 tx/s
    batch latency p00 = 14 ms
    batch latency p10 = 36 ms
    batch latency p20 = 37 ms
    batch latency p30 = 40 ms
    batch latency p40 = 41 ms
    batch latency p50 = 42 ms
    batch latency p60 = 44 ms
    batch latency p70 = 53 ms
    batch latency p80 = 65 ms
    batch latency p90 = 76 ms
    batch latency p100 = 10387 ms
    transfer latency p00 = 14 ms
    transfer latency p10 = 4021 ms
    transfer latency p20 = 12763 ms
    transfer latency p30 = 23200 ms
    transfer latency p40 = 35534 ms
    transfer latency p50 = 52215 ms
    transfer latency p60 = 72989 ms
    transfer latency p70 = 93839 ms
    transfer latency p80 = 117310 ms
    transfer latency p90 = 143592 ms
    transfer latency p100 = 162340 ms
    ```

