### PR TITLE
Fix next_version.sh

### DIFF
--- a/scripts/next_version.sh
+++ b/scripts/next_version.sh
@@ -8,9 +8,8 @@ MINOR=13
 
 git fetch --tags --all
 version="$MAJOR.$MINOR.0"
-latest="$(git tag | grep $MAJOR.$MINOR | sort -r | head -n1)"
-if [ "$latest" != "" ]; then
-    patch="$(echo "$latest" | cut -d '.' -f 3)"
+patch="$(git tag | grep $MAJOR.$MINOR | cut -d '.' -f 3 | sort -nr | head -n1)"
+if [ "$patch" != "" ]; then
     version="$MAJOR.$MINOR.$((patch+1))"
 fi
 echo "$version"


### PR DESCRIPTION
Sort next version in numeric order.
This was causing the publish job to fail.

## Pre-merge checklist

* [X] I am very sure this PR could not affect performance.
