### PR TITLE
VSR: Ack committed prepares

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -537,15 +537,14 @@ pub const Header = extern struct {
         switch (self.operation) {
             .reserved => return "operation == .reserved",
             .root => {
+                const root_checksum = Header.root_prepare(self.cluster).checksum;
                 if (self.parent != 0) return "root: parent != 0";
                 if (self.client != 0) return "root: client != 0";
-                if (self.context != 0) return "root: context != 0";
+                if (self.context != root_checksum) return "root: context != expected";
                 if (self.request != 0) return "root: request != 0";
-                if (self.view != 0) return "root: view != 0";
                 if (self.op != 0) return "root: op != 0";
                 if (self.commit != 0) return "root: commit != 0";
                 if (self.timestamp != 0) return "root: timestamp != 0";
-                if (self.replica != 0) return "root: replica != 0";
             },
             else => {
                 if (self.client == 0) return "client == 0";

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5123,15 +5123,10 @@ pub fn ReplicaType(
             }
 
             assert(self.status == .normal);
-            // After a view change, replicas send prepare_oks for uncommitted ops with older views:
+            // After a view change, replicas send prepare_oks for ops with older views.
             // However, we only send to the primary of the current view (see below where we send).
             assert(header.view <= self.view);
             assert(header.op <= self.op);
-
-            if (header.op <= self.commit_max) {
-                log.debug("{}: send_prepare_ok: not sending (committed)", .{self.replica});
-                return;
-            }
 
             if (self.journal.has_clean(header)) {
                 log.debug("{}: send_prepare_ok: op={} checksum={}", .{

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -532,6 +532,55 @@ test "Cluster: repair: corrupt reply" {
     try expectEqual(c.replies(), 21);
 }
 
+test "Cluster: repair: ack committed prepare" {
+    const t = try TestContext.init(.{ .replica_count = 3 });
+    defer t.deinit();
+
+    var c = t.clients(0, t.cluster.clients.len);
+    try c.request(20, 20);
+    try expectEqual(t.replica(.R_).commit(), 20);
+
+    const p = t.replica(.A0);
+    const b1 = t.replica(.B1);
+    const b2 = t.replica(.B2);
+
+    // A0 commits 21.
+    // B1 prepares 21, but does not commit.
+    t.replica(.R_).drop(.R_, .bidirectional, .start_view_change);
+    t.replica(.R_).drop(.R_, .bidirectional, .do_view_change);
+    p.drop(.__, .outgoing, .commit);
+    b2.drop(.__, .incoming, .prepare);
+    try c.request(21, 21);
+    try expectEqual(p.commit(), 21);
+    try expectEqual(b1.commit(), 20);
+    try expectEqual(b2.commit(), 20);
+
+    try expectEqual(p.op_head(), 21);
+    try expectEqual(b1.op_head(), 21);
+    try expectEqual(b2.op_head(), 20);
+
+    // Change views. B1/B2 participate. Don't allow B2 to repair op=21.
+    t.replica(.R_).pass(.R_, .bidirectional, .start_view_change);
+    t.replica(.R_).pass(.R_, .bidirectional, .do_view_change);
+    p.drop(.__, .bidirectional, .prepare);
+    p.drop(.__, .bidirectional, .do_view_change);
+    t.run();
+    try expectEqual(b1.commit(), 20);
+    try expectEqual(b2.commit(), 20);
+
+    // But other than that, heal A0/B1, but partition B2 completely.
+    // (Prevent another view change.)
+    p.pass_all(.__, .bidirectional);
+    b1.pass_all(.__, .bidirectional);
+    b2.drop_all(.__, .bidirectional);
+    t.replica(.R_).drop(.R_, .bidirectional, .start_view_change);
+    t.replica(.R_).drop(.R_, .bidirectional, .do_view_change);
+    t.run();
+
+    // A0 acks op=21 even though it already committed it.
+    try expectEqual(b1.commit(), 21);
+}
+
 test "Cluster: view-change: DVC, 1+1/2 faulty header stall, 2+1/3 faulty header succeed" {
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();


### PR DESCRIPTION
Previously we did not ack messages that are committed by the cluster.
But that could that result in unnecessary view changes.

e.g. (replica_count=3):

1. R0 (primary) prepares op=10.
2. R1 prepares op=10.
3. R0 commits op=10.
4. (View change due to random network whatever. R1 and R2 participate in DVC quorum. R1 is new primary)
5. R1 and R2 currently believe the commit_max is 9.
6. If R2 is now partitioned, then R1 will keep trying to prepare op=10 — R0 has prepared (and committed!) op=10, but doesn't ack it. Eventually R1 gives up. The cluster can progress when R0 becomes primary or R2 un-partitions and prepares op=10.

Additionally, fix the root prepare's ack's validation. (It was previously dead code since we would never ack the root prepare.)

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
