### PR TITLE
Leave docs_website alone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ simulator
 zig/
 zig-cache/
 zig-out/
+
+docs_website

--- a/scripts/validate_docs.sh
+++ b/scripts/validate_docs.sh
@@ -21,4 +21,3 @@ if [[ -n "$SOURCE_REPO" ]]; then
 fi
 
 ( cd docs_website && npm install && ./scripts/build.sh "$BRANCH" "$REPO" )
-rm -rf docs_website


### PR DESCRIPTION
I had to move the docs build system into Docker to make the builds reproducible but not everyone has Docker permissions set up correctly so the files built inside the docs builder come out owned by `root` so you need a `sudo rm -rf docs_website` but I don't like putting `sudo` into scripts since not everyone has `sudo`. So this just stops trying to remove it and adds it to gitignore. You can remove it if you want.

* [x] I am very sure this PR could not affect performance.
