### PR TITLE
Simulator: Don't count standbys as participants

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3576,7 +3576,7 @@ pub fn ReplicaType(
         ///
         /// Standbys follow the cluster without participating in consensus. In particular,
         /// standbys receive and replicate prepares, but never send prepare-oks.
-        fn standby(self: *const Self) bool {
+        pub fn standby(self: *const Self) bool {
             assert(self.replica < self.node_count);
             return self.replica >= self.replica_count;
         }


### PR DESCRIPTION
## Background

If a replica crashes/recovers and storage faults are enabled during the recovery, there is a risk that it will end up in `recovering_head`. The simulator must be aware of this because `status=recovering_head` replicas cannot participate in consensus. And the simulator wants to make sure that the cluster can eventually recover. The simulator can always crash a replica, but in some cases it will disable storage faults during that replica's recovery.

(This manifested as an availability bug in the VOPR).

## Change

- When the simulator computes the number of replicas that are healthy (i.e. part of consensus), it must not count standbys.
- If the replica being crashed _is_ a standby, then it isn't a participant, so it is always safe to crash with storage faults enabled.

I'm not 100% sure about using `Replica.standby()` from within the simulator. Maybe `Cluster` should track which replica is a standby itself instead of trusting the replica to know?

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
