### PR TITLE
VSR: op_certain=false when op_checkpoint is faulty

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4355,6 +4355,11 @@ pub fn ReplicaType(
             // slot may have originally been op that is a wrap ahead.
             if (self.journal.faulty.bit(slot_op_head)) return false;
 
+            // If faulty, this slot may hold either:
+            // - op=op_checkpoint, or
+            // - op=op_checkpoint_trigger
+            if (self.journal.faulty.bit(slot_op_checkpoint)) return false;
+
             const slot_known_range = vsr.SlotRange{
                 .head = slot_op_checkpoint,
                 .tail = slot_op_head,


### PR DESCRIPTION
Fixes https://github.com/tigerbeetledb/tigerbeetle/issues/869. (Note that the seed is from the [state sync](https://github.com/tigerbeetledb/tigerbeetle/pull/834) branch, but it is unrelated to state sync.)

In the above seed, the `StateChecker` fails at:

    if (replica.status != .recovering_head) {
        const head_max = &state_checker.replica_head_max[replica_index];
        assert(replica.view > head_max.view or
            (replica.view == head_max.view and replica.op >= head_max.op));
    }

with:

    head_max.view=1
    head_max.op=123 ← We acked op 123.
    replica.view=1
    replica.op=122  ← But after recovering, our head op has backtracked!

The replica recovers with `op_checkpoint=59`.
Its logs just before the failure:

    [warn] (journal): 0: recover_slot: recovered slot=0051 label=@C decision=vsr command=Command.reserved op=51
    [debug] (journal): 0: recover_slot: recovered slot=0052 label=@M decision=eql command=Command.prepare op=116
    [warn] (journal): 0: recover_slot: recovered slot=0053 label=@C decision=vsr command=Command.reserved op=53
    [debug] (journal): 0: recover_slot: recovered slot=0054 label=@M decision=eql command=Command.prepare op=118
    [debug] (journal): 0: recover_slot: recovered slot=0055 label=@M decision=eql command=Command.prepare op=119
    [debug] (journal): 0: recover_slot: recovered slot=0056 label=@M decision=eql command=Command.prepare op=120
    [debug] (journal): 0: recover_slot: recovered slot=0057 label=@M decision=eql command=Command.prepare op=121
    [debug] (journal): 0: recover_slot: recovered slot=0058 label=@M decision=eql command=Command.prepare op=122
    [warn] (journal): 0: recover_slot: recovered slot=0059 label=@C decision=vsr command=Command.reserved op=59
    [debug] (journal): 0: recover_slot: recovered slot=0060 label=@M decision=eql command=Command.prepare op=60
    [debug] (journal): 0: recover_slot: recovered slot=0061 label=@M decision=eql command=Command.prepare op=61
    [debug] (journal): 0: recover_slot: recovered slot=0062 label=@M decision=eql command=Command.prepare op=62
    [debug] (journal): 0: recover_slot: recovered slot=0063 label=@M decision=eql command=Command.prepare op=63
    [debug] (journal): 0: recover_slots: dirty=5 faulty=5
    [debug] (replica): 0: transition_to_normal_from_recovering_status: view=1 backup

op=122 is the highest (intact) op in the WAL.
op=59 is the checkpoint op. The prepare is corrupt; we only have the header.

slot=59's corruption is hiding op=123, our true op head.

We recovered into `status=normal`, but we should be in `status=recovering_head` – slot 59 can either hold op=59 (`op_checkpoint`) *or* (as is actually the case here) op=123 (`op_checkpoint_trigger`).