### PR TITLE
[Dotnet client] Set rollForward flag for runtime compatibility

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
+++ b/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
-		<RollForward>LatestMajor</RollForward>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TigerBeetle\TigerBeetle.csproj" />
   </ItemGroup>
-	<ItemGroup>
+  <ItemGroup>
     <Content Include="..\TigerBeetle\runtimes\$(RuntimeIdentifier)\native\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-	</ItemGroup>
+  </ItemGroup>
 </Project>

--- a/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
+++ b/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+		<RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TigerBeetle\TigerBeetle.csproj" />

--- a/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
+++ b/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+		<RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
+++ b/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
-		<RollForward>LatestMajor</RollForward>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="TigerBeetle.props" />
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
 		<LangVersion>10</LangVersion>
 		<Nullable>enable</Nullable>
 		<AssemblyName>TigerBeetle</AssemblyName>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>		
+		<RollForward>LatestMajor</RollForward>
 	</PropertyGroup>
 	<PropertyGroup>
 		<OS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</OS>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Project="TigerBeetle.props" />
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
-		<LangVersion>10</LangVersion>
-		<Nullable>enable</Nullable>
-		<AssemblyName>TigerBeetle</AssemblyName>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
-		<RollForward>LatestMajor</RollForward>
-	</PropertyGroup>
-	<PropertyGroup>
-		<OS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</OS>
-	</PropertyGroup>
-	<Target Name="BuildZig" BeforeTargets="CoreCompile" Condition="'$(OS)'=='Windows'">
-		<Exec Command=".\zig\zig.exe build dotnet_client -Drelease-safe" WorkingDirectory="$(ProjectDir)\..\..\..\.." />
-	</Target>
-	<Target Name="BuildZig" BeforeTargets="CoreCompile" Condition="'$(OS)'!='Windows'">
-		<Exec Command="zig/zig build dotnet_client -Drelease-safe" WorkingDirectory="$(ProjectDir)/../../../.." />
-	</Target>
-	<ItemGroup>
-		<Content Include="runtimes\**\*.so">
-		  <PackagePath>%(Identity)</PackagePath>
-		  <Pack>true</Pack>
-		</Content>
-		<Content Include="runtimes\**\*.dylib">
-			<PackagePath>%(Identity)</PackagePath>
-			<Pack>true</Pack>
-		</Content>
-		<Content Include="runtimes\**\*.dll">
-			<PackagePath>%(Identity)</PackagePath>
-			<Pack>true</Pack>
-		</Content>		
-	</ItemGroup>
+  <Import Project="TigerBeetle.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>TigerBeetle</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</OS>
+  </PropertyGroup>
+  <Target Name="BuildZig" BeforeTargets="CoreCompile" Condition="'$(OS)'=='Windows'">
+    <Exec Command=".\zig\zig.exe build dotnet_client -Drelease-safe" WorkingDirectory="$(ProjectDir)\..\..\..\.." />
+  </Target>
+  <Target Name="BuildZig" BeforeTargets="CoreCompile" Condition="'$(OS)'!='Windows'">
+    <Exec Command="zig/zig build dotnet_client -Drelease-safe" WorkingDirectory="$(ProjectDir)/../../../.." />
+  </Target>
+  <ItemGroup>
+    <Content Include="runtimes\**\*.so">
+      <PackagePath>%(Identity)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="runtimes\**\*.dylib">
+      <PackagePath>%(Identity)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="runtimes\**\*.dll">
+      <PackagePath>%(Identity)</PackagePath>
+      <Pack>true</Pack>
+    </Content>    
+  </ItemGroup>
 </Project>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -30,6 +30,6 @@
     <Content Include="runtimes\**\*.dll">
       <PackagePath>%(Identity)</PackagePath>
       <Pack>true</Pack>
-    </Content>    
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change enables building and running the client and tests using newer versions of DotNet SDK, however the minimum required version was kept as is.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
