### PR TITLE
[stdx][perf] div_ceil alternative implementation.

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -21,8 +21,7 @@ pub inline fn div_ceil(numerator: anytype, denominator: anytype) @TypeOf(numerat
 
     assert(denominator > 0);
 
-    if (numerator == 0) return 0;
-    return @divFloor(numerator - 1, denominator) + 1;
+    return @divFloor(numerator - 1 + denominator, denominator);
 }
 
 test "div_ceil" {


### PR DESCRIPTION
In C++ this leads to a more [efficient assembly](https://godbolt.org/z/f35PrfP76) and [~30% faster execution](https://quick-bench.com/q/om3CRcHNHO7hQld5mZaJRxPoM4w).

The disadvantage of this approach is that unlike previous implementation it can overflow if `nominator - 1 + denominator` is greater than the largest possible int value. Whether it matters or not for your workloads is up to you, so feel free to
- add additional parameter to control which version to use
- add extra asserts detecting this overflow
- reject the PR