### PR TITLE
Increase the grid cache size in production to 16gb

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -67,6 +67,7 @@ const ConfigProcess = struct {
     clock_epoch_max_ms: u64 = 60000,
     clock_synchronization_window_min_ms: u64 = 2000,
     clock_synchronization_window_max_ms: u64 = 20000,
+    grid_cache_size: u64,
     grid_iops_read_max: u64 = 16,
     grid_iops_write_max: u64 = 16,
 };
@@ -145,6 +146,7 @@ pub const configs = struct {
             .cache_transfers_max = 0,
             .cache_transfers_posted_max = 256 * 1024,
             .verify = false,
+            .grid_cache_size = 16 * 1024 * 1024 * 1024,
         },
         .cluster = .{
             .clients_max = 32,
@@ -162,6 +164,7 @@ pub const configs = struct {
             .cache_transfers_max = 0,
             .cache_transfers_posted_max = 256 * 1024,
             .verify = true,
+            .grid_cache_size = 128 * 1024 * 1024,
         },
         .cluster = default_production.cluster,
     };
@@ -176,6 +179,7 @@ pub const configs = struct {
             .cache_transfers_max = 0,
             .cache_transfers_posted_max = 2048,
             .verify = true,
+            .grid_cache_size = 128 * 1024 * 1024,
         },
         .cluster = .{
             .clients_max = 4 + 3,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -312,6 +312,8 @@ pub const journal_iops_read_max = config.process.journal_iops_read_max;
 /// Ideally this is at least as high as pipeline_prepare_queue_max, but it is safe to be lower.
 pub const journal_iops_write_max = config.process.journal_iops_write_max;
 
+/// The number of bytes allocated for the grid cache.
+pub const grid_cache_size = config.process.grid_cache_size;
 /// The maximum number of concurrent grid read I/O operations to allow at once.
 pub const grid_iops_read_max = config.process.grid_iops_read_max;
 /// The maximum number of concurrent grid write I/O operations to allow at once.

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -162,9 +162,7 @@ pub fn GridType(comptime Storage: type) type {
         read_resolving: bool = false,
 
         pub fn init(allocator: mem.Allocator, superblock: *SuperBlock) !Grid {
-            // TODO Determine this at runtime based on runtime configured maximum
-            // memory usage of tigerbeetle.
-            const cache_blocks_count = 2048;
+            const cache_blocks_count = @divExact(constants.grid_cache_size, constants.block_size);
 
             const cache_blocks = try allocator.alloc(BlockPtr, cache_blocks_count);
             errdefer allocator.free(cache_blocks);


### PR DESCRIPTION
Dev and test are left at 128mb, as before.

Doesn't improve performance, at least for small benchmarks, as discussed in https://github.com/tigerbeetledb/tigerbeetle/issues/551#issuecomment-1462853718. Even though the db file is 13gb.

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
``` sh
# benchmark results before
1223 batches in 105.79 s
load offered = 1000000 tx/s
load accepted = 94527 tx/s
batch latency p00 = 5 ms
batch latency p10 = 31 ms
batch latency p20 = 32 ms
batch latency p30 = 32 ms
batch latency p40 = 32 ms
batch latency p50 = 36 ms
batch latency p60 = 37 ms
batch latency p70 = 37 ms
batch latency p80 = 37 ms
batch latency p90 = 37 ms
batch latency p100 = 4049 ms
transfer latency p00 = 5 ms
transfer latency p10 = 3565 ms
transfer latency p20 = 10669 ms
transfer latency p30 = 17949 ms
transfer latency p40 = 26392 ms
transfer latency p50 = 37194 ms
transfer latency p60 = 48950 ms
transfer latency p70 = 60220 ms
transfer latency p80 = 72309 ms
transfer latency p90 = 84444 ms
transfer latency p100 = 95760 ms
    
# benchmark results after
1223 batches in 102.93 s
load offered = 1000000 tx/s
load accepted = 97149 tx/s
batch latency p00 = 5 ms
batch latency p10 = 31 ms
batch latency p20 = 32 ms
batch latency p30 = 32 ms
batch latency p40 = 32 ms
batch latency p50 = 32 ms
batch latency p60 = 36 ms
batch latency p70 = 37 ms
batch latency p80 = 37 ms
batch latency p90 = 37 ms
batch latency p100 = 5151 ms
transfer latency p00 = 5 ms
transfer latency p10 = 3496 ms
transfer latency p20 = 10126 ms
transfer latency p30 = 17715 ms
transfer latency p40 = 25784 ms
transfer latency p50 = 35901 ms
transfer latency p60 = 47219 ms
transfer latency p70 = 57791 ms
transfer latency p80 = 70066 ms
transfer latency p90 = 82694 ms
transfer latency p100 = 92901 ms
```
OR
* [ ] I am very sure this PR could not affect performance.
