### PR TITLE
LSM: make `tree.compact` asynchronous to caller

### DIFF
--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -577,7 +577,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
         fn compact_ready_next_tick(next_tick: *Grid.NextTick) void {
             const tree = @fieldParentPtr(Tree, "compaction_next_tick", next_tick);
             assert(tree.compaction_io_pending == 0);
-            
+
             const callback = tree.compaction_callback.?;
             tree.compaction_callback = null;
             callback(tree);
@@ -851,7 +851,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 // We are at the end of a half-bar, but the compactions have not finished.
                 // We keep ticking them until they finish.
                 log.debug(tree_name ++ ": compact_done: driving outstanding compactions", .{});
-                tree.compact_drive();
+                tree.grid.on_next_tick(compact_continue_drive_next_tick, &tree.compaction_next_tick);
                 return;
             }
 
@@ -927,6 +927,15 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             // At the end of the second/fourth beat:
             // - Compact the manifest before invoking the compact() callback.
             tree.manifest.compact(compact_manifest_callback);
+        }
+
+        fn compact_continue_drive_next_tick(next_tick: *Grid.NextTick) void {
+            const tree = @fieldParentPtr(Tree, "compaction_next_tick", next_tick);
+            assert(tree.compaction_io_pending == 0);
+            assert(tree.compaction_callback != null);
+            assert(tree.compaction_op == tree.lookup_snapshot_max);
+
+            tree.compact_drive();
         }
 
         /// Called after the last beat of a full compaction bar.


### PR DESCRIPTION
There were certain paths in `tree.compact` which would resolve the given callback or themselves in a recursive manner. This ends up with large stack traces and potentially stack overflow when enough depth occurs. To resolve this, `Grid.on_next_tick` is used to defer calls asynchronously. Next tick became more viable once it no longer required going through a syscall during IO (see #522)

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1222 batches in 157.34 s
    load offered = 1000000 tx/s
    load accepted = 63556 tx/s
    batch latency p00 = 16 ms
    batch latency p10 = 34 ms
    batch latency p20 = 35 ms
    batch latency p30 = 36 ms
    batch latency p40 = 37 ms
    batch latency p50 = 38 ms
    batch latency p60 = 39 ms
    batch latency p70 = 40 ms
    batch latency p80 = 41 ms
    batch latency p90 = 45 ms
    batch latency p100 = 15828 ms
    transfer latency p00 = 16 ms
    transfer latency p10 = 4178 ms
    transfer latency p20 = 12260 ms
    transfer latency p30 = 22013 ms
    transfer latency p40 = 33912 ms
    transfer latency p50 = 48703 ms
    transfer latency p60 = 70527 ms
    transfer latency p70 = 88706 ms
    transfer latency p80 = 109102 ms
    transfer latency p90 = 133390 ms
    transfer latency p100 = 147307 ms
    
    # benchmark results after
    1222 batches in 147.34 s
    load offered = 1000000 tx/s
    load accepted = 67868 tx/s
    batch latency p00 = 14 ms
    batch latency p10 = 34 ms
    batch latency p20 = 35 ms
    batch latency p30 = 36 ms
    batch latency p40 = 37 ms
    batch latency p50 = 38 ms
    batch latency p60 = 39 ms
    batch latency p70 = 40 ms
    batch latency p80 = 41 ms
    batch latency p90 = 45 ms
    batch latency p100 = 11595 ms
    transfer latency p00 = 14 ms
    transfer latency p10 = 4140 ms
    transfer latency p20 = 12473 ms
    transfer latency p30 = 22401 ms
    transfer latency p40 = 34211 ms
    transfer latency p50 = 48949 ms
    transfer latency p60 = 64968 ms
    transfer latency p70 = 86773 ms
    transfer latency p80 = 107607 ms
    transfer latency p90 = 122557 ms
    transfer latency p100 = 137312 ms
    ```
