### PR TITLE
state_machine: add missing alignment attributes

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -338,7 +338,7 @@ pub fn StateMachineType(
         }
 
         /// Updates `prepare_timestamp` to the highest timestamp of the response.
-        pub fn prepare(self: *StateMachine, operation: Operation, input: []u8) void {
+        pub fn prepare(self: *StateMachine, operation: Operation, input: []align(16) u8) void {
             self.prepare_timestamp += switch (operation) {
                 .create_accounts => mem.bytesAsSlice(Account, input).len,
                 .create_transfers => mem.bytesAsSlice(Transfer, input).len,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -102,7 +102,7 @@ pub fn StateMachineType(
         pub fn prepare(
             state_machine: *StateMachine,
             operation: Operation,
-            input: []u8,
+            input: []align(16) u8,
         ) void {
             _ = state_machine;
             _ = operation;
@@ -114,7 +114,7 @@ pub fn StateMachineType(
             callback: fn (*StateMachine) void,
             op: u64,
             operation: Operation,
-            input: []const u8,
+            input: []align(16) const u8,
         ) void {
             _ = op;
             _ = operation;
@@ -143,8 +143,8 @@ pub fn StateMachineType(
             op: u64,
             timestamp: u64,
             operation: Operation,
-            input: []const u8,
-            output: []u8,
+            input: []align(16) const u8,
+            output: *align(16) [constants.message_body_size_max]u8,
         ) usize {
             _ = client;
             assert(op != 0);

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -21,6 +21,7 @@ pub const Account = extern struct {
     comptime {
         assert(@sizeOf(Account) == 128);
         assert(@bitSizeOf(Account) == @sizeOf(Account) * 8);
+        assert(@alignOf(Account) == 16);
     }
 
     pub fn debits_exceed_credits(self: *const Account, amount: u64) bool {
@@ -76,6 +77,7 @@ pub const Transfer = extern struct {
     comptime {
         assert(@sizeOf(Transfer) == 128);
         assert(@bitSizeOf(Transfer) == @sizeOf(Transfer) * 8);
+        assert(@alignOf(Transfer) == 16);
     }
 };
 


### PR DESCRIPTION
It's a part of state machine contract that it operates on well-aligned buffers.