### PR TITLE
Add a timeout to benchmark jobs, use a random port if Python is available

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,7 +41,7 @@ jobs:
   benchmark:
     if: inputs.version == ''
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/benchmark.sh --transfer-count 4000

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,6 +41,7 @@ jobs:
   benchmark:
     if: inputs.version == ''
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/benchmark.sh --transfer-count 4000

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
       - run: ./scripts/install.sh
 
   benchmark:
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         target: [macos-latest, [self-hosted, ARM64, macos-12.6], [self-hosted, ARM64, macos-13.2]]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,7 @@ jobs:
       - run: ./scripts/install.sh
 
   benchmark:
+    timeout-minutes: 5
     strategy:
       matrix:
         target: [macos-latest, [self-hosted, ARM64, macos-12.6], [self-hosted, ARM64, macos-13.2]]

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -14,6 +14,11 @@ if [ ! -d "zig" ]; then
     scripts/install_zig.sh
 fi
 
+PORT=3001
+if command -v python &> /dev/null; then
+    PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+fi
+
 COLOR_RED='\033[1;31m'
 COLOR_END='\033[0m'
 
@@ -62,13 +67,13 @@ for I in $REPLICAS
 do
     echo "Starting replica $I..."
     FILE="./0_${I}.tigerbeetle.benchmark"
-    ./tigerbeetle start --addresses=3001 "$FILE" >> benchmark.log 2>&1 &
+    ./tigerbeetle start "--addresses=${PORT}" "$FILE" >> benchmark.log 2>&1 &
 done
 
 echo ""
 echo "Benchmarking..."
 # shellcheck disable=SC2086
-./scripts/build.sh benchmark -Drelease-safe -Dconfig=production $cpu $ZIG_TARGET -- "$@"
+./scripts/build.sh benchmark -Drelease-safe -Dconfig=production $cpu $ZIG_TARGET -- --addresses "${PORT}" "$@"
 echo ""
 
 for I in $REPLICAS


### PR DESCRIPTION
Fixes hanging benchmark jobs in CI

## Pre-merge checklist

Performance:
* [x] I am very sure this PR could not affect performance.
