### PR TITLE
LSM Compaction: Removing table_count from Manifest.CompactionRange.

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -256,10 +256,6 @@ pub fn CompactionType(
                 @src(),
             );
 
-            // context.range_b.tables holds references to the tables in Level B that intersect
-            // with the optimal compaction table in Level A. The move-table optimization can
-            // be applied if the optimal compaction table in Level A does not intersect with any
-            // table in Level B.
             const move_table =
                 context.table_info_a == .disk and
                 context.range_b.tables.len == 0;
@@ -279,7 +275,7 @@ pub fn CompactionType(
             const grid_reservation = if (move_table)
                 null
             else
-                // We add 1 to account for the optimal compaction table from Level A.
+                // +1 to count the input table from level A.
                 context.grid.reserve(
                     (context.range_b.tables.len + 1) * Table.block_count_max,
                 ).?;

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -127,8 +127,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         };
 
         pub const CompactionRange = struct {
-            /// The total number of tables in the compaction across both levels, always at least 1.
-            table_count: usize,
             /// The minimum key across both levels.
             key_min: Key,
             /// The maximum key across both levels.
@@ -443,10 +441,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             const compaction_table_range = CompactionTableRange{
                 .table_a = least_overlap_table.table,
                 .range_b = CompactionRange{
-                    // The range.table_count includes the input table from
-                    // level A represented by key_min/max. Thus, range.table_count=1
-                    // means that the table may be moved directly between levels.
-                    .table_count = least_overlap_table.range.tables.len + 1,
                     .key_min = least_overlap_table.range.key_min,
                     .key_max = least_overlap_table.range.key_max,
                     .tables = least_overlap_table.range.tables,
@@ -481,10 +475,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             assert(compare_keys(range.key_max, key_max) != .lt);
 
             return .{
-                // The range.table_count includes the input table from
-                // level A represented by key_min/max. Thus, range.table_count=1
-                // means that the table may be moved directly between levels.
-                .table_count = range.tables.len + 1,
                 .key_min = range.key_min,
                 .key_max = range.key_max,
                 .tables = range.tables,
@@ -498,7 +488,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             range: CompactionRange,
         ) bool {
             assert(level_b < constants.lsm_levels);
-            assert(range.table_count > 0);
             assert(compare_keys(range.key_min, range.key_max) != .gt);
 
             var level_c: u8 = level_b + 1;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -683,9 +683,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 tree.table_immutable.key_max(),
             );
 
-            // range_b.tables holds references to the tables in Level B that intersect
-            // with the optimal compaction table in Level A. We add 1 to account for the optimal
-            // compaction table.
+            // +1 to count the input table from level A.
             assert(range_b.tables.len + 1 <= compaction_tables_input_max);
             assert(compare_keys(range_b.key_min, tree.table_immutable.key_min()) != .gt);
             assert(compare_keys(range_b.key_max, tree.table_immutable.key_max()) != .lt);


### PR DESCRIPTION
_Manifest.CompactionRange.table_count_ can be removed as _Manifest.CompactionRange.tables_ holds references to the tables in Level B that intersect with the optimal compaction table in Level A.