### PR TITLE
vopr: fix generation for linked transfers.

### DIFF
--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -410,15 +410,20 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                     {
                         // Convert the previous transfer to a single-phase no-limit transfer, but
                         // link it to the current transfer — it will still fail.
-                        _ = self.build_transfer(transfers[i - 1].id, .{
+                        const result_set_opt = self.build_transfer(transfers[i - 1].id, .{
                             .valid = true,
                             .limit = false,
                             .method = .single_phase,
                         }, &transfers[i - 1]);
-                        transfers[i - 1].flags.linked = true;
-                        results[i - 1] = accounting_auditor.CreateTransferResultSet.init(.{
-                            .linked_event_failed = true,
-                        });
+                        if (result_set_opt) |result_set| {
+                            assert(result_set.count() == 1);
+                            assert(result_set.contains(.ok));
+
+                            transfers[i - 1].flags.linked = true;
+                            results[i - 1] = accounting_auditor.CreateTransferResultSet.init(.{
+                                .linked_event_failed = true,
+                            });
+                        }
                     }
                 }
                 assert(results[i].count() > 0);


### PR DESCRIPTION
`_ =` is a bug: `build_transfer` can return a `null` if it failed to create the transfer. If this happens, we don't override the old transfer, and it might fail with some different error (eg, the ledger can be zero or some such).

See the second seed in https://github.com/tigerbeetledb/tigerbeetle/commit/2dda8fd6e7c2ca82350a55230ccd1fb6014140f4 for repro (need a different seed for main)

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
