### PR TITLE
VSR: Incremental client table

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -58,6 +58,8 @@ const ConfigProcess = struct {
     direct_io_required: bool,
     journal_iops_read_max: usize = 8,
     journal_iops_write_max: usize = 8,
+    client_replies_iops_read_max: usize = 1,
+    client_replies_iops_write_max: usize = 2,
     tick_ms: u63 = 10,
     rtt_ms: u64 = 300,
     rtt_multiple: u8 = 2,

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -10,7 +10,6 @@ const vsr = @import("../vsr.zig");
 const log = std.log.scoped(.lsm_forest_fuzz);
 const tracer = @import("../tracer.zig");
 
-const MessagePool = @import("../message_pool.zig").MessagePool;
 const Transfer = @import("../tigerbeetle.zig").Transfer;
 const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
@@ -92,7 +91,6 @@ const Environment = struct {
 
     state: State,
     storage: *Storage,
-    message_pool: MessagePool,
     superblock: SuperBlock,
     superblock_context: SuperBlock.Context,
     grid: Grid,
@@ -102,12 +100,10 @@ const Environment = struct {
 
     fn init(env: *Environment, storage: *Storage) !void {
         env.storage = storage;
-        env.message_pool = try MessagePool.init(allocator, .replica);
 
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = env.storage,
             .storage_size_limit = constants.storage_size_max,
-            .message_pool = &env.message_pool,
         });
 
         env.grid = try Grid.init(allocator, &env.superblock);
@@ -118,7 +114,6 @@ const Environment = struct {
     }
 
     fn deinit(env: *Environment) void {
-        env.message_pool.deinit(allocator);
         env.superblock.deinit(allocator);
         env.grid.deinit(allocator);
     }

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -18,7 +18,6 @@ const log = std.log.scoped(.fuzz_lsm_manifest_log);
 const vsr = @import("../vsr.zig");
 const constants = @import("../constants.zig");
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
-const MessagePool = @import("../message_pool.zig").MessagePool;
 const SuperBlock = @import("../vsr/superblock.zig").SuperBlockType(Storage);
 const data_file_size_min = @import("../vsr/superblock.zig").data_file_size_min;
 const TableExtent = @import("../vsr/superblock_manifest.zig").Manifest.TableExtent;
@@ -70,21 +69,15 @@ fn run_fuzz(
     var storage_verify = try Storage.init(allocator, constants.storage_size_max, storage_options);
     defer storage_verify.deinit(allocator);
 
-    // The MessagePool is shared by both superblocks because they will not use it.
-    var message_pool = try MessagePool.init(allocator, .replica);
-    defer message_pool.deinit(allocator);
-
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
         .storage_size_limit = constants.storage_size_max,
-        .message_pool = &message_pool,
     });
     defer superblock.deinit(allocator);
 
     var superblock_verify = try SuperBlock.init(allocator, .{
         .storage = &storage_verify,
         .storage_size_limit = constants.storage_size_max,
-        .message_pool = &message_pool,
     });
     defer superblock_verify.deinit(allocator);
 
@@ -467,7 +460,6 @@ const Environment = struct {
                 .{
                     .storage = test_storage,
                     .storage_size_limit = constants.storage_size_max,
-                    .message_pool = env.manifest_log.superblock.client_sessions.message_pool,
                 },
             );
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -467,7 +467,7 @@ const Environment = struct {
                 .{
                     .storage = test_storage,
                     .storage_size_limit = constants.storage_size_max,
-                    .message_pool = env.manifest_log.superblock.client_table.message_pool,
+                    .message_pool = env.manifest_log.superblock.client_sessions.message_pool,
                 },
             );
 

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -8,7 +8,6 @@ const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const log = std.log.scoped(.lsm_forest_test);
 
-const MessagePool = @import("../message_pool.zig").MessagePool;
 const Transfer = @import("../tigerbeetle.zig").Transfer;
 const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../storage.zig").Storage;
@@ -54,7 +53,6 @@ const Environment = struct {
     fd: os.fd_t,
     io: IO,
     storage: Storage,
-    message_pool: MessagePool,
     superblock: SuperBlock,
     superblock_context: SuperBlock.Context,
     grid: Grid,
@@ -78,13 +76,9 @@ const Environment = struct {
         env.storage = try Storage.init(&env.io, env.fd);
         errdefer env.storage.deinit();
 
-        env.message_pool = try MessagePool.init(allocator, .replica);
-        errdefer env.message_pool.deinit(allocator);
-
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = &env.storage,
             .storage_size_limit = constants.storage_size_max,
-            .message_pool = &env.message_pool,
         });
         env.superblock_context = undefined;
         errdefer env.superblock.deinit(allocator);
@@ -109,7 +103,6 @@ const Environment = struct {
         }
         env.grid.deinit(allocator);
         env.superblock.deinit(allocator);
-        env.message_pool.deinit(allocator);
         env.storage.deinit();
         env.io.deinit();
         std.os.close(env.fd);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -10,7 +10,6 @@ const vsr = @import("../vsr.zig");
 const log = std.log.scoped(.lsm_tree_fuzz);
 const tracer = @import("../tracer.zig");
 
-const MessagePool = @import("../message_pool.zig").MessagePool;
 const Transfer = @import("../tigerbeetle.zig").Transfer;
 const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
@@ -126,7 +125,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         state: State,
         storage: *Storage,
-        message_pool: MessagePool,
         superblock: SuperBlock,
         superblock_context: SuperBlock.Context,
         grid: Grid,
@@ -141,13 +139,9 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.state = .init;
             env.storage = storage;
 
-            env.message_pool = try MessagePool.init(allocator, .replica);
-            defer env.message_pool.deinit(allocator);
-
             env.superblock = try SuperBlock.init(allocator, .{
                 .storage = env.storage,
                 .storage_size_limit = constants.storage_size_max,
-                .message_pool = &env.message_pool,
             });
             defer env.superblock.deinit(allocator);
 

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -20,7 +20,8 @@ pub const messages_max_replica = messages_max: {
 
     sum += constants.journal_iops_read_max; // Journal reads
     sum += constants.journal_iops_write_max; // Journal writes
-    sum += constants.clients_max; // SuperBlock.client_table // TODO Update.
+    sum += constants.client_replies_iops_read_max; // Client-reply reads
+    sum += constants.client_replies_iops_write_max; // Client-reply writes
     sum += 1; // Replica.loopback_queue
     sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
     sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -20,7 +20,7 @@ pub const messages_max_replica = messages_max: {
 
     sum += constants.journal_iops_read_max; // Journal reads
     sum += constants.journal_iops_write_max; // Journal writes
-    sum += constants.clients_max; // SuperBlock.client_table
+    sum += constants.clients_max; // SuperBlock.client_table // TODO Update.
     sum += 1; // Replica.loopback_queue
     sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
     sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1358,7 +1358,6 @@ test "sum_overflows" {
 
 const TestContext = struct {
     const Storage = @import("testing/storage.zig").Storage;
-    const MessagePool = @import("message_pool.zig").MessagePool;
     const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
     const SuperBlock = @import("vsr/superblock.zig").SuperBlockType(Storage);
     const Grid = @import("lsm/grid.zig").GridType(Storage);
@@ -1371,7 +1370,6 @@ const TestContext = struct {
     const message_body_size_max = 32 * @sizeOf(Account);
 
     storage: Storage,
-    message_pool: MessagePool,
     superblock: SuperBlock,
     grid: Grid,
     state_machine: StateMachine,
@@ -1389,16 +1387,9 @@ const TestContext = struct {
         );
         errdefer ctx.storage.deinit(allocator);
 
-        ctx.message_pool = .{
-            .free_list = null,
-            .messages_max = 0,
-        };
-        errdefer ctx.message_pool.deinit(allocator);
-
         ctx.superblock = try SuperBlock.init(allocator, .{
             .storage = &ctx.storage,
             .storage_size_limit = data_file_size_min,
-            .message_pool = &ctx.message_pool,
         });
         errdefer ctx.superblock.deinit(allocator);
 
@@ -1423,7 +1414,6 @@ const TestContext = struct {
         ctx.superblock.deinit(allocator);
         ctx.grid.deinit(allocator);
         ctx.state_machine.deinit(allocator);
-        ctx.message_pool.deinit(allocator);
         ctx.* = undefined;
     }
 };

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -213,7 +213,6 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             for (storages) |*storage, replica_index| {
                 var superblock = try SuperBlock.init(allocator, .{
                     .storage = storage,
-                    .message_pool = &replica_pools[replica_index],
                     .storage_size_limit = options.storage_size_limit,
                 });
                 defer superblock.deinit(allocator);

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -10,7 +10,8 @@
 //!
 //! Areas verified at checkpoint:
 //! - WAL prepares
-//! - SuperBlock Manifest, FreeSet, ClientTable
+//! - SuperBlock Manifest, FreeSet, ClientSessions
+//! - TODO Verify ClientReplies
 //! - Acquired Grid blocks
 //!
 //! Areas not verified:
@@ -47,7 +48,7 @@ const Checkpoint = struct {
     // `SuperBlockHeader.{trailer}_checksum`.
     checksum_superblock_manifest: u128,
     checksum_superblock_free_set: u128,
-    checksum_superblock_client_table: u128,
+    checksum_superblock_client_sessions: u128,
     checksum_wal_prepares: u128,
     checksum_grid: u128,
 };
@@ -127,12 +128,12 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             var checkpoint = Checkpoint{
                 .checksum_superblock_manifest = 0,
                 .checksum_superblock_free_set = 0,
-                .checksum_superblock_client_table = 0,
+                .checksum_superblock_client_sessions = 0,
                 .checksum_wal_prepares = checksum_wal_prepares(storage),
                 .checksum_grid = checksum_grid(replica),
             };
 
-            inline for (.{ .manifest, .free_set, .client_table }) |trailer| {
+            inline for (.{ .manifest, .free_set, .client_sessions }) |trailer| {
                 const trailer_area = @field(superblock.areas, trailer);
                 const trailer_size = @field(working, @tagName(trailer) ++ "_size");
                 var copy: u8 = 0;

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -11,7 +11,7 @@
 //! Areas verified at checkpoint:
 //! - WAL prepares
 //! - SuperBlock Manifest, FreeSet, ClientSessions
-//! - TODO Verify ClientReplies
+//! - ClientReplies
 //! - Acquired Grid blocks
 //!
 //! Areas not verified:
@@ -50,6 +50,7 @@ const Checkpoint = struct {
     checksum_superblock_free_set: u128,
     checksum_superblock_client_sessions: u128,
     checksum_wal_prepares: u128,
+    checksum_client_replies: u128,
     checksum_grid: u128,
 };
 
@@ -121,24 +122,24 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             const storage = replica.superblock.storage;
             const working = replica.superblock.working;
 
-            // TODO(Beat Compaction) Remove when deterministic storage is fixed.
-            // Until then this is too noisy.
-            if (1 == 1) return;
-
             var checkpoint = Checkpoint{
                 .checksum_superblock_manifest = 0,
                 .checksum_superblock_free_set = 0,
                 .checksum_superblock_client_sessions = 0,
                 .checksum_wal_prepares = checksum_wal_prepares(storage),
-                .checksum_grid = checksum_grid(replica),
+                .checksum_client_replies = checksum_client_replies(storage),
+                // TODO(Beat Compaction) Enable grid check when deterministic storage is fixed.
+                // Until then this is too noisy.
+                // checksum_grid(replica),
+                .checksum_grid = 0,
             };
 
             inline for (.{ .manifest, .free_set, .client_sessions }) |trailer| {
-                const trailer_area = @field(superblock.areas, trailer);
+                const trailer_area = @field(superblock.areas, @tagName(trailer));
                 const trailer_size = @field(working, @tagName(trailer) ++ "_size");
                 var copy: u8 = 0;
                 while (copy < constants.superblock_copies) : (copy += 1) {
-                    @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer.field)) |=
+                    @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer)) |=
                         vsr.checksum(storage.memory[trailer_area.offset(copy)..][0..trailer_size]);
                 }
             }
@@ -186,6 +187,12 @@ pub fn StorageCheckerType(comptime Replica: type) type {
                 checksum ^= vsr.checksum(std.mem.asBytes(prepare)[0..prepare.header.size]);
             }
             return checksum;
+        }
+
+        fn checksum_client_replies(storage: *const Storage) u128 {
+            const offset = vsr.Zone.client_replies.offset(0);
+            const size = constants.clients_max * constants.message_size_max;
+            return vsr.checksum(storage.memory[offset..][0..size]);
         }
 
         fn checksum_grid(replica: *const Replica) u128 {

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -427,6 +427,7 @@ pub const Storage = struct {
             .superblock => atlas.faulty_superblock(replica_index, offset_in_zone, size),
             .wal_headers => atlas.faulty_wal_headers(replica_index, offset_in_zone, size),
             .wal_prepares => atlas.faulty_wal_prepares(replica_index, offset_in_zone, size),
+            .client_replies => null, // TODO Allow client-reply faults.
             .grid => null,
         } orelse return;
 
@@ -544,6 +545,7 @@ pub const Area = union(enum) {
     superblock: struct { area: superblock.Area, copy: u8 },
     wal_headers: struct { sector: usize },
     wal_prepares: struct { slot: usize },
+    client_replies: struct { slot: usize },
     grid: struct { address: u64 },
 
     fn sectors(area: Area) SectorRange {
@@ -560,6 +562,11 @@ pub const Area = union(enum) {
             ),
             .wal_prepares => |data| SectorRange.from_zone(
                 .wal_prepares,
+                constants.message_size_max * data.slot,
+                constants.message_size_max,
+            ),
+            .client_replies => |data| SectorRange.from_zone(
+                .client_replies,
                 constants.message_size_max * data.slot,
                 constants.message_size_max,
             ),

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -720,7 +720,7 @@ pub const ClusterFaultAtlas = struct {
             superblock.areas.header.base => .header,
             superblock.areas.manifest.base => .manifest,
             superblock.areas.free_set.base => .free_set,
-            superblock.areas.client_table.base => .client_table,
+            superblock.areas.client_sessions.base => .client_sessions,
             else => unreachable,
         };
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -112,7 +112,6 @@ const Command = struct {
             .{
                 .storage = &command.storage,
                 .storage_size_limit = data_file_size_min,
-                .message_pool = &command.message_pool,
             },
         );
         defer superblock.deinit(allocator);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -37,6 +37,7 @@ pub const Status = @import("vsr/replica.zig").Status;
 pub const Client = @import("vsr/client.zig").Client;
 pub const ClockType = @import("vsr/clock.zig").ClockType;
 pub const JournalType = @import("vsr/journal.zig").JournalType;
+pub const ClientRepliesType = @import("vsr/client_replies.zig").ClientRepliesType;
 pub const SlotRange = @import("vsr/journal.zig").SlotRange;
 pub const SuperBlockType = superblock.SuperBlockType;
 pub const VSRState = superblock.SuperBlockHeader.VSRState;
@@ -51,17 +52,20 @@ pub const Zone = enum {
     superblock,
     wal_headers,
     wal_prepares,
+    client_replies,
     grid,
 
     const size_superblock = superblock.superblock_zone_size;
     const size_wal_headers = constants.journal_size_headers;
     const size_wal_prepares = constants.journal_size_prepares;
+    const size_client_replies = constants.client_replies_size;
 
     comptime {
         for (.{
             size_superblock,
             size_wal_headers,
             size_wal_prepares,
+            size_client_replies,
         }) |zone_size| {
             assert(zone_size % constants.sector_size == 0);
         }
@@ -76,7 +80,8 @@ pub const Zone = enum {
             .superblock => 0,
             .wal_headers => size_superblock,
             .wal_prepares => size_superblock + size_wal_headers,
-            .grid => size_superblock + size_wal_headers + size_wal_prepares,
+            .client_replies => size_superblock + size_wal_headers + size_wal_prepares,
+            .grid => size_superblock + size_wal_headers + size_wal_prepares + size_client_replies,
         };
     }
 
@@ -85,6 +90,7 @@ pub const Zone = enum {
             .superblock => size_superblock,
             .wal_headers => size_wal_headers,
             .wal_prepares => size_wal_prepares,
+            .client_replies => size_client_replies,
             .grid => null,
         };
     }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -76,14 +76,16 @@ pub const Zone = enum {
             assert(offset_logical < zone_size);
         }
 
-        var offset_ = offset_logical;
-        // TODO(Zig): "inline for" when "unable to evaluate constant expression" is fixed.
-        for (std.enums.values(Zone)) |z| {
-            if (zone == z) return offset_;
-            offset_ += z.size().?;
-        } else {
-            unreachable;
+        return zone.start() + offset_logical;
+    }
+
+    pub fn start(zone: Zone) u64 {
+        comptime var start_offset = 0;
+        inline for (comptime std.enums.values(Zone)) |z| {
+            if (z == zone) return start_offset;
+            start_offset += comptime size(z) orelse 0;
         }
+        unreachable;
     }
 
     pub fn size(zone: Zone) ?u64 {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -76,13 +76,14 @@ pub const Zone = enum {
             assert(offset_logical < zone_size);
         }
 
-        return offset_logical + switch (zone) {
-            .superblock => 0,
-            .wal_headers => size_superblock,
-            .wal_prepares => size_superblock + size_wal_headers,
-            .client_replies => size_superblock + size_wal_headers + size_wal_prepares,
-            .grid => size_superblock + size_wal_headers + size_wal_prepares + size_client_replies,
-        };
+        var offset_ = offset_logical;
+        // TODO(Zig): "inline for" when "unable to evaluate constant expression" is fixed.
+        for (std.enums.values(Zone)) |z| {
+            if (zone == z) return offset_;
+            offset_ += z.size().?;
+        } else {
+            unreachable;
+        }
     }
 
     pub fn size(zone: Zone) ?u64 {

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -1,0 +1,262 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
+const log = std.log.scoped(.client_replies);
+
+const stdx = @import("../stdx.zig");
+const constants = @import("../constants.zig");
+const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
+const IOPS = @import("../iops.zig").IOPS;
+const vsr = @import("../vsr.zig");
+const Message = @import("../message_pool.zig").MessagePool.Message;
+const MessagePool = @import("../message_pool.zig").MessagePool;
+const Slot = @import("superblock_client_sessions.zig").ReplySlot;
+const Entry = @import("superblock_client_sessions.zig").ClientSessions.Entry;
+
+const client_replies_iops_max =
+    constants.client_replies_iops_read_max + constants.client_replies_iops_write_max;
+
+fn slot_offset(slot: Slot) usize {
+    return slot.index * constants.message_size_max;
+}
+
+pub fn ClientRepliesType(comptime Storage: type) type {
+    return struct {
+        const ClientReplies = @This();
+
+        const Read = struct {
+            client_replies: *ClientReplies,
+            completion: Storage.Read,
+            callback: fn (client_replies: *ClientReplies, reply: ?*Message) void,
+            message: *Message,
+            /// The header of the expected reply.
+            header: vsr.Header,
+        };
+
+        const Write = struct {
+            client_replies: *ClientReplies,
+            completion: Storage.Write,
+            callback: fn (client_replies: *ClientReplies, wrote: *Message) void,
+            slot: Slot,
+            message: *Message,
+        };
+
+        storage: *Storage,
+        message_pool: *MessagePool,
+        replica: u8,
+
+        reads: IOPS(Read, constants.client_replies_iops_read_max) = .{},
+        writes: IOPS(Write, constants.client_replies_iops_write_max) = .{},
+
+        /// Track which slots have a write currently in progress.
+        writing: std.StaticBitSet(constants.clients_max) =
+            std.StaticBitSet(constants.clients_max).initEmpty(),
+
+        /// Guard against multiple concurrent writes to the same slot.
+        /// Pointers are into `writes`.
+        write_queue: RingBuffer(*Write, constants.client_replies_iops_write_max, .array) = .{},
+
+        pub fn init(storage: *Storage, message_pool: *MessagePool, replica_index: u8) ClientReplies {
+            return .{
+                .storage = storage,
+                .message_pool = message_pool,
+                .replica = replica_index,
+            };
+        }
+
+        pub fn deinit(client_replies: *ClientReplies) void {
+            {
+                var it = client_replies.reads.iterate();
+                while (it.next()) |read| client_replies.message_pool.unref(read.message);
+            }
+            {
+                var it = client_replies.writes.iterate();
+                while (it.next()) |write| client_replies.message_pool.unref(write.message);
+            }
+            // Don't unref `write_queue`'s Writes — they are a subset of `writes`.
+        }
+
+        pub fn read_reply(
+            client_replies: *ClientReplies,
+            slot: Slot,
+            entry: *const Entry,
+            callback: fn (*ClientReplies, ?*Message) void,
+        ) void {
+            const client = entry.header.client;
+
+            if (client_replies.writing.isSet(slot.index)) {
+                var writes = client_replies.writes.iterate();
+                var write_latest: ?*const Write = null;
+                while (writes.next()) |write| {
+                    if (write.message.header.client == client) {
+                        if (write_latest == null or
+                            write_latest.?.message.header.request < write.message.header.request)
+                        {
+                            write_latest = write;
+                        }
+                    }
+                }
+                assert(write_latest.?.message.header.checksum == entry.header.checksum);
+
+                callback(client_replies, write_latest.?.message);
+                return;
+            }
+
+            const read = client_replies.reads.acquire() orelse {
+                log.debug("{}: read_reply: busy (client={} reply={})", .{
+                    client_replies.replica,
+                    entry.header.client,
+                    entry.header.checksum,
+                });
+
+                callback(client_replies, null);
+                return;
+            };
+
+            const message = client_replies.message_pool.get_message();
+            defer client_replies.message_pool.unref(message);
+
+            read.* = .{
+                .client_replies = client_replies,
+                .completion = undefined,
+                .message = message.ref(),
+                .callback = callback,
+                .header = entry.header,
+            };
+
+            const buffer: []u8 = message.buffer[0..vsr.sector_ceil(entry.header.size)];
+
+            log.debug("{}: read_reply: start (client={} reply={})", .{
+                client_replies.replica,
+                read.header.client,
+                read.header.checksum,
+            });
+
+            client_replies.storage.read_sectors(
+                read_reply_callback,
+                &read.completion,
+                buffer,
+                .client_replies,
+                slot_offset(slot),
+            );
+        }
+
+        fn read_reply_callback(completion: *Storage.Read) void {
+            const read = @fieldParentPtr(ClientReplies.Read, "completion", completion);
+            const client_replies = read.client_replies;
+
+            defer {
+                client_replies.message_pool.unref(read.message);
+                client_replies.reads.release(read);
+            }
+
+            if (!read.message.header.valid_checksum()) {
+                log.warn("{}: read_reply: corrupt header (client={} reply={})", .{
+                    client_replies.replica,
+                    read.header.client,
+                    read.header.checksum,
+                });
+
+                read.callback(client_replies, null);
+                return;
+            }
+
+            if (read.message.header.checksum != read.header.checksum) {
+                log.warn("{}: read_reply: unexpected header (client={} reply={} found={})", .{
+                    client_replies.replica,
+                    read.header.client,
+                    read.header.checksum,
+                    read.message.header.checksum,
+                });
+
+                read.callback(client_replies, null);
+                return;
+            }
+
+            assert(read.message.header.command == .reply);
+            assert(read.message.header.cluster == read.header.cluster);
+
+            if (!read.message.header.valid_checksum_body(read.message.body())) {
+                log.warn("{}: read_reply: corrupt body (client={} reply={})", .{
+                    client_replies.replica,
+                    read.header.client,
+                    read.header.checksum,
+                });
+
+                read.callback(client_replies, null);
+                return;
+            }
+
+            log.debug("{}: read_reply: done (client={} reply={})", .{
+                client_replies.replica,
+                read.header.client,
+                read.header.checksum,
+            });
+
+            read.callback(client_replies, read.message);
+        }
+
+        pub fn can_write_reply(client_replies: *ClientReplies) bool {
+            return client_replies.writes.available() > 0;
+        }
+
+        pub fn write_reply(
+            client_replies: *ClientReplies,
+            slot: Slot,
+            message: *Message,
+            callback: fn (client_replies: *ClientReplies, wrote: *Message) void,
+        ) void {
+            assert(client_replies.can_write_reply());
+            assert(message.header.command == .reply);
+            // There is never any need to write a body-less message, since the header is
+            // stored safely in the client sessions superblock trailer.
+            assert(message.header.size != @sizeOf(vsr.Header));
+
+            const write = client_replies.writes.acquire().?;
+            write.* = .{
+                .client_replies = client_replies,
+                .completion = undefined,
+                .callback = callback,
+                .message = message.ref(),
+                .slot = slot,
+            };
+
+            // TODO Optimization — if there is already a write for this slot queued (but not started), replace it.
+            client_replies.write_queue.push_assume_capacity(write);
+            client_replies.write_reply_next();
+        }
+
+        fn write_reply_next(client_replies: *ClientReplies) void {
+            while (client_replies.write_queue.head()) |write| {
+                if (client_replies.writing.isSet(write.slot.index)) break;
+
+                const message = write.message;
+                _ = client_replies.write_queue.pop();
+                client_replies.writing.set(write.slot.index);
+                client_replies.storage.write_sectors(
+                    write_reply_callback,
+                    &write.completion,
+                    message.buffer[0..vsr.sector_ceil(message.header.size)],
+                    .client_replies,
+                    slot_offset(write.slot),
+                );
+            }
+        }
+
+        fn write_reply_callback(completion: *Storage.Write) void {
+            const write = @fieldParentPtr(ClientReplies.Write, "completion", completion);
+            const client_replies = write.client_replies;
+            const callback = write.callback;
+            const message = write.message;
+
+            // Release the write *before* invoking the callback, so that if the callback
+            // uses can_write_reply() it doesn't appear busy when its not.
+            client_replies.writing.unset(write.slot.index);
+            client_replies.writes.release(write);
+            callback(client_replies, message);
+
+            client_replies.message_pool.unref(message);
+            client_replies.write_reply_next();
+        }
+    };
+}

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -20,6 +20,10 @@ fn slot_offset(slot: Slot) usize {
     return slot.index * constants.message_size_max;
 }
 
+// TODO Optimization:
+// Don't always immediately start writing a reply. Instead, hold onto it in the hopes that
+// the same client will queue another request. If they do (within the same checkpoint),
+// then we no longer need to persist the original reply.
 pub fn ClientRepliesType(comptime Storage: type) type {
     return struct {
         const ClientReplies = @This();

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -239,11 +239,17 @@ pub fn ClientRepliesType(comptime Storage: type) type {
 
                 const message = write.message;
                 _ = client_replies.write_queue.pop();
+
+                // Zero sector padding to ensure deterministic storage.
+                const size = message.header.size;
+                const size_ceil = vsr.sector_ceil(size);
+                std.mem.set(u8, message.buffer[size..size_ceil], 0);
+
                 client_replies.writing.set(write.slot.index);
                 client_replies.storage.write_sectors(
                     write_reply_callback,
                     &write.completion,
-                    message.buffer[0..vsr.sector_ceil(message.header.size)],
+                    message.buffer[0..size_ceil],
                     .client_replies,
                     slot_offset(write.slot),
                 );

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2574,6 +2574,17 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op == self.op_checkpoint_trigger());
 
+            self.client_replies.checkpoint(commit_op_checkpoint_client_replies_callback);
+        }
+
+        fn commit_op_checkpoint_client_replies_callback(client_replies: *ClientReplies) void {
+            const self = @fieldParentPtr(Self, "client_replies", client_replies);
+            assert(self.committing);
+            assert(self.commit_callback != null);
+            assert(self.commit_prepare.?.header.op == self.op);
+            assert(self.commit_prepare.?.header.op == self.commit_min);
+            assert(self.commit_prepare.?.header.op == self.op_checkpoint_trigger());
+
             // For the given WAL (journal_slot_count=8, lsm_batch_multiple=2, op=commit_min=7):
             //
             //   A  B  C  D  E

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -77,6 +77,7 @@ pub fn ReplicaType(
         const Self = @This();
 
         const Journal = vsr.JournalType(Self, Storage);
+        const ClientReplies = vsr.ClientRepliesType(Storage);
         const Clock = vsr.ClockType(Time);
 
         /// We use this allocator during open/init and then disable it.
@@ -120,6 +121,9 @@ pub fn ReplicaType(
 
         /// The persistent log of hash-chained journal entries:
         journal: Journal,
+
+        /// The persistent log of the latest reply per active client.
+        client_replies: ClientReplies,
 
         /// An abstraction to send messages from the replica to another replica or client.
         /// The message bus will also deliver messages to this replica by calling `on_message_from_bus()`.
@@ -374,7 +378,6 @@ pub fn ReplicaType(
                 .{
                     .storage = options.storage,
                     .storage_size_limit = options.storage_size_limit,
-                    .message_pool = options.message_pool,
                 },
             );
 
@@ -653,6 +656,13 @@ pub fn ReplicaType(
             self.journal = try Journal.init(allocator, options.storage, replica_index);
             errdefer self.journal.deinit(allocator);
 
+            var client_replies = ClientReplies.init(
+                options.storage,
+                options.message_pool,
+                replica_index,
+            );
+            errdefer client_replies.deinit();
+
             self.message_bus = try MessageBus.init(
                 allocator,
                 options.cluster,
@@ -688,6 +698,7 @@ pub fn ReplicaType(
                 .time = self.time,
                 .clock = self.clock,
                 .journal = self.journal,
+                .client_replies = client_replies,
                 .message_bus = self.message_bus,
                 .state_machine = self.state_machine,
                 .superblock = self.superblock,
@@ -769,15 +780,6 @@ pub fn ReplicaType(
                 self.quorum_view_change,
                 self.quorum_replication,
             });
-
-            // To reduce the probability of clustering, for efficient linear probing, the hash map will
-            // always overallocate capacity by a factor of two.
-            log.debug("{}: init: client_table.capacity()={} for constants.clients_max={} entries", .{
-                self.replica,
-                self.client_table().capacity(),
-                constants.clients_max,
-            });
-
             assert(self.status == .recovering);
         }
 
@@ -789,6 +791,7 @@ pub fn ReplicaType(
 
             self.static_allocator.transition_from_static_to_deinit();
 
+            self.client_replies.deinit();
             self.journal.deinit(allocator);
             self.clock.deinit(allocator);
             self.state_machine.deinit(allocator);
@@ -1858,7 +1861,8 @@ pub fn ReplicaType(
             if (self.solo()) {
                 // Replica=1 doesn't write prepares concurrently to avoid gaps in its WAL.
                 assert(self.journal.writes.executing() <= 1);
-                assert(self.journal.writes.executing() == 1 or self.committing);
+                assert(self.journal.writes.executing() == 1 or self.committing or
+                    self.client_replies.writes.executing() > 0);
 
                 self.prepare_timeout.reset();
                 return;
@@ -2342,6 +2346,18 @@ pub fn ReplicaType(
                 const op = self.commit_min + 1;
                 const header = self.journal.header_with_op(op).?;
 
+                if (!self.client_replies.can_write_reply()) {
+                    log.debug("{}: commit_journal_next: waiting to write reply " ++
+                        "(client={} commit={})", .{
+                        self.replica,
+                        header.client,
+                        header.checksum,
+                    });
+
+                    self.commit_ops_done();
+                    return;
+                }
+
                 if (self.pipeline.cache.prepare_by_op_and_checksum(op, header.checksum)) |prepare| {
                     log.debug("{}: commit_journal_next: cached prepare op={} checksum={}", .{
                         self.replica,
@@ -2446,6 +2462,7 @@ pub fn ReplicaType(
                 (self.status == .recovering and self.solo()));
             assert(self.commit_prepare == null);
             assert(self.commit_callback == null);
+            assert(self.client_replies.can_write_reply());
             assert(prepare.header.command == .prepare);
             assert(prepare.header.operation != .root);
             assert(prepare.header.op == self.commit_min + 1);
@@ -2736,8 +2753,8 @@ pub fn ReplicaType(
                 // updated with entries for one bar beyond the op_checkpoint.
                 assert(self.op_checkpoint() == self.superblock.working.vsr_state.commit_min);
                 if (self.client_table().get(prepare.header.client)) |entry| {
-                    assert(entry.reply.header.command == .reply);
-                    assert(entry.reply.header.op >= prepare.header.op);
+                    assert(entry.header.command == .reply);
+                    assert(entry.header.op >= prepare.header.op);
                 } else {
                     assert(self.client_table().count() == self.client_table().capacity());
                 }
@@ -2792,7 +2809,19 @@ pub fn ReplicaType(
 
                 if (!prepare.ok_quorum_received) {
                     // Eventually handled by on_prepare_timeout().
-                    log.debug("{}: commit_pipeline: waiting for quorum", .{self.replica});
+                    log.debug("{}: commit_pipeline_next: waiting for quorum", .{self.replica});
+                    self.commit_ops_done();
+                    return;
+                }
+
+                if (!self.client_replies.can_write_reply()) {
+                    log.debug("{}: commit_pipeline_next: waiting to write reply " ++
+                        "(client={} commit={})", .{
+                        self.replica,
+                        prepare.message.header.client,
+                        prepare.message.header.checksum,
+                    });
+
                     self.commit_ops_done();
                     return;
                 }
@@ -2887,24 +2916,24 @@ pub fn ReplicaType(
             const clients = self.client_table().count();
             assert(clients <= constants.clients_max);
             if (clients == constants.clients_max) {
-                var evictee: ?*Message = null;
+                var evictee: ?*const Header = null;
                 var iterated: usize = 0;
                 var iterator = self.client_table().iterator();
                 while (iterator.next()) |entry| : (iterated += 1) {
-                    assert(entry.reply.header.command == .reply);
-                    assert(entry.reply.header.context == 0);
-                    assert(entry.reply.header.op == entry.reply.header.commit);
-                    assert(entry.reply.header.commit >= entry.session);
+                    assert(entry.header.command == .reply);
+                    assert(entry.header.context == 0);
+                    assert(entry.header.op == entry.header.commit);
+                    assert(entry.header.commit >= entry.session);
 
                     if (evictee) |evictee_reply| {
-                        assert(entry.reply.header.client != evictee_reply.header.client);
-                        assert(entry.reply.header.commit != evictee_reply.header.commit);
+                        assert(entry.header.client != evictee_reply.client);
+                        assert(entry.header.commit != evictee_reply.commit);
 
-                        if (entry.reply.header.commit < evictee_reply.header.commit) {
-                            evictee = entry.reply;
+                        if (entry.header.commit < evictee_reply.commit) {
+                            evictee = &entry.header;
                         }
                     } else {
-                        evictee = entry.reply;
+                        evictee = &entry.header;
                     }
                 }
                 assert(iterated == clients);
@@ -2912,13 +2941,12 @@ pub fn ReplicaType(
                     self.replica,
                     clients,
                     constants.clients_max,
-                    evictee.?.header.client,
+                    evictee.?.client,
                 });
-                self.client_table().remove(evictee.?.header.client);
-                self.message_bus.unref(evictee.?);
+                self.client_table().remove(evictee.?.client);
             }
 
-            log.debug("{}: create_client_table_entry: client={} session={} request={}", .{
+            log.debug("{}: create_client_table_entry: write (client={} session={} request={})", .{
                 self.replica,
                 reply.header.client,
                 session,
@@ -2927,11 +2955,42 @@ pub fn ReplicaType(
 
             // Any duplicate .register requests should have received the same session number if the
             // client table entry already existed, or been dropped if a session was being committed:
-            self.client_table().put(&.{
+            const reply_slot = self.client_table().put(&.{
                 .session = session,
-                .reply = reply.ref(),
+                .header = reply.header.*,
             });
             assert(self.client_table().count() <= constants.clients_max);
+
+            if (reply.header.size != @sizeOf(Header)) {
+                self.client_replies.write_reply(reply_slot, reply, client_replies_write_callback);
+            }
+        }
+
+        fn client_replies_write_callback(
+            client_replies: *ClientReplies,
+            wrote: *Message,
+        ) void {
+            const self = @fieldParentPtr(Self, "client_replies", client_replies);
+            assert(self.status == .normal or self.status == .view_change or
+                (self.status == .recovering and self.solo()));
+            assert(self.client_replies.can_write_reply());
+            maybe(self.committing);
+
+            log.debug("{}: client_replies: wrote (client={} request={})", .{
+                client_replies.replica,
+                wrote.header.client,
+                wrote.header.request,
+            });
+
+            // Committing may have stopped prematurely because the ClientReplies was busy.
+            // It isn't busy anymore — attempt to resume it.
+            if (self.status == .normal and self.primary()) {
+                if (self.pipeline.queue.prepare_queue.count > 0) {
+                    self.commit_pipeline();
+                }
+            } else {
+                self.commit_journal(self.commit_max);
+            }
         }
 
         /// Construct a SV/DVC message, including attached headers from the current log_view.
@@ -3075,10 +3134,10 @@ pub fn ReplicaType(
 
         /// The caller owns the returned message, if any, which has exactly 1 reference.
         fn create_message_from_header(self: *Self, header: Header) *Message {
-            assert(header.replica == self.replica);
             assert(
                 header.view == self.view or
                     header.command == .request_start_view or
+                    header.command == .reply or
                     header.command == .ping or header.command == .pong,
             );
             assert(header.size == @sizeOf(Header));
@@ -3382,8 +3441,8 @@ pub fn ReplicaType(
             assert(message.header.request == 0 or message.header.operation != .register);
 
             if (self.client_table().get(message.header.client)) |entry| {
-                assert(entry.reply.header.command == .reply);
-                assert(entry.reply.header.client == message.header.client);
+                assert(entry.header.command == .reply);
+                assert(entry.header.client == message.header.client);
 
                 if (message.header.operation == .register) {
                     // Fall through below to check if we should resend the .register session reply.
@@ -3397,22 +3456,30 @@ pub fn ReplicaType(
                     return true;
                 }
 
-                if (entry.reply.header.request > message.header.request) {
+                if (entry.header.request > message.header.request) {
                     log.debug("{}: on_request: ignoring older request", .{self.replica});
                     return true;
-                } else if (entry.reply.header.request == message.header.request) {
-                    if (message.header.checksum == entry.reply.header.parent) {
-                        assert(entry.reply.header.operation == message.header.operation);
+                } else if (entry.header.request == message.header.request) {
+                    if (message.header.checksum == entry.header.parent) {
+                        assert(entry.header.operation == message.header.operation);
 
                         log.debug("{}: on_request: replying to duplicate request", .{self.replica});
-                        self.message_bus.send_message_to_client(message.header.client, entry.reply);
+                        if (entry.header.size == @sizeOf(Header)) {
+                            self.send_header_to_client(message.header.client, entry.header);
+                        } else {
+                            self.client_replies.read_reply(
+                                self.client_table().get_slot(message.header.client).?,
+                                entry,
+                                on_request_read_reply_callback,
+                            );
+                        }
                         return true;
                     } else {
                         log.err("{}: on_request: request collision (client bug)", .{self.replica});
                         return true;
                     }
-                } else if (entry.reply.header.request + 1 == message.header.request) {
-                    if (message.header.parent == entry.reply.header.checksum) {
+                } else if (entry.header.request + 1 == message.header.request) {
+                    if (message.header.parent == entry.header.checksum) {
                         // The client has proved that they received our last reply.
                         log.debug("{}: on_request: new request", .{self.replica});
                         return false;
@@ -3450,6 +3517,19 @@ pub fn ReplicaType(
                 self.send_eviction_message_to_client(message.header.client);
                 return true;
             }
+        }
+
+        fn on_request_read_reply_callback(client_replies: *ClientReplies, reply_: ?*Message) void {
+            const self = @fieldParentPtr(Self, "client_replies", client_replies);
+            const reply = reply_ orelse return;
+
+            log.debug("{}: on_request: repeat reply (client={} request={})", .{
+                self.replica,
+                reply.header.client,
+                reply.header.request,
+            });
+
+            self.message_bus.send_message_to_client(reply.header.client, reply);
         }
 
         /// Returns whether the replica is eligible to process this request as the primary.
@@ -6102,15 +6182,15 @@ pub fn ReplicaType(
             assert(reply.header.request > 0);
 
             if (self.client_table().get(reply.header.client)) |entry| {
-                assert(entry.reply.header.command == .reply);
-                assert(entry.reply.header.context == 0);
-                assert(entry.reply.header.op == entry.reply.header.commit);
-                assert(entry.reply.header.commit >= entry.session);
+                assert(entry.header.command == .reply);
+                assert(entry.header.context == 0);
+                assert(entry.header.op == entry.header.commit);
+                assert(entry.header.commit >= entry.session);
 
-                assert(entry.reply.header.client == reply.header.client);
-                assert(entry.reply.header.request + 1 == reply.header.request);
-                assert(entry.reply.header.op < reply.header.op);
-                assert(entry.reply.header.commit < reply.header.commit);
+                assert(entry.header.client == reply.header.client);
+                assert(entry.header.request + 1 == reply.header.request);
+                assert(entry.header.op < reply.header.op);
+                assert(entry.header.commit < reply.header.commit);
 
                 // TODO Use this reply's prepare to cross-check against the entry's prepare, if we
                 // still have access to the prepare in the journal (it may have been snapshotted).
@@ -6122,8 +6202,14 @@ pub fn ReplicaType(
                     reply.header.request,
                 });
 
-                self.message_bus.unref(entry.reply);
-                entry.reply = reply.ref();
+                entry.header = reply.header.*;
+                if (entry.header.size != @sizeOf(Header)) {
+                    self.client_replies.write_reply(
+                        self.client_table().get_slot(reply.header.client).?,
+                        reply,
+                        client_replies_write_callback,
+                    );
+                }
             } else {
                 // If no entry exists, then the session must have been evicted while being prepared.
                 // We can still send the reply, the next request will receive an eviction message.

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -146,7 +146,6 @@ fn ReplicaFormatType(comptime Storage: type) type {
 test "format" {
     const superblock_zone_size = @import("./superblock.zig").superblock_zone_size;
     const data_file_size_min = @import("./superblock.zig").data_file_size_min;
-    const MessagePool = @import("../message_pool.zig").MessagePool;
     const Storage = @import("../testing/storage.zig").Storage;
     const SuperBlock = vsr.SuperBlockType(Storage);
     const allocator = std.testing.allocator;
@@ -166,13 +165,9 @@ test "format" {
     );
     defer storage.deinit(allocator);
 
-    var message_pool = try MessagePool.init(allocator, .replica);
-    defer message_pool.deinit(allocator);
-
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
         .storage_size_limit = data_file_size_min,
-        .message_pool = &message_pool,
     });
     defer superblock.deinit(allocator);
 

--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -219,7 +219,7 @@ pub const ClientSessions = struct {
 
     pub const Iterator = struct {
         client_sessions: *const ClientSessions,
-        index: usize,
+        index: usize = 0,
 
         pub fn next(it: *Iterator) ?*const Entry {
             while (it.index < it.client_sessions.entries.len) {
@@ -235,9 +235,6 @@ pub const ClientSessions = struct {
     };
 
     pub fn iterator(client_sessions: *const ClientSessions) Iterator {
-        return .{
-            .client_sessions = client_sessions,
-            .index = 0,
-        };
+        return .{ .client_sessions = client_sessions };
     }
 };

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -19,7 +19,6 @@ const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
 const Storage = @import("../testing/storage.zig").Storage;
 const StorageFaultAtlas = @import("../testing/storage.zig").ClusterFaultAtlas;
-const MessagePool = @import("../message_pool.zig").MessagePool;
 const superblock_zone_size = @import("superblock.zig").superblock_zone_size;
 const data_file_size_min = @import("superblock.zig").data_file_size_min;
 const VSRState = @import("superblock.zig").SuperBlockHeader.VSRState;
@@ -74,20 +73,15 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
     var storage_verify = try Storage.init(allocator, superblock_zone_size, storage_options);
     defer storage_verify.deinit(allocator);
 
-    var message_pool = try MessagePool.init(allocator, .replica);
-    defer message_pool.deinit(allocator);
-
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
         .storage_size_limit = constants.storage_size_max,
-        .message_pool = &message_pool,
     });
     defer superblock.deinit(allocator);
 
     var superblock_verify = try SuperBlock.init(allocator, .{
         .storage = &storage_verify,
         .storage_size_limit = constants.storage_size_max,
-        .message_pool = &message_pool,
     });
     defer superblock_verify.deinit(allocator);
 


### PR DESCRIPTION
NOTE: This PR does not implement repair for the `client_replies` zone.
(Accordingly, the simulator does not inject storage faults into the `client_replies` zone yet.)
(That will be my next PR.)

Previously the client table was a superblock trailer:
- We keep four copies of it per replica.
- We rewrite (four copies of) the whole thing every checkpoint (i.e. WAL wrap).
- We keep it all in memory — one message per client (for each of `clients_max`).

This has some issues:
- Redundant writes, causing a latency spike at checkpoint.
- High RAM overhead per-client.

To address this:

- Split the client table out of the superblock — move it to its own zone.
- (Only keep 1 copy of the client table per replica.)
- The client table superblock trailer just stores reply metadata — slot index (implicitly), session, and reply header.
- Update the client table zone incrementally, in-place on disk.
- Drop the in-memory client table, just read from the zone as needed.
- Instead of replicating the client table locally, repair it via a new `command=request_reply` message (similar to how the WAL repairs with `request_prepare`).

As a bonus, this will help state sync be more lazy about transferring the client table.
(The client table is frequently-rewritten and infrequently-used.)

## Pre-merge checklist

Performance:

* [x] Compare `zig benchmark` on linux before and after this pr.

``` sh
    # benchmark results before
1223 batches in 545.86 s
load offered = 1000000 tx/s
load accepted = 18319 tx/s
batch latency p00 = 3 ms
batch latency p10 = 65 ms
batch latency p20 = 69 ms
batch latency p30 = 73 ms
batch latency p40 = 77 ms
batch latency p50 = 94 ms
batch latency p60 = 105 ms
batch latency p70 = 109 ms
batch latency p80 = 115 ms
batch latency p90 = 130 ms
batch latency p100 = 52104 ms
transfer latency p00 = 3 ms
transfer latency p10 = 11193 ms
transfer latency p20 = 35379 ms
transfer latency p30 = 70407 ms
transfer latency p40 = 117706 ms
transfer latency p50 = 176211 ms
transfer latency p60 = 240513 ms
transfer latency p70 = 299360 ms
transfer latency p80 = 362602 ms
transfer latency p90 = 430966 ms
transfer latency p100 = 535868 ms

    
    # benchmark results after
1223 batches in 531.52 s
load offered = 1000000 tx/s
load accepted = 18813 tx/s
batch latency p00 = 3 ms
batch latency p10 = 64 ms
batch latency p20 = 66 ms
batch latency p30 = 69 ms
batch latency p40 = 72 ms
batch latency p50 = 88 ms
batch latency p60 = 101 ms
batch latency p70 = 105 ms
batch latency p80 = 109 ms
batch latency p90 = 122 ms
batch latency p100 = 51412 ms
transfer latency p00 = 3 ms
transfer latency p10 = 11389 ms
transfer latency p20 = 35604 ms
transfer latency p30 = 71834 ms
transfer latency p40 = 119412 ms
transfer latency p50 = 178786 ms
transfer latency p60 = 240835 ms
transfer latency p70 = 299428 ms
transfer latency p80 = 362978 ms
transfer latency p90 = 422016 ms
transfer latency p100 = 521531 ms
```
