### PR TITLE
POC: mix config into root's prepare hash

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -194,8 +194,9 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             }
             errdefer for (clients) |*c| c.deinit(allocator);
 
+            const configuration = vsr.Configuration{ .replica_count = options.replica_count };
             var state_checker =
-                try StateChecker.init(allocator, options.cluster_id, replicas, clients);
+                try StateChecker.init(allocator, options.cluster_id, &configuration, replicas, clients);
             errdefer state_checker.deinit();
 
             var storage_checker = StorageChecker.init(allocator);

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -36,10 +36,11 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
         pub fn init(
             allocator: mem.Allocator,
             cluster: u32,
+            configuration: *const vsr.Configuration,
             replicas: []const Replica,
             clients: []const Client,
         ) !Self {
-            const root_prepare = vsr.Header.root_prepare(cluster);
+            const root_prepare = vsr.Header.root_prepare(cluster, configuration);
 
             var commits = Commits.init(allocator);
             errdefer commits.deinit();

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1182,9 +1182,9 @@ test "Headers.ViewChangeSlice.view_for_op" {
 const ViewChangeHeadersArray = struct {
     array: Headers.Array,
 
-    pub fn root(cluster: u32) ViewChangeHeadersArray {
+    pub fn root(cluster: u32, configuration: *const Configuration) ViewChangeHeadersArray {
         var array = Headers.Array{ .buffer = undefined };
-        array.appendAssumeCapacity(Header.root_prepare(cluster));
+        array.appendAssumeCapacity(Header.root_prepare(cluster, configuration));
         return ViewChangeHeadersArray.init(array);
     }
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -46,6 +46,10 @@ pub const Version: u8 = 0;
 
 pub const ProcessType = enum { replica, client };
 
+pub const Configuration = extern struct {
+    replica_count: u8,
+};
+
 pub const Zone = enum {
     superblock,
     wal_headers,
@@ -693,12 +697,14 @@ pub const Header = extern struct {
         return header;
     }
 
-    pub fn root_prepare(cluster: u32) Header {
+    pub fn root_prepare(cluster: u32, configuration: *const Configuration) Header {
+        const configuration_checksum = checksum(std.mem.asBytes(configuration));
         var header = Header{
             .cluster = cluster,
             .size = @sizeOf(Header),
             .command = .prepare,
             .operation = .root,
+            .context = configuration_checksum,
         };
         header.set_checksum_body(&[0]u8{});
         header.set_checksum();


### PR DESCRIPTION
Mostly just got curious what  will happen.

On `main`, if I start three nodes, one of which thinks there are only two nodes, the cluster "works" and can silently lead to corruption

With this PR, the cluster correctly shuts itself down.

Don't think it's worth to merge this as is though, as I think we'll move the point where we know configuration to `open`, rather than `format`