### PR TITLE
vopr: fix false error

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5942,14 +5942,13 @@ pub fn ReplicaType(
                 }
             }
 
-            if (self.on_message_sent) |on_message_sent| {
-                on_message_sent(self, message);
-            }
-
             if (replica == self.replica) {
                 assert(self.loopback_queue == null);
                 self.loopback_queue = message.ref();
             } else {
+                if (self.on_message_sent) |on_message_sent| {
+                    on_message_sent(self, message);
+                }
                 self.message_bus.send_message_to_replica(replica, message);
             }
         }


### PR DESCRIPTION
See VOPR seed in https://github.com/tigerbeetledb/tigerbeetle/pull/843#issuecomment-1578337066

We debugged this live on Twitch!

The problem was around replica=0, view=65, op=70.

A0 is the primary for 65 and it crashed in the middle of view change.

Specifically, the following happened:

- A0 recevied a quorum of DVC messages.
- A0 updated its log_view
- A0 send prepare_ok for view=65 op=70 to itself
- A0 crashed before log_view_durable update

- A0 restarts, again in view=65
- its op is 69, from DVC headers