### PR TITLE
VSR: Nack during DVC-phase of view-change, not repair-phase

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -200,6 +200,10 @@ comptime {
     assert(pipeline_prepare_queue_max + pipeline_request_queue_max <= clients_max);
     assert(pipeline_prepare_queue_max > 0);
     assert(pipeline_request_queue_max >= 0);
+
+    // A DVC message uses the `header.context` (u128) field as a bitset to mark whether it has
+    // prepared the corresponding header's message.
+    assert(pipeline_prepare_queue_max + 1 <= @bitSizeOf(u128));
 }
 
 /// Maximum number of headers from the WAL suffix to include in an SV message.

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -686,7 +686,7 @@ pub const ClusterFaultAtlas = struct {
         }
 
         // A cluster-of-2 is special-cased to mirror the special case in replica.zig.
-        // See repair_prepare()/on_nack_prepare().
+        // See repair_prepare().
         const quorums = vsr.quorums(replica_count);
         const faults_max = if (replica_count == 2) 1 else replica_count - quorums.replication;
         assert(faults_max < replica_count);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1325,6 +1325,7 @@ const ViewChangeHeadersArray = struct {
         // checkpoint, so the start_view has a full suffix of headers.
         assert(headers.array.get(0).op >= constants.journal_slot_count);
         assert(headers.array.len >= constants.view_change_headers_suffix_max);
+        assert(headers.array.len >= constants.pipeline_prepare_queue_max + 1);
 
         const commit_max = std.math.max(
             headers.array.get(0).op -| constants.pipeline_prepare_queue_max,
@@ -1340,10 +1341,7 @@ const ViewChangeHeadersArray = struct {
         //   (SV headers are determined by view_change_headers_suffix_max,
         //   but DVC headers must stop at commit_max.)
         headers.command = .do_view_change;
-        headers.array.len = std.math.min(
-            headers.array.len,
-            constants.pipeline_prepare_queue_max + 1,
-        );
+        headers.array.len = constants.pipeline_prepare_queue_max + 1;
 
         headers.verify();
     }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -223,7 +223,7 @@ pub const Header = extern struct {
     /// * A `prepare_ok` sets this to the checksum of the prepare being acked.
     /// * A `commit` sets this to the checksum of the latest committed prepare.
     /// * A `do_view_change` sets this to a bitset, with set bits indicating headers
-    ///   in the message body which it has definitely not prepared (i.e. "missing").
+    ///   in the message body which it has definitely not prepared (i.e. "nack").
     ///   The corresponding header may be an actual prepare header, or it may be a "blank" header.
     /// * A `request_prepare` sets this to the checksum of the prepare being requested.
     ///

--- a/src/vsr/README.md
+++ b/src/vsr/README.md
@@ -20,7 +20,6 @@
 |    `request_headers` | replica |      replica | [Repair Journal](#protocol-repair-journal)                     |
 |    `request_prepare` | replica |      replica | [Repair WAL](#protocol-repair-wal)                             |
 |            `headers` | replica |      replica | [Repair Journal](#protocol-repair-journal)                     |
-|       `nack_prepare` |  backup |      primary | [Repair WAL](#protocol-repair-wal)                             |
 |           `eviction` | primary |       client | [Client](#protocol-client)                                     |
 
 ### Recovery
@@ -176,8 +175,6 @@ During repair, missing/damaged prepares are requested & repaired chronologically
 In response to a `request_prepare`:
 
 - Reply the `command=prepare` with the requested prepare, if available and valid.
-- Reply `command=nack_prepare` if the request origin is the primary of the ongoing view-change and we never received the prepare.
-  (If the primary collects a _nack quorum_, it truncates uncommitted messages from the logs, improving availability).
 - Otherwise do not reply. (e.g. the corresponding slot in the WAL is corrupt)
 
 Per [PAR's CTRL Protocol](https://www.usenix.org/system/files/conference/fast18/fast18-alagappan.pdf), we do not nack corrupt entries, since they _might_ be the prepare being requested.


### PR DESCRIPTION
Move the nack-prepare phase into the DVC step.
How this works:
- Use `dvc.header.context` as a "missing" bitset to indicate nack-able (or situationally-nackable) messages (see DVCQuorum's updated docs for detail).
- Don't send "fault" entries in the DVC headers anymore — send the real header if available, and a blank otherwise.
- The new primary uses the combination of the "missing" bitset with the headers/blanks to nack+truncate before the repair phase of the view change even begins.

Note that this design means that `pipeline_prepare_queue_max` now has a hard limit of `@bitSizeOf(u128) - 1`.
We won't use a value that high even in production.

## Pre-merge checklist

Performance:


* [x] I am very sure this PR could not affect performance.
