### PR TITLE
vopr: relax liveness check

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -444,13 +444,14 @@ pub const Simulator = struct {
                 replica.status == .normal and replica.primary() and
                 !simulator.core.isSet(replica.replica))
             {
-                // `replica` considers itself a primary, check that the core thinks so as well.
+                // `replica` considers itself a primary, check that at least part of the core thinks
+                // so as well.
                 var it = simulator.core.iterator(.{});
                 while (it.next()) |replica_core_index| {
-                    if (simulator.cluster.replicas[replica_core_index].view != replica.view) {
-                        break;
+                    if (simulator.cluster.replicas[replica_core_index].view == replica.view) {
+                        return true;
                     }
-                } else return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
If a primary is partially connected to the core, replicas in the core
might be in different views, when a replica partitioned from the primary
ends up in an _earlier_ view. It won't view jump because it doesn't
receive commits from the primary, and it won't DVC itself, because it'll
fail to collect an SVC quorum.