### PR TITLE
IO/Storage: CPU-bound and cross-thread scheduling

### DIFF
--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -13,274 +13,73 @@ const log = std.log.scoped(.tb_client_signal);
 /// It does this by using OS sockets (which are thread safe) 
 /// to resolve IO.Completions on the tigerbeetle thread.
 pub const Signal = struct {
-    io: *IO,
-    server_socket: os.socket_t,
-    accept_socket: os.socket_t,
-    connect_socket: os.socket_t,
-
-    completion: IO.Completion,
-    recv_buffer: [1]u8,
-    send_buffer: [1]u8,
-
-    on_signal_fn: fn (*Signal) void,
-    state: Atomic(enum(u8) {
-        running,
+    const State = enum(u8) {
         waiting,
         notified,
-        shutdown,
-    }),
+        running,
+    };
+
+    io: *IO,
+    on_signal_fn: fn (*Signal) void,
+
+    event: u32,
+    event_completion: IO.Completion,
+
+    state: Atomic(State),
+    terminated: Atomic(bool),
 
     pub fn init(self: *Signal, io: *IO, on_signal_fn: fn (*Signal) void) !void {
         self.io = io;
-        self.server_socket = os.socket(
-            os.AF.INET,
-            os.SOCK.STREAM | os.SOCK.NONBLOCK,
-            os.IPPROTO.TCP,
-        ) catch |err| {
-            log.err("failed to create signal server socket: {}", .{err});
-            return switch (err) {
-                error.PermissionDenied, error.ProtocolNotSupported, error.SocketTypeNotSupported, error.AddressFamilyNotSupported, error.ProtocolFamilyNotAvailable => error.NetworkSubsystemFailed,
-                error.ProcessFdQuotaExceeded, error.SystemFdQuotaExceeded, error.SystemResources => error.SystemResources,
-                error.Unexpected => error.Unexpected,
-            };
-        };
-        errdefer os.closeSocket(self.server_socket);
-
-        // Windows requires that the socket is bound before listening
-        if (builtin.target.os.tag == .windows) {
-            const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0); // zero port lets the OS choose
-            os.bind(self.server_socket, &addr.any, addr.getOsSockLen()) catch |err| {
-                log.err("failed to bind the server socket to a local random port: {}", .{err});
-                return switch (err) {
-                    error.AccessDenied => unreachable,
-                    error.AlreadyBound => unreachable,
-                    error.AddressInUse, error.AddressNotAvailable => unreachable,
-                    error.SymLinkLoop => unreachable,
-                    error.NameTooLong => unreachable,
-                    error.FileNotFound, error.FileDescriptorNotASocket => unreachable,
-                    error.NotDir => unreachable,
-                    error.ReadOnlyFileSystem => unreachable,
-                    error.SystemResources, error.NetworkSubsystemFailed, error.Unexpected => |e| e,
-                };
-            };
-        }
-
-        os.listen(self.server_socket, 1) catch |err| {
-            log.err("failed to listen on signal server socket: {}", .{err});
-            return switch (err) {
-                error.AddressInUse => unreachable,
-                error.FileDescriptorNotASocket => unreachable,
-                error.AlreadyConnected => unreachable,
-                error.SocketNotBound => unreachable,
-                error.OperationNotSupported, error.NetworkSubsystemFailed => error.NetworkSubsystemFailed,
-                error.SystemResources => error.SystemResources,
-                error.Unexpected => error.Unexpected,
-            };
-        };
-
-        var addr = std.net.Address.initIp4(undefined, undefined);
-        var addr_len = addr.getOsSockLen();
-        os.getsockname(self.server_socket, &addr.any, &addr_len) catch |err| {
-            log.err("failed to get address of signal server socket: {}", .{err});
-            return switch (err) {
-                error.SocketNotBound => unreachable,
-                error.FileDescriptorNotASocket => unreachable,
-                error.SystemResources => error.SystemResources,
-                error.NetworkSubsystemFailed => error.NetworkSubsystemFailed,
-                error.Unexpected => error.Unexpected,
-            };
-        };
-
-        self.connect_socket = self.io.open_socket(
-            os.AF.INET,
-            os.SOCK.STREAM,
-            os.IPPROTO.TCP,
-        ) catch |err| {
-            log.err("failed to create signal connect socket: {}", .{err});
-            return error.Unexpected;
-        };
-        errdefer os.closeSocket(self.connect_socket);
-
-        // Tracks when the connect_socket connects to the server_socket
-        const DoConnect = struct {
-            result: IO.ConnectError!void = undefined,
-            completion: IO.Completion = undefined,
-            is_connected: bool = false,
-
-            fn on_connect(
-                do_connect: *@This(),
-                _completion: *IO.Completion,
-                result: IO.ConnectError!void,
-            ) void {
-                assert(&do_connect.completion == _completion);
-                assert(!do_connect.is_connected);
-                do_connect.is_connected = true;
-                do_connect.result = result;
-            }
-        };
-
-        var do_connect = DoConnect{};
-        self.io.connect(
-            *DoConnect,
-            &do_connect,
-            DoConnect.on_connect,
-            &do_connect.completion,
-            self.connect_socket,
-            addr,
-        );
-
-        // Wait for the connect_socket to connect to the server_socket.
-        self.accept_socket = IO.INVALID_SOCKET;
-        while (!do_connect.is_connected or self.accept_socket == IO.INVALID_SOCKET) {
-            self.io.tick() catch |err| {
-                log.err("failed to tick IO when setting up signal: {}", .{err});
-                return error.Unexpected;
-            };
-
-            // Try to accept the connection from the connect_socket as the accept_socket
-            if (self.accept_socket == IO.INVALID_SOCKET) {
-                self.accept_socket = os.accept(self.server_socket, null, null, 0) catch |e| switch (e) {
-                    error.WouldBlock => continue,
-                    error.ConnectionAborted => unreachable,
-                    error.ConnectionResetByPeer => unreachable,
-                    error.FileDescriptorNotASocket => unreachable,
-                    error.ProcessFdQuotaExceeded, error.SystemFdQuotaExceeded, error.SystemResources => return error.SystemResources,
-                    error.SocketNotListening => unreachable,
-                    error.BlockedByFirewall => unreachable,
-                    error.ProtocolFailure, error.OperationNotSupported, error.NetworkSubsystemFailed => return error.NetworkSubsystemFailed,
-                    error.Unexpected => return error.Unexpected,
-                };
-            }
-        }
-
-        _ = do_connect.result catch |err| {
-            log.err("failed to connect on signal client socket: {}", .{err});
-            return error.Unexpected;
-        };
-
-        assert(do_connect.is_connected);
-        assert(self.accept_socket != IO.INVALID_SOCKET);
-        assert(self.connect_socket != IO.INVALID_SOCKET);
-
-        self.completion = undefined;
-        self.recv_buffer = undefined;
-        self.send_buffer = undefined;
-
-        self.state = @TypeOf(self.state).init(.running);
         self.on_signal_fn = on_signal_fn;
-        self.wait();
+
+        self.event = try io.open_event(&self.event_completion, on_event);
+        errdefer io.close_event(self.event, &self.event_completion);
+
+        self.state = Atomic(State).init(.waiting);
+        self.terminated = Atomic(bool).init(false);
     }
 
     pub fn deinit(self: *Signal) void {
-        os.closeSocket(self.server_socket);
-        os.closeSocket(self.accept_socket);
-        os.closeSocket(self.connect_socket);
+        self.io.close_event(self.event, &self.event_completion);
+        self.* = undefined;
     }
 
     /// Schedules the on_signal callback to be invoked on the IO thread.
     /// Safe to call from multiple threads.
     pub fn notify(self: *Signal) void {
         if (self.state.swap(.notified, .Release) == .waiting) {
-            self.wake();
+            self.io.trigger_event(self.event, &self.event_completion);
         }
     }
 
     /// Stops the signal from firing on_signal callbacks on the IO thread.
     /// Safe to call from multiple threads.
     pub fn shutdown(self: *Signal) void {
-        if (self.state.swap(.shutdown, .Release) == .waiting) {
-            self.wake();
-        }
+        self.terminated.store(true, .Monotonic);
+        self.notify();
     }
 
     /// Return true if the Signal was marked disabled and should no longer fire on_signal callbacks.
     /// Safe to call from multiple threads.
     pub fn is_shutdown(self: *const Signal) bool {
-        return self.state.load(.Acquire) == .shutdown;
+        return self.terminated.load(.Monotonic);
     }
 
-    fn wake(self: *Signal) void {
-        assert(self.accept_socket != IO.INVALID_SOCKET);
-        self.send_buffer[0] = 0;
+    fn on_event(completion: *IO.Completion) IO.EventResponse {
+        const self = @fieldParentPtr(Signal, "event_completion", completion);
+        while (true) {
+            // We must have been notified. Begin trying to run the signal handler.
+            assert(self.state.swap(.running, .Acquire) == .notified);
 
-        // TODO: use os.send() instead when it gets fixed for windows
-        if (builtin.target.os.tag != .windows) {
-            _ = os.send(self.accept_socket, &self.send_buffer, 0) catch unreachable;
-            return;
-        }
+            // Bail if we were shutdown.
+            if (self.is_shutdown()) return .cancel;
 
-        const buf: []const u8 = &self.send_buffer;
-        const rc = os.windows.sendto(self.accept_socket, buf.ptr, buf.len, 0, null, 0);
-        assert(rc != os.windows.ws2_32.SOCKET_ERROR);
-    }
+            self.on_signal_fn(self);
 
-    fn wait(self: *Signal) void {
-        const state = self.state.compareAndSwap(
-            .running,
-            .waiting,
-            .Acquire,
-            .Acquire,
-        ) orelse return self.io.recv(
-            *Signal,
-            self,
-            on_recv,
-            &self.completion,
-            self.connect_socket,
-            &self.recv_buffer,
-        );
-
-        switch (state) {
-            .running => unreachable, // Not possible due to CAS semantics.
-            .waiting => unreachable, // We should be the only ones who could've started waiting.
-            .notified => {}, // A thread woke us up before we started waiting so reschedule below.
-            .shutdown => return, // A thread shut down the signal before we started waiting.
-        }
-
-        self.io.timeout(
-            *Signal,
-            self,
-            on_timeout,
-            &self.completion,
-            0, // zero-timeout functions as a yield
-        );
-    }
-
-    fn on_recv(
-        self: *Signal,
-        completion: *IO.Completion,
-        result: IO.RecvError!usize,
-    ) void {
-        assert(completion == &self.completion);
-        _ = result catch |err| std.debug.panic("Signal recv error: {}", .{err});
-        self.on_signal();
-    }
-
-    fn on_timeout(
-        self: *Signal,
-        completion: *IO.Completion,
-        result: IO.TimeoutError!void,
-    ) void {
-        assert(completion == &self.completion);
-        _ = result catch |err| std.debug.panic("Signal timeout error: {}", .{err});
-        self.on_signal();
-    }
-
-    fn on_signal(self: *Signal) void {
-        const state = self.state.compareAndSwap(
-            .notified,
-            .running,
-            .Acquire,
-            .Acquire,
-        ) orelse {
-            (self.on_signal_fn)(self);
-            return self.wait();
-        };
-
-        switch (state) {
-            .running => unreachable, // Multiple racing calls to on_signal().
-            .waiting => unreachable, // on_signal() called without transitioning to a waking state.
-            .notified => unreachable, // Not possible due to CAS semantics.
-            .shutdown => return, // A thread shut down the signal before we started running.
+            // Transition from running to waiting to return .listen for the event handler.
+            // If this fails, it means another thread notified us while we were running so retry.
+            const state = self.state.compareAndSwap(.running, .waiting, .Release, .Monotonic) orelse return .listen;
+            assert(state == .notified);
         }
     }
 };

--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -8,10 +8,9 @@ const Atomic = std.atomic.Atomic;
 
 const log = std.log.scoped(.tb_client_signal);
 
-/// A Signal is a way to trigger a registered callback on a tigerbeetle IO instance 
-/// when notification occurs from another thread.
-/// It does this by using OS sockets (which are thread safe) 
-/// to resolve IO.Completions on the tigerbeetle thread.
+/// A Signal is a way to trigger a registered callback on a tigerbeetle IO instance when 
+/// notification occurs from another thread, generally to resolve IO.Completions on the 
+/// tigerbeetle main thread.
 pub const Signal = struct {
     const State = enum(u8) {
         waiting,
@@ -22,7 +21,7 @@ pub const Signal = struct {
     io: *IO,
     on_signal_fn: fn (*Signal) void,
 
-    event: u32,
+    event: i32,
     event_completion: IO.Completion,
 
     state: Atomic(State),

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -11,7 +11,7 @@ const buffer_limit = @import("../io.zig").buffer_limit;
 
 pub const IO = struct {
     kq: os.fd_t,
-    event_id: u32 = 0,
+    event_id: i21 = 0,
     time: Time = .{},
     io_inflight: usize = 0,
     timeouts: FIFO(Completion) = .{ .name = "io_timeouts" },
@@ -642,7 +642,7 @@ pub const IO = struct {
         );
     }
 
-    pub const INVALID_EVENT: u32 = 0;
+    pub const INVALID_EVENT: i32 = 0;
 
     pub const EventResponse = enum {
         listen,
@@ -653,12 +653,12 @@ pub const IO = struct {
         self: *IO,
         completion: *Completion,
         comptime on_event: fn (*Completion) EventResponse,
-    ) !u32 {
+    ) !i32 {
         self.event_id += 1;
         const event = self.event_id;
 
         var kev = mem.zeroes([1]os.Kevent);
-        kev[0].ident = event;
+        kev[0].ident = @intCast(@TypeOf(kev[0].ident), event);
         kev[0].filter = os.system.EVFILT_USER;
         kev[0].flags = os.system.EV_ADD | os.system.EV_ENABLE | os.system.EV_CLEAR;
 
@@ -689,23 +689,23 @@ pub const IO = struct {
         return event;
     }
 
-    pub fn trigger_event(self: *IO, event: u32, completion: *Completion) void {
+    pub fn trigger_event(self: *IO, event: i32, completion: *Completion) void {
         assert(event != INVALID_EVENT);
 
         var kev = mem.zeroes([1]os.Kevent);
-        kev[0].ident = event;
+        kev[0].ident = @intCast(@TypeOf(kev[0].ident), event);
         kev[0].filter = os.system.EVFILT_USER;
         kev[0].fflags = os.system.NOTE_TRIGGER;
         kev[0].udata = @ptrToInt(completion);
         assert((os.kevent(self.kq, &kev, kev[0..0], null) catch unreachable) == 0);
     }
 
-    pub fn close_event(self: *IO, event: u32, completion: *Completion) void {
+    pub fn close_event(self: *IO, event: i32, completion: *Completion) void {
         assert(event != INVALID_EVENT);
         _ = completion;
 
         var kev = mem.zeroes([1]os.Kevent);
-        kev[0].ident = event;
+        kev[0].ident = @intCast(@TypeOf(kev[0].ident), event);
         kev[0].filter = os.system.EVFILT_USER;
         kev[0].flags = os.system.EV_DELETE;
         kev[0].udata = 0; // Not needed for EV_DELETE.

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -267,7 +267,7 @@ test "event" {
         io: IO,
         done: bool = false,
         main_thread_id: std.Thread.Id,
-        event: u32 = IO.INVALID_EVENT,
+        event: i32 = IO.INVALID_EVENT,
         event_completion: IO.Completion = undefined,
 
         const delay = 1 * std.time.ns_per_s;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -903,7 +903,7 @@ pub const IO = struct {
         );
     }
 
-    pub const INVALID_EVENT: u32 = 0;
+    pub const INVALID_EVENT: i32 = 0;
 
     pub const EventResponse = enum {
         listen,
@@ -914,7 +914,7 @@ pub const IO = struct {
         self: *IO,
         completion: *Completion,
         comptime on_event: fn (*Completion) EventResponse,
-    ) !u32 {
+    ) !i32 {
         completion.* = .{
             .next = null,
             .context = null,
@@ -935,7 +935,7 @@ pub const IO = struct {
         return INVALID_EVENT + 1;
     }
 
-    pub fn trigger_event(self: *IO, event: u32, completion: *Completion) void {
+    pub fn trigger_event(self: *IO, event: i32, completion: *Completion) void {
         assert(event == INVALID_EVENT + 1);
         completion.operation = .{
             .event = .{
@@ -952,7 +952,7 @@ pub const IO = struct {
         ) catch unreachable;
     }
 
-    pub fn close_event(self: *IO, event: u32, completion: *Completion) void {
+    pub fn close_event(self: *IO, event: i32, completion: *Completion) void {
         // Nothing to close as events are just intrusive OVERLAPPED structs.
         assert(event == INVALID_EVENT + 1);
         _ = completion;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -939,7 +939,7 @@ pub const IO = struct {
         assert(event == INVALID_EVENT + 1);
         completion.operation = .{
             .event = .{
-                .overlapped = std.mem.zeroes(os.windows.OVERLAPPED),
+                .raw = std.mem.zeroes(os.windows.OVERLAPPED),
                 .completion = completion,
             },
         };
@@ -948,7 +948,7 @@ pub const IO = struct {
             self.iocp,
             undefined,
             undefined,
-            &completion.operation.event.overlapped,
+            &completion.operation.event.raw,
         ) catch unreachable;
     }
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -296,7 +296,7 @@ pub fn CompactionType(
                 context.tree.manifest.move_table(level_a, level_b, table_a);
 
                 compaction.state = .next_tick;
-                compaction.context.grid.on_next_tick(done_on_next_tick, &compaction.next_tick);
+                compaction.context.grid.on_next_tick(done_on_next_tick, &compaction.next_tick, .yield);
             } else {
                 // Otherwise, start merging.
 
@@ -743,7 +743,7 @@ pub fn CompactionType(
             switch (compaction.input_state) {
                 .remaining => {
                     compaction.state = .next_tick;
-                    compaction.context.grid.on_next_tick(loop_on_next_tick, &compaction.next_tick);
+                    compaction.context.grid.on_next_tick(loop_on_next_tick, &compaction.next_tick, .yield);
                 },
                 .exhausted => {
                     // Mark the level_a table as invisible if it was provided;
@@ -767,7 +767,7 @@ pub fn CompactionType(
                     }
 
                     compaction.state = .next_tick;
-                    compaction.context.grid.on_next_tick(done_on_next_tick, &compaction.next_tick);
+                    compaction.context.grid.on_next_tick(done_on_next_tick, &compaction.next_tick, .yield);
                 },
             }
         }

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -206,12 +206,15 @@ pub fn GridType(comptime Storage: type) type {
             grid.* = undefined;
         }
 
+        pub const NextTickIntent = Storage.NextTickIntent;
+
         pub fn on_next_tick(
             grid: *Grid,
             callback: fn (*Grid.NextTick) void,
             next_tick: *Grid.NextTick,
+            intent: NextTickIntent,
         ) void {
-            grid.superblock.storage.on_next_tick(callback, next_tick);
+            grid.superblock.storage.on_next_tick(callback, next_tick, intent);
         }
 
         /// Returning null indicates that there are not enough free blocks to fill the reservation.
@@ -434,7 +437,7 @@ pub fn GridType(comptime Storage: type) type {
             // Become the "root" read thats fetching the block for the given address.
             // The fetch happens asynchronously to avoid stack-overflow and nested cache invalidation.
             grid.read_queue.push(read);
-            grid.on_next_tick(read_block_tick_callback, &read.next_tick);
+            grid.on_next_tick(read_block_tick_callback, &read.next_tick, .yield);
         }
 
         fn read_block_tick_callback(next_tick: *Storage.NextTick) void {

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -117,7 +117,7 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                 );
             } else {
                 it.callback = .{ .next_tick = callback };
-                it.context.grid.on_next_tick(on_next_tick, &it.next_tick, .yield);
+                it.context.grid.on_next_tick(on_next_tick, &it.next_tick, .main_thread);
             }
         }
 

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -117,7 +117,7 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                 );
             } else {
                 it.callback = .{ .next_tick = callback };
-                it.context.grid.on_next_tick(on_next_tick, &it.next_tick);
+                it.context.grid.on_next_tick(on_next_tick, &it.next_tick, .yield);
             }
         }
 

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -91,7 +91,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                 it.context.grid.read_block(on_read, &it.read, address, checksum, .data);
             } else {
                 it.callback = .{ .next_tick = callback };
-                it.context.grid.on_next_tick(on_next_tick, &it.next_tick);
+                it.context.grid.on_next_tick(on_next_tick, &it.next_tick, .yield);
             }
         }
 

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -91,7 +91,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                 it.context.grid.read_block(on_read, &it.read, address, checksum, .data);
             } else {
                 it.callback = .{ .next_tick = callback };
-                it.context.grid.on_next_tick(on_next_tick, &it.next_tick, .yield);
+                it.context.grid.on_next_tick(on_next_tick, &it.next_tick, .main_thread);
             }
         }
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -75,7 +75,7 @@ const Environment = struct {
         env.io = try IO.init(128, 0);
         errdefer env.io.deinit();
 
-        env.storage = try Storage.init(&env.io, env.fd);
+        try env.storage.init(&env.io, env.fd);
         errdefer env.storage.deinit();
 
         env.message_pool = try MessagePool.init(allocator, .replica);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -553,7 +553,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 }
 
                 tree.compaction_callback = .{ .next_tick = callback };
-                tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick);
+                tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick, .yield);
                 return;
             }
 
@@ -572,7 +572,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 }
 
                 tree.compaction_callback = .{ .next_tick = callback };
-                tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick);
+                tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick, .yield);
                 return;
             }
             assert(op == tree.lookup_snapshot_max);
@@ -624,13 +624,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                     tree.lookup_snapshot_max = tree.compaction_op + 1;
 
                     tree.compaction_callback = .{ .next_tick = callback };
-                    tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick);
+                    tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick, .yield);
                 },
                 .half_bar_middle => {
                     tree.lookup_snapshot_max = tree.compaction_op + 1;
 
                     tree.compaction_callback = .{ .next_tick = callback };
-                    tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick);
+                    tree.grid.on_next_tick(compact_finish_next_tick, &tree.compaction_next_tick, .yield);
                 },
                 .half_bar_end => {
                     // At the end of a half-bar, we have to wait for all compactions to finish.

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -287,7 +287,7 @@ pub const Storage = struct {
         next_tick: *Storage.NextTick,
         intent: NextTickIntent,
     ) void {
-        // All on_next_tick requests are fullened through next_tick_queue for determinism.
+        // All on_next_tick requests are fulfilled through next_tick_queue for determinism.
         // `yield` - This already goes through next_tick_queue.
         // `cpu_work` - Avoid multi-threading and go through next_tick_queue.
         // `cpu_inject` - `cpu_work` goes through next_tick_queue so this does as well.

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -275,11 +275,24 @@ pub const Storage = struct {
         }
     }
 
+    pub const NextTickIntent = enum {
+        yield,
+        cpu_work,
+        cpu_inject,
+    };
+
     pub fn on_next_tick(
         storage: *Storage,
         callback: fn (next_tick: *Storage.NextTick) void,
         next_tick: *Storage.NextTick,
+        intent: NextTickIntent,
     ) void {
+        // All on_next_tick requests are fullened through next_tick_queue for determinism.
+        // `yield` - This already goes through next_tick_queue.
+        // `cpu_work` - Avoid multi-threading and go through next_tick_queue.
+        // `cpu_inject` - `cpu_work` goes through next_tick_queue so this does as well.
+        _ = intent;
+
         next_tick.* = .{ .callback = callback };
         storage.next_tick_queue.push(next_tick);
     }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -87,7 +87,7 @@ const Command = struct {
         command.io = try IO.init(128, 0);
         errdefer command.io.deinit();
 
-        command.storage = try Storage.init(&command.io, command.fd);
+        try command.storage.init(&command.io, command.fd);
         errdefer command.storage.deinit();
 
         command.message_pool = try MessagePool.init(allocator, .replica);

--- a/src/tracer.zig
+++ b/src/tracer.zig
@@ -76,6 +76,9 @@ pub const Event = union(enum) {
     },
     io_flush,
     io_callback,
+    thread_pool_callback: struct {
+        thread_id: std.Thread.Id,
+    },
 
     pub fn format(
         event: Event,
@@ -135,6 +138,10 @@ pub const Event = union(enum) {
             },
             .grid_read_iop => |args| try writer.print("grid_read_iop({})", .{args.index}),
             .grid_write_iop => |args| try writer.print("grid_write_iop({})", .{args.index}),
+            .thread_pool_callback => |args| try writer.print(
+                "thread_pool_callback({})",
+                .{args.thread_id},
+            ),
         }
     }
 
@@ -168,6 +175,7 @@ pub const Event = union(enum) {
                 .index = args.index,
             } },
             .io_flush, .io_callback => .io,
+            .thread_pool_callback => |args| .{ .thread_pool = .{ .thread_id = args.thread_id } },
         };
     }
 };
@@ -191,6 +199,9 @@ const Fiber = union(enum) {
         index: usize,
     },
     io,
+    thread_pool: struct {
+        thread_id: std.Thread.Id,
+    },
 
     pub fn format(
         fiber: Fiber,
@@ -221,6 +232,7 @@ const Fiber = union(enum) {
             },
             .grid_read_iop => |args| try writer.print("grid_read_iop({})", .{args.index}),
             .grid_write_iop => |args| try writer.print("grid_write_iop({})", .{args.index}),
+            .thread_pool => |args| try writer.print("thread_pool({})", .{args.thread_id}),
         };
     }
 };


### PR DESCRIPTION
This introduces the concept of an `intent` enum for `Storage.on_next_tick` which controls how the NextTick is scheduled. The enum includes: `yield` which defaults to `IO.timeout(0)` as usual, `cpu_work` which runs the NextTick on a thread pool, and `cpu_inject` which brings the NextTick back from a random (pool) thread to the IO thread. This is done with `tb_client.Signal` which now uses proper IO events (eventfd, EVFILT_USER, PostQueuedCompletionStatus) instead of a hacky, local TCP server.

The following LSM bits now utilize `cpu_work` to offload heavy tasks from the main thread:
* Sorting of `TableMutable` to `TableImmutable`.
* `TableBuilder.data_block_finish` in `Compaction` (this calls `vsr.calculate_checksum_body`)
* `Grid.read_block_validate` after a `Storage.read_sectors` occurs (this also calls `vsr.calculate_checksum_body`).

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1223 batches in 135.30 s
    load offered = 1000000 tx/s
    load accepted = 73908 tx/s
    batch latency p00 = 0 ms
    batch latency p10 = 28 ms
    batch latency p20 = 29 ms
    batch latency p30 = 30 ms
    batch latency p40 = 30 ms
    batch latency p50 = 31 ms
    batch latency p60 = 32 ms
    batch latency p70 = 33 ms
    batch latency p80 = 34 ms
    batch latency p90 = 36 ms
    batch latency p100 = 5517 ms
    transfer latency p00 = 0 ms
    transfer latency p10 = 4166 ms
    transfer latency p20 = 10805 ms
    transfer latency p30 = 21106 ms
    transfer latency p40 = 34218 ms
    transfer latency p50 = 49408 ms
    transfer latency p60 = 64719 ms
    transfer latency p70 = 74813 ms
    transfer latency p80 = 90404 ms
    transfer latency p90 = 106386 ms
    transfer latency p100 = 125316 ms
    
    # benchmark results after
    1223 batches in 82.40 s
    load offered = 1000000 tx/s
    load accepted = 121362 tx/s
    batch latency p00 = 1 ms
    batch latency p10 = 27 ms
    batch latency p20 = 28 ms
    batch latency p30 = 29 ms
    batch latency p40 = 30 ms
    batch latency p50 = 32 ms
    batch latency p60 = 33 ms
    batch latency p70 = 34 ms
    batch latency p80 = 35 ms
    batch latency p90 = 37 ms
    batch latency p100 = 3281 ms
    transfer latency p00 = 1 ms
    transfer latency p10 = 2101 ms
    transfer latency p20 = 5877 ms
    transfer latency p30 = 11111 ms
    transfer latency p40 = 17961 ms
    transfer latency p50 = 26298 ms
    transfer latency p60 = 35204 ms
    transfer latency p70 = 44132 ms
    transfer latency p80 = 53201 ms
    transfer latency p90 = 62509 ms
    transfer latency p100 = 72410 ms
    ```
