### PR TITLE
ci: benchmark script fails on compilation errors

### DIFF
--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -3,7 +3,7 @@ setlocal enabledelayedexpansion
 
 REM Install Zig if it does not already exist:
 if not exist "zig" (
-    call .\scripts\install_zig.bat
+    call .\scripts\install_zig.bat || exit /b
 )
 
 if "%~1" equ ":main" (
@@ -27,13 +27,13 @@ echo.
 exit /b
 
 :main
-zig\zig.exe build install -Drelease-safe -Dconfig=production
+zig\zig.exe build install -Drelease-safe -Dconfig=production || exit /b
 
 for /l %%i in (0, 1, 0) do (
     echo Initializing replica %%i
     set ZIG_FILE=.\0_%%i.tigerbeetle.benchmark
     if exist "!ZIG_FILE!" DEL /F "!ZIG_FILE!"
-    .\tigerbeetle.exe format --cluster=0 --replica=%%i --replica-count=1 !ZIG_FILE! > benchmark.log 2>&1
+    .\tigerbeetle.exe format --cluster=0 --replica=%%i --replica-count=1 !ZIG_FILE! > benchmark.log 2>&1 || exit /b
 )
 
 for /l %%i in (0, 1, 0) do (


### PR DESCRIPTION
The problem here is that we don't do `set -e`, so any subcommands failing do not terminate the script, and it just hangs in the benchmark itself. It looks like there is _no_ `set -e` for .bat, and we have to manually check each call.

I _didn't_ check the `start` call as I don't know how that interracts with start /B, but that seems relatively unimportant.

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
