### PR TITLE
built: don't build demos if running a specific test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -188,7 +188,7 @@ pub fn build(b: *std.build.Builder) void {
 
         const test_step = b.step("test", "Run the unit tests");
         test_step.dependOn(&unit_tests.step);
-        if (test_filter != null) {
+        if (test_filter == null) {
             // Test that our demos compile, but don't run them.
             inline for (.{
                 "demo_01_create_accounts",

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -26,8 +26,8 @@ pub const vsr_options = .{
     .config_base = vsr.config.ConfigBase.default,
     .tracer_backend = vsr.config.TracerBackend.none,
     .hash_log_mode = vsr.config.HashLogMode.none,
-    .config_aof = @as(?bool, false),
-    .config_aof_recovery = @as(?bool, false),
+    .config_aof_record = false,
+    .config_aof_recovery = false,
 };
 
 pub fn request(


### PR DESCRIPTION
The idea behind #626  was good, but the implementation was the opposite of what's needed. 

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
