### PR TITLE
VSR: `op_repair_min()` + chronological repair

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -136,7 +136,10 @@ comptime {
     assert(journal_slot_count >= Config.Cluster.journal_slot_count_min);
     assert(journal_slot_count >= lsm_batch_multiple * 2);
     assert(journal_slot_count % lsm_batch_multiple == 0);
-    assert(journal_slot_count > pipeline_prepare_queue_max);
+    // The journal must have at least two pipelines of messages to ensure that a new, fully-repaired
+    // primary has enough headers for a complete SV message, even if the view-change just truncated
+    // another pipeline of messages. (See op_repair_min()).
+    assert(journal_slot_count >= pipeline_prepare_queue_max * 2);
 
     assert(journal_size_max == journal_size_headers + journal_size_prepares);
 }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -355,7 +355,6 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 &self.tracer_slot,
                 .main,
                 .state_machine_prefetch,
-
                 @src(),
             );
 

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
+const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const log = std.log.scoped(.state_machine);
@@ -108,7 +109,7 @@ pub fn StateMachineType(comptime Storage: type, comptime constants_: struct {
                 .reserved, .root => unreachable,
                 .register => return 0,
                 .echo => {
-                    std.mem.copy(u8, output, input);
+                    stdx.copy_disjoint(.exact, u8, output, input);
                     return input.len;
                 },
             }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -434,8 +434,8 @@ pub fn ReplicaType(
                     if (self.log_view == self.view) op_head = header.op;
                 }
             }
-
             self.op = op_head;
+
             for (vsr_headers.slice) |*header| {
                 const slot = .{ .index = header.op % constants.journal_slot_count };
                 if (self.journal.has(header)) {
@@ -3719,6 +3719,57 @@ pub fn ReplicaType(
             return self.op_checkpoint_next() + constants.lsm_batch_multiple;
         }
 
+        /// Returns the oldest op that the replica must/(is permitted to) repair.
+        /// The goal is to repair as much as possible without triggering unnecessary state transfer.
+        ///
+        /// - Repairing uncommitted ops is necessary as primary — we will need them to proceed.
+        /// - Repairing committed + not-yet-checkpointed ops is useful because we might crash,
+        ///   in which case we will need them to recover.
+        /// - Repairing committed + checkpointed ops:
+        ///   - backups don't repair checkpointed ops, since there is no guarantee that they will
+        ///     ever be available (if our head is behind), and we don't want to stall the new view
+        ///     startup.
+        ///   - primaries do repair checkpointed ops — as many as are guaranteed to exist anywhere in
+        ///     the cluster, so that they can help lagging backups catch up.
+        fn op_repair_min(self: *const Self) u64 {
+            assert(self.status == .normal or self.status == .view_change);
+            assert(self.op >= self.op_checkpoint());
+
+            const op = op: {
+                if (self.primary_index(self.view) == self.replica) {
+                    assert(self.status == .normal or self.do_view_change_quorum);
+                    // This is the oldest op that is guaranteed to be in the WALs of any replica.
+                    // (Assuming that this primary has not been superseded.)
+                    break :op std.math.min(
+                        // Add the oldest pipeline_prepare_queue_max ops because they may have been
+                        // newer ops which were then truncated by a view-change, causing the head op
+                        // to backtrack.
+                        self.op + constants.pipeline_prepare_queue_max,
+                        // ...But the pipeline messages could not have moved past the checkpoint.
+                        self.op_checkpoint_trigger(),
+                    ) -| (constants.journal_slot_count - 1);
+                } else {
+                    // Strictly speaking a backup only needs to repair commit_min+1… to proceed.
+                    // However, if the backup crashes and recovers, it will need to replay ops
+                    // from the checkpoint, so we repair slightly more.
+                    if (self.op_checkpoint() == self.op) {
+                        // Don't allow "op_repair_min > op_head".
+                        break :op self.op_checkpoint();
+                    } else {
+                        // +1 because the primary (and other replicas) may overwrite op_checkpoint.
+                        // And we don't need op_checkpoint's prepare/header in our log if we crash.
+                        break :op self.op_checkpoint() + 1;
+                    }
+                }
+            };
+
+            assert(op <= self.op);
+            assert(op <= self.commit_min + 1);
+            assert(op <= self.op_checkpoint() + 1);
+            assert(op >= self.op -| (constants.journal_slot_count - 1));
+            return op;
+        }
+
         /// Finds the header with the highest op number in a slice of headers from a replica.
         /// The headers must be continuous, in reverse order, all connected, and with no gaps.
         fn op_highest(headers: []const Header) u64 {
@@ -3926,43 +3977,36 @@ pub fn ReplicaType(
             }
 
             // Request any missing or disconnected headers:
-            if (self.commit_min != self.op) {
-                var broken = self.journal.find_latest_headers_break_between(
-                    self.commit_min + 1,
-                    self.op,
+            if (self.journal.find_latest_headers_break_between(
+                self.op_repair_min(),
+                self.op,
+            )) |range| {
+                log.debug(
+                    "{}: repair: break: view={} break={}..{} (commit={}..{} op={})",
+                    .{
+                        self.replica,
+                        self.view,
+                        range.op_min,
+                        range.op_max,
+                        self.commit_min,
+                        self.commit_max,
+                        self.op,
+                    },
                 );
-                if (broken) |range| {
-                    log.debug(
-                        "{}: repair: break: view={} op_min={} op_max={} (commit={}..{} op={})",
-                        .{
-                            self.replica,
-                            self.view,
-                            range.op_min,
-                            range.op_max,
-                            self.commit_min,
-                            self.commit_max,
-                            self.op,
-                        },
-                    );
-                    assert(range.op_min > self.commit_min);
-                    assert(range.op_max < self.op);
-                    // A range of `op_min=0` or `op_max=0` should be impossible as a header break:
-                    // This is the root op that is prepared when the cluster is initialized.
-                    assert(range.op_min > 0);
-                    assert(range.op_max > 0);
+                assert(range.op_min >= self.op_repair_min());
+                assert(range.op_max < self.op);
 
-                    if (self.choose_any_other_replica()) |replica| {
-                        self.send_header_to_replica(replica, .{
-                            .command = .request_headers,
-                            .cluster = self.cluster,
-                            .replica = self.replica,
-                            .view = self.view,
-                            .commit = range.op_min,
-                            .op = range.op_max,
-                        });
-                    }
-                    return;
+                if (self.choose_any_other_replica()) |replica| {
+                    self.send_header_to_replica(replica, .{
+                        .command = .request_headers,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .view = self.view,
+                        .commit = range.op_min,
+                        .op = range.op_max,
+                    });
                 }
+                return;
             }
 
             // Assert that all headers are now present and connected with a perfect hash chain:
@@ -4057,19 +4101,13 @@ pub fn ReplicaType(
                 return false;
             }
 
-            if (header.op <= self.op_checkpoint()) {
-                if (header.op == 0 and self.op_checkpoint() == 0) {
-                    // Repairing the root op is allowed until the first checkpoint.
-                } else {
-                    // It is critical that we do not repair checkpointed ops; their slots now belong
-                    // to the next wrap of the log, and overwriting a new op with an old op is a
-                    // correctness violation.
-                    log.debug("{}: repair_header: false (precedes self.op_checkpoint={})", .{
-                        self.replica,
-                        self.op_checkpoint(),
-                    });
-                    return false;
-                }
+            if (header.op < self.op_repair_min()) {
+                // Slots too far back belong to the next wrap of the log.
+                log.debug("{}: repair_header: false (precedes op_repair_min={})", .{
+                    self.replica,
+                    self.op_repair_min(),
+                });
+                return false;
             }
 
             if (self.journal.header_for_prepare(header)) |existing| {
@@ -4138,12 +4176,9 @@ pub fn ReplicaType(
                 return false;
             }
 
-            if (header.op <= self.commit_min) {
-                if (self.journal.header_with_op(header.op)) |existing| {
-                    // If we already committed this op, the repair must be the identical message.
-                    assert(header.checksum == existing.checksum);
-                }
-            }
+            // If we already committed this op, the repair must be the identical message.
+            assert(header.op <= self.op_checkpoint() or header.op > self.commit_min or
+                self.journal.has(header));
 
             self.journal.set_header_as_dirty(header);
             return true;
@@ -4359,13 +4394,8 @@ pub fn ReplicaType(
             assert(self.journal.dirty.count > 0);
             assert(self.op >= self.commit_min);
             assert(self.op - self.commit_min <= constants.journal_slot_count);
-
-            // Request enough prepares to utilize our max IO depth:
-            var budget = self.journal.writes.available();
-            if (budget == 0) {
-                log.debug("{}: repair_prepares: waiting for IOP", .{self.replica});
-                return;
-            }
+            assert(self.op - self.op_checkpoint() <= constants.journal_slot_count);
+            assert(self.valid_hash_chain_between(self.commit_min, self.op));
 
             if (self.op < constants.journal_slot_count) {
                 // The op is known, and this is the first WAL cycle.
@@ -4390,58 +4420,34 @@ pub fn ReplicaType(
                 }
             }
 
-            var op = self.op + 1;
-            // To maximize durability, repair all prepares for which we have a header (not only
-            // uncommitted headers). This in turn enables the replica to help repair other replicas.
-            const op_min = op -| constants.journal_slot_count;
-            while (op > op_min) {
-                op -= 1;
+            // Request enough prepares to utilize our max IO depth:
+            var budget = self.journal.writes.available();
+            if (budget == 0) {
+                log.debug("{}: repair_prepares: waiting for IOP", .{self.replica});
+                return;
+            }
 
-                const slot = self.journal.slot_for_op(op);
+            // Repair prepares in chronological order. Older prepares will be overwritten by the
+            // cluster earlier, so we prioritize their repair. This also encourages concurrent
+            // commit/repair.
+            var op = self.op_repair_min();
+            while (op <= self.op) : (op += 1) {
+                const slot = self.journal.slot_with_op(op).?;
                 if (self.journal.dirty.bit(slot)) {
-                    if (self.journal.slot_with_op(op) == null) {
-                        // If this op was between `commit_min` and `replica.op`, we would have
-                        // requested and repaired these headers.
-                        // If this op was between `op_checkpoint` and `commit_min`, we would have
-                        // a header (since we couldn't have committed otherwise).
-                        //
-                        // Therefore, this op must be either:
-                        // - less-than-or-equal-to `op_checkpoint` — we committed before
-                        //   checkpointing, but the entry in our WAL was found corrupt after
-                        //   recovering from a crash.
-                        // - or (indistinguishably) this might originally have been an op greater
-                        //   than replica.op, which was truncated, but is now corrupt.
-                        //
-                        // We don't try to repair this op because the slot belongs (or will soon
-                        // belong) to a newer op, from the new WAL wrap. Additionally, we may not
-                        // still have access to its surrounding commits to verify the hash chain.
-                        assert(op <= self.commit_min);
-                        assert(op <= self.op_checkpoint());
-                        assert(self.journal.faulty.bit(slot));
-
-                        log.debug("{}: repair_prepares: remove slot={} " ++
-                            "(faulty, precedes checkpoint)", .{
-                            self.replica,
-                            slot.index,
-                        });
-                        self.journal.remove_entry(slot);
-                        continue;
-                    }
-
-                    // If this is an uncommitted op, and we are the primary in `view_change` status,
+                    // This is an uncommitted op — if we are the primary in `view_change` status,
                     // then we will `request_prepare` from the cluster, set `nack_prepare_op`,
                     // and stop repairing any further prepares:
                     // This will also rebroadcast any `request_prepare` every `repair_timeout` tick.
                     if (self.repair_prepare(op)) {
                         if (self.nack_prepare_op) |nack_prepare_op| {
-                            assert(nack_prepare_op == op);
                             assert(self.status == .view_change);
                             assert(self.primary_index(self.view) == self.replica);
-                            assert(op > self.commit_max);
+                            assert(nack_prepare_op >= op);
+                            assert(nack_prepare_op > self.commit_max);
                             return;
                         }
 
-                        // Otherwise, we continue to request prepares until our budget is used:
+                        // Otherwise, continue to request prepares until our budget is depleted.
                         budget -= 1;
                         if (budget == 0) {
                             log.debug("{}: repair_prepares: request budget used", .{self.replica});
@@ -4450,6 +4456,37 @@ pub fn ReplicaType(
                     }
                 } else {
                     assert(!self.journal.faulty.bit(slot));
+                }
+            }
+
+            // Clean up out-of-bounds dirty slots so repair() can finish.
+            const slots_repaired = vsr.SlotRange{
+                .head = self.journal.slot_for_op(self.op_repair_min()),
+                .tail = self.journal.slot_with_op(self.op).?,
+            };
+            var slot_index: usize = 0;
+            while (slot_index < constants.journal_slot_count) : (slot_index += 1) {
+                const slot = self.journal.slot_for_op(slot_index);
+                if (slots_repaired.head.index == slots_repaired.tail.index or
+                    slots_repaired.contains(slot))
+                {
+                    // In-bounds — handled by the previous loop. The slot is either already
+                    // repaired, or we sent a request_prepare and are waiting for a reply.
+                } else {
+                    // This op must be either:
+                    // - less-than-or-equal-to `op_checkpoint` — we committed before
+                    //   checkpointing, but the entry in our WAL was found corrupt after
+                    //   recovering from a crash.
+                    // - or (indistinguishably) this might originally have been an op greater
+                    //   than replica.op, which was truncated, but is now corrupt.
+                    if (self.journal.dirty.bit(slot)) {
+                        log.debug("{}: repair_prepares: remove slot={} " ++
+                            "(faulty, precedes checkpoint)", .{
+                            self.replica,
+                            slot.index,
+                        });
+                        self.journal.remove_entry(slot);
+                    }
                 }
             }
         }
@@ -4564,18 +4601,13 @@ pub fn ReplicaType(
                 }
 
                 // Initialize the `nack_prepare` quorum counter for this uncommitted op:
-                // It is also possible that we may start repairing a lower uncommitted op, having
-                // initialized `nack_prepare_op` before we learn of a higher uncommitted dirty op,
-                // in which case we also want to reset the quorum counter.
                 if (self.nack_prepare_op) |nack_prepare_op| {
-                    assert(nack_prepare_op <= op);
-                    if (nack_prepare_op != op) {
-                        self.nack_prepare_op = op;
-                        self.reset_quorum_counter(&self.nack_prepare_from_other_replicas);
-                    }
+                    // Prepares are repaired chronologically. If we already are already waiting for
+                    // a nack, this must be a retried repair for that same op.
+                    assert(nack_prepare_op == op);
                 } else {
+                    assert(self.nack_prepare_from_other_replicas.count() == 0);
                     self.nack_prepare_op = op;
-                    self.reset_quorum_counter(&self.nack_prepare_from_other_replicas);
                 }
 
                 assert(self.nack_prepare_op.? == op);
@@ -4592,11 +4624,9 @@ pub fn ReplicaType(
                     reason,
                 });
 
-                // We expect that `repair_prepare()` is called in reverse chronological order:
-                // Any uncommitted ops should have already been dealt with.
-                // We never roll back committed ops, and thus never regard `nack_prepare` responses.
-                // Alternatively, we may not be the primary, in which case we do distinguish anyway.
-                assert(self.nack_prepare_op == null);
+                // `repair_prepare()` is called in chronological order, and stops when it
+                // encounters an op awaiting nacks.
+                assert(self.nack_prepare_op == null or self.nack_prepare_op.? > op);
                 assert(request_prepare.context == checksum);
                 if (self.choose_any_other_replica()) |replica| {
                     self.send_header_to_replica(replica, request_prepare);
@@ -4606,7 +4636,7 @@ pub fn ReplicaType(
             return true;
         }
 
-        fn repairs_allowed(self: *Self) bool {
+        fn repairs_allowed(self: *const Self) bool {
             switch (self.status) {
                 .view_change => {
                     if (self.do_view_change_quorum) {
@@ -4621,29 +4651,21 @@ pub fn ReplicaType(
             }
         }
 
-        /// Replaces the header if the header is different and not already committed.
-        /// The caller must ensure that the header is trustworthy.
+        /// Replaces the header if the header is different and greater than op_repair_min.
+        /// The caller must ensure that the header is trustworthy (part of the current view's log).
         fn replace_header(self: *Self, header: *const Header) void {
+            assert(self.status == .normal or self.status == .view_change);
             assert(self.op_checkpoint() <= self.commit_min);
+
             assert(header.command == .prepare);
             assert(header.op <= self.op); // Never advance the op.
             assert(header.op <= self.op_checkpoint_trigger());
 
-            if (header.op <= self.commit_min) {
-                if (self.journal.header_with_op(header.op)) |existing_header| {
-                    assert(existing_header.checksum == header.checksum);
-                    return;
-                } else {
-                    if (header.op <= self.op_checkpoint()) {
-                        // Never replace a checkpointed op — those slots are needed by the following
-                        // WAL wrap.
-                        return;
-                    } else {
-                        // If an op is committed but not checkpointed, we must still have the header.
-                        @panic("missing committed, uncheckpointed header");
-                    }
-                }
-            }
+            // If we already committed this op, the repair must be the identical message.
+            assert(header.op <= self.op_checkpoint() or header.op > self.commit_min or
+                self.journal.has(header));
+
+            if (header.op < self.op_repair_min()) return;
 
             // Do not set an op as dirty if we already have it exactly because:
             // 1. this would trigger a repair and delay the view change, or worse,
@@ -6030,16 +6052,14 @@ pub fn ReplicaType(
         }
 
         fn write_prepare(self: *Self, message: *Message, trigger: Journal.Write.Trigger) void {
+            assert(self.status == .normal or self.status == .view_change);
+            assert(self.status == .normal or self.primary_index(self.view) == self.replica);
+            assert(self.status == .normal or self.do_view_change_quorum);
             assert(message.references > 0);
             assert(message.header.command == .prepare);
             assert(message.header.view <= self.view);
             assert(message.header.op <= self.op);
-
-            if (message.header.op == self.op_checkpoint()) {
-                assert(message.header.op == 0);
-            } else {
-                assert(message.header.op > self.op_checkpoint());
-            }
+            assert(message.header.op >= self.op_repair_min());
 
             if (!self.journal.has(message.header)) {
                 log.debug("{}: write_prepare: ignoring op={} checksum={} (header changed)", .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4015,7 +4015,7 @@ pub fn ReplicaType(
             if (self.op < self.commit_max) {
                 @panic("unimplemented (state transfer)");
             }
-            assert(self.valid_hash_chain_between(self.commit_min, self.op));
+            assert(self.valid_hash_chain_between(self.op_repair_min(), self.op));
 
             // Request and repair any dirty or faulty prepares:
             if (self.journal.dirty.count > 0) return self.repair_prepares();
@@ -4250,7 +4250,7 @@ pub fn ReplicaType(
             assert(self.commit_max == self.commit_min);
             assert(self.commit_max <= self.op);
             assert(self.journal.dirty.count == 0);
-            assert(self.valid_hash_chain_between(self.commit_min, self.op));
+            assert(self.valid_hash_chain_between(self.op_repair_min(), self.op));
             assert(self.pipeline == .cache);
             assert(!self.pipeline_repairing);
             assert(self.primary_repair_pipeline() == .done);
@@ -4395,7 +4395,7 @@ pub fn ReplicaType(
             assert(self.op >= self.commit_min);
             assert(self.op - self.commit_min <= constants.journal_slot_count);
             assert(self.op - self.op_checkpoint() <= constants.journal_slot_count);
-            assert(self.valid_hash_chain_between(self.commit_min, self.op));
+            assert(self.valid_hash_chain_between(self.op_repair_min(), self.op));
 
             if (self.op < constants.journal_slot_count) {
                 // The op is known, and this is the first WAL cycle.
@@ -4651,7 +4651,7 @@ pub fn ReplicaType(
             }
         }
 
-        /// Replaces the header if the header is different and greater than op_repair_min.
+        /// Replaces the header if the header is different and at least op_repair_min.
         /// The caller must ensure that the header is trustworthy (part of the current view's log).
         fn replace_header(self: *Self, header: *const Header) void {
             assert(self.status == .normal or self.status == .view_change);
@@ -5567,7 +5567,7 @@ pub fn ReplicaType(
             assert(self.journal.dirty.count == 0);
             assert(self.journal.faulty.count == 0);
             assert(self.nack_prepare_op == null);
-            assert(self.valid_hash_chain_between(self.commit_min, self.op));
+            assert(self.valid_hash_chain_between(self.op_repair_min(), self.op));
 
             {
                 const pipeline_queue = self.primary_repair_pipeline_done();
@@ -5894,6 +5894,9 @@ pub fn ReplicaType(
         /// Returns true if the hash chain is valid and up to date for the current view.
         /// This is a stronger guarantee than `valid_hash_chain_between()` below.
         fn valid_hash_chain(self: *Self, method: []const u8) bool {
+            assert(self.op_checkpoint() <= self.commit_min);
+            assert(self.op_checkpoint() <= self.op);
+
             // If we know we could validate the hash chain even further, then wait until we can:
             // This is partial defense-in-depth in case `self.op` is ever advanced by a reordered op.
             if (self.op < self.commit_max) {
@@ -5906,8 +5909,12 @@ pub fn ReplicaType(
                 return false;
             }
 
+            // When commit_min=op_checkpoint, the checkpoint may be missing.
+            // valid_hash_chain_between() will still verify that we are connected.
+            const op_verify_min = std.math.max(self.commit_min, self.op_checkpoint() + 1);
+
             // We must validate the hash chain as far as possible, since `self.op` may disclose a fork:
-            if (!self.valid_hash_chain_between(self.commit_min, self.op)) {
+            if (!self.valid_hash_chain_between(op_verify_min, self.op)) {
                 log.debug("{}: {s}: waiting for repair (hash chain)", .{ self.replica, method });
                 return false;
             }
@@ -5919,8 +5926,9 @@ pub fn ReplicaType(
         /// chain, between `op_min` and `op_max` (both inclusive).
         fn valid_hash_chain_between(self: *const Self, op_min: u64, op_max: u64) bool {
             assert(op_min <= op_max);
-            // Headers with ops preceding the checkpoint may be unavailable due to a WAL wrap.
-            assert(op_min >= self.op_checkpoint());
+            assert(op_min <= self.commit_min + 1);
+            assert(op_min <= self.commit_min or self.commit_min == self.op_checkpoint());
+            assert(op_max >= self.op_checkpoint());
 
             // If we use anything less than self.op then we may commit ops for a forked hash chain
             // that have since been reordered by a new primary.
@@ -5930,27 +5938,6 @@ pub fn ReplicaType(
             var op = op_max;
             while (op > op_min) {
                 op -= 1;
-
-                if (self.op_checkpoint() == op) {
-                    // op_checkpoint's slot may have been overwritten in the WAL — but we can
-                    // always use the VSRState to anchor the hash chain.
-                    assert(op == op_min);
-                    assert(op == self.superblock.working.vsr_state.commit_min);
-                    if (self.superblock.working.vsr_state.commit_min_checksum == b.parent) {
-                        return true;
-                    } else {
-                        log.debug("{}: valid_hash_chain_between: break A: {} (checkpoint={})", .{
-                            self.replica,
-                            self.superblock.working.vsr_state.commit_min_checksum,
-                            self.op_checkpoint(),
-                        });
-                        log.debug("{}: valid_hash_chain_between: break B: {}", .{
-                            self.replica,
-                            b,
-                        });
-                        return false;
-                    }
-                }
 
                 if (self.journal.header_with_op(op)) |a| {
                     assert(a.op + 1 == b.op);
@@ -5968,6 +5955,14 @@ pub fn ReplicaType(
                 }
             }
             assert(b.op == op_min);
+
+            // The op immediately after the checkpoint always connects to the checkpoint.
+            if (op_min <= self.op_checkpoint() + 1 and op_max > self.op_checkpoint()) {
+                assert(self.superblock.working.vsr_state.commit_min == self.op_checkpoint());
+                assert(self.superblock.working.vsr_state.commit_min_checksum ==
+                    self.journal.header_with_op(self.op_checkpoint() + 1).?.parent);
+            }
+
             return true;
         }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4189,8 +4189,9 @@ pub fn ReplicaType(
             }
 
             // If we already committed this op, the repair must be the identical message.
-            assert(header.op <= self.op_checkpoint() or header.op > self.commit_min or
-                self.journal.has(header));
+            if (self.op_checkpoint() < header.op and header.op <= self.commit_min) {
+                assert(self.journal.has(header));
+            }
 
             self.journal.set_header_as_dirty(header);
             return true;
@@ -4672,8 +4673,9 @@ pub fn ReplicaType(
             assert(header.op <= self.op_checkpoint_trigger());
 
             // If we already committed this op, the repair must be the identical message.
-            assert(header.op <= self.op_checkpoint() or header.op > self.commit_min or
-                self.journal.has(header));
+            if (self.op_checkpoint() < header.op and header.op <= self.commit_min) {
+                assert(self.journal.has(header));
+            }
 
             if (header.op < self.op_repair_min()) return;
 


### PR DESCRIPTION
## `op_repair_min()` + chronological repair

(copied from the first commit's message)

This commit has two different changes because I implemented them at the same time and they were too much work to untangle. Sorry!

1. Repair prepares in chronological order.
2. Repair prepares back to `op_repair_min()` which is:
  - For backups, it is usually `op_checkpoint + 1`.
  - For primary, it is usually `op_head - journal_slots + pipeline`.

Guiding principle: State transfer is expensive, prefer to repair WAL whenever possible.

### 1. Repair prepares in chronological order.

(Formerly prepares were repaired in _reverse_ chronological order, i.e. starting at op-head, and then going backwards.)

#### Primary:

For a *primary* (during a view-change), the order of repairs is irrelevant because:

  - no one else is advancing their ops anyway,
  - and we need to repair these prepares to progress.

#### Backup:

(Background:
- The WAL is an on-disk ring buffer.
- A "slot" is `message.header.op % journal_slot_count`.
- `journal_slot_count` is a cluster constant.)

But for a *backup* (which just joined a view), the oldest prepares will be overwritten by the primary (and other backups) earlier than the newest prepares.
Consider a backup's WAL (`journal_slot_count = 8`):

           slot  0  1  2  3  4  5  6  7
    primary WAL  8  9 10 11 12 13  6  7
     backup WAL  0  1  2  3  4  5  _  _

In this example, the backup is lagging behind the primary — it is missing ops 6…13. It must repair to catch up.
But while it is repairing, the primary (and the rest of the cluster) are preparing even more ops (14, 15, ...).
The backup needs to repair op 6 as soon as possible since it is about to be overwritten (by op 14, because 14%8=6).

If the backup *can't* repair the prepare (already overwritten) it will have to resort to state transfer.

Tl;dr: To maximize the chances of repairing a prepare, repair prepares from oldest to newest.

(Aside: As a bonus, chronological repair enables better pipelining of repair + commit — we can commit op=X while repairing op=X+1).

### 2. Repair prepares back to `op_repair_min()`.

(See `op_repair_min()`'s comment & code for details.)

At a high level, the idea is:

  - The backup needs to get caught up to the primary as soon as possible.
    - Repair any messages we need to progress.
    - And repair any messages we would need to recover if we crash before checkpointing.
  - The primary should repair more aggressively (i.e. further back):
    - The further back the primary can repair, the more it can help repair backups.
    - This decreases the likelihood that backups will need to resort to state transfer to catch up.

#### Primary:

For the primary, the reason this _isn't_ as simple as `op_repair_min = op_head -| (journal_slot_count - 1)` is that `op_head` can venture ahead and then backtrack (by as much as `pipeline_prepare_queue_max`) when a view-change truncates uncommitted ops.
We also know that the "venture ahead" is bounded by the checkpoint trigger.
When a primary is starting a view & repairing, all committed ops greater-or-equal-to the primary's `op_repair_min()` are guaranteed to be available in _someone's_ WAL (assuming ≤f/(2f+1) faults).

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
