### PR TITLE
VSR: Grid repair protocol

### DIFF
--- a/scripts/.cspell.json
+++ b/scripts/.cspell.json
@@ -127,6 +127,7 @@
 	"threadpools",
 	"snapshotting",
 	"checkpointing",
-	"checkpointed"
+	"checkpointed",
+        "freeset"
     ]
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -71,6 +71,9 @@ const ConfigProcess = struct {
     clock_synchronization_window_max_ms: u64 = 20000,
     grid_iops_read_max: u64 = 16,
     grid_iops_write_max: u64 = 16,
+    grid_repair_request_max: usize = 4,
+    grid_repair_reads_max: usize = 4,
+    grid_repair_writes_max: usize = 1,
     aof_record: bool = false,
     aof_recovery: bool = false,
 };

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -254,6 +254,24 @@ comptime {
     assert(view_change_headers_max > view_change_headers_suffix_max);
 }
 
+/// The maximum number of block addresses/checksums requested by a single command=request_blocks.
+pub const grid_repair_request_max = config.process.grid_repair_request_max;
+
+/// The number of grid reads allocated to handle incoming command=request_blocks messages.
+pub const grid_repair_reads_max = config.process.grid_repair_reads_max;
+
+/// The number of grid writes allocated to handle incoming command=block messages.
+pub const grid_repair_writes_max = config.process.grid_repair_writes_max;
+
+comptime {
+    assert(grid_repair_request_max > 0);
+    assert(grid_repair_request_max <= @divFloor(message_body_size_max, @sizeOf(vsr.BlockRequest)));
+    assert(grid_repair_request_max <= grid_repair_reads_max);
+
+    assert(grid_repair_reads_max > 0);
+    assert(grid_repair_writes_max > 0);
+}
+
 /// The minimum and maximum amount of time in milliseconds to wait before initiating a connection.
 /// Exponential backoff and jitter are applied within this range.
 pub const connection_delay_min_ms = config.process.connection_delay_min_ms;
@@ -418,6 +436,9 @@ pub const block_size = config.cluster.block_size;
 
 comptime {
     assert(block_size % sector_size == 0);
+    assert(block_size > @sizeOf(vsr.Header));
+    // Blocks are sent over the network as messages during grid repair and state sync.
+    assert(block_size <= message_size_max);
 }
 
 /// The number of levels in an LSM tree.

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -85,14 +85,10 @@ pub fn GridType(comptime Storage: type) type {
         };
 
         pub const Read = struct {
-            callback: union(enum) {
-                normal: fn (*Grid.Read, BlockPtrConst) void, // repair == false
-                repair: fn (*Grid.Read, ?BlockPtrConst) void, // repair == true
-            },
+            callback: fn (*Grid.Read, BlockPtrConst) void,
             address: u64,
             checksum: u128,
-            block_type: ?BlockType,
-            repair: bool,
+            block_type: BlockType,
 
             pending: ReadPending = .{},
             resolves: FIFO(ReadPending) = .{ .name = null },
@@ -102,6 +98,16 @@ pub fn GridType(comptime Storage: type) type {
 
             /// Link for Grid.read_queue/Grid.read_faulty_queue linked lists.
             next: ?*Read = null,
+        };
+
+        pub const ReadRepair = struct {
+            callback: fn (*Grid.ReadRepair, error{BlockNotFound}!void) void,
+            address: u64,
+            checksum: u128,
+            block: BlockPtr,
+            grid: *Grid,
+            next_tick: Grid.NextTick = undefined,
+            completion: Storage.Read = undefined,
         };
 
         const ReadPending = struct {
@@ -267,8 +273,6 @@ pub fn GridType(comptime Storage: type) type {
 
             var it = grid.read_faulty_queue.peek();
             while (it) |faulty_read| : (it = faulty_read.next) {
-                assert(!faulty_read.repair);
-
                 if (faulty_read.address == address) {
                     assert(grid.cache.get_index(address) == null);
                     assert(!grid.superblock.free_set.is_free(address));
@@ -315,7 +319,7 @@ pub fn GridType(comptime Storage: type) type {
             return result;
         }
 
-        /// Assert that the address is not currently being read from.
+        /// Assert that the address is not currently being read from (disregarding repairs).
         /// Assert that the block pointer is not being used for any read if non-null.
         fn assert_not_reading(grid: *Grid, address: u64, block: ?BlockPtrConst) void {
             assert(address > 0);
@@ -325,13 +329,13 @@ pub fn GridType(comptime Storage: type) type {
             }) |queue| {
                 var it = queue.peek();
                 while (it) |queued_read| : (it = queued_read.next) {
-                    assert(address != queued_read.address or queued_read.repair);
+                    assert(address != queued_read.address);
                 }
             }
             {
                 var it = grid.read_iops.iterate();
                 while (it.next()) |iop| {
-                    assert(address != iop.read.address or iop.read.repair);
+                    assert(address != iop.read.address);
                     const iop_block = grid.read_iop_blocks[grid.read_iops.index(iop)];
                     assert(block != iop_block);
                 }
@@ -471,8 +475,6 @@ pub fn GridType(comptime Storage: type) type {
 
                 var read_ = grid.read_faulty_queue.peek();
                 while (read_) |read| : (read_ = read.next) {
-                    assert(!read.repair);
-
                     if (read.checksum == header.checksum and
                         read.address == completed_write.address)
                     {
@@ -511,11 +513,10 @@ pub fn GridType(comptime Storage: type) type {
             assert(grid.writing(address, null) != .init);
 
             read.* = .{
-                .callback = .{ .normal = callback },
+                .callback = callback,
                 .address = address,
                 .checksum = checksum,
                 .block_type = block_type,
-                .repair = false,
                 .grid = grid,
             };
 
@@ -526,61 +527,12 @@ pub fn GridType(comptime Storage: type) type {
             }) |queue| {
                 var it = queue.peek();
                 while (it) |queued_read| : (it = queued_read.next) {
-                    // To simplify read-resolution, don't queue up behind repairs.
-                    if (!queued_read.repair and queued_read.address == address) {
+                    if (queued_read.address == address) {
                         assert(checksum == queued_read.checksum);
-                        assert(block_type == queued_read.block_type.?);
+                        assert(block_type == queued_read.block_type);
                         queued_read.resolves.push(&read.pending);
                         return;
                     }
-                }
-            }
-
-            // Become the "root" read thats fetching the block for the given address.
-            // The fetch happens asynchronously to avoid stack-overflow and nested cache invalidation.
-            grid.read_queue.push(read);
-            grid.on_next_tick(read_block_tick_callback, &read.next_tick);
-        }
-
-        /// If the block is not present (or corrupt), we do not attempt to repair it — the repair's
-        /// address/checksum is not assumed to match what "should" be in our block.
-        /// Relatedly we still attempt to read free blocks — they might still hold the requested data.
-        pub fn read_block_repair(
-            grid: *Grid,
-            callback: fn (*Grid.Read, ?BlockPtrConst) void,
-            read: *Grid.Read,
-            address: u64,
-            checksum: u128,
-        ) void {
-            assert(address > 0);
-
-            assert(grid.superblock.opened);
-            // We try to read the block even when it is free — if we recently released it,
-            // it might be found on disk anyway.
-            maybe(grid.superblock.free_set.is_free(address));
-            // The caller will not attempt to help another replica repair a block that
-            // we are already trying to repair ourselves.
-            assert(!grid.faulty(address, null));
-            maybe(grid.writing(address, null) == .init);
-
-            read.* = .{
-                .callback = .{ .repair = callback },
-                .address = address,
-                .checksum = checksum,
-                .block_type = null,
-                .repair = true,
-                .grid = grid,
-            };
-
-            // Check if a repair-read is already processing and merge with it.
-            var it = grid.read_queue.peek();
-            while (it) |queued_read| : (it = queued_read.next) {
-                if (queued_read.repair and
-                    queued_read.address == address and
-                    queued_read.checksum == checksum)
-                {
-                    queued_read.resolves.push(&read.pending);
-                    return;
                 }
             }
 
@@ -600,18 +552,12 @@ pub fn GridType(comptime Storage: type) type {
 
                 const header = mem.bytesAsValue(vsr.Header, cache_block[0..@sizeOf(vsr.Header)]);
                 assert(header.op == read.address);
+                assert(header.checksum == read.checksum);
                 if (constants.verify) grid.verify_read(read.address, cache_block);
 
                 // Remove the "root" read so that the address is no longer actively reading / locked.
                 grid.read_queue.remove(read);
-
-                if (header.checksum == read.checksum) {
-                    maybe(read.repair);
-                    grid.read_block_resolve(read, cache_block);
-                } else {
-                    assert(read.repair);
-                    grid.read_block_resolve(read, null);
-                }
+                grid.read_block_resolve(read, cache_block);
                 return;
             }
 
@@ -684,43 +630,37 @@ pub fn GridType(comptime Storage: type) type {
             grid.read_queue.remove(read);
 
             // A valid block filled by storage means the reads for the address can be resolved.
-            if (read_block_valid(read, cache_block.*)) {
+            if (read_block_valid(cache_block.*, .{
+                .address = read.address,
+                .checksum = read.checksum,
+                .block_type = read.block_type,
+            })) {
                 grid.read_block_resolve(read, cache_block.*);
-
-                if (read.repair) {
-                    // Even though this block is the block we expected to read, we can't safely
-                    // cache this result:
-                    // 1. Replica A write block X₁ to address X.
-                    // 2. Replica A write block X₂ to address X (write is lost/misdirected).
-                    // 3. Replica B requests block X₁ from replica A.
-                    // It is safe for A to send back X₁, but A must not allow it to poison its cache.
-                    grid.cache.remove(read.address);
-                }
                 return;
             }
 
             // Don't cache a corrupt or incorrect block.
             grid.cache.remove(read.address);
 
-            if (read.repair) {
-                grid.read_block_resolve(read, null);
+            // On the result of an invalid block, move the "root" read (and all others it resolves)
+            // to recovery queue. Future reads on the same address will see the "root" read in the
+            // recovery queue and enqueue to it.
+            grid.read_faulty_queue.push(read);
+            if (grid.on_read_fault) |on_read_fault| {
+                on_read_fault(grid, read);
             } else {
-                // On the result of an invalid block, move the "root" read (and all others it resolves)
-                // to recovery queue. Future reads on the same address will see the "root" read in the
-                // recovery queue and enqueue to it.
-                grid.read_faulty_queue.push(read);
-                if (grid.on_read_fault) |on_read_fault| {
-                    on_read_fault(grid, read);
-                } else {
-                    @panic("Grid.on_read_fault not set");
-                }
+                @panic("Grid.on_read_fault not set");
             }
         }
 
-        fn read_block_valid(read: *const Grid.Read, block: BlockPtrConst) bool {
-            const address = read.address;
-            const checksum = read.checksum;
-            const block_type = read.block_type;
+        fn read_block_valid(block: BlockPtrConst, expect: struct {
+            address: u64,
+            checksum: u128,
+            block_type: ?BlockType,
+        }) bool {
+            const address = expect.address;
+            const checksum = expect.checksum;
+            const block_type = expect.block_type;
 
             const header_bytes = block[0..@sizeOf(vsr.Header)];
             const header = mem.bytesAsValue(vsr.Header, header_bytes);
@@ -738,7 +678,7 @@ pub fn GridType(comptime Storage: type) type {
             if (header.checksum != checksum) {
                 log.err(
                     "expected address={} checksum={} block_type={}, " ++
-                        "found address={} checksum={} block_type={} (repair={})",
+                        "found address={} checksum={} block_type={}",
                     .{
                         address,
                         checksum,
@@ -746,7 +686,6 @@ pub fn GridType(comptime Storage: type) type {
                         header.op,
                         header.checksum,
                         @enumToInt(header.operation),
-                        read.repair,
                     },
                 );
                 return false;
@@ -759,7 +698,7 @@ pub fn GridType(comptime Storage: type) type {
             return true;
         }
 
-        fn read_block_resolve(grid: *Grid, read: *Grid.Read, block: ?BlockPtrConst) void {
+        fn read_block_resolve(grid: *Grid, read: *Grid.Read, block: BlockPtrConst) void {
             // Guard to make sure the cache cannot be updated by any read.callbacks() below.
             assert(!grid.read_resolving);
             grid.read_resolving = true;
@@ -768,33 +707,102 @@ pub fn GridType(comptime Storage: type) type {
                 grid.read_resolving = false;
             }
 
-            if (block) |b| {
-                const header = mem.bytesAsValue(vsr.Header, b[0..@sizeOf(vsr.Header)]);
-                assert(header.op == read.address);
-                assert(header.checksum == read.checksum);
-                maybe(read.repair);
-            } else {
-                assert(read.repair);
-            }
+            const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+            assert(header.op == read.address);
+            assert(header.checksum == read.checksum);
 
             // Resolve all reads queued to the address with the block.
             while (read.resolves.pop()) |pending| {
                 const pending_read = @fieldParentPtr(Read, "pending", pending);
                 assert(pending_read.address == read.address);
                 assert(pending_read.checksum == read.checksum);
-                assert(pending_read.repair == read.repair);
 
-                switch (pending_read.callback) {
-                    .normal => |callback| callback(pending_read, block.?),
-                    .repair => |callback| callback(pending_read, block),
-                }
+                pending_read.callback(pending_read, block);
             }
 
             // Then invoke the callback with the cache block (which should be valid for the duration
             // of the callback as any nested Grid calls cannot synchronously update the cache).
-            switch (read.callback) {
-                .normal => |callback| callback(read, block.?),
-                .repair => |callback| callback(read, block),
+            read.callback(read, block);
+        }
+
+        /// If the block is not present (or corrupt), we do not attempt to repair it — the repair's
+        /// address/checksum is not assumed to match what "should" be in our block.
+        /// Relatedly we still attempt to read free blocks — they might still hold the requested data.
+        pub fn read_block_repair(
+            grid: *Grid,
+            callback: fn (*Grid.ReadRepair, error{BlockNotFound}!void) void,
+            read: *Grid.ReadRepair,
+            block: BlockPtr,
+            address: u64,
+            checksum: u128,
+        ) void {
+            assert(address > 0);
+
+            assert(grid.superblock.opened);
+            // We try to read the block even when it is free — if we recently released it,
+            // it might be found on disk anyway.
+            maybe(grid.superblock.free_set.is_free(address));
+            // The caller will not attempt to help another replica repair a block that
+            // we are already trying to repair ourselves.
+            assert(!grid.faulty(address, null));
+            maybe(grid.writing(address, null) == .init);
+
+            read.* = .{
+                .callback = callback,
+                .address = address,
+                .checksum = checksum,
+                .block = block,
+                .grid = grid,
+            };
+
+            grid.on_next_tick(read_block_repair_tick_callback, &read.next_tick);
+        }
+
+        fn read_block_repair_tick_callback(next_tick: *Grid.NextTick) void {
+            const read = @fieldParentPtr(ReadRepair, "next_tick", next_tick);
+            const grid = read.grid;
+
+            if (grid.cache.get_index(read.address)) |cache_index| {
+                const cache_block = grid.cache_blocks[cache_index];
+
+                const header = mem.bytesAsValue(vsr.Header, cache_block[0..@sizeOf(vsr.Header)]);
+                assert(header.op == read.address);
+                if (constants.verify) grid.verify_read(read.address, cache_block);
+
+                if (header.checksum == read.checksum) {
+                    stdx.copy_disjoint(.inexact, u8, read.block, cache_block[0..header.size]);
+                    read.callback(read, {});
+                } else {
+                    read.callback(read, error.BlockNotFound);
+                }
+            } else {
+                grid.superblock.storage.read_sectors(
+                    read_block_repair_callback,
+                    &read.completion,
+                    read.block,
+                    .grid,
+                    block_offset(read.address),
+                );
+            }
+        }
+
+        fn read_block_repair_callback(completion: *Storage.Read) void {
+            const read = @fieldParentPtr(ReadRepair, "completion", completion);
+
+            if (read_block_valid(read.block, .{
+                .address = read.address,
+                .checksum = read.checksum,
+                .block_type = null,
+            })) {
+                // Even though this block is the block we expected to read, we can't safely
+                // cache this result:
+                // 1. Replica A write block X₁ to address X.
+                // 2. Replica A write block X₂ to address X (write is lost/misdirected).
+                // 3. Replica B requests block X₁ from replica A.
+                // It is safe for A to send back X₁, but A must not allow it to poison its cache.
+                read.callback(read, {});
+            } else {
+                read.callback(read, error.BlockNotFound);
             }
         }
 

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -22,6 +22,7 @@ pub const messages_max_replica = messages_max: {
     sum += constants.journal_iops_write_max; // Journal writes
     sum += constants.client_replies_iops_read_max; // Client-reply reads
     sum += constants.client_replies_iops_write_max; // Client-reply writes
+    sum += constants.grid_repair_reads_max; // Grid repair reads
     sum += 1; // Replica.loopback_queue
     sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
     sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7,7 +7,9 @@ const constants = @import("../constants.zig");
 const stdx = @import("../stdx.zig");
 
 const StaticAllocator = @import("../static_allocator.zig");
+const alloc_block = @import("../lsm/grid.zig").alloc_block;
 const GridType = @import("../lsm/grid.zig").GridType;
+const IOPS = @import("../iops.zig").IOPS;
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Message = @import("../message_pool.zig").MessagePool.Message;
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
@@ -80,6 +82,17 @@ pub fn ReplicaType(
         const ClientReplies = vsr.ClientRepliesType(Storage);
         const Clock = vsr.ClockType(Time);
 
+        const BlockRead = struct {
+            read: Grid.Read,
+            replica: *Self,
+            destination: u8,
+        };
+
+        const BlockWrite = struct {
+            write: Grid.Write,
+            replica: *Self,
+        };
+
         /// We use this allocator during open/init and then disable it.
         /// An accidental dynamic allocation after open/init will cause an assertion failure.
         static_allocator: StaticAllocator,
@@ -132,6 +145,10 @@ pub fn ReplicaType(
         /// For executing service up-calls after an operation has been committed:
         state_machine: StateMachine,
 
+        /// Set to true once StateMachine.open() completes.
+        /// When false, the replica must not commit/compact/checkpoint.
+        state_machine_opened: bool = false,
+
         /// Durably store VSR state, the "root" of the LSM tree, and other replica metadata.
         superblock: SuperBlock,
 
@@ -141,6 +158,10 @@ pub fn ReplicaType(
         superblock_context_view_change: SuperBlock.Context = undefined,
 
         grid: Grid,
+        grid_reads: IOPS(BlockRead, constants.grid_repair_reads_max) = .{},
+        grid_writes: IOPS(BlockWrite, constants.grid_repair_writes_max) = .{},
+        grid_write_blocks: [constants.grid_repair_writes_max]Grid.BlockPtr,
+
         opened: bool,
 
         /// The current view.
@@ -319,6 +340,10 @@ pub fn ReplicaType(
         /// (status=normal or (status=view-change and primary))
         repair_timeout: Timeout,
 
+        /// The number of ticks before sending a command=request_blocks.
+        /// (grid.read_faulty_queue.count>0)
+        grid_repair_message_timeout: Timeout,
+
         /// Used to provide deterministic entropy to `choose_any_other_replica()`.
         /// Incremented whenever `choose_any_other_replica()` is called.
         choose_any_other_replica_ticks: u64 = 0,
@@ -425,13 +450,6 @@ pub fn ReplicaType(
             initialized = true;
             errdefer self.deinit(allocator);
 
-            // Open the (Forest inside) StateMachine:
-            // TODO If this encounters corruption (in the ManifestLog) we must repair + resume it later.
-            // And maybe transition to a different status — but it may coincide with recovering_head...
-            self.opened = false;
-            self.state_machine.open(state_machine_open_callback);
-            while (!self.opened) self.superblock.storage.tick();
-
             self.opened = false;
             self.journal.recover(journal_recover_callback);
             while (!self.opened) self.superblock.storage.tick();
@@ -519,11 +537,17 @@ pub fn ReplicaType(
                 // Solo replicas must increment their view after recovery.
                 // Otherwise, two different versions of an op could exist within a single view
                 // (the former version truncated as a torn write).
+                //
+                // on_request() will ignore incoming requests until the view_durable_update()
+                // completes.
                 self.log_view += 1;
                 self.view += 1;
                 self.primary_update_view_headers();
                 self.view_durable_update();
-                // Recovery will resume in view_durable_update_callback.
+
+                if (self.commit_min == self.op) {
+                    self.transition_to_normal_from_recovering_status();
+                }
             } else {
                 // Even if op_head_certain() returns false, a DVC always has a certain head op.
                 if (self.log_view < self.view or self.op_head_certain()) {
@@ -548,6 +572,10 @@ pub fn ReplicaType(
                     self.status == .view_change or
                     self.status == .recovering_head,
             );
+
+            // Asynchronously open the (Forest inside) StateMachine so that we can repair grid
+            // blocks if necessary:
+            self.state_machine.open(state_machine_open_callback);
         }
 
         fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
@@ -556,16 +584,41 @@ pub fn ReplicaType(
             self.opened = true;
         }
 
-        fn state_machine_open_callback(state_machine: *StateMachine) void {
-            const self = @fieldParentPtr(Self, "state_machine", state_machine);
-            assert(!self.opened);
-            self.opened = true;
-        }
-
         fn journal_recover_callback(journal: *Journal) void {
             const self = @fieldParentPtr(Self, "journal", journal);
             assert(!self.opened);
             self.opened = true;
+        }
+
+        fn state_machine_open_callback(state_machine: *StateMachine) void {
+            const self = @fieldParentPtr(Self, "state_machine", state_machine);
+            assert(!self.state_machine_opened);
+            assert(!self.committing);
+
+            log.debug("{}: state_machine_open_callback", .{self.replica});
+
+            self.state_machine_opened = true;
+
+            if (self.solo()) {
+                if (self.commit_min < self.op) {
+                    self.commit_journal(self.op);
+
+                    // Recovery will complete when commit_journal finishes.
+                    assert(self.status == .recovering);
+                } else {
+                    assert(self.status == .normal);
+                }
+            } else {
+                if (self.status == .normal and self.primary()) {
+                    if (self.pipeline.queue.prepare_queue.count > 0) {
+                        self.commit_pipeline();
+                    }
+                } else {
+                    if (self.status != .recovering_head) {
+                        self.commit_journal(self.commit_max);
+                    }
+                }
+            }
         }
 
         const Options = struct {
@@ -666,6 +719,12 @@ pub fn ReplicaType(
             });
             errdefer self.grid.deinit(allocator);
 
+            for (self.grid_write_blocks) |*block, i| {
+                errdefer for (self.grid_write_blocks[0..i]) |b| allocator.free(b);
+                block.* = try alloc_block(allocator);
+            }
+            errdefer for (self.grid_write_blocks) |b| allocator.free(b);
+
             self.state_machine = try StateMachine.init(
                 allocator,
                 &self.grid,
@@ -693,6 +752,7 @@ pub fn ReplicaType(
                 .state_machine = self.state_machine,
                 .superblock = self.superblock,
                 .grid = self.grid,
+                .grid_write_blocks = self.grid_write_blocks,
                 .opened = self.opened,
                 .view = self.superblock.working.vsr_state.view,
                 .log_view = self.superblock.working.vsr_state.log_view,
@@ -759,6 +819,11 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 50,
                 },
+                .grid_repair_message_timeout = Timeout{
+                    .name = "grid_repair_message_timeout",
+                    .id = replica_index,
+                    .after = 50,
+                },
                 .prng = std.rand.DefaultPrng.init(replica_index),
 
                 .aof = options.aof,
@@ -810,6 +875,8 @@ pub fn ReplicaType(
                 assert(self.commit_callback == null);
             }
 
+            for (self.grid_write_blocks) |block| allocator.free(block);
+
             for (self.do_view_change_from_all_replicas) |message| {
                 if (message) |m| self.message_bus.unref(m);
             }
@@ -845,6 +912,7 @@ pub fn ReplicaType(
             self.do_view_change_message_timeout.tick();
             self.request_start_view_message_timeout.tick();
             self.repair_timeout.tick();
+            self.grid_repair_message_timeout.tick();
 
             if (self.ping_timeout.fired()) self.on_ping_timeout();
             if (self.prepare_timeout.fired()) self.on_prepare_timeout();
@@ -857,6 +925,7 @@ pub fn ReplicaType(
             if (self.do_view_change_message_timeout.fired()) self.on_do_view_change_message_timeout();
             if (self.request_start_view_message_timeout.fired()) self.on_request_start_view_message_timeout();
             if (self.repair_timeout.fired()) self.on_repair_timeout();
+            if (self.grid_repair_message_timeout.fired()) self.on_grid_repair_message_timeout();
 
             // None of the on_timeout() functions above should send a message to this replica.
             assert(self.loopback_queue == null);
@@ -921,6 +990,8 @@ pub fn ReplicaType(
                 .request_headers => self.on_request_headers(message),
                 .request_reply => self.on_request_reply(message),
                 .headers => self.on_headers(message),
+                .request_blocks => self.on_request_blocks(message),
+                .block => self.on_block(message),
                 // A replica should never handle misdirected messages intended for a client:
                 .pong_client, .eviction => {
                     log.warn("{}: on_message: misdirected message ({s})", .{
@@ -929,8 +1000,6 @@ pub fn ReplicaType(
                     });
                     return;
                 },
-                .request_block => unreachable, // TODO
-                .block => unreachable, // TODO
                 .reserved => unreachable,
             }
 
@@ -1939,6 +2008,203 @@ pub fn ReplicaType(
             self.repair();
         }
 
+        fn on_request_blocks(self: *Self, message: *const Message) void {
+            assert(message.header.command == .request_blocks);
+
+            if (message.header.replica == self.replica) {
+                log.warn("{}: on_request_blocks: ignoring; misdirected message (self)", .{self.replica});
+                return;
+            }
+
+            if (self.standby()) {
+                log.warn("{}: on_request_blocks: ignoring; misdirected message (standby)", .{self.replica});
+                return;
+            }
+
+            // TODO Rate limit replicas that keep requesting the same blocks (maybe via checksum_body?)
+            // to avoid unnecessary work in the presence of an asymmetric partition.
+            const requests = std.mem.bytesAsSlice(vsr.BlockRequest, message.body());
+            assert(requests.len > 0);
+
+            request_loop: for (requests) |*request, i| {
+                if (self.grid.faulty(request.block_address, null)) {
+                    log.warn("{}: on_request_blocks: ignoring block request; faulty " ++
+                        "(replica={} address={} checksum={})", .{
+                        self.replica,
+                        message.header.replica,
+                        request.block_address,
+                        request.block_checksum,
+                    });
+                    continue;
+                }
+
+                var reads = self.grid_reads.iterate();
+                while (reads.next()) |read| {
+                    if (read.read.address == request.block_address and
+                        read.read.checksum == request.block_checksum and
+                        read.destination == message.header.replica)
+                    {
+                        log.debug("{}: on_request_blocks: ignoring block request;" ++
+                            " already reading (replica={} address={} checksum={})", .{
+                            self.replica,
+                            message.header.replica,
+                            request.block_address,
+                            request.block_checksum,
+                        });
+                        continue :request_loop;
+                    }
+                }
+
+                const read = self.grid_reads.acquire() orelse {
+                    log.debug("{}: on_request_blocks: ignoring remaining blocks; busy " ++
+                        "(replica={} ignored={}/{})", .{
+                        self.replica,
+                        message.header.replica,
+                        requests.len - i,
+                        requests.len,
+                    });
+                    return;
+                };
+
+                log.debug("{}: on_request_blocks: reading block " ++
+                    "(replica={} address={} checksum={})", .{
+                    self.replica,
+                    message.header.replica,
+                    request.block_address,
+                    request.block_checksum,
+                });
+
+                read.* = .{
+                    .replica = self,
+                    .destination = message.header.replica,
+                    .read = undefined,
+                };
+
+                self.grid.read_block_repair(
+                    on_block_read_repair,
+                    &read.read,
+                    request.block_address,
+                    request.block_checksum,
+                );
+            }
+        }
+
+        fn on_block(self: *Self, message: *const Message) void {
+            maybe(!self.state_machine_opened);
+            assert(message.header.command == .block);
+            assert(message.header.size <= constants.block_size);
+            assert(message.header.op > 0); // op holds the block's address.
+
+            // TODO State sync
+
+            if (!self.grid.faulty(message.header.op, message.header.checksum)) {
+                log.debug("{}: on_block: ignoring; block not repairing (address={} checksum={})", .{
+                    self.replica,
+                    message.header.op,
+                    message.header.checksum,
+                });
+                return;
+            }
+
+            switch (self.grid.writing(message.header.op, null)) {
+                .init => unreachable,
+                .repair => {
+                    log.debug("{}: on_block: ignoring; already writing block (address={} checksum={})", .{
+                        self.replica,
+                        message.header.op,
+                        message.header.checksum,
+                    });
+                    return;
+                },
+                .none => {},
+            }
+
+            const write = self.grid_writes.acquire() orelse {
+                log.debug("{}: on_block: ignoring; no write available (address={} checksum={})", .{
+                    self.replica,
+                    message.header.op,
+                    message.header.checksum,
+                });
+                return;
+            };
+
+            log.debug("{}: on_block: repairing block (address={} checksum={})", .{
+                self.replica,
+                message.header.op,
+                message.header.checksum,
+            });
+
+            write.* = .{
+                .replica = self,
+                .write = undefined,
+            };
+
+            const block = &self.grid_write_blocks[self.grid_writes.index(write)];
+            stdx.copy_disjoint(.inexact, u8, block.*, message.buffer[0..message.header.size]);
+
+            self.grid.write_block_repair(
+                on_block_write_repair,
+                &write.write,
+                block,
+                message.header.op,
+            );
+        }
+
+        fn on_block_read_repair(grid_read: *Grid.Read, block_: ?Grid.BlockPtrConst) void {
+            const read = @fieldParentPtr(BlockRead, "read", grid_read);
+            const self = read.replica;
+            defer self.grid_reads.release(read);
+
+            assert(read.destination != self.replica);
+
+            const block = block_ orelse {
+                log.debug("{}: on_request_blocks: block not found " ++
+                    "(address={} checksum={} destination={})", .{
+                    self.replica,
+                    grid_read.address,
+                    grid_read.checksum,
+                    read.destination,
+                });
+                return;
+            };
+
+            log.debug("{}: on_request_blocks: block found " ++
+                "(address={} checksum={} destination={})", .{
+                self.replica,
+                grid_read.address,
+                grid_read.checksum,
+                read.destination,
+            });
+
+            var message = self.message_bus.get_message();
+            defer self.message_bus.unref(message);
+
+            stdx.copy_disjoint(.inexact, u8, message.buffer, block);
+            assert(message.header.command == .block);
+            assert(message.header.op == grid_read.address);
+            assert(message.header.checksum == grid_read.checksum);
+            assert(message.header.size <= constants.block_size);
+
+            self.send_message_to_replica(read.destination, message);
+        }
+
+        fn on_block_write_repair(grid_write: *Grid.Write) void {
+            const write = @fieldParentPtr(BlockWrite, "write", grid_write);
+            const self = write.replica;
+            assert(self.grid_repair_message_timeout.ticking);
+
+            defer self.grid_writes.release(write);
+
+            log.debug("{}: on_block: wrote address={}", .{
+                self.replica,
+                grid_write.address,
+            });
+
+            if (self.grid.read_faulty_queue.empty()) {
+                self.grid_repair_message_timeout.stop();
+            }
+        }
+
         fn on_ping_timeout(self: *Self) void {
             self.ping_timeout.reset();
 
@@ -2181,6 +2447,57 @@ pub fn ReplicaType(
             self.repair();
         }
 
+        fn on_grid_repair_message_timeout(self: *Self) void {
+            assert(self.grid_repair_message_timeout.ticking);
+            assert(!self.grid.read_faulty_queue.empty());
+            maybe(!self.state_machine_opened);
+
+            self.grid_repair_message_timeout.reset();
+
+            var message = self.message_bus.get_message();
+            defer self.message_bus.unref(message);
+
+            var requests_count: usize = 0;
+            var requests = std.mem.bytesAsSlice(
+                vsr.BlockRequest,
+                message.buffer[@sizeOf(Header)..],
+            );
+
+            var reads = self.grid.read_faulty_queue.peek();
+            while (reads) |read| : (reads = read.next) {
+                assert(read.address > 0);
+                assert(!self.superblock.free_set.is_free(read.address));
+
+                log.debug("{}: on_grid_repair_message_timeout: request address={} checksum={}", .{
+                    self.replica,
+                    read.address,
+                    read.checksum,
+                });
+
+                requests[requests_count] = .{
+                    .block_checksum = read.checksum,
+                    .block_address = read.address,
+                };
+                requests_count += 1;
+
+                if (requests_count == constants.grid_repair_request_max) break;
+            }
+            assert(requests_count > 0);
+            assert(requests_count <= constants.grid_repair_request_max);
+
+            message.header.* = .{
+                .command = .request_blocks,
+                .cluster = self.cluster,
+                .replica = self.replica,
+                .view = self.view,
+                .size = @sizeOf(Header) + @intCast(u32, requests_count) * @sizeOf(vsr.BlockRequest),
+            };
+            message.header.set_checksum_body(message.body());
+            message.header.set_checksum();
+
+            self.send_message_to_replica(self.choose_any_other_replica(), message);
+        }
+
         fn primary_receive_do_view_change(self: *Self, message: *Message) void {
             assert(!self.solo());
             assert(self.status == .view_change);
@@ -2406,6 +2723,11 @@ pub fn ReplicaType(
                 self.commit_max = commit;
             }
 
+            if (!self.state_machine_opened) {
+                assert(!self.committing);
+                return;
+            }
+
             // Guard against multiple concurrent invocations of commit_journal()/commit_pipeline():
             if (self.committing) {
                 log.debug("{}: commit_journal: already committing...", .{self.replica});
@@ -2551,6 +2873,7 @@ pub fn ReplicaType(
             callback: fn (*Self) void,
         ) void {
             assert(self.committing);
+            assert(self.state_machine_opened);
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(self.commit_prepare == null);
@@ -2665,6 +2988,10 @@ pub fn ReplicaType(
                 );
                 if (self.on_checkpoint_start) |on_checkpoint| on_checkpoint(self);
 
+                assert(self.grid.read_faulty_queue.empty());
+                assert(self.grid.write_queue.empty());
+                assert(self.grid.write_iops.executing() == 0);
+
                 self.state_machine.checkpoint(commit_op_checkpoint_state_machine_callback);
             } else {
                 self.commit_op_done();
@@ -2678,6 +3005,9 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.op);
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op == self.op_checkpoint_trigger());
+            assert(self.grid.read_faulty_queue.empty());
+            assert(self.grid.write_queue.empty());
+            assert(self.grid.write_iops.executing() == 0);
 
             self.client_replies.checkpoint(commit_op_checkpoint_client_replies_callback);
         }
@@ -2689,6 +3019,9 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.op);
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op == self.op_checkpoint_trigger());
+            assert(self.grid.read_faulty_queue.empty());
+            assert(self.grid.write_queue.empty());
+            assert(self.grid.write_iops.executing() == 0);
 
             // For the given WAL (journal_slot_count=8, lsm_batch_multiple=2, op=commit_min=7):
             //
@@ -2904,6 +3237,11 @@ pub fn ReplicaType(
             assert(self.status == .normal);
             assert(self.primary());
             assert(self.pipeline.queue.prepare_queue.count > 0);
+
+            if (!self.state_machine_opened) {
+                assert(!self.committing);
+                return;
+            }
 
             // Guard against multiple concurrent invocations of commit_journal()/commit_pipeline():
             if (self.committing) {
@@ -3471,6 +3809,13 @@ pub fn ReplicaType(
                     @enumToInt(message.header.operation),
                 });
                 return true;
+            }
+
+            if (self.solo()) {
+                if (self.view_durable_updating()) {
+                    log.debug("{}: on_request: ignoring (still persisting view)", .{self.replica});
+                    return true;
+                }
             }
 
             if (self.ignore_request_message_backup(message)) return true;
@@ -5492,8 +5837,15 @@ pub fn ReplicaType(
                     assert(message.header.view == self.view);
                     assert(message.header.replica == self.replica);
                 },
-                .request_block => unreachable,
-                .block => unreachable,
+                .request_blocks => {
+                    maybe(self.standby());
+                    assert(message.header.replica == self.replica);
+                    assert(message.header.replica != replica);
+                    assert(message.header.view == self.view);
+                },
+                .block => {
+                    assert(!self.standby());
+                },
             }
 
             if (replica != self.replica) {
@@ -5707,19 +6059,6 @@ pub fn ReplicaType(
 
             if (self.status == .view_change and self.log_view < self.view) {
                 if (!self.do_view_change_quorum) self.send_do_view_change();
-            }
-
-            if (self.solo()) {
-                assert(self.status == .recovering);
-                assert(self.view == self.log_view);
-                assert(!update_dvc);
-                assert(!update_sv);
-
-                if (self.commit_min < self.op) {
-                    self.commit_journal(self.op);
-                } else {
-                    self.transition_to_normal_from_recovering_status();
-                }
             }
         }
 
@@ -6044,7 +6383,6 @@ pub fn ReplicaType(
             assert(self.view == self.log_view);
             assert(self.commit_max >= self.op -| constants.pipeline_prepare_queue_max);
             assert(!self.committing);
-            assert(!self.solo() or self.commit_min == self.op);
             assert(self.journal.header_with_op(self.op) != null);
             assert(self.pipeline == .cache);
             assert(self.view_headers.command == .start_view);
@@ -6647,6 +6985,15 @@ pub fn ReplicaType(
                 read.checksum,
                 read.block_type,
             });
+
+            if (self.solo()) @panic("grid is corrupt");
+
+            if (!self.grid_repair_message_timeout.ticking) {
+                assert(self.grid.read_faulty_queue.count == 1);
+
+                self.grid_repair_message_timeout.start();
+                self.on_grid_repair_message_timeout();
+            }
         }
     };
 }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6960,7 +6960,6 @@ pub fn ReplicaType(
                 assert(self.grid.read_faulty_queue.count == 1);
 
                 self.grid_repair_message_timeout.start();
-                self.send_request_blocks();
                 self.grid.on_next_tick(
                     on_grid_read_fault_next_tick,
                     &self.grid_read_fault_next_tick,


### PR DESCRIPTION
Repair corrupt grid blocks.

(Note that grid corruption is still disabled in the VOPR, pending state sync, because grid repair alone may stall if the block is unavailable. However, I have tested the VOPR locally to check that there are no VOPR issues besides the liveness issue.)

The `Replica.open()` sequence changes somewhat, because grid repair must run during `StateMachine.open()`. So where before the replica could run `StateMachine.open()` "synchronously", it must now run asynchronously. Commits are blocked until this finishes.

Related: a solo replica that starts with `op == commit_min` will now transition immediately to `status=normal` rather than waiting for `view_durable_update()` to complete. And `on_request` will reject incoming requests until `view_durable_update()` completes, to guard against the solo replica committing a message, then restarting and discarding it because it is part of a newer view.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
