### PR TITLE
vsr: correctly infer presence from DVC messages

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -237,6 +237,9 @@ pub const Header = extern struct {
     /// detecting whether a session has been evicted is solved by the session number.
     ///
     /// * A `request_reply` sets this to the client of the reply being requested.
+    /// * A `do_view_change` sets this to a bitset of "present" prepares. If a bit is set, then
+    ///   the corresponding header is not "blank", the replica has the prepare, and the prepare
+    ///   is not known to be faulty.
     client: u128 = 0,
 
     /// The checksum of the message to which this message refers.
@@ -610,7 +613,6 @@ pub const Header = extern struct {
     fn invalid_do_view_change(self: *const Header) ?[]const u8 {
         assert(self.command == .do_view_change);
         if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
         if (self.operation != .reserved) return "operation != .reserved";
         return null;
     }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3398,7 +3398,14 @@ pub fn ReplicaType(
             const BitSet = std.bit_set.IntegerBitSet(128);
             comptime assert(BitSet.MaskInt == std.meta.fieldInfo(Header, .context).field_type);
 
+            // Collect nack and presence bits for the headers, so that the new primary can run CTRL
+            // protocol to truncate uncomitted headers. When:
+            // - a header has quorum of nacks -- the header is truncated
+            // - a header isn't truncated and is present -- the header gets into the next view
+            // - a header is neither truncated nor present -- the primary waits for more
+            //   DVC messages to decide whether to keep or truncate the header.
             var nacks = BitSet.initEmpty();
+            var present = BitSet.initEmpty();
             if (command == .do_view_change) {
                 for (self.view_headers.array.constSlice()) |*header, i| {
                     const slot = self.journal.slot_for_op(header.op);
@@ -3421,6 +3428,13 @@ pub fn ReplicaType(
                     // Case 3: We don't have a prepare at all, and that's not due to a fault.
                     if (journal_header == null and !faulty) {
                         nacks.set(i);
+                    }
+
+                    if (journal_header != null and journal_header.?.checksum == header.checksum and
+                        !faulty)
+                    {
+                        maybe(nacks.isSet(i));
+                        present.set(i);
                     }
                 }
             }
@@ -3446,6 +3460,8 @@ pub fn ReplicaType(
                 .commit = self.commit_min,
                 // DVC: Signal which headers correspond to definitely not-prepared messages.
                 .context = nacks.mask,
+                // DVC: Signal which headers correspond to locally available prepares.
+                .client = present.mask,
             };
 
             stdx.copy_disjoint(
@@ -7187,6 +7203,11 @@ const DVCQuorum = struct {
         comptime assert(@TypeOf(nacks) == u128);
         assert(@popCount(u128, nacks) <= headers.slice.len);
         assert(@clz(u128, nacks) + headers.slice.len >= @bitSizeOf(u128));
+
+        const present = message.header.client;
+        comptime assert(@TypeOf(present) == u128);
+        assert(@popCount(u128, present) <= headers.slice.len);
+        assert(@clz(u128, present) + headers.slice.len >= @bitSizeOf(u128));
     }
 
     fn dvcs_all(dvc_quorum: QuorumMessages) DVCArray {
@@ -7395,12 +7416,15 @@ const DVCQuorum = struct {
                 assert(header.op == op);
 
                 const header_nacks = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.context };
+                const header_present = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.client };
                 if (header_nacks.isSet(header_index)) {
                     nacks += 1;
                 } else if (header_canonical) |expect| {
                     if (vsr.Headers.dvc_header_type(header) == .valid) {
                         if (expect.checksum == header.checksum) {
-                            copies += 1;
+                            if (header_present.isSet(header_index)) {
+                                copies += 1;
+                            }
                         } else {
                             // The replica's prepare is available, but for a different header.
                             nacks += 1;


### PR DESCRIPTION
When a primary receives a DVC quorum, it should wait until each piepeline message is either nacked, or known to be present. In the ambiguous casees, the primary must wait for further DVCs. Otherwise, if the primary doesn't truncate a prepare which is not present, it will get stuck trying to repair it.

Before this PR, a prepare was considered as present if it wasn't nacked or a blank. This is wrong: if the prepare is faulty, but the header for it is available, it woun't be nacked, won't be a blank, and would not be present.

To fix this, use `client` field to send an explicit bitset of present prepares instead of inferring it.

The VOPRs seed makes the cluster to enter a view-change loop, where the cluster tries to repair a prepare which should have been truncated.

SEED: 4596119782490370426

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
