### PR TITLE
Test/Cluster: Don't open replica immediately after crash

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -322,13 +322,13 @@ pub const Simulator = struct {
     pub fn done(simulator: *Simulator) bool {
         assert(simulator.requests_sent <= simulator.options.requests_max);
 
-        if (!simulator.cluster.state_checker.convergence()) return false;
-        if (!simulator.reply_sequence.empty()) return false;
-        if (simulator.requests_sent < simulator.options.requests_max) return false;
-
         for (simulator.cluster.replica_health) |health| {
             if (health == .down) return false;
         }
+
+        if (!simulator.cluster.state_checker.convergence()) return false;
+        if (!simulator.reply_sequence.empty()) return false;
+        if (simulator.requests_sent < simulator.options.requests_max) return false;
 
         for (simulator.cluster.clients) |*client| {
             if (client.request_queue.count > 0) return false;
@@ -494,7 +494,7 @@ pub const Simulator = struct {
                     }
 
                     log_simulator.debug("{}: crash replica (faults={})", .{ replica.replica, fault });
-                    simulator.cluster.crash_replica(replica.replica) catch unreachable;
+                    simulator.cluster.crash_replica(replica.replica);
                     replica.superblock.storage.faulty = true;
 
                     recoverable_count -=
@@ -506,7 +506,7 @@ pub const Simulator = struct {
                 },
                 .down => {
                     if (chance_f64(simulator.random, simulator.options.replica_restart_probability)) {
-                        simulator.cluster.restart_replica(replica.replica);
+                        simulator.cluster.restart_replica(replica.replica) catch unreachable;
                         log_simulator.debug("{}: restart replica", .{replica.replica});
                         simulator.replica_stability[replica.replica] =
                             simulator.options.replica_restart_stability;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -269,7 +269,12 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             cluster.network.deinit();
             for (cluster.clients) |*client| client.deinit(cluster.allocator);
             for (cluster.client_pools) |*pool| pool.deinit(cluster.allocator);
-            for (cluster.replicas) |*replica| replica.deinit(cluster.allocator);
+            for (cluster.replicas) |*replica, i| {
+                switch (cluster.replica_health[i]) {
+                    .up => replica.deinit(cluster.allocator),
+                    .down => {},
+                }
+            }
             for (cluster.replica_pools) |*pool| pool.deinit(cluster.allocator);
             for (cluster.storages) |*storage| storage.deinit(cluster.allocator);
 
@@ -300,9 +305,14 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             }
         }
 
-        pub fn restart_replica(cluster: *Self, replica_index: u8) void {
+        /// Returns whether the replica was crashed.
+        /// Returns an error when the replica was unable to recover (open).
+        pub fn restart_replica(cluster: *Self, replica_index: u8) !void {
             assert(cluster.replica_health[replica_index] == .down);
 
+            // Pass the old replica's Time through to the new replica. It will continue to tick while
+            // the replica is crashed, to ensure the clocks don't desyncronize too far to recover.
+            try cluster.open_replica(replica_index, cluster.replicas[replica_index].time);
             cluster.network.process_enable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .up;
         }
@@ -310,18 +320,13 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
         /// Reset a replica to its initial state, simulating a random crash/panic.
         /// Leave the persistent storage untouched, and leave any currently
         /// inflight messages to/from the replica in the network.
-        ///
-        /// Returns whether the replica was crashed.
-        /// Returns an error when the replica was unable to recover (open).
-        pub fn crash_replica(cluster: *Self, replica_index: u8) !void {
+        pub fn crash_replica(cluster: *Self, replica_index: u8) void {
             assert(cluster.replica_health[replica_index] == .up);
 
             // Reset the storage before the replica so that pending writes can (partially) finish.
             cluster.storages[replica_index].reset();
 
-            const replica = &cluster.replicas[replica_index];
-            const replica_time = replica.time;
-            replica.deinit(cluster.allocator);
+            cluster.replicas[replica_index].deinit(cluster.allocator);
             cluster.network.process_disable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .down;
 
@@ -333,14 +338,6 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 while (it) |message| : (it = message.next) messages_in_pool += 1;
             }
             assert(messages_in_pool == message_pool.messages_max_replica);
-
-            // Logically it would make more sense to run this during restart, not immediately following
-            // the crash. But having it here allows the replica's MessageBus to initialize and begin
-            // queueing packets.
-            //
-            // Pass the old replica's Time through to the new replica. It will continue to tick while
-            // the replica is crashed, to ensure the clocks don't desyncronize too far to recover.
-            try cluster.open_replica(replica_index, replica_time);
         }
 
         fn open_replica(cluster: *Self, replica_index: u8, time: Time) !void {
@@ -424,6 +421,8 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
         fn on_replica_change_state(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            if (cluster.replica_health[replica.replica] == .down) return;
+
             cluster.state_checker.check_state(replica.replica) catch |err| {
                 fatal(.correctness, "state checker error: {}", .{err});
             };

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -312,7 +312,8 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
             // Pass the old replica's Time through to the new replica. It will continue to tick while
             // the replica is crashed, to ensure the clocks don't desyncronize too far to recover.
-            try cluster.open_replica(replica_index, cluster.replicas[replica_index].time);
+            var time = cluster.replicas[replica_index].time;
+            try cluster.open_replica(replica_index, time);
             cluster.network.process_enable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .up;
         }

--- a/src/testing/table.zig
+++ b/src/testing/table.zig
@@ -106,7 +106,7 @@ fn field(comptime Enum: type, name: []const u8) Enum {
             return @field(Enum, variant.name);
         }
     }
-    std.debug.panic("Unkown field name={s} for type={}", .{ name, Enum });
+    std.debug.panic("Unknown field name={s} for type={}", .{ name, Enum });
 }
 
 fn test_parse(


### PR DESCRIPTION
Reopening the replica immediately after crash was a shortcut that kept all of the cluster's `Replica`s valid. (Then the "crashed" replicas would just not be `tick`'d until they restarted).

But it makes more sense to `open` when the replica is actually restarted.

This allows `Cluster.restart_replica()` to report `open`'s error, rather than `Cluster.crash_replica()`.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
