### PR TITLE
Use the c implementation of blake3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tools/tracy"]
 	path = tools/tracy
 	url = https://github.com/wolfpld/tracy.git
+[submodule "deps/blake3"]
+	path = deps/blake3
+	url = git@github.com:BLAKE3-team/BLAKE3.git

--- a/src/blake3.zig
+++ b/src/blake3.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const c = @cImport({
+    @cInclude("blake3.h");
+});
+
+pub fn hash(source: []const u8) u128 {
+    var hasher: c.blake3_hasher = undefined;
+    c.blake3_hasher_init(&hasher);
+    c.blake3_hasher_update(&hasher, @ptrCast(?*const anyopaque, source), source.len);
+    // TODO We use 32 here like std.crypto.hash because we have to produce the same hash
+    //      as vsr.checksum_comptime for all inputs.
+    //      But @sizeOf(u128) would be preferable.
+    comptime {
+        assert(c.BLAKE3_OUT_LEN == 32);
+    }
+    var target: [c.BLAKE3_OUT_LEN]u8 = undefined;
+    c.blake3_hasher_finalize(&hasher, &target, c.BLAKE3_OUT_LEN);
+    return @bitCast(u128, target[0..@sizeOf(u128)].*);
+}

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -429,7 +429,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
             // Checksum transfers only after the whole batch is ready.
             // The opportunistic linking backtracks to modify transfers.
             for (transfers[0..transfers_count]) |*transfer| {
-                transfer.user_data = vsr.checksum(std.mem.asBytes(transfer));
+                transfer.user_data = vsr.checksum_runtime(std.mem.asBytes(transfer));
             }
             assert(transfers_count == i);
             assert(transfers_count <= transfers.len);
@@ -710,7 +710,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                     var check = transfer.*;
                     check.user_data = 0;
                     check.timestamp = 0;
-                    const checksum_expect = vsr.checksum(std.mem.asBytes(&check));
+                    const checksum_expect = vsr.checksum_runtime(std.mem.asBytes(&check));
                     assert(checksum_expect == checksum_actual);
                 }
 

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -138,7 +138,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
                 var copy: u8 = 0;
                 while (copy < constants.superblock_copies) : (copy += 1) {
                     @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer.field)) |=
-                        vsr.checksum(storage.memory[trailer_area.offset(copy)..][0..trailer_size]);
+                        vsr.checksum_runtime(storage.memory[trailer_area.offset(copy)..][0..trailer_size]);
                 }
             }
 
@@ -182,7 +182,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
 
                 // Only checksum the actual message header+body. Any leftover space is nondeterministic,
                 // because the current prepare may have overwritten a longer message.
-                checksum ^= vsr.checksum(std.mem.asBytes(prepare)[0..prepare.header.size]);
+                checksum ^= vsr.checksum_runtime(std.mem.asBytes(prepare)[0..prepare.header.size]);
             }
             return checksum;
         }
@@ -194,7 +194,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             while (acquired.next()) |address_index| {
                 const block = storage.grid_block(address_index + 1);
                 const block_header = std.mem.bytesToValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
-                checksum ^= vsr.checksum(block[0..block_header.size]);
+                checksum ^= vsr.checksum_runtime(block[0..block_header.size]);
             }
             return checksum;
         }

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -246,7 +246,7 @@ pub const SuperBlockHeader = extern struct {
 
         const ignore_size = checksum_size + copy_size;
 
-        return vsr.checksum(std.mem.asBytes(superblock)[ignore_size..]);
+        return vsr.checksum_runtime(std.mem.asBytes(superblock)[ignore_size..]);
     }
 
     pub fn set_checksum(superblock: *SuperBlockHeader) void {
@@ -882,7 +882,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             const target = superblock.manifest_buffer;
 
             staging.manifest_size = @intCast(u32, superblock.manifest.encode(target));
-            staging.manifest_checksum = vsr.checksum(target[0..staging.manifest_size]);
+            staging.manifest_checksum = vsr.checksum_runtime(target[0..staging.manifest_size]);
         }
 
         fn write_staging_encode_free_set(superblock: *SuperBlock) void {
@@ -912,7 +912,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             } else {
                 staging.free_set_size = @intCast(u32, superblock.free_set.encode(target));
             }
-            staging.free_set_checksum = vsr.checksum(target[0..staging.free_set_size]);
+            staging.free_set_checksum = vsr.checksum_runtime(target[0..staging.free_set_size]);
         }
 
         fn write_staging_encode_client_table(superblock: *SuperBlock) void {
@@ -920,7 +920,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             const target = superblock.client_table_buffer;
 
             staging.client_table_size = @intCast(u32, superblock.client_table.encode(target));
-            staging.client_table_checksum = vsr.checksum(target[0..staging.client_table_size]);
+            staging.client_table_checksum = vsr.checksum_runtime(target[0..staging.client_table_size]);
         }
 
         fn write_manifest(superblock: *SuperBlock, context: *Context) void {
@@ -934,7 +934,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
             mem.set(u8, buffer[superblock.staging.manifest_size..], 0); // Zero sector padding.
 
-            assert(superblock.staging.manifest_checksum == vsr.checksum(
+            assert(superblock.staging.manifest_checksum == vsr.checksum_runtime(
                 superblock.manifest_buffer[0..superblock.staging.manifest_size],
             ));
 
@@ -977,7 +977,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
             mem.set(u8, buffer[superblock.staging.free_set_size..], 0); // Zero sector padding.
 
-            assert(superblock.staging.free_set_checksum == vsr.checksum(
+            assert(superblock.staging.free_set_checksum == vsr.checksum_runtime(
                 superblock.free_set_buffer[0..superblock.staging.free_set_size],
             ));
 
@@ -1020,7 +1020,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
             mem.set(u8, buffer[superblock.staging.client_table_size..], 0); // Zero sector padding.
 
-            assert(superblock.staging.client_table_checksum == vsr.checksum(
+            assert(superblock.staging.client_table_checksum == vsr.checksum_runtime(
                 superblock.client_table_buffer[0..superblock.staging.client_table_size],
             ));
 
@@ -1328,7 +1328,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.manifest.count == 0);
 
             const slice = superblock.manifest_buffer[0..superblock.working.manifest_size];
-            if (vsr.checksum(slice) == superblock.working.manifest_checksum) {
+            if (vsr.checksum_runtime(slice) == superblock.working.manifest_checksum) {
                 superblock.manifest.decode(slice);
 
                 log.debug("open: read_manifest: manifest blocks: {}/{}", .{
@@ -1397,7 +1397,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.free_set.count_acquired() == 0);
 
             const slice = superblock.free_set_buffer[0..superblock.working.free_set_size];
-            if (vsr.checksum(slice) == superblock.working.free_set_checksum) {
+            if (vsr.checksum_runtime(slice) == superblock.working.free_set_checksum) {
                 superblock.free_set.decode(slice);
 
                 log.debug("open: read_free_set: acquired blocks: {}/{}/{}", .{
@@ -1471,7 +1471,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.client_table.count() == 0);
 
             const slice = superblock.client_table_buffer[0..superblock.working.client_table_size];
-            if (vsr.checksum(slice) == superblock.working.client_table_checksum) {
+            if (vsr.checksum_runtime(slice) == superblock.working.client_table_checksum) {
                 superblock.client_table.decode(slice);
 
                 log.debug("open: read_client_table: client requests: {}/{}", .{

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -408,5 +408,5 @@ fn checksum_free_set(superblock: *const SuperBlock) u128 {
     const mask_bits = @bitSizeOf(std.DynamicBitSetUnmanaged.MaskInt);
     const count_bits = superblock.free_set.blocks.bit_length;
     const count_words = stdx.div_ceil(count_bits, mask_bits);
-    return vsr.checksum(std.mem.sliceAsBytes(superblock.free_set.blocks.masks[0..count_words]));
+    return vsr.checksum_runtime(std.mem.sliceAsBytes(superblock.free_set.blocks.masks[0..count_words]));
 }


### PR DESCRIPTION
See https://github.com/tigerbeetledb/tigerbeetle/issues/324#issuecomment-1464621015.

We get a 17% throughput boost and blake3 goes from ~33% of runtime to ~14%. The question is whether we want to deal with having a small c dependency. Certainly, cross-platform builds might become more complicated.

In https://github.com/tigerbeetledb/tigerbeetle/commit/1abd41ffccd01944f0b2bb6f37ed6c33f5c98de6 I tried copying the zig implementation and disabling runtime safety anywhere, in case the difference was just bounds-checking. This had no noticeable effect.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
``` sh
# benchmark results before
1223 batches in 107.08 s
load offered = 1000000 tx/s
load accepted = 93391 tx/s
batch latency p00 = 5 ms
batch latency p10 = 31 ms
batch latency p20 = 32 ms
batch latency p30 = 32 ms
batch latency p40 = 36 ms
batch latency p50 = 37 ms
batch latency p60 = 37 ms
batch latency p70 = 37 ms
batch latency p80 = 37 ms
batch latency p90 = 42 ms
batch latency p100 = 4889 ms
transfer latency p00 = 5 ms
transfer latency p10 = 3499 ms
transfer latency p20 = 9987 ms
transfer latency p30 = 17466 ms
transfer latency p40 = 25862 ms
transfer latency p50 = 36263 ms
transfer latency p60 = 48690 ms
transfer latency p70 = 60384 ms
transfer latency p80 = 73001 ms
transfer latency p90 = 85980 ms
transfer latency p100 = 97044 ms
    
# benchmark results after
load offered = 1000000 tx/s
load accepted = 109809 tx/s
batch latency p00 = 5 ms
batch latency p10 = 31 ms
batch latency p20 = 31 ms
batch latency p30 = 31 ms
batch latency p40 = 31 ms
batch latency p50 = 31 ms
batch latency p60 = 31 ms
batch latency p70 = 32 ms
batch latency p80 = 36 ms
batch latency p90 = 36 ms
batch latency p100 = 3393 ms
transfer latency p00 = 5 ms
transfer latency p10 = 3214 ms
transfer latency p20 = 9354 ms
transfer latency p30 = 15894 ms
transfer latency p40 = 23340 ms
transfer latency p50 = 32597 ms
transfer latency p60 = 42940 ms
transfer latency p70 = 52574 ms
transfer latency p80 = 63298 ms
transfer latency p90 = 73050 ms
transfer latency p100 = 81034 ms
```
OR
* [ ] I am very sure this PR could not affect performance.
