### PR TITLE
VSR: Fix client sessions eviction assert

### DIFF
--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -257,7 +257,6 @@ pub const ClientSessions = struct {
         var entries = client_sessions.iterator();
         while (entries.next()) |entry| : (iterated += 1) {
             assert(entry.header.command == .reply);
-            assert(entry.header.context == 0);
             assert(entry.header.op == entry.header.commit);
             assert(entry.header.commit >= entry.session);
 


### PR DESCRIPTION
Replies use `context` as of https://github.com/tigerbeetledb/tigerbeetle/pull/679. Client eviction is not currently covered by any tests because it triggers a client panic.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
