### PR TITLE
vsr: introduce u128 replica ids

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1097,6 +1097,49 @@ test "quorums" {
     }
 }
 
+/// Deterministically assigns replica_ids for the initial configuration.
+///
+/// Eventualy, we want to identify replicas using random u128 ids to prevent operator errors.
+/// However, that requires unergonomic two-step process for spinning a new cluster up.  To avoid
+/// needlessly compromizing the experience until reconfiguration is fully implemented, derive
+/// replica ids for the initial cluster deterministically.
+pub fn root_members(cluster: u32) [constants.nodes_max]u128 {
+    const IdSeed = packed struct {
+        cluster_config_checksum: u128 = config.configs.current.cluster.checksum(),
+        cluster: u32,
+        replica: u8,
+    };
+
+    var result = [_]u128{0} ** constants.nodes_max;
+    var replica: u8 = 0;
+    while (replica < constants.nodes_max) : (replica += 1) {
+        result[replica] = checksum(std.mem.asBytes(&IdSeed{ .cluster = cluster, .replica = replica }));
+    }
+
+    assert_valid_members(&result);
+    return result;
+}
+
+/// Check that:
+///  - all non-zero elements are different
+///  - all zero elements are trailing
+pub fn assert_valid_members(members: *const [constants.nodes_max]u128) void {
+    for (members) |replica_i, i| {
+        for (members[0..i]) |replica_j| {
+            if (replica_j == 0) assert(replica_i == 0);
+            if (replica_j != 0) assert(replica_j != replica_i);
+        }
+    }
+}
+
+pub fn assert_valid_member(members: *const [constants.nodes_max]u128, replica_id: u128) void {
+    assert(replica_id != 0);
+    assert_valid_members(members);
+    for (members) |member| {
+        if (member == replica_id) break;
+    } else unreachable;
+}
+
 pub const Headers = struct {
     pub const Array = std.BoundedArray(Header, constants.view_change_headers_max);
     /// The SuperBlock's persisted VSR headers.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -384,11 +384,14 @@ pub fn ReplicaType(
             while (!self.opened) self.superblock.storage.tick();
             self.superblock.working.vsr_state.assert_internally_consistent();
 
-            const replica = self.superblock.working.vsr_state.replica;
+            const replica_id = self.superblock.working.vsr_state.replica_id;
+            const replica = for (self.superblock.working.vsr_state.members) |member, index| {
+                if (member == replica_id) break @intCast(u8, index);
+            } else unreachable;
             const replica_count = self.superblock.working.vsr_state.replica_count;
             if (replica >= options.node_count or replica_count > options.node_count) {
                 log.err("{}: open: no address for replica (replica_count={} node_count={})", .{
-                    self.superblock.working.vsr_state.replica,
+                    replica,
                     replica_count,
                     options.node_count,
                 });

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -195,7 +195,10 @@ test "format" {
         try std.testing.expectEqual(superblock_header.vsr_state.commit_max, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.view, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.log_view, 0);
-        try std.testing.expectEqual(superblock_header.vsr_state.replica, replica);
+        try std.testing.expectEqual(
+            superblock_header.vsr_state.replica_id,
+            superblock_header.vsr_state.members[replica],
+        );
         try std.testing.expectEqual(superblock_header.vsr_state.replica_count, replica_count);
     }
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -149,6 +149,11 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
 
 const Environment = struct {
     const replica = 0;
+    const replica_id = members[replica];
+    const members = members: {
+        @setEvalBranchQuota(100_000);
+        break :members vsr.root_members(cluster);
+    };
     const replica_count = 6;
 
     /// Track the expected value of parameters at a particular sequence.
@@ -177,7 +182,8 @@ const Environment = struct {
         .commit_max = 0,
         .log_view = 0,
         .view = 0,
-        .replica = replica,
+        .replica_id = replica_id,
+        .members = members,
         .replica_count = replica_count,
     },
 
@@ -290,7 +296,8 @@ const Environment = struct {
         try env.sequence_states.append(.{
             .vsr_state = VSRState.root(.{
                 .cluster = cluster,
-                .replica = replica,
+                .replica_id = replica_id,
+                .members = members,
                 .replica_count = replica_count,
             }),
             .vsr_headers = vsr_headers,
@@ -316,7 +323,7 @@ const Environment = struct {
         env.pending.remove(.open);
 
         assert(env.superblock.working.sequence == 1);
-        assert(env.superblock.working.vsr_state.replica == replica);
+        assert(env.superblock.working.vsr_state.replica_id == replica_id);
         assert(env.superblock.working.vsr_state.replica_count == replica_count);
         assert(env.superblock.working.cluster == cluster);
     }
@@ -331,7 +338,8 @@ const Environment = struct {
             .commit_max = env.superblock.staging.vsr_state.commit_max + 3,
             .log_view = env.superblock.staging.vsr_state.log_view + 4,
             .view = env.superblock.staging.vsr_state.view + 5,
-            .replica = replica,
+            .replica_id = replica_id,
+            .members = members,
             .replica_count = replica_count,
         };
 
@@ -379,7 +387,8 @@ const Environment = struct {
             .commit_max = env.superblock.staging.vsr_state.commit_max + 1,
             .log_view = env.superblock.staging.vsr_state.log_view,
             .view = env.superblock.staging.vsr_state.view,
-            .replica = replica,
+            .replica_id = replica_id,
+            .members = members,
             .replica_count = replica_count,
         };
 

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -149,11 +149,11 @@ pub fn QuorumsType(comptime options: Options) type {
                     continue;
                 }
 
-                if (a.header.vsr_state.replica != b.header.vsr_state.replica) {
-                    log.warn("superblock copy={} has replica={} instead of {}", .{
+                if (a.header.vsr_state.replica_id != b.header.vsr_state.replica_id) {
+                    log.warn("superblock copy={} has replica_id={} instead of {}", .{
                         a.header.copy,
-                        a.header.vsr_state.replica,
-                        b.header.vsr_state.replica,
+                        a.header.vsr_state.replica_id,
+                        b.header.vsr_state.replica_id,
                     });
                     continue;
                 }
@@ -174,7 +174,7 @@ pub fn QuorumsType(comptime options: Options) type {
                 if (a.header.sequence + 1 == b.header.sequence) {
                     assert(a.header.checksum != b.header.checksum);
                     assert(a.header.cluster == b.header.cluster);
-                    assert(a.header.vsr_state.replica == b.header.vsr_state.replica);
+                    assert(a.header.vsr_state.replica_id == b.header.vsr_state.replica_id);
 
                     if (a.header.checksum != b.header.parent) {
                         return error.ParentNotConnected;


### PR DESCRIPTION
vsr: introduce u128 replica ids

Before replicas were identified by their index in the configuration.
This is susceptible to operator errors, and does not really work in a
world with reconfiguration (if a replica joins a cluster after being
offline through several reconfigurations, neither the replica nor the
cluster have any idea what this replica's index is).

What we do now instead is identify replica by a globally unique u128
number, which is generated during format.

It's not clear how _exactly_ we generate the ID though. The bullet proof
option is to pick the id randomly, but that makes creating a cluster
less ergonomic in a significant way (as you don't know ids until you
format). An alternative, for initial cluster members, it so pre-generate
ids based on initial replica indexes. It's more convenient, but less
safe.

In this PR I pick the second approach for now, to avoid disturbing  the
CLI until we fully implement reconfiguration. This isn't as useless as
it might seem -- although we generate id based on initial `replica`,
with ID generated and persisted we can now change `replica` over epochs!

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
