### PR TITLE
vopr: disable livenss checking with many faults

### DIFF
--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -184,5 +184,12 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 }
             }
         }
+
+        pub fn header_with_op(state_checker: *Self, op: u64) vsr.Header {
+            const commit = &state_checker.commits.items[op];
+            assert(commit.header.op == op);
+            assert(commit.replicas.count() > 0);
+            return commit.header;
+        }
     };
 }


### PR DESCRIPTION
With the addition of core/liveness checking logic, it became possible for cluster to fail to converge if a prepare is available only outside the core.

In theory, we _could_ patch FaultAtlas to not put too many faults into the core, but that's a bit complicated, and also makes faults less interesting.

Instead, here we allow FaultAtlas to fault whatever, and then check, at the end, that, if we are not live, there indeed exists a prepare which is faulty in core.

We don't assert that we have this prepare outside of the core for two reasons:

* Some replicas might be down and might not have a journal to consult at all.
* Ideally, we'd allow simulator to corrupt all copies of prepare, to have extra checking that we remain unavailable in this case

However, we do verify that the state_checker is aware about the prepare, which means that we check that the prepare was committed at one point, which implies that we had appropriate durability at some point.