### PR TITLE
vopr: fix display of percentage probabilities

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -219,9 +219,9 @@ pub fn main() !void {
         cluster_options.storage.write_latency_mean,
         cluster_options.storage.read_fault_probability,
         cluster_options.storage.write_fault_probability,
-        simulator_options.replica_crash_probability * 100,
+        simulator_options.replica_crash_probability,
         simulator_options.replica_crash_stability,
-        simulator_options.replica_restart_probability * 100,
+        simulator_options.replica_restart_probability,
         simulator_options.replica_restart_stability,
     });
 


### PR DESCRIPTION
These two are already percentages, no need to multiply by 100:

```
        assert(options.replica_crash_probability < 100.0);
        assert(options.replica_crash_probability >= 0.0);
        assert(options.replica_restart_probability < 100.0);
        assert(options.replica_restart_probability >= 0.0);
```

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
