### PR TITLE
VSR/SuperBlock: Fix client table recovery

### DIFF
--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1413,6 +1413,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 superblock.verify_manifest_blocks_are_acquired_in_free_set();
 
                 // TODO Repair any impaired copies before we continue.
+                context.copy = 0;
                 superblock.read_client_table(context);
             } else if (copy + 1 == constants.superblock_copies) {
                 @panic("superblock free set lost");


### PR DESCRIPTION
By not resetting the `copy` prior to `read_client_table()`, the recovery potentially skips over multiple (valid!) copies of the client table trailer. This can trigger an incorrect `superblock client table lost` panic.

(Bug discovered by the simulator, but in a different branch, so there isn't a seed here).

## Pre-merge checklist

* [x] I am very sure this PR could not affect performance.
