### PR TITLE
vopr: add logging for which WAL slot is corrupted

### DIFF
--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -439,11 +439,33 @@ pub const Storage = struct {
     fn fault_sector(storage: *Storage, zone: vsr.Zone, sector: usize) void {
         storage.faults.set(sector);
         if (storage.options.replica_index) |replica_index| {
-            log.debug("{}: corrupting sector at zone={} offset={}", .{
-                replica_index,
-                zone,
-                sector * constants.sector_size - zone.offset(0),
-            });
+            const offset = sector * constants.sector_size - zone.offset(0);
+            switch (zone) {
+                .wal_prepares => {
+                    comptime assert(constants.message_size_max % constants.sector_size == 0);
+                    const slot = @divFloor(offset, constants.message_size_max);
+                    log.debug(
+                        "{}: corrupting sector at zone={} offset={} slot={}",
+                        .{ replica_index, zone, offset, slot },
+                    );
+                },
+                .wal_headers => {
+                    comptime assert(constants.sector_size % @sizeOf(vsr.Header) == 0);
+                    const slot_min = @divFloor(offset, @sizeOf(vsr.Header));
+                    const slot_max = slot_min +
+                        @divExact(constants.sector_size, @sizeOf(vsr.Header));
+                    log.debug(
+                        "{}: corrupting sector at zone={} offset={} slots={}...{}",
+                        .{ replica_index, zone, offset, slot_min, slot_max },
+                    );
+                },
+                .superblock, .client_replies, .grid => {
+                    log.debug(
+                        "{}: corrupting sector at zone={} offset={}",
+                        .{ replica_index, zone, offset },
+                    );
+                },
+            }
         }
     }
 


### PR DESCRIPTION
## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
