### PR TITLE
Grid: Include Grid in read_block/write_block callbacks

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -333,7 +333,7 @@ pub fn CompactionType(
             }
         }
 
-        fn on_iter_init_a(read: *Grid.Read, index_block: BlockPtrConst) void {
+        fn on_iter_init_a(_: *Grid, read: *Grid.Read, index_block: BlockPtrConst) void {
             const compaction = @fieldParentPtr(Compaction, "read", read);
             assert(compaction.state == .iter_init_a);
 
@@ -709,7 +709,7 @@ pub fn CompactionType(
                     );
                 }
 
-                fn on_write(write: *Grid.Write) void {
+                fn on_write(_: *Grid, write: *Grid.Write) void {
                     const compaction = @fieldParentPtr(
                         Compaction,
                         switch (write_block_field) {

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -121,7 +121,7 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
             }
         }
 
-        fn on_read(read: *Grid.Read, block: Grid.BlockPtrConst) void {
+        fn on_read(_: *Grid, read: *Grid.Read, block: Grid.BlockPtrConst) void {
             const it = @fieldParentPtr(LevelIndexIterator, "read", read);
             assert(it.callback == .read);
 

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -231,7 +231,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             }
         }
 
-        fn open_read_block_callback(read: *Grid.Read, block: Grid.BlockPtrConst) void {
+        fn open_read_block_callback(_: *Grid, read: *Grid.Read, block: Grid.BlockPtrConst) void {
             const manifest_log = @fieldParentPtr(ManifestLog, "read", read);
             assert(!manifest_log.opened);
             assert(manifest_log.reading);
@@ -434,7 +434,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             manifest_log.blocks.advance_head();
         }
 
-        fn write_block_callback(write: *Grid.Write) void {
+        fn write_block_callback(_: *Grid, write: *Grid.Write) void {
             const manifest_log = @fieldParentPtr(ManifestLog, "write", write);
             assert(manifest_log.opened);
             assert(manifest_log.writing);
@@ -520,7 +520,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             }
         }
 
-        fn compact_read_block_callback(read: *Grid.Read, block: BlockPtrConst) void {
+        fn compact_read_block_callback(_: *Grid, read: *Grid.Read, block: BlockPtrConst) void {
             const manifest_log = @fieldParentPtr(ManifestLog, "read", read);
             assert(manifest_log.opened);
             assert(manifest_log.reading);

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -95,7 +95,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
             }
         }
 
-        fn on_read(read: *Grid.Read, block: Grid.BlockPtrConst) void {
+        fn on_read(_: *Grid, read: *Grid.Read, block: Grid.BlockPtrConst) void {
             const it = @fieldParentPtr(TableDataIterator, "read", read);
             assert(it.callback == .read);
 

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -372,7 +372,11 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 );
             }
 
-            fn read_index_block_callback(completion: *Read, index_block: BlockPtrConst) void {
+            fn read_index_block_callback(
+                _: *Grid,
+                completion: *Read,
+                index_block: BlockPtrConst,
+            ) void {
                 const context = @fieldParentPtr(LookupContext, "completion", completion);
                 assert(context.data_block == null);
                 assert(context.index_block < context.index_block_count);
@@ -395,7 +399,11 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 );
             }
 
-            fn read_filter_block_callback(completion: *Read, filter_block: BlockPtrConst) void {
+            fn read_filter_block_callback(
+                _: *Grid,
+                completion: *Read,
+                filter_block: BlockPtrConst,
+            ) void {
                 const context = @fieldParentPtr(LookupContext, "completion", completion);
                 assert(context.data_block != null);
                 assert(context.index_block < context.index_block_count);
@@ -429,7 +437,11 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 }
             }
 
-            fn read_data_block_callback(completion: *Read, data_block: BlockPtrConst) void {
+            fn read_data_block_callback(
+                _: *Grid,
+                completion: *Read,
+                data_block: BlockPtrConst,
+            ) void {
                 const context = @fieldParentPtr(LookupContext, "completion", completion);
                 assert(context.data_block != null);
                 assert(context.index_block < context.index_block_count);

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -157,7 +157,7 @@ pub fn StateMachineType(
             );
         }
 
-        fn next_tick_callback(write: *Grid.Write) void {
+        fn next_tick_callback(_: *Grid, write: *Grid.Write) void {
             const state_machine = @fieldParentPtr(StateMachine, "grid_write", write);
             const callback = state_machine.callback.?;
             state_machine.callback = null;


### PR DESCRIPTION
For grid repair and state sync, the Replica will have multiple `Grid.Write`s.
So it can't use `@fieldParentPtr`.
It does own the `Grid`, though.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
