### PR TITLE
vsr: cleanups

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -247,6 +247,16 @@ comptime {
     assert(view_change_headers_max > view_change_headers_suffix_max);
 }
 
+/// The maximum number of headers to include with a response to a command=request_headers message.
+pub const request_headers_max = std.math.min(
+    @divFloor(message_body_size_max, @sizeOf(vsr.Header)),
+    64,
+);
+
+comptime {
+    assert(request_headers_max > 0);
+}
+
 /// The maximum number of block addresses/checksums requested by a single command=request_blocks.
 pub const grid_repair_request_max = config.process.grid_repair_request_max;
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3318,9 +3318,9 @@ pub fn ReplicaType(
                 });
             } else {
                 if (reply.header.operation == .register) {
-                    self.create_client_table_entry(reply);
+                    self.client_table_entry_create(reply);
                 } else {
-                    self.update_client_table_entry(reply);
+                    self.client_table_entry_update(reply);
                 }
             }
 
@@ -3366,7 +3366,7 @@ pub fn ReplicaType(
         /// Creates an entry in the client table when registering a new client session.
         /// Asserts that the new session does not yet exist.
         /// Evicts another entry deterministically, if necessary, to make space for the insert.
-        fn create_client_table_entry(self: *Self, reply: *Message) void {
+        fn client_table_entry_create(self: *Self, reply: *Message) void {
             assert(reply.header.command == .reply);
             assert(reply.header.operation == .register);
             assert(reply.header.client > 0);
@@ -3399,7 +3399,7 @@ pub fn ReplicaType(
 
                 assert(self.client_sessions().count() == constants.clients_max - 1);
 
-                log.err("{}: create_client_table_entry: clients={}/{} evicting client={}", .{
+                log.err("{}: client_table_entry_create: clients={}/{} evicting client={}", .{
                     self.replica,
                     clients,
                     constants.clients_max,
@@ -3407,7 +3407,7 @@ pub fn ReplicaType(
                 });
             }
 
-            log.debug("{}: create_client_table_entry: write (client={} session={} request={})", .{
+            log.debug("{}: client_table_entry_create: write (client={} session={} request={})", .{
                 self.replica,
                 reply.header.client,
                 session,
@@ -6791,7 +6791,7 @@ pub fn ReplicaType(
             self.send_do_view_change();
         }
 
-        fn update_client_table_entry(self: *Self, reply: *Message) void {
+        fn client_table_entry_update(self: *Self, reply: *Message) void {
             assert(reply.header.command == .reply);
             assert(reply.header.operation != .register);
             assert(reply.header.client > 0);
@@ -6812,7 +6812,7 @@ pub fn ReplicaType(
                 // TODO Use this reply's prepare to cross-check against the entry's prepare, if we
                 // still have access to the prepare in the journal (it may have been snapshotted).
 
-                log.debug("{}: update_client_table_entry: client={} session={} request={}", .{
+                log.debug("{}: client_table_entry_update: client={} session={} request={}", .{
                     self.replica,
                     reply.header.client,
                     entry.session,


### PR DESCRIPTION
The first three commits just move/rename code around so that we don't have `(create|update)_client_table_entry` in completely different sections of the file. 

The last commit is a simple, but non-trivial refactor, is probably best reviewed separately (it is a part of this PR because, after code motions, `copy_latest_headers_and_set_size` seemed out of place, and the best place for that turned out to be no place at all). 

