### PR TITLE
VSR: Explicit blank/faulty DVC headers; DVC-nack

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -82,7 +82,7 @@ const ConfigCluster = struct {
     cache_line_size: comptime_int = 64,
     clients_max: usize,
     pipeline_prepare_queue_max: usize = 8,
-    view_change_headers_suffix_max: usize = 8,
+    view_change_headers_suffix_max: usize = 8 + 1,
     quorum_replication_max: u8 = 3,
     journal_slot_count: usize = 1024,
     message_size_max: usize = 1 * 1024 * 1024,
@@ -180,7 +180,7 @@ pub const configs = struct {
         .cluster = .{
             .clients_max = 4 + 3,
             .pipeline_prepare_queue_max = 4,
-            .view_change_headers_suffix_max = 4,
+            .view_change_headers_suffix_max = 4 + 1,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(4),
             .storage_size_max = 4 * 1024 * 1024 * 1024,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1249,33 +1249,6 @@ const ViewChangeHeadersSlice = struct {
         }
         unreachable;
     }
-
-    pub const Iterator = struct {
-        headers: *const ViewChangeHeadersSlice,
-        index: usize = 0,
-
-        pub fn reset(it: *Iterator) void {
-            it.index = 0;
-        }
-
-        pub fn next(it: *Iterator) ?*const Header {
-            while (it.index < it.headers.slice.len) {
-                const header = &it.headers.slice[it.index];
-                it.index += 1;
-
-                switch (Headers.dvc_header_type(header)) {
-                    .blank => assert(it.headers.command == .do_view_change),
-                    .fault => assert(it.headers.command == .do_view_change),
-                    .valid => return header,
-                }
-            }
-            return null;
-        }
-    };
-
-    pub fn iterate_valid(headers: *const ViewChangeHeadersSlice) Iterator {
-        return .{ .headers = headers };
-    }
 };
 
 test "Headers.ViewChangeSlice.view_for_op" {

--- a/src/vsr/README.md
+++ b/src/vsr/README.md
@@ -172,7 +172,8 @@ During repair, missing/damaged prepares are requested & repaired chronologically
 In response to a `request_prepare`:
 
 - Reply the `command=prepare` with the requested prepare, if available and valid.
-- Reply `command=nack_prepare` if the request origin is the primary of the ongoing view-change and we never received the prepare. (This enables the primary to truncate uncommitted messages and remain available).
+- Reply `command=nack_prepare` if the request origin is the primary of the ongoing view-change and we never received the prepare.
+  (If the primary collects a _nack quorum_, it truncates uncommitted messages from the logs, improving availability).
 - Otherwise do not reply. (e.g. the corresponding slot in the WAL is corrupt)
 
 Per [PAR's CTRL Protocol](https://www.usenix.org/system/files/conference/fast18/fast18-alagappan.pdf), we do not nack corrupt entries, since they _might_ be the prepare being requested.
@@ -207,13 +208,15 @@ TODO (Unimplemented)
 
 - The _replication quorum_ is the minimum number of replicas required to complete a commit.
 - The _view-change quorum_ is the minimum number of replicas required to complete a view-change.
+- The _nack quorum_ is the minimum number of unique nacks required to truncate an uncommitted op.
 
 With the default configuration:
 
-|      **Replica Count** |   1 |  2 |  3 |  4 |  5 |  6 |
-| ---------------------: | --: | -: | -: | -: | -: | -: |
-| **Replication Quorum** |   1 |  2 |  2 |  2 |  3 |  3 |
-| **View-Change Quorum** |   1 |  2 |  2 |  3 |  3 |  4 |
+|      **Replica Count** |   1 |     2 |  3 |  4 |  5 |  6 |
+| ---------------------: | --: | ----: | -: | -: | -: | -: |
+| **Replication Quorum** |   1 |     2 |  2 |  2 |  3 |  3 |
+| **View-Change Quorum** |   1 |     2 |  2 |  3 |  3 |  4 |
+|        **Nack Quorum** |   1 | **1** |  2 |  3 |  3 |  4 |
 
 See also:
 

--- a/src/vsr/README.md
+++ b/src/vsr/README.md
@@ -104,11 +104,15 @@ A replica sends `command=do_view_change` to all replicas, with the `view` it is 
 - The _backup_ of the `view` uses to `do_view_change` to updates its current `view` (transitioning to `status=view_change`).
 
 DVCs include headers from prepares which are:
-- _present_ (in the replica's WAL) and valid
-- _missing_ (never written to the replica's WAL)
-- _corrupt_ (in the replica's WAL)
+- _present_: A valid header, corresponding to a valid prepare in the replica's WAL.
+- _missing_: A valid header, corresponding to a prepare that the replica has not prepared/acked.
+- _corrupt_: A valid header, corresponding to a corrupt prepare in the replica's WAL.
+- _blank_: A placeholder (fake) header, corresponding to a header that the replica has never seen.
+- _fault_: A placeholder (fake) header, corresponding to a header that the replica _may have_ prepared/acked.
 
-These cases are distinguished during [WAL repair](#protocol-repair-wal).
+If the new primary collects a _nack quorum_ of _blank_ headers for a particular possibly-uncommitted op, it truncates the log.
+
+These cases are farther distinguished during [WAL repair](#protocol-repair-wal).
 
 When the primary collects its DVC quorum:
 1. If any DVC in the quorum is ahead of the primary by more than one checkpoint,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1219,7 +1219,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                     const slot = Slot{ .index = index };
                     if (header_ok(replica.cluster, slot, header_untrusted)) |header| {
                         var view_range = view_change_headers.view_for_op(header.op, log_view);
-                        view_range.max = std.math.min(view_range.max, log_view);
+                        assert(view_range.max <= log_view);
 
                         if (header.command == .prepare and !view_range.contains(header.view)) {
                             header_untrusted.* = Header.reserved(replica.cluster, index);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -427,7 +427,8 @@ pub fn ReplicaType(
             while (!self.opened) self.superblock.storage.tick();
 
             const vsr_headers = self.superblock.working.vsr_headers();
-            for (vsr_headers.slice) |*header| {
+            var vsr_headers_iterator = vsr_headers.iterate_valid();
+            while (vsr_headers_iterator.next()) |header| {
                 const slot = .{ .index = header.op % constants.journal_slot_count };
                 if (header.op > self.op_checkpoint_trigger()) {
                     // Ignore an op that is too far head for our journal.
@@ -462,7 +463,8 @@ pub fn ReplicaType(
             // the vsr_headers head op may be part of the checkpoint after this one.
             maybe(vsr_headers.slice[0].op > self.op_checkpoint_trigger());
 
-            var op_head = for (vsr_headers.slice) |*header| {
+            vsr_headers_iterator.reset();
+            var op_head = while (vsr_headers_iterator.next()) |header| {
                 if (header.op <= self.op_checkpoint_trigger()) break header.op;
             } else unreachable;
             assert(op_head <= self.op_checkpoint_trigger());
@@ -504,10 +506,7 @@ pub fn ReplicaType(
                 // (the former version truncated as a torn write).
                 self.log_view += 1;
                 self.view += 1;
-                self.view_headers.array.len = 0;
-                self.view_headers.array.appendAssumeCapacity(
-                    self.journal.header_with_op(self.op).?.*,
-                );
+                self.primary_update_view_headers();
                 self.view_durable_update();
 
                 if (self.commit_min < self.op) {
@@ -680,6 +679,7 @@ pub fn ReplicaType(
                 .commit_max = self.superblock.working.vsr_state.commit_max,
                 .pipeline = .{ .cache = .{} },
                 .view_headers = vsr.Headers.ViewChangeArray.init_from_slice(
+                    self.superblock.working.vsr_headers().command,
                     self.superblock.working.vsr_headers().slice,
                 ),
                 .ping_timeout = Timeout{
@@ -1379,84 +1379,64 @@ pub fn ReplicaType(
             assert(message.header.command == .do_view_change);
             if (self.ignore_view_change_message(message)) return;
 
-            assert(self.status == .normal or self.status == .view_change);
-            assert(message.header.view >= self.view);
+            assert(!self.solo());
+            assert(self.status == .view_change);
+            assert(!self.do_view_change_quorum);
+            assert(message.header.view == self.view);
             DVCQuorum.verify_message(message);
 
-            assert(self.status == .view_change);
-            assert(message.header.view == self.view);
-
-            if (self.primary_index(message.header.view) != self.replica) {
-                for (self.do_view_change_from_all_replicas) |dvc| assert(dvc == null);
-
-                log.debug("{}: on_do_view_change: view={} backup awaiting start_view", .{
-                    self.replica,
-                    self.view,
-                });
-                return;
-            }
+            self.add_message_to_quorum(&self.do_view_change_from_all_replicas, message);
 
             // Wait until we have a quorum of messages (including ourself):
-            assert(!self.solo());
-            const threshold = self.quorum_view_change;
-
-            const count = self.reference_message_and_receive_quorum_exactly_once(
-                &self.do_view_change_from_all_replicas,
-                message,
-                threshold,
-            ) orelse return;
-
-            assert(count == threshold);
             assert(self.do_view_change_from_all_replicas[self.replica] != null);
             assert(self.do_view_change_from_all_replicas[self.replica].?.header.timestamp <=
                 self.op_checkpoint());
             DVCQuorum.verify(self.do_view_change_from_all_replicas);
+
+            const op_head = switch (DVCQuorum.headers_canonical(
+                self.do_view_change_from_all_replicas,
+                .{
+                    .quorum_nack_prepare = self.quorum_nack_prepare,
+                    .quorum_view_change = self.quorum_view_change,
+                    .replica_count = self.replica_count,
+                },
+            )) {
+                .awaiting_quorum => {
+                    log.debug("{}: on_do_view_change: view={} waiting for quorum", .{
+                        self.replica,
+                        self.view,
+                    });
+                    return;
+                },
+                .awaiting_repair => {
+                    log.warn("{}: on_do_view_change: view={} quorum received, awaiting repair", .{
+                        self.replica,
+                        self.view,
+                    });
+                    self.primary_print_do_view_change_quorum("on_do_view_change");
+                    return;
+                },
+                .complete_invalid => {
+                    log.err("{}: on_do_view_change: view={} quorum received, deadlocked", .{
+                        self.replica,
+                        self.view,
+                    });
+                    self.primary_print_do_view_change_quorum("on_do_view_change");
+                    return;
+                },
+                .complete_valid => |*headers_canonical| headers_canonical.next().?.op,
+            };
+
             log.debug("{}: on_do_view_change: view={} quorum received", .{
                 self.replica,
                 self.view,
             });
+            self.primary_print_do_view_change_quorum("on_do_view_change");
 
-            const dvcs_all = DVCQuorum.dvcs_all(self.do_view_change_from_all_replicas);
-            assert(dvcs_all.len == self.quorum_view_change);
-
-            for (dvcs_all.constSlice()) |dvc| {
-                log.debug(
-                    "{}: on_do_view_change: dvc: " ++
-                        "replica={} log_view={} op={} commit_min={} checkpoint={}",
-                    .{
-                        self.replica,
-                        dvc.header.replica,
-                        dvc.header.request, // The `log_view` of the replica.
-                        dvc.header.op,
-                        dvc.header.commit, // The `commit_min` of the replica.
-                        dvc.header.timestamp, // The `op_checkpoint` of the replica.
-                    },
-                );
-            }
-
-            const dvcs_canonical = DVCQuorum.dvcs_canonical(self.do_view_change_from_all_replicas);
-            assert(dvcs_canonical.len > 0);
-
-            for (dvcs_canonical.constSlice()) |dvc| {
-                for (message_body_as_headers_chain_disjoint(dvc)) |*header| {
-                    log.debug(
-                        "{}: on_do_view_change: canonical: replica={} op={} checksum={}",
-                        .{
-                            self.replica,
-                            dvc.header.replica,
-                            header.op,
-                            header.checksum,
-                        },
-                    );
-                }
-            }
-
-            const op_canonical_max =
-                DVCQuorum.headers_canonical(self.do_view_change_from_all_replicas).next().?.op;
             const op_checkpoint_max =
                 DVCQuorum.op_checkpoint_max(self.do_view_change_from_all_replicas);
             if (op_checkpoint_max > self.op_checkpoint() and
-                op_canonical_max > self.op_checkpoint_trigger())
+                op_head > self.op_checkpoint_trigger())
             {
                 // When:
                 // 1. the cluster is at a checkpoint ahead of the local checkpoint,
@@ -1514,23 +1494,25 @@ pub fn ReplicaType(
                 // identify an unambiguous set of canonical headers.
                 self.log_view = self.view;
 
-                if (op_canonical_max > self.op_checkpoint_trigger()) {
+                assert(self.op >= self.commit_max);
+                assert(self.state_machine.prepare_timestamp >=
+                    self.journal.header_with_op(self.op).?.timestamp);
+
+                if (op_head > self.op_checkpoint_trigger()) {
                     assert(self.op == self.commit_max);
                     assert(self.op == self.op_checkpoint_trigger());
-                    assert(op_canonical_max - self.op_checkpoint_trigger() <=
+                    assert(op_head - self.op_checkpoint_trigger() <=
                         constants.pipeline_prepare_queue_max);
 
                     log.debug("{}: on_do_view_change: discarded uncommitted ops after trigger" ++
                         " (op={}..{})", .{
                         self.replica,
                         self.op_checkpoint_trigger() + 1,
-                        op_canonical_max,
+                        op_head,
                     });
+                } else {
+                    assert(self.op == op_head);
                 }
-
-                assert(self.op >= self.commit_max);
-                assert(self.state_machine.prepare_timestamp >=
-                    self.journal.header_with_op(self.op).?.timestamp);
 
                 // Start repairs according to the CTRL protocol:
                 assert(!self.repair_timeout.ticking);
@@ -1589,10 +1571,11 @@ pub fn ReplicaType(
             }
             assert(self.view == message.header.view);
 
-            const view_headers = message_body_as_headers_chain_disjoint(message);
-            vsr.Headers.ViewChangeSlice.verify(view_headers);
+            const view_headers = message_body_as_view_headers(message);
+            assert(view_headers.command == .start_view);
+            assert(view_headers.slice[0].op == message.header.op);
 
-            for (view_headers) |*header| {
+            for (view_headers.slice) |*header| {
                 assert(header.commit <= message.header.commit);
 
                 if (header.op <= self.op_checkpoint_trigger()) {
@@ -1613,14 +1596,14 @@ pub fn ReplicaType(
                 stdx.unimplemented("state transfer");
             }
 
-            for (view_headers) |*header| {
+            for (view_headers.slice) |*header| {
                 if (header.op <= self.op_checkpoint_trigger()) {
                     self.replace_header(header);
                 }
             }
 
             if (self.status != .normal) {
-                self.view_headers.replace(view_headers);
+                self.view_headers.replace(.start_view, view_headers.slice);
                 assert(self.view_headers.array.get(0).view <= self.view);
                 assert(self.view_headers.array.get(0).op == message.header.op);
                 maybe(self.view_headers.array.get(0).op > self.op_checkpoint_trigger());
@@ -2212,15 +2195,7 @@ pub fn ReplicaType(
             self.repair();
         }
 
-        fn reference_message_and_receive_quorum_exactly_once(
-            self: *Self,
-            messages: *QuorumMessages,
-            message: *Message,
-            threshold: u32,
-        ) ?usize {
-            assert(threshold >= 1);
-            assert(threshold <= self.replica_count);
-
+        fn add_message_to_quorum(self: *Self, messages: *QuorumMessages, message: *Message) void {
             assert(messages.len == constants.replicas_max);
             assert(message.header.cluster == self.cluster);
             assert(message.header.replica < self.replica_count);
@@ -2228,8 +2203,6 @@ pub fn ReplicaType(
             switch (message.header.command) {
                 .do_view_change => {
                     assert(!self.solo());
-                    if (self.replica_count == 2) assert(threshold == 2);
-
                     assert(self.status == .view_change);
                     assert(self.primary_index(self.view) == self.replica);
                 },
@@ -2292,34 +2265,11 @@ pub fn ReplicaType(
                     command,
                     message.header.replica,
                 });
-                return null;
+            } else {
+                // Record the first receipt of this message:
+                assert(messages[message.header.replica] == null);
+                messages[message.header.replica] = message.ref();
             }
-
-            // Record the first receipt of this message:
-            assert(messages[message.header.replica] == null);
-            messages[message.header.replica] = message.ref();
-
-            // Count the number of unique messages now received:
-            const count = self.count_quorum(messages, message.header.command, message.header.context);
-            log.debug("{}: on_{s}: {} message(s)", .{ self.replica, command, count });
-
-            // Wait until we have exactly `threshold` messages for quorum:
-            if (count < threshold) {
-                log.debug("{}: on_{s}: waiting for quorum", .{ self.replica, command });
-                return null;
-            }
-
-            // This is not the first time we have had quorum, the state transition has already happened:
-            if (count > threshold) {
-                log.debug("{}: on_{s}: ignoring (quorum received already)", .{
-                    self.replica,
-                    command,
-                });
-                return null;
-            }
-
-            assert(count == threshold);
-            return count;
         }
 
         fn count_message_and_receive_quorum_exactly_once(
@@ -3023,32 +2973,6 @@ pub fn ReplicaType(
             return count;
         }
 
-        fn count_quorum(
-            self: *Self,
-            messages: *QuorumMessages,
-            command: Command,
-            context: u128,
-        ) usize {
-            assert(messages.len == constants.replicas_max);
-            var count: usize = 0;
-            for (messages) |received, replica| {
-                if (received) |m| {
-                    assert(replica < self.replica_count);
-                    assert(m.header.cluster == self.cluster);
-                    assert(m.header.command == command);
-                    assert(m.header.context == context);
-                    assert(m.header.replica == replica);
-                    switch (command) {
-                        .do_view_change => assert(m.header.view == self.view),
-                        else => unreachable,
-                    }
-                    count += 1;
-                }
-            }
-            assert(count <= self.replica_count);
-            return count;
-        }
-
         /// Creates an entry in the client table when registering a new client session.
         /// Asserts that the new session does not yet exist.
         /// Evicts another entry deterministically, if necessary, to make space for the insert.
@@ -3146,46 +3070,17 @@ pub fn ReplicaType(
                 // The DVC headers are already up to date, either via:
                 // - transition_to_view_change_status(), or
                 // - superblock's vsr_headers (after recovery).
-                .do_view_change => assert(self.view_headers.array.get(0).op >= self.op),
+                .do_view_change => {
+                    assert(self.view_headers.command == .do_view_change);
+                    assert(self.view_headers.array.get(0).op >= self.op);
+                },
                 .start_view => {
-                    self.view_headers.array.len = 0;
-
-                    var op = self.op + 1;
-                    while (op > 0 and
-                        self.view_headers.array.len < constants.view_change_headers_suffix_max)
-                    {
-                        op -= 1;
-                        self.view_headers.array.appendAssumeCapacity(self.journal.header_with_op(op).?.*);
-                    }
-                    assert(self.view_headers.array.len + 2 <= constants.view_change_headers_max);
-
-                    // Determine the consecutive extent of the log that we can help recover.
-                    // This may precede op_repair_min if we haven't had a view-change recently.
-                    const range_min = (self.op + 1) -| constants.journal_slot_count;
-                    const range = self.journal.find_latest_headers_break_between(range_min, self.op);
-                    const op_min = if (range) |r| r.op_max + 1 else range_min;
-                    assert(op_min <= op);
-                    assert(op_min <= self.op_repair_min());
-
-                    // The SV includes headers corresponding to the triggers for preceding
-                    // checkpoints (as many as we have and can help repair, which is at most 2).
-                    for ([_]u64{
-                        self.op_checkpoint_trigger() -|
-                            (constants.journal_slot_count - constants.lsm_batch_multiple),
-                        self.op_checkpoint_trigger() -|
-                            (constants.journal_slot_count - constants.lsm_batch_multiple) * 2,
-                    }) |op_hook| {
-                        if (op > op_hook and op_hook >= op_min) {
-                            op = op_hook;
-                            self.view_headers.array.appendAssumeCapacity(
-                                self.journal.header_with_op(op).?.*,
-                            );
-                        }
-                    }
+                    self.primary_update_view_headers();
+                    assert(self.view_headers.command == .start_view);
                 },
                 else => unreachable,
             }
-            vsr.Headers.ViewChangeSlice.verify(self.view_headers.array.constSlice());
+            self.view_headers.verify();
 
             message.header.* = .{
                 .size = @intCast(u32, @sizeOf(Header) * (1 + self.view_headers.array.len)),
@@ -3218,6 +3113,47 @@ pub fn ReplicaType(
             message.header.set_checksum();
 
             return message.ref();
+        }
+
+        fn primary_update_view_headers(self: *Self) void {
+            assert(self.status != .recovering_head);
+            assert(self.replica == self.primary_index(self.view));
+            assert(self.view == self.log_view);
+            assert(self.view_headers.command == .start_view);
+            if (self.status == .recovering) assert(self.solo());
+
+            self.view_headers.array.len = 0;
+
+            var op = self.op + 1;
+            while (op > 0 and
+                self.view_headers.array.len < constants.view_change_headers_suffix_max)
+            {
+                op -= 1;
+                self.view_headers.append(self.journal.header_with_op(op).?);
+            }
+            assert(self.view_headers.array.len + 2 <= constants.view_change_headers_max);
+
+            // Determine the consecutive extent of the log that we can help recover.
+            // This may precede op_repair_min if we haven't had a view-change recently.
+            const range_min = (self.op + 1) -| constants.journal_slot_count;
+            const range = self.journal.find_latest_headers_break_between(range_min, self.op);
+            const op_min = if (range) |r| r.op_max + 1 else range_min;
+            assert(op_min <= op);
+            assert(op_min <= self.op_repair_min());
+
+            // The SV includes headers corresponding to the triggers for preceding
+            // checkpoints (as many as we have and can help repair, which is at most 2).
+            for ([_]u64{
+                self.op_checkpoint_trigger() -|
+                    (constants.journal_slot_count - constants.lsm_batch_multiple),
+                self.op_checkpoint_trigger() -|
+                    (constants.journal_slot_count - constants.lsm_batch_multiple) * 2,
+            }) |op_hook| {
+                if (op > op_hook and op_hook >= op_min) {
+                    op = op_hook;
+                    self.view_headers.append(self.journal.header_with_op(op).?);
+                }
+            }
         }
 
         /// The caller owns the returned message, if any, which has exactly 1 reference.
@@ -3744,6 +3680,24 @@ pub fn ReplicaType(
                         });
                         return true;
                     }
+
+                    if (self.do_view_change_quorum) {
+                        log.debug("{}: on_{s}: ignoring (quorum received already)", .{
+                            self.replica,
+                            command,
+                        });
+                        return true;
+                    }
+
+                    if (self.primary_index(self.view) != self.replica) {
+                        for (self.do_view_change_from_all_replicas) |dvc| assert(dvc == null);
+
+                        log.debug("{}: on_{s}: ignoring (backup awaiting start_view)", .{
+                            self.replica,
+                            command,
+                        });
+                        return true;
+                    }
                 },
                 else => unreachable,
             }
@@ -3962,15 +3916,17 @@ pub fn ReplicaType(
         ///       and we don't want to stall the new view startup.
         ///   - primaries do repair checkpointed ops — as many as are guaranteed to exist anywhere in
         ///     the cluster, so that they can help lagging backups catch up.
+        ///
+        /// When called from status=recovering_head or status=recovering, the caller is responsible
+        /// for ensuring that replica.op is valid.
         fn op_repair_min(self: *const Self) u64 {
-            assert(self.status == .normal or self.status == .view_change or
-                self.status == .recovering_head);
+            if (self.status == .recovering) assert(self.solo());
             assert(self.op >= self.op_checkpoint());
             assert(self.op <= self.op_checkpoint_trigger());
 
             const op = op: {
                 if (self.primary_index(self.view) == self.replica) {
-                    assert(self.status == .normal or self.do_view_change_quorum);
+                    assert(self.status == .normal or self.do_view_change_quorum or self.solo());
                     // This is the oldest op that is guaranteed to be in the WALs of any replica.
                     // (Assuming that this primary has not been superseded.)
                     break :op std.math.min(
@@ -5153,7 +5109,7 @@ pub fn ReplicaType(
             assert(message.header.command == .do_view_change);
             assert(message.header.view == self.view);
             assert(message.header.op >= self.op);
-            assert(message.header.op == message_body_as_headers(message)[0].op);
+            assert(message.header.op == message_body_as_view_headers(message).slice[0].op);
             // Each replica must advertise its own commit number, so that the new primary can know
             // which headers must be replaced in its log. Otherwise, a gap in the log may prevent
             // the new primary from repairing its log, resulting in the log being forked if the new
@@ -5369,6 +5325,7 @@ pub fn ReplicaType(
                 },
                 .nack_prepare => {
                     assert(!self.standby());
+                    assert(self.status == .view_change);
                     assert(message.header.view == self.view);
                     assert(message.header.replica == self.replica);
                     assert(message.header.replica != replica);
@@ -5689,7 +5646,7 @@ pub fn ReplicaType(
             DVCQuorum.verify(self.do_view_change_from_all_replicas);
 
             const dvcs_all = DVCQuorum.dvcs_all(self.do_view_change_from_all_replicas);
-            assert(dvcs_all.len == self.quorum_view_change);
+            assert(dvcs_all.len >= self.quorum_view_change);
 
             for (dvcs_all.constSlice()) |message| {
                 assert(message.header.op <=
@@ -5706,8 +5663,14 @@ pub fn ReplicaType(
                 self.state_machine.prepare_timestamp = timestamp_max;
             }
 
-            var headers_canonical =
-                DVCQuorum.headers_canonical(self.do_view_change_from_all_replicas);
+            var headers_canonical = DVCQuorum.headers_canonical(
+                self.do_view_change_from_all_replicas,
+                .{
+                    .quorum_nack_prepare = self.quorum_nack_prepare,
+                    .quorum_view_change = self.quorum_view_change,
+                    .replica_count = self.replica_count,
+                },
+            ).complete_valid;
             const header_head = while (headers_canonical.next()) |header| {
                 if (header.op > self.op_checkpoint_trigger()) {
                     // Any ops in the next checkpoint are definitely uncommitted — otherwise,
@@ -5753,19 +5716,22 @@ pub fn ReplicaType(
                 assert(self.commit_max <= self.op);
                 maybe(self.journal.header_with_op(self.op) == null);
 
-                self.replace_header(&header_head);
+                self.replace_header(header_head);
                 assert(self.journal.header_with_op(self.op) != null);
             }
 
             while (headers_canonical.next()) |header| {
                 assert(header.op < header_head.op);
-                self.replace_header(&header);
+                self.replace_header(header);
             }
+            assert(self.journal.header_with_op(self.commit_max) != null);
 
             const dvcs_uncanonical =
                 DVCQuorum.dvcs_uncanonical(self.do_view_change_from_all_replicas);
             for (dvcs_uncanonical.constSlice()) |message| {
-                for (message_body_as_headers_chain_disjoint(message)) |*header| {
+                const message_headers = message_body_as_view_headers(message);
+                var message_headers_iterator = message_headers.iterate_valid();
+                while (message_headers_iterator.next()) |header| {
                     // We must trust headers that other replicas have committed, because
                     // repair_header() will not repair a header if the hash chain has a gap.
                     if (header.op <= message.header.commit) {
@@ -5782,6 +5748,48 @@ pub fn ReplicaType(
                     } else {
                         _ = self.repair_header(header);
                     }
+                }
+            }
+        }
+
+        fn primary_print_do_view_change_quorum(
+            self: *const Self,
+            comptime context: []const u8,
+        ) void {
+            assert(self.status == .view_change);
+            assert(self.primary_index(self.view) == self.replica);
+            assert(self.view > self.log_view);
+
+            const dvcs_all = DVCQuorum.dvcs_all(self.do_view_change_from_all_replicas);
+            for (dvcs_all.constSlice()) |dvc| {
+                log.debug(
+                    "{}: {s}: dvc: replica={} log_view={} op={} commit_min={} checkpoint={}",
+                    .{
+                        self.replica,
+                        context,
+                        dvc.header.replica,
+                        dvc.header.request, // The `log_view` of the replica.
+                        dvc.header.op,
+                        dvc.header.commit, // The `commit_min` of the replica.
+                        dvc.header.timestamp, // The `op_checkpoint` of the replica.
+                    },
+                );
+            }
+
+            const dvcs_canonical = DVCQuorum.dvcs_canonical(self.do_view_change_from_all_replicas);
+            for (dvcs_canonical.constSlice()) |dvc| {
+                const dvc_headers = message_body_as_view_headers(dvc);
+                for (dvc_headers.slice) |*header| {
+                    log.debug(
+                        "{}: {s}: canonical: replica={} op={} checksum={}",
+                        .{
+                            self.replica,
+                            context,
+                            dvc.header.replica,
+                            header.op,
+                            header.checksum,
+                        },
+                    );
                 }
             }
         }
@@ -5833,15 +5841,9 @@ pub fn ReplicaType(
 
             // No need to include "hook" headers; these view_headers will be written to vsr_headers,
             // not broadcast in an SV message.
-            self.view_headers.array.len = 0;
-            var op = self.op + 1;
-            while (op > 0) {
-                op -= 1;
-                assert(op >= self.op_repair_min());
-
-                self.view_headers.array.append(self.journal.header_with_op(op).?.*) catch break;
-            }
-            vsr.Headers.ViewChangeSlice.verify(self.view_headers.array.constSlice());
+            self.view_headers.command = .start_view;
+            self.primary_update_view_headers();
+            self.view_headers.verify();
 
             self.transition_to_normal_from_view_change_status(self.view);
 
@@ -5881,6 +5883,7 @@ pub fn ReplicaType(
             assert(!self.solo() or self.commit_min == self.op);
             assert(self.journal.header_with_op(self.op) != null);
             assert(self.pipeline == .cache);
+            assert(self.view_headers.command == .start_view);
 
             self.status = .normal;
 
@@ -5944,6 +5947,7 @@ pub fn ReplicaType(
             assert(!self.committing);
             assert(self.journal.header_with_op(self.op) != null);
             assert(self.pipeline == .cache);
+            assert(self.view_headers.command == .start_view);
 
             log.debug(
                 "{}: transition_to_normal_from_recovering_head_status: view={}..{} backup",
@@ -5988,6 +5992,7 @@ pub fn ReplicaType(
             assert(view_new >= self.view);
             assert(self.journal.header_with_op(self.op) != null);
             assert(!self.primary_abdicating);
+            assert(self.view_headers.command == .start_view);
 
             self.status = .normal;
 
@@ -6082,6 +6087,7 @@ pub fn ReplicaType(
             assert(view_new > self.view or self.status == .recovering);
             assert(view_new > self.log_view);
             assert(self.commit_max >= self.op -| constants.pipeline_prepare_queue_max);
+            defer assert(self.view_headers.command == .do_view_change);
 
             log.debug("{}: transition_to_view_change_status: view={}..{} status={}..{}", .{
                 self.replica,
@@ -6100,6 +6106,7 @@ pub fn ReplicaType(
                 // We will reuse the SV headers as our DVC headers to ensure that participating in
                 // another view-change won't allow the op to backtrack.
                 assert(self.log_view == self.view);
+                assert(self.view_headers.command == .start_view);
 
                 log.debug("{}: transition_to_view_change_status: " ++
                     "(op_head={} view_headers_head={})", .{
@@ -6107,6 +6114,8 @@ pub fn ReplicaType(
                     self.op,
                     self.view_headers.array.get(0).op,
                 });
+
+                self.view_headers.start_view_into_do_view_change();
             } else if (status_before == .normal or
                 (status_before == .recovering and self.log_view == self.view) or
                 (status_before == .view_change and self.log_view == self.view))
@@ -6118,29 +6127,34 @@ pub fn ReplicaType(
                 assert(self.view == self.log_view);
                 assert(self.view < view_new);
 
+                self.view_headers.command = .do_view_change;
                 self.view_headers.array.len = 0;
+                self.view_headers.append(self.journal.header_with_op(self.op).?);
 
-                var op = self.op + 1;
-                while (op > 0) {
+                // The DVC headers include:
+                // - all available cluster-uncommitted ops, and
+                // - the highest cluster-committed op (if available).
+                // We cannot safely go beyond that in all cases:
+                // - During a prior view-change we might have only accepted a single header from the
+                //   DVC: "header.op = op_checkpoint_trigger", and then not completed any repair.
+                // - Similarly, we might have receive a catch-up SV message and only installed a
+                //   single (checkpoint trigger) hook header.
+                var op = self.op;
+                while (op > self.commit_max) {
                     op -= 1;
 
                     if (self.journal.header_with_op(op)) |header| {
-                        self.view_headers.array.appendAssumeCapacity(header.*);
-
-                        // The DVC headers must connect to the cluster's committed ops.
-                        // We cannot safely go beyond that in all cases:
-                        // - During a prior view-change we might have only accepted a single header
-                        //   from the DVC: "header.op = op_checkpoint_trigger", and then not
-                        //   completed any repair.
-                        // - Similarly, we might have receive a catch-up SV message and only
-                        //   installed a single (checkpoint trigger) hook header.
-                        if (op <= self.commit_max + 1) break;
+                        self.view_headers.append(header);
                     } else {
-                        // Skip over the gap.
+                        if (self.journal.faulty.bit(self.journal.slot_for_op(op))) {
+                            self.view_headers.append_fault(op);
+                        } else {
+                            self.view_headers.append_blank(op);
+                        }
                     }
                 }
-                assert(self.view_headers.array.len > 0);
-                assert(self.view_headers.array.len <= constants.pipeline_prepare_queue_max);
+                assert(op <= self.commit_max);
+                assert(op == self.commit_max or self.commit_max > self.op);
                 // We could safely include any additional chained headers.
                 // However, that can make view-change bugs harder to trigger.
 
@@ -6154,9 +6168,10 @@ pub fn ReplicaType(
                 // included if necessary thanks to the "DVC connects to commit_max" invariant.
             }
 
-            vsr.Headers.ViewChangeSlice.verify(self.view_headers.array.constSlice());
+            self.view_headers.verify();
+            assert(self.view_headers.command == .do_view_change);
             assert(self.view_headers.array.get(self.view_headers.array.len - 1).op <=
-                self.commit_max + 1);
+                self.commit_max);
 
             if (self.view == view_new) {
                 assert(status_before == .recovering);
@@ -6482,6 +6497,8 @@ pub fn ReplicaType(
 ///   the highest op.
 ///
 /// - *gap*: There is a header for op X and X+n (n>1), but no header at op X+1.
+/// - *blank*: A header that explicitly marks a gap in the DVC headers.
+///   (See `vsr.Headers.dvc_blank()`).
 /// - *break*/*chain break*: The header for op X is not the parent of the header for op X+1.
 /// - *fork*: A correctness bug in which a committed (or possibly committed) message is discarded.
 ///
@@ -6499,36 +6516,34 @@ pub fn ReplicaType(
 ///
 /// For each DVC message:
 ///
-/// - The headers all belong to the same hash chain.
+/// - Each header in the DVC is one of:
+///   - "valid": The corresponding header is known. The actual message may be:
+///     - prepared (and WAL is valid), or
+///     - prepared (but WAL is corrupt), or
+///     - never prepared.
+///   - "blank": The replica never prepared the corresponding op, and does not have the header.
+///   - "fault": The replica may have prepared the corresponding op, but it does not know the
+///     header and the entry is corrupt.
+/// - The "valid" headers all belong to the same hash chain.
 ///   - Reason: If multiple replicas with the same canonical log_view disagree about an op, the new
 ///     primary could not determine which is correct.
-///   - Gaps are permitted, but the DVC-sender is responsible for ensuring they do not conceal
-///     chain breaks.
+///   - The DVC-sender is responsible for ensuring blanks/faults do not conceal chain breaks.
 ///   - For example,
-///     - a DVC of 6a,8a is valid (6a/8a belong to the same chain).
-///     - a DVC of 6b,8a is invalid (the gap at 7 conceal a chain break).
+///     - a DVC of 6a,7_,8a is valid (6a/8a belong to the same chain).
+///     - a DVC of 6b,7_,8a is invalid (the gap at 7 conceal a chain break).
 ///     - a DVC of 6b,7b,8a is invalid (7b/8a is a chain break)..
 /// - All pipeline headers present on the replica must be included in the DVC headers.
-///
-/// - If the replica does not possess the oldest known pipeline entry (the "DVC anchor")
-///   (usually 1 + op_head -| pipeline_prepare_queue_max, except it does not need to move backwards
-///   when op_head is truncated), then they should include `op_head -| pipeline_prepare_queue_max`
-///   if it is in the journal.
-///   (By the intersection property, at least one DVC will contain one or the other).
-///   - Reason: The new primary may truncate the entire pipeline (6,7,8,9) due to a gap (6),
-///     but afterwards it still requires a head op to repair/chain backward from.
-///     (According to the intersection property, a gap in the unified pipeline indicates an
-///     uncommitted op).
-///   - For example, given pipeline_prepare_queue_max=3:
-///     - a DVC of 7,8 is invalid if replica.commit_min=5.
-///     - a DVC of 7,8 is valid if replica.commit_min=6.
-///     - a DVC of 5,7,8 is valid. (5,_,7,8)
-///     - a DVC of 5,8 is valid.   (5,_,_,8)
-///     - a DVC of 0,1 is valid.
+///   - When `replica.commit_max ≤ replica.op`,
+///     the DVC must include a valid/blank/fault header for every op in that range.
+///   - When `replica.commit_max > replica.op`, only a single header (`replica.op`) is included.
+///   - The DVC will need a valid `commit_max` to complete, since the entire pipeline may be
+///     truncated, and the new primary still needs a head op.
+/// - The header corresponding to `replica.op` is always "valid", never a "blank"/"fault".
+///   (Otherwise the replica would be in status=recovering_head and unable to participate).
 ///
 /// Across all DVCs in the quorum:
 ///
-/// - The headers of every DVC with the same log_view must not conflict.
+/// - The valid headers of every DVC with the same log_view must not conflict.
 ///   - In other words:
 ///     dvc₁.headers[i].op       == dvc₂.headers[j].op implies
 ///     dvc₁.headers[i].checksum == dvc₂.headers[j].checksum.
@@ -6547,7 +6562,6 @@ const DVCQuorum = struct {
 
     fn verify(dvc_quorum: QuorumMessages) void {
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
-        assert(dvcs.len >= 2);
         for (dvcs.constSlice()) |message| verify_message(message);
 
         var log_views_all = std.BoundedArray(u32, constants.replicas_max){ .buffer = undefined };
@@ -6556,13 +6570,6 @@ const DVCQuorum = struct {
             if (std.mem.count(u32, log_views_all.constSlice(), &.{log_view}) == 0) {
                 log_views_all.appendAssumeCapacity(log_view);
             }
-        }
-
-        // Verify that DVCs with the same log_view do not conflict.
-        for (log_views_all.constSlice()) |log_view| {
-            const view_dvcs = dvcs_with_log_view(dvc_quorum, log_view);
-            var view_headers = HeaderIterator.init(view_dvcs, null);
-            while (view_headers.next()) |_| {}
         }
     }
 
@@ -6579,8 +6586,10 @@ const DVCQuorum = struct {
         const log_view = message.header.request;
         assert(log_view < message.header.view);
 
-        // Ignore the headers, but perform the validation.
-        _ = message_body_as_headers_chain_disjoint(message);
+        // Ignore the result, init() verifies the headers.
+        const headers = message_body_as_view_headers(message);
+        assert(headers.slice[0].op == message.header.op);
+        assert(headers.slice[0].view <= log_view);
     }
 
     fn dvcs_all(dvc_quorum: QuorumMessages) DVCArray {
@@ -6666,19 +6675,19 @@ const DVCQuorum = struct {
 
         var commit_max_: u64 = 0;
         for (dvcs.constSlice()) |dvc| {
-            const dvc_headers = message_body_as_headers_chain_disjoint(dvc);
-            // The DVC is connected to the committed ops.
-            const dvc_commit_max_connected = dvc_headers[dvc_headers.len - 1].op -| 1;
+            const dvc_headers = message_body_as_view_headers(dvc);
+            // DVC generation stops when a header with op ≤ commit_max is appended.
+            const dvc_commit_max_tail = dvc_headers.slice[dvc_headers.slice.len - 1].op;
             // An op cannot be uncommitted if it is definitely outside the pipeline.
             // Use `do_view_change_op_head` instead of `replica.op` since the former is
             // about to become the new `replica.op`.
             const dvc_commit_max_pipeline =
                 dvc.header.op -| constants.pipeline_prepare_queue_max;
 
-            commit_max_ = std.math.max(commit_max_, dvc_commit_max_connected);
+            commit_max_ = std.math.max(commit_max_, dvc_commit_max_tail);
             commit_max_ = std.math.max(commit_max_, dvc_commit_max_pipeline);
             commit_max_ = std.math.max(commit_max_, dvc.header.commit);
-            commit_max_ = std.math.max(commit_max_, dvc_headers[0].commit);
+            commit_max_ = std.math.max(commit_max_, dvc_headers.slice[0].commit);
         }
         return commit_max_;
     }
@@ -6687,10 +6696,11 @@ const DVCQuorum = struct {
     fn timestamp_max(dvc_quorum: QuorumMessages) u64 {
         var timestamp_max_: ?u64 = null;
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
-        for (dvcs.constSlice()) |message| {
-            const message_headers = message_body_as_headers_chain_disjoint(message);
-            if (timestamp_max_ == null or timestamp_max_.? < message_headers[0].timestamp) {
-                timestamp_max_ = message_headers[0].timestamp;
+        for (dvcs.constSlice()) |dvc| {
+            const dvc_headers = message_body_as_view_headers(dvc);
+            const dvc_head = &dvc_headers.slice[0];
+            if (timestamp_max_ == null or timestamp_max_.? < dvc_head.timestamp) {
+                timestamp_max_ = dvc_head.timestamp;
             }
         }
         return timestamp_max_.?;
@@ -6707,152 +6717,186 @@ const DVCQuorum = struct {
         return op_max.?;
     }
 
-    /// Return an iterator over the canonical DVC's headers, from high-to-low op.
-    /// The first header returned is the new head message.
-    fn headers_canonical(dvc_quorum: QuorumMessages) HeaderIterator {
-        const dvcs = DVCQuorum.dvcs_canonical(dvc_quorum);
-
-        const op_head_max = op_max_canonical(dvc_quorum);
-        // The number of uncommitted ops cannot be more than the length of the pipeline.
-        const op_suffix_min = op_head_max -| constants.pipeline_prepare_queue_max;
-        assert(op_suffix_min <= op_head_max);
-
-        var op_head_min = op_suffix_min;
-        var ops_in_suffix = std.StaticBitSet(constants.pipeline_prepare_queue_max).initEmpty();
-        for (dvcs.constSlice()) |message| {
-            const message_headers = message_body_as_headers_chain_disjoint(message);
-            for (message_headers) |header| {
-                if (header.op > op_suffix_min) {
-                    ops_in_suffix.set((header.op - op_suffix_min) - 1);
-                }
-            }
-            op_head_min = std.math.max(op_head_min, message_headers[message_headers.len - 1].op);
+    /// When the view is ready to begin:
+    /// - Return an iterator over the canonical DVC's headers, from high-to-low op.
+    ///   The first header returned is the new head message.
+    /// Otherwise:
+    /// - Return the reason the view cannot begin.
+    fn headers_canonical(dvc_quorum: QuorumMessages, options: struct {
+        quorum_nack_prepare: u8,
+        quorum_view_change: u8,
+        replica_count: u8,
+    }) union(enum) {
+        // The quorum has fewer than "quorum_view_change" DVCs.
+        // We are waiting for DVCs from the remaining replicas.
+        awaiting_quorum: void,
+        // The quorum has at least "quorum_view_change" DVCs.
+        // The quorum has fewer than "replica_count" DVCs.
+        // The quorum collected so far is insufficient to determine which headers can be nacked
+        // (due to an excess of faults).
+        // We must wait for DVCs from one or more remaining replicas.
+        awaiting_repair: void,
+        // All replicas have contributed a DVC, but there are too many faults to start a new view.
+        // The cluster is deadlocked, unable to ever complete a view change.
+        complete_invalid: void,
+        // The quorum is complete, and sufficient to start the new view.
+        complete_valid: HeaderIterator,
+    } {
+        assert(options.replica_count >= 2);
+        assert(options.replica_count <= constants.replicas_max);
+        assert(options.quorum_view_change >= 2);
+        assert(options.quorum_view_change <= options.replica_count);
+        if (options.replica_count == 2) {
+            assert(options.quorum_nack_prepare == 1);
+        } else {
+            assert(options.quorum_nack_prepare == options.quorum_view_change);
         }
-        assert(op_head_max == 0 or ops_in_suffix.isSet((op_head_max - op_suffix_min) - 1));
-        assert(op_head_min >= op_suffix_min);
-        assert(op_head_min <= op_head_max);
 
-        const op_head = blk: {
-            var op = op_head_min + 1;
-            while (op < op_head_max) : (op += 1) {
-                if (!ops_in_suffix.isSet((op - op_suffix_min) - 1)) {
-                    break :blk op - 1;
+        const dvcs_total = DVCQuorum.dvcs_all(dvc_quorum).len;
+        if (dvcs_total < options.quorum_view_change) return .awaiting_quorum;
+
+        const dvcs = DVCQuorum.dvcs_canonical(dvc_quorum);
+        assert(dvcs.len > 0);
+        assert(dvcs.len <= dvcs_total);
+
+        const op_head_max = DVCQuorum.op_max_canonical(dvc_quorum);
+        const op_head_min = DVCQuorum.commit_max(dvc_quorum);
+
+        // Iterate the highest definitely committed op and all maybe-uncommitted ops.
+        var op = op_head_min;
+        const op_head = while (op <= op_head_max) : (op += 1) {
+            // Replicas with non-canonical log-views implicitly nack all uncommitted ops.
+            var nacks: usize = dvcs_total - dvcs.len;
+
+            const found = for (dvcs.constSlice()) |dvc| {
+                if (dvc.header.op < op) {
+                    nacks += 1;
+                    continue;
                 }
+
+                const headers = message_body_as_view_headers(dvc);
+                const header_index = dvc.header.op - op;
+                if (header_index >= headers.slice.len) {
+                    // This op is definitely committed by the cluster.
+                } else {
+                    const header = &headers.slice[header_index];
+                    assert(header.op == op);
+
+                    switch (vsr.Headers.dvc_header_type(header)) {
+                        .blank => nacks += 1,
+                        .fault => {},
+                        .valid => break true,
+                    }
+                }
+            } else false;
+
+            if (found) {
+                // This op is eligible to be the view's head.
             } else {
-                break :blk op_head_max;
+                // Never nack op_head_min (aka commit_max).
+                if (op != op_head_min and nacks >= options.quorum_nack_prepare) {
+                    break op - 1;
+                } else {
+                    if (dvcs_total < options.replica_count) {
+                        return .awaiting_repair;
+                    } else {
+                        return .complete_invalid;
+                    }
+                }
             }
-        };
+        } else op_head_max;
         assert(op_head >= op_head_min);
         assert(op_head <= op_head_max);
 
-        return HeaderIterator.init(dvcs, op_head);
+        return .{ .complete_valid = .{
+            .dvcs = dvcs,
+            .op_max = op_head,
+            .op_min = op_head_min,
+        } };
     }
 
     /// Iterate the headers of a set of (same-log_view) DVCs, from high-to-low op.
     const HeaderIterator = struct {
         dvcs: DVCArray,
-        dvcs_offsets: std.BoundedArray(usize, constants.replicas_max),
+        op_max: u64,
+        op_min: u64,
+        child_op: ?u64 = null,
+        child_parent: ?u128 = null,
 
-        child: ?struct {
-            op: u64,
-            parent: u128,
-        } = null,
+        fn next(iterator: *HeaderIterator) ?*const Header {
+            assert(iterator.dvcs.len > 0);
+            assert(iterator.op_min <= iterator.op_max);
+            assert((iterator.child_op == null) == (iterator.child_parent == null));
 
-        fn init(dvcs: DVCArray, op_head: ?u64) HeaderIterator {
-            assert(dvcs.len > 0);
+            if (iterator.child_op != null and iterator.child_op.? == iterator.op_min) return null;
 
-            const dvcs_log_view = dvcs.get(0).header.request;
-            for (dvcs.constSlice()) |message| {
-                const message_log_view = message.header.request;
-                assert(message_log_view == dvcs_log_view);
-            }
+            const op = (iterator.child_op orelse (iterator.op_max + 1)) - 1;
 
-            var dvcs_offsets = std.BoundedArray(usize, constants.replicas_max){
-                .buffer = undefined,
-            };
+            var header: ?*const Header = null;
 
-            if (op_head) |op_head_| {
-                // Skip over discarded headers.
-                for (dvcs.constSlice()) |message| {
-                    const offset = for (message_body_as_headers_chain_disjoint(message)) |header, i| {
-                        if (header.op <= op_head_) break i;
-                    } else 0;
-                    dvcs_offsets.appendAssumeCapacity(offset);
-                }
-            } else {
-                for (dvcs.constSlice()) |_| dvcs_offsets.appendAssumeCapacity(0);
-            }
-            assert(dvcs.len == dvcs_offsets.len);
+            const log_view = iterator.dvcs.get(0).header.request;
+            for (iterator.dvcs.constSlice()) |dvc| {
+                assert(log_view == dvc.header.request);
 
-            return .{
-                .dvcs = dvcs,
-                .dvcs_offsets = dvcs_offsets,
-            };
-        }
+                if (op > dvc.header.op) continue;
 
-        fn next(iterator: *HeaderIterator) ?Header {
-            const ReplicaSet = std.StaticBitSet(constants.replicas_max);
-            var next_header: ?*const Header = null;
-            var next_advance = ReplicaSet.initEmpty();
+                const dvc_headers = message_body_as_view_headers(dvc);
+                const dvc_header_index = dvc.header.op - op;
+                if (dvc_header_index >= dvc_headers.slice.len) continue;
 
-            for (iterator.dvcs.constSlice()) |message, i| {
-                const message_headers = message_body_as_headers_chain_disjoint(message);
-                const message_headers_offset = iterator.dvcs_offsets.get(i);
-                if (message_headers_offset == message_headers.len) continue;
-
-                const header = &message_headers[message_headers_offset];
-                if (next_header == null or
-                    next_header.?.op < header.op)
-                {
-                    next_header = header;
-                    next_advance = ReplicaSet.initEmpty();
-                }
-                assert((next_header.?.op == header.op) ==
-                    (next_header.?.checksum == header.checksum));
-
-                if (next_header.?.op == header.op) {
-                    next_advance.set(i);
+                const dvc_header = &dvc_headers.slice[dvc_header_index];
+                switch (vsr.Headers.dvc_header_type(dvc_header)) {
+                    .blank => continue,
+                    .fault => continue,
+                    .valid => {
+                        if (header) |h| {
+                            assert(h.checksum == dvc_header.checksum);
+                        } else {
+                            header = dvc_header;
+                        }
+                    },
                 }
             }
-            assert((next_advance.count() == 0) == (next_header == null));
 
-            var next_advance_iterator = next_advance.iterator(.{});
-            while (next_advance_iterator.next()) |i| {
-                iterator.dvcs_offsets.slice()[i] += 1;
+            if (iterator.child_parent) |parent| {
+                assert(header.?.checksum == parent);
             }
 
-            if (next_header) |header| {
-                if (iterator.child) |child| {
-                    assert(child.op > header.op);
-                    assert((child.op == header.op + 1) == (child.parent == header.checksum));
-                }
-                iterator.child = .{ .op = header.op, .parent = header.parent };
-                return header.*;
-            } else {
-                return null;
-            }
+            iterator.child_op = op;
+            iterator.child_parent = header.?.parent;
+            return header.?;
         }
     };
 };
+
+fn message_body_as_view_headers(message: *const Message) vsr.Headers.ViewChangeSlice {
+    assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
+    assert(message.header.command == .do_view_change or
+        message.header.command == .start_view);
+
+    return vsr.Headers.ViewChangeSlice.init(
+        switch (message.header.command) {
+            .do_view_change => .do_view_change,
+            .start_view => .start_view,
+            else => unreachable,
+        },
+        message_body_as_headers_unchecked(message),
+    );
+}
 
 /// Asserts that the headers are in descending op order.
 /// The headers may contain gaps and/or breaks.
 fn message_body_as_headers(message: *const Message) []const Header {
     assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
-    assert(message.header.command == .do_view_change or
-        message.header.command == .start_view or
+    assert(message.header.command == .start_view or
         message.header.command == .headers);
 
-    const headers = std.mem.bytesAsSlice(
-        Header,
-        message.buffer[@sizeOf(Header)..message.header.size],
-    );
-
+    const headers = message_body_as_headers_unchecked(message);
     var child: ?*const Header = null;
     for (headers) |*header| {
-        assert(!constants.verify or header.valid_checksum());
-        assert(header.cluster == message.header.cluster);
+        if (constants.verify) assert(header.valid_checksum());
         assert(header.command == .prepare);
+        assert(header.cluster == message.header.cluster);
         assert(header.view <= message.header.view);
 
         if (child) |child_header| {
@@ -6866,28 +6910,16 @@ fn message_body_as_headers(message: *const Message) []const Header {
     return headers;
 }
 
-/// Asserts that the headers are in descending op order, and there are no breaks.
-/// The headers may contain gaps.
-fn message_body_as_headers_chain_disjoint(message: *const Message) []const Header {
-    assert(message.header.command == .do_view_change or message.header.command == .start_view);
+fn message_body_as_headers_unchecked(message: *const Message) []const Header {
+    assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
+    assert(message.header.command == .do_view_change or
+        message.header.command == .start_view or
+        message.header.command == .headers);
 
-    const message_headers = message_body_as_headers(message);
-    assert(message_headers.len > 0);
-    assert(message_headers[0].op == message.header.op);
-
-    var child: ?*const Header = null;
-    for (message_headers) |*header| {
-        assert(header.op <= message.header.op);
-
-        if (child) |child_header| {
-            assert(header.view <= child_header.view);
-            assert(header.op < child_header.op);
-            assert((header.op + 1 == child_header.op) == (header.checksum == child_header.parent));
-            assert(header.timestamp < child_header.timestamp);
-        }
-        child = header;
-    }
-    return message_headers;
+    return std.mem.bytesAsSlice(
+        Header,
+        message.buffer[@sizeOf(Header)..message.header.size],
+    );
 }
 
 /// The PipelineQueue belongs to a normal-status primary. It consists of two queues:

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -298,6 +298,10 @@ pub const SuperBlockHeader = extern struct {
 
     pub fn vsr_headers(superblock: *const SuperBlockHeader) vsr.Headers.ViewChangeSlice {
         return vsr.Headers.ViewChangeSlice.init(
+            if (superblock.vsr_state.log_view < superblock.vsr_state.view)
+                .do_view_change
+            else
+                .start_view,
             superblock.vsr_headers_all[0..superblock.vsr_headers_count],
         );
     }
@@ -772,7 +776,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.staging.vsr_state.log_view < update.log_view or
                 superblock.staging.vsr_state.view < update.view);
 
-            vsr.Headers.ViewChangeSlice.verify(update.headers.array.constSlice());
+            update.headers.verify();
             assert(update.view >= update.log_view);
 
             const vsr_state = SuperBlockHeader.VSRState{

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -356,7 +356,10 @@ const Environment = struct {
             .commit_max = vsr_state.commit_max,
             .log_view = vsr_state.log_view,
             .view = vsr_state.view,
-            .headers = &.{ .array = vsr_headers },
+            .headers = &.{
+                .command = .do_view_change,
+                .array = vsr_headers,
+            },
         });
     }
 


### PR DESCRIPTION
Change DVC messages and protocol:
- Previously, gaps were implicit — the headers would have ops 8,7,5,4 (implicit gap at op=6).
- Now, gaps are explicit ("blanks"). And these are now distinct from "faults" — gaps caused by WAL corruption.
- The former (blanks) count as nacks; the latter (faults) do not count as nacks.
- If the new primary collects a view-change quorum of DVCs, and 1+ headers are both missing and have insufficient nacks,
  then it will wait for even more DVC messages before it will complete the view-change.
  (At this point it warn-logs `quorum received, awaiting repair`.
- If the new primary collects DVCs from every replica in the cluster, but it still isn't enough
  (i.e. too much corruption to nack, but no one has the header),
  then we error-log `quorum received, deadlocked`.

There is a minor change the SVs as well:
- Since an SV can be "converted" to a DVC, it needs to include an extra header from before.
  (This is why `view_change_headers_suffix_max` now has a +1 in `config.zig`).
- Note that DVCs cannot have "hook" headers (like SVs have), since that would leave implicit gaps.
  When an SV is converted to a DVC, the hook headers are dropped.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
