### PR TITLE
vsr: head can be recovered in an idle cluster 

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1704,7 +1704,7 @@ pub fn ReplicaType(
             assert(message.header.op - message.header.commit <=
                 constants.pipeline_prepare_queue_max);
 
-            if (message.header.view == self.log_view and message.header.op <= self.op) {
+            if (message.header.view == self.log_view and message.header.op < self.op) {
                 // We were already in this view prior to receiving the SV.
                 assert(self.status == .normal or self.status == .recovering_head);
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -609,9 +609,10 @@ test "Cluster: repair: crash, corrupt committed pipeline op, repair it, view-cha
     try expectEqual(b1.status(), .recovering_head);
     t.run();
 
-    a0.stop();
     b1.pass_all(.R_, .bidirectional);
     b2.pass_all(.R_, .bidirectional);
+    a0.stop();
+    a0.drop_all(.R_, .outgoing);
     t.run();
 
     // The cluster is stuck trying to repair op=30 (requesting the prepare).
@@ -621,6 +622,7 @@ test "Cluster: repair: crash, corrupt committed pipeline op, repair it, view-cha
     try expectEqual(b1.op_head(), 30);
 
     // A0 provides prepare=30.
+    a0.pass_all(.R_, .outgoing);
     try a0.open();
     t.run();
     try expectEqual(t.replica(.R_).status(), .normal);


### PR DESCRIPTION
When we are in `.recovering_head`, the `op == message.header.op` case
isn't necessary outdated, it tells us that our provisional op is in fact
ok. This is especially important in idle cluster, where we might not get
a fresher op.

We _could_ return here if are not in .recovering_head, but let's rather
hit the rest of assertions.
