### PR TITLE
[C client] Add extern "C" for compatibility with C++

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -5,6 +5,10 @@
 
 #ifndef TB_CLIENT_H
 #define TB_CLIENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
  
 #include <stddef.h>
 #include <stdint.h>
@@ -219,5 +223,8 @@ void tb_client_deinit(
     tb_client_t client
 );
 
-#endif // TB_CLIENT_H
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
+#endif // TB_CLIENT_H

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -143,6 +143,10 @@ pub fn main() !void {
         \\
         \\#ifndef TB_CLIENT_H
         \\#define TB_CLIENT_H
+        \\
+        \\#ifdef __cplusplus
+        \\extern "C" {{
+        \\#endif
         \\ 
         \\#include <stddef.h>
         \\#include <stdint.h>
@@ -217,6 +221,13 @@ pub fn main() !void {
         \\
     , .{});
 
-    try buffer.writer().print("#endif // TB_CLIENT_H\n\n", .{});
+    try buffer.writer().print(
+        \\#ifdef __cplusplus
+        \\}} // extern "C"
+        \\#endif
+        \\
+        \\#endif // TB_CLIENT_H
+        \\
+    , .{});
     try std.fs.cwd().writeFile("src/clients/c/tb_client.h", buffer.items);
 }

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -5,6 +5,10 @@
 
 #ifndef TB_CLIENT_H
 #define TB_CLIENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
  
 #include <stddef.h>
 #include <stdint.h>
@@ -219,5 +223,8 @@ void tb_client_deinit(
     tb_client_t client
 );
 
-#endif // TB_CLIENT_H
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
+#endif // TB_CLIENT_H


### PR DESCRIPTION
This PR improves DX by removing friction when using `tb_client.h` from C++ source code.

Note: In this article, the author advocates in favor of only using `extern "C"` from the caller side (the opposite idea of this PR), keeping the C header free of C++ keywords: https://arne-mertz.de/2018/10/calling-cpp-code-from-c-with-extern-c/
Although, using `#ifdef __cplusplus` inside C headers is a very common pattern.

Closes #788

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
