### PR TITLE
vopr: liveness checking

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -22,6 +22,7 @@ const StateMachine = Cluster.StateMachine;
 const Failure = @import("testing/cluster.zig").Failure;
 const PartitionMode = @import("testing/packet_simulator.zig").PartitionMode;
 const PartitionSymmetry = @import("testing/packet_simulator.zig").PartitionSymmetry;
+const Core = @import("testing/cluster/network.zig").Network.Core;
 const ReplySequence = @import("testing/reply_sequence.zig").ReplySequence;
 const IdPermutation = @import("testing/id.zig").IdPermutation;
 const Message = @import("message_pool.zig").MessagePool.Message;
@@ -237,23 +238,55 @@ pub fn main() !void {
     var simulator = try Simulator.init(allocator, random, simulator_options);
     defer simulator.deinit(allocator);
 
-    const ticks_max = 50_000_000;
+    // Safety: replicas crash and restart; at any given point in time arbitrary many replicas may be
+    // crashed, but each replica restarts eventually. The cluster must process all requests without
+    // split-brain.
+    const ticks_max_requests = 5_000_000;
     var tick: u64 = 0;
-    while (tick < ticks_max) : (tick += 1) {
+    while (tick < ticks_max_requests) : (tick += 1) {
+        const requests_replied_old = simulator.requests_replied;
         simulator.tick();
-        if (simulator.done()) break;
+        if (simulator.requests_replied > requests_replied_old) {
+            tick = 0;
+        }
+        if (simulator.requests_replied == simulator.options.requests_max) {
+            break;
+        }
     } else {
         output.info("no liveness, final cluster state:", .{});
         simulator.cluster.log_cluster();
         output.err("you can reproduce this failure with seed={}", .{seed});
         fatal(.liveness, "unable to complete requests_committed_max before ticks_max", .{});
     }
+
+    simulator.transition_to_liveness_mode();
+
+    // Liveness: a core set of replicas is up and fully connected. The rest of replicas might be
+    // crashed or partitioned permanently. The core should converge to the same state.
+    const ticks_max_convergence = 5_000_000;
+    tick = 0;
+    while (tick < ticks_max_convergence) : (tick += 1) {
+        simulator.tick();
+        if (simulator.done()) {
+            break;
+        }
+    } else {
+        output.info("no liveness, final cluster state (core={b})", .{simulator.core.mask});
+        simulator.cluster.log_cluster();
+        output.err("you can reproduce this failure with seed={}", .{seed});
+        fatal(.liveness, "no state convergence", .{});
+    }
+
     assert(simulator.done());
 
     const commits = simulator.cluster.state_checker.commits.items;
     const last_checksum = commits[commits.len - 1].header.checksum;
-    for (simulator.cluster.aofs) |*aof| {
-        try aof.validate(last_checksum);
+    for (simulator.cluster.aofs) |*aof, replica_index| {
+        if (simulator.core.isSet(replica_index)) {
+            try aof.validate(last_checksum);
+        } else {
+            try aof.validate(null);
+        }
     }
 
     output.info("\n          PASSED ({} ticks)", .{tick});
@@ -289,9 +322,13 @@ pub const Simulator = struct {
     replica_stability: []usize,
     reply_sequence: ReplySequence,
 
+    /// Fully-connected subgraph of replicas for liveness checking.
+    core: Core = Core.initEmpty(),
+
     /// Total number of requests sent, including those that have not been delivered.
     /// Does not include `register` messages.
     requests_sent: usize = 0,
+    requests_replied: usize = 0,
     requests_idle: bool = false,
 
     pub fn init(allocator: std.mem.Allocator, random: std.rand.Random, options: Options) !Simulator {
@@ -338,18 +375,25 @@ pub const Simulator = struct {
 
     pub fn done(simulator: *const Simulator) bool {
         assert(simulator.requests_sent <= simulator.options.requests_max);
+        assert(simulator.core.count() > 0);
 
-        for (simulator.cluster.replica_health) |health| {
-            if (health == .down) return false;
+        for (simulator.cluster.replicas) |*replica| {
+            if (simulator.core.isSet(replica.replica)) {
+                if (!simulator.cluster.state_checker.replica_convergence(replica.replica)) {
+                    return false;
+                }
+            }
         }
 
-        if (!simulator.cluster.state_checker.convergence()) return false;
+        simulator.cluster.state_checker.assert_cluster_convergence();
+
         if (!simulator.reply_sequence.empty()) return false;
         if (simulator.requests_sent < simulator.options.requests_max) return false;
 
         for (simulator.cluster.clients) |*client| {
             if (client.request_queue.count > 0) return false;
         }
+        assert(simulator.requests_replied == simulator.requests_sent);
         return true;
     }
 
@@ -360,6 +404,27 @@ pub const Simulator = struct {
         simulator.cluster.tick();
         simulator.tick_requests();
         simulator.tick_crash();
+    }
+
+    pub fn transition_to_liveness_mode(simulator: *Simulator) void {
+        simulator.core = random_core(
+            simulator.random,
+            simulator.options.cluster.replica_count,
+            simulator.options.cluster.standby_count,
+        );
+        log_simulator.debug("transition_to_liveness_mode: core={b}", .{simulator.core.mask});
+
+        var it = simulator.core.iterator(.{});
+        while (it.next()) |replica_index| {
+            const fault = false;
+            if (simulator.cluster.replica_health[replica_index] == .down) {
+                simulator.restart_replica(@intCast(u8, replica_index), fault);
+            }
+        }
+
+        simulator.cluster.network.transition_to_liveness_mode(simulator.core);
+        simulator.options.replica_crash_probability = 0;
+        simulator.options.replica_restart_probability = 0;
     }
 
     fn on_cluster_reply(
@@ -394,6 +459,7 @@ pub const Simulator = struct {
             });
 
             if (commit.request.header.operation != .register) {
+                simulator.requests_replied += 1;
                 simulator.workload.on_reply(
                     commit.client_index,
                     commit.reply.header.operation,
@@ -511,36 +577,44 @@ pub const Simulator = struct {
                     }
 
                     const fault = recoverable_count > recoverable_count_min or replica.standby();
-                    if (!fault) {
-                        // The journal writes redundant headers of faulty ops as zeroes to ensure
-                        // that they remain faulty after a crash/recover. Since that fault cannot
-                        // be disabled by `storage.faulty`, we must manually repair it here to
-                        // ensure a cluster cannot become stuck in status=recovering_head.
-                        // See recover_slots() for more detail.
-                        const offset = vsr.Zone.wal_headers.offset(0);
-                        const size = vsr.Zone.wal_headers.size().?;
-                        const headers_bytes = replica_storage.memory[offset..][0..size];
-                        const headers = mem.bytesAsSlice(vsr.Header, headers_bytes);
-                        for (headers) |*h, slot| {
-                            if (h.checksum == 0) h.* = replica_storage.wal_prepares()[slot].header;
-                        }
-                    }
-
-                    log_simulator.debug("{}: restart replica (faults={})", .{
-                        replica.replica,
-                        fault,
-                    });
-
-                    replica_storage.faulty = fault;
-                    simulator.cluster.restart_replica(replica.replica) catch unreachable;
-                    assert(replica.status != .recovering_head or fault);
-
-                    replica_storage.faulty = true;
-                    simulator.replica_stability[replica.replica] =
-                        simulator.options.replica_restart_stability;
+                    simulator.restart_replica(replica.replica, fault);
                 },
             }
         }
+    }
+
+    fn restart_replica(simulator: *Simulator, replica_index: u8, fault: bool) void {
+        assert(simulator.cluster.replica_health[replica_index] == .down);
+
+        const replica_storage = &simulator.cluster.storages[replica_index];
+
+        if (!fault) {
+            // The journal writes redundant headers of faulty ops as zeroes to ensure
+            // that they remain faulty after a crash/recover. Since that fault cannot
+            // be disabled by `storage.faulty`, we must manually repair it here to
+            // ensure a cluster cannot become stuck in status=recovering_head.
+            // See recover_slots() for more detail.
+            const offset = vsr.Zone.wal_headers.offset(0);
+            const size = vsr.Zone.wal_headers.size().?;
+            const headers_bytes = replica_storage.memory[offset..][0..size];
+            const headers = mem.bytesAsSlice(vsr.Header, headers_bytes);
+            for (headers) |*h, slot| {
+                if (h.checksum == 0) h.* = replica_storage.wal_prepares()[slot].header;
+            }
+        }
+
+        log_simulator.debug("{}: restart replica (faults={})", .{
+            replica_index,
+            fault,
+        });
+
+        replica_storage.faulty = fault;
+        simulator.cluster.restart_replica(replica_index) catch unreachable;
+        assert(simulator.cluster.replicas[replica_index].status != .recovering_head or fault);
+
+        replica_storage.faulty = true;
+        simulator.replica_stability[replica_index] =
+            simulator.options.replica_restart_stability;
     }
 };
 
@@ -579,6 +653,46 @@ fn random_partition_symmetry(random: std.rand.Random) PartitionSymmetry {
     const typeInfo = @typeInfo(PartitionSymmetry).Enum;
     var enumAsInt = random.uintAtMost(typeInfo.tag_type, typeInfo.fields.len - 1);
     return @intToEnum(PartitionSymmetry, enumAsInt);
+}
+
+/// Returns a random fully-connected subgraph which includes at least view change
+/// quorum of active replicas.
+fn random_core(random: std.rand.Random, replica_count: u8, standby_count: u8) Core {
+    assert(replica_count > 0);
+    assert(replica_count <= constants.replicas_max);
+    assert(standby_count <= constants.standbys_max);
+
+    const quorum_view_change = vsr.quorums(replica_count).view_change;
+    const replica_core_count = random.intRangeAtMost(u8, quorum_view_change, replica_count);
+    const standby_core_count = random.intRangeAtMost(u8, 0, standby_count);
+
+    var result: Core = Core.initEmpty();
+
+    var need = replica_core_count;
+    var left = replica_count;
+    var replica: u8 = 0;
+    while (replica < replica_count + standby_count) : (replica += 1) {
+        if (random.uintLessThan(u8, left) < need) {
+            result.set(replica);
+            need -= 1;
+        }
+        left -= 1;
+
+        if (replica == replica_count - 1) {
+            // Having selected active replicas, switch to selection of standbys.
+            assert(left == 0);
+            assert(need == 0);
+            assert(result.count() == replica_core_count);
+            assert(result.count() >= quorum_view_change);
+            left = standby_count;
+            need = standby_core_count;
+        }
+    }
+    assert(left == 0);
+    assert(need == 0);
+    assert(result.count() == replica_core_count + standby_core_count);
+
+    return result;
 }
 
 pub fn parse_seed(bytes: []const u8) u64 {

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -48,6 +48,14 @@ pub const Network = struct {
         target: Process,
     };
 
+    /// Core is a strongly-connected component of replicas containing a view change quorum.
+    /// It is used to define and check liveness --- if a core exists, it should converge
+    /// to normal status in a bounded number of ticks.
+    ///
+    /// At the moment, we require core members to have direct bidirectional connectivity, but this
+    /// could be relaxed in the future to indirect connectivity.
+    pub const Core = std.StaticBitSet(constants.nodes_max);
+
     allocator: std.mem.Allocator,
 
     options: NetworkOptions,
@@ -124,6 +132,26 @@ pub const Network = struct {
 
     pub fn tick(network: *Network) void {
         network.packet_simulator.tick();
+    }
+
+    pub fn transition_to_liveness_mode(network: *Network, core: Core) void {
+        network.packet_simulator.options.packet_loss_probability = 0;
+        network.packet_simulator.options.packet_replay_probability = 0;
+        network.packet_simulator.options.partition_probability = 0;
+        network.packet_simulator.options.unpartition_probability = 0;
+
+        var it_source = core.iterator(.{});
+        while (it_source.next()) |replica_source| {
+            var it_target = core.iterator(.{});
+            while (it_target.next()) |replica_target| {
+                if (replica_target != replica_source) {
+                    network.link_filter(.{
+                        .source = .{ .replica = @intCast(u8, replica_source) },
+                        .target = .{ .replica = @intCast(u8, replica_target) },
+                    }).* = LinkFilter.initFull();
+                }
+            }
+        }
     }
 
     pub fn link(network: *Network, process: Process, message_bus: *MessageBus) void {

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -135,6 +135,8 @@ pub const Network = struct {
     }
 
     pub fn transition_to_liveness_mode(network: *Network, core: Core) void {
+        assert(core.count() > 0);
+
         network.packet_simulator.options.packet_loss_probability = 0;
         network.packet_simulator.options.packet_replay_probability = 0;
         network.packet_simulator.options.partition_probability = 0;

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -166,16 +166,14 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             state_checker.commits.items[header_b.?.op].replicas.set(replica_index);
         }
 
-        pub fn convergence(state_checker: *Self) bool {
+        pub fn replica_convergence(state_checker: *Self, replica_index: u8) bool {
             const a = state_checker.commits.items.len - 1;
-            for (state_checker.commit_mins[0..state_checker.replica_count]) |b| {
-                if (b != a) {
-                    return false;
-                }
-            }
+            const b = state_checker.commit_mins[replica_index];
+            return a == b;
+        }
 
+        pub fn assert_cluster_convergence(state_checker: *Self) void {
             for (state_checker.commits.items) |commit, i| {
-                assert(commit.replicas.count() == state_checker.replica_count);
                 assert(commit.header.command == .prepare);
                 assert(commit.header.op == i);
                 if (i > 0) {
@@ -184,7 +182,6 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                     assert(commit.header.view >= previous.view);
                 }
             }
-            return true;
         }
     };
 }

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -174,6 +174,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
 
         pub fn assert_cluster_convergence(state_checker: *Self) void {
             for (state_checker.commits.items) |commit, i| {
+                assert(commit.replicas.count() > 0);
                 assert(commit.header.command == .prepare);
                 assert(commit.header.op == i);
                 if (i > 0) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4252,7 +4252,7 @@ pub fn ReplicaType(
 
         /// Returns whether the replica is the primary for the current view.
         /// This may be used only when the replica status is normal.
-        fn primary(self: *const Self) bool {
+        pub fn primary(self: *const Self) bool {
             assert(self.status == .normal);
             return self.primary_index(self.view) == self.replica;
         }


### PR DESCRIPTION
This allows VOPR to catch more liveness bugs, using fewer tick.

The idea is to split simulator run into two phases, safety and liveness.

The "safety" phase is almost exactly as the previous implementation. The only difference is that we have a (small) tick budget to process a single request, rather than a large budget for the whole run.

The "liveness" phase is different --- we designate a subset of replicas, "core", and make sure they are up & connected. For other replicas, we "freeze" their current failure mode. Eg, if a non-core replica is crashed, it remains crashed forever. This is in contrast to safety phase, where each replica is eventually available.