### PR TITLE
LSM/Grid: Block repair

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -108,7 +108,6 @@ const Environment = struct {
 
         env.grid = try Grid.init(allocator, .{
             .superblock = &env.superblock,
-            .on_read_fault = on_grid_read_fault,
         });
 
         env.forest = undefined;
@@ -119,12 +118,6 @@ const Environment = struct {
     fn deinit(env: *Environment) void {
         env.superblock.deinit(allocator);
         env.grid.deinit(allocator);
-    }
-
-    fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
-        _ = grid;
-        _ = read;
-        unreachable;
     }
 
     pub fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -106,7 +106,10 @@ const Environment = struct {
             .storage_size_limit = constants.storage_size_max,
         });
 
-        env.grid = try Grid.init(allocator, &env.superblock);
+        env.grid = try Grid.init(allocator, .{
+            .superblock = &env.superblock,
+            .on_read_fault = on_grid_read_fault,
+        });
 
         env.forest = undefined;
         env.checkpoint_op = null;
@@ -116,6 +119,12 @@ const Environment = struct {
     fn deinit(env: *Environment) void {
         env.superblock.deinit(allocator);
         env.grid.deinit(allocator);
+    }
+
+    fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
+        _ = grid;
+        _ = read;
+        unreachable;
     }
 
     pub fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
+const maybe = stdx.maybe;
 const mem = std.mem;
 
 const constants = @import("../constants.zig");
@@ -12,7 +13,7 @@ const IOPS = @import("../iops.zig").IOPS;
 const SetAssociativeCache = @import("set_associative_cache.zig").SetAssociativeCache;
 const stdx = @import("../stdx.zig");
 
-const log = std.log.scoped(.grid);
+const log = stdx.log.scoped(.grid);
 const tracer = @import("../tracer.zig");
 
 /// A block's type is implicitly determined by how its address is stored (e.g. in the index block).
@@ -70,6 +71,7 @@ pub fn GridType(comptime Storage: type) type {
         pub const Write = struct {
             callback: fn (*Grid.Write) void,
             address: u64,
+            repair: bool,
             block: *BlockPtr,
 
             /// Link for the Grid.write_queue linked list.
@@ -83,10 +85,14 @@ pub fn GridType(comptime Storage: type) type {
         };
 
         pub const Read = struct {
-            callback: fn (*Grid.Read, BlockPtrConst) void,
+            callback: union(enum) {
+                normal: fn (*Grid.Read, BlockPtrConst) void, // repair == false
+                repair: fn (*Grid.Read, ?BlockPtrConst) void, // repair == true
+            },
             address: u64,
             checksum: u128,
-            block_type: BlockType,
+            block_type: ?BlockType,
+            repair: bool,
 
             pending: ReadPending = .{},
             resolves: FIFO(ReadPending) = .{ .name = null },
@@ -94,7 +100,7 @@ pub fn GridType(comptime Storage: type) type {
             grid: *Grid,
             next_tick: Grid.NextTick = undefined,
 
-            /// Link for Grid.read_queue/Grid.read_recovery_queue linked lists.
+            /// Link for Grid.read_queue/Grid.read_faulty_queue linked lists.
             next: ?*Read = null,
         };
 
@@ -156,12 +162,16 @@ pub fn GridType(comptime Storage: type) type {
 
         // List if Read.pending's which are in `read_queue` but also waiting for a free `read_iops`.
         read_pending_queue: FIFO(ReadPending) = .{ .name = "grid_read_pending" },
-        // TODO interrogate this list and do recovery in Replica.tick().
-        read_recovery_queue: FIFO(Read) = .{ .name = "grid_read_recovery" },
+        read_faulty_queue: FIFO(Read) = .{ .name = "grid_read_faulty" },
         // True if there's a read thats resolving callbacks. If so, the read cache must not be invalidated.
         read_resolving: bool = false,
 
-        pub fn init(allocator: mem.Allocator, superblock: *SuperBlock) !Grid {
+        on_read_fault: fn (*Grid, *Grid.Read) void,
+
+        pub fn init(allocator: mem.Allocator, options: struct {
+            superblock: *SuperBlock,
+            on_read_fault: fn (*Grid, *Grid.Read) void,
+        }) !Grid {
             // TODO Determine this at runtime based on runtime configured maximum
             // memory usage of tigerbeetle.
             const cache_blocks_count = 2048;
@@ -173,6 +183,7 @@ pub fn GridType(comptime Storage: type) type {
                 errdefer for (cache_blocks[0..i]) |block| allocator.free(block);
                 cache_block.* = try alloc_block(allocator);
             }
+            errdefer for (cache_blocks) |block| allocator.free(block);
 
             var cache = try Cache.init(allocator, cache_blocks_count);
             errdefer cache.deinit(allocator);
@@ -183,12 +194,14 @@ pub fn GridType(comptime Storage: type) type {
                 errdefer for (read_iop_blocks[0..i]) |block| allocator.free(block);
                 read_iop_block.* = try alloc_block(allocator);
             }
+            errdefer for (&read_iop_blocks) |block| allocator.free(block);
 
             return Grid{
-                .superblock = superblock,
+                .superblock = options.superblock,
                 .cache_blocks = cache_blocks,
                 .cache = cache,
                 .read_iop_blocks = read_iop_blocks,
+                .on_read_fault = options.on_read_fault,
             };
         }
 
@@ -240,7 +253,7 @@ pub fn GridType(comptime Storage: type) type {
         ///
         /// Asserts that the address is not currently being read from or written to.
         pub fn release(grid: *Grid, address: u64) void {
-            grid.assert_not_writing(address, null);
+            assert(grid.writing(address, null) != .init);
             // It's safe to release an address that is being read from,
             // because the superblock will not allow it to be overwritten before
             // the end of the measure.
@@ -249,24 +262,57 @@ pub fn GridType(comptime Storage: type) type {
             grid.superblock.free_set.release(address);
         }
 
-        /// Assert that the address is not currently being written to.
-        /// Assert that the block pointer is not being used for any write if non-null.
-        fn assert_not_writing(grid: *Grid, address: u64, block: ?BlockPtrConst) void {
+        pub fn faulty(grid: *Grid, address: u64, checksum: ?u128) bool {
             assert(address > 0);
+
+            var it = grid.read_faulty_queue.peek();
+            while (it) |faulty_read| : (it = faulty_read.next) {
+                assert(!faulty_read.repair);
+
+                if (faulty_read.address == address) {
+                    assert(grid.cache.get_index(address) == null);
+                    assert(!grid.superblock.free_set.is_free(address));
+
+                    if (checksum == null or checksum.? == faulty_read.checksum) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        const Writing = enum { init, repair, none };
+
+        /// If the address is being written to by a non-repair, return `.init`.
+        /// If the address is being written to by a repair, return `.repair`.
+        /// Otherwise return `.none`.
+        ///
+        /// Assert that the block pointer is not being used for any write if non-null.
+        pub fn writing(grid: *Grid, address: u64, block: ?BlockPtrConst) Writing {
+            assert(address > 0);
+
+            var result = Writing.none;
             {
                 var it = grid.write_queue.peek();
                 while (it) |queued_write| : (it = queued_write.next) {
-                    assert(address != queued_write.address);
                     assert(block != queued_write.block.*);
+                    if (address == queued_write.address) {
+                        assert(result == .none);
+                        result = if (queued_write.repair) .repair else .init;
+                    }
                 }
             }
             {
                 var it = grid.write_iops.iterate();
                 while (it.next()) |iop| {
-                    assert(address != iop.write.address);
                     assert(block != iop.write.block.*);
+                    if (address == iop.write.address) {
+                        assert(result == .none);
+                        result = if (iop.write.repair) .repair else .init;
+                    }
                 }
             }
+            return result;
         }
 
         /// Assert that the address is not currently being read from.
@@ -275,17 +321,17 @@ pub fn GridType(comptime Storage: type) type {
             assert(address > 0);
             for ([_]*const FIFO(Read){
                 &grid.read_queue,
-                &grid.read_recovery_queue,
+                &grid.read_faulty_queue,
             }) |queue| {
                 var it = queue.peek();
                 while (it) |queued_read| : (it = queued_read.next) {
-                    assert(address != queued_read.address);
+                    assert(address != queued_read.address or queued_read.repair);
                 }
             }
             {
                 var it = grid.read_iops.iterate();
                 while (it.next()) |iop| {
-                    assert(address != iop.read.address);
+                    assert(address != iop.read.address or iop.read.repair);
                     const iop_block = grid.read_iop_blocks[grid.read_iops.index(iop)];
                     assert(block != iop_block);
                 }
@@ -301,7 +347,7 @@ pub fn GridType(comptime Storage: type) type {
             address: u64,
         ) void {
             assert(address > 0);
-            grid.assert_not_writing(address, block.*);
+            assert(grid.writing(address, block.*) == .none);
             grid.assert_not_reading(address, block.*);
 
             if (constants.verify) {
@@ -316,6 +362,41 @@ pub fn GridType(comptime Storage: type) type {
             write.* = .{
                 .callback = callback,
                 .address = address,
+                .repair = false,
+                .block = block,
+            };
+
+            const iop = grid.write_iops.acquire() orelse {
+                grid.write_queue.push(write);
+                return;
+            };
+
+            grid.write_block_with(iop, write);
+        }
+
+        /// NOTE: This will consume `block` and replace it with a fresh block.
+        pub fn write_block_repair(
+            grid: *Grid,
+            callback: fn (*Grid.Write) void,
+            write: *Grid.Write,
+            block: *BlockPtr,
+            address: u64,
+        ) void {
+            const header_bytes = block.*[0..@sizeOf(vsr.Header)];
+            const header = mem.bytesAsValue(vsr.Header, header_bytes);
+
+            assert(address > 0);
+            assert(address == header.op);
+            assert(grid.superblock.opened);
+            assert(!grid.superblock.free_set.is_free(address));
+            assert(grid.faulty(address, header.checksum));
+            assert(grid.writing(address, block.*) == .none);
+            if (constants.verify) grid.verify_read(address, block.*);
+
+            write.* = .{
+                .callback = callback,
+                .address = address,
+                .repair = true,
                 .block = block,
             };
 
@@ -382,7 +463,29 @@ pub fn GridType(comptime Storage: type) type {
                 grid.write_iops.release(iop);
             }
 
-            // This call must come after (logicall) releasing the IOP. Otherwise we risk tripping
+            if (completed_write.repair) {
+                // We wait until the write completes to resolve the repair queue, to prevent
+                // these writes from ever overlapping with compaction or checkpoints.
+                const header_bytes = cache_block.*[0..@sizeOf(vsr.Header)];
+                const header = mem.bytesAsValue(vsr.Header, header_bytes);
+
+                var read_ = grid.read_faulty_queue.peek();
+                while (read_) |read| : (read_ = read.next) {
+                    assert(!read.repair);
+
+                    if (read.checksum == header.checksum and
+                        read.address == completed_write.address)
+                    {
+                        grid.read_faulty_queue.remove(read);
+                        grid.read_block_resolve(read, cache_block.*);
+                        break;
+                    }
+                } else {
+                    unreachable;
+                }
+            }
+
+            // This call must come after (logically) releasing the IOP. Otherwise we risk tripping
             // assertions forbidding concurrent writes using the same block/address
             // if the callback calls write_block().
             completed_write.callback(completed_write);
@@ -402,32 +505,83 @@ pub fn GridType(comptime Storage: type) type {
         ) void {
             assert(address > 0);
             assert(block_type != .reserved);
-            grid.assert_not_writing(address, null);
 
             assert(grid.superblock.opened);
             assert(!grid.superblock.free_set.is_free(address));
+            assert(grid.writing(address, null) != .init);
 
             read.* = .{
-                .callback = callback,
+                .callback = .{ .normal = callback },
                 .address = address,
                 .checksum = checksum,
                 .block_type = block_type,
+                .repair = false,
                 .grid = grid,
             };
 
             // Check if a read is already processing/recovering and merge with it.
             for ([_]*const FIFO(Read){
                 &grid.read_queue,
-                &grid.read_recovery_queue,
+                &grid.read_faulty_queue,
             }) |queue| {
                 var it = queue.peek();
                 while (it) |queued_read| : (it = queued_read.next) {
-                    if (address == queued_read.address) {
+                    // To simplify read-resolution, don't queue up behind repairs.
+                    if (!queued_read.repair and queued_read.address == address) {
                         assert(checksum == queued_read.checksum);
-                        assert(block_type == queued_read.block_type);
+                        assert(block_type == queued_read.block_type.?);
                         queued_read.resolves.push(&read.pending);
                         return;
                     }
+                }
+            }
+
+            // Become the "root" read thats fetching the block for the given address.
+            // The fetch happens asynchronously to avoid stack-overflow and nested cache invalidation.
+            grid.read_queue.push(read);
+            grid.on_next_tick(read_block_tick_callback, &read.next_tick);
+        }
+
+        /// If the block is not present (or corrupt), we do not attempt to repair it — the repair's
+        /// address/checksum is not assumed to match what "should" be in our block.
+        /// Relatedly we still attempt to read free blocks — they might still hold the requested data.
+        pub fn read_block_repair(
+            grid: *Grid,
+            callback: fn (*Grid.Read, ?BlockPtrConst) void,
+            read: *Grid.Read,
+            address: u64,
+            checksum: u128,
+        ) void {
+            assert(address > 0);
+
+            assert(grid.superblock.opened);
+            // We *could* try to read the block even when it is free — if we recently release it,
+            // it might be found on disk anyway.
+            // But what would preclude the TestStorage's "memory_written.isSet" assertion.
+            assert(!grid.superblock.free_set.is_free(address));
+            // The caller will not attempt to help another replica repair a block that
+            // we are already trying to repair ourselves.
+            assert(!grid.faulty(address, null));
+            maybe(grid.writing(address, null) == .init);
+
+            read.* = .{
+                .callback = .{ .repair = callback },
+                .address = address,
+                .checksum = checksum,
+                .block_type = null,
+                .repair = true,
+                .grid = grid,
+            };
+
+            // Check if a repair-read is already processing and merge with it.
+            var it = grid.read_queue.peek();
+            while (it) |queued_read| : (it = queued_read.next) {
+                if (queued_read.repair and
+                    queued_read.address == address and
+                    queued_read.checksum == checksum)
+                {
+                    queued_read.resolves.push(&read.pending);
+                    return;
                 }
             }
 
@@ -444,8 +598,21 @@ pub fn GridType(comptime Storage: type) type {
             // Try to resolve the read from the cache.
             if (grid.cache.get_index(read.address)) |cache_index| {
                 const cache_block = grid.cache_blocks[cache_index];
-                if (constants.verify) grid.verify_cached_read(read.address, cache_block);
-                grid.read_block_resolve(read, cache_block);
+
+                const header = mem.bytesAsValue(vsr.Header, cache_block[0..@sizeOf(vsr.Header)]);
+                assert(header.op == read.address);
+                if (constants.verify) grid.verify_read(read.address, cache_block);
+
+                // Remove the "root" read so that the address is no longer actively reading / locked.
+                grid.read_queue.remove(read);
+
+                if (header.checksum == read.checksum) {
+                    maybe(read.repair);
+                    grid.read_block_resolve(read, cache_block);
+                } else {
+                    assert(read.repair);
+                    grid.read_block_resolve(read, null);
+                }
                 return;
             }
 
@@ -514,20 +681,40 @@ pub fn GridType(comptime Storage: type) type {
                 grid.read_iops.release(iop);
             }
 
-            // A valid block filled by storage means the reads for the address can be resolved
+            // Remove the "root" read so that the address is no longer actively reading / locked.
+            grid.read_queue.remove(read);
+
+            // A valid block filled by storage means the reads for the address can be resolved.
             if (read_block_valid(read, cache_block.*)) {
                 grid.read_block_resolve(read, cache_block.*);
+
+                if (read.repair) {
+                    // Even though this block is the block we expected to read, we can't safely
+                    // cache this result:
+                    // 1. Replica A write block X₁ to address X.
+                    // 2. Replica A write block X₂ to address X (write is lost/misdirected).
+                    // 3. Replica B requests block X₁ from replica A.
+                    // It is safe for A to send back X₁, but A must not allow it to poison its cache.
+                    grid.cache.remove(read.address);
+                }
                 return;
             }
 
-            // On the result of an invalid block, move the "root" read (and all others it resolves)
-            // to recovery queue. Future reads on the same address will see the "root" read in the
-            // recovery queue and enqueue to it.
-            grid.read_queue.remove(read);
-            grid.read_recovery_queue.push(read);
+            // Don't cache a corrupt or incorrect block.
+            grid.cache.remove(read.address);
+
+            if (read.repair) {
+                grid.read_block_resolve(read, null);
+            } else {
+                // On the result of an invalid block, move the "root" read (and all others it resolves)
+                // to recovery queue. Future reads on the same address will see the "root" read in the
+                // recovery queue and enqueue to it.
+                grid.read_faulty_queue.push(read);
+                grid.on_read_fault(grid, read);
+            }
         }
 
-        fn read_block_valid(read: *Grid.Read, block: BlockPtrConst) bool {
+        fn read_block_valid(read: *const Grid.Read, block: BlockPtrConst) bool {
             const address = read.address;
             const checksum = read.checksum;
             const block_type = read.block_type;
@@ -536,19 +723,19 @@ pub fn GridType(comptime Storage: type) type {
             const header = mem.bytesAsValue(vsr.Header, header_bytes);
 
             if (!header.valid_checksum()) {
-                log.err("invalid checksum at address {}", .{address});
+                log.err("invalid checksum at address {} (expected={})", .{ address, checksum });
                 return false;
             }
 
             if (!header.valid_checksum_body(block[@sizeOf(vsr.Header)..header.size])) {
-                log.err("invalid checksum body at address {}", .{address});
+                log.err("invalid checksum body at address {} (expected={})", .{ address, checksum });
                 return false;
             }
 
             if (header.checksum != checksum) {
                 log.err(
                     "expected address={} checksum={} block_type={}, " ++
-                        "found address={} checksum={} block_type={}",
+                        "found address={} checksum={} block_type={} (repair={})",
                     .{
                         address,
                         checksum,
@@ -556,17 +743,20 @@ pub fn GridType(comptime Storage: type) type {
                         header.op,
                         header.checksum,
                         @enumToInt(header.operation),
+                        read.repair,
                     },
                 );
                 return false;
             }
 
             assert(header.op == address);
-            assert(header.operation == block_type.operation());
+            if (block_type) |block_type_| {
+                assert(header.operation == block_type_.operation());
+            }
             return true;
         }
 
-        fn read_block_resolve(grid: *Grid, read: *Grid.Read, block: BlockPtrConst) void {
+        fn read_block_resolve(grid: *Grid, read: *Grid.Read, block: ?BlockPtrConst) void {
             // Guard to make sure the cache cannot be updated by any read.callbacks() below.
             assert(!grid.read_resolving);
             grid.read_resolving = true;
@@ -575,18 +765,34 @@ pub fn GridType(comptime Storage: type) type {
                 grid.read_resolving = false;
             }
 
-            // Remove the "root" read so that the address is no longer actively reading / locked.
-            grid.read_queue.remove(read);
+            if (block) |b| {
+                const header = mem.bytesAsValue(vsr.Header, b[0..@sizeOf(vsr.Header)]);
+                assert(header.op == read.address);
+                assert(header.checksum == read.checksum);
+                maybe(read.repair);
+            } else {
+                assert(read.repair);
+            }
 
             // Resolve all reads queued to the address with the block.
             while (read.resolves.pop()) |pending| {
                 const pending_read = @fieldParentPtr(Read, "pending", pending);
-                pending_read.callback(pending_read, block);
+                assert(pending_read.address == read.address);
+                assert(pending_read.checksum == read.checksum);
+                assert(pending_read.repair == read.repair);
+
+                switch (pending_read.callback) {
+                    .normal => |callback| callback(pending_read, block.?),
+                    .repair => |callback| callback(pending_read, block),
+                }
             }
 
             // Then invoke the callback with the cache block (which should be valid for the duration
             // of the callback as any nested Grid calls cannot synchronously update the cache).
-            read.callback(read, block);
+            switch (read.callback) {
+                .normal => |callback| callback(read, block.?),
+                .repair => |callback| callback(read, block),
+            }
         }
 
         fn block_offset(address: u64) u64 {
@@ -595,7 +801,7 @@ pub fn GridType(comptime Storage: type) type {
             return (address - 1) * block_size;
         }
 
-        fn verify_cached_read(grid: *Grid, address: u64, cached_block: BlockPtrConst) void {
+        fn verify_read(grid: *Grid, address: u64, cached_block: BlockPtrConst) void {
             if (Storage != @import("../testing/storage.zig").Storage)
                 // Too complicated to do async verification
                 return;

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -83,13 +83,11 @@ fn run_fuzz(
 
     var grid = try Grid.init(allocator, .{
         .superblock = &superblock,
-        .on_read_fault = on_grid_read_fault,
     });
     defer grid.deinit(allocator);
 
     var grid_verify = try Grid.init(allocator, .{
         .superblock = &superblock_verify,
-        .on_read_fault = on_grid_read_fault,
     });
     defer grid_verify.deinit(allocator);
 
@@ -120,12 +118,6 @@ fn run_fuzz(
             .noop => {},
         }
     }
-}
-
-fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
-    _ = grid;
-    _ = read;
-    unreachable;
 }
 
 const ManifestEvent = union(enum) {
@@ -478,7 +470,6 @@ const Environment = struct {
             test_grid.deinit(env.allocator);
             test_grid.* = try Grid.init(env.allocator, .{
                 .superblock = test_superblock,
-                .on_read_fault = on_grid_read_fault,
             });
 
             test_manifest_log.deinit(env.allocator);

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -85,7 +85,6 @@ const Environment = struct {
 
         env.grid = try Grid.init(allocator, .{
             .superblock = &env.superblock,
-            .on_read_fault = on_grid_read_fault,
         });
         errdefer env.grid.deinit(allocator);
 
@@ -110,12 +109,6 @@ const Environment = struct {
         env.io.deinit();
         std.os.close(env.fd);
         std.os.close(env.dir_fd);
-    }
-
-    fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
-        _ = grid;
-        _ = read;
-        unreachable;
     }
 
     fn tick(env: *Environment) !void {

--- a/src/lsm/test.zig
+++ b/src/lsm/test.zig
@@ -83,7 +83,10 @@ const Environment = struct {
         env.superblock_context = undefined;
         errdefer env.superblock.deinit(allocator);
 
-        env.grid = try Grid.init(allocator, &env.superblock);
+        env.grid = try Grid.init(allocator, .{
+            .superblock = &env.superblock,
+            .on_read_fault = on_grid_read_fault,
+        });
         errdefer env.grid.deinit(allocator);
 
         // Forest must be initialized with an open superblock.
@@ -107,6 +110,12 @@ const Environment = struct {
         env.io.deinit();
         std.os.close(env.fd);
         std.os.close(env.dir_fd);
+    }
+
+    fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
+        _ = grid;
+        _ = read;
+        unreachable;
     }
 
     fn tick(env: *Environment) !void {

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -149,7 +149,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
             env.grid = try Grid.init(allocator, .{
                 .superblock = &env.superblock,
-                .on_read_fault = on_grid_read_fault,
             });
             defer env.grid.deinit(allocator);
 
@@ -161,12 +160,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.checkpoint_op = null;
 
             try env.open_then_apply(fuzz_ops);
-        }
-
-        fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
-            _ = grid;
-            _ = read;
-            unreachable;
         }
 
         fn change_state(env: *Environment, current_state: State, next_state: State) void {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1397,7 +1397,10 @@ const TestContext = struct {
         ctx.superblock.opened = true;
         ctx.superblock.working.vsr_state.commit_min = 0;
 
-        ctx.grid = try Grid.init(allocator, &ctx.superblock);
+        ctx.grid = try Grid.init(allocator, .{
+            .superblock = &ctx.superblock,
+            .on_read_fault = on_grid_read_fault,
+        });
         errdefer ctx.grid.deinit(allocator);
 
         ctx.state_machine = try StateMachine.init(allocator, &ctx.grid, .{
@@ -1415,6 +1418,12 @@ const TestContext = struct {
         ctx.grid.deinit(allocator);
         ctx.state_machine.deinit(allocator);
         ctx.* = undefined;
+    }
+
+    fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
+        _ = grid;
+        _ = read;
+        unreachable;
     }
 };
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1399,7 +1399,6 @@ const TestContext = struct {
 
         ctx.grid = try Grid.init(allocator, .{
             .superblock = &ctx.superblock,
-            .on_read_fault = on_grid_read_fault,
         });
         errdefer ctx.grid.deinit(allocator);
 
@@ -1418,12 +1417,6 @@ const TestContext = struct {
         ctx.grid.deinit(allocator);
         ctx.state_machine.deinit(allocator);
         ctx.* = undefined;
-    }
-
-    fn on_grid_read_fault(grid: *Grid, read: *const Grid.Read) void {
-        _ = grid;
-        _ = read;
-        unreachable;
     }
 };
 


### PR DESCRIPTION
`Grid.Options.on_read_fault`: A callback invoked when any "normal" read fails. Will signal the `Replica` that the `read_faulty_queue` is non-empty to trigger block repair protocol.

Add `read_block_repair()`, which will be called by the replica when another replica asks for a particular block. Unlike `read_block()`, we do not necessarily expect/require the block to exist.

Add `write_block_repair()`, which replicas use to repair faulty blocks.

Repair reads do *not* queue up (`resolves`) behind non-repair reads. And repair reads targeting the same address but different checksums also do not queue up together. This is purely to keep the implementation of "on read" much simpler.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
