### PR TITLE
LSM: `TableMutable` benchmark

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -371,6 +371,11 @@ pub fn build(b: *std.build.Builder) void {
             .file = "src/lsm/segmented_array_benchmark.zig",
             .description = "SegmentedArray search",
         },
+        .{
+            .name = "benchmark_table_mutable",
+            .file = "src/lsm/table_mutable_benchmark.zig",
+            .description = "TableMutable insert, lookup, and sorting",
+        },
     }) |benchmark| {
         const exe = b.addExecutable(benchmark.name, benchmark.file);
         exe.setTarget(target);

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -66,10 +66,7 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
         // The value type will be []u8 and this will be shared by trees with the same value size."
         values_cache: ?*ValuesCache,
 
-        pub fn init(
-            allocator: mem.Allocator,
-            values_cache: ?*ValuesCache,
-        ) !TableMutable {
+        pub fn init(allocator: mem.Allocator, values_cache: ?*ValuesCache) !TableMutable {
             var values: Values = .{};
             try values.ensureTotalCapacity(allocator, value_count_max);
             errdefer values.deinit(allocator);

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -66,7 +66,10 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
         // The value type will be []u8 and this will be shared by trees with the same value size."
         values_cache: ?*ValuesCache,
 
-        pub fn init(allocator: mem.Allocator, values_cache: ?*ValuesCache) !TableMutable {
+        pub fn init(
+            allocator: mem.Allocator,
+            values_cache: ?*ValuesCache,
+        ) !TableMutable {
             var values: Values = .{};
             try values.ensureTotalCapacity(allocator, value_count_max);
             errdefer values.deinit(allocator);
@@ -196,6 +199,332 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
 
         fn sort_values_by_key_in_ascending_order(_: void, a: Value, b: Value) bool {
             return compare_keys(key_from_value(&a), key_from_value(&b)) == .lt;
+        }
+    };
+}
+
+pub fn TableMutableTreeType(comptime Table: type, comptime tree_name: [:0]const u8) type {
+    const Key = Table.Key;
+    const Value = Table.Value;
+    const compare_keys = Table.compare_keys;
+    const key_from_value = Table.key_from_value;
+    const tombstone_from_key = Table.tombstone_from_key;
+    const tombstone = Table.tombstone;
+    const value_count_max = Table.value_count_max;
+    const usage = Table.usage;
+
+    return struct {
+        const TableMutable = @This();
+        const AATree = AATreeType(Key, Value, key_from_value, compare_keys);
+
+        pub const ValuesCache = SetAssociativeCache(
+            Key,
+            Value,
+            Table.key_from_value,
+            struct {
+                inline fn hash(key: Key) u64 {
+                    return std.hash.Wyhash.hash(0, mem.asBytes(&key));
+                }
+            }.hash,
+            struct {
+                inline fn equal(a: Key, b: Key) bool {
+                    return compare_keys(a, b) == .eq;
+                }
+            }.equal,
+            .{},
+            tree_name,
+        );
+
+        /// Rather than using values.count(), we count how many values we could have had if every
+        /// operation had been on a different key. This means that mistakes in calculating
+        /// value_count_max are much easier to catch when fuzzing, rather than requiring very
+        /// specific workloads.
+        /// Invariant: value_count_worst_case <= value_count_max
+        value_count_worst_case: u32 = 0,
+
+        /// This is used to accelerate point lookups and is not used for range queries.
+        /// Secondary index trees used only for range queries can therefore set this to null.
+        ///
+        /// The values cache is only used for the latest snapshot for simplicity.
+        /// Earlier snapshots will still be able to utilize the block cache.
+        ///
+        /// The values cache is updated (in bulk) when the mutable table is sorted and frozen,
+        /// rather than updating on every `put()`/`remove()`.
+        /// This amortizes cache inserts for hot keys in the mutable table, and avoids redundantly
+        /// storing duplicate values in both the mutable table and values cache.
+        // TODO Share cache between trees of different grooves:
+        // "A set associative cache of values shared by trees with the same key/value sizes.
+        // The value type will be []u8 and this will be shared by trees with the same value size."
+        values_cache: ?*ValuesCache,
+
+        /// Self-balancing binary search tree optimized for searching & inserting only.
+        values_tree: AATree,
+
+        pub fn init(allocator: mem.Allocator, values_cache: ?*ValuesCache) !TableMutable {
+            var values_tree = try AATree.init(allocator, @intCast(u32, value_count_max));
+            errdefer values_tree.deinit(allocator);
+
+            return TableMutable{
+                .values_cache = values_cache,
+                .values_tree = values_tree,
+            };
+        }
+
+        pub fn deinit(table: *TableMutable, allocator: mem.Allocator) void {
+            table.values_tree.deinit(allocator);
+        }
+
+        pub fn get(table: *const TableMutable, key: Key) ?*const Value {
+            if (table.values_tree.get(key)) |value| {
+                return value;
+            }
+
+            if (table.values_cache) |cache| {
+                // Check the cache after the mutable table (see `values_cache` for explanation).
+                if (cache.get(key)) |value| return value;
+            }
+
+            return null;
+        }
+
+        pub fn put(table: *TableMutable, value: *const Value) void {
+            assert(table.value_count_worst_case < value_count_max);
+            table.value_count_worst_case += 1;
+
+            const key = key_from_value(value);
+            const entry = table.values_tree.get_or_put(key);
+            switch (usage) {
+                .secondary_index => {
+                    if (entry.exists) {
+                        // If there was a previous operation on this key then it must have been a
+                        // remove. The put and remove cancel out.
+                        assert(tombstone(entry.value));
+                    } else {
+                        entry.value.* = value.*;
+                    }
+                },
+                .general => {
+                    // Make sure to overwrite the old value if it exists.
+                    entry.value.* = value.*;
+                },
+            }
+
+            assert(table.values_tree.count() <= value_count_max);
+        }
+
+        pub fn remove(table: *TableMutable, value: *const Value) void {
+            assert(table.value_count_worst_case < value_count_max);
+            table.value_count_worst_case += 1;
+
+            const key = key_from_value(value);
+            const entry = table.values_tree.get_or_put(key);
+            switch (usage) {
+                .secondary_index => {
+                    if (entry.exists) {
+                        // The previous operation on this key then it must have been a put.
+                        // The put and remove cancel out.
+                        assert(!tombstone(entry.value));
+                    } else {
+                        // If the put is already on-disk, we need to follow it with a tombstone.
+                        // The put and tombstone may cancel each other out later during compaction.
+                        entry.value.* = tombstone_from_key(key);
+                    }
+                },
+                .general => {
+                    // Make sure to overwrite the old value if it exists.
+                    entry.value.* = tombstone_from_key(key);
+                },
+            }
+
+            assert(table.values_tree.count() <= value_count_max);
+        }
+
+        pub fn clear(table: *TableMutable) void {
+            assert(table.count() > 0);
+            table.value_count_worst_case = 0;
+            table.values_tree.clear();
+            assert(table.values_tree.count() == 0);
+        }
+
+        pub fn count(table: *const TableMutable) u32 {
+            const value_count = table.values_tree.count();
+            assert(value_count <= value_count_max);
+            return value_count;
+        }
+
+        /// The returned slice is invalidated whenever this is called for any tree.
+        pub fn sort_into_values_and_clear(
+            table: *TableMutable,
+            values_max: []Value,
+        ) []const Value {
+            assert(table.count() > 0);
+            assert(table.count() <= value_count_max);
+            assert(table.count() <= values_max.len);
+            assert(values_max.len == value_count_max);
+
+            const values = table.values_tree.sort_into(values_max);
+            assert(values.len == table.count());
+
+            table.clear();
+            assert(table.count() == 0);
+
+            return values;
+        }
+    };
+}
+
+fn AATreeType(
+    comptime Key: type,
+    comptime Value: type,
+    comptime key_from_value: fn (value: *const Value) callconv(.Inline) Key,
+    comptime compare_keys: fn (key: Key, key: Key) callconv(.Inline) math.Order,
+) type {
+    const AAList = std.MultiArrayList(struct {
+        value: Value,
+        links: [2]u32,
+        stack: u32,
+        level: u8,
+    });
+
+    return struct {
+        const AATree = @This();
+
+        list: AAList,
+        root: u32 = 0,
+
+        pub fn init(allocator: mem.Allocator, max_entries: u32) !AATree {
+            var list = AAList{};
+            try list.ensureTotalCapacity(allocator, max_entries);
+            errdefer list.deinit(allocator);
+
+            return AATree{ .list = list };
+        }
+
+        pub fn deinit(tree: *AATree, allocator: mem.Allocator) void {
+            tree.list.deinit(allocator);
+        }
+
+        pub fn count(tree: *const AATree) u32 {
+            return @intCast(u32, tree.list.len);
+        }
+
+        pub fn clear(tree: *AATree) void {
+            tree.list.shrinkRetainingCapacity(0);
+            tree.root = 0;
+        }
+
+        pub fn get(tree: *const AATree, key: Key) ?*const Value {
+            var index = tree.root;
+            const slice = tree.list.slice();
+            while (true) {
+                const slot = std.math.sub(u32, index, 1) catch return null;
+                const value = &slice.items(.value)[slot];
+                const cmp = compare_keys(key, key_from_value(value));
+                if (cmp == .eq) return value;
+                index = slice.items(.links)[slot][@boolToInt(cmp == .gt)];
+            }
+        }
+
+        pub const AAEntry = struct {
+            value: *Value,
+            exists: bool,
+        };
+
+        pub fn get_or_put(tree: *AATree, key: Key) AAEntry {
+            var entry: AAEntry = undefined;
+            tree.root = tree.insert(tree.root, &key, &entry);
+            return entry;
+        }
+
+        fn insert(tree: *AATree, index: u32, key: *const Key, entry: *AAEntry) u32 {
+            const slot = std.math.sub(u32, index, 1) catch {
+                const new_slot = @intCast(u32, tree.list.addOneAssumeCapacity());
+                const slice = tree.list.slice();
+
+                slice.items(.links)[new_slot] = .{0, 0};
+                slice.items(.level)[new_slot] = 1;
+
+                entry.value = &slice.items(.value)[new_slot];
+                entry.exists = false;
+                return new_slot + 1;
+            };
+
+            const slice = tree.list.slice();
+            entry.value = &slice.items(.value)[slot];
+
+            const cmp = compare_keys(key.*, key_from_value(entry.value));
+            entry.exists = cmp == .eq;
+            if (entry.exists) return index;
+
+            const link = &slice.items(.links)[slot][@boolToInt(cmp == .gt)];
+            link.* = tree.insert(link.*, key, entry);
+            return tree.split(tree.skew(index));
+        }
+
+        fn skew(tree: *const AATree, index: u32) u32 {
+            const slot = std.math.sub(u32, index, 1) catch unreachable;
+            const slice = tree.list.slice();
+
+            const left_link = &slice.items(.links)[slot][0];
+            const left_index = left_link.*;
+            const left_slot = std.math.sub(u32, left_index, 1) catch return index;
+            if (slice.items(.level)[left_slot] != slice.items(.level)[slot]) return index;
+
+            left_link.* = index;
+            mem.swap(u32, left_link, &slice.items(.links)[left_slot][1]);
+            return left_index;
+        }
+
+        fn split(tree: *const AATree, index: u32) u32 {
+            const slot = std.math.sub(u32, index, 1) catch unreachable;
+            const slice = tree.list.slice();
+
+            const right_link = &slice.items(.links)[slot][1];
+            const right_index = right_link.*;
+            const right_slot = std.math.sub(u32, right_index, 1) catch return index;
+
+            const rr_index = slice.items(.links)[right_slot][1];
+            const rr_slot = std.math.sub(u32, rr_index, 1) catch return index;
+            if (slice.items(.level)[rr_slot] != slice.items(.level)[slot]) return index;
+
+            right_link.* = index;
+            mem.swap(u32, right_link, &slice.items(.links)[right_slot][0]);
+            slice.items(.level)[right_slot] += 1;
+            return right_index;
+        }
+
+        pub fn sort_into(tree: *const AATree, values: []Value) []const Value {
+            const slice = tree.list.slice();
+            assert(slice.len <= values.len);
+
+            var top: u32 = 0;
+            var index: u32 = 0;
+            var current = tree.root;
+
+            while (true) {
+                while (std.math.sub(u32, current, 1) catch null) |slot| {
+                    slice.items(.stack)[top] = slot;
+                    top += 1;
+                    current = slice.items(.links)[slot][0];
+                }
+
+                top = std.math.sub(u32, top, 1) catch {
+                    assert(index == tree.count());
+                    return values[0..index];
+                };
+
+                const slot = slice.items(.stack)[top];
+                current = slice.items(.links)[slot][1];
+
+                const value = &slice.items(.value)[slot];
+                values[index] = value.*;
+                defer index += 1;
+
+                if (std.math.sub(u32, index, 1) catch null) |prev_index| {
+                    const prev_key = key_from_value(&values[prev_index]);
+                    assert(compare_keys(prev_key, key_from_value(value)) != .gt);
+                }
+            }
         }
     };
 }

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -378,15 +378,16 @@ pub fn HashMapSlotSortTreeType(comptime Table: type) type {
                     }
                 };
 
-                it.keys = it.tree.map.keyIterator();
-                const context = SortContext{ .values = it.keys.items };
-                const slots = it.tree.slots.items;
-                std.sort.sort(u32, slots, context, SortContext.less_than);
-
                 assert(it.add == it.tree.count());
+                it.keys = it.tree.map.keyIterator();
+
+                const slots = it.tree.slots.items;
+                const context = SortContext{ .values = it.keys.items };
+                std.sort.sort(u32, slots, context, SortContext.less_than);
+                for (slots) |slot, i| it.values_max[i] = context.values[slot];
+
                 it.tree.clear();
                 assert(it.tree.count() == 0);
-
                 return null;
             }
         };

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -633,7 +633,7 @@ pub fn SlotMapTreeType(comptime Table: type) type {
             }
         };
 
-        const load_factor = 50;
+        const load_factor = 90;
         const SlotMap = std.HashMapUnmanaged(u32, void, SlotMapContext, load_factor);
 
         slots: SlotMap,

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -2,429 +2,194 @@ const std = @import("std");
 const mem = std.mem;
 const assert = std.debug.assert;
 
+const vsr = @import("../vsr.zig");
 const constants = @import("../constants.zig");
 const SetAssociativeCache = @import("set_associative_cache.zig").SetAssociativeCache;
 
-const TableType = @import("table.zig").TableType;
-const TableUsage = @import("table.zig").TableUsage;
-const TableMutableType = @import("table_mutable.zig").TableMutableType;
+const Key = packed struct {
+    id: u64 align(@alignOf(u64)),
+
+    const Value = packed struct {
+        id: u64,
+        value: u63,
+        tombstone: u1 = 0,
+    };
+
+    inline fn compare_keys(a: Key, b: Key) std.math.Order {
+        return std.math.order(a.id, b.id);
+    }
+
+    inline fn key_from_value(value: *const Key.Value) Key {
+        return Key{ .id = value.id };
+    }
+
+    const sentinel_key = Key{
+        .id = std.math.maxInt(u64),
+    };
+
+    inline fn tombstone(value: *const Key.Value) bool {
+        return value.tombstone != 0;
+    }
+
+    inline fn tombstone_from_key(key: Key) Key.Value {
+        return Key.Value{
+            .id = key.id,
+            .value = 0,
+            .tombstone = 1,
+        };
+    }
+};
+
+const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
+const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
+const value_count_max = constants.lsm_batch_multiple * commit_entries_max;
+
+const Table = @import("table.zig").TableType(
+    Key,
+    Key.Value,
+    Key.compare_keys,
+    Key.key_from_value,
+    Key.sentinel_key,
+    Key.tombstone,
+    Key.tombstone_from_key,
+    value_count_max,
+    .general,
+);
 
 pub fn main() !void {
+    var prng = std.rand.DefaultPrng.init(42);
+    const random = prng.random();
 
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const sorted_values = try allocator.alloc(Key.Value, value_count_max);
+    defer allocator.free(sorted_values);
+
+    const values = try allocator.alloc(Key.Value, value_count_max);
+    defer allocator.free(values);
+
+    var random_id = random.uintLessThanBiased(u64, values.len);
+    for (values) |_| {
+        assert(random_id < values.len);
+        values[random_id] = .{
+            .id = random_id,
+            .value = random.int(u63),
+        };
+
+        random_id += values.len - 1;
+        if (random_id >= values.len) random_id -= values.len;
+    }
+
+    var timer = try std.time.Timer.start();
+    const rng_seed = random.int(u64);
+
+    inline for (.{
+        .{ "std.HashMap", @import("table_mutable.zig").TableMutableType(Table, "") },
+        .{ "AA-Tree", @import("table_mutable.zig").TableMutableTreeType(Table, "") },
+    }) |setup| {
+        try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
+    }
 }
 
+fn bench(
+    comptime TableMutable: type,
+    comptime table_mutable_name: []const u8, 
+    allocator: mem.Allocator,
+    values: []const Key.Value,
+    sorted_values: []Key.Value,
+    timer: *std.time.Timer,
+    rng_seed: u64,
+) !void {
+    const stdout = std.io.getStdOut().writer();
+    const separator = "-" ** 54;
 
+    try stdout.print("{s}\n{s:^53}|\n" ++ ("{s:>7} |" ** 6) ++ "\n{s}\n", .{
+        separator,
+        "TableMutable(" ++ table_mutable_name ++ ")",
+        "size",
+        "put",
+        "get",
+        "miss",
+        "sort",
+        "total",
+        separator,
+    });
 
-fn TableMutableHeapType(comptime Table: type, comptime tree_name: [:0]const u8) type {
-    const Key = Table.Key;
-    const Value = Table.Value;
-    const compare_keys = Table.compare_keys;
-    const key_from_value = Table.key_from_value;
-    const tombstone_from_key = Table.tombstone_from_key;
-    const tombstone = Table.tombstone;
-    const value_count_max = Table.value_count_max;
-    const usage = Table.usage;
+    var table_mutable = try TableMutable.init(allocator, null);
+    defer table_mutable.deinit(allocator);
 
-    const AVLTree = struct {
-        const AVLNode = struct {
-            parent: u32,
-            balance: i32,
-            links: [2]u32,
-        };
+    var prng = std.rand.DefaultPrng.init(rng_seed);
+    const random = prng.random();
 
-        const max_entries = value_count_max;
-        const buffer_size = comptime blk: {
-            assert(@alignOf(Value) >= @alignOf(AVLNode));
-            break :blk (@sizeOf(Value) * max_entries) + (@sizeOf(AVLNode) * max_entries);
-        };
+    var count_max = std.math.min(1024, value_count_max);
+    while (count_max <= value_count_max) {
+        var put_elapsed: u64 = 0;
+        var get_elapsed: u64 = 0;
+        var miss_elapsed: u64 = 0;
+        var sort_elapsed: u64 = 0;
 
-        
-        const AVLBuffer = struct {
-            bytes: [buffer_size]u8 align(@alignOf(Value)) = undefined,
+        assert(table_mutable.count() == 0);
+        for (values[0..count_max]) |*value, index| {
+            assert(value.id == index);
 
-            inline fn at(buffer: *AVLBuffer, comptime Type: type, index: u32) *Type {
-                comptime assert(Type == AVLNode or Type == Value);
-                const offset = @sizeOf(Value) * @boolToInt(Type != Value);
-                const ptr = &buffer.bytes[offset + (index * @sizeOf(Type))];
-                return @ptrCast(*Type, @alignCast(@alignOf(Type), ptr));
-            }
-        };
+            // Insert the value into TableMutable.
+            const put_start = timer.read();
+            table_mutable.put(value);
+            put_elapsed += timer.read() - put_start;
 
-        buffer: *AVLBuffer,
-        count: u32 = 0,
-        root: u32 = 0,
+            // Fetch a random, previously inserted, value from TableMutable.
+            const get_index = random.uintAtMostBiased(usize, index);
+            const get_start = timer.read();
+            const get_result = table_mutable.get(.{ .id = get_index }).?;
+            get_elapsed += timer.read() - get_start;
+            assert(mem.eql(u8, mem.asBytes(get_result), mem.asBytes(&values[get_index])));
 
-        pub fn init(allocator: mem.Allocator) !AVLTree {
-            const buffer = try allocator.create(AVLBuffer);
-            errdefer allocator.destroy(buffer);
-
-            return AVLTree{ .buffer = buffer };
+            // Fetch a random value that we know will not be in TableMutable.
+            const miss_range = index + 1;
+            if (miss_range >= count_max) continue;
+            const miss_index = random.intRangeLessThanBiased(usize, miss_range, count_max);
+            const miss_start = timer.read();
+            const miss_result = table_mutable.get(.{ .id = miss_index });
+            miss_elapsed += timer.read() - miss_start;
+            assert(miss_result == null);
         }
 
-        pub fn deinit(tree: *AVLTree, allocator: mem.Allocator) void {
-            allocator.destroy(tree.buffer);
+        const sort_start = timer.read();
+        const sorted = table_mutable.sort_into_values_and_clear(sorted_values);
+        sort_elapsed = timer.read() - sort_start;
+
+        for (sorted) |*value, i| {
+            const prev = std.math.sub(usize, i, 1) catch continue;
+            const prev_key = Table.key_from_value(&sorted[prev]);
+            const key = Table.key_from_value(value);
+            assert(Table.compare_keys(prev_key, key) != .gt);
         }
 
-        /// A packed representation of the found entry for a given key.
-        /// If the first bit is set, the following bits encode the found slot for the Value.
-        /// If the first bit is NOT set, the following bit encodes if the slot is to the right of
-        /// the parent and the remaining bits encode the parent slot + 1 (or 0 if parent == root).
-        const AVLEntry = u32;
-        
-        pub fn search(tree: *const AVLTree, key: Key) AVLEntry {
-            var index = tree.root;
-            var parent_link: u31 = 0;
-            while (index <= tree.count) {
-                const entry = index - 1;
-                const cmp = compare_keys(key, key_from_value(tree.buffer.at(Value, entry)));
-                if (cmp == .eq) return (entry << 1) | 1;
-
-                const right = cmp == .gt;
-                parent_link = (@as(u31, @intCast(u30, index)) << 1) | @boolToInt(right);
-                index = tree.buffer.at(AVLNode, entry).links[@boolToInt(right)];
-            }
-            return @as(u32, parent_link) << 1;
-        }
-
-        pub fn slot(tree: *const AVLTree, entry: AVLEntry) ?*const Value {
-            if (entry & 1 == 0) return null;
-            return tree.buffer.at(Value, entry >> 1);
-        }
-
-        pub fn insert(tree: *AVLTree, entry: AVLEntry, new_value: *const Value) void {
-            switch (@truncate(u1, entry)) {
-                0 => tree.insert_no_clobber(entry, new_value),
-                1 => tree.buffer.at(Value, entry >> 1).* = new_value.*,
-            }
-        }
-
-        pub fn insert_no_clobber(tree: *AVLTree, entry: AVLEntry, new_value: *const Value) void {
-            // Extract the entry items.
-            assert(entry & 1 == 0);
-            var right = entry & 2 != 0;
-            var parent_entry = entry >> 2;
-
-            // Reserve a new slot for the new AVLNode and Value in tree.buffer.
-            var slot = tree.count;
-            assert(slot < max_entries);
-            tree.count += 1;
-
-            tree.buffer.at(Value, slot).* = new_value;
-            tree.buffer.at(AVLNode, slot).* = .{
-                .parent = parent_entry,
-                .balance = 0,
-                .links = [_]u32{ 0, 0 },
-            };
-
-            // Get the parent AVLNode (or insert into root if none).
-            var slot_entry = slot + 1;
-            var parent_slot = std.math.sub(u32, parent_entry, 1) catch {
-                assert(tree.root == 0);
-                tree.root = slot_entry;
-                return;
-            };
-
-            // Link the parent AVLNode to our new AVLNode.
-            var parent_node = tree.buffer.at(AVLNode, parent_slot);
-            const parent_link = &parent_node.links[@boolToInt(right)];
-            assert(parent_link.* == 0);
-            parent_link.* = slot_entry;
-            
-            // Update the balance factors for all the nodes starting from our new one up to parent.
-            const scale = [_]i32{ -1, 1 };
-            while (true) {
-                // Update and check if the parent is balanced.
-                const balance = parent.balance + scale[@boolToInt(right)];
-                parent_node.balance = balance;
-                if (balance == 0) return;
-
-                // Try to balance the parent's children.
-                const signed = balance < 0;
-                if (std.math.absInt(balance) > 1) {
-                    const child_slot = parent_node.links[@boolToInt(signed)] - 1;
-                    const child_balance = tree.buffer.at(AVLNode, child_slot).balance;
-                    if (child_balance === scale[@bool(signed)]) {
-                        _ = tree.rotate(child_slot, signed);
-                    }
-
-                    const new_root = tree.rotate(parent_slot, !signed);
-                    if (tree.root == parent_entry) tree.root = parent_entry;
-                    break;
-                }
-
-                // Inspect the next parent.
-                slot_entry = parent_entry;
-                parent_entry = parent_node.parent;
-                parent_slot = std.math.sub(u32, parent_entry, 1) catch break;
-                parent = tree.buffer.at(AVLNode, parent_slot);
-                right = parent.links[1] == slot_entry;
-                assert(parent.links[@boolToInt(right)] == slot_entry);
+        try stdout.print("{d:>7} |", .{count_max});
+        for ([_]u64{
+            put_elapsed,
+            get_elapsed,
+            miss_elapsed,
+            sort_elapsed,
+            put_elapsed + get_elapsed + miss_elapsed + sort_elapsed,
+        }) |ns| {
+            if (ns < std.time.ns_per_us) {
+                try stdout.print("{d:>5}ns |", .{ns});
+            } else if (ns < std.time.ns_per_ms) {
+                try stdout.print("{d:>5}us |", .{ns / std.time.ns_per_us});
+            } else if (ns < std.time.ns_per_s) {
+                try stdout.print("{d:>5}ms |", .{ns / std.time.ns_per_ms});
+            } else {
+                try stdout.print("{d:>6.2}s |", .{@intToFloat(f64, ns) / std.time.ns_per_s});
             }
         }
+        try stdout.print("\n", .{});
 
-        // Branchless version of this: https://github.com/w8r/avl/blob/master/src/index.js#L34-L97    
-        fn rotate(tree: *AVLTree, slot: u32, right: bool) u32 {
-            assert(slot < tree.count);
-            const entry = slot + 1;
-            const node = tree.buffer.at(AVLNode, slot);
+        if (count_max == value_count_max) break;
+        count_max = std.math.min(count_max * 2, value_count_max);
+    }
 
-            const target_link = &node.links[@boolToInt(!right)];
-            const target_entry = target_link.*;
-            const target_slot = target_entry - 1;
-            const target = tree.buffer.at(AVLNode, target_slot);
-
-            const other_link = &target.links[@boolToInt(right)];;
-            const other_entry = other_link.*;
-            target_link.* = other_entry;
-            if (std.math.sub(u32, other_entry, 1) catch null) |other_slot| {
-                tree.buffer.at(AVLNode, other_slot).parent = entry;
-            }
-
-            const parent_entry = node.parent;
-            target.parent = parent_entry;
-            if (std.math.sub(u32, parent_entry, 1) catch null) |parent_slot| {
-                const parent = tree.buffer.at(AVLNode, parent_slot);
-                const parent_link = parent.links[@boolToInt(parent.links[1] == entry)];
-                assert(parent_link.* == entry);
-                parent_link.* = target_entry;
-            }
-
-            const scale = ([_]i32{ 1, -1 })[@boolToInt(right)];
-            node.parent = target_entry;
-            other_link.* = entry;
-
-            node.balance += scale;
-            if (target.balance != 0 and (target.balance > 0 == right)) {
-                node.balance -= target.balance;
-            }
-
-            target.balance += scale;
-            if (node.balance != 0 and (node.balance < 0 == right)) {
-                target.balance += node.balance;
-            }
-
-            return target_slot;
-        }
-
-        pub fn clear(tree: *AVLTree) void {
-            assert(tree.count <= max_entries);
-            tree.count = 0;
-        }
-
-        pub fn iterator(tree: *const AVLTree) Iterator {
-            var it = Iterator{ .tree = tree };
-            it.stack[0] = tree.root;
-            it.top = @boolToInt(tree.root > 0);
-            return it;
-        }
-
-        pub const Iterator = struct {
-            tree: *const AVLTree,
-            top: u32 = 0,
-            stack: [32]u32 = undefined,
-
-            pub fn next(it: *Iterator) ?*const Value {
-                it.top = std.math.sub(u32, it.top, 1) catch return null;
-
-                // Push all the left-side nodes to the stack.
-                var entry = it.stack[it.top];
-                while (std.math.sub(u32, entry, 1) catch null) |slot| {
-                    assert(it.top < it.stack.len);
-                    it.stack[it.top] = entry;
-                    it.top += 1;
-                    entry = it.tree.buffer.at(AVLNode, slot).links[0];
-                }
-
-                // Pop the top of the stack to get left-most node.
-                it.top -= 1;
-                const stack_slot = &it.stack[it.top];
-                const slot = stack_slot.* - 1;
-
-                // Push the right (if any) of the left-mode node to the stack.
-                entry = it.tree.buffer.at(AVLNode, slot).links[1];
-                stack_slot.* = entry;
-                it.top += @boolToInt(entry > 0);
-
-                return it.tree.buffer.at(Value, slot);
-            }
-        };
-    };
-
-    return struct {
-        const TableMutable = @This();
-
-        pub const ValuesCache = SetAssociativeCache(
-            Key,
-            Value,
-            Table.key_from_value,
-            struct {
-                inline fn hash(key: Key) u64 {
-                    return std.hash.Wyhash.hash(0, mem.asBytes(&key));
-                }
-            }.hash,
-            struct {
-                inline fn equal(a: Key, b: Key) bool {
-                    return compare_keys(a, b) == .eq;
-                }
-            }.equal,
-            .{},
-            tree_name,
-        );
-
-        /// Rather than using values.count(), we count how many values we could have had if every
-        /// operation had been on a different key. This means that mistakes in calculating
-        /// value_count_max are much easier to catch when fuzzing, rather than requiring very
-        /// specific workloads.
-        /// Invariant: value_count_worst_case <= value_count_max
-        value_count_worst_case: u32 = 0,
-
-        /// This is used to accelerate point lookups and is not used for range queries.
-        /// Secondary index trees used only for range queries can therefore set this to null.
-        ///
-        /// The values cache is only used for the latest snapshot for simplicity.
-        /// Earlier snapshots will still be able to utilize the block cache.
-        ///
-        /// The values cache is updated (in bulk) when the mutable table is sorted and frozen,
-        /// rather than updating on every `put()`/`remove()`.
-        /// This amortizes cache inserts for hot keys in the mutable table, and avoids redundantly
-        /// storing duplicate values in both the mutable table and values cache.
-        // TODO Share cache between trees of different grooves:
-        // "A set associative cache of values shared by trees with the same key/value sizes.
-        // The value type will be []u8 and this will be shared by trees with the same value size."
-        values_cache: ?*ValuesCache,
-
-        /// Self-balancing binary search tree optimized for searching & inserting only.
-        values_tree: AVLTree,
-
-        pub fn init(allocator: mem.Allocator, values_cache: ?*ValuesCache) !TableMutable {
-            var values_tree = try AVLTree.init(allocator);
-            errdefer values_tree.deinit(allocator);
-
-            return TableMutable{
-                .values_cache = values_cache,
-                .values_tree = values_tree,
-            };
-        }
-
-        pub fn deinit(table: *TableMutable, allocator: mem.Allocator) void {
-            table.values_tree.deinit(allocator);
-        }
-
-        pub fn get(table: *const TableMutable, key: Key) ?*const Value {
-            const entry = table.values_tree.search(key);
-            if (table.values_tree.slot(entry)) |value| {
-                return value;
-            }
-
-            if (table.values_cache) |cache| {
-                // Check the cache after the mutable table (see `values_cache` for explanation).
-                if (cache.get(key)) |value| return value;
-            }
-
-            return null;
-        }
-
-        pub fn put(table: *TableMutable, value: *const Value) void {
-            assert(table.value_count_worst_case < value_count_max);
-            table.value_count_worst_case += 1;
-            
-            const entry = table.values_tree.search(key);
-            switch (usage) {
-                .secondary_index => {
-                    if (table.values_tree.slot(entry)) |existing| {
-                        // If there was a previous operation on this key then it must have been a 
-                        // remove. The put and remove cancel out.
-                        assert(!tombstone(key_from_value(existing)));
-                    } else {
-                        table.values_tree.insert_no_clobber(entry, value);
-                    }
-                },
-                .general => {
-                    // Make sure to overwrite the old the key if it exists (avoid no_clobber).
-                    table.values_tree.insert(entry, value);
-                },
-            }
-            
-            assert(table.values_tree.count <= value_count_max);
-        }
-
-        pub fn remove(table: *TableMutable, value: *const Value) void {
-            assert(table.value_count_worst_case < value_count_max);
-            table.value_count_worst_case += 1;
-
-            const tombstone_value = tombstone_from_key(key_from_value(value));
-            const entry = table.values_free.search(key);
-            switch (usage) {
-                .secondary_index => {
-                    if (table.values_free.slot(entry)) |existing| {
-                        // The previous operation on this key then it must have been a put.
-                        // The put and remove cancel out.
-                        assert(!tombstone(key_from_value(existing)));
-                    } else {
-                        // If the put is already on-disk, we need to follow it with a tombstone.
-                        // The put and tombstone may cancel each other out later during compaction.
-                        table.values_tree.insert_no_clobber(entry, &tombstone_value);
-                    }
-                },
-                .general => {
-                    // Make sure to overwrite the old the key if it exists (avoid no_clobber).
-                    table.values_tree.insert(entry, &tombstone_value);
-                },
-            }
-
-            assert(table.values_tree.count <= value_count_max);
-        }
-
-        pub fn clear(table: *TableMutable) void {
-            assert(table.count() > 0);
-            table.value_count_worst_case = 0;
-            table.values_cache.clear();
-            assert(table.values_cache.count== 0);
-        }
-
-        pub fn count(table: *const TableMutable) u32 {
-            const value_count = table.values_tree.count;
-            assert(value_count <= value_count_max);
-            return value;
-        }
-
-        /// The returned slice is invalidated whenever this is called for any tree.
-        pub fn sort_into_values_and_clear(
-            table: *TableMutable,
-            values_max: []Value,
-        ) []const Value {
-            assert(table.count() > 0);
-            assert(table.count() <= value_count_max);
-            assert(table.count() <= values_max.len);
-            assert(values_max.len == value_count_max);
-
-            var i: u32 = 0;
-            var it = table.values_tree.iterator();
-            while (it.next()) |value| : (i += 1) {
-                values_max[i] = value.*;
-
-                // Make sure the iterator is returning sorted values.
-                if (std.math.sub(u32, i, 1) catch null) |prev| {
-                    const prev_key = key_from_value(&values_max[prev]);
-                    assert(compare_keys(prev_key, key_from_value(value)) != .gt);
-                }
-
-                // Update the value_cache with new sorted values or tombstones accordingly.
-                if (table.values_cache) |cache| {
-                    if (tombstone(value)) {
-                        cache.remove(key_from_value(value));
-                    } else {
-                        cache.insert(value);
-                    }
-                }
-            }
-
-            const values = values_max[0..i];
-            assert(values.len == table.count());
-            table.clear();
-            assert(table.count() == 0);
-
-            return values;
-        }
-    };
+    try stdout.print("\n", .{});
 }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,13 +89,14 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableTreeType(Table, "", tm.HashMapTreeType) },
-        // .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
+        .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
         .{ "SkipHash", tm.TableMutableTreeType(Table, "", tm.SkipHashTreeType) },
-        .{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
+        .{ "SkipHashMap", tm.TableMutableTreeType(Table, "", tm.SkipHashMapTreeType) },
+        //.{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
         // .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
         // .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
         .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
-        .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
+        // .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
         // .{ "SwissMap", tm.TableMutableTreeType(Table, "", tm.SwissMapTreeType) },
         // .{ "F14", tm.TableMutableTreeType(Table, "", tm.F14TreeType) },
     }) |setup| {

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -95,6 +95,7 @@ pub fn main() !void {
         .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
         .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
         .{ "SwissMap", tm.TableMutableTreeType(Table, "", tm.SwissMapTreeType) },
+        .{ "F14", tm.TableMutableTreeType(Table, "", tm.F14TreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -94,6 +94,7 @@ pub fn main() !void {
         .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
         .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
         .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
+        .{ "SwissMap", tm.TableMutableTreeType(Table, "", tm.SwissMapTreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,10 +89,11 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableType(Table, "") },
-        .{ "IndexMap", tm.TableMutableIndexType(Table, "") },
-        .{ "MinHeap", tm.TableMutableTreeType(Table, "", tm.HeapTreeType) },
-        .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
-        .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
+        // .{ "IndexMap", tm.TableMutableIndexType(Table, "") },
+        .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
+        // .{ "MinHeap", tm.TableMutableTreeType(Table, "", tm.HeapTreeType) },
+        // .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
+        // .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,14 +89,15 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableTreeType(Table, "", tm.HashMapTreeType) },
-        .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
+        // .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
+        .{ "SkipHash", tm.TableMutableTreeType(Table, "", tm.SkipHashTreeType) },
         .{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
-        .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
-        .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
+        // .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
+        // .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
         .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
         .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
-        .{ "SwissMap", tm.TableMutableTreeType(Table, "", tm.SwissMapTreeType) },
-        .{ "F14", tm.TableMutableTreeType(Table, "", tm.F14TreeType) },
+        // .{ "SwissMap", tm.TableMutableTreeType(Table, "", tm.SwissMapTreeType) },
+        // .{ "F14", tm.TableMutableTreeType(Table, "", tm.F14TreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -85,9 +85,10 @@ pub fn main() !void {
     var timer = try std.time.Timer.start();
     const rng_seed = random.int(u64);
 
+    const tm = @import("table_mutable.zig");
     inline for (.{
-        .{ "std.HashMap", @import("table_mutable.zig").TableMutableType(Table, "") },
-        .{ "AA-Tree", @import("table_mutable.zig").TableMutableTreeType(Table, "") },
+        .{ "std.HashMap", tm.TableMutableType(Table, "") },
+        .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -1,0 +1,430 @@
+const std = @import("std");
+const mem = std.mem;
+const assert = std.debug.assert;
+
+const constants = @import("../constants.zig");
+const SetAssociativeCache = @import("set_associative_cache.zig").SetAssociativeCache;
+
+const TableType = @import("table.zig").TableType;
+const TableUsage = @import("table.zig").TableUsage;
+const TableMutableType = @import("table_mutable.zig").TableMutableType;
+
+pub fn main() !void {
+
+}
+
+
+
+fn TableMutableHeapType(comptime Table: type, comptime tree_name: [:0]const u8) type {
+    const Key = Table.Key;
+    const Value = Table.Value;
+    const compare_keys = Table.compare_keys;
+    const key_from_value = Table.key_from_value;
+    const tombstone_from_key = Table.tombstone_from_key;
+    const tombstone = Table.tombstone;
+    const value_count_max = Table.value_count_max;
+    const usage = Table.usage;
+
+    const AVLTree = struct {
+        const AVLNode = struct {
+            parent: u32,
+            balance: i32,
+            links: [2]u32,
+        };
+
+        const max_entries = value_count_max;
+        const buffer_size = comptime blk: {
+            assert(@alignOf(Value) >= @alignOf(AVLNode));
+            break :blk (@sizeOf(Value) * max_entries) + (@sizeOf(AVLNode) * max_entries);
+        };
+
+        
+        const AVLBuffer = struct {
+            bytes: [buffer_size]u8 align(@alignOf(Value)) = undefined,
+
+            inline fn at(buffer: *AVLBuffer, comptime Type: type, index: u32) *Type {
+                comptime assert(Type == AVLNode or Type == Value);
+                const offset = @sizeOf(Value) * @boolToInt(Type != Value);
+                const ptr = &buffer.bytes[offset + (index * @sizeOf(Type))];
+                return @ptrCast(*Type, @alignCast(@alignOf(Type), ptr));
+            }
+        };
+
+        buffer: *AVLBuffer,
+        count: u32 = 0,
+        root: u32 = 0,
+
+        pub fn init(allocator: mem.Allocator) !AVLTree {
+            const buffer = try allocator.create(AVLBuffer);
+            errdefer allocator.destroy(buffer);
+
+            return AVLTree{ .buffer = buffer };
+        }
+
+        pub fn deinit(tree: *AVLTree, allocator: mem.Allocator) void {
+            allocator.destroy(tree.buffer);
+        }
+
+        /// A packed representation of the found entry for a given key.
+        /// If the first bit is set, the following bits encode the found slot for the Value.
+        /// If the first bit is NOT set, the following bit encodes if the slot is to the right of
+        /// the parent and the remaining bits encode the parent slot + 1 (or 0 if parent == root).
+        const AVLEntry = u32;
+        
+        pub fn search(tree: *const AVLTree, key: Key) AVLEntry {
+            var index = tree.root;
+            var parent_link: u31 = 0;
+            while (index <= tree.count) {
+                const entry = index - 1;
+                const cmp = compare_keys(key, key_from_value(tree.buffer.at(Value, entry)));
+                if (cmp == .eq) return (entry << 1) | 1;
+
+                const right = cmp == .gt;
+                parent_link = (@as(u31, @intCast(u30, index)) << 1) | @boolToInt(right);
+                index = tree.buffer.at(AVLNode, entry).links[@boolToInt(right)];
+            }
+            return @as(u32, parent_link) << 1;
+        }
+
+        pub fn slot(tree: *const AVLTree, entry: AVLEntry) ?*const Value {
+            if (entry & 1 == 0) return null;
+            return tree.buffer.at(Value, entry >> 1);
+        }
+
+        pub fn insert(tree: *AVLTree, entry: AVLEntry, new_value: *const Value) void {
+            switch (@truncate(u1, entry)) {
+                0 => tree.insert_no_clobber(entry, new_value),
+                1 => tree.buffer.at(Value, entry >> 1).* = new_value.*,
+            }
+        }
+
+        pub fn insert_no_clobber(tree: *AVLTree, entry: AVLEntry, new_value: *const Value) void {
+            // Extract the entry items.
+            assert(entry & 1 == 0);
+            var right = entry & 2 != 0;
+            var parent_entry = entry >> 2;
+
+            // Reserve a new slot for the new AVLNode and Value in tree.buffer.
+            var slot = tree.count;
+            assert(slot < max_entries);
+            tree.count += 1;
+
+            tree.buffer.at(Value, slot).* = new_value;
+            tree.buffer.at(AVLNode, slot).* = .{
+                .parent = parent_entry,
+                .balance = 0,
+                .links = [_]u32{ 0, 0 },
+            };
+
+            // Get the parent AVLNode (or insert into root if none).
+            var slot_entry = slot + 1;
+            var parent_slot = std.math.sub(u32, parent_entry, 1) catch {
+                assert(tree.root == 0);
+                tree.root = slot_entry;
+                return;
+            };
+
+            // Link the parent AVLNode to our new AVLNode.
+            var parent_node = tree.buffer.at(AVLNode, parent_slot);
+            const parent_link = &parent_node.links[@boolToInt(right)];
+            assert(parent_link.* == 0);
+            parent_link.* = slot_entry;
+            
+            // Update the balance factors for all the nodes starting from our new one up to parent.
+            const scale = [_]i32{ -1, 1 };
+            while (true) {
+                // Update and check if the parent is balanced.
+                const balance = parent.balance + scale[@boolToInt(right)];
+                parent_node.balance = balance;
+                if (balance == 0) return;
+
+                // Try to balance the parent's children.
+                const signed = balance < 0;
+                if (std.math.absInt(balance) > 1) {
+                    const child_slot = parent_node.links[@boolToInt(signed)] - 1;
+                    const child_balance = tree.buffer.at(AVLNode, child_slot).balance;
+                    if (child_balance === scale[@bool(signed)]) {
+                        _ = tree.rotate(child_slot, signed);
+                    }
+
+                    const new_root = tree.rotate(parent_slot, !signed);
+                    if (tree.root == parent_entry) tree.root = parent_entry;
+                    break;
+                }
+
+                // Inspect the next parent.
+                slot_entry = parent_entry;
+                parent_entry = parent_node.parent;
+                parent_slot = std.math.sub(u32, parent_entry, 1) catch break;
+                parent = tree.buffer.at(AVLNode, parent_slot);
+                right = parent.links[1] == slot_entry;
+                assert(parent.links[@boolToInt(right)] == slot_entry);
+            }
+        }
+
+        // Branchless version of this: https://github.com/w8r/avl/blob/master/src/index.js#L34-L97    
+        fn rotate(tree: *AVLTree, slot: u32, right: bool) u32 {
+            assert(slot < tree.count);
+            const entry = slot + 1;
+            const node = tree.buffer.at(AVLNode, slot);
+
+            const target_link = &node.links[@boolToInt(!right)];
+            const target_entry = target_link.*;
+            const target_slot = target_entry - 1;
+            const target = tree.buffer.at(AVLNode, target_slot);
+
+            const other_link = &target.links[@boolToInt(right)];;
+            const other_entry = other_link.*;
+            target_link.* = other_entry;
+            if (std.math.sub(u32, other_entry, 1) catch null) |other_slot| {
+                tree.buffer.at(AVLNode, other_slot).parent = entry;
+            }
+
+            const parent_entry = node.parent;
+            target.parent = parent_entry;
+            if (std.math.sub(u32, parent_entry, 1) catch null) |parent_slot| {
+                const parent = tree.buffer.at(AVLNode, parent_slot);
+                const parent_link = parent.links[@boolToInt(parent.links[1] == entry)];
+                assert(parent_link.* == entry);
+                parent_link.* = target_entry;
+            }
+
+            const scale = ([_]i32{ 1, -1 })[@boolToInt(right)];
+            node.parent = target_entry;
+            other_link.* = entry;
+
+            node.balance += scale;
+            if (target.balance != 0 and (target.balance > 0 == right)) {
+                node.balance -= target.balance;
+            }
+
+            target.balance += scale;
+            if (node.balance != 0 and (node.balance < 0 == right)) {
+                target.balance += node.balance;
+            }
+
+            return target_slot;
+        }
+
+        pub fn clear(tree: *AVLTree) void {
+            assert(tree.count <= max_entries);
+            tree.count = 0;
+        }
+
+        pub fn iterator(tree: *const AVLTree) Iterator {
+            var it = Iterator{ .tree = tree };
+            it.stack[0] = tree.root;
+            it.top = @boolToInt(tree.root > 0);
+            return it;
+        }
+
+        pub const Iterator = struct {
+            tree: *const AVLTree,
+            top: u32 = 0,
+            stack: [32]u32 = undefined,
+
+            pub fn next(it: *Iterator) ?*const Value {
+                it.top = std.math.sub(u32, it.top, 1) catch return null;
+
+                // Push all the left-side nodes to the stack.
+                var entry = it.stack[it.top];
+                while (std.math.sub(u32, entry, 1) catch null) |slot| {
+                    assert(it.top < it.stack.len);
+                    it.stack[it.top] = entry;
+                    it.top += 1;
+                    entry = it.tree.buffer.at(AVLNode, slot).links[0];
+                }
+
+                // Pop the top of the stack to get left-most node.
+                it.top -= 1;
+                const stack_slot = &it.stack[it.top];
+                const slot = stack_slot.* - 1;
+
+                // Push the right (if any) of the left-mode node to the stack.
+                entry = it.tree.buffer.at(AVLNode, slot).links[1];
+                stack_slot.* = entry;
+                it.top += @boolToInt(entry > 0);
+
+                return it.tree.buffer.at(Value, slot);
+            }
+        };
+    };
+
+    return struct {
+        const TableMutable = @This();
+
+        pub const ValuesCache = SetAssociativeCache(
+            Key,
+            Value,
+            Table.key_from_value,
+            struct {
+                inline fn hash(key: Key) u64 {
+                    return std.hash.Wyhash.hash(0, mem.asBytes(&key));
+                }
+            }.hash,
+            struct {
+                inline fn equal(a: Key, b: Key) bool {
+                    return compare_keys(a, b) == .eq;
+                }
+            }.equal,
+            .{},
+            tree_name,
+        );
+
+        /// Rather than using values.count(), we count how many values we could have had if every
+        /// operation had been on a different key. This means that mistakes in calculating
+        /// value_count_max are much easier to catch when fuzzing, rather than requiring very
+        /// specific workloads.
+        /// Invariant: value_count_worst_case <= value_count_max
+        value_count_worst_case: u32 = 0,
+
+        /// This is used to accelerate point lookups and is not used for range queries.
+        /// Secondary index trees used only for range queries can therefore set this to null.
+        ///
+        /// The values cache is only used for the latest snapshot for simplicity.
+        /// Earlier snapshots will still be able to utilize the block cache.
+        ///
+        /// The values cache is updated (in bulk) when the mutable table is sorted and frozen,
+        /// rather than updating on every `put()`/`remove()`.
+        /// This amortizes cache inserts for hot keys in the mutable table, and avoids redundantly
+        /// storing duplicate values in both the mutable table and values cache.
+        // TODO Share cache between trees of different grooves:
+        // "A set associative cache of values shared by trees with the same key/value sizes.
+        // The value type will be []u8 and this will be shared by trees with the same value size."
+        values_cache: ?*ValuesCache,
+
+        /// Self-balancing binary search tree optimized for searching & inserting only.
+        values_tree: AVLTree,
+
+        pub fn init(allocator: mem.Allocator, values_cache: ?*ValuesCache) !TableMutable {
+            var values_tree = try AVLTree.init(allocator);
+            errdefer values_tree.deinit(allocator);
+
+            return TableMutable{
+                .values_cache = values_cache,
+                .values_tree = values_tree,
+            };
+        }
+
+        pub fn deinit(table: *TableMutable, allocator: mem.Allocator) void {
+            table.values_tree.deinit(allocator);
+        }
+
+        pub fn get(table: *const TableMutable, key: Key) ?*const Value {
+            const entry = table.values_tree.search(key);
+            if (table.values_tree.slot(entry)) |value| {
+                return value;
+            }
+
+            if (table.values_cache) |cache| {
+                // Check the cache after the mutable table (see `values_cache` for explanation).
+                if (cache.get(key)) |value| return value;
+            }
+
+            return null;
+        }
+
+        pub fn put(table: *TableMutable, value: *const Value) void {
+            assert(table.value_count_worst_case < value_count_max);
+            table.value_count_worst_case += 1;
+            
+            const entry = table.values_tree.search(key);
+            switch (usage) {
+                .secondary_index => {
+                    if (table.values_tree.slot(entry)) |existing| {
+                        // If there was a previous operation on this key then it must have been a 
+                        // remove. The put and remove cancel out.
+                        assert(!tombstone(key_from_value(existing)));
+                    } else {
+                        table.values_tree.insert_no_clobber(entry, value);
+                    }
+                },
+                .general => {
+                    // Make sure to overwrite the old the key if it exists (avoid no_clobber).
+                    table.values_tree.insert(entry, value);
+                },
+            }
+            
+            assert(table.values_tree.count <= value_count_max);
+        }
+
+        pub fn remove(table: *TableMutable, value: *const Value) void {
+            assert(table.value_count_worst_case < value_count_max);
+            table.value_count_worst_case += 1;
+
+            const tombstone_value = tombstone_from_key(key_from_value(value));
+            const entry = table.values_free.search(key);
+            switch (usage) {
+                .secondary_index => {
+                    if (table.values_free.slot(entry)) |existing| {
+                        // The previous operation on this key then it must have been a put.
+                        // The put and remove cancel out.
+                        assert(!tombstone(key_from_value(existing)));
+                    } else {
+                        // If the put is already on-disk, we need to follow it with a tombstone.
+                        // The put and tombstone may cancel each other out later during compaction.
+                        table.values_tree.insert_no_clobber(entry, &tombstone_value);
+                    }
+                },
+                .general => {
+                    // Make sure to overwrite the old the key if it exists (avoid no_clobber).
+                    table.values_tree.insert(entry, &tombstone_value);
+                },
+            }
+
+            assert(table.values_tree.count <= value_count_max);
+        }
+
+        pub fn clear(table: *TableMutable) void {
+            assert(table.count() > 0);
+            table.value_count_worst_case = 0;
+            table.values_cache.clear();
+            assert(table.values_cache.count== 0);
+        }
+
+        pub fn count(table: *const TableMutable) u32 {
+            const value_count = table.values_tree.count;
+            assert(value_count <= value_count_max);
+            return value;
+        }
+
+        /// The returned slice is invalidated whenever this is called for any tree.
+        pub fn sort_into_values_and_clear(
+            table: *TableMutable,
+            values_max: []Value,
+        ) []const Value {
+            assert(table.count() > 0);
+            assert(table.count() <= value_count_max);
+            assert(table.count() <= values_max.len);
+            assert(values_max.len == value_count_max);
+
+            var i: u32 = 0;
+            var it = table.values_tree.iterator();
+            while (it.next()) |value| : (i += 1) {
+                values_max[i] = value.*;
+
+                // Make sure the iterator is returning sorted values.
+                if (std.math.sub(u32, i, 1) catch null) |prev| {
+                    const prev_key = key_from_value(&values_max[prev]);
+                    assert(compare_keys(prev_key, key_from_value(value)) != .gt);
+                }
+
+                // Update the value_cache with new sorted values or tombstones accordingly.
+                if (table.values_cache) |cache| {
+                    if (tombstone(value)) {
+                        cache.remove(key_from_value(value));
+                    } else {
+                        cache.insert(value);
+                    }
+                }
+            }
+
+            const values = values_max[0..i];
+            assert(values.len == table.count());
+            table.clear();
+            assert(table.count() == 0);
+
+            return values;
+        }
+    };
+}

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -91,8 +91,9 @@ pub fn main() !void {
         .{ "std.HashMap", tm.TableMutableTreeType(Table, "", tm.HashMapTreeType) },
         .{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
         .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
-        .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
         .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
+        .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
+        .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,6 +89,7 @@ pub fn main() !void {
     inline for (.{
         .{ "std.HashMap", tm.TableMutableType(Table, "") },
         .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
+        .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }
@@ -96,7 +97,7 @@ pub fn main() !void {
 
 fn bench(
     comptime TableMutable: type,
-    comptime table_mutable_name: []const u8, 
+    comptime table_mutable_name: []const u8,
     allocator: mem.Allocator,
     values: []const Key.Value,
     sorted_values: []Key.Value,

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,6 +89,7 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableTreeType(Table, "", tm.HashMapTreeType) },
+        .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
         .{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
         .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
         .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -88,6 +88,7 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableType(Table, "") },
+        .{ "MinHeap", tm.TableMutableTreeType(Table, "", tm.HeapTreeType) },
         .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
         .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
     }) |setup| {

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,6 +89,7 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableType(Table, "") },
+        .{ "IndexMap", tm.TableMutableIndexType(Table, "") },
         .{ "MinHeap", tm.TableMutableTreeType(Table, "", tm.HeapTreeType) },
         .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
         .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -89,13 +89,13 @@ pub fn main() !void {
     const tm = @import("table_mutable.zig");
     inline for (.{
         .{ "std.HashMap", tm.TableMutableTreeType(Table, "", tm.HashMapTreeType) },
-        .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
-        .{ "SkipHash", tm.TableMutableTreeType(Table, "", tm.SkipHashTreeType) },
-        .{ "SkipHashMap", tm.TableMutableTreeType(Table, "", tm.SkipHashMapTreeType) },
+        // .{ "HashMapSlotSort", tm.TableMutableTreeType(Table, "", tm.HashMapSlotSortTreeType) },
+        // .{ "SkipHash", tm.TableMutableTreeType(Table, "", tm.SkipHashTreeType) },
+        .{ "ManualSlot", tm.TableMutableTreeType(Table, "", tm.ManualSlotTreeType) },
         //.{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
         // .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
         // .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
-        .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
+        // .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
         // .{ "RobinHood", tm.TableMutableTreeType(Table, "", tm.RobinHoodTreeType) },
         // .{ "SwissMap", tm.TableMutableTreeType(Table, "", tm.SwissMapTreeType) },
         // .{ "F14", tm.TableMutableTreeType(Table, "", tm.F14TreeType) },
@@ -163,6 +163,7 @@ fn bench(
             assert(miss_result == null);
         }
 
+        mem.set(Key.Value, sorted_values[0..count_max], undefined);
         const sort_start = timer.read();
         const sorted = table_mutable.sort_into_values_and_clear(sorted_values);
         sort_elapsed = timer.read() - sort_start;

--- a/src/lsm/table_mutable_benchmark.zig
+++ b/src/lsm/table_mutable_benchmark.zig
@@ -88,12 +88,11 @@ pub fn main() !void {
 
     const tm = @import("table_mutable.zig");
     inline for (.{
-        .{ "std.HashMap", tm.TableMutableType(Table, "") },
-        // .{ "IndexMap", tm.TableMutableIndexType(Table, "") },
+        .{ "std.HashMap", tm.TableMutableTreeType(Table, "", tm.HashMapTreeType) },
+        .{ "SlotMap", tm.TableMutableTreeType(Table, "", tm.SlotMapTreeType) },
+        .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
         .{ "SkipList", tm.TableMutableTreeType(Table, "", tm.SkipListTreeType) },
-        // .{ "MinHeap", tm.TableMutableTreeType(Table, "", tm.HeapTreeType) },
-        // .{ "AA-Tree", tm.TableMutableTreeType(Table, "", tm.AATreeType) },
-        // .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
+        .{ "RB-Tree", tm.TableMutableTreeType(Table, "", tm.RBTreeType) },
     }) |setup| {
         try bench(setup[1], setup[0], allocator, values, sorted_values, &timer, rng_seed);
     }


### PR DESCRIPTION
In an attempt to resolve #550, this implements a separate version of TableMutable which uses a self-balancing binary-search-tree to keep sort() times low. It also implements `benchmark_table_mutable` to see how it compares against the reference implementation (atm, scales great until `table_count_max ~= 32k` using an [AA-Tree](https://en.wikipedia.org/wiki/AA_tree))

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
