### PR TITLE
IO: `DSYNC` WAL writes and `fdatasync` the rest on checkpoint. 

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -304,7 +304,8 @@ pub const IO = struct {
                     };
                 },
                 .fsync => |op| {
-                    linux.io_uring_prep_fsync(sqe, op.fd, 0);
+                    // We only need to fdatasync.
+                    linux.io_uring_prep_fsync(sqe, op.fd, linux.IORING_FSYNC_DATASYNC);
                 },
             }
             sqe.user_data = @ptrToInt(completion);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -122,6 +122,8 @@ pub const Storage = struct {
         }
     };
 
+    pub const Sync = NextTick;
+
     pub const NextTick = struct {
         next: ?*NextTick = null,
         callback: fn (next_tick: *NextTick) void,
@@ -404,6 +406,8 @@ pub const Storage = struct {
 
         write.callback(write);
     }
+
+    pub const sync_sectors = on_next_tick;
 
     fn read_latency(storage: *Storage) u64 {
         return storage.latency(storage.options.read_latency_min, storage.options.read_latency_mean);


### PR DESCRIPTION
We currently open the database file with `O_DSYNC` (along with `O_DIRECT`) which makes all writes ensure the data (not file metadata) is flushed to disk before completing. While this is important for the Write-Ahead-Log (WAL), it may not be necessary for other writes given we have an explicit `checkpoint()` to flush changes to `Storage`.

@cb22 made the observation that we could apply `O_DSYNC` to individual writes using [pwritev2](https://manpages.debian.org/testing/manpages-dev/preadv2.2.en.html) and RWF_DSYNC. `io_uring` supports the RWF flags using the standard `IORING_OP_WRITEV` using `sqe.rw_flags` so it was doable.

This PR makes WAL writes use `DSYNC` for its data integrity and uses `fdatasync` after a checkpoint (but before its callback) for data integrity of other writes. The f(data)sync portion is only implemented for linux ATM as this is currently exploratory work.

## Pre-merge checklist

Performance:

* [x] Compare `zig build benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    1224 batches in 84.66 s
    load offered = 1000000 tx/s
    load accepted = 118113 tx/s
    batch latency p00 = 0 ms
    batch latency p10 = 23 ms
    batch latency p20 = 24 ms
    batch latency p30 = 25 ms
    batch latency p40 = 26 ms
    batch latency p50 = 28 ms
    batch latency p60 = 28 ms
    batch latency p70 = 29 ms
    batch latency p80 = 30 ms
    batch latency p90 = 31 ms
    batch latency p100 = 4305 ms
    transfer latency p00 = 0 ms
    transfer latency p10 = 3644 ms
    transfer latency p20 = 7668 ms
    transfer latency p30 = 14368 ms
    transfer latency p40 = 22154 ms
    transfer latency p50 = 31379 ms
    transfer latency p60 = 40727 ms
    transfer latency p70 = 50935 ms
    transfer latency p80 = 60691 ms
    transfer latency p90 = 68430 ms
    transfer latency p100 = 74678 ms
    
    # benchmark results after
    1225 batches in 57.92 s
    load offered = 1000000 tx/s
    load accepted = 172637 tx/s
    batch latency p00 = 0 ms
    batch latency p10 = 23 ms
    batch latency p20 = 23 ms
    batch latency p30 = 24 ms
    batch latency p40 = 25 ms
    batch latency p50 = 26 ms
    batch latency p60 = 28 ms
    batch latency p70 = 28 ms
    batch latency p80 = 29 ms
    batch latency p90 = 30 ms
    batch latency p100 = 1724 ms
    transfer latency p00 = 0 ms
    transfer latency p10 = 2986 ms
    transfer latency p20 = 5948 ms
    transfer latency p30 = 10091 ms
    transfer latency p40 = 14713 ms
    transfer latency p50 = 19815 ms
    transfer latency p60 = 25335 ms
    transfer latency p70 = 30870 ms
    transfer latency p80 = 36533 ms
    transfer latency p90 = 42163 ms
    transfer latency p100 = 47937 ms
    ```
