### PR TITLE
Benchmark: use `-Dconfig=production` over development

### DIFF
--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -51,5 +51,5 @@ for %%a in (%*) do (
         SET ARGS=!ARGS! %%a
     )
 )
-zig\zig.exe build benchmark -Drelease-safe -- %ARGS%
+zig\zig.exe build benchmark -Drelease-safe -Dconfig=production -- %ARGS%
 exit /b %errorlevel%

--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -27,7 +27,7 @@ echo.
 exit /b
 
 :main
-zig\zig.exe build install -Drelease-safe
+zig\zig.exe build install -Drelease-safe -Dconfig=production
 
 for /l %%i in (0, 1, 0) do (
     echo Initializing replica %%i

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -12,7 +12,7 @@ fi
 COLOR_RED='\033[1;31m'
 COLOR_END='\033[0m'
 
-zig/zig build install -Drelease-safe
+zig/zig build install -Drelease-safe -Dconfig=production
 
 function onerror {
     if [ "$?" == "0" ]; then

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -54,7 +54,7 @@ done
 
 echo ""
 echo "Benchmarking..."
-zig/zig build benchmark -Drelease-safe -- "$@"
+zig/zig build benchmark -Drelease-safe -Dconfig=production -- "$@"
 echo ""
 
 for I in $REPLICAS


### PR DESCRIPTION
The benchmark is meant to asses performance in a likely production scenario. The default (development) config has `process.verify=true` which helps for double checking assertions but slows down normal operations. Using the production config in benchmark disables `verify`.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1222 batches in 171.78 s
    load offered = 1000000 tx/s
    load accepted = 58215 tx/s
    batch latency p00 = 17 ms
    batch latency p10 = 34 ms
    batch latency p20 = 36 ms
    batch latency p30 = 37 ms
    batch latency p40 = 39 ms
    batch latency p50 = 41 ms
    batch latency p60 = 43 ms
    batch latency p70 = 55 ms
    batch latency p80 = 66 ms
    batch latency p90 = 81 ms
    batch latency p100 = 8822 ms
    transfer latency p00 = 17 ms
    transfer latency p10 = 4195 ms
    transfer latency p20 = 12929 ms
    transfer latency p30 = 23362 ms
    transfer latency p40 = 36108 ms
    transfer latency p50 = 52999 ms
    transfer latency p60 = 74178 ms
    transfer latency p70 = 95342 ms
    transfer latency p80 = 118262 ms
    transfer latency p90 = 142472 ms
    transfer latency p100 = 161747 ms
    
    # benchmark results after
    1222 batches in 167.85 s
    load offered = 1000000 tx/s
    load accepted = 59575 tx/s
    batch latency p00 = 16 ms
    batch latency p10 = 34 ms
    batch latency p20 = 35 ms
    batch latency p30 = 37 ms
    batch latency p40 = 38 ms
    batch latency p50 = 40 ms
    batch latency p60 = 46 ms
    batch latency p70 = 58 ms
    batch latency p80 = 67 ms
    batch latency p90 = 81 ms
    batch latency p100 = 8663 ms
    transfer latency p00 = 16 ms
    transfer latency p10 = 3975 ms
    transfer latency p20 = 12631 ms
    transfer latency p30 = 22563 ms
    transfer latency p40 = 34791 ms
    transfer latency p50 = 51093 ms
    transfer latency p60 = 71518 ms
    transfer latency p70 = 92318 ms
    transfer latency p80 = 115574 ms
    transfer latency p90 = 138775 ms
    transfer latency p100 = 157821 ms
    ```
