### PR TITLE
vsr: assert that BlockRequest's padding is zero

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2065,6 +2065,8 @@ pub fn ReplicaType(
             assert(requests.len > 0);
 
             request_loop: for (requests) |*request, i| {
+                for (std.mem.bytesAsSlice(u64, &request.reserved)) |word| assert(word == 0);
+
                 if (self.grid.faulty(request.block_address, null)) {
                     log.warn("{}: on_request_blocks: ignoring block request; faulty " ++
                         "(replica={} address={} checksum={})", .{


### PR DESCRIPTION
~~We could also check this in `invalid_request_blocks`, but I'd rather not waste CPU cache for flipping through the memory twice.~~ nevermind, we can only assert it here. 

