### PR TITLE
CLI: fix `--replica` validation

### DIFF
--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -428,10 +428,16 @@ fn parse_size_to_count(comptime T: type, string_opt: ?[]const u8, comptime defau
 }
 
 fn parse_replica(raw_replica: []const u8) u8 {
-    comptime assert(constants.replicas_max <= std.math.maxInt(u8));
+    comptime assert(constants.nodes_max <= std.math.maxInt(u8));
     const replica = fmt.parseUnsigned(u8, raw_replica, 10) catch |err| switch (err) {
         error.Overflow => fatal("--replica: value exceeds an 8-bit unsigned integer", .{}),
         error.InvalidCharacter => fatal("--replica: value contains an invalid character", .{}),
     };
+    if (replica >= constants.nodes_max) {
+        fatal(
+            "--replica: value is too large ({}), at most {} is allowed",
+            .{ replica, constants.nodes_max - 1 },
+        );
+    }
     return replica;
 }


### PR DESCRIPTION
* It can be larger than `replicas_max` for standbys
* However, it can't be bigger than `node_max` (pre-existing bug, we used to assert-crash in superblock.format on this)

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
