### PR TITLE
Show version from git tags

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -212,8 +212,11 @@ const Command = struct {
 
         var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
         const stdout = stdout_buffer.writer();
-        // TODO Pass an actual version number in on build, instead of just saying "experimental".
-        try stdout.writeAll("TigerBeetle version experimental\n");
+        try std.fmt.format(
+            stdout,
+            "TigerBeetle version {s}",
+            .{build_options.git_tag orelse "experimental"},
+        );
 
         if (verbose) {
             try std.fmt.format(


### PR DESCRIPTION
Off a new tag:

```console
$ git tag 0.14.0
$ ./scripts/build.sh
$ ./tigerbeetle version
$ TigerBeetle version 0.14.0
```

Off main:

```console
$ git tag --delete 0.14.0
Deleted tag '0.14.0' (was 0f911de9)
$ ./scripts/build.sh
$ ./tigerbeetle version
TigerBeetle version release-20230508.1432-1-gfca50072
```

* [x] I am very sure this PR could not affect performance.
