### PR TITLE
fix: undefined reference to `__zig_probe_stack'

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -774,6 +774,7 @@ fn c_client(
 
         const shared_lib = b.addSharedLibrary("tb_client", "src/clients/c/tb_client.zig", .unversioned);
         const static_lib = b.addStaticLibrary("tb_client", "src/clients/c/tb_client.zig");
+        static_lib.bundle_compiler_rt = true;
 
         for ([_]*std.build.LibExeObjStep{ shared_lib, static_lib }) |lib| {
             lib.setMainPkgPath("src");

--- a/build.zig
+++ b/build.zig
@@ -775,6 +775,7 @@ fn c_client(
         const shared_lib = b.addSharedLibrary("tb_client", "src/clients/c/tb_client.zig", .unversioned);
         const static_lib = b.addStaticLibrary("tb_client", "src/clients/c/tb_client.zig");
         static_lib.bundle_compiler_rt = true;
+        static_lib.pie = true;
 
         for ([_]*std.build.LibExeObjStep{ shared_lib, static_lib }) |lib| {
             lib.setMainPkgPath("src");


### PR DESCRIPTION
Allows another C compiler link to this library.

If the library allowed build `ReleaseFast` then this command would be useless.

cc: @batiati @kprotty 

**Reference:**
- https://github.com/ziglang/zig/issues/6817#issuecomment-736129115

> Now you can pass -fcompiler-rt to include compiler-rt in static libraries. Feel free to open a proposal to change the default, which is currently only dynamic libraries and executables get compiler-rt included. - **Andrewrk**

## Pre-merge checklist

* [x] I am very sure this PR could not affect performance.
