### PR TITLE
vopr: build-time log control

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6253,7 +6253,7 @@ pub fn ReplicaType(
                 const dvc_nacks = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.context };
                 for (dvc_headers.slice) |*header, i| {
                     log.debug(
-                        "{}: {s}: dvc: header: replica={} op={} checksum={} nack={}",
+                        "{}: {s}: dvc: header: replica={} op={} checksum={} nack={} type={s}",
                         .{
                             self.replica,
                             context,
@@ -6261,6 +6261,7 @@ pub fn ReplicaType(
                             header.op,
                             header.checksum,
                             dvc_nacks.isSet(i),
+                            @tagName(vsr.Headers.dvc_header_type(header)),
                         },
                     );
                 }


### PR DESCRIPTION
You can now run

  $ ./zig/zig build simualtor_run -Dsimulator-log=full -- <SEED>

to repro a failure without getting pages of output.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
