### PR TITLE
Add Node steps to client_integration rather than manual setup

### DIFF
--- a/.github/workflows/clients-go.yml
+++ b/.github/workflows/clients-go.yml
@@ -100,8 +100,11 @@ jobs:
 
       # Grab Zig
       - run: ./scripts/install.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
+
       # Specifically for self-hosted M1 runners, OK if this fails on other envs.
       - if: matrix.os != 'windows-latest'
         run: rm -rf /Users/macos/Library/Caches/go-build
+
+      # Build and run the integration tests
       - run: ./scripts/build.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }} client_integration
       - run: ./zig-out/bin/client_integration${{ matrix.os == 'windows-latest' && '.exe' || '' }} --language go --sample ${{ matrix.sample }}

--- a/.github/workflows/clients-node.yml
+++ b/.github/workflows/clients-node.yml
@@ -25,18 +25,6 @@ jobs:
           name: node-binaries
           path: src/clients/node/tigerbeetle-node-*.tgz
 
-      # Integration tests depend on dist rather than the .tgz version
-      # since these files refer to a local directory. There's not a
-      # way to refer to a .tgz file in a package.json file with a
-      # wildcard in it. If we hardcoded a version in the .tgz name of
-      # the package.json dependency then it would break every time we
-      # bumped the version.
-      - name: Upload dist
-        uses: actions/upload-artifact@v3
-        with:
-          name: node-dist
-          path: src/clients/node/dist
-
   test_install:
     # We use self hosted runners for M1 here. See macos.yml for an explaination
     permissions:
@@ -95,6 +83,10 @@ jobs:
         os: [macos-latest, ubuntu-latest]
         sample: [basic, two-phase]
 
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -102,12 +94,11 @@ jobs:
       - name: Download dist
         uses: actions/download-artifact@v3
         with:
-          name: node-dist
-          path: src/clients/node/dist
+          name: node-binaries
+          path: src/clients/node
 
-      - run: cd ../../../ && ./scripts/install.sh
+      # Grab Zig
+      - run: ./scripts/install.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
 
-      # Set up sample dependencies
-      - run: cd samples/${{ matrix.sample }} && npm install
-
-      - run: cd ../../../ && R_CWD=$(pwd)/src/clients/node/samples/${{ matrix.sample }} ./scripts/build.sh run_with_tb -- node main.js
+      - run: ./scripts/build.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }} client_integration
+      - run: ./zig-out/bin/client_integration${{ matrix.os == 'windows-latest' && '.exe' || '' }} --language node --sample ${{ matrix.sample }}

--- a/build.zig
+++ b/build.zig
@@ -465,11 +465,7 @@ const platforms = .{
     .{ "x86_64-macos", "osx-x64" },
     .{ "aarch64-linux-gnu", "linux-arm64" },
     .{ "aarch64-linux-musl", "linux-musl-arm64" },
-    .{
-        // Works around our build issues with Zig 0.9.1 and Ventura Macs. Can be dropped when we upgrade Zig.
-        if (builtin.cpu.arch == .aarch64 and builtin.os.tag == .macos) "native-macos" else "aarch64-macos",
-        "osx-arm64",
-    },
+    .{ "aarch64-macos", "osx-arm64" },
     .{ "x86_64-windows", "win-x64" },
 };
 

--- a/src/clients/node/samples/basic/package-lock.json
+++ b/src/clients/node/samples/basic/package-lock.json
@@ -5,11 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tigerbeetle-node": "file:../.."
+        "tigerbeetle-node": "^0.12.52"
       }
     },
     "../..": {
+      "name": "tigerbeetle-node",
       "version": "0.12.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^14.14.41",
@@ -21,18 +23,19 @@
       }
     },
     "node_modules/tigerbeetle-node": {
-      "resolved": "../..",
-      "link": true
+      "version": "0.12.52",
+      "resolved": "https://registry.npmjs.org/tigerbeetle-node/-/tigerbeetle-node-0.12.52.tgz",
+      "integrity": "sha512-oQKqC+JAXAaAjc07FTfcXjQOn2A1zV5LFBquGDdbtKfsY1pxkZCCwKlh46e++1CDCWoHjRQsHHsCpwPsmbC14g==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     }
   },
   "dependencies": {
     "tigerbeetle-node": {
-      "version": "file:../..",
-      "requires": {
-        "@types/node": "^14.14.41",
-        "node-api-headers": "^0.0.2",
-        "typescript": "^4.0.2"
-      }
+      "version": "0.12.52",
+      "resolved": "https://registry.npmjs.org/tigerbeetle-node/-/tigerbeetle-node-0.12.52.tgz",
+      "integrity": "sha512-oQKqC+JAXAaAjc07FTfcXjQOn2A1zV5LFBquGDdbtKfsY1pxkZCCwKlh46e++1CDCWoHjRQsHHsCpwPsmbC14g=="
     }
   }
 }

--- a/src/clients/node/samples/basic/package.json
+++ b/src/clients/node/samples/basic/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tigerbeetle-node": "file:../.."
+    "tigerbeetle-node": "^0.12.52"
   }
 }

--- a/src/clients/node/samples/two-phase/package-lock.json
+++ b/src/clients/node/samples/two-phase/package-lock.json
@@ -5,11 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tigerbeetle-node": "file:../.."
+        "tigerbeetle-node": "^0.12.52"
       }
     },
     "../..": {
+      "name": "tigerbeetle-node",
       "version": "0.12.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^14.14.41",
@@ -21,18 +23,19 @@
       }
     },
     "node_modules/tigerbeetle-node": {
-      "resolved": "../..",
-      "link": true
+      "version": "0.12.52",
+      "resolved": "https://registry.npmjs.org/tigerbeetle-node/-/tigerbeetle-node-0.12.52.tgz",
+      "integrity": "sha512-oQKqC+JAXAaAjc07FTfcXjQOn2A1zV5LFBquGDdbtKfsY1pxkZCCwKlh46e++1CDCWoHjRQsHHsCpwPsmbC14g==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     }
   },
   "dependencies": {
     "tigerbeetle-node": {
-      "version": "file:../..",
-      "requires": {
-        "@types/node": "^14.14.41",
-        "node-api-headers": "^0.0.2",
-        "typescript": "^4.0.2"
-      }
+      "version": "0.12.52",
+      "resolved": "https://registry.npmjs.org/tigerbeetle-node/-/tigerbeetle-node-0.12.52.tgz",
+      "integrity": "sha512-oQKqC+JAXAaAjc07FTfcXjQOn2A1zV5LFBquGDdbtKfsY1pxkZCCwKlh46e++1CDCWoHjRQsHHsCpwPsmbC14g=="
     }
   }
 }

--- a/src/clients/node/samples/two-phase/package.json
+++ b/src/clients/node/samples/two-phase/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tigerbeetle-node": "file:../.."
+    "tigerbeetle-node": "^0.12.52"
   }
 }

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -579,7 +579,7 @@ fn request(env: c.napi_env, info: c.napi_callback_info) callconv(.C) c.napi_valu
     const context = contextCast(context_raw.?) catch return null;
     const operation_int = translate.u32_from_value(env, argv[1], "operation") catch return null;
 
-    if (operation_int >= @typeInfo(Operation).Enum.fields.len) {
+    if (!@intToEnum(vsr.Operation, operation_int).valid(StateMachine)) {
         translate.throw(env, "Unknown operation.") catch return null;
     }
 
@@ -628,7 +628,7 @@ fn raw_request(env: c.napi_env, info: c.napi_callback_info) callconv(.C) c.napi_
     const context = contextCast(context_raw.?) catch return null;
     const operation_int = translate.u32_from_value(env, argv[1], "operation") catch return null;
 
-    if (operation_int >= @typeInfo(Operation).Enum.fields.len) {
+    if (!@intToEnum(vsr.Operation, operation_int).valid(StateMachine)) {
         translate.throw(env, "Unknown operation.") catch return null;
     }
     const operation = @intToEnum(Operation, @intCast(u8, operation_int));


### PR DESCRIPTION
Brings Node CI in line with the Go and Java integration test paths. I also made a mistake in a refactor of build.zig's run_with_tb step so the Node integration tests actually weren't running before. This allowed in a bug after a different PR was merged in the Node client when detecting invalid operations. This PR fixes that bug. Node integration steps are running.

* [x] I am very sure this PR could not affect performance.