### PR TITLE
[Dotnet client] Disable UseCurrentRuntimeIdentifier.

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
+++ b/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -2,11 +2,12 @@
   <Import Project="TigerBeetle.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <Platforms>AnyCPU</Platforms>
+    <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>TigerBeetle</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This `.csproj` setting forced the assembly to be compiled with the target's machine RID (runtime identifier).
Since our CI runs on x64, the Nuget package was distributed with x64-only binaries, failing on aarch64 (MacOS M1).

This fix sets `UseCurrentRuntimeIdentifier=false` and explicitly sets the MSIL output to `AnyCPU`, allowing the pre-built binary to run in any platform dotnet supports, limited only by the target list of the native client dependency: `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64` and `win-x64`.

Closes #929