### PR TITLE
Client/Header: Use actual enum value, not variant index

### DIFF
--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -152,7 +152,7 @@ fn to_case(
 
 fn emit_enum(
     buffer: *std.ArrayList(u8),
-    comptime type_info: anytype,
+    comptime Type: type,
     comptime mapping: TypeMapping,
     comptime int_type: []const u8,
 ) !void {
@@ -167,6 +167,7 @@ fn emit_enum(
         .name = mapping.name,
     });
 
+    const type_info = @typeInfo(Type).Enum;
     inline for (type_info.fields) |field, i| {
         if (comptime mapping.is_private(field.name)) continue;
 
@@ -189,7 +190,7 @@ fn emit_enum(
         , .{
             .enum_name = to_case(field.name, .pascal),
             .int_type = int_type,
-            .value = i,
+            .value = @enumToInt(@field(Type, field.name)),
             .separator = if (i == type_info.fields.len - 1) ';' else ',',
         });
     }
@@ -745,9 +746,9 @@ pub fn generate_bindings(
                 @sizeOf(ZigType),
             ),
         },
-        .Enum => |info| try emit_enum(
+        .Enum => try emit_enum(
             buffer,
-            info,
+            ZigType,
             mapping,
             comptime java_type(std.meta.Int(.unsigned, @bitSizeOf(ZigType))),
         ),

--- a/src/clients/node/node_bindings.zig
+++ b/src/clients/node/node_bindings.zig
@@ -88,21 +88,21 @@ fn get_mapped_type_name(comptime Type: type) ?[]const u8 {
 
 fn emit_enum(
     buffer: *std.ArrayList(u8),
-    comptime type_info: anytype,
+    comptime Type: type,
     comptime mapping: TypeMapping,
 ) !void {
     try emit_docs(buffer, mapping, 0, null);
 
     try buffer.writer().print("export enum {s} {{\n", .{mapping.name});
 
-    inline for (type_info.fields) |field, i| {
+    inline for (@typeInfo(Type).Enum.fields) |field| {
         if (comptime mapping.hidden(field.name)) continue;
 
         try emit_docs(buffer, mapping, 1, field.name);
 
         try buffer.writer().print("  {s} = {d},\n", .{
             field.name,
-            i,
+            @enumToInt(@field(Type, field.name)),
         });
     }
 
@@ -209,7 +209,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
                 .Packed => try emit_packed_struct(buffer, info, mapping),
                 .Extern => try emit_struct(buffer, info, mapping),
             },
-            .Enum => |info| try emit_enum(buffer, info, mapping),
+            .Enum => try emit_enum(buffer, ZigType, mapping),
             else => @compileError("Type cannot be represented: " ++ @typeName(ZigType)),
         }
     }


### PR DESCRIPTION
Currently our enum variants' values match their respective indexes within the enum. But that will soon not (necessarily) be true.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
