### PR TITLE
vsr: commit concurrently with repair

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4363,8 +4363,6 @@ pub fn ReplicaType(
                 });
             }
 
-            assert(self.commit_max <= self.op);
-
             if (self.commit_min < self.commit_max) {
                 // Try to the commit prepares we already have, even if we don't have all of them.
                 // This helps when a replica is recovering from a crash and has a mostly intact
@@ -4379,6 +4377,9 @@ pub fn ReplicaType(
                 self.primary_index(self.view) == self.replica and
                 self.commit_min == self.commit_max)
             {
+                assert(self.journal.dirty.count == 0);
+                assert(self.commit_max <= self.op);
+
                 // Repair the pipeline, which may discover faulty prepares and drive more repairs.
                 switch (self.primary_repair_pipeline()) {
                     // primary_repair_pipeline() is already working.


### PR DESCRIPTION
Before, repair would only trigger commit if we collected all of the missing prepares. This is not optimal: if we have a WAL-full of prepares, and only the last couple are faulty, we want to start committing earlier prepares immediately, so that, by the time we get the requested prepares, those can be immediately committed as well.

SEED=16825366195277209080 shows how we don't commit earlier prepares if a later one is missing (although I _think_ this PR does not fix the root issue for that VOPR failure; rather it fixes a mostly unrelated problem).

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
