### PR TITLE
vsr: standby clocks do not affect the cluster

### DIFF
--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -160,13 +160,9 @@ pub fn ClockType(comptime Time: type) type {
         /// * the remote replica's `realtime()` timestamp `t1`, and
         /// * our monotonic timestamp `m2` as captured by our `Replica.on_pong()` handler.
         pub fn learn(self: *Self, replica: u8, m0: u64, t1: i64, m2: u64) void {
-            if (self.synchronization_disabled) return;
+            assert(replica != self.replica);
 
-            // A network routing fault must have replayed one of our outbound messages back against us:
-            if (replica == self.replica) {
-                log.warn("{}: learn: replica == self.replica", .{self.replica});
-                return;
-            }
+            if (self.synchronization_disabled) return;
 
             // Our m0 and m2 readings should always be monotonically increasing if not equal.
             // Crucially, it is possible for a very fast network to have m0 == m2, especially where


### PR DESCRIPTION
Backstory for implementation: originally I started with adding `standby_count` parameter to the clock, to push the logic of not caring about standbys to the clock itself. But that meant that I need to extend the testing for clocks significantly, as they now have all this extra logic to care about. 

Upon reflection, I find that I can think about the clock as an abstract structure which cares about N time sources, and its up to the call-site to setup those sources as it likes. So I used the trick where active replicas use N sources, sandbys use N+1 source, and standby's repilca_index is remapped to `replica_count`. 

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
