### PR TITLE
LSM: Manifest(/Log) storage determinism

### DIFF
--- a/src/lsm/README.md
+++ b/src/lsm/README.md
@@ -88,7 +88,7 @@ Invariants:
 
 ### Compaction Selection Policy
 
-Compaction targets the table from level `A` which overlaps the fewest tables of level `B`.
+Compaction targets the table from level `A` which overlaps the fewest visible tables of level `B`.
 
 For example, in the following table (with `lsm_growth_factor=2`), each table is depicted as the range of keys it includes. The tables with uppercase letters would be chosen for compaction next.
 
@@ -103,6 +103,31 @@ Links:
 - [`Manifest.compaction_table`](manifest.zig)
 - [Constructing and Analyzing the LSM Compaction Design Space](http://vldb.org/pvldb/vol14/p2216-sarkar.pdf) describes the tradeoffs of various data movement policies. TigerBeetle implements the "least overlapping with parent" policy.
 - [Option of Compaction Priority](https://rocksdb.org/blog/2016/01/29/compaction_pri.html)
+
+#### Compaction Move Table
+
+When the [selected input table](#compaction-selection-policy) from level `A` does not overlap _any_
+input tables in level `B`, the input table can be "moved" to level `B`.
+That is, instead of sort-merging `A` and `B`, just update the input table's metadata in the manifest.
+
+This is referred to as the _move table_ optimization.
+
+#### Compaction Table Overlap
+
+When compacting a table from level `A` to level `B`, what is the maximum number of level-`B` tables
+that may overlap the level-`A` table (i.e. the "worst case")?
+
+Perhaps surprisingly, this is `lsm_growth_factor`:
+
+- Tables within a level are disjoint.
+- Level `B` has at most `lsm_growth_factor` times as many tables as level `A`.
+- To trigger compaction, level `A`'s visible-table count exceeds
+  `table_count_max_for_level(lsm_growth_factor, level_a)`.
+- The [selection policy](#compaction-selection-policy) chooses the table from level `A`
+  which overlaps the fewest visible tables in level `B`.
+- If any table in level `A` overlaps _more than_ `lsm_growth_factor` tables in level `B`,
+  that implies the existence of a table in level `A` with _less than_ `lsm_growth_factor` overlap.
+  The latter table would be selected over the former.
 
 ## Snapshots
 

--- a/src/lsm/README.md
+++ b/src/lsm/README.md
@@ -88,7 +88,7 @@ Invariants:
 
 ### Compaction Selection Policy
 
-Compaction targets the table from level `A` which overlaps the fewest visible tables of level `B`.
+Compaction selects the table from level `A` which overlaps the fewest visible tables of level `B`.
 
 For example, in the following table (with `lsm_growth_factor=2`), each table is depicted as the range of keys it includes. The tables with uppercase letters would be chosen for compaction next.
 
@@ -111,6 +111,9 @@ input tables in level `B`, the input table can be "moved" to level `B`.
 That is, instead of sort-merging `A` and `B`, just update the input table's metadata in the manifest.
 
 This is referred to as the _move table_ optimization.
+
+Where a tree performs inserts mostly in sort order, with a minimum of updates, this _move table_
+optimization should enable the tree's performance to approach that of an append-only log.
 
 #### Compaction Table Overlap
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -111,17 +111,19 @@ pub fn CompactionType(
         table_builder: Table.Builder,
         last_keys_in: [2]?Key = .{ null, null },
 
-        /// Manifest log appends are queued up until `finish()` is expicitly called to ensure
-        /// they are applied consistently relative to other concurrent compactions.
+        /// Manifest log appends are queued up until `finish()` is explicitly called to ensure
+        /// they are applied deterministically relative to other concurrent compactions.
         manifest_entries: std.BoundedArray(struct {
-            operation: union(enum) {
-                move,
-                insert,
-                update: struct { level: u8 },
+            operation: enum {
+                insert_to_level_b,
+                update_in_level_a,
+                update_in_level_b,
+                move_to_level_b,
             },
             table: TableInfo,
         }, manifest_entries_max: {
             // Worst-case manifest updates:
+            // See lsm/README.md "Compaction Table Overlap" for more detail.
             var count = 0;
             count += 1; // Update the input table from level A.
             count += constants.lsm_growth_factor; // Update the input tables from level B.
@@ -216,37 +218,30 @@ pub fn CompactionType(
             compaction.iterator_a.deinit(allocator);
         }
 
-        pub fn finish(compaction: *Compaction) void {
+        pub fn apply_to_manifest(compaction: *Compaction) void {
             assert(compaction.state == .done);
 
             // Each compaction's manifest (log) updates are deferred to the end of the last
             // half-beat to ensure they are ordered deterministically relative to one
             // another.
             // TODO: If compaction is sequential, deferring manifest updates is unnecessary.
+            const manifest = &compaction.context.tree.manifest;
+            const level_b = compaction.context.level_b;
+            const snapshot_max = snapshot_max_for_table_input(compaction.context.op_min);
             for (compaction.manifest_entries.slice()) |*entry| {
                 switch (entry.operation) {
-                    .insert => compaction.context.tree.manifest.insert_table(
-                        compaction.context.level_b,
-                        &entry.table,
-                    ),
-                    .update => |update| compaction.context.tree.manifest.update_table(
-                        update.level,
-                        snapshot_max_for_table_input(compaction.context.op_min),
-                        &entry.table,
-                    ),
-                    .move => {
-                        const level_b = compaction.context.level_b;
-                        const level_a = level_b - 1;
-                        compaction.context.tree.manifest.move_table(level_a, level_b, &entry.table);
-                    },
+                    .insert_to_level_b => manifest.insert_table(level_b, &entry.table),
+                    .update_in_level_a => manifest.update_table(level_b - 1, snapshot_max, &entry.table),
+                    .update_in_level_b => manifest.update_table(level_b, snapshot_max, &entry.table),
+                    .move_to_level_b => manifest.move_table(level_b - 1, level_b, &entry.table),
                 }
             }
 
-            compaction.state = .idle;
             compaction.manifest_entries.len = 0;
+            compaction.state = .idle;
             if (compaction.grid_reservation) |grid_reservation| {
-                compaction.context.grid.forfeit(grid_reservation);
                 compaction.grid_reservation = null;
+                compaction.context.grid.forfeit(grid_reservation);
             }
         }
 
@@ -336,7 +331,7 @@ pub fn CompactionType(
                 assert(table_a.snapshot_max >= snapshot_max);
 
                 compaction.manifest_entries.appendAssumeCapacity(.{
-                    .operation = .move,
+                    .operation = .move_to_level_b,
                     .table = table_a.*,
                 });
 
@@ -442,7 +437,7 @@ pub fn CompactionType(
 
             // Tables that we've compacted should become invisible at the end of this half-bar.
             compaction.manifest_entries.appendAssumeCapacity(.{
-                .operation = .{ .update = .{ .level = compaction.context.level_b } },
+                .operation = .update_in_level_b,
                 .table = table_info,
             });
 
@@ -719,7 +714,7 @@ pub fn CompactionType(
                 });
                 // Make this table visible at the end of this half-bar.
                 compaction.manifest_entries.appendAssumeCapacity(.{
-                    .operation = .insert,
+                    .operation = .insert_to_level_b,
                     .table = table,
                 });
                 WriteBlock(.index).write_block(compaction);
@@ -797,13 +792,10 @@ pub fn CompactionType(
                     // TODO: Release the grid blocks associated with level_a as well
                     switch (compaction.context.table_info_a) {
                         .immutable => {},
-                        .disk => |table| {
-                            const level_a = compaction.context.level_b - 1;
-                            compaction.manifest_entries.appendAssumeCapacity(.{
-                                .operation = .{ .update = .{ .level = level_a } },
-                                .table = table,
-                            });
-                        },
+                        .disk => |table| compaction.manifest_entries.appendAssumeCapacity(.{
+                            .operation = .update_in_level_a,
+                            .table = table,
+                        }),
                     }
 
                     compaction.state = .next_tick;

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -164,6 +164,12 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
                             forest.join_pending -= 1;
                             if (forest.join_pending > 0) return;
 
+                            if (join_op == .compacting) {
+                                inline for (std.meta.fields(Grooves)) |field| {
+                                    @field(forest.grooves, field.name).compact_end();
+                                }
+                            }
+
                             if (join_op == .checkpoint) {
                                 if (Storage == @import("../testing/storage.zig").Storage) {
                                     // We should have finished all checkpoint io by now.

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -731,8 +731,8 @@ pub fn GridType(comptime Storage: type) type {
         ///
         /// Even though this block is the block we expected to read, we can't safely
         /// cache this result:
-        /// 1. Replica A write block X₁ to address X.
-        /// 2. Replica A write block X₂ to address X (write is lost/misdirected).
+        /// 1. Replica A writes block X₁ to address X.
+        /// 2. Replica A writes block X₂ to address X (write is lost/misdirected).
         /// 3. Replica B requests block X₁ from replica A.
         /// It is safe for A to send back X₁, but A must not allow it to poison its cache.
         ///

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -962,7 +962,7 @@ pub fn GrooveType(
             const Join = JoinType(.compacting);
             Join.start(groove, callback);
 
-            // Compact the ObjectTree and IdTree
+            // Compact the ObjectTree and IdTree.
             if (has_id) groove.ids.compact(Join.tree_callback(.ids), op);
             groove.objects.compact(Join.tree_callback(.objects), op);
 
@@ -970,6 +970,17 @@ pub fn GrooveType(
             inline for (std.meta.fields(IndexTrees)) |field| {
                 const compact_callback = Join.tree_callback(.{ .index = field.name });
                 @field(groove.indexes, field.name).compact(compact_callback, op);
+            }
+        }
+
+        pub fn compact_end(groove: *Groove) void {
+            assert(groove.join_callback == null);
+
+            if (has_id) groove.ids.compact_end();
+            groove.objects.compact_end();
+
+            inline for (std.meta.fields(IndexTrees)) |field| {
+                @field(groove.indexes, field.name).compact_end();
             }
         }
 

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -584,6 +584,13 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             manifest.manifest_log.reserve();
         }
 
+        pub fn forfeit(manifest: *Manifest) void {
+            assert(manifest.compact_callback == null);
+            assert(manifest.checkpoint_callback == null);
+
+            manifest.manifest_log.forfeit();
+        }
+
         pub fn compact(manifest: *Manifest, callback: Callback) void {
             assert(manifest.compact_callback == null);
             assert(manifest.checkpoint_callback == null);

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -399,6 +399,7 @@ const Environment = struct {
         env.manifest_log.compact(compact_callback);
         env.wait(&env.manifest_log);
 
+        env.manifest_log.forfeit();
         env.manifest_log_reserved = false;
     }
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -48,6 +48,7 @@ pub fn main() !void {
     defer allocator.free(events);
 
     try run_fuzz(allocator, prng.random(), events);
+    log.info("Passed!", .{});
 }
 
 fn run_fuzz(

--- a/src/lsm/posted_groove.zig
+++ b/src/lsm/posted_groove.zig
@@ -345,6 +345,11 @@ pub fn PostedGrooveType(comptime Storage: type, value_count_max: usize) type {
             groove.tree.compact(tree_callback, op);
         }
 
+        pub fn compact_end(groove: *PostedGroove) void {
+            assert(groove.callback == null);
+            groove.tree.compact_end();
+        }
+
         pub fn checkpoint(groove: *PostedGroove, callback: fn (*PostedGroove) void) void {
             assert(groove.callback == null);
             groove.callback = callback;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -849,7 +849,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 switch (tree.compaction_table_immutable.state) {
                     // The compaction wasn't started for this half bar.
                     .idle => assert(tree.table_immutable.free),
-                    .done_writing_tables => {
+                    .tables_writing_done => {
                         tree.compaction_table_immutable.apply_to_manifest();
                         tree.manifest.remove_invisible_tables(
                             tree.compaction_table_immutable.context.level_b,
@@ -870,7 +870,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             while (it.next()) |context| {
                 switch (context.compaction.state) {
                     .idle => {}, // The compaction wasn't started for this half bar.
-                    .done_writing_tables => {
+                    .tables_writing_done => {
                         context.compaction.apply_to_manifest();
                         tree.manifest.remove_invisible_tables(
                             context.compaction.context.level_b,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -110,6 +110,14 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
 
         manifest: Manifest,
 
+        compaction_phase: enum {
+            idle,
+            skipped,
+            skipped_done,
+            running,
+            running_done,
+        } = .idle,
+
         compaction_table_immutable: Compaction,
 
         /// The number of Compaction instances is divided by two as, at any given compaction tick,
@@ -529,6 +537,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
         /// Compactions start on the down beat of a half bar, using 0-based beats.
         /// For example, if there are 4 beats in a bar, start on beat 0 or beat 2.
         pub fn compact(tree: *Tree, callback: fn (*Tree) void, op: u64) void {
+            assert(tree.compaction_phase == .idle);
             assert(tree.compaction_callback == .none);
             assert(op != 0);
             assert(op == tree.compaction_op + 1);
@@ -546,6 +555,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 // There is nothing to compact for the first measure.
                 // We skip the main compaction code path first compaction bar entirely because it
                 // is a special case — its first beat is 1, not 0.
+                tree.compaction_phase = .skipped;
 
                 tree.lookup_snapshot_max = op + 1;
                 if (op + 1 == constants.lsm_batch_multiple) {
@@ -563,6 +573,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 // compactions would actually perform different compactions than before,
                 // causing the storage state of the replica to diverge from the cluster.
                 // See also: lookup_snapshot_max_for_checkpoint().
+                tree.compaction_phase = .skipped;
 
                 if (op + 1 == tree.lookup_snapshot_max) {
                     // This is the last op of the skipped compaction bar.
@@ -576,6 +587,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 return;
             }
             assert(op == tree.lookup_snapshot_max);
+
+            tree.compaction_phase = .running;
 
             const op_min = compaction_op_min(tree.compaction_op);
             assert(op_min < snapshot_latest);
@@ -770,6 +783,12 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             const tree = @fieldParentPtr(Tree, "compaction_next_tick", next_tick);
             assert(tree.compaction_callback == .next_tick);
 
+            switch (tree.compaction_phase) {
+                .running => tree.compaction_phase = .running_done,
+                .skipped => tree.compaction_phase = .skipped_done,
+                else => unreachable,
+            }
+
             tracer.end(
                 &tree.tracer_slot,
                 .{ .tree_compaction_beat = .{ .tree_name = tree_name } },
@@ -781,8 +800,11 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
         }
 
         fn compact_finish(tree: *Tree) void {
+            assert(tree.compaction_phase == .running);
             assert(tree.compaction_io_pending == 0);
             assert(tree.compaction_callback == .awaiting);
+
+            tree.compaction_phase = .running_done;
 
             if (constants.verify) {
                 tree.manifest.verify(tree.lookup_snapshot_max);
@@ -799,11 +821,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
         }
 
         pub fn compact_end(tree: *Tree) void {
-            // Only run if compact() actually compacted.
-            if (tree.compaction_op < constants.lsm_batch_multiple or
-                tree.grid.superblock.working.vsr_state.op_compacted(tree.compaction_op))
-            {
-                return;
+            const state_old = tree.compaction_phase;
+            tree.compaction_phase = .idle;
+
+            switch (state_old) {
+                .running_done => {}, // Fall through.
+                .skipped_done => return,
+                else => unreachable,
             }
 
             // Only run at the end of each half-bar.
@@ -826,7 +850,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                     // The compaction wasn't started for this half bar.
                     .idle => assert(tree.table_immutable.free),
                     .done => {
-                        tree.compaction_table_immutable.finish();
+                        tree.compaction_table_immutable.apply_to_manifest();
                         tree.manifest.remove_invisible_tables(
                             tree.compaction_table_immutable.context.level_b,
                             tree.lookup_snapshot_max,
@@ -846,7 +870,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 switch (context.compaction.state) {
                     .idle => {}, // The compaction wasn't started for this half bar.
                     .done => {
-                        context.compaction.finish();
+                        context.compaction.apply_to_manifest();
                         tree.manifest.remove_invisible_tables(
                             context.compaction.context.level_b,
                             tree.lookup_snapshot_max,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -849,7 +849,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 switch (tree.compaction_table_immutable.state) {
                     // The compaction wasn't started for this half bar.
                     .idle => assert(tree.table_immutable.free),
-                    .done => {
+                    .done_writing_tables => {
                         tree.compaction_table_immutable.apply_to_manifest();
                         tree.manifest.remove_invisible_tables(
                             tree.compaction_table_immutable.context.level_b,
@@ -858,6 +858,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                             tree.compaction_table_immutable.context.range_b.key_max,
                         );
                         tree.table_immutable.clear();
+                        tree.compaction_table_immutable.reset();
                     },
                     else => unreachable,
                 }
@@ -869,7 +870,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             while (it.next()) |context| {
                 switch (context.compaction.state) {
                     .idle => {}, // The compaction wasn't started for this half bar.
-                    .done => {
+                    .done_writing_tables => {
                         context.compaction.apply_to_manifest();
                         tree.manifest.remove_invisible_tables(
                             context.compaction.context.level_b,
@@ -885,6 +886,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                                 context.compaction.context.range_b.key_max,
                             );
                         }
+                        context.compaction.reset();
                     },
                     else => unreachable,
                 }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -233,6 +233,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.fuzzing, .tree_compact);
             env.tree.compact(tree_compact_callback, op);
             env.tick_until_state_change(.tree_compact, .fuzzing);
+            env.tree.compact_end();
         }
 
         fn tree_compact_callback(tree: *Tree) void {

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -95,7 +95,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             if ((replica.commit_min + 1) % half_measure_beat_count != 0) return;
 
             const checksum = checksum_grid(replica);
-            log.debug("{}: replica_compact: op={} area=grid checksum={}", .{
+            log.debug("{}: replica_compact: op={} area=grid checksum={x:>32}", .{
                 replica.replica,
                 replica.commit_min,
                 checksum,
@@ -108,7 +108,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             } else {
                 const checksum_expect = checker.compactions.items[compactions_index];
                 if (checksum_expect != checksum) {
-                    log.err("{}: replica_compact: mismatch area=grid expect={} actual={}", .{
+                    log.err("{}: replica_compact: mismatch area=grid expect={x:>32} actual={x:>32}", .{
                         replica.replica,
                         checksum_expect,
                         checksum,
@@ -144,7 +144,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
             }
 
             inline for (std.meta.fields(Checkpoint)) |field| {
-                log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={}", .{
+                log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={x:>32}", .{
                     replica.replica,
                     replica.op_checkpoint(),
                     field.name,
@@ -164,7 +164,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
                 const field_expect = @field(checkpoint_expect, field.name);
                 if (!std.meta.eql(field_expect, field_actual)) {
                     fail = true;
-                    log.debug("{}: replica_checkpoint: mismatch area={s} expect={} actual={}", .{
+                    log.err("{}: replica_checkpoint: mismatch area={s} expect={x:>32} actual={x:>32}", .{
                         replica.replica,
                         field.name,
                         @field(checkpoint_expect, field.name),

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -127,10 +127,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
                 .checksum_superblock_free_set = 0,
                 .checksum_superblock_client_sessions = 0,
                 .checksum_client_replies = checksum_client_replies(storage),
-                // TODO(Beat Compaction) Enable grid check when deterministic storage is fixed.
-                // Until then this is too noisy.
-                // checksum_grid(replica),
-                .checksum_grid = 0,
+                .checksum_grid = checksum_grid(replica),
             };
 
             inline for (.{ .manifest, .free_set, .client_sessions }) |trailer| {

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -183,7 +183,7 @@ pub fn StorageCheckerType(comptime Replica: type) type {
 
         fn checksum_grid(replica: *const Replica) u128 {
             const storage = replica.superblock.storage;
-            var acquired = replica.superblock.free_set.blocks.iterator(.{ .kind = .unset });
+            var acquired = replica.superblock.free_set.blocks.iterator(.{});
             var checksum: u128 = 0;
             while (acquired.next()) |address_index| {
                 const block = storage.grid_block(address_index + 1);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -113,7 +113,7 @@ test "Cluster: recovery: WAL prepare corruption (R=3, corrupt checkpoint…head)
     try c.request(slot_count + 1, slot_count + 1);
 }
 
-test "Cluster: recovery: WAL prepare corruption (R=1, between checkpoint and head)" {
+test "Cluster: recovery: WAL prepare corruption (R=1, corrupt between checkpoint and head)" {
     // R=1 can never recover if a WAL-prepare is corrupt.
     const t = try TestContext.init(.{ .replica_count = 1 });
     defer t.deinit();


### PR DESCRIPTION
Fix (grid) storage determinism (at checkpoint) of ManifestLog and SuperBlock Manifest.

These are the last two (known) storage determinism issues, so the `StorageChecker` is now enabled at checkpoint.
`StorageChecker` is still disabled for other compaction beats though (see code for explanation).

### Problems:

1. Order of `ManifestLog` appends depends on the ordering of compaction IO.
2. Order of `SuperBlock.Manifest` appends+removes depends on the ordering of compaction IO.

### Fixes:

##### 1.

`Compaction` queues up `ManifestLog` appends. It holds onto them until `finish()` (formerly `reset()`) is invoked, rather than just appending as it progresses.

`compact_finish_join()` previously handled all of the compaction "prelude".
This is now in a separate step: `compact_end()`.
`compact_end()` is called in a consistent order (by `Groove` and `Forest`) regardless of compaction concurrency.

##### 1b:

`finish()` is now called _before_ `remove_invisible_tables` to ensure the invisible table cleanup doesn't lag behind.

##### 2.

`SuperBlock.Manifest` appends are performed by the `ManifestLog` when it flushes blocks to the disk.

During `ManifestLog.checkpoint()` this is a non-issue, since it happens synchronously with respect to the `Forest.checkpoint()`/`Tree.checkpoint()` invocation.
However, `ManifestLog.compact()` was previously called asynchronously with respect to `Forest.compact()`/`Tree.compact()`, and thus could be interleaved unpredictably.

`ManifestLog.compact()` now runs concurrently to compaction. This is safe now because `Compaction` is queuing its `ManifestLog` appends.


## Pre-merge checklist

Performance:

* [x] Compare `zig build benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1223 batches in 537.43 s
    load offered = 1000000 tx/s
    load accepted = 18607 tx/s
    batch latency p00 = 3 ms
    batch latency p10 = 56 ms
    batch latency p20 = 59 ms
    batch latency p30 = 62 ms
    batch latency p40 = 65 ms
    batch latency p50 = 88 ms
    batch latency p60 = 99 ms
    batch latency p70 = 103 ms
    batch latency p80 = 111 ms
    batch latency p90 = 125 ms
    batch latency p100 = 52028 ms
    transfer latency p00 = 3 ms
    transfer latency p10 = 10274 ms
    transfer latency p20 = 33719 ms
    transfer latency p30 = 69368 ms
    transfer latency p40 = 117064 ms
    transfer latency p50 = 178294 ms
    transfer latency p60 = 239797 ms
    transfer latency p70 = 300107 ms
    transfer latency p80 = 362484 ms
    transfer latency p90 = 421176 ms
    transfer latency p100 = 527439 ms

    
    # benchmark results after
    1223 batches in 492.30 s
    load offered = 1000000 tx/s
    load accepted = 20312 tx/s
    batch latency p00 = 3 ms
    batch latency p10 = 58 ms
    batch latency p20 = 60 ms
    batch latency p30 = 62 ms
    batch latency p40 = 65 ms
    batch latency p50 = 86 ms
    batch latency p60 = 97 ms
    batch latency p70 = 101 ms
    batch latency p80 = 105 ms
    batch latency p90 = 110 ms
    batch latency p100 = 26695 ms
    transfer latency p00 = 3 ms
    transfer latency p10 = 10475 ms
    transfer latency p20 = 34136 ms
    transfer latency p30 = 70119 ms
    transfer latency p40 = 118096 ms
    transfer latency p50 = 177697 ms
    transfer latency p60 = 239884 ms
    transfer latency p70 = 301274 ms
    transfer latency p80 = 364407 ms
    transfer latency p90 = 425338 ms
    transfer latency p100 = 482315 ms
    ```
