### PR TITLE
[Java Client] Restore tests coverage

### DIFF
--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -36,7 +36,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <!-- JaCoCo thresholds -->
-    <jacoco.unit-tests.limit.instruction-ratio>94%</jacoco.unit-tests.limit.instruction-ratio>
+    <jacoco.unit-tests.limit.instruction-ratio>95%</jacoco.unit-tests.limit.instruction-ratio>
     <jacoco.unit-tests.limit.branch-ratio>90%</jacoco.unit-tests.limit.branch-ratio>
   </properties>
 

--- a/src/clients/java/src/test/java/com/tigerbeetle/AccountTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AccountTest.java
@@ -35,6 +35,16 @@ public class AccountTest {
     }
 
     @Test
+    public void testIdLong() {
+        var accounts = new AccountBatch(1);
+        accounts.add();
+
+        accounts.setId(100);
+        assertEquals(100L, accounts.getId(UInt128.LeastSignificant));
+        assertEquals(0L, accounts.getId(UInt128.MostSignificant));
+    }
+
+    @Test
     public void testIdAsBytes() {
         var accounts = new AccountBatch(1);
         accounts.add();
@@ -62,6 +72,16 @@ public class AccountTest {
         var id = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
         accounts.setId(id);
         assert false;
+    }
+
+    @Test
+    public void testUserDataLong() {
+        var accounts = new AccountBatch(2);
+        accounts.add();
+
+        accounts.setUserData(100);
+        assertEquals(100L, accounts.getUserData(UInt128.LeastSignificant));
+        assertEquals(0L, accounts.getUserData(UInt128.MostSignificant));
     }
 
     @Test

--- a/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
@@ -498,6 +498,18 @@ public class BatchTest {
         assertFalse(batch.next());
     }
 
+    @Test
+    public void testWriteCreateAccountResults() {
+        var batch = new CreateAccountResultBatch(1);
+        batch.add();
+
+        batch.setIndex(1);
+        assertEquals(1, batch.getIndex());
+
+        batch.setResult(createAccountResult1);
+        assertEquals(createAccountResult1, batch.getResult());
+    }
+
     @Test(expected = AssertionError.class)
     public void testInvalidCreateAccountResultsBuffer() {
 
@@ -527,6 +539,18 @@ public class BatchTest {
         assertEquals(createTransferResult2, batch.getResult());
 
         assertFalse(batch.next());
+    }
+
+    @Test
+    public void testWriteCreateTransferResults() {
+        var batch = new CreateTransferResultBatch(1);
+        batch.add();
+
+        batch.setIndex(1);
+        assertEquals(1, batch.getIndex());
+
+        batch.setResult(createTransferResult1);
+        assertEquals(createTransferResult1, batch.getResult());
     }
 
     @Test(expected = AssertionError.class)
@@ -658,6 +682,14 @@ public class BatchTest {
         batch.add();
         batch.setId(null);
         assert false;
+    }
+
+    @Test
+    public void testLongIds() {
+        var batch = new IdBatch(1);
+        batch.add(100L);
+        assertEquals(100L, batch.getId(UInt128.LeastSignificant));
+        assertEquals(0L, batch.getId(UInt128.MostSignificant));
     }
 
     private static void setAccount(AccountBatch batch, DummyAccountDto account) {

--- a/src/clients/java/src/test/java/com/tigerbeetle/TransferTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/TransferTest.java
@@ -40,6 +40,16 @@ public class TransferTest {
     }
 
     @Test
+    public void testIdLong() {
+        var transfers = new TransferBatch(1);
+        transfers.add();
+
+        transfers.setId(100);
+        assertEquals(100L, transfers.getId(UInt128.LeastSignificant));
+        assertEquals(0L, transfers.getId(UInt128.MostSignificant));
+    }
+
+    @Test
     public void testIdAsBytes() {
         var transfers = new TransferBatch(1);
         transfers.add();
@@ -78,6 +88,16 @@ public class TransferTest {
         transfers.setDebitAccountId(100, 200);
         assertEquals(100L, transfers.getDebitAccountId(UInt128.LeastSignificant));
         assertEquals(200L, transfers.getDebitAccountId(UInt128.MostSignificant));
+    }
+
+    @Test
+    public void testDebitAccountIdLong() {
+        var transfers = new TransferBatch(1);
+        transfers.add();
+
+        transfers.setDebitAccountId(100);
+        assertEquals(100L, transfers.getDebitAccountId(UInt128.LeastSignificant));
+        assertEquals(0L, transfers.getDebitAccountId(UInt128.MostSignificant));
     }
 
     @Test
@@ -122,6 +142,16 @@ public class TransferTest {
     }
 
     @Test
+    public void testCreditAccountIdLong() {
+        var transfers = new TransferBatch(1);
+        transfers.add();
+
+        transfers.setCreditAccountId(100);
+        assertEquals(100L, transfers.getCreditAccountId(UInt128.LeastSignificant));
+        assertEquals(0L, transfers.getCreditAccountId(UInt128.MostSignificant));
+    }
+
+    @Test
     public void testCreditAccountIdAsBytes() {
         var transfers = new TransferBatch(1);
         transfers.add();
@@ -160,6 +190,16 @@ public class TransferTest {
         transfers.setUserData(100, 200);
         assertEquals(100L, transfers.getUserData(UInt128.LeastSignificant));
         assertEquals(200L, transfers.getUserData(UInt128.MostSignificant));
+    }
+
+    @Test
+    public void testUserDataLong() {
+        var transfers = new TransferBatch(1);
+        transfers.add();
+
+        transfers.setUserData(100);
+        assertEquals(100L, transfers.getUserData(UInt128.LeastSignificant));
+        assertEquals(0L, transfers.getUserData(UInt128.MostSignificant));
     }
 
     @Test
@@ -204,6 +244,16 @@ public class TransferTest {
     }
 
     @Test
+    public void testReservedLong() {
+        var transfers = new TransferBatch(1);
+        transfers.add();
+
+        transfers.setReserved(100);
+        assertEquals(100L, transfers.getReserved(UInt128.LeastSignificant));
+        assertEquals(0L, transfers.getReserved(UInt128.MostSignificant));
+    }
+
+    @Test
     public void testReservedAsBytes() {
         var transfers = new TransferBatch(1);
         transfers.add();
@@ -242,6 +292,16 @@ public class TransferTest {
         transfers.setPendingId(100, 200);
         assertEquals(100L, transfers.getPendingId(UInt128.LeastSignificant));
         assertEquals(200L, transfers.getPendingId(UInt128.MostSignificant));
+    }
+
+    @Test
+    public void testPendingIdLong() {
+        var transfers = new TransferBatch(1);
+        transfers.add();
+
+        transfers.setPendingId(100);
+        assertEquals(100L, transfers.getPendingId(UInt128.LeastSignificant));
+        assertEquals(0L, transfers.getPendingId(UInt128.MostSignificant));
     }
 
     @Test


### PR DESCRIPTION
Restores the test coverage threshold to 95%.

- It was reduced to 94% in https://github.com/tigerbeetledb/tigerbeetle/commit/2ac3fc474f45a32e80d8632760bf2f927110b8cd
 - Our actual test coverage after this PR is at 98%

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.