### PR TITLE
bus: gracefully handle buggy TCP

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -719,7 +719,8 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                                 "message from unexpected peer: peer={} header={}",
                                 .{ connection.peer, header },
                             );
-                            unreachable;
+                            connection.terminate(bus, .shutdown);
+                            return null;
                         },
                         // The client connects only to replicas and should set peer when connecting:
                         .client => assert(connection.peer == .replica),


### PR DESCRIPTION
In replica.zig, we gracefully handle misdirected messages, lets do the same on the bus level as bell.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
