### PR TITLE
VSR/ClientSessions: Fix backwards assert

### DIFF
--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -221,7 +221,7 @@ pub const ClientSessions = struct {
             const existing = &client_sessions.entries[entry_index];
             assert(existing.session == session);
             assert(existing.header.client == client);
-            assert(existing.header.commit > header.commit);
+            assert(existing.header.commit < header.commit);
 
             existing.header = header.*;
             return ReplySlot{ .index = entry_index };


### PR DESCRIPTION
Eviction is still not tested (b/c client panics), so this wasn't caught.