### PR TITLE
Split {core,clients,other} pipelines

### DIFF
--- a/.github/workflows/clients-dotnet.yml
+++ b/.github/workflows/clients-dotnet.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NUGET_KEY:
-        required: true
+        required: false
     inputs:
       version:
         required: false

--- a/.github/workflows/clients-go.yml
+++ b/.github/workflows/clients-go.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       TIGERBEETLE_GO_DEPLOY_KEY:
-        required: true
+        required: false
     inputs:
       version:
         required: false

--- a/.github/workflows/clients-java.yml
+++ b/.github/workflows/clients-java.yml
@@ -62,6 +62,7 @@ jobs:
           src/clients/java/target/*.jar
           !src/clients/java/target/*javadoc.jar
           !src/clients/java/target/*sources.jar
+
     - name: Publish to the Maven Central Repository
       if: inputs.version != ''
       working-directory: src/clients/java

--- a/.github/workflows/clients-java.yml
+++ b/.github/workflows/clients-java.yml
@@ -6,13 +6,13 @@ on:
   workflow_call:
     secrets:
       MAVEN_GPG_SECRET_KEY:
-        required: true
+        required: false
       MAVEN_CENTRAL_USERNAME:
-        required: true
+        required: false
       MAVEN_CENTRAL_TOKEN:
-        required: true
+        required: false
       MAVEN_GPG_SECRET_KEY_PASSWORD:
-        required: true
+        required: false
     inputs:
       version:
         required: false

--- a/.github/workflows/clients-node.yml
+++ b/.github/workflows/clients-node.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     secrets:
       TIGERBEETLE_NODE_PUBLISH_KEY:
-        required: true
+        required: false
     inputs:
       version:
         required: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,25 +67,22 @@ jobs:
   fuzz:
     if: inputs.version == ''
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - "fuzz_ewah -- --seed 123"
-          - "fuzz_lsm_manifest_log -- --seed 123 --events-max 400"
-          - "fuzz_lsm_segmented_array -- --seed 123"
-          - "fuzz_lsm_tree -- --seed 123 --events-max 400"
-          - "fuzz_vsr_journal_format -- --seed 123"
-          - "fuzz_vsr_superblock -- --seed 123 --events-max 3"
-          - "fuzz_vsr_superblock_free_set -- --seed 123"
-          - "fuzz_vsr_superblock_quorums -- --seed 123"
-
-          # This both checks that the hash_log builds and acts as a regression test for
-          # https://github.com/tigerbeetledb/tigerbeetle/issues/404
-          - "fuzz_lsm_forest -Dhash-log-mode=create -Drelease-safe -- --seed 16319736705930193193 --events-max 10000 && zig/zig build fuzz_lsm_forest -Dhash-log-mode=check -- --seed 16319736705930193193 --events-max 10000"
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: zig/zig build ${{ matrix.target }}
+      - run: zig/zig build fuzz_ewah -- --seed 123
+      - run: zig/zig build fuzz_lsm_segmented_array -- --seed 123
+      - run: zig/zig build fuzz_lsm_tree -- --seed 123 --events-max 400
+      - run: zig/zig build fuzz_vsr_journal_format -- --seed 123
+      - run: zig/zig build fuzz_vsr_superblock -- --seed 123 --events-max 3
+      - run: zig/zig build fuzz_vsr_superblock_quorums -- --seed 123
+
+      # Disabled for now, since they're slow.
+      # # This both checks that the hash_log builds and acts as a regression test for
+      # # https://github.com/tigerbeetledb/tigerbeetle/issues/404
+      # - run: zig/zig build fuzz_lsm_manifest_log -- --seed 123 --events-max 400
+      # - run: zig/zig build fuzz_vsr_superblock_free_set -- --seed 123
+      # - run: zig/zig build fuzz_lsm_forest -Dhash-log-mode=create -Drelease-safe -- --seed 16319736705930193193 --events-max 10000 && zig/zig build fuzz_lsm_forest -Dhash-log-mode=check -- --seed 16319736705930193193 --events-max 10000
 
   # Check some build steps that would otherwise not get checked.
   # Things like "go_client", "java_client", "dotnet_client" are excluded here
@@ -93,15 +90,15 @@ jobs:
   verify:
     if: inputs.version == ''
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: ["build_benchmark_ewah", "build_benchmark_eytzinger", "build_benchmark_segmented_array", "-Dtracer-backend=tracy"]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - run: ./scripts/install_zig.sh
-      - run: zig/zig build ${{ matrix.target }}
+      - run: zig/zig build build_benchmark_ewah
+      - run: zig/zig build build_benchmark_eytzinger
+      - run: zig/zig build build_benchmark_segmented_array
+      - run: zig/zig build -Dtracer-backend=tracy
 
   # This is just a canary to make sure that the simulator compiles
   # It would be a good idea to also _run_ a single iteration,
@@ -110,13 +107,11 @@ jobs:
   simulate:
     if: inputs.version == ''
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        state_machine: ["accounting", "testing"]
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: zig/zig build simulator -Dsimulator-state-machine=${{ matrix.state_machine }}
+      - run: zig/zig build simulator -Dsimulator-state-machine=accounting
+      - run: zig/zig build simulator -Dsimulator-state-machine=testing
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline-clients.yml
+++ b/.github/workflows/pipeline-clients.yml
@@ -5,13 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - 'main'
-
-  # Run on Merge queue
-  merge_group:
-
   # Run CI for any PRs that target 'main' when they are opened or updated.
   pull_request:
     branches:
@@ -20,26 +13,17 @@ on:
       - opened
       - synchronize
 
+  workflow_call:
+
 jobs:
   client-dotnet:
     uses: ./.github/workflows/clients-dotnet.yml
-    secrets:
-      NUGET_KEY: ${{ secrets.NUGET_KEY }}     
   client-go:
     uses: ./.github/workflows/clients-go.yml
-    secrets:
-      TIGERBEETLE_GO_DEPLOY_KEY: ${{ secrets.TIGERBEETLE_GO_DEPLOY_KEY }}
   client-java:
     uses: ./.github/workflows/clients-java.yml
-    secrets:
-      MAVEN_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_SECRET_KEY }}
-      MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-      MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-      MAVEN_GPG_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
   client-node:
     uses: ./.github/workflows/clients-node.yml
-    secrets:
-      TIGERBEETLE_NODE_PUBLISH_KEY: ${{ secrets.TIGERBEETLE_NODE_PUBLISH_KEY }}
   clients-pipeline:
     needs:
       - client-dotnet
@@ -49,6 +33,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: All CI Jobs Passed
+      - name: All Client CI Jobs Passed
         working-directory: ./
         run: exit 0

--- a/.github/workflows/pipeline-clients.yml
+++ b/.github/workflows/pipeline-clients.yml
@@ -1,4 +1,4 @@
-name: CI Pipeline
+name: Clients Pipeline
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,14 +21,6 @@ on:
       - synchronize
 
 jobs:
-  smoke:
-    uses: ./.github/workflows/smoke.yml
-  linux:
-    uses: ./.github/workflows/linux.yml
-  windows:
-    uses: ./.github/workflows/windows.yml
-  macos:
-    uses: ./.github/workflows/macos.yml
   client-dotnet:
     uses: ./.github/workflows/clients-dotnet.yml
     secrets:
@@ -48,12 +40,8 @@ jobs:
     uses: ./.github/workflows/clients-node.yml
     secrets:
       TIGERBEETLE_NODE_PUBLISH_KEY: ${{ secrets.TIGERBEETLE_NODE_PUBLISH_KEY }}
-  full-pipeline:
+  clients-pipeline:
     needs:
-      - smoke
-      - linux
-      - windows
-      - macos
       - client-dotnet
       - client-go
       - client-java

--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -1,0 +1,37 @@
+name: Core Pipeline
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 'main'
+
+  # Run on Merge queue
+  merge_group:
+
+  # Run CI for any PRs that target 'main' when they are opened or updated.
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  smoke:
+    uses: ./.github/workflows/smoke.yml
+  linux:
+    uses: ./.github/workflows/linux.yml
+  core-pipeline:
+    needs:
+      - smoke
+      - linux
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: All Core CI Jobs Passed
+        working-directory: ./
+        run: exit 0

--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -5,10 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - 'main'
-
   # Run on Merge queue
   merge_group:
 
@@ -19,6 +15,8 @@ on:
     types:
       - opened
       - synchronize
+
+  workflow_call:
 
 jobs:
   smoke:

--- a/.github/workflows/pipeline-other.yml
+++ b/.github/workflows/pipeline-other.yml
@@ -5,13 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - 'main'
-
-  # Run on Merge queue
-  merge_group:
-
   # Run CI for any PRs that target 'main' when they are opened or updated.
   pull_request:
     branches:
@@ -19,6 +12,8 @@ on:
     types:
       - opened
       - synchronize
+
+  workflow_call:
 
 jobs:
   windows:

--- a/.github/workflows/pipeline-other.yml
+++ b/.github/workflows/pipeline-other.yml
@@ -1,0 +1,37 @@
+name: Other Pipeline
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 'main'
+
+  # Run on Merge queue
+  merge_group:
+
+  # Run CI for any PRs that target 'main' when they are opened or updated.
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  windows:
+    uses: ./.github/workflows/windows.yml
+  macos:
+    uses: ./.github/workflows/macos.yml
+  other-pipeline:
+    needs:
+      - windows
+      - macos
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: All Other CI Jobs Passed
+        working-directory: ./
+        run: exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,28 @@
 name: "Release (latest)"
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+
+  workflow_call:
+    secrets:
+      TIGERBEETLE_NODE_PUBLISH_KEY:
+        required: true
+      NUGET_KEY:
+        required: true
+      MAVEN_GPG_SECRET_KEY:
+        required: true
+      MAVEN_CENTRAL_USERNAME:
+        required: true
+      MAVEN_CENTRAL_TOKEN:
+        required: true
+      MAVEN_GPG_SECRET_KEY_PASSWORD:
+        required: true
+      TIGERBEETLE_GO_DEPLOY_KEY:
+        required: true
+    inputs:
+      version:
+        required: false
+        type: string
 
 jobs:
   version:

--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -51,6 +51,7 @@ jobs:
   build_and_upload_binaries:
     needs: version
     strategy:
+      max-parallel: 2
       matrix:
         debug: ["", "--debug"]
         target: [aarch64-linux, x86_64-linux, aarch64-macos, x86_64-macos, x86_64-windows]
@@ -87,7 +88,6 @@ jobs:
           "https://uploads.github.com/repos/tigerbeetledb/tigerbeetle/releases/$RELEASE_ID/assets?name=tigerbeetle-${{ matrix.target }}-${GIT_TAG}${{ matrix.debug }}.zip"
 
   # Publish all clients and Docker image.
-
   client-dotnet:
     needs: version
     uses: ./.github/workflows/clients-dotnet.yml

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -17,6 +17,8 @@ fi
 PORT=3001
 if command -v python &> /dev/null; then
     PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+elif command -v python3 &> /dev/null; then
+    PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 fi
 
 COLOR_RED='\033[1;31m'

--- a/scripts/tests_on_alpine.sh
+++ b/scripts/tests_on_alpine.sh
@@ -6,5 +6,4 @@ docker run --entrypoint sh -v "$(pwd)":/wrk -w /wrk alpine -c "
 set -e
 ./scripts/install_zig.sh
 zig/zig build test
-./scripts/install.sh
 "

--- a/scripts/tests_on_ubuntu.sh
+++ b/scripts/tests_on_ubuntu.sh
@@ -10,5 +10,4 @@ apt-get install -y curl xz-utils
 
 ./scripts/install_zig.sh
 zig/zig build test
-./scripts/install.sh
 "


### PR DESCRIPTION
The splits out our single CI pipeline into 3, `core`, `clients`, and `other` (Windows & macOS).

If you open a PR:
* All pipelines runs, however, only `core` is a blocker for merging.

You add a PR to the merge 
* Only `core` runs again on the merge queue (eg, no point running `clients` / `other` since if they fail they wouldn't block the merge anyhow)

Your merge queue passes, and the changes are now on main:
* A new pipeline, `main` now runs. This runs all 3 pipelines (`core`, `clients`, `other`) and if they all pass, then runs the `release` pipeline. (technically, `core` could be skipped here)

On PRs, the others still run and report failures - so you can wait for them before merging if you wish. This needs to be combined with a change to `Status checks that are required` on the repo settings to only require `core-pipeline`. It also cuts concurrency down a bit on the `core` pipeline.

`core` currently takes ~5 minutes, and should be much less prone to flakes than the others.