### PR TITLE
Add basic organization of internals docs folder for the docs site

### DIFF
--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,0 +1,16 @@
+# Internals
+
+This section collects our internal developer documentation. The
+intended audience is folks who are contributing to TigerBeetle source.
+
+It will not be particularly useful on its own for understanding
+TigerBeetle at a high level.
+
+Furthermore, it isn't particularly organized for reading. It is
+primarily a reference.
+
+## Contents
+
+- [LSM](./lsm.md): Documentation for code (roughly) in the `src/lsm` directory.
+- [VSR](./vsr.md): Documentation for code (roughly) in the `src/vsr` directory.
+- [Testing](./testing.md): Documentation for code (roughly) in the `src/testing` directory.

--- a/docs/internals/_category_.json
+++ b/docs/internals/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Internals",
+    "position": 9
+}

--- a/docs/internals/lsm.md
+++ b/docs/internals/lsm.md
@@ -1,3 +1,7 @@
+# LSM
+
+Documentation for (roughly) code in the `src/lsm` directory.
+
 # Glossary
 
 - _bar_/_measure_: `lsm_batch_multiple` beats; unit of incremental compaction.

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -1,3 +1,7 @@
+# Testing
+
+Documentation for (roughly) code in the `src/testing` directory.
+
 ## VOPR Output
 
 ### Columns

--- a/docs/internals/vsr.md
+++ b/docs/internals/vsr.md
@@ -1,3 +1,7 @@
+# VSR
+
+Documentation for (roughly) code in the `src/vsr` directory.
+
 # Glossary
 
 - _checkpoint_: Ensure that all updates from the past wrap of the WAL are durable in the _grid_, then advance the replica's recovery point by updating the superblock. After a checkpoint, the checkpointed WAL entries are safe to be overwritten by the next wrap. (Sidenote: in consensus literature this is sometimes called snapshotting. But we use that term to mean something else.)


### PR DESCRIPTION
Here's what this will look like on the docs site.

<img width="1354" alt="image" src="https://github.com/tigerbeetledb/tigerbeetle/assets/3925912/d62b2ada-1ac5-4764-afbc-64eeccce5fd7">

* [x] I am very sure this PR could not affect performance.
