### PR TITLE
Assert that no additional writes are pending during superblock/forest checkpoints.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -246,6 +246,8 @@ pub fn build(b: *std.build.Builder) void {
 
         const simulator = b.addExecutable("simulator", "src/simulator.zig");
         simulator.setTarget(target);
+        // Ensure that we get stack traces even in release builds.
+        simulator.omit_frame_pointer = false;
         simulator.addOptions("vsr_options", options);
         simulator.addOptions("vsr_simulator_options", simulator_options);
         link_tracer_backend(simulator, tracer_backend, target);

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -194,6 +194,12 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
         }
 
         pub fn checkpoint(forest: *Forest, callback: Callback) void {
+            if (Storage == @import("../testing/storage.zig").Storage) {
+                // We should have finished all pending io before checkpointing.
+                forest.grid.superblock.storage.assert_no_pending_io(.grid);
+                forest.grid.superblock.storage.assert_no_pending_io(.superblock);
+            }
+
             const Join = JoinType(.checkpoint);
             Join.start(forest, callback);
 

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1528,6 +1528,14 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 superblock.queue_head = context;
                 log.debug("{s}: started", .{@tagName(context.caller)});
 
+                if (Storage == @import("../testing/storage.zig").Storage) {
+                    // We should have finished all pending io before starting any more.
+                    superblock.storage.assert_no_pending_io(.superblock);
+                    if (context.caller == .checkpoint) {
+                        superblock.storage.assert_no_pending_io(.grid);
+                    }
+                }
+
                 if (context.caller == .open) {
                     superblock.read_working(context, .open);
                 } else {
@@ -1540,6 +1548,11 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.queue_head == context);
 
             log.debug("{s}: complete", .{@tagName(context.caller)});
+
+            if (Storage == @import("../testing/storage.zig").Storage) {
+                // We should have finished all pending io by now.
+                superblock.storage.assert_no_pending_io(.superblock);
+            }
 
             switch (context.caller) {
                 .format => {},


### PR DESCRIPTION
This reveals that there are sometimes writes pending from superblock.view_change during forest.checkpoint eg `zig build simulator_run -- 11414157658330439066`.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
