### PR TITLE
WIP: reconfiguration

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -148,6 +148,7 @@ typedef struct tb_create_transfers_result_t {
 } tb_create_transfers_result_t;
 
 typedef enum TB_OPERATION {
+    TB_OPERATION_RECONFIGURE = 3,
     TB_OPERATION_CREATE_ACCOUNTS = 128,
     TB_OPERATION_CREATE_TRANSFERS = 129,
     TB_OPERATION_LOOKUP_ACCOUNTS = 130,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -30,14 +30,22 @@ pub const output = std.log.scoped(.cluster);
 
 /// Set this to `false` if you want to see how literally everything works.
 /// This will run much slower but will trace all logic across the cluster.
-const log_state_transitions_only = builtin.mode != .Debug;
+const log_state_transitions_only = true;
 
 const log_simulator = std.log.scoped(.simulator);
 
 pub const tigerbeetle_config = @import("config.zig").configs.test_min;
 
 /// You can fine tune your log levels even further (debug/info/warn/err):
-pub const log_level: std.log.Level = if (log_state_transitions_only) .info else .debug;
+pub const log_level: std.log.Level = .err;
+pub const scope_levels = [_]std.log.ScopeLevel{ .{
+    .scope = .cluster,
+    .level = .info,
+}, .{
+    .scope = .replica,
+    .level = .err,
+} };
+// pub const log_level: std.log.Level = .err;
 
 const cluster_id = 0;
 
@@ -78,7 +86,7 @@ pub fn main() !void {
     var prng = std.rand.DefaultPrng.init(seed);
     const random = prng.random();
 
-    const replica_count = 1 + random.uintLessThan(u8, constants.replicas_max);
+    const replica_count = 2 + random.uintLessThan(u8, constants.replicas_max - 1);
     const standby_count = random.uintAtMost(u8, constants.standbys_max);
     const node_count = replica_count + standby_count;
     const client_count = 1 + random.uintLessThan(u8, constants.clients_max);
@@ -150,7 +158,7 @@ pub fn main() !void {
         .cluster = cluster_options,
         .workload = workload_options,
         // TODO Swarm testing: Test long+few crashes and short+many crashes separately.
-        .replica_crash_probability = 0.00002,
+        .replica_crash_probability = 0,
         .replica_crash_stability = random.uintLessThan(u32, 1_000),
         .replica_restart_probability = 0.0002,
         .replica_restart_stability = random.uintLessThan(u32, 1_000),
@@ -236,6 +244,7 @@ pub fn main() !void {
         if (simulator.done()) break;
     } else {
         output.err("you can reproduce this failure with seed={}", .{seed});
+        simulator.cluster.log_cluster();
         fatal(.liveness, "unable to complete requests_committed_max before ticks_max", .{});
     }
     assert(simulator.done());
@@ -350,6 +359,25 @@ pub const Simulator = struct {
         simulator.cluster.tick();
         simulator.tick_requests();
         simulator.tick_crash();
+
+        var switch_epoch = false;
+        for (simulator.cluster.replicas) |replica| {
+            if (replica.epoch == 1) {
+                switch_epoch = true;
+                break;
+            }
+        }
+        if (switch_epoch) {
+            var perm = [_]u8{0} ** constants.nodes_max;
+            for (simulator.cluster.replicas) |*replica, replica_index| {
+                for (simulator.workload.members) |member, member_index| {
+                    if (replica.replica_id == member) {
+                        perm[member_index] = @intCast(u8, replica_index);
+                    }
+                }
+            }
+            simulator.cluster.update_client_epoch(&perm);
+        }
     }
 
     fn on_cluster_reply(
@@ -435,7 +463,13 @@ pub const Simulator = struct {
         var request_message = client.get_message();
         defer client.unref(request_message);
 
+        var replica_ids = [_]u128{0} ** constants.nodes_max;
+        for (simulator.cluster.replicas) |replica, i| {
+            replica_ids[i] = replica.replica_id;
+        }
+
         const request_metadata = simulator.workload.build_request(
+            &replica_ids,
             client_index,
             @alignCast(
                 @alignOf(vsr.Header),
@@ -588,7 +622,7 @@ pub fn log(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    if (log_state_transitions_only and scope != .cluster) return;
+    // if (log_state_transitions_only and scope != .cluster) return;
 
     const prefix_default = "[" ++ @tagName(level) ++ "] " ++ "(" ++ @tagName(scope) ++ "): ";
     const prefix = if (log_state_transitions_only) "" else prefix_default;

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -230,6 +230,7 @@ pub fn StateMachineType(
             reserved = 0,
             root = 1,
             register = 2,
+            reconfigure = 3,
 
             /// Operations exported by TigerBeetle:
             create_accounts = config.vsr_operations_reserved + 0,
@@ -330,6 +331,7 @@ pub fn StateMachineType(
                 .reserved => unreachable,
                 .root => unreachable,
                 .register => {},
+                .reconfigure => {},
                 .create_accounts => self.prepare_timestamp += mem.bytesAsSlice(Account, input).len,
                 .create_transfers => self.prepare_timestamp += mem.bytesAsSlice(Transfer, input).len,
                 .lookup_accounts => {},
@@ -372,7 +374,7 @@ pub fn StateMachineType(
             self.forest.grooves.posted.prefetch_setup(null);
 
             return switch (operation) {
-                .reserved, .root, .register => unreachable,
+                .reserved, .root, .register, .reconfigure => unreachable,
                 .create_accounts => {
                     self.prefetch_create_accounts(mem.bytesAsSlice(Account, input));
                 },

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -94,6 +94,13 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
         context: ?*anyopaque = null,
 
+        pub fn dump(cluster: *const Self) void {
+            for (cluster.replicas) |replica| {
+                replica.dump();
+            }
+            std.debug.print("\n", .{});
+        }
+
         pub fn init(
             allocator: mem.Allocator,
             /// Includes command=register messages.
@@ -314,9 +321,9 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 switch (cluster.replica_health[i]) {
                     .up => {
                         replica.tick();
-                        cluster.state_checker.check_state(replica.replica) catch |err| {
-                            fatal(.correctness, "state checker error: {}", .{err});
-                        };
+                        // cluster.state_checker.check_state(replica.replica) catch |err| {
+                        //     fatal(.correctness, "state checker error: {}", .{err});
+                        // };
                     },
                     // Keep ticking the time so that it won't have diverged too far to synchronize
                     // when the replica restarts.
@@ -336,7 +343,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             try cluster.open_replica(replica_index, time);
             cluster.network.process_enable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .up;
-            cluster.log_replica(.recover, replica_index);
+            // cluster.log_replica(.recover, replica_index);
         }
 
         /// Reset a replica to its initial state, simulating a random crash/panic.
@@ -351,7 +358,7 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             cluster.replicas[replica_index].deinit(cluster.allocator);
             cluster.network.process_disable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .down;
-            cluster.log_replica(.crash, replica_index);
+            // cluster.log_replica(.crash, replica_index);
 
             // Ensure that none of the replica's messages leaked when it was deinitialized.
             var messages_in_pool: usize = 0;
@@ -427,6 +434,15 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             };
         }
 
+        pub fn update_client_epoch(cluster: *Self, replicas: []const u8) void {
+            for (cluster.clients) |*c| {
+                for (replicas) |member, index| {
+                    c.message_bus_members[index] = member;
+                }
+                c.epoch += 1;
+            }
+        }
+
         fn client_on_reply(client: *Client, request_message: *Message, reply_message: *Message) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), client.on_reply_context.?));
             assert(reply_message.header.cluster == cluster.options.cluster_id);
@@ -443,19 +459,27 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             cluster.on_client_reply(cluster, client_index, request_message, reply_message);
         }
 
+        fn get_stable_index(cluster: *const Self, replica: *const Replica) u8 {
+            for (cluster.replicas) |*r, i| {
+                if (r.replica_id == replica.replica_id) return @intCast(u8, i);
+            } else unreachable;
+        }
+
         fn on_replica_commit(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
-            assert(cluster.replica_health[replica.replica] == .up);
+            const stable_index = cluster.get_stable_index(replica);
+            assert(cluster.replica_health[stable_index] == .up);
 
-            cluster.log_replica(.commit, replica.replica);
-            cluster.state_checker.check_state(replica.replica) catch |err| {
+            // cluster.log_replica(.commit, stable_index);
+            cluster.state_checker.check_state(stable_index) catch |err| {
                 fatal(.correctness, "state checker error: {}", .{err});
             };
         }
 
         fn on_replica_compact(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
-            assert(cluster.replica_health[replica.replica] == .up);
+            const stable_index = cluster.get_stable_index(replica);
+            assert(cluster.replica_health[stable_index] == .up);
             cluster.storage_checker.replica_compact(replica) catch |err| {
                 fatal(.correctness, "storage checker error: {}", .{err});
             };
@@ -463,16 +487,18 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
 
         fn on_replica_checkpoint_start(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
-            assert(cluster.replica_health[replica.replica] == .up);
+            const stable_index = cluster.get_stable_index(replica);
+            assert(cluster.replica_health[stable_index] == .up);
 
-            cluster.log_replica(.checkpoint_start, replica.replica);
+            // cluster.log_replica(.checkpoint_start, stable_index);
         }
 
         fn on_replica_checkpoint_done(replica: *const Replica) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), replica.context.?));
-            assert(cluster.replica_health[replica.replica] == .up);
+            const stable_index = cluster.get_stable_index(replica);
+            assert(cluster.replica_health[stable_index] == .up);
 
-            cluster.log_replica(.checkpoint_done, replica.replica);
+            // cluster.log_replica(.checkpoint_done, stable_index);
             cluster.storage_checker.replica_checkpoint(replica) catch |err| {
                 fatal(.correctness, "storage checker error: {}", .{err});
             };
@@ -549,13 +575,14 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
                 }
 
                 info = std.fmt.bufPrint(&info_buffer, "" ++
-                    "{[view]:>4}V " ++
+                    "{[view]:>4}/{[epoch]:_>2}V " ++
                     "{[commit_min]:>3}/{[commit_max]:_>3}C " ++
                     "{[journal_op_min]:>3}:{[journal_op_max]:_>3}Jo " ++
                     "{[journal_faulty]:>2}/{[journal_dirty]:_>2}J! " ++
                     "{[wal_op_min]:>3}:{[wal_op_max]:>3}Wo " ++
                     "{[grid_blocks_free]:>7}Gf", .{
                     .view = replica.view,
+                    .epoch = replica.epoch,
                     .commit_min = replica.commit_min,
                     .commit_max = replica.commit_max,
                     .journal_op_min = journal_op_min,

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -35,8 +35,10 @@ pub const MessageBus = struct {
         process: Process,
         message_pool: *MessagePool,
         on_message_callback: fn (message_bus: *MessageBus, message: *Message) void,
+        resolve_replica_callback: fn (message_bus: *MessageBus, header: *const Header) ?u8,
         options: Options,
     ) !MessageBus {
+        _ = resolve_replica_callback;
         return MessageBus{
             .network = options.network,
             .pool = message_pool,

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -147,8 +147,8 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 assert(commit.header.op == i);
                 if (i > 0) {
                     const previous = state_checker.commits.items[i - 1].header;
-                    assert(commit.header.parent == previous.checksum);
-                    assert(commit.header.view >= previous.view);
+                    assert(previous.checksum == commit.header.parent);
+                    assert(vsr.view_order_or_eql(previous, commit.header));
                 }
             }
             return true;

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -1,3 +1,5 @@
+pub const log_level = .debug;
+
 test {
     _ = @import("ewah.zig");
     _ = @import("fifo.zig");

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -36,6 +36,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
 
         allocator: mem.Allocator,
         message_bus: MessageBus,
+        message_bus_members: [constants.nodes_max]u8,
 
         /// A universally unique identifier for the client (must not be zero).
         /// Used for routing replies back to the client via any network path (multi-path routing).
@@ -67,6 +68,8 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
         /// The highest view number seen by the client in messages exchanged with the cluster.
         /// Used to locate the current primary, and provide more information to a partitioned primary.
         view: u32 = 0,
+
+        epoch: u32 = 0,
 
         /// A client is allowed at most one inflight request at a time at the protocol layer.
         /// We therefore queue any further concurrent requests made by the application layer.
@@ -109,13 +112,20 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 .{ .client = id },
                 message_pool,
                 Self.on_message,
+                Self.resolve_replica,
                 message_bus_options,
             );
             errdefer message_bus.deinit(allocator);
 
+            var message_bus_members = [_]u8{0} ** constants.nodes_max;
+            for (message_bus_members) |*member, index| {
+                member.* = @intCast(u8, index);
+            }
+
             var self = Self{
                 .allocator = allocator,
                 .message_bus = message_bus,
+                .message_bus_members = message_bus_members,
                 .id = id,
                 .cluster = cluster,
                 .replica_count = replica_count,
@@ -142,6 +152,16 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 self.message_bus.unref(inflight.message);
             }
             self.message_bus.deinit(allocator);
+        }
+
+        fn resolve_replica(message_bus: *MessageBus, header: *const Header) ?u8 {
+            const self = @fieldParentPtr(Self, "message_bus", message_bus);
+            if (header.epoch == self.epoch) {
+                for (self.message_bus_members) |member, index| {
+                    if (member == header.replica) return @intCast(u8, index) else unreachable;
+                }
+            }
+            return null;
         }
 
         pub fn on_message(message_bus: *MessageBus, message: *Message) void {
@@ -193,7 +213,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             message: *Message,
             message_body_size: usize,
         ) void {
-            assert(@enumToInt(operation) >= constants.vsr_operations_reserved);
+            assert(operation == .reconfigure or @enumToInt(operation) >= constants.vsr_operations_reserved);
 
             self.register();
             assert(self.request_number > 0);
@@ -513,6 +533,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             const message = self.create_message_from_header(header);
             defer self.message_bus.unref(message);
 
+
             self.send_message_to_replica(replica, message);
         }
 
@@ -539,7 +560,8 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(message.header.client == self.id);
             assert(message.header.cluster == self.cluster);
 
-            self.message_bus.send_message_to_replica(replica, message);
+            const message_bus_replica = self.message_bus_members[replica];
+            self.message_bus.send_message_to_replica(message_bus_replica, message);
         }
 
         fn send_request_for_the_first_time(self: *Self, message: *Message) void {


### PR DESCRIPTION
First stab at reconfiguration, basically looking around at what would break if we do reconfig. A bunch of stuff breaks!

The interesting bits here are:

* The Readme update
* `epoch_initiate_new`, `epoch_switch_to_new` and `epoch_retire_old` family of functions in replica
* the test in `replica_tests` which demonstrates that we can actually switch epoch 

The overall flow is:

* we _initiate_ new epoch when we prepare a `.reconfigure` (primary additionaly promises to not prepare anything else in this epoch)
* we _switch_ to the new epoch when we commit
* we _retire_ old epoch once we get a checkpoint in the new epoch

---

My overall plan here is 

* implement simplest possible approach from VRR paper without any optimization and ignoring repairs
* (i wanted to initially skip the persistance bit, and test with non-crashing replicas, but it seems we have enough assertions in the superblock that just doing persistance is easier)
* implement cross-epoch repair
* implement reconfiguration safety checks (ie, primary rejects reconfigure request if standbys are not caught up)
* implement cross-epoch pipelining (so that, rather stopping prepares, we send them in the next epoch)
* implement a faster way to retire old epoch then waiting for a checkpoint
* implement adding and removing standbys once we have state sync