### PR TITLE
Trace time spent in io_uring separately from time spent in callbacks.

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -136,6 +136,11 @@ pub const IO = struct {
             while (copy.pop()) |completion| self.enqueue(completion);
         }
 
+        tracer.end(
+            &self.flush_tracer_slot,
+            .io_flush,
+        );
+
         // Run completions only after all completions have been flushed:
         // Loop until all completions are processed. Calls to complete() may queue more work
         // and extend the duration of the loop, but this is fine as it 1) executes completions
@@ -146,11 +151,6 @@ pub const IO = struct {
         // At this point, unqueued could have completions either by 1) those who didn't get an SQE
         // during the popping of unqueued or 2) completion.complete() which start new IO. These
         // unqueued completions will get priority to acquiring SQEs on the next flush().
-
-        tracer.end(
-            &self.flush_tracer_slot,
-            .io_flush,
-        );
     }
 
     fn flush_completions(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {


### PR DESCRIPTION
This makes it easier to figure out how often we're waiting on io.

## Pre-merge checklist

Performance:

* [ ] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
