### PR TITLE
vsr: correctness, don't prepare-ok until the log view is durable

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5836,11 +5836,12 @@ pub fn ReplicaType(
                     return;
                 }
 
-                // For DVCs and SVCs we must wait for the log_view to be durable:
+                // For DVCs, SVCs, and prepare_oks we must wait for the log_view to be durable:
                 // - A DVC includes the log_view.
-                // - A SV implies the log_view.
+                // - A SV or a prepare_ok imply the log_view.
                 if (message.header.command == .do_view_change or
-                    message.header.command == .start_view)
+                    message.header.command == .start_view or
+                    message.header.command == .prepare_ok)
                 {
                     if (self.log_view_durable() < self.log_view) {
                         log.debug("{}: send_message_to_replica: dropped {s} " ++

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -464,6 +464,18 @@ pub fn ReplicaType(
             // the vsr_headers head op may be part of the checkpoint after this one.
             maybe(vsr_headers.slice[0].op > self.op_checkpoint_trigger());
 
+            // Given on-disk state, try to recover the head op after a restart.
+            //
+            // If the replica crashed in status == .normal (view == log_view), the head is generally
+            // the last record in WAL. As a special case, during  the first open the last (and the
+            // only) record in WAL is the root prepare.
+            //
+            // Otherwise, the head is recovered from the superblock. When transitioninig to a
+            // view_change, replicas encode the current head into vsr_headers.
+            //
+            // It is a possibility that the head can't be recovered from the local data.
+            // In this case, the replica transitions to .recovering_head and waits for a .start_view
+            // message from a primary to reset its head.
             var op_head: ?u64 = null;
 
             if (self.log_view == self.view) {


### PR DESCRIPTION
Before the fix, replica can switch to a view, send a `prepare_ok` before
`log_view_durable` is updated, and crash. After restart, it will then
incorrectly infer that it crashed during view change and will use SV to
infer the head message. This then can lead to prepare_oked message being
nacked in a subsequent view change.

I also added a comment explaining the overall `open` flow, as it took me a while to puzzle out how exactly are we recovering

SEED: 6196862537461562170
closes: #757

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
