### PR TITLE
verify that safety checks are on

### DIFF
--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -232,4 +232,9 @@ comptime {
     if (target.cpu.arch.endian() != .Little) {
         @compileError("big-endian systems not supported");
     }
+
+    switch (builtin.mode) {
+        .Debug, .ReleaseSafe => {},
+        .ReleaseFast, .ReleaseSmall => @compileError("safety checks are required for correctness"),
+    }
 }


### PR DESCRIPTION
We use asserts to, eg, verify that hashchain never breaks, and we definitely don't want to skip that validation in production.

More specifically:

- if the cluster is functioning normally, then disabling asserts should be fine --- we obviously properly check for invalid inputs and such.
- however, if the cluster is in a highly abnormal situation (eg, there are operator errors), we should _correctly_ shut the node down, and for these cases we rely on asserts


I think this enforcement _might_ make some ad-hoc performance investigations a bit more annoying, but it seems important to actually state our guarantee explicitly for users which might not be aware of the context here. 

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
