### PR TITLE
[Dotnet Client] NuGet publish

### DIFF
--- a/.github/workflows/clients-dotnet.yml
+++ b/.github/workflows/clients-dotnet.yml
@@ -2,6 +2,9 @@ name: "clients/dotnet"
 
 on:
   workflow_call:
+    secrets:
+      NUGET_KEY:
+        required: true
 
 jobs:
   build:
@@ -19,19 +22,27 @@ jobs:
 
       - name: Build dotnet
         working-directory: src/clients/dotnet
-        run: dotnet build -c Release
+        run: dotnet build --configuration Release
 
       - name: Tests
         working-directory: src/clients/dotnet
-        run: dotnet test /p:CollectCoverage=true /p:Threshold=\"95,85,95\" /p:ThresholdType=\"line,branch,method\"
-
+        run: |
+          dotnet test \
+          /p:CollectCoverage=true \
+          /p:Threshold=\"95,85,95\" \
+          /p:ThresholdType=\"line,branch,method\"
       - name: Pack
         working-directory: src/clients/dotnet
-        run: dotnet pack -c Release
+        run: |
+          dotnet pack TigerBeetle \
+          --configuration Release \
+          /p:AssemblyVersion=$BASE_VERSION.$(git rev-list --count HEAD) \
+          /p:Version=$BASE_VERSION.$(git rev-list --count HEAD)
+        env:
+          BASE_VERSION: 0.0.1
 
       - name: Save nuget package
         uses: actions/upload-artifact@v3
-        ## if: ${{ github.ref != 'refs/heads/main' }}
         with:
           name: nuget-artifact
           path: src/clients/dotnet/TigerBeetle/bin/Release/*.nupkg
@@ -79,7 +90,7 @@ jobs:
           mkdir test-project && cd test-project
           dotnet nuget add source ../nuget
           dotnet new console
-          dotnet add package tigerbeetle-dotnet -s ../nuget
+          dotnet add package tigerbeetle -s ../nuget
       - uses: actions/download-artifact@v3
         with:
           name: test-project-artifact
@@ -117,7 +128,24 @@ jobs:
           mkdir test-project && cd test-project
           dotnet nuget add source /nuget
           dotnet new console
-          dotnet add package tigerbeetle-dotnet -s /nuget
+          dotnet add package tigerbeetle -s /nuget
           cp -f /Program.cs .
           dotnet run
           "
+
+  publish:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: [run_validation_tests, run_validation_tests_on_containers]
+    name: Publish NuGet package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: nuget-artifact
+          path: ./nuget
+      - run: |
+          dotnet nuget push ./nuget/*.nupkg \
+          --api-key $NUGET_KEY \
+          --source https://api.nuget.org/v3/index.json
+        env:
+          NUGET_KEY: ${{ secrets.NUGET_KEY }}

--- a/.github/workflows/clients-dotnet.yml
+++ b/.github/workflows/clients-dotnet.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0      
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,6 +27,8 @@ jobs:
     uses: ./.github/workflows/macos.yml
   client-dotnet:
     uses: ./.github/workflows/clients-dotnet.yml
+    secrets:
+      NUGET_KEY: ${{ secrets.NUGET_KEY }}     
   client-go:
     uses: ./.github/workflows/clients-go.yml
     secrets:

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.props
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.props
@@ -4,7 +4,7 @@
       <Copyright>TigerBeetle Inc.</Copyright>
       <Authors>TigerBeetle Inc.</Authors>
       <NeutralLanguage>en-US</NeutralLanguage>
-      <PackageId>tigerbeetle-dotnet</PackageId>
+      <PackageId>tigerbeetle</PackageId>
       <PackageTags>TigerBeetle</PackageTags>
       <PackageProjectUrl>https://github.com/tigerbeetledb/tigerbeetle</PackageProjectUrl>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Publishes a [NuGet package](https://www.nuget.org/) for the C# client. so it can be installed using `dotnet add package tigerbeetle` command.

- Packages are published using the version number `0.0.1` + `git rev-list --count HEAD`
- The required secret `NUGET_KEY` is already set up in this repository.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
