### PR TITLE
VSR: Dont transition R=1 to normal until view_durable_update

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -531,12 +531,7 @@ pub fn ReplicaType(
                 self.view += 1;
                 self.primary_update_view_headers();
                 self.view_durable_update();
-
-                if (self.commit_min < self.op) {
-                    self.commit_journal(self.op);
-                } else {
-                    self.transition_to_normal_from_recovering_status();
-                }
+                // Recovery will resume in view_durable_update_callback.
             } else {
                 // Even if op_head_certain() returns false, a DVC always has a certain head op.
                 if (self.log_view < self.view or self.op_head_certain()) {
@@ -5671,6 +5666,14 @@ pub fn ReplicaType(
 
             if (self.status == .view_change and self.log_view < self.view) {
                 if (!self.do_view_change_quorum) self.send_do_view_change();
+            }
+
+            if (self.solo()) {
+                if (self.commit_min < self.op) {
+                    self.commit_journal(self.op);
+                } else {
+                    self.transition_to_normal_from_recovering_status();
+                }
             }
         }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5669,6 +5669,11 @@ pub fn ReplicaType(
             }
 
             if (self.solo()) {
+                assert(self.status == .recovering);
+                assert(self.view == self.log_view);
+                assert(!update_dvc);
+                assert(!update_sv);
+
                 if (self.commit_min < self.op) {
                     self.commit_journal(self.op);
                 } else {


### PR DESCRIPTION
This was a correctness bug found by the VOPR.
Seed `10893958420516144951` on commit `7074a12f23342662a7cc97db555336d3bb02eb83`.

Sequence of events (replica_count=1):

1. R0 starts up in view=0.
2. During `Replica.open()`, R0 kicks off a "view change" to view=1 (i.e. it increments its view and then calls `view_durable_update`). (This is required to avoid a different correctness bug).
3. R0 prepares op=1 (in view=1).
4. R0 commits op=1 (in view=1).
5. R0 crashes. (Note that `view_durable_update` never finished!)
6. R0 recovers into view=0.
7. WAL recovery ignores op=1 — since view=0 is durable, a message from view=1 could not possibly be prepared/committed, so it is ignored(!).

The solution is that `R=1` must not transition to `status=normal` until its initial `view_durable_update` completes.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
