### PR TITLE
 Node CI: Don't check versions in publish.sh anymore; until we can test without merging into main

### DIFF
--- a/src/clients/node/scripts/publish.sh
+++ b/src/clients/node/scripts/publish.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 set -eu
 
-PACKAGE_JSON_VERSION=$(jq -r '.version' package.json)
 echo "//registry.npmjs.org/:_authToken=${TIGERBEETLE_NODE_PUBLISH_KEY}" > ~/.npmrc
-
-exists="true"
-npm show "tigerbeetle-node@${PACKAGE_JSON_VERSION}" --json 2>/dev/null || exists="false"
-
-if [ "${exists}" = "true" ]; then
-    echo "Package tigerbeetle-node@${PACKAGE_JSON_VERSION} already exists - did you not bump manually or run version_set.sh?"
-    exit 1
-else
-    npm publish tigerbeetle-node-*.tgz
-fi
+npm publish tigerbeetle-node-*.tgz


### PR DESCRIPTION
Checking package.json here is counterproductive, since it needs to check the version in the package not the repo

Skip all this for now, until we have environments and PR testing for publishing

## Pre-merge checklist

Performance:
* [x] I am very sure this PR could not affect performance.
