### PR TITLE
minor: clearer name

### DIFF
--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -921,9 +921,9 @@ const TestClients = struct {
                     const message = client.get_message();
                     defer client.unref(message);
 
-                    const size = 123;
-                    std.mem.set(u8, message.buffer[@sizeOf(vsr.Header)..][0..size], 42);
-                    t.cluster.request(c, .echo, message, size);
+                    const body_size = 123;
+                    std.mem.set(u8, message.buffer[@sizeOf(vsr.Header)..][0..body_size], 42);
+                    t.cluster.request(c, .echo, message, body_size);
                 }
             }
         }


### PR DESCRIPTION
Though this is the message size, not the body size, and trippend an assert

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
