### PR TITLE
vsr: prevent old primaries from evicting clients

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -232,6 +232,9 @@ pub const Header = extern struct {
     /// We use this cryptographic context in various ways, for example:
     ///
     /// * A `request` sets this to the client's session number.
+    /// * A `reply` sets this to a "stable" checksum.
+    ///   Replies for a specific op may have different views (and checksums),
+    ///   but are guaranteed to have the same context.
     /// * A `prepare` sets this to the checksum of the client's request.
     /// * A `prepare_ok` sets this to the checksum of the prepare being acked.
     /// * A `commit` sets this to the checksum of the latest committed prepare.
@@ -551,7 +554,6 @@ pub const Header = extern struct {
         assert(self.command == .reply);
         // Initialization within `client.zig` asserts that client `id` is greater than zero:
         if (self.client == 0) return "client == 0";
-        if (self.context != 0) return "context != 0";
         if (self.op != self.commit) return "op != commit";
         if (self.timestamp == 0) return "timestamp == 0";
         if (self.operation == .register) {

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -377,14 +377,13 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
 
             assert(reply.header.parent == self.parent);
             assert(reply.header.client == self.id);
-            assert(reply.header.context == 0);
             assert(reply.header.request == inflight.message.header.request);
             assert(reply.header.cluster == self.cluster);
             assert(reply.header.op == reply.header.commit);
             assert(reply.header.operation == inflight.message.header.operation);
 
-            // The checksum of this reply becomes the parent of our next request:
-            self.parent = reply.header.checksum;
+            // The context of this reply becomes the parent of our next request:
+            self.parent = reply.header.context;
 
             if (reply.header.view > self.view) {
                 log.debug("{}: on_reply: newer view={}..{}", .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2873,6 +2873,8 @@ pub fn ReplicaType(
             assert(reply.header.epoch == 0);
 
             reply.header.set_checksum_body(reply.body());
+            // See `send_reply_message_to_client` for why we compute the checksum twice.
+            reply.header.context = reply.header.calculate_checksum();
             reply.header.set_checksum();
 
             if (self.superblock.working.vsr_state.op_compacted(prepare.header.op)) {
@@ -2901,7 +2903,7 @@ pub fn ReplicaType(
 
             if (self.primary_index(self.view) == self.replica) {
                 log.debug("{}: commit_op: replying to client: {}", .{ self.replica, reply.header });
-                self.message_bus.send_message_to_client(reply.header.client, reply);
+                self.send_reply_message_to_client(reply);
             }
         }
 
@@ -3008,7 +3010,6 @@ pub fn ReplicaType(
             assert(reply.header.command == .reply);
             assert(reply.header.operation == .register);
             assert(reply.header.client > 0);
-            assert(reply.header.context == 0);
             assert(reply.header.op == reply.header.commit);
             assert(reply.header.size == @sizeOf(Header));
 
@@ -3544,7 +3545,7 @@ pub fn ReplicaType(
                         return true;
                     }
                 } else if (entry.header.request + 1 == message.header.request) {
-                    if (message.header.parent == entry.header.checksum) {
+                    if (message.header.parent == entry.header.context) {
                         // The client has proved that they received our last reply.
                         log.debug("{}: on_request: new request", .{self.replica});
                         return false;
@@ -3601,7 +3602,10 @@ pub fn ReplicaType(
             assert(message.header.request == entry.header.request);
 
             if (entry.header.size == @sizeOf(Header)) {
-                self.send_header_to_client(message.header.client, entry.header);
+                const reply = self.create_message_from_header(entry.header);
+                defer self.message_bus.unref(reply);
+
+                self.send_reply_message_to_client(reply);
                 return;
             }
 
@@ -3655,7 +3659,7 @@ pub fn ReplicaType(
                 reply.header.request,
             });
 
-            self.message_bus.send_message_to_client(reply.header.client, reply);
+            self.send_reply_message_to_client(reply);
         }
 
         /// Returns whether the replica is eligible to process this request as the primary.
@@ -5266,8 +5270,46 @@ pub fn ReplicaType(
             });
         }
 
+        fn send_reply_message_to_client(self: *Self, reply: *Message) void {
+            assert(reply.header.command == .reply);
+            assert(reply.header.view <= self.view);
+
+            // If the request committed in a different view than the one it was originally prepared
+            // in, we must inform the client about this newer view before we send it a reply.
+            // Otherwise, the client might send a next request to the old primary, which would
+            // observe a broken hash chain.
+            //
+            // To do this, we always set reply's view to the current one, and use the `context`
+            // field for hash chaining.
+
+            if (reply.header.view == self.view) {
+                // Hot path: no need to clone the message if the view is the same.
+                self.message_bus.send_message_to_client(reply.header.client, reply);
+                return;
+            }
+
+            const reply_copy = self.message_bus.get_message();
+            defer self.message_bus.unref(reply_copy);
+
+            // Copy the message and update the view.
+            // We could optimize this by using in-place modification if `reply.references == 1`.
+            // We don't bother, as that complicates reasoning on the call-site, and this is
+            // a cold path anyway.
+            stdx.copy_disjoint(
+                .inexact,
+                u8,
+                reply_copy.buffer,
+                reply.buffer[0..reply.header.size],
+            );
+            reply_copy.header.view = self.view;
+            reply_copy.header.set_checksum();
+
+            self.message_bus.send_message_to_client(reply.header.client, reply_copy);
+        }
+
         fn send_header_to_client(self: *Self, client: u128, header: Header) void {
             assert(header.cluster == self.cluster);
+            assert(header.view == self.view);
 
             const message = self.create_message_from_header(header);
             defer self.message_bus.unref(message);
@@ -6329,14 +6371,12 @@ pub fn ReplicaType(
             assert(reply.header.command == .reply);
             assert(reply.header.operation != .register);
             assert(reply.header.client > 0);
-            assert(reply.header.context == 0);
             assert(reply.header.op == reply.header.commit);
             assert(reply.header.commit > 0);
             assert(reply.header.request > 0);
 
             if (self.client_sessions().get(reply.header.client)) |entry| {
                 assert(entry.header.command == .reply);
-                assert(entry.header.context == 0);
                 assert(entry.header.op == entry.header.commit);
                 assert(entry.header.commit >= entry.session);
 


### PR DESCRIPTION
We want to maintain the following invariant:

If the client knows a certain reply, it is aware of a view that committed the corresponding prepare.

Otherwise, the client sends a next request to the old primary and gets kicked out.

To do so, we include current view whenever we send a reply back to the client (we keep the original view on disk for storage determinism).

This creates a problem: replies for the same request now have different checksums. This breaks reply's hashchaining. Fix that by using the `context`

Closes: #662
Seed: 9315705680320980549

## Pre-merge checklist

Performance:

* [x] Compare `zig build benchmark` on linux before and after this pr.

Before:

```
λ ./scripts/benchmark.sh --transfer-count 1000000
++ uname
+ '[' Linux = Linux ']'
+ ZIG_OS=linux
+ target_set=false
+ case "$*" in
+ target_set=true
+ TARGET=
+ '[' true = false ']'
+ ZIG_EXE=./zig/zig
+ BUILD_ROOT=./
+ CACHE_ROOT=./zig-cache
+ GLOBAL_CACHE_ROOT=/home/matklad/.cache/zig
+ ./zig/zig run ./scripts/build_runner.zig -target native-linux --main-pkg-path ./ -- ./zig/zig ./ ./zig-cache /home/matklad/.cache/zig install -Drelease-safe -Dconfig=production -Dtarget=native-linux
Formatting replica 0...
Starting replica 0...

Benchmarking...
++ uname
+ '[' Linux = Linux ']'
+ ZIG_OS=linux
+ target_set=false
+ case "$*" in
+ target_set=true
+ TARGET=
+ '[' true = false ']'
+ ZIG_EXE=./zig/zig
+ BUILD_ROOT=./
+ CACHE_ROOT=./zig-cache
+ GLOBAL_CACHE_ROOT=/home/matklad/.cache/zig
+ ./zig/zig run ./scripts/build_runner.zig -target native-linux --main-pkg-path ./ -- ./zig/zig ./ ./zig-cache /home/matklad/.cache/zig benchmark -Drelease-safe -Dconfig=production -Dtarget=native-linux -- --transfer-count 1000000
error(message_bus): error connecting to replica 0: error.ConnectionRefused
124 batches in 6.11 s
load offered = 1000000 tx/s
load accepted = 163624 tx/s
```

After:
```
λ ./scripts/benchmark.sh --transfer-count 1000000
++ uname
+ '[' Linux = Linux ']'
+ ZIG_OS=linux
+ target_set=false
+ case "$*" in
+ target_set=true
+ TARGET=
+ '[' true = false ']'
+ ZIG_EXE=./zig/zig
+ BUILD_ROOT=./
+ CACHE_ROOT=./zig-cache
+ GLOBAL_CACHE_ROOT=/home/matklad/.cache/zig
+ ./zig/zig run ./scripts/build_runner.zig -target native-linux --main-pkg-path ./ -- ./zig/zig ./ ./zig-cache /home/matklad/.cache/zig install -Drelease-safe -Dconfig=production -Dtarget=native-linux
Formatting replica 0...
Starting replica 0...

Benchmarking...
++ uname
+ '[' Linux = Linux ']'
+ ZIG_OS=linux
+ target_set=false
+ case "$*" in
+ target_set=true
+ TARGET=
+ '[' true = false ']'
+ ZIG_EXE=./zig/zig
+ BUILD_ROOT=./
+ CACHE_ROOT=./zig-cache
+ GLOBAL_CACHE_ROOT=/home/matklad/.cache/zig
+ ./zig/zig run ./scripts/build_runner.zig -target native-linux --main-pkg-path ./ -- ./zig/zig ./ ./zig-cache /home/matklad/.cache/zig benchmark -Drelease-safe -Dconfig=production -Dtarget=native-linux -- --transfer-count 1000000
124 batches in 5.86 s
load offered = 1000000 tx/s
load accepted = 170666 tx/s
```

Sanity checks as "no big regression", and this seems unlikely to affect the results much otherwise. 