### PR TITLE
Set order of internals docs for sidebar

### DIFF
--- a/docs/internals/lsm.md
+++ b/docs/internals/lsm.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # LSM
 
 Documentation for (roughly) code in the `src/lsm` directory.

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Testing
 
 Documentation for (roughly) code in the `src/testing` directory.

--- a/docs/internals/vsr.md
+++ b/docs/internals/vsr.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # VSR
 
 Documentation for (roughly) code in the `src/vsr` directory.


### PR DESCRIPTION
For the docs.tigerbeetle.com sidebar: should be VSR, LSM, Testing.