### PR TITLE
forest_fuzz crash testing

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -332,6 +332,9 @@ pub fn build(b: *std.build.Builder) void {
         exe.omit_frame_pointer = false;
         exe.addOptions("vsr_options", options);
         link_tracer_backend(exe, tracer_backend, target);
+        const install_step = b.addInstallArtifact(exe);
+        const build_step = b.step("build_" ++ fuzzer.name, fuzzer.description);
+        build_step.dependOn(&install_step.step);
 
         const run_cmd = exe.run();
         if (b.args) |args| run_cmd.addArgs(args);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -334,12 +334,12 @@ const Environment = struct {
                 while (log_index < log_size) : (log_index += 1) {
                     const entry = model.log.peekItem(log_index);
                     if (entry.op > checkpointable) {
-                        model.log.discard(log_index);
                         break;
                     }
 
                     try model.checkpointed.put(entry.account.id, entry.account);
                 }
+                model.log.discard(log_index);
             }
 
             pub fn storage_reset(model: *Model) void {

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -322,13 +322,7 @@ const Environment = struct {
             }
 
             pub fn checkpoint(model: *Model, op: u64) !void {
-                const checkpointable = blk: {
-                    if (op > constants.lsm_batch_multiple) {
-                        break :blk op - (op % constants.lsm_batch_multiple) - 1;
-                    } else {
-                        break :blk 0;
-                    }
-                };
+                const checkpointable = op - (op % constants.lsm_batch_multiple) -| 1;
                 const log_size = model.log.readableLength();
                 var log_index: usize = 0;
                 while (log_index < log_size) : (log_index += 1) {

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -277,7 +277,6 @@ const Environment = struct {
 
     fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
         // The forest should behave like a simple key-value data-structure.
-        // We'll compare it to a hash map.
         const Model = struct {
             checkpointed: KVType, // represents persistent state
             log: LogType, // represents in-memory state
@@ -287,9 +286,11 @@ const Environment = struct {
             const LogType = std.fifo.LinearFifo(LogEntry, .Dynamic);
             const Model = @This();
 
-            pub fn init(model: *Model) void {
-                model.checkpointed = KVType.init(allocator);
-                model.log = LogType.init(allocator);
+            pub fn init() Model {
+                return .{
+                    .checkpointed = KVType.init(allocator),
+                    .log = LogType.init(allocator),
+                };
             }
 
             pub fn deinit(model: *Model) void {
@@ -344,8 +345,7 @@ const Environment = struct {
                 model.log.discard(model.log.readableLength());
             }
         };
-        var model: Model = undefined;
-        model.init();
+        var model = Model.init();
         defer model.deinit();
 
         for (fuzz_ops) |fuzz_op, fuzz_op_index| {

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -499,7 +499,9 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
                     compact_op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
                     compact_op > constants.lsm_batch_multiple and
                     // Never checkpoint at the same op twice
-                    compact_op > checkpointed_op + constants.lsm_batch_multiple;
+                    compact_op > checkpointed_op + constants.lsm_batch_multiple and
+                    // Checkpoint at roughly the same rate as log wraparound.
+                    random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
                 if (checkpoint) {
                     checkpointed_op = op - constants.lsm_batch_multiple;
                 }

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -330,12 +330,11 @@ const Environment = struct {
                     }
                 };
                 const log_size = model.log.readableLength();
-                var log_left = log_size;
-                while (log_left > 0) : (log_left -= 1) {
-                    const entry = model.log.peekItem(log_size - log_left);
+                var log_index: usize = 0;
+                while (log_index < log_size) : (log_index += 1) {
+                    const entry = model.log.peekItem(log_index);
                     if (entry.op > checkpointable) {
-                        const checkpointed_count = log_size - log_left;
-                        model.log.discard(checkpointed_count);
+                        model.log.discard(log_index);
                         break;
                     }
 
@@ -415,9 +414,9 @@ const Environment = struct {
                 // resets to the last checkpoint on crash by looking through what's been added
                 // afterwards. This won't work if we add account removal to the fuzzer though.
                 const log_size = model.log.readableLength();
-                var log_left = log_size;
-                while (log_left > 0) : (log_left -= 1) {
-                    const entry = model.log.peekItem(log_size - log_left);
+                var log_index: usize = 0;
+                while (log_index < log_size) : (log_index += 1) {
+                    const entry = model.log.peekItem(log_index);
                     const id = entry.account.id;
                     if (model.checkpointed.get(id)) |checkpointed_account| {
                         env.prefetch_account(id);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -407,8 +407,8 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
         .put_account = constants.lsm_batch_multiple * 2,
         // Maybe do some gets.
         .get_account = if (random.boolean()) 0 else constants.lsm_batch_multiple,
-        // Let's crash this party
-        .storage_reset = 1,
+        // Let's crash this party, but not too much that nothing happens
+        .storage_reset = 0.2,
     };
     log.info("fuzz_op_distribution = {d:.2}", .{fuzz_op_distribution});
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -357,8 +357,8 @@ const Environment = struct {
             log.debug("storage.size_used = {}/{}", .{ storage_size_used, env.storage.size });
 
             const model_size = (model.log.readableLength() + model.checkpointed.count()) * @sizeOf(Account);
-            // FIXME: This isn't accurate anymore because the model can contain multiple copies of an account in the log
-            log.debug("space_amplification = {d:.2}", .{
+            // NOTE: This isn't accurate anymore because the model can contain multiple copies of an account in the log
+            log.debug("space_amplification ~= {d:.2}", .{
                 @intToFloat(f64, storage_size_used) / @intToFloat(f64, model_size),
             });
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -459,12 +459,12 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
     var fuzz_op_distribution = fuzz.Distribution(FuzzOpTag){
         // Maybe compact more often than forced to by `puts_since_compact`.
         .compact = if (random.boolean()) 0 else 1,
-        // Always do puts, and always more puts than removes.
+        // Always do puts.
         .put_account = constants.lsm_batch_multiple * 2,
         // Maybe do some gets.
         .get_account = if (random.boolean()) 0 else constants.lsm_batch_multiple,
-        // Let's crash this party, but not too much that nothing happens (less often than checkpoint)
-        .storage_reset = random.floatExp(f64) / 4.0,
+        // Maybe crash and recover from the last checkpoint a few times per fuzzer run.
+        .storage_reset = if (random.boolean()) 0 else 1E-4,
     };
     log.info("fuzz_op_distribution = {d:.2}", .{fuzz_op_distribution});
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -471,7 +471,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
         // Maybe do some gets.
         .get_account = if (random.boolean()) 0 else constants.lsm_batch_multiple,
         // Let's crash this party, but not too much that nothing happens (less often than checkpoint)
-        .storage_reset = 0.05,
+        .storage_reset = random.floatExp(f64) / 4.0,
     };
     log.info("fuzz_op_distribution = {d:.2}", .{fuzz_op_distribution});
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -402,9 +402,11 @@ const Environment = struct {
                 env.close();
                 env.deinit();
                 env.storage.reset();
+
+                env.change_state(.fuzzing, .init);
                 try env.init(env.storage);
 
-                env.state = .superblock_open;
+                env.change_state(.init, .superblock_open);
                 try env.open();
 
                 // TODO: currently this checks that everything added to the LSM after checkpoint

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -334,6 +334,8 @@ const Environment = struct {
                 while (log_left > 0) : (log_left -= 1) {
                     const entry = model.log.peekItem(log_size - log_left);
                     if (entry.op > checkpointable) {
+                        const checkpointed_count = log_size - log_left;
+                        model.log.discard(checkpointed_count);
                         break;
                     }
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -499,8 +499,8 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
                     // Can only checkpoint on the last beat of the bar.
                     compact_op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
                     compact_op > constants.lsm_batch_multiple and
-                    // Checkpoint at roughly the same rate as log wraparound.
-                    random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
+                    // Never checkpoint at the same op twice
+                    compact_op > checkpointed_op + constants.lsm_batch_multiple;
                 if (checkpoint) {
                     checkpointed_op = op - constants.lsm_batch_multiple;
                 }

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -439,7 +439,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
                     // Checkpoint at roughly the same rate as log wraparound.
                     random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
                 if (checkpoint) {
-                    checkpointed_op = op;
+                    checkpointed_op = op - constants.lsm_batch_multiple;
                 }
                 break :compact FuzzOp{
                     .compact = .{
@@ -518,6 +518,8 @@ pub fn main() !void {
         .read_latency_mean = 0 + fuzz.random_int_exponential(random, u64, 20),
         .write_latency_min = 0,
         .write_latency_mean = 0 + fuzz.random_int_exponential(random, u64, 20),
+        // We can't actually recover from a crash in this fuzzer since we would need
+        // to transfer state from a different replica to continue
         .crash_fault_probability = 0,
     }, fuzz_ops);
 


### PR DESCRIPTION
Add crash and reset storage fuzz_op so that we can test that forest checkpointing works correctly. This can't test crashes that are concurrent with checkpointing though.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.