### PR TITLE
Test/StateMachine: Fix Operation enum values

### DIFF
--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -21,11 +21,11 @@ pub fn StateMachineType(
 
         pub const Operation = enum(u8) {
             /// Operations reserved by VR protocol (for all state machines):
-            reserved,
-            root,
-            register,
+            reserved = 0,
+            root = 1,
+            register = 2,
 
-            echo,
+            echo = config.vsr_operations_reserved + 0,
         };
 
         pub const Options = struct {};


### PR DESCRIPTION
Fix bug introduced by the combination of https://github.com/tigerbeetledb/tigerbeetle/pull/612 and https://github.com/tigerbeetledb/tigerbeetle/pull/609.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
