### PR TITLE
vsr: store configuration in the superblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ GitHub.
 
 ```bash
 $ curl -LO https://github.com/tigerbeetledb/tigerbeetle/releases/download/2022-11-16-weekly/tigerbeetle-Linux-x64-2022-11-16-weekly.zip
-$ unzip tigerbeetle-Linux-x64-2022-11-16-weekly.zip 
+$ unzip tigerbeetle-Linux-x64-2022-11-16-weekly.zip
 $ sudo cp tigerbeetle /usr/local/bin/tigerbeetle
 $ tigerbeetle version --verbose | head -n6
 TigerBeetle version experimental
@@ -68,7 +68,7 @@ mode=Mode.ReleaseSafe
 
 ```bash
 $ curl -LO https://github.com/tigerbeetledb/tigerbeetle/releases/download/2022-11-16-weekly/tigerbeetle-macOS-x64-2022-11-16-weekly.zip
-$ unzip tigerbeetle-macOS-x64-2022-11-16-weekly.zip 
+$ unzip tigerbeetle-macOS-x64-2022-11-16-weekly.zip
 $ sudo cp tigerbeetle /usr/local/bin/tigerbeetle
 $ tigerbeetle version --verbose | head -n6
 TigerBeetle version experimental
@@ -102,7 +102,7 @@ directory. No global changes. The result will place the compiled
 Then create the TigerBeetle data file.
 
 ```bash
-$ ./tigerbeetle format --cluster=0 --replica=0 0_0.tigerbeetle
+$ ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
 info(io): creating "0_0.tigerbeetle"...
 info(io): allocating 660.140625MiB...
 ```

--- a/docs/DEEP_DIVE.md
+++ b/docs/DEEP_DIVE.md
@@ -56,7 +56,7 @@ Let's turn up the log level some more (and your favorite album), so you can see 
 
 - Start a single replica cluster:
 Format the data file:
-`./tigerbeetle format --cluster=0 --replica=0 0_0.tigerbeetle`
+`./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle`
 Start the replica from the data file:
 `./tigerbeetle start --addresses=3001 0_0.tigerbeetle &`
 

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -27,9 +27,9 @@ scripts/benchmark.sh
 Launch a TigerBeetle cluster on your local machine by running each of these commands in a new terminal tab:
 
 ```
-$ ./tigerbeetle format --cluster=0 --replica=0 0_0.tigerbeetle
-$ ./tigerbeetle format --cluster=0 --replica=1 0_1.tigerbeetle
-$ ./tigerbeetle format --cluster=0 --replica=2 0_2.tigerbeetle
+$ ./tigerbeetle format --cluster=0 --replica=0 --replica-count=3 0_0.tigerbeetle
+$ ./tigerbeetle format --cluster=0 --replica=1 --replica-count=3 0_1.tigerbeetle
+$ ./tigerbeetle format --cluster=0 --replica=2 --replica-count=3 0_2.tigerbeetle
 
 $ ./tigerbeetle start --addresses=3001,3002,3003 0_0.tigerbeetle
 $ ./tigerbeetle start --addresses=3001,3002,3003 0_1.tigerbeetle

--- a/docs/deployment/single-binary.md
+++ b/docs/deployment/single-binary.md
@@ -11,7 +11,7 @@ GitHub.
 
 ```bash
 $ curl -LO https://github.com/tigerbeetledb/tigerbeetle/releases/download/2022-11-16-weekly/tigerbeetle-Linux-x64-2022-11-16-weekly.zip
-$ unzip tigerbeetle-Linux-x64-2022-11-16-weekly.zip 
+$ unzip tigerbeetle-Linux-x64-2022-11-16-weekly.zip
 $ sudo cp tigerbeetle /usr/local/bin/tigerbeetle
 $ tigerbeetle version --verbose | head -n6
 TigerBeetle version experimental
@@ -36,7 +36,7 @@ $ curl -LO https://github.com/tigerbeetledb/tigerbeetle/releases/download/2022-1
 
 ```bash
 $ curl -LO https://github.com/tigerbeetledb/tigerbeetle/releases/download/2022-11-16-weekly/tigerbeetle-macOS-x64-2022-11-16-weekly.zip
-$ unzip tigerbeetle-macOS-x64-2022-11-16-weekly.zip 
+$ unzip tigerbeetle-macOS-x64-2022-11-16-weekly.zip
 $ sudo cp tigerbeetle /usr/local/bin/tigerbeetle
 $ tigerbeetle version --verbose | head -n6
 TigerBeetle version experimental
@@ -89,7 +89,7 @@ $ DEBUG=true ./scripts/install.sh
 Now create the TigerBeetle data file.
 
 ```bash
-$ ./tigerbeetle format --cluster=0 --replica=0 0_0.tigerbeetle
+$ ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
 info(io): creating "0_0.tigerbeetle"...
 info(io): allocating 660.140625MiB...
 ```

--- a/docs/deployment/with-docker-compose.md
+++ b/docs/deployment/with-docker-compose.md
@@ -7,9 +7,9 @@ sidebar_position: 3
 First, provision the data file for each node:
 
 ```
-$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=0 /data/0_0.tigerbeetle
-$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=1 /data/0_1.tigerbeetle
-$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=2 /data/0_2.tigerbeetle
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=0 --replica-count=3 /data/0_0.tigerbeetle
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=1 --replica-count=3 /data/0_1.tigerbeetle
+$ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle format --cluster=0 --replica=2 --replica-count=3 /data/0_2.tigerbeetle
 ```
 
 Then create a docker-compose.yml file:
@@ -19,7 +19,7 @@ version: "3.7"
 
 ##
 # Note: this example might only work with linux + using `network_mode:host` because of 2 reasons:
-# 
+#
 # 1. When specifying an internal docker network, other containers are only available using dns based routing:
 #    e.g. from tigerbeetle_0, the other replicas are available at `tigerbeetle_1:3002` and
 #    `tigerbeetle_2:3003` respectively.

--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -33,7 +33,7 @@ for /l %%i in (0, 1, 0) do (
     echo Initializing replica %%i
     set ZIG_FILE=.\0_%%i.tigerbeetle.benchmark
     if exist "!ZIG_FILE!" DEL /F "!ZIG_FILE!"
-    .\tigerbeetle.exe format --cluster=0 --replica=%%i !ZIG_FILE! > benchmark.log 2>&1
+    .\tigerbeetle.exe format --cluster=0 --replica=%%i --replica-count=1 !ZIG_FILE! > benchmark.log 2>&1
 )
 
 for /l %%i in (0, 1, 0) do (

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -49,7 +49,7 @@ do
         rm "$FILE"
     fi
 
-    ./tigerbeetle format --cluster=0 --replica="$I" "$FILE" > benchmark.log 2>&1
+    ./tigerbeetle format --cluster=0 --replica="$I" --replica-count=1 "$FILE" > benchmark.log 2>&1
 done
 
 for I in $REPLICAS

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -867,7 +867,7 @@ namespace TigerBeetle.Tests
         private const string TB_EXE = "tigerbeetle";
         private const string TB_FILE = "dotnet-tests.tigerbeetle";
         private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
-        private const string FORMAT = $"format --cluster=0 --replica=0 ./" + TB_FILE;
+        private const string FORMAT = $"format --cluster=0 --replica=0 --replica-count=1 ./" + TB_FILE;
         private const string START = $"start --addresses=" + TB_PORT + " ./" + TB_FILE;
 
         private readonly Process process;

--- a/src/clients/dotnet/scripts/benchmark.bat
+++ b/src/clients/dotnet/scripts/benchmark.bat
@@ -26,13 +26,13 @@ exit /b
 echo "Building TigerBeetle..."
 cd ..\..\..
 .\zig\zig.exe build install -Dcpu=baseline -Drelease-safe
-cd src/clients/dotnet 
+cd src/clients/dotnet
 
 for /l %%i in (0, 1, 0) do (
     echo Initializing replica %%i
     set ZIG_FILE=.\0_%%i.tigerbeetle.benchmark
     if exist "!ZIG_FILE!" DEL /F "!ZIG_FILE!"
-    ..\..\..\tigerbeetle.exe format --cluster=0 --replica=%%i !ZIG_FILE! > benchmark.log 2>&1
+    ..\..\..\tigerbeetle.exe format --cluster=0 --replica=%%i --replica-count=1 !ZIG_FILE! > benchmark.log 2>&1
 )
 
 for /l %%i in (0, 1, 0) do (

--- a/src/clients/dotnet/scripts/benchmark.sh
+++ b/src/clients/dotnet/scripts/benchmark.sh
@@ -38,7 +38,7 @@ do
         rm "$FILE"
     fi
 
-    ../../../tigerbeetle format --cluster=0 --replica="$I" "$FILE" > benchmark.log 2>&1
+    ../../../tigerbeetle format --cluster=0 --replica="$I" --replica-count=1 "$FILE" > benchmark.log 2>&1
 done
 
 for I in $REPLICAS

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	TIGERBEETLE_PORT              = "3000"
-	TIGERBEETLE_CLUSTER_ID uint32 = 0
-	TIGERBEETLE_REPLICA_ID uint32 = 0
+	TIGERBEETLE_PORT                 = "3000"
+	TIGERBEETLE_CLUSTER_ID    uint32 = 0
+	TIGERBEETLE_REPLICA_ID    uint32 = 0
+	TIGERBEETLE_REPLICA_COUNT uint32 = 1
 )
 
 func toU128(value string) *types.Uint128 {
@@ -37,12 +38,13 @@ func WithClient(s testing.TB, withClient func(Client)) {
 
 	addressArg := "--addresses=" + TIGERBEETLE_PORT
 	replicaArg := fmt.Sprintf("--replica=%d", TIGERBEETLE_REPLICA_ID)
+	replicaCountArg := fmt.Sprintf("--replica-count=%d", TIGERBEETLE_REPLICA_COUNT)
 	clusterArg := fmt.Sprintf("--cluster=%d", TIGERBEETLE_CLUSTER_ID)
 
 	fileName := fmt.Sprintf("./%d_%d.tigerbeetle", TIGERBEETLE_CLUSTER_ID, TIGERBEETLE_REPLICA_ID)
 	_ = os.Remove(fileName)
 
-	tbInit := exec.Command(tigerbeetlePath, "format", clusterArg, replicaArg, fileName)
+	tbInit := exec.Command(tigerbeetlePath, "format", clusterArg, replicaArg, replicaCountArg, fileName)
 	var tbErr bytes.Buffer
 	tbInit.Stdout = &tbErr
 	tbInit.Stderr = &tbErr

--- a/src/clients/java/scripts/benchmark.bat
+++ b/src/clients/java/scripts/benchmark.bat
@@ -35,7 +35,7 @@ for /l %%i in (0, 1, 0) do (
     echo Initializing replica %%i
     set ZIG_FILE=.\0_%%i.tigerbeetle.benchmark
     if exist "!ZIG_FILE!" DEL /F "!ZIG_FILE!"
-    ..\..\..\tigerbeetle.exe format --cluster=0 --replica=%%i !ZIG_FILE! > benchmark.log 2>&1
+    ..\..\..\tigerbeetle.exe format --cluster=0 --replica=%%i --replica-count=1 !ZIG_FILE! > benchmark.log 2>&1
 )
 
 for /l %%i in (0, 1, 0) do (

--- a/src/clients/java/scripts/benchmark.sh
+++ b/src/clients/java/scripts/benchmark.sh
@@ -41,7 +41,7 @@ do
         rm "$FILE"
     fi
 
-    ../../../tigerbeetle format --cluster=0 --replica="$I" "$FILE" > benchmark.log 2>&1
+    ../../../tigerbeetle format --cluster=0 --replica="$I" --replica-count=1 "$FILE" > benchmark.log 2>&1
 done
 
 for I in $REPLICAS

--- a/src/clients/java/scripts/run_tigerbeetle.bat
+++ b/src/clients/java/scripts/run_tigerbeetle.bat
@@ -10,7 +10,7 @@ set ZIG_FILE=.\0_0.tigerbeetle.examples
 
 echo Initializing replica
 if exist "!ZIG_FILE!" DEL /F "!ZIG_FILE!"
-..\..\..tigerbeetle.exe format --cluster=0 --replica=0 !ZIG_FILE!
+..\..\..tigerbeetle.exe format --cluster=0 --replica=0 --replica-count=1 !ZIG_FILE!
 
 echo Starting replica
 ..\..\..tigerbeetle.exe start --addresses=3000 !ZIG_FILE!

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1230,8 +1230,8 @@ public class IntegrationTest {
                     break;
             }
 
-            var format = Runtime.getRuntime()
-                    .exec(new String[] {exe, "format", "--cluster=0", "--replica=0", TB_FILE});
+            var format = Runtime.getRuntime().exec(new String[] {exe, "format", "--cluster=0",
+                    "--replica=0", "--replica-count=1", TB_FILE});
             if (format.waitFor() != 0) {
                 var reader = new BufferedReader(new InputStreamReader(format.getErrorStream()));
                 var error = reader.lines().collect(Collectors.joining(". "));

--- a/src/clients/node/scripts/benchmark.sh
+++ b/src/clients/node/scripts/benchmark.sh
@@ -40,7 +40,7 @@ FILE="./benchmark/cluster_${CLUSTER_ID}_replica_0.tigerbeetle"
 if [ -f $FILE ]; then
     rm $FILE
 fi
-./tigerbeetle format --cluster=$CLUSTER_ID --replica=0 $FILE
+./tigerbeetle format --cluster=$CLUSTER_ID --replica=0 --replica-count=1 $FILE
 
 for I in $REPLICAS
 do

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -46,6 +46,7 @@ const FuzzOpTag = std.meta.Tag(FuzzOp);
 const Environment = struct {
     const cluster = 32;
     const replica = 4;
+    const replica_count = 6;
 
     const node_count = 1024;
     // This is the smallest size that set_associative_cache will allow us.
@@ -124,6 +125,7 @@ const Environment = struct {
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
             .cluster = cluster,
             .replica = replica,
+            .replica_count = replica_count,
         });
         env.tick_until_state_change(.superblock_format, .superblock_open);
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -334,6 +334,7 @@ const Environment = struct {
         env.manifest_log.superblock.format(format_superblock_callback, &env.superblock_context, .{
             .cluster = 0,
             .replica = 0,
+            .replica_count = 6,
         });
     }
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -81,6 +81,7 @@ const value_count_max = constants.lsm_batch_multiple * commit_entries_max;
 
 const cluster = 32;
 const replica = 4;
+const replica_count = 6;
 const node_count = 1024;
 const tree_options = .{
     // This is the smallest size that set_associative_cache will allow us.
@@ -184,6 +185,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.superblock.format(superblock_format_callback, &env.superblock_context, .{
                 .cluster = cluster,
                 .replica = replica,
+                .replica_count = replica_count,
             });
 
             env.tick_until_state_change(.superblock_format, .superblock_open);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -214,8 +214,11 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 try vsr.format(
                     Storage,
                     allocator,
-                    options.cluster_id,
-                    @intCast(u8, replica_index),
+                    .{
+                        .cluster = options.cluster_id,
+                        .replica = @intCast(u8, replica_index),
+                        .replica_count = options.replica_count,
+                    },
                     storage,
                     &superblock,
                 );
@@ -346,8 +349,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             try replica.open(
                 cluster.allocator,
                 .{
-                    .replica_count = cluster.replica_count,
-                    .standby_count = cluster.standby_count,
+                    .node_count = cluster.options.replica_count + cluster.options.standby_count,
                     .storage = &cluster.storages[replica_index],
                     // TODO Test restarting with a higher storage limit.
                     .storage_size_limit = cluster.options.storage_size_limit,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -46,7 +46,11 @@ pub fn main() !void {
     defer parse_args.deinit(allocator);
 
     switch (parse_args) {
-        .format => |*args| try Command.format(allocator, args.cluster, args.replica, args.path),
+        .format => |*args| try Command.format(allocator, .{
+            .cluster = args.cluster,
+            .replica = args.replica,
+            .replica_count = args.replica_count,
+        }, args.path),
         .start => |*args| try Command.start(&arena, args),
         .version => |*args| try Command.version(allocator, args.verbose),
     }
@@ -97,7 +101,7 @@ const Command = struct {
         os.close(command.dir_fd);
     }
 
-    pub fn format(allocator: mem.Allocator, cluster: u32, replica: u8, path: [:0]const u8) !void {
+    pub fn format(allocator: mem.Allocator, options: SuperBlock.FormatOptions, path: [:0]const u8) !void {
         var command: Command = undefined;
         try command.init(allocator, path, true);
         defer command.deinit(allocator);
@@ -112,11 +116,12 @@ const Command = struct {
         );
         defer superblock.deinit(allocator);
 
-        try vsr.format(Storage, allocator, cluster, replica, &command.storage, &superblock);
+        try vsr.format(Storage, allocator, options, &command.storage, &superblock);
 
-        log_main.info("{}: formatted: cluster={}", .{
-            replica,
-            cluster,
+        log_main.info("{}: formatted: cluster={} replica_count={}", .{
+            options.replica,
+            options.cluster,
+            options.replica_count,
         });
     }
 
@@ -140,8 +145,7 @@ const Command = struct {
 
         var replica: Replica = undefined;
         replica.open(allocator, .{
-            .replica_count = @intCast(u8, args.addresses.len) - args.standby_count,
-            .standby_count = args.standby_count,
+            .node_count = @intCast(u8, args.addresses.len),
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .message_pool = &command.message_pool,

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -149,11 +149,11 @@ pub fn QuorumsType(comptime options: Options) type {
                     continue;
                 }
 
-                if (a.header.replica != b.header.replica) {
+                if (a.header.vsr_state.replica != b.header.vsr_state.replica) {
                     log.warn("superblock copy={} has replica={} instead of {}", .{
                         a.header.copy,
-                        a.header.replica,
-                        b.header.replica,
+                        a.header.vsr_state.replica,
+                        b.header.vsr_state.replica,
                     });
                     continue;
                 }
@@ -174,7 +174,7 @@ pub fn QuorumsType(comptime options: Options) type {
                 if (a.header.sequence + 1 == b.header.sequence) {
                     assert(a.header.checksum != b.header.checksum);
                     assert(a.header.cluster == b.header.cluster);
-                    assert(a.header.replica == b.header.replica);
+                    assert(a.header.vsr_state.replica == b.header.vsr_state.replica);
 
                     if (a.header.checksum != b.header.parent) {
                         return error.ParentNotConnected;
@@ -255,7 +255,7 @@ pub fn QuorumsType(comptime options: Options) type {
             } else if (quorum.copies.isSet(copy.copy)) {
                 // Ignore the duplicate copy.
             } else {
-                quorum.slots[slot] = copy.copy;
+                quorum.slots[slot] = @intCast(u8, copy.copy);
                 quorum.copies.set(copy.copy);
             }
 

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -122,10 +122,13 @@ fn test_quorums_working(
         header.* = std.mem.zeroInit(SuperBlockHeader, .{
             .copy = @intCast(u8, i),
             .version = SuperBlockVersion,
-            .replica = 1,
             .storage_size_max = superblock.data_file_size_min,
             .sequence = copies[i].sequence,
             .parent = checksums[copies[i].sequence - 1],
+            .vsr_state = std.mem.zeroInit(SuperBlockHeader.VSRState, .{
+                .replica = 1,
+                .replica_count = 6,
+            }),
         });
 
         var checksum: ?u128 = null;
@@ -148,7 +151,7 @@ fn test_quorums_working(
                 if (misdirect) {
                     header.cluster += 1;
                 } else {
-                    header.replica += 1;
+                    header.vsr_state.replica += 1;
                 }
             },
             .invalid_vsr_state => header.vsr_state.view += 1,
@@ -255,10 +258,14 @@ pub fn fuzz_quorum_repairs(
             header.* = std.mem.zeroInit(SuperBlockHeader, .{
                 .copy = @intCast(u8, i),
                 .version = SuperBlockVersion,
-                .replica = 1,
                 .storage_size_max = superblock.data_file_size_min,
                 .sequence = 123,
+                .vsr_state = std.mem.zeroInit(SuperBlockHeader.VSRState, .{
+                    .replica = 1,
+                    .replica_count = 6,
+                }),
             });
+
             header.set_checksum();
         }
         break :blk headers;


### PR DESCRIPTION
- today, configuration is replica+replica_count
- store both in VSR State (move replica, add count)
- plumbing to specify `--replica-count` on format

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
