### PR TITLE
LSM: Avoid sorting TableMutable when updated in sorted order.

### DIFF
--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -21,9 +21,6 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
     return struct {
         const TableMutable = @This();
 
-        const load_factor = 50;
-        const Values = std.HashMapUnmanaged(Value, void, Table.HashMapContextValue, load_factor);
-
         pub const ValuesCache = SetAssociativeCache(
             Key,
             Value,
@@ -42,7 +39,142 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
             tree_name,
         );
 
-        values: Values = .{},
+        const ValuesMap = struct {
+            const Values = struct {
+                active: [value_count_max / 8]u8,
+                items: [value_count_max]Value,
+            };
+
+            const load_factor = 50;
+            const IndexMap = std.HashMapUnmanaged(u32, void, IndexMapContext, load_factor);
+
+            const IndexMapContext = struct {
+                values: *const Values,
+                search_key: Key,
+                search_index: u32 = math.maxInt(u32),
+
+                inline fn key_from_index(ctx: *const IndexMapContext, index: u32) Key {
+                    if (index == ctx.search_index) return ctx.search_key;
+                    return key_from_value(&ctx.values.items[index]);
+                }
+
+                pub inline fn eql(ctx: IndexMapContext, a: u32, b: u32) bool {
+                    return compare_keys(ctx.key_from_index(a), ctx.key_from_index(b)) == .eq;
+                }
+
+                pub inline fn hash(ctx: IndexMapContext, index: u32) u64 {
+                    const key = ctx.key_from_index(index);
+                    return std.hash.Wyhash.hash(0, mem.asBytes(&key));
+                }
+            };
+
+            index_map: IndexMap,
+            values: *Values,
+            active: u32,
+
+            pub fn init(allocator: mem.Allocator) !ValuesMap {
+                var index_map = IndexMap{};
+                try index_map.ensureTotalCapacityContext(allocator, value_count_max, undefined);
+                errdefer index_map.deinit(allocator);
+
+                const values = try allocator.create(Values);
+                errdefer allocator.destroy(values);
+
+                return ValuesMap{
+                    .index_map = index_map,
+                    .values = values,
+                    .active = 0,
+                };
+            }
+
+            pub fn deinit(map: *ValuesMap, allocator: mem.Allocator) void {
+                allocator.destroy(map.values);
+                map.index_map.deinit(allocator);
+            }
+
+            pub inline fn count(map: *const ValuesMap) u32 {
+                return map.index_map.count();
+            }
+
+            pub inline fn clear(map: *ValuesMap) void {
+                map.index_map.clearRetainingCapacity();
+                map.active = 0;
+            }
+
+            pub fn find(map: *const ValuesMap, key: Key) ?*const Value {
+                const ctx = IndexMapContext{ .values = map.values, .search_key = key };
+                const index = map.index_map.getKeyAdapted(ctx.search_index, ctx) orelse return null;
+                return &map.values.items[index];
+            }
+
+            pub fn upsert(map: *ValuesMap, value: *const Value) *Value {
+                const ctx = IndexMapContext{ .values = map.values, .search_key = key_from_value(value) };
+                const result = map.index_map.getOrPutAssumeCapacityContext(ctx.search_index, ctx);
+                if (result.found_existing) {
+                    return &map.values.items[result.key_ptr.*];
+                }
+
+                const index = @intCast(u32, map.active);
+                map.active += 1;
+
+                result.key_ptr.* = index;
+                map.values.active[index / 8] |= @as(u8, 1) << @intCast(u3, index % 8);
+                return &map.values.items[index];
+            }
+
+            pub fn fetch_remove(map: *ValuesMap, value: *const Value) ?*Value {
+                const ctx = IndexMapContext{ .values = map.values, .search_key = key_from_value(value) };
+                const kv = map.index_map.fetchRemoveContext(ctx.search_index, ctx) orelse return null;
+                const index = kv.key;
+
+                map.values.active[index / 8] &= ~(@as(u8, 1) << @intCast(u3, index % 8));
+                return &map.values.items[index];
+            }
+
+            pub fn insert_no_clobber(map: *ValuesMap, value: Value) void {
+                const index = @intCast(u32, map.active);
+                map.active += 1;
+
+                const ctx = IndexMapContext{
+                    .values = map.values,
+                    .search_key = key_from_value(&value),
+                    .search_index = index,
+                };
+
+                map.index_map.putAssumeCapacityNoClobberContext(ctx.search_index, {}, ctx);
+                map.values.active[index / 8] |= @as(u8, 1) << @intCast(u3, index % 8);
+                map.values.items[index] = value;
+            }
+
+            pub inline fn iterator(map: *const ValuesMap) Iterator {
+                return .{
+                    .index = 0,
+                    .active = map.active,
+                    .values = map.values,
+                };
+            }
+
+            pub const Iterator = struct {
+                index: u32,
+                active: u32,
+                values: *const Values,
+
+                pub fn next(it: *Iterator) ?*const Value {
+                    while (true) {
+                        it.active = math.sub(u32, it.active, 1) catch return null;
+                        const index = it.index;
+                        it.index += 1;
+
+                        const mask = @as(u8, 1) << @intCast(u3, index % 8);
+                        if (it.values.active[index / 8] & mask != 0) {
+                            return &it.values.items[index];
+                        }
+                    }
+                }
+            };
+        };
+
+        values: ValuesMap,
 
         /// Rather than using values.count(), we count how many values we could have had if every
         /// operation had been on a different key. This means that mistakes in calculating
@@ -70,8 +202,7 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
             allocator: mem.Allocator,
             values_cache: ?*ValuesCache,
         ) !TableMutable {
-            var values: Values = .{};
-            try values.ensureTotalCapacity(allocator, value_count_max);
+            var values = try ValuesMap.init(allocator);
             errdefer values.deinit(allocator);
 
             return TableMutable{
@@ -85,7 +216,7 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
         }
 
         pub fn get(table: *const TableMutable, key: Key) ?*const Value {
-            if (table.values.getKeyPtr(tombstone_from_key(key))) |value| {
+            if (table.values.find(key)) |value| {
                 return value;
             }
             if (table.values_cache) |cache| {
@@ -100,21 +231,17 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
             table.value_count_worst_case += 1;
             switch (usage) {
                 .secondary_index => {
-                    const existing = table.values.fetchRemove(value.*);
-                    if (existing) |kv| {
+                    if (table.values.fetch_remove(value)) |existing| {
                         // If there was a previous operation on this key then it must have been a remove.
                         // The put and remove cancel out.
-                        assert(tombstone(&kv.key));
+                        assert(tombstone(existing));
                     } else {
-                        table.values.putAssumeCapacityNoClobber(value.*, {});
+                        table.values.insert_no_clobber(value.*);
                     }
                 },
                 .general => {
-                    // If the key is already present in the hash map, the old key will not be overwritten
-                    // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
-                    // level getOrPut() API and manually overwrite the old key.
-                    const upsert = table.values.getOrPutAssumeCapacity(value.*);
-                    upsert.key_ptr.* = value.*;
+                    // Overwrite the old key and value if any.
+                    table.values.upsert(value).* = value.*;
                 },
             }
 
@@ -127,23 +254,19 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
             table.value_count_worst_case += 1;
             switch (usage) {
                 .secondary_index => {
-                    const existing = table.values.fetchRemove(value.*);
-                    if (existing) |kv| {
+                    if (table.values.fetch_remove(value)) |existing| {
                         // The previous operation on this key then it must have been a put.
                         // The put and remove cancel out.
-                        assert(!tombstone(&kv.key));
+                        assert(!tombstone(existing));
                     } else {
                         // If the put is already on-disk, then we need to follow it with a tombstone.
                         // The put and the tombstone may cancel each other out later during compaction.
-                        table.values.putAssumeCapacityNoClobber(tombstone_from_key(key_from_value(value)), {});
+                        table.values.insert_no_clobber(tombstone_from_key(key_from_value(value)));
                     }
                 },
                 .general => {
-                    // If the key is already present in the hash map, the old key will not be overwritten
-                    // by the new one if using e.g. putAssumeCapacity(). Instead we must use the lower
-                    // level getOrPut() API and manually overwrite the old key.
-                    const upsert = table.values.getOrPutAssumeCapacity(value.*);
-                    upsert.key_ptr.* = tombstone_from_key(key_from_value(value));
+                    // Overwrite the old key and value if any.
+                    table.values.upsert(value).* = tombstone_from_key(key_from_value(value));
                 },
             }
 
@@ -153,7 +276,7 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
         pub fn clear(table: *TableMutable) void {
             assert(table.values.count() > 0);
             table.value_count_worst_case = 0;
-            table.values.clearRetainingCapacity();
+            table.values.clear();
             assert(table.values.count() == 0);
         }
 
@@ -174,9 +297,15 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
             assert(values_max.len == value_count_max);
 
             var i: usize = 0;
-            var it = table.values.keyIterator();
+            var sorted = true;
+            var it = table.values.iterator();
             while (it.next()) |value| : (i += 1) {
                 values_max[i] = value.*;
+
+                if (i > 0 and sorted) {
+                    const prev_key = key_from_value(&values_max[i - 1]);
+                    sorted = compare_keys(prev_key, key_from_value(value)) != .gt;
+                }
 
                 if (table.values_cache) |cache| {
                     if (tombstone(value)) {
@@ -189,7 +318,7 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
 
             const values = values_max[0..i];
             assert(values.len == table.count());
-            std.sort.sort(Value, values, {}, sort_values_by_key_in_ascending_order);
+            if (!sorted) std.sort.sort(Value, values, {}, sort_values_by_key_in_ascending_order);
 
             table.clear();
             assert(table.count() == 0);


### PR DESCRIPTION
Implements a wrapper around `[]Value`, `HashMap(u24)`, and `[]u8` for TableMutable. Values are appended to the array, their indexes are added to the HashMap, and there's a bitset to track which ones were removed. When iterating, removed Values are ignored using the bitset and we track if the values were inserted in sorted order. If so, we can skip `std.sort.sort`.

## Pre-merge checklist

Performance:

* [x] Compare `zig build benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1223 batches in 133.25 s
    load offered = 1000000 tx/s
    load accepted = 75047 tx/s
    batch latency p00 = 0 ms
    batch latency p10 = 27 ms
    batch latency p20 = 28 ms
    batch latency p30 = 29 ms
    batch latency p40 = 29 ms
    batch latency p50 = 30 ms
    batch latency p60 = 31 ms
    batch latency p70 = 32 ms
    batch latency p80 = 33 ms
    batch latency p90 = 34 ms
    batch latency p100 = 5404 ms
    transfer latency p00 = 0 ms
    transfer latency p10 = 4066 ms
    transfer latency p20 = 10537 ms
    transfer latency p30 = 20729 ms
    transfer latency p40 = 33777 ms
    transfer latency p50 = 48780 ms
    transfer latency p60 = 63997 ms
    transfer latency p70 = 74013 ms
    transfer latency p80 = 89395 ms
    transfer latency p90 = 104911 ms
    transfer latency p100 = 123261 ms
    
    # benchmark results after
    1223 batches in 123.42 s
    load offered = 1000000 tx/s
    load accepted = 81021 tx/s
    batch latency p00 = 0 ms
    batch latency p10 = 26 ms
    batch latency p20 = 27 ms
    batch latency p30 = 28 ms
    batch latency p40 = 28 ms
    batch latency p50 = 29 ms
    batch latency p60 = 30 ms
    batch latency p70 = 30 ms
    batch latency p80 = 31 ms
    batch latency p90 = 33 ms
    batch latency p100 = 5406 ms
    transfer latency p00 = 0 ms
    transfer latency p10 = 3215 ms
    transfer latency p20 = 9149 ms
    transfer latency p30 = 18426 ms
    transfer latency p40 = 30364 ms
    transfer latency p50 = 44402 ms
    transfer latency p60 = 58471 ms
    transfer latency p70 = 67372 ms
    transfer latency p80 = 81779 ms
    transfer latency p90 = 96208 ms
    transfer latency p100 = 113436 ms
    ```
