### PR TITLE
docs: update docker instructions to use the new --replica-count arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ First provision TigerBeetle's data directory.
 
 ```bash
 $ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle \
-    format --cluster=0 --replica=0 /data/0_0.tigerbeetle
+    format --cluster=0 --replica=0 --replica-count=1 /data/0_0.tigerbeetle
 info(io): creating "0_0.tigerbeetle"...
 info(io): allocating 660.140625MiB...
 ```

--- a/docs/deployment/with-docker.md
+++ b/docs/deployment/with-docker.md
@@ -8,7 +8,7 @@ First provision TigerBeetle's data directory.
 
 ```bash
 $ docker run -v $(pwd)/data:/data ghcr.io/tigerbeetledb/tigerbeetle \
-    format --cluster=0 --replica=0 /data/0_0.tigerbeetle
+    format --cluster=0 --replica=0 --replica-count=1 /data/0_0.tigerbeetle
 info(io): creating "0_0.tigerbeetle"...
 info(io): allocating 660.140625MiB...
 ```


### PR DESCRIPTION
Missed that in the original refactor, as I was grepping for `tigerbeetle format`, and `\` got me.

Thanks for heads up about this Phil!

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
