### PR TITLE
Simulator: Log detailed state

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -26,7 +26,7 @@ const IdPermutation = @import("testing/id.zig").IdPermutation;
 const Message = @import("message_pool.zig").MessagePool.Message;
 
 /// The `log` namespace in this root file is required to implement our custom `log` function.
-pub const output = std.log.scoped(.state_checker);
+pub const output = std.log.scoped(.cluster);
 
 /// Set this to `false` if you want to see how literally everything works.
 /// This will run much slower but will trace all logic across the cluster.
@@ -581,7 +581,7 @@ pub fn log(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    if (log_state_transitions_only and scope != .state_checker) return;
+    if (log_state_transitions_only and scope != .cluster) return;
 
     const prefix_default = "[" ++ @tagName(level) ++ "] " ++ "(" ++ @tagName(scope) ++ "): ";
     const prefix = if (log_state_transitions_only) "" else prefix_default;

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -1,0 +1,60 @@
+## VOPR Output
+
+### Columns
+
+1. Replica index.
+2. Event:
+    - `$`: crash
+    - `^`: recover
+    - ` `: commit
+    - `[`: checkpoint start
+    - `]`: checkpoint done
+3. Role (according to the replica itself):
+    - `/`: primary
+    - `\`: backup
+    - `|`: standby
+    - `#`: (crashed)
+4. Status:
+    - The column (e.g. `.   ` vs `   .`) corresponds to the replica index. (This can help identify events' replicas at a quick glance.)
+    - The symbol indicates the `replica.status`.
+    - `.`: `normal`
+    - `v`: `view_change`
+    - `r`: `recovering`
+    - `h`: `recovering_head`
+5. View: e.g. `74V` indicates `replica.view=74`.
+6. Commit: e.g. `150/160C` indicates `replica.commit_min=150` and `replica.commit_max=160`.
+7. Journal op: e.g. `87:150Jo` indicates that the minimum op in the journal is `87` and the maximum is `150`.
+8. Journal dirty: `0Jd` indicates that the journal has 0 dirty headers.
+9. Journal faulty: `0Jf` indicates that the journal has 0 faulty headers.
+10. WAL prepare ops: e.g. `85:149Wo` indicates that the op of the oldest prepare in the WAL is `85` and the op of the newest prepare in the WAL is `149`.
+11. Grid blocks free: e.g. `122695Gf` indicates that the grid has `122695` blocks free.
+12. Pipeline prepares (primary-only): e.g. `2/4Pp` indicates that the primary's pipeline has 2 prepares queued, out of a capacity of 4.
+13. Pipeline requests (primary-only): e.g. `0/3Pq` indicates that the primary's pipeline has 0 requests queued, out of a capacity of 3.
+
+### Example
+
+```
+ 1 2 3 4------- 5-- 6-------  7-------  8--  9--  10------  11------   12---  13---
+
+ 0   \ .        74V 146/146C  86:149Jo  2Jd  0Jf  86:149Wo  122695Gf
+ 4   /     .    74V 147/147C  86:149Jo  0Jd  0Jf  86:149Wo  122695Gf   3/4Pp  0/3Pq
+ 0   \ .        74V 147/147C  86:149Jo  2Jd  0Jf  86:149Wo  122695Gf
+ 3   \    .     74V 147/147C  84:147Jo  0Jd  0Jf  84:147Wo  122695Gf
+ 2   \   .      74V 147/147C  84:147Jo  0Jd  0Jf  84:147Wo  122695Gf
+ 1   \  .       74V 147/147C  85:148Jo  0Jd  0Jf  85:148Wo  122695Gf
+ 4   /     .    74V 148/148C  86:149Jo  0Jd  0Jf  86:149Wo  122695Gf   2/4Pp  0/3Pq
+ 1   \  .       74V 148/148C  85:148Jo  0Jd  0Jf  85:148Wo  122695Gf
+ 2   \   .      74V 148/148C  85:148Jo  0Jd  0Jf  85:148Wo  122695Gf
+ 0   \ .        74V 148/148C  87:150Jo  1Jd  0Jf  86:149Wo  122695Gf
+ 3   \    .     74V 148/148C  85:148Jo  0Jd  0Jf  85:148Wo  122695Gf
+ 2 $ #   #
+ 4   /     .    74V 149/149C  87:150Jo  0Jd  0Jf  87:150Wo  122695Gf   2/4Pp  0/3Pq
+ 0   \ .        74V 149/149C  87:150Jo  0Jd  0Jf  87:150Wo  122695Gf
+ 3   \    .     74V 149/149C  86:149Jo  0Jd  0Jf  86:149Wo  122695Gf
+ 1   \  .       74V 149/149C  86:149Jo  0Jd  0Jf  86:149Wo  122695Gf
+ 4   /     .    74V 150/150C  87:150Jo  0Jd  0Jf  87:150Wo  122695Gf   1/4Pp  0/3Pq
+ 0   \ .        74V 150/150C  87:150Jo  0Jd  0Jf  87:150Wo  122695Gf
+ 1   \  .       74V 150/150C  87:150Jo  0Jd  0Jf  87:150Wo  122695Gf
+ 3   \    .     74V 150/150C  87:150Jo  0Jd  0Jf  87:150Wo  122695Gf
+ 4   /     .    74V 151/151C  91:154Jo  0Jd  0Jf  91:154Wo  122695Gf   4/4Pp  0/3Pq
+```

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
+const log = std.log.scoped(.cluster);
 
 const constants = @import("../constants.zig");
 const message_pool = @import("../message_pool.zig");
@@ -299,12 +300,16 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             for (cluster.storages) |*storage| storage.tick();
             for (cluster.replicas) |*replica, i| {
                 switch (cluster.replica_health[i]) {
-                    .up => replica.tick(),
+                    .up => {
+                        replica.tick();
+                        cluster.state_checker.check_state(replica.replica) catch |err| {
+                            fatal(.correctness, "state checker error: {}", .{err});
+                        };
+                    },
                     // Keep ticking the time so that it won't have diverged too far to synchronize
                     // when the replica restarts.
                     .down => replica.clock.time.tick(),
                 }
-                on_replica_change_state(replica);
             }
         }
 
@@ -319,6 +324,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             try cluster.open_replica(replica_index, time);
             cluster.network.process_enable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .up;
+            cluster.log_replica(.recover, replica_index);
         }
 
         /// Reset a replica to its initial state, simulating a random crash/panic.
@@ -333,6 +339,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             cluster.replicas[replica_index].deinit(cluster.allocator);
             cluster.network.process_disable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .down;
+            cluster.log_replica(.crash, replica_index);
 
             // Ensure that none of the replica's messages leaked when it was deinitialized.
             var messages_in_pool: usize = 0;
@@ -365,9 +372,10 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             assert(replica.standby_count == cluster.standby_count);
 
             replica.context = cluster;
-            replica.on_change_state = on_replica_change_state;
+            replica.on_change_state = on_replica_commit;
             replica.on_compact = on_replica_compact;
-            replica.on_checkpoint = on_replica_checkpoint;
+            replica.on_checkpoint_start = on_replica_checkpoint_start;
+            replica.on_checkpoint_done = on_replica_checkpoint_done;
             cluster.network.link(replica.message_bus.process, &replica.message_bus);
         }
 
@@ -422,10 +430,11 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             cluster.on_client_reply(cluster, client_index, request_message, reply_message);
         }
 
-        fn on_replica_change_state(replica: *const Replica) void {
+        fn on_replica_commit(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
-            if (cluster.replica_health[replica.replica] == .down) return;
+            assert(cluster.replica_health[replica.replica] == .up);
 
+            cluster.log_replica(.commit, replica.replica);
             cluster.state_checker.check_state(replica.replica) catch |err| {
                 fatal(.correctness, "state checker error: {}", .{err});
             };
@@ -433,13 +442,24 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
         fn on_replica_compact(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            assert(cluster.replica_health[replica.replica] == .up);
             cluster.storage_checker.replica_compact(replica) catch |err| {
                 fatal(.correctness, "storage checker error: {}", .{err});
             };
         }
 
-        fn on_replica_checkpoint(replica: *const Replica) void {
+        fn on_replica_checkpoint_start(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            assert(cluster.replica_health[replica.replica] == .up);
+
+            cluster.log_replica(.checkpoint_start, replica.replica);
+        }
+
+        fn on_replica_checkpoint_done(replica: *const Replica) void {
+            const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
+            assert(cluster.replica_health[replica.replica] == .up);
+
+            cluster.log_replica(.checkpoint_done, replica.replica);
             cluster.storage_checker.replica_checkpoint(replica) catch |err| {
                 fatal(.correctness, "storage checker error: {}", .{err});
             };
@@ -449,6 +469,106 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
         fn fatal(failure: Failure, comptime fmt_string: []const u8, args: anytype) noreturn {
             std.log.scoped(.state_checker).err(fmt_string, args);
             std.os.exit(@enumToInt(failure));
+        }
+
+        fn log_replica(cluster: *const Self, event: enum {
+            crash,
+            recover,
+            commit,
+            checkpoint_start,
+            checkpoint_done,
+        }, replica_index: u8) void {
+            const replica = &cluster.replicas[replica_index];
+
+            const event_character: u8 = switch (event) {
+                .crash => '$',
+                .recover => '^',
+                .commit => ' ',
+                .checkpoint_start => '[',
+                .checkpoint_done => ']',
+            };
+
+            var statuses = [_]u8{' '} ** constants.nodes_max;
+            if (cluster.replica_health[replica_index] == .down) {
+                statuses[replica_index] = '#';
+            } else {
+                statuses[replica_index] = switch (replica.status) {
+                    .normal => @as(u8, '.'),
+                    .view_change => @as(u8, 'v'),
+                    .recovering => @as(u8, 'r'),
+                    .recovering_head => @as(u8, 'h'),
+                };
+            }
+
+            const role: u8 = role: {
+                if (cluster.replica_health[replica_index] == .down) break :role '#';
+                if (replica.standby()) break :role '|';
+                if (replica.primary_index(replica.view) == replica.replica) break :role '/';
+                break :role '\\';
+            };
+
+            var info_buffer: [64]u8 = undefined;
+            var info: []u8 = "";
+            var pipeline_buffer: [16]u8 = undefined;
+            var pipeline: []u8 = "";
+
+            if (cluster.replica_health[replica_index] == .up) {
+                var journal_op_min: u64 = std.math.maxInt(u64);
+                var journal_op_max: u64 = 0;
+                for (replica.journal.headers) |*header| {
+                    if (header.command == .prepare) {
+                        if (journal_op_min > header.op) journal_op_min = header.op;
+                        if (journal_op_max < header.op) journal_op_max = header.op;
+                    }
+                }
+
+                var wal_op_min: u64 = std.math.maxInt(u64);
+                var wal_op_max: u64 = 0;
+                for (cluster.storages[replica_index].wal_prepares()) |*prepare| {
+                    if (prepare.header.valid_checksum() and prepare.header.command == .prepare) {
+                        if (wal_op_min > prepare.header.op) wal_op_min = prepare.header.op;
+                        if (wal_op_max < prepare.header.op) wal_op_max = prepare.header.op;
+                    }
+                }
+
+                info = std.fmt.bufPrint(&info_buffer, "" ++
+                    "{[view]:>4}V " ++
+                    "{[commit_min]:>3}/{[commit_max]:_>3}C " ++
+                    "{[journal_op_min]:>3}:{[journal_op_max]:_>3}Jo " ++
+                    "{[journal_dirty]:>2}Jd {[journal_faulty]:>2}Jf " ++
+                    "{[wal_op_min]:>3}:{[wal_op_max]:>3}Wo " ++
+                    "{[grid_blocks_free]:>7}Gf", .{
+                    .view = replica.view,
+                    .commit_min = replica.commit_min,
+                    .commit_max = replica.commit_max,
+                    .journal_op_min = journal_op_min,
+                    .journal_op_max = journal_op_max,
+                    .journal_dirty = replica.journal.dirty.count,
+                    .journal_faulty = replica.journal.faulty.count,
+                    .wal_op_min = wal_op_min,
+                    .wal_op_max = wal_op_max,
+                    .grid_blocks_free = replica.superblock.free_set.count_free(),
+                }) catch unreachable;
+
+                if (replica.pipeline == .queue) {
+                    pipeline = std.fmt.bufPrint(&pipeline_buffer, "{:>2}/{}Pp {:>2}/{}Pq", .{
+                        replica.pipeline.queue.prepare_queue.count,
+                        constants.pipeline_prepare_queue_max,
+                        replica.pipeline.queue.request_queue.count,
+                        constants.pipeline_request_queue_max,
+                    }) catch unreachable;
+                }
+            }
+
+            log.info("{[index]: >2} {[event]c} {[role]c} {[statuses]s}" ++
+                "  {[replica]s}  {[pipeline]s}", .{
+                .index = replica.replica,
+                .event = event_character,
+                .role = role,
+                .statuses = statuses[0 .. cluster.replica_count + cluster.standby_count],
+                .replica = info,
+                .pipeline = pipeline,
+            });
         }
     };
 }

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -63,6 +63,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             state_checker.commits.deinit();
         }
 
+        /// Returns whether the replica's state changed since the last check_state().
         pub fn check_state(state_checker: *Self, replica_index: u8) !void {
             const replica = &state_checker.replicas[replica_index];
 
@@ -95,13 +96,6 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 // restarting after a crash and replaying the log. The more important invariant is that
                 // the cluster as a whole may not transition to the same state more than once, and once
                 // transitioned may not regress.
-                log.info("{d:0>4}/{d:0>4} {x:0>32} > {x:0>32} {}", .{
-                    replica.commit_min,
-                    state_checker.requests_committed,
-                    checksum_a,
-                    checksum_b,
-                    replica_index,
-                });
                 return;
             }
 
@@ -133,13 +127,6 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
 
             state_checker.requests_committed += 1;
             assert(state_checker.requests_committed == header_b.?.op);
-
-            log.info("     {d:0>4} {x:0>32} > {x:0>32} {}", .{
-                state_checker.requests_committed,
-                checksum_a,
-                checksum_b,
-                replica_index,
-            });
 
             assert(state_checker.commits.items.len == header_b.?.op);
             state_checker.commits.append(.{ .header = header_b.?.* }) catch unreachable;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -329,13 +329,15 @@ pub fn ReplicaType(
         on_change_state: ?fn (replica: *const Self) void = null,
         /// Called immediately after a compaction.
         on_compact: ?fn (replica: *const Self) void = null,
+        /// Called immediately before a checkpoint.
+        on_checkpoint_start: ?fn (replica: *const Self) void = null,
         /// Called immediately after a checkpoint.
         /// Note: The replica may checkpoint without calling this function:
         /// 1. Begin checkpoint.
         /// 2. Write 2/4 SuperBlock copies.
         /// 3. Crash.
         /// 4. Recover in the new checkpoint (but op_checkpoint wasn't called).
-        on_checkpoint: ?fn (replica: *const Self) void = null,
+        on_checkpoint_done: ?fn (replica: *const Self) void = null,
 
         /// Called when `commit_prepare` finishes committing.
         commit_callback: ?fn (*Self) void = null,
@@ -2724,6 +2726,8 @@ pub fn ReplicaType(
                     .checkpoint,
                     @src(),
                 );
+                if (self.on_checkpoint_start) |on_checkpoint| on_checkpoint(self);
+
                 self.state_machine.checkpoint(commit_op_checkpoint_state_machine_callback);
             } else {
                 self.commit_op_done();
@@ -2782,7 +2786,7 @@ pub fn ReplicaType(
                 .checkpoint,
             );
 
-            if (self.on_checkpoint) |on_checkpoint| on_checkpoint(self);
+            if (self.on_checkpoint_done) |on_checkpoint| on_checkpoint(self);
             self.commit_op_done();
         }
 
@@ -3759,7 +3763,7 @@ pub fn ReplicaType(
         }
 
         /// Returns the index into the configuration of the primary for a given view.
-        fn primary_index(self: *const Self, view: u32) u8 {
+        pub fn primary_index(self: *const Self, view: u32) u8 {
             return @intCast(u8, @mod(view, self.replica_count));
         }
 


### PR DESCRIPTION
See `src/testing/README.md` for example + explanation.

Motivation: Make the non-debug vopr logs expose useful cluster state (rather than only commits).
(The message/state checksums that part of the existing vopr output are now omitted — they are verbose, and on occasions where they are useful, they can be easily found in the debug logs.)

Previously we logged "maximum commit op by any replica", but now log "commit_max per replica" — the former can be determined from the latter.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
