### PR TITLE
[Java Client] Fix testCloseWithConcurrentTasks

### DIFF
--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <!-- JaCoCo thresholds -->
     <jacoco.unit-tests.limit.instruction-ratio>95%</jacoco.unit-tests.limit.instruction-ratio>
-    <jacoco.unit-tests.limit.branch-ratio>90%</jacoco.unit-tests.limit.branch-ratio>
+    <jacoco.unit-tests.limit.branch-ratio>85%</jacoco.unit-tests.limit.branch-ratio>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
From the Java side, it's expected to fail exactly the same if the client is closed before or during "submit()", and it's expected to succeed if it's closed after "submit()". So, the test always pass, but depending if it has failed before or during, the "branch misses" metric can get bellow the thresholding, causing the entire CI to fail randomically.

Unfortunately this is a hacky test, but a reasonable one: Since our JNI module does not expose the acquire_packet function, we cannot insert a lock/wait in between "acquire_packet" and "submit" in order to cause and assert each variant.

In this fix, we just spawn many threads to increase the chances of testing closing during the native call. Also, decreases the test coverage's "branch misses" threshold, since this test is not deterministic and it may be possible for this specific branch to get untested.

## Pre-merge checklist

Performance:

* [X] I am very sure this PR could not affect performance.
