### PR TITLE
Rename grid.alloc_block() to grid.allocate_block()

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -43,7 +43,7 @@ const constants = @import("../constants.zig");
 
 const stdx = @import("../stdx.zig");
 const GridType = @import("grid.zig").GridType;
-const alloc_block = @import("grid.zig").alloc_block;
+const allocate_block = @import("grid.zig").allocate_block;
 const TableInfoType = @import("manifest.zig").TableInfoType;
 const ManifestType = @import("manifest.zig").ManifestType;
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
@@ -175,18 +175,18 @@ pub fn CompactionType(
             var iterator_b = try LevelTableValueBlockIterator.init();
             errdefer iterator_b.deinit();
 
-            const index_block_a = try alloc_block(allocator);
+            const index_block_a = try allocate_block(allocator);
             errdefer allocator.free(index_block_a);
 
-            const index_block_b = try alloc_block(allocator);
+            const index_block_b = try allocate_block(allocator);
             errdefer allocator.free(index_block_b);
 
             var data_blocks: [2]Grid.BlockPtr = undefined;
 
-            data_blocks[0] = try alloc_block(allocator);
+            data_blocks[0] = try allocate_block(allocator);
             errdefer allocator.free(data_blocks[0]);
 
-            data_blocks[1] = try alloc_block(allocator);
+            data_blocks[1] = try allocate_block(allocator);
             errdefer allocator.free(data_blocks[1]);
 
             var table_builder = try Table.Builder.init(allocator);

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -39,7 +39,7 @@ pub const BlockType = enum(u8) {
 };
 
 // Leave this outside GridType so we can call it from modules that don't know about Storage.
-pub fn alloc_block(
+pub fn allocate_block(
     allocator: mem.Allocator,
 ) !*align(constants.sector_size) [constants.block_size]u8 {
     const block = try allocator.alignedAlloc(u8, constants.sector_size, constants.block_size);
@@ -184,7 +184,7 @@ pub fn GridType(comptime Storage: type) type {
 
             for (cache_blocks) |*cache_block, i| {
                 errdefer for (cache_blocks[0..i]) |block| allocator.free(block);
-                cache_block.* = try alloc_block(allocator);
+                cache_block.* = try allocate_block(allocator);
             }
             errdefer for (cache_blocks) |block| allocator.free(block);
 
@@ -195,7 +195,7 @@ pub fn GridType(comptime Storage: type) type {
 
             for (&read_iop_blocks) |*read_iop_block, i| {
                 errdefer for (read_iop_blocks[0..i]) |block| allocator.free(block);
-                read_iop_block.* = try alloc_block(allocator);
+                read_iop_block.* = try allocate_block(allocator);
             }
             errdefer for (&read_iop_blocks) |block| allocator.free(block);
 

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -7,7 +7,7 @@ const constants = @import("../constants.zig");
 
 const stdx = @import("../stdx.zig");
 const ManifestType = @import("manifest.zig").ManifestType;
-const alloc_block = @import("grid.zig").alloc_block;
+const allocate_block = @import("grid.zig").allocate_block;
 const GridType = @import("grid.zig").GridType;
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
 

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -33,7 +33,7 @@ const stdx = @import("../stdx.zig");
 const SuperBlockType = vsr.SuperBlockType;
 const GridType = @import("grid.zig").GridType;
 const BlockType = @import("grid.zig").BlockType;
-const alloc_block = @import("grid.zig").alloc_block;
+const allocate_block = @import("grid.zig").allocate_block;
 const tree = @import("tree.zig");
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
@@ -154,7 +154,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             var blocks: [blocks_count_max]BlockPtr = undefined;
             for (blocks) |*block, i| {
                 errdefer for (blocks[0..i]) |b| allocator.free(b);
-                block.* = try alloc_block(allocator);
+                block.* = try allocate_block(allocator);
             }
             errdefer for (blocks) |b| allocator.free(b);
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -14,7 +14,7 @@ const eytzinger = @import("eytzinger.zig").eytzinger;
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const BlockType = @import("grid.zig").BlockType;
-const alloc_block = @import("grid.zig").alloc_block;
+const allocate_block = @import("grid.zig").allocate_block;
 const TableInfoType = @import("manifest.zig").TableInfoType;
 
 pub const TableUsage = enum {
@@ -459,13 +459,13 @@ pub fn TableType(
             data_blocks_in_filter: u32 = 0,
 
             pub fn init(allocator: mem.Allocator) !Builder {
-                const index_block = try alloc_block(allocator);
+                const index_block = try allocate_block(allocator);
                 errdefer allocator.free(index_block);
 
-                const filter_block = try alloc_block(allocator);
+                const filter_block = try allocate_block(allocator);
                 errdefer allocator.free(filter_block);
 
-                const data_block = try alloc_block(allocator);
+                const data_block = try allocate_block(allocator);
                 errdefer allocator.free(data_block);
 
                 return Builder{

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -688,7 +688,6 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
             assert(compare_keys(range_b.key_min, tree.table_immutable.key_min()) != .gt);
             assert(compare_keys(range_b.key_max, tree.table_immutable.key_max()) != .lt);
 
-
             log.debug(tree_name ++
                 ": compacting immutable table to level 0 " ++
                 "(values.len={d} snapshot_min={d} compaction.op_min={d} table_count={d})", .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -17,7 +17,7 @@ const Storage = @import("../testing/storage.zig").Storage;
 const ClusterFaultAtlas = @import("../testing/storage.zig").ClusterFaultAtlas;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, constants.state_machine_config);
 const GridType = @import("grid.zig").GridType;
-const alloc_block = @import("grid.zig").alloc_block;
+const allocate_block = @import("grid.zig").allocate_block;
 const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 const TableUsage = @import("table.zig").TableUsage;
 const TableType = @import("table.zig").TableType;
@@ -164,7 +164,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             });
             defer env.grid.deinit(allocator);
 
-            env.grid_repair_block = try alloc_block(allocator);
+            env.grid_repair_block = try allocate_block(allocator);
             defer allocator.free(env.grid_repair_block);
 
             env.grid_repair_queue = GridRepairQueue.init(allocator);

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -61,13 +61,7 @@ pub fn main() !void {
 const filename_fmt = "cluster_{d:0>10}_replica_{d:0>3}.tigerbeetle";
 const filename_len = fmt.count(filename_fmt, .{ 0, 0 });
 
-const Command = struct 
-
-
-       {
-
-
-
+const Command = struct {
     dir_fd: os.fd_t,
     fd: os.fd_t,
     io: IO,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7,7 +7,7 @@ const constants = @import("../constants.zig");
 const stdx = @import("../stdx.zig");
 
 const StaticAllocator = @import("../static_allocator.zig");
-const alloc_block = @import("../lsm/grid.zig").alloc_block;
+const allocate_block = @import("../lsm/grid.zig").allocate_block;
 const GridType = @import("../lsm/grid.zig").GridType;
 const IOPS = @import("../iops.zig").IOPS;
 const MessagePool = @import("../message_pool.zig").MessagePool;
@@ -753,7 +753,7 @@ pub fn ReplicaType(
 
             for (self.grid_write_blocks) |*block, i| {
                 errdefer for (self.grid_write_blocks[0..i]) |b| allocator.free(b);
-                block.* = try alloc_block(allocator);
+                block.* = try allocate_block(allocator);
             }
             errdefer for (self.grid_write_blocks) |b| allocator.free(b);
 


### PR DESCRIPTION
Switched to this PR instead of #941 so that @ItIsOHM still gets credit but so that I could run `zig/zig fmt .` on top and collapse @ItIsOHM 's commits into one rather than including the merge commit in #941.

Closes #927 