### PR TITLE
Trigger benchmark runs from CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,26 @@
+name: Benchmark
+
+on:
+  push:
+    branches:
+      - 'main'
+
+  # Run benchmarking for any PRs that target 'main' when they are opened or updated.
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cd /tmp && wget https://releases.hashicorp.com/nomad/1.5.3/nomad_1.5.3_linux_amd64.zip && unzip nomad_1.5.3_linux_amd64.zip && chmod +x nomad && sudo mv nomad /usr/bin/
+      - run: echo "# Benchmarks" >> ${GITHUB_STEP_SUMMARY}
+      - run: cd scripts/benchmark && ./orchestrate.sh 3 m6id.xlarge ${GITHUB_SHA} >> ${GITHUB_STEP_SUMMARY}
+        env:
+          NOMAD_ADDR: https://ci.arewe1mtpsyet.com
+          NOMAD_HTTP_AUTH: ${{ secrets.NOMAD_BENCHMARK_HTTP_AUTH }}

--- a/scripts/benchmark/client.hcl
+++ b/scripts/benchmark/client.hcl
@@ -1,0 +1,124 @@
+variable "instance_id" {
+  type = string
+}
+
+variable "replica_instance_ids" {
+  type = string
+  default = ""
+}
+
+variable "cluster_id" {
+  type = string
+  default = "0"
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "addresses" {
+  type = string
+}
+
+variable "git_url" {
+  type = string
+  default = "https://github.com/tigerbeetledb/tigerbeetle.git"
+}
+
+variable "git_ref" {
+  type = string
+  default = "main"
+}
+
+job "__JOB_NAME__" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  constraint {
+    attribute = attr.unique.platform.aws.instance-id
+    operator  = "="
+    value     = var.instance_id
+  }
+
+  reschedule {
+    attempts  = 0
+    unlimited = false
+  }
+
+  group "tigerbeetle-client" {
+    network {
+      mode = "host"
+    }
+
+    task "tigerbeetle-client" {
+      driver = "docker"
+      shutdown_delay = "10s"
+
+      config {
+        image = "debian:bullseye"
+        entrypoint = ["/local/tigerbeetle-client.sh"]
+        network_mode = "host"
+      }
+
+      template {
+        data = <<EOF
+#!/usr/bin/env bash
+set -eux
+
+apt-get update
+apt-get -y install git curl xz-utils unzip wget awscli
+
+# Hack - set to real region
+export AWS_REGION=eu-west-1
+export AWS_DEFAULT_REGION=eu-west-1
+
+# Try do a best effort cleanup. We have TTLs and a reaper process, so there's
+# no risk of leaking machines, but no sense in letting them run longer than
+# they need to, either.
+function finish {
+  # Shut down all instances - the instance role has permission to do this
+  aws ec2 terminate-instances --instance-ids ${var.replica_instance_ids} || true
+
+  # Purge Nomad jobs, then terminate this instance. We have a shutdown delay of
+  # 10s which should be plenty of time.
+  if [ -e /tmp/nomad ]; then
+    (/tmp/nomad job status | grep tigerbeetle-${var.test_id} | awk '{print $1}' | xargs -L1 /tmp/nomad job stop -purge) || true
+  else
+    echo "No Nomad yet - not purging."
+  fi
+
+  aws ec2 terminate-instances --instance-ids ${var.instance_id} || true
+}
+trap finish EXIT
+
+# Fetch and extract Nomad
+cd /tmp
+wget https://releases.hashicorp.com/nomad/1.5.3/nomad_1.5.3_linux_amd64.zip
+unzip nomad_1.5.3_linux_amd64.zip
+chmod +x nomad
+
+git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
+git clone ${var.git_url}
+cd tigerbeetle
+git checkout ${var.git_ref}
+./scripts/install_zig.sh
+
+cmd="./zig/zig build benchmark -Drelease-safe=true -- --account-count 10000 --transfer-count 10000000 --transfer-count-per-second 1000000 --addresses ${var.addresses} --statsd true --print-batch-timings true"
+echo "TigerBeetle Benchmark Command: ${cmd}"
+$cmd
+
+# Ensure time for results to have shipped
+sleep 10
+    EOF
+
+        destination = "local/tigerbeetle-client.sh"
+        perms = "755"
+      }
+
+      resources {
+        cores = 1
+        memory = 14000
+      }
+    }
+  }
+}

--- a/scripts/benchmark/orchestrate.sh
+++ b/scripts/benchmark/orchestrate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+REPLICA_COUNT="${1}"
+AWS_INSTANCE_TYPE="${2}"
+
+AMI_ID="ami-05227d1de84630a07"
+SECURITY_GROUP_IDS="sg-0cfff65f4c5b93588 sg-042df46f5cea3faf8 sg-0e9bb6ac7fa2d665b"
+SUBNET_ID="subnet-05a08d203fecbf048"
+
+TEST_ID=$(uuidgen)
+
+REPLICA_INSTANCE_IDS=()
+REPLICA_PRIVATE_IPS=()
+
+# Pull down AWS creds from Nomad
+export AWS_ACCESS_KEY_ID=$(nomad var get -item=AWS_ACCESS_KEY_ID aws)
+export AWS_SECRET_ACCESS_KEY=$(nomad var get -item=AWS_SECRET_ACCESS_KEY aws)
+export AWS_REGION=eu-west-1
+export AWS_DEFAULT_REGION=eu-west-1
+
+# Spin up EC2 instances
+echo "Spinning up replica EC2 instances - ${REPLICA_COUNT}..." 1>&2
+epoch_plus_hour=$(($(date +%s) + 3600))
+
+output=$(aws ec2 run-instances \
+	--image-id "${AMI_ID}" \
+	--count "${REPLICA_COUNT}" \
+	--instance-type "${AWS_INSTANCE_TYPE}" \
+	--security-group-ids ${SECURITY_GROUP_IDS} \
+	--subnet-id "${SUBNET_ID}" \
+	--associate-public-ip-address \
+	--iam-instance-profile Name="worker-profile" \
+	--tag-specifications "ResourceType=instance,Tags=[{Key=test_id,Value=${TEST_ID}},{Key=ttl,Value=${epoch_plus_hour}}]" \
+)
+
+for i in $(seq 1 "${REPLICA_COUNT}"); do
+	# 0-index our replicas
+	i=$((i - 1))
+
+	REPLICA_INSTANCE_IDS+=("$(echo "${output}" | jq -r .Instances[${i}].InstanceId)")
+	REPLICA_PRIVATE_IPS+=("$(echo "${output}" | jq -r .Instances[${i}].PrivateIpAddress)":3001)
+done
+
+# The below are set for both client and replicas.
+# We fix our git URL, so we'll only ever run this on our own branches and not random PRs
+export NOMAD_VAR_git_url="https://github.com/tigerbeetledb/tigerbeetle.git"
+export NOMAD_VAR_git_ref="${3}"
+
+# Build the address string
+function join_by { local IFS="$1"; shift; echo "$*"; }
+addresses=$(join_by , "${REPLICA_PRIVATE_IPS[@]}")
+
+# Template and spawn each Tigerbeetle replica's Nomad job.
+for replica in $(seq 1 "${REPLICA_COUNT}"); do
+	# 0-index our replicas
+	replica=$((replica - 1))
+	JOB_NAME="tigerbeetle-${TEST_ID}-${replica}"
+
+	export NOMAD_VAR_instance_id=${REPLICA_INSTANCE_IDS[$replica]}
+	export NOMAD_VAR_test_id="${TEST_ID}"
+	export NOMAD_VAR_replica="${replica}"
+	export NOMAD_VAR_replica_count="${REPLICA_COUNT}"
+	export NOMAD_VAR_addresses="${addresses}"
+
+	cat tigerbeetle.hcl | sed "s/__JOB_NAME__/${JOB_NAME}/g" | nomad job run -detach - 1>&2
+done
+
+# Spin up EC2 instance for test client
+echo "Spinning up client EC2 instance..." 1>&2
+output=$(aws ec2 run-instances \
+	--image-id "${AMI_ID}" \
+	--count 1 \
+	--instance-type "t3.xlarge" \
+	--security-group-ids ${SECURITY_GROUP_IDS} \
+	--subnet-id "${SUBNET_ID}" \
+	--associate-public-ip-address \
+	--iam-instance-profile Name="worker-profile" \
+	--tag-specifications "ResourceType=instance,Tags=[{Key=test_id,Value=${TEST_ID}},{Key=ttl,Value=${epoch_plus_hour}}]" \
+)
+
+CLIENT_INSTANCE_ID=$(echo "${output}" | jq -r .Instances[0].InstanceId)
+
+# Spin up test client Nomad Job
+JOB_NAME="tigerbeetle-${TEST_ID}-client"
+
+export NOMAD_VAR_instance_id=${CLIENT_INSTANCE_ID}
+export NOMAD_VAR_test_id="${TEST_ID}"
+export NOMAD_VAR_addresses="${addresses}"
+export NOMAD_VAR_replica_instance_ids="${REPLICA_INSTANCE_IDS[*]}"
+
+cat client.hcl | sed "s/__JOB_NAME__/${JOB_NAME}/g" | nomad job run -detach - 1>&2
+
+epoch_ms=$(date +%s%N | cut -b1-13)
+echo "https://grafana.arewe1mtpsyet.com/d/5_Y-UcE4z/test-dashboard?orgId=1&from=${epoch_ms}&to=now-30s&var-test_id=${TEST_ID}"

--- a/scripts/benchmark/tigerbeetle.hcl
+++ b/scripts/benchmark/tigerbeetle.hcl
@@ -1,0 +1,121 @@
+variable "instance_id" {
+  type = string
+}
+
+variable "storage_type" {
+  type = string
+  default = "nvme" # or ram, or ebs
+}
+
+variable "cluster_id" {
+  type = string
+  default = "0"
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "replica" {
+  type = string
+}
+
+variable "replica_count" {
+  type = string
+}
+
+variable "bind_port" {
+  type = string
+  default = "3001"
+}
+
+variable "addresses" {
+  type = string
+}
+
+variable "git_url" {
+  type = string
+  default = "https://github.com/tigerbeetledb/tigerbeetle.git"
+}
+
+variable "git_ref" {
+  type = string
+  default = "main"
+}
+
+job "__JOB_NAME__" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  constraint {
+    attribute = attr.unique.platform.aws.instance-id
+    operator  = "="
+    value     = var.instance_id
+  }
+
+  reschedule {
+    attempts  = 0
+    unlimited = false
+  }
+
+  group "tigerbeetle" {
+    network {
+      mode = "host"
+
+      port "tigerbeetle" {
+        static = "${var.bind_port}"
+      }
+    }
+
+    task "tigerbeetle" {
+      driver = "docker"
+
+      config {
+        image = "debian:bullseye"
+        entrypoint = ["/local/tigerbeetle.sh"]
+        network_mode = "host"
+        memory_hard_limit = 60000
+
+        mounts = [
+          {
+            type   = "bind",
+            source = "/tank/${var.storage_type}",
+            target = "/tank"
+          }
+        ]
+      }
+
+      template {
+        data = <<EOF
+#!/bin/sh
+set -eux
+
+apt-get update
+apt-get -y install git curl xz-utils unzip wget
+cd /tmp
+
+git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
+git clone ${var.git_url}
+cd tigerbeetle
+git checkout ${var.git_ref}
+./scripts/install_zig.sh
+./zig/zig build install -Drelease-safe=true
+
+if ! [ -e "/tank/{{ env "NOMAD_JOB_ID" }}.tigerbeetle" ]; then
+  ./tigerbeetle format --cluster=${var.cluster_id} --replica=${var.replica} --replica-count=${var.replica_count} /tank/{{ env "NOMAD_JOB_ID" }}.tigerbeetle
+fi
+
+exec ./tigerbeetle start --addresses=${var.addresses} /tank/{{ env "NOMAD_JOB_ID" }}.tigerbeetle
+    EOF
+
+        destination = "local/tigerbeetle.sh"
+        perms = "755"
+      }
+
+      resources {
+        cores = 1
+        memory = 3192
+      }
+    }
+  }
+}

--- a/src/statsd.zig
+++ b/src/statsd.zig
@@ -1,13 +1,18 @@
 const std = @import("std");
 
 const IO = @import("io.zig").IO;
+const FIFO = @import("fifo.zig").FIFO;
 
 pub const StatsD = struct {
     buffer: []u8,
     socket: std.os.socket_t,
-    address: std.net.Address,
-    address_size: u32,
+    io: *IO,
+    completions: []IO.Completion,
+    completions_fifo: FIFO(IO.Completion) = .{ .name = "statsd" },
 
+    /// Creates a statsd instance, which will send UDP packets via the IO instance provided.
+    /// Not thread safe, since it uses a single buffer shared between gauge and timing methods
+    /// with no locking.
     pub fn init(allocator: std.mem.Allocator, io: *IO, address: std.net.Address) !StatsD {
         // Limit the max packet size to 1000.
         const buffer = try allocator.alloc(u8, 1000);
@@ -20,58 +25,70 @@ pub const StatsD = struct {
         );
         errdefer std.os.closeSocket(socket);
 
-        return StatsD{
+        // Allocate our completions - hardcoded max of 256.
+        var completions = try allocator.alloc(IO.Completion, 256);
+        errdefer allocator.free(completions);
+
+        var statsd = StatsD{
             .buffer = buffer,
             .socket = socket,
-            .address = address,
-            .address_size = address.getOsSockLen(),
+            .io = io,
+            .completions = completions,
         };
+
+        for (completions) |*completion| {
+            completion.next = null;
+            statsd.completions_fifo.push(completion);
+        }
+
+        // 'Connect' the UDP socket, so we can just send() to it normally.
+        try std.os.connect(socket, &address.any, address.getOsSockLen());
+
+        return statsd;
     }
 
     pub fn deinit(self: *StatsD, allocator: std.mem.Allocator) void {
         allocator.free(self.buffer);
         std.os.closeSocket(self.socket);
+        allocator.free(self.completions);
     }
 
     pub fn gauge(self: *StatsD, stat: []const u8, value: usize) !void {
         const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|g", .{ stat, value });
+        var completion = self.completions_fifo.pop() orelse return error.NoSpaceLeft;
+        completion.next = null;
 
-        var iovec = [_]std.os.iovec_const{.{
-            .iov_base = statsd_packet.ptr,
-            .iov_len = statsd_packet.len,
-        }};
-
-        var msg = std.os.msghdr_const{
-            .name = &self.address.any,
-            .namelen = self.address_size,
-            .iov = &iovec,
-            .iovlen = 1,
-            .control = null,
-            .controllen = 0,
-            .flags = 0,
-        };
-
-        _ = try std.os.sendmsg(self.socket, msg, 0);
+        self.io.send(
+            *StatsD,
+            self,
+            StatsD.send_callback,
+            completion,
+            self.socket,
+            statsd_packet,
+        );
     }
 
     pub fn timing(self: *StatsD, stat: []const u8, ms: usize) !void {
         const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|ms", .{ stat, ms });
+        var completion = self.completions_fifo.pop() orelse return error.NoSpaceLeft;
+        completion.next = null;
 
-        var iovec = [_]std.os.iovec_const{.{
-            .iov_base = statsd_packet.ptr,
-            .iov_len = statsd_packet.len,
-        }};
+        self.io.send(
+            *StatsD,
+            self,
+            StatsD.send_callback,
+            completion,
+            self.socket,
+            statsd_packet,
+        );
+    }
 
-        var msg = std.os.msghdr_const{
-            .name = &self.address.any,
-            .namelen = self.address_size,
-            .iov = &iovec,
-            .iovlen = 1,
-            .control = null,
-            .controllen = 0,
-            .flags = 0,
-        };
+    pub fn send_callback(context: *StatsD, completion: *IO.Completion, result: IO.SendError!usize) void {
+        _ = context;
+        _ = completion;
+        _ = result catch {};
 
-        _ = try std.os.sendmsg(self.socket, msg, 0);
+        completion.next = null;
+        context.completions_fifo.push(completion);
     }
 };

--- a/src/statsd.zig
+++ b/src/statsd.zig
@@ -3,21 +3,22 @@ const std = @import("std");
 const IO = @import("io.zig").IO;
 const FIFO = @import("fifo.zig").FIFO;
 
+const BufferCompletion = struct {
+    next: ?*BufferCompletion = null,
+    buffer: [256]u8,
+    completion: IO.Completion = undefined,
+};
+
 pub const StatsD = struct {
-    buffer: []u8,
     socket: std.os.socket_t,
     io: *IO,
-    completions: []IO.Completion,
-    completions_fifo: FIFO(IO.Completion) = .{ .name = "statsd" },
+    buffer_completions: []BufferCompletion,
+    buffer_completions_fifo: FIFO(BufferCompletion) = .{ .name = "statsd" },
 
     /// Creates a statsd instance, which will send UDP packets via the IO instance provided.
     /// Not thread safe, since it uses a single buffer shared between gauge and timing methods
     /// with no locking.
     pub fn init(allocator: std.mem.Allocator, io: *IO, address: std.net.Address) !StatsD {
-        // Limit the max packet size to 1000.
-        const buffer = try allocator.alloc(u8, 1000);
-        errdefer allocator.free(buffer);
-
         const socket = try io.open_socket(
             address.any.family,
             std.os.SOCK.DGRAM,
@@ -25,20 +26,18 @@ pub const StatsD = struct {
         );
         errdefer std.os.closeSocket(socket);
 
-        // Allocate our completions - hardcoded max of 256.
-        var completions = try allocator.alloc(IO.Completion, 256);
-        errdefer allocator.free(completions);
+        const buffer_completions = try allocator.alloc(BufferCompletion, 256);
+        errdefer allocator.free(buffer_completions);
 
         var statsd = StatsD{
-            .buffer = buffer,
             .socket = socket,
             .io = io,
-            .completions = completions,
+            .buffer_completions = buffer_completions,
         };
 
-        for (completions) |*completion| {
-            completion.next = null;
-            statsd.completions_fifo.push(completion);
+        for (buffer_completions) |*buffer_completion| {
+            buffer_completion.next = null;
+            statsd.buffer_completions_fifo.push(buffer_completion);
         }
 
         // 'Connect' the UDP socket, so we can just send() to it normally.
@@ -48,47 +47,41 @@ pub const StatsD = struct {
     }
 
     pub fn deinit(self: *StatsD, allocator: std.mem.Allocator) void {
-        allocator.free(self.buffer);
         std.os.closeSocket(self.socket);
-        allocator.free(self.completions);
+        allocator.free(self.buffer_completions);
     }
 
     pub fn gauge(self: *StatsD, stat: []const u8, value: usize) !void {
-        const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|g", .{ stat, value });
-        var completion = self.completions_fifo.pop() orelse return error.NoSpaceLeft;
-        completion.next = null;
+        var buffer_completion = self.buffer_completions_fifo.pop() orelse return error.NoSpaceLeft;
+        const statsd_packet = try std.fmt.bufPrint(buffer_completion.buffer[0..], "{s}:{}|g", .{ stat, value });
 
         self.io.send(
             *StatsD,
             self,
             StatsD.send_callback,
-            completion,
+            &buffer_completion.completion,
             self.socket,
             statsd_packet,
         );
     }
 
     pub fn timing(self: *StatsD, stat: []const u8, ms: usize) !void {
-        const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|ms", .{ stat, ms });
-        var completion = self.completions_fifo.pop() orelse return error.NoSpaceLeft;
-        completion.next = null;
+        var buffer_completion = self.buffer_completions_fifo.pop() orelse return error.NoSpaceLeft;
+        const statsd_packet = try std.fmt.bufPrint(buffer_completion.buffer[0..], "{s}:{}|g", .{ stat, ms });
 
         self.io.send(
             *StatsD,
             self,
             StatsD.send_callback,
-            completion,
+            &buffer_completion.completion,
             self.socket,
             statsd_packet,
         );
     }
 
     pub fn send_callback(context: *StatsD, completion: *IO.Completion, result: IO.SendError!usize) void {
-        _ = context;
-        _ = completion;
         _ = result catch {};
-
-        completion.next = null;
-        context.completions_fifo.push(completion);
+        var buffer_completion = @fieldParentPtr(BufferCompletion, "completion", completion);
+        context.buffer_completions_fifo.push(buffer_completion);
     }
 };

--- a/src/statsd.zig
+++ b/src/statsd.zig
@@ -35,23 +35,43 @@ pub const StatsD = struct {
 
     pub fn gauge(self: *StatsD, stat: []const u8, value: usize) !void {
         const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|g", .{ stat, value });
-        _ = try std.os.sendto(
-            self.socket,
-            statsd_packet,
-            0,
-            &self.address.any,
-            self.address_size,
-        );
+
+        var iovec = [_]std.os.iovec_const{.{
+            .iov_base = statsd_packet.ptr,
+            .iov_len = statsd_packet.len,
+        }};
+
+        var msg = std.os.msghdr_const{
+            .name = &self.address.any,
+            .namelen = self.address_size,
+            .iov = &iovec,
+            .iovlen = 1,
+            .control = null,
+            .controllen = 0,
+            .flags = 0,
+        };
+
+        _ = try std.os.sendmsg(self.socket, msg, 0);
     }
 
     pub fn timing(self: *StatsD, stat: []const u8, ms: usize) !void {
         const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|ms", .{ stat, ms });
-        _ = try std.os.sendto(
-            self.socket,
-            statsd_packet,
-            0,
-            &self.address.any,
-            self.address_size,
-        );
+
+        var iovec = [_]std.os.iovec_const{.{
+            .iov_base = statsd_packet.ptr,
+            .iov_len = statsd_packet.len,
+        }};
+
+        var msg = std.os.msghdr_const{
+            .name = &self.address.any,
+            .namelen = self.address_size,
+            .iov = &iovec,
+            .iovlen = 1,
+            .control = null,
+            .controllen = 0,
+            .flags = 0,
+        };
+
+        _ = try std.os.sendmsg(self.socket, msg, 0);
     }
 };

--- a/src/statsd.zig
+++ b/src/statsd.zig
@@ -16,8 +16,6 @@ pub const StatsD = struct {
     buffer_completions_fifo: FIFO(BufferCompletion) = .{ .name = "statsd" },
 
     /// Creates a statsd instance, which will send UDP packets via the IO instance provided.
-    /// Not thread safe, since it uses a single buffer shared between gauge and timing methods
-    /// with no locking.
     pub fn init(allocator: std.mem.Allocator, io: *IO, address: std.net.Address) !StatsD {
         const socket = try io.open_socket(
             address.any.family,

--- a/src/statsd.zig
+++ b/src/statsd.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+
+const IO = @import("io.zig").IO;
+
+pub const StatsD = struct {
+    buffer: []u8,
+    socket: std.os.socket_t,
+    address: std.net.Address,
+    address_size: u32,
+
+    pub fn init(allocator: std.mem.Allocator, io: *IO, address: std.net.Address) !StatsD {
+        // Limit the max packet size to 1000.
+        const buffer = try allocator.alloc(u8, 1000);
+        errdefer allocator.free(buffer);
+
+        const socket = try io.open_socket(
+            address.any.family,
+            std.os.SOCK.DGRAM,
+            std.os.IPPROTO.UDP,
+        );
+        errdefer std.os.closeSocket(socket);
+
+        return StatsD{
+            .buffer = buffer,
+            .socket = socket,
+            .address = address,
+            .address_size = address.getOsSockLen(),
+        };
+    }
+
+    pub fn deinit(self: *StatsD, allocator: std.mem.Allocator) void {
+        allocator.free(self.buffer);
+        std.os.closeSocket(self.socket);
+    }
+
+    pub fn gauge(self: *StatsD, stat: []const u8, value: usize) !void {
+        const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|g", .{ stat, value });
+        _ = try std.os.sendto(
+            self.socket,
+            statsd_packet,
+            0,
+            &self.address.any,
+            self.address_size,
+        );
+    }
+
+    pub fn timing(self: *StatsD, stat: []const u8, ms: usize) !void {
+        const statsd_packet = try std.fmt.bufPrint(self.buffer, "{s}:{}|ms", .{ stat, ms });
+        _ = try std.os.sendto(
+            self.socket,
+            statsd_packet,
+            0,
+            &self.address.any,
+            self.address_size,
+        );
+    }
+};

--- a/src/statsd.zig
+++ b/src/statsd.zig
@@ -65,7 +65,7 @@ pub const StatsD = struct {
 
     pub fn timing(self: *StatsD, stat: []const u8, ms: usize) !void {
         var buffer_completion = self.buffer_completions_fifo.pop() orelse return error.NoSpaceLeft;
-        const statsd_packet = try std.fmt.bufPrint(buffer_completion.buffer[0..], "{s}:{}|g", .{ stat, ms });
+        const statsd_packet = try std.fmt.bufPrint(buffer_completion.buffer[0..], "{s}:{}|ms", .{ stat, ms });
 
         self.io.send(
             *StatsD,


### PR DESCRIPTION
This submits a job to run our benchmark suite on each commit, and brings in a very simple statsd implementation for us to push metrics. Currently, all that's done are a few in `benchmark.zig` that are used in our dashboard.

The statsd implementation does use our IO subsystem, but this is more of a stop-gap measure until we have a more holistic metric view in mind.

It also adds `--addresses` (and `--statsd`, `--print-batch-timings`) support to `benchmark.zig`.

You can see benchmark runs for any PR / commit by going into the Benchmark check, clicking summary, and following the link to Grafana. The benchmark parameters aren't configurable easily at the moment, but you can edit them in `scripts/benchmark/client.hcl` and push a commit, if you'd like to test a specific configuration.


## Pre-merge checklist

Performance:
* [x] I am very sure this PR could not affect performance. (heh)
