### PR TITLE
Trigger release after merge, not weekly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: "Release (weekly)"
+name: "Release (latest)"
 
 on:
-  schedule:
-    # Every Monday at 14:00
-    - cron: "0 14 * * 1"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Explicitly pass in the sha, even though it's very likely to be HEAD.
-      - run: hub release create --prerelease --message "Weekly automated build. Do not use in production." -t ${{ github.sha }} "$(date +%Y-%m-%d)-weekly"
+      - run: hub release create --prerelease --message "Automated build. Do not use in production." -t ${{ github.sha }} "release-$(date +%Y%m%d.%H%M)"
 
         # Propagate token into environment
         env:

--- a/scripts/next_version.sh
+++ b/scripts/next_version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# Update these as needed.
+MAJOR=0
+MINOR=13
+
+git fetch --tags --all
+version="$MAJOR.$MINOR.0"
+latest="$(git tag | grep $MAJOR.$MINOR | sort -r | head -n1)"
+if [ "$latest" != "" ]; then
+    patch="$(echo $latest | cut -d '.' -f 3)"
+    version="$MAJOR.$MINOR.$((patch+1))"
+fi
+echo "$version"

--- a/scripts/next_version.sh
+++ b/scripts/next_version.sh
@@ -10,7 +10,7 @@ git fetch --tags --all
 version="$MAJOR.$MINOR.0"
 latest="$(git tag | grep $MAJOR.$MINOR | sort -r | head -n1)"
 if [ "$latest" != "" ]; then
-    patch="$(echo $latest | cut -d '.' -f 3)"
+    patch="$(echo "$latest" | cut -d '.' -f 3)"
     version="$MAJOR.$MINOR.$((patch+1))"
 fi
 echo "$version"


### PR DESCRIPTION
Until we decide on a good naming convention we can share across all artifacts we release (which basically must be semver) this is just another random naming scheme for the release and built binaries.

* [x] I am very sure this PR could not affect performance.
