### PR TITLE
[Java Client] Minor optimization for zero-length replies

### DIFF
--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -390,7 +390,7 @@ const NativeClient = struct {
         var request_obj = @ptrCast(jui.jobject, packet.user_data);
         defer env.deleteReference(.global, request_obj);
 
-        var result: ?[]const u8 = switch (packet.status) {
+        var result: ?[]const u8 = if (result_len == 0) null else switch (packet.status) {
             .ok => if (result_ptr) |ptr| ptr[0..@intCast(usize, result_len)] else null,
             else => null,
         };

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -102,35 +102,31 @@ abstract class Request<TResponse extends Batch> {
 
                 exception = new RequestException(status);
 
-            } else if (buffer == null) {
-
-                exception = new AssertionError("Unexpected callback buffer: buffer=null");
-
             } else {
 
                 switch (operation) {
                     case CREATE_ACCOUNTS: {
-                        result = buffer.capacity() == 0 ? CreateAccountResultBatch.EMPTY
+                        result = buffer == null ? CreateAccountResultBatch.EMPTY
                                 : new CreateAccountResultBatch(memcpy(buffer));
                         break;
                     }
 
                     case CREATE_TRANSFERS: {
-                        result = buffer.capacity() == 0 ? CreateTransferResultBatch.EMPTY
+                        result = buffer == null ? CreateTransferResultBatch.EMPTY
                                 : new CreateTransferResultBatch(memcpy(buffer));
                         break;
                     }
 
                     case ECHO_ACCOUNTS:
                     case LOOKUP_ACCOUNTS: {
-                        result = buffer.capacity() == 0 ? AccountBatch.EMPTY
+                        result = buffer == null ? AccountBatch.EMPTY
                                 : new AccountBatch(memcpy(buffer));
                         break;
                     }
 
                     case ECHO_TRANSFERS:
                     case LOOKUP_TRANSFERS: {
-                        result = buffer.capacity() == 0 ? TransferBatch.EMPTY
+                        result = buffer == null ? TransferBatch.EMPTY
                                 : new TransferBatch(memcpy(buffer));
                         break;
                     }

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -156,7 +156,7 @@ public class AsyncRequestTest {
         }
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void testEndRequestWithNullBuffer() throws Throwable {
 
         var client = NativeClient.initEcho(0, "3000", 1);
@@ -171,13 +171,8 @@ public class AsyncRequestTest {
         callback.start();
         assertFalse(future.isDone());
 
-        try {
-            future.get();
-            assert false;
-        } catch (ExecutionException e) {
-            assertNotNull(e.getCause());
-            throw e.getCause();
-        }
+        var result = future.get();
+        assertEquals(0, result.getLength());
     }
 
     @Test(expected = AssertionError.class)
@@ -526,12 +521,9 @@ public class AsyncRequestTest {
         var batch = new IdBatch(1);
         batch.add();
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocateDirect(0);
-
         var callback =
                 new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer.position(0), 1,
+                        Request.Operations.LOOKUP_TRANSFERS.value, null, 1,
                         PacketStatus.TooMuchData.value, 250);
 
         Future<TransferBatch> future = callback.request.getFuture();
@@ -557,12 +549,9 @@ public class AsyncRequestTest {
         var batch = new IdBatch(1);
         batch.add();
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocateDirect(0);
-
         var callback =
                 new CallbackSimulator<AccountBatch>(AsyncRequest.lookupAccounts(client, batch),
-                        Request.Operations.LOOKUP_ACCOUNTS.value, dummyReplyBuffer.position(0), 1,
+                        Request.Operations.LOOKUP_ACCOUNTS.value, null, 1,
                         PacketStatus.InvalidDataSize.value, 100);
 
         Future<AccountBatch> future = callback.request.getFuture();

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -138,7 +138,7 @@ public class BlockingRequestTest {
         assert false;
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void testEndRequestWithNullBuffer() throws RequestException {
 
         var client = NativeClient.initEcho(0, "3000", 1);
@@ -154,8 +154,8 @@ public class BlockingRequestTest {
 
         assertTrue(request.isDone());
 
-        request.waitForResult();
-        assert false;
+        var result = request.waitForResult();
+        assertEquals(0, result.getLength());
     }
 
     @Test(expected = AssertionError.class)
@@ -466,12 +466,9 @@ public class BlockingRequestTest {
         var batch = new IdBatch(1);
         batch.add();
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocateDirect(0);
-
         var callback =
                 new CallbackSimulator<TransferBatch>(BlockingRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer.position(0), 1,
+                        Request.Operations.LOOKUP_TRANSFERS.value, null, 1,
                         PacketStatus.TooMuchData.value, 250);
 
         callback.start();


### PR DESCRIPTION
This PR implements a minor optimization found during #523:

Empty replies (e.g. success) don't need to instantiate a new Java `ByteBuffer`, instead, we can use a null reference to represent zero-length replies on the JVM side.

Rationale: This change avoids allocating unnecessary GCed objects for successful replies.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
