### PR TITLE
VSR/Journal: Carefully truncate out-of-view prepares during recovery

### DIFF
--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1288,6 +1288,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             // - after prepare_op_max is computed,
             // - after the case decisions are made (to avoid @H:vsr arising from an
             //   artificially reserved prepare),
+            // - after recover_torn_prepare(), which computes its own max ops.
             // - before we repair the 'fix' cases.
             //
             // (These headers can originate if we join a view, write some prepares from the new

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -2355,14 +2355,15 @@ fn header_ok(cluster: u32, slot: Slot, header: *const Header) ?*const Header {
 }
 
 test "recovery_cases" {
+    const parameters_count = 9;
     // Verify that every pattern matches exactly one case.
     //
     // Every possible combination of parameters must either:
     // * have a matching case
     // * have a case that fails (which would result in a panic).
     var i: usize = 0;
-    while (i <= std.math.maxInt(u8)) : (i += 1) {
-        var parameters: [9]bool = undefined;
+    while (i < (1 << parameters_count)) : (i += 1) {
+        var parameters: [parameters_count]bool = undefined;
         comptime var j: usize = 0;
         inline while (j < parameters.len) : (j += 1) {
             parameters[j] = i & (1 << j) != 0;

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1206,7 +1206,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         ///   header reserved          _   1   0   _   _   _   1   0   1   0   0   0   0
         ///   prepare valid            0   0   0   1   1   1   1   1   1   1   1   1   1
         ///   prepare reserved         _   _   _   1   0   0   0   1   1   0   0   0   0
-        ///   prepare.op is maximum    _   _   _   _   0   1   1   _   _   _   _   _   _
+        ///   prepare.op is maximum    _   _   _   _   0   1   _   _   _   _   _   _   _
         ///   match checksum           _   _   _   _   _   _   _   _  !1   0   0   0   1
         ///   match op                 _   _   _   _   _   _   _   _  !1   <   >   1  !1
         ///   match view               _   _   _   _   _   _   _   _  !1   _   _  !0  !1

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1289,6 +1289,9 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             // - after the case decisions are made (to avoid @H:vsr arising from an
             //   artificially reserved prepare),
             // - before we repair the 'fix' cases.
+            //
+            // (These headers can originate if we join a view, write some prepares from the new
+            // view, and then crash before the view_durable_update() finished.)
             for ([_][]align(constants.sector_size) Header{
                 journal.headers_redundant,
                 journal.headers,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1224,7 +1224,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         ///    >  header.op > prepare.op
         ///  eql  The header and prepare are identical; no repair necessary.
         ///  nil  Reserved; dirty/faulty are clear, no repair necessary.
-        ///  fix  When replicas=1, use intact prepare. When replicas>1, use VSR `request_prepare`.
+        ///  fix  Repair header using local intact prepare.
         ///  vsr  Repair with VSR `request_prepare`.
         ///
         /// A "valid" header/prepare:
@@ -2096,7 +2096,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 }
 
 /// @B and @C:
-/// This prepare header is corrupt.
+/// This prepare is corrupt.
 /// We may have a valid redundant header, but need to recover the full message.
 ///
 /// Case @B may be caused by crashing while writing the prepare (torn write).
@@ -2165,7 +2165,6 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 ///
 /// @L:
 /// The message was rewritten due to a view change.
-/// A single-replica cluster doesn't ever change views.
 ///
 ///
 /// @M:


### PR DESCRIPTION
Fixes https://github.com/tigerbeetledb/tigerbeetle/issues/783.

### Bug

In the seed reference in the above issue (`14295907088955483715` on `fd94fadf804e6ce612372106093d168fe128e6d7`), the simulator fails in `simulator.zig` on

    assert(replica.status != .recovering_head or fault);

Specifically, replica `1` restarts into `recovering_head` even though storage faults were disabled during its recovery. Slot 21 of the WAL is the problem:

    [warn] (journal): 1: recover_slot: recovered slot=0021 label=@H decision=vsr command=Command.reserved op=21

Case `@H` is:
- the redundant header is a valid prepare, but
- the prepare is reserved.

The prepare is actually present in the log. It is being converted to `reserved` by `recover_slots()`:

    // Discard headers which we are certain do not belong in the current log_view.

### Fix

There are two possible fixes here.
The first is to remove the redundant header at the same time we remove the prepare. The second is to defer the removal, and modify the recovery decision directly.

There was originally a note that this code should precede `prepare_op_max`'s computation. But I think that is actually not right — even if we are pretending those last messages don't exist because they don't belong in our newer view, it doesn't mean that the earlier message should be treated as op-max for the purposes of the recovery decision table.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
