### PR TITLE
build: don't shellcheck submodules

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -115,7 +115,11 @@ pub fn build(b: *std.build.Builder) void {
         lint_tigerstyle_step.dependOn(&run_cmd.step);
 
         // lint_shellcheck
-        const lint_shellcheck = b.addSystemCommand(&.{ "sh", "-c", "command -v shellcheck >/dev/null || (echo -e '\\033[0;31mPlease install shellcheck - https://www.shellcheck.net/\\033[0m' && exit 1) && shellcheck $(find . -type f -name '*.sh')" });
+        const lint_shellcheck = b.addSystemCommand(&.{ "sh", "-c",
+            "command -v shellcheck >/dev/null" ++
+            " || (echo -e '\\033[0;31mPlease install shellcheck - https://www.shellcheck.net/\\033[0m' && exit 1)" ++
+            " && shellcheck $(find ./src ./scripts -type f -name '*.sh')"
+        });
         const lint_shellcheck_step = b.step("lint_shellcheck", "Run shellcheck on **.sh");
         lint_shellcheck_step.dependOn(&lint_shellcheck.step);
 


### PR DESCRIPTION
We checkout tracy into tools/tracy, and we don't want to run shellcheck on that, as that would fail

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
