### PR TITLE
vopr: catch replica-local bugs earlier

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -385,6 +385,7 @@ pub fn ReplicaType(
         /// 3. Crash.
         /// 4. Recover in the new checkpoint (but op_checkpoint wasn't called).
         on_checkpoint_done: ?fn (replica: *const Self) void = null,
+        on_message_sent: ?fn (replica: *const Self, message: *Message) void = null,
 
         /// The prepare message being committed.
         commit_prepare: ?*Message = null,
@@ -5939,6 +5940,10 @@ pub fn ReplicaType(
                         std.mem.sliceAsBytes(self.superblock.working.vsr_headers().slice),
                     ));
                 }
+            }
+
+            if (self.on_message_sent) |on_message_sent| {
+                on_message_sent(self, message);
             }
 
             if (replica == self.replica) {


### PR DESCRIPTION
State checker catches bug once they break cluster-wide linearizability. However not every correctness bug immediately leads to cluster divergance.

For example, if a replica forgets its prepare_ok, this might lead to erroneous truncation during a view change, but it is more likely to be just repaired over.

In this PR, we enhance the state checker to take a closer look at individual state of each replica, and prevent replicas from rolling back their commitments.

Note that we can't track this purely with asserts inside the replica, as the invariant might be broken across restarts.

I've verified that it makes discovering problem in

https://github.com/tigerbeetledb/tigerbeetle/pull/828

more likely.