### PR TITLE
vopr: don't fault all available prepares

### DIFF
--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -697,11 +697,11 @@ pub const ClusterFaultAtlas = struct {
             }
         }
 
-        // A cluster-of-2 is special-cased to mirror the special case in replica.zig.
-        // See repair_prepare().
         const quorums = vsr.quorums(replica_count);
-        const faults_max = if (replica_count == 2) 1 else replica_count - quorums.replication;
+        const faults_max = quorums.replication - 1;
         assert(faults_max < replica_count);
+        assert(faults_max < quorums.replication);
+        assert(faults_max < quorums.view_change);
         assert(faults_max > 0 or replica_count == 1);
 
         var sector: usize = 0;


### PR DESCRIPTION
We have quorums.replication copies of data in the cluster, so we should avoid faulting all of them.

closes #687

## Pre-merge checklist

Performance:
* [X] I am very sure this PR could not affect performance.
