### PR TITLE
[Java Client] Fix mvn install

### DIFF
--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -53,23 +53,23 @@
     <profile>
       <id>Windows</id>
       <activation>
-	<os>
-	  <family>Windows</family>
-	</os>
+        <os>
+          <family>Windows</family>
+        </os>
       </activation>
       <properties>
-	<script.extension>.bat</script.extension>
+        <script.extension>.bat</script.extension>
       </properties>
     </profile>
     <profile>
       <id>unix</id>
       <activation>
-	<os>
-	  <family>unix</family>
-	</os>
+        <os>
+          <family>unix</family>
+        </os>
       </activation>
       <properties>
-	<script.extension>.sh</script.extension>
+        <script.extension>.sh</script.extension>
       </properties>
     </profile>
   </profiles>
@@ -139,7 +139,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>3.0.1</version>
-        </plugin>                 
+        </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
@@ -302,7 +302,7 @@
         <executions>
             <execution>
                 <id>sign-artifacts</id>
-                <phase>verify</phase>
+                <phase>deploy</phase>
                 <goals>
                     <goal>sign</goal>
                 </goals>


### PR DESCRIPTION
Moves the gpg plugin to sign the artifact during the deploy phase, allowing users to run `mvn install` in order to build locally.

The command `mvn deploy` is not intended to be used by final users because it signs and uploads to Maven Central, therefore requiring proper keys that are set up only in CI.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
