### PR TITLE
VSR: `commit_status`; `commit_dispatch()`

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2844,11 +2844,7 @@ pub fn ReplicaType(
             assert(self.commit_min <= self.op);
 
             if (self.status == .normal and self.primary()) {
-                if (self.pipeline.queue.prepare_queue.empty()) {
-                    self.commit_ops_done();
-                } else {
-                    self.commit_pipeline_next();
-                }
+                self.commit_pipeline_next();
             } else {
                 self.commit_journal_next();
             }
@@ -2856,11 +2852,11 @@ pub fn ReplicaType(
 
         /// Begin the commit path that is common between `commit_pipeline` and `commit_journal`:
         ///
-        /// 1. prefetch
-        /// 2. commit_op: Update the state machine and the replica's commit_min/commit_max.
-        /// 3. compact
-        /// 4. checkpoint: (Only called when `commit_min == op_checkpoint_trigger`).
-        /// 5. done: Call the `callback` that was passed to `commit_op_prefetch`.
+        /// 1. Prefetch.
+        /// 2. Commit_op: Update the state machine and the replica's commit_min/commit_max.
+        /// 3. Compact.
+        /// 4. Checkpoint: (Only called when `commit_min == op_checkpoint_trigger`).
+        /// 5. Done: Call the `callback` that was passed to `commit_op_prefetch`.
         fn commit_op_prefetch(
             self: *Self,
             prepare: *Message,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -589,6 +589,9 @@ pub fn ReplicaType(
                 }
             }
 
+            maybe(self.status == .normal);
+            maybe(self.status == .view_change);
+            maybe(self.status == .recovering_head);
             if (self.status == .recovering) assert(self.solo());
 
             // Asynchronously open the (Forest inside) StateMachine so that we can repair grid

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2694,8 +2694,6 @@ pub fn ReplicaType(
                     CommitStatus.next_pipeline
                 else
                     CommitStatus.next_journal,
-                .next_journal => unreachable,
-                .next_pipeline => unreachable,
                 else => status_new,
             };
 
@@ -2782,7 +2780,7 @@ pub fn ReplicaType(
             // op.
 
             assert(self.commit_status == .idle);
-            self.commit_step(.next);
+            self.commit_step(.next_journal);
         }
 
         fn commit_journal_next(self: *Self) void {
@@ -3269,7 +3267,7 @@ pub fn ReplicaType(
                 return;
             }
 
-            self.commit_step(.next);
+            self.commit_step(.next_pipeline);
         }
 
         fn commit_pipeline_next(self: *Self) void {


### PR DESCRIPTION
## `commit_status`

Replace the `Replica.committing` boolean with a `commit_status` enum.
State sync will need to track the progress through the commit so that it can tell how to cancel the commit.
(e.g. Whether it can cancel the grid, or whether it needs to wait.)

## `commit_dispatch()`
Previously the commit "chain" of callbacks was like:

    fn foo()
      foo_start(foo_callback)
    fn foo_callback()
      bar_start(bar_callback)
    fn bar_callback()
      ... etc

But now it is:

    fn dispatch(next_state)
      switch (state)
        .foo -> foo_start(foo_callback)
        .bar -> bar_start(bar_callback)
        ...etc

    fn foo_callback()
      dispatch(.bar)
    fn bar_callback()
      dispatch(...etc)

This is preparation for state sync. State sync needs to be able to "interrupt" commits between steps.
How this will work: in `commit_dispatch()`, check whether we are syncing.
If we are, instead of continuing to the next step of commit, abort and signal to state sync that we have reached a stopping point.

Another approach would be to put a `if (syncing) { signal sync; return }` hook before every commit state transition, but that is more brittle & intrusive.

## Pre-merge checklist

Performance:

* [x] I am very sure this PR could not affect performance.
