### PR TITLE
Docs: Small clarification in 'Compaction Table Overlap'.

### DIFF
--- a/docs/internals/lsm.md
+++ b/docs/internals/lsm.md
@@ -119,7 +119,7 @@ optimization should enable the tree's performance to approach that of an append-
 
 Applying [this](#compaction-selection-policy) selection policy while compacting a table
 from level A to level B, what is the maximum number of level-B tables that may overlap with the
-selected level-A table (i.e. the “worst case”)?”
+selected level-A table (i.e. the "worst case")?
 
 Perhaps surprisingly, this is `lsm_growth_factor`:
 

--- a/docs/internals/lsm.md
+++ b/docs/internals/lsm.md
@@ -117,8 +117,9 @@ optimization should enable the tree's performance to approach that of an append-
 
 #### Compaction Table Overlap
 
-When compacting a table from level `A` to level `B`, what is the maximum number of level-`B` tables
-that may overlap the level-`A` table (i.e. the "worst case")?
+Applying [this](#compaction-selection-policy) selection policy while compacting a table
+from level A to level B, what is the maximum number of level-B tables that may overlap with the
+selected level-A table (i.e. the “worst case”)?”
 
 Perhaps surprisingly, this is `lsm_growth_factor`:
 


### PR DESCRIPTION
## Pre-merge checklist

Performance:

* [ ] Compare `zig build benchmark` on linux before and after this pr.
    ``` sh
    # benchmark results before
    ...
    
    # benchmark results after
    ...
    ```
OR
* [x] I am very sure this PR could not affect performance.
