### PR TITLE
State Machine: Optimize positive & negative prefetch by maintaining LSM Tree & Level key ranges

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -387,7 +387,12 @@ pub fn GrooveType(
 
         const primary_field = if (has_id) "id" else "timestamp";
         const PrimaryKey = @TypeOf(@field(@as(Object, undefined), primary_field));
-        const PrefetchIDs = std.AutoHashMapUnmanaged(PrimaryKey, void);
+        const PrefetchKey = struct { level: u8, kind: union(enum) {
+            id: PrimaryKey,
+            timestamp: u64,
+        } };
+
+        const PrefetchKeys = std.AutoHashMapUnmanaged(PrefetchKey, void);
 
         const PrefetchObjectsContext = struct {
             pub inline fn hash(_: PrefetchObjectsContext, object: Object) u64 {
@@ -421,7 +426,7 @@ pub fn GrooveType(
         /// Prefetching ensures that point lookups against the latest snapshot are synchronous.
         /// This shields state machine implementations from the challenges of concurrency and I/O,
         /// and enables simple state machine function signatures that commit writes atomically.
-        prefetch_ids: PrefetchIDs,
+        prefetch_keys: PrefetchKeys,
 
         /// The prefetched Objects. This hash map holds the subset of objects in the LSM trees
         /// that are required for the current commit. All get()/put()/remove() operations during
@@ -499,9 +504,9 @@ pub fn GrooveType(
                 index_trees_initialized += 1;
             }
 
-            var prefetch_ids = PrefetchIDs{};
-            try prefetch_ids.ensureTotalCapacity(allocator, options.prefetch_entries_max);
-            errdefer prefetch_ids.deinit(allocator);
+            var prefetch_keys = PrefetchKeys{};
+            try prefetch_keys.ensureTotalCapacity(allocator, options.prefetch_entries_max);
+            errdefer prefetch_keys.deinit(allocator);
 
             var prefetch_objects = PrefetchObjects{};
             try prefetch_objects.ensureTotalCapacity(allocator, options.prefetch_entries_max);
@@ -512,7 +517,7 @@ pub fn GrooveType(
                 .ids = id_tree,
                 .indexes = index_trees,
 
-                .prefetch_ids = prefetch_ids,
+                .prefetch_keys = prefetch_keys,
                 .prefetch_objects = prefetch_objects,
                 .prefetch_snapshot = null,
             };
@@ -526,7 +531,7 @@ pub fn GrooveType(
             groove.objects.deinit(allocator);
             if (has_id) groove.ids.deinit(allocator);
 
-            groove.prefetch_ids.deinit(allocator);
+            groove.prefetch_keys.deinit(allocator);
             groove.prefetch_objects.deinit(allocator);
 
             groove.* = undefined;
@@ -539,14 +544,14 @@ pub fn GrooveType(
             groove.objects.reset();
             if (has_id) groove.ids.reset();
 
-            groove.prefetch_ids.clearRetainingCapacity();
+            groove.prefetch_keys.clearRetainingCapacity();
             groove.prefetch_objects.clearRetainingCapacity();
 
             groove.* = .{
                 .objects = groove.objects,
                 .ids = groove.ids,
                 .indexes = groove.indexes,
-                .prefetch_ids = groove.prefetch_ids,
+                .prefetch_keys = groove.prefetch_keys,
                 .prefetch_objects = groove.prefetch_objects,
                 .prefetch_snapshot = null,
             };
@@ -559,14 +564,8 @@ pub fn GrooveType(
         /// Must be called directly before the state machine begins queuing ids for prefetch.
         /// When `snapshot` is null, prefetch from the current snapshot.
         pub fn prefetch_setup(groove: *Groove, snapshot: ?u64) void {
-            // We may query the input tables of an ongoing compaction, but must not query the
-            // output tables until the compaction is complete. (Until then, the output tables may
-            // be in the manifest but not yet on disk).
-            const snapshot_max = groove.objects.lookup_snapshot_max.?;
-            assert(!has_id or snapshot_max == groove.ids.lookup_snapshot_max.?);
-
-            const snapshot_target = snapshot orelse snapshot_max;
-            assert(snapshot_target <= snapshot_max);
+            const snapshot_target = snapshot orelse snapshot_latest;
+            assert(snapshot_target <= snapshot_latest);
 
             if (groove.prefetch_snapshot == null) {
                 groove.prefetch_objects.clearRetainingCapacity();
@@ -577,37 +576,59 @@ pub fn GrooveType(
 
             groove.prefetch_snapshot = snapshot_target;
             assert(groove.prefetch_objects.count() == 0);
-            assert(groove.prefetch_ids.count() == 0);
+            assert(groove.prefetch_keys.count() == 0);
         }
 
         /// This must be called by the state machine for every key to be prefetched.
         /// We tolerate duplicate IDs enqueued by the state machine.
         /// For example, if all unique operations require the same two dependencies.
         pub fn prefetch_enqueue(groove: *Groove, key: PrimaryKey) void {
-            if (!has_id) {
-                groove.prefetch_ids.putAssumeCapacity(key, {});
-                return;
-            }
-
-            if (groove.ids.lookup_from_memory(groove.prefetch_snapshot.?, key)) |id_tree_value| {
-                if (id_tree_value.tombstone()) {
-                    // Do nothing; an explicit ID tombstone indicates that the object was deleted.
-                } else {
-                    if (groove.objects.lookup_from_memory(
-                        groove.prefetch_snapshot.?,
-                        id_tree_value.timestamp,
-                    )) |object| {
-                        assert(!ObjectTreeHelpers(Object).tombstone(object));
-                        assert(object.id == key);
-                        groove.prefetch_objects.putAssumeCapacity(object.*, {});
-                    } else {
-                        // The id was in the IdTree's value cache, but not in the ObjectTree's
-                        // value cache.
-                        groove.prefetch_ids.putAssumeCapacity(key, {});
-                    }
-                }
+            if (has_id) {
+                if (!groove.ids.key_range_contains(groove.prefetch_snapshot.?, key)) return;
+                groove.prefetch_from_memory_with_id(key);
             } else {
-                groove.prefetch_ids.putAssumeCapacity(key, {});
+                groove.prefetch_from_memory_with_timestamp(key);
+            }
+        }
+
+        /// This function attempts to prefetch a value for the given id from the IdTree's
+        /// mutable table, immutable table, and the table blocks in the grid cache.
+        /// If found in the IdTree, we attempt to prefetch a value for the timestamp.
+        /// TODO: We may have to remove this function once Fed's prefetching changes are merged,
+        /// since those changes remove lookup_from_memory.
+        fn prefetch_from_memory_with_id(groove: *Groove, id: PrimaryKey) void {
+            switch (groove.ids.lookup_from_memory(groove.prefetch_snapshot.?, id)) {
+                .does_not_exist => {},
+                .exists => |id_tree_value| {
+                    if (IdTreeValue.tombstone(id_tree_value)) return;
+                    groove.prefetch_from_memory_with_timestamp(id_tree_value.timestamp);
+                },
+                .may_exist => |level| {
+                    groove.prefetch_keys.putAssumeCapacity(.{
+                        .level = level,
+                        .kind = .{ .id = id },
+                    }, {});
+                },
+            }
+        }
+
+        /// This function attempts to prefetch a value for the timestamp from the ObjectTree's
+        /// mutable table, immutable table, and the table blocks in the grid cache.
+        /// TODO: We may have to remove this function once Fed's prefetching changes are merged,
+        /// since those changes remove lookup_from_memory.
+        fn prefetch_from_memory_with_timestamp(groove: *Groove, timestamp: u64) void {
+            switch (groove.objects.lookup_from_memory(groove.prefetch_snapshot.?, timestamp)) {
+                .does_not_exist => {},
+                .may_exist => |level| {
+                    groove.prefetch_keys.putAssumeCapacity(.{
+                        .level = level,
+                        .kind = .{ .timestamp = timestamp },
+                    }, {});
+                },
+                .exists => |object| {
+                    assert(!ObjectTreeHelpers(Object).tombstone(object));
+                    groove.prefetch_objects.putAssumeCapacity(object.*, {});
+                },
             }
         }
 
@@ -622,7 +643,7 @@ pub fn GrooveType(
                 .groove = groove,
                 .callback = callback,
                 .snapshot = groove.prefetch_snapshot.?,
-                .id_iterator = groove.prefetch_ids.keyIterator(),
+                .key_iterator = groove.prefetch_keys.keyIterator(),
             };
             groove.prefetch_snapshot = null;
             context.start_workers();
@@ -633,7 +654,7 @@ pub fn GrooveType(
             callback: *const fn (*PrefetchContext) void,
             snapshot: u64,
 
-            id_iterator: PrefetchIDs.KeyIterator,
+            key_iterator: PrefetchKeys.KeyIterator,
 
             /// The goal is to fully utilize the disk I/O to ensure the prefetch completes as
             /// quickly as possible, so we run multiple lookups in parallel based on the max
@@ -671,9 +692,9 @@ pub fn GrooveType(
             fn finish(context: *PrefetchContext) void {
                 assert(context.workers_busy == 0);
 
-                assert(context.id_iterator.next() == null);
-                context.groove.prefetch_ids.clearRetainingCapacity();
-                assert(context.groove.prefetch_ids.count() == 0);
+                assert(context.key_iterator.next() == null);
+                context.groove.prefetch_keys.clearRetainingCapacity();
+                assert(context.groove.prefetch_keys.count() == 0);
 
                 context.callback(context);
             }
@@ -709,43 +730,39 @@ pub fn GrooveType(
             lookup: LookupContext = undefined,
 
             fn lookup_start_next(worker: *PrefetchWorker) void {
-                const id = worker.context.id_iterator.next() orelse {
+                const prefetch_key = worker.context.key_iterator.next() orelse {
                     worker.context.worker_finished();
                     return;
                 };
 
-                if (!has_id) {
-                    worker.lookup_with_timestamp(id.*);
-                    return;
-                }
-
-                // Set the union tag so access via &worker.lookup.id doesn't trap.
-                worker.lookup = .{ .id = undefined };
-
-                if (worker.context.groove.ids.lookup_from_memory(
-                    worker.context.snapshot,
-                    id.*,
-                )) |id_tree_value| {
-                    assert(!id_tree_value.tombstone());
-                    lookup_id_callback(&worker.lookup.id, id_tree_value);
-
-                    if (constants.verify) {
-                        // If the id is cached, then we must be prefetching it because the object
-                        // was not also cached.
-                        assert(worker.context.groove.objects.lookup_from_memory(
-                            worker.context.snapshot,
-                            id_tree_value.timestamp,
-                        ) == null);
-                    }
-                } else {
-                    // If not in the LSM tree's cache, the object must be read from disk and added
-                    // to the auxiliary prefetch_objects hash map.
-                    worker.context.groove.ids.lookup_from_levels(
-                        lookup_id_callback,
-                        &worker.lookup.id,
-                        worker.context.snapshot,
-                        id.*,
-                    );
+                // prefetch_enqueue() ensures that the tree's cache is checked before queueing the
+                // object for prefetching. If not in the LSM tree's cache, the object must be read
+                // from disk and added to the auxiliary prefetch_objects hash map.
+                switch (prefetch_key.kind) {
+                    .id => |id| {
+                        // Set the union tag so access via &worker.lookup.id doesn't trap.
+                        worker.lookup = .{ .id = undefined };
+                        if (has_id) {
+                            worker.context.groove.ids.lookup_from_levels_storage(.{
+                                .callback = lookup_id_callback,
+                                .context = &worker.lookup.id,
+                                .snapshot = worker.context.snapshot,
+                                .key = id,
+                                .start_level = prefetch_key.level,
+                            });
+                        } else unreachable;
+                    },
+                    .timestamp => |timestamp| {
+                        // Set the union tag so access via &worker.lookup.id doesn't trap.
+                        worker.lookup = .{ .object = undefined };
+                        worker.context.groove.objects.lookup_from_levels_storage(.{
+                            .callback = lookup_object_callback,
+                            .context = &worker.lookup.object,
+                            .snapshot = worker.context.snapshot,
+                            .key = timestamp,
+                            .start_level = prefetch_key.level,
+                        });
+                    },
                 }
             }
 
@@ -754,24 +771,9 @@ pub fn GrooveType(
                 result: ?*const IdTreeValue,
             ) void {
                 const worker = LookupContext.parent(.id, completion);
-                const key_verify = if (constants.verify) worker.lookup.id.key else {};
                 worker.lookup = undefined;
 
                 if (result) |id_tree_value| {
-                    if (constants.verify) {
-                        // This was checked in prefetch_enqueue().
-                        assert(
-                            worker.context.groove.ids.lookup_from_memory(
-                                worker.context.snapshot,
-                                key_verify,
-                            ) == null or
-                                worker.context.groove.objects.lookup_from_memory(
-                                worker.context.snapshot,
-                                id_tree_value.timestamp,
-                            ) == null,
-                        );
-                    }
-
                     if (!id_tree_value.tombstone()) {
                         worker.lookup_with_timestamp(id_tree_value.timestamp);
                         return;
@@ -782,27 +784,28 @@ pub fn GrooveType(
             }
 
             fn lookup_with_timestamp(worker: *PrefetchWorker, timestamp: u64) void {
-                if (worker.context.groove.objects.lookup_from_memory(
-                    worker.context.snapshot,
-                    timestamp,
-                )) |object| {
-                    // The object is not a tombstone; the ID (if any) and Object trees are in sync.
-                    assert(!ObjectTreeHelpers(Object).tombstone(object));
-
-                    worker.context.groove.prefetch_objects.putAssumeCapacityNoClobber(object.*, {});
-                    worker.lookup_start_next();
-                    return;
-                }
-
                 // Set the union tag so access via &worker.lookup.object doesn't trap.
                 worker.lookup = .{ .object = undefined };
-
-                worker.context.groove.objects.lookup_from_levels(
-                    lookup_object_callback,
-                    &worker.lookup.object,
+                switch (worker.context.groove.objects.lookup_from_memory(
                     worker.context.snapshot,
                     timestamp,
-                );
+                )) {
+                    .exists => |value| {
+                        lookup_object_callback(&worker.lookup.object, value);
+                    },
+                    .does_not_exist => {
+                        lookup_object_callback(&worker.lookup.object, null);
+                    },
+                    .may_exist => |start_level| {
+                        worker.context.groove.objects.lookup_from_levels_storage(.{
+                            .callback = lookup_object_callback,
+                            .context = &worker.lookup.object,
+                            .snapshot = worker.context.snapshot,
+                            .key = timestamp,
+                            .start_level = start_level,
+                        });
+                    },
+                }
             }
 
             fn lookup_object_callback(
@@ -852,7 +855,10 @@ pub fn GrooveType(
         /// Insert the value into the objects tree and its fields into the index trees.
         fn insert(groove: *Groove, object: *const Object) void {
             groove.objects.put(object);
-            if (has_id) groove.ids.put(&IdTreeValue{ .id = object.id, .timestamp = object.timestamp });
+            if (has_id) {
+                groove.ids.put(&IdTreeValue{ .id = object.id, .timestamp = object.timestamp });
+                groove.ids.key_range_update(object.id);
+            }
 
             inline for (std.meta.fields(IndexTrees)) |field| {
                 const Helper = IndexTreeFieldHelperType(field.name);

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -110,16 +110,17 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
         pub const TableInfo = TableInfoType(Table);
 
+        pub const LevelIterator = Level.Iterator;
+        pub const TableInfoReference = Level.TableInfoReference;
+        pub const KeyRange = Level.KeyRange;
+
         const Grid = GridType(Storage);
         const Callback = *const fn (*Manifest) void;
 
         /// Here, we use a structure with indexes over the segmented array for performance.
         const Level = ManifestLevelType(NodePool, Key, TableInfo, compare_keys, table_count_max);
-        const KeyRange = Level.KeyRange;
 
         const ManifestLog = ManifestLogType(Storage, TableInfo);
-
-        pub const TableInfoReference = Level.TableInfoReference;
 
         const CompactionTableRange = struct {
             table_a: TableInfoReference,
@@ -134,6 +135,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             // References to tables in level B that intersect with the chosen table in level A.
             tables: std.BoundedArray(TableInfoReference, constants.lsm_growth_factor),
         };
+
         node_pool: *NodePool,
 
         levels: [constants.lsm_levels]Level,
@@ -240,8 +242,6 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         }
 
         /// Updates the snapshot_max on the provided table for the given level.
-        /// The table provided could either be a pointer to the table (from_level) in the
-        /// ManifestLevel or a pointer to a copy of that table (copy).
         pub fn update_table(
             manifest: *Manifest,
             level: u8,
@@ -298,6 +298,28 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             }
         }
 
+        /// Returns the key range spanned by all ManifestLevels.
+        pub fn key_range(manifest: *Manifest) ?KeyRange {
+            assert(manifest.manifest_log.opened);
+
+            var manifest_range: ?KeyRange = null;
+            for (manifest.levels) |*level| {
+                if (level.key_range.key_range) |level_range| {
+                    if (manifest_range) |*range| {
+                        if (compare_keys(level_range.key_min, range.key_min) == .lt) {
+                            range.key_min = level_range.key_min;
+                        }
+                        if (compare_keys(level_range.key_max, range.key_max) == .gt) {
+                            range.key_max = level_range.key_max;
+                        }
+                    } else {
+                        manifest_range = level_range;
+                    }
+                }
+            }
+            return manifest_range;
+        }
+
         pub fn remove_invisible_tables(
             manifest: *Manifest,
             level: u8,
@@ -334,12 +356,14 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             if (constants.verify) manifest.assert_no_invisible_tables_at_level(level, snapshot);
         }
 
-        /// Returns an iterator over tables that might contain `key` (but are not guaranteed to).
-        pub fn lookup(manifest: *Manifest, snapshot: u64, key: Key) LookupIterator {
+        /// Returns an iterator over the tables visible to `snapshot` that may contain `key`
+        /// (but are not guaranteed to), across all levels > `level_min`.
+        pub fn lookup(manifest: *Manifest, snapshot: u64, key: Key, level_min: u8) LookupIterator {
             return .{
                 .manifest = manifest,
                 .snapshot = snapshot,
                 .key = key,
+                .level = level_min,
             };
         }
 
@@ -347,12 +371,13 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             manifest: *const Manifest,
             snapshot: u64,
             key: Key,
-            level: u8 = 0,
+            level: u8,
             inner: ?Level.Iterator = null,
 
             pub fn next(it: *LookupIterator) ?*const TableInfo {
                 while (it.level < constants.lsm_levels) : (it.level += 1) {
                     const level = &it.manifest.levels[it.level];
+                    if (!level.key_range_contains(it.snapshot, it.key)) continue;
 
                     var inner = level.iterator(
                         .visible,

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -89,6 +89,8 @@ pub fn ManifestLevelType(
                     assert(table != null);
                     self.key_range.?.key_min = table.?.key_min;
                 }
+                assert(self.key_range != null);
+                assert(compare_keys(self.key_range.?.key_min, self.key_range.?.key_max) != .gt);
             }
 
             fn include(self: *LevelKeyRange, include_range: KeyRange) void {
@@ -103,6 +105,9 @@ pub fn ManifestLevelType(
                     self.key_range = include_range;
                 }
                 assert(self.key_range != null);
+                assert(compare_keys(self.key_range.?.key_min, self.key_range.?.key_max) != .gt);
+                assert(compare_keys(self.key_range.?.key_min, include_range.key_min) != .gt and
+                    compare_keys(self.key_range.?.key_max, include_range.key_max) != .lt);
             }
 
             inline fn contains(self: *const LevelKeyRange, key: Key) bool {

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -78,14 +78,22 @@ pub fn ManifestLevelType(
 
                 const snapshots = &[1]u64{lsm.snapshot_latest};
                 if (compare_keys(exclude_range.key_max, self.key_range.?.key_max) == .eq) {
-                    const table = level.iterator(.visible, snapshots, .descending, null).next();
-                    // Since level.table_count_visible is non-zero, we're guaranteed to find a table
-                    // visible to snapshot_latest.
+                    const table: ?*const TableInfo = level.iterator(
+                        .visible,
+                        snapshots,
+                        .descending,
+                        null,
+                    ).next();
                     assert(table != null);
                     self.key_range.?.key_max = table.?.key_max;
                 }
                 if (compare_keys(exclude_range.key_min, self.key_range.?.key_min) == .eq) {
-                    const table = level.iterator(.visible, snapshots, .ascending, null).next();
+                    const table: ?*const TableInfo = level.iterator(
+                        .visible,
+                        snapshots,
+                        .ascending,
+                        null,
+                    ).next();
                     assert(table != null);
                     self.key_range.?.key_min = table.?.key_min;
                 }
@@ -430,6 +438,8 @@ pub fn ManifestLevelType(
         ) ?Keys.Cursor {
             assert(compare_keys(key_min, key_max) != .gt);
             assert(level.keys.len() == level.tables.len());
+
+            if (level.keys.len() == 0) return null;
 
             // Ascending:  Find the first table where table.key_max ≤ iterator.key_min.
             // Descending: Find the first table where table.key_max ≤ iterator.key_max.

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -78,22 +78,14 @@ pub fn ManifestLevelType(
 
                 const snapshots = &[1]u64{lsm.snapshot_latest};
                 if (compare_keys(exclude_range.key_max, self.key_range.?.key_max) == .eq) {
-                    const table: ?*const TableInfo = level.iterator(
-                        .visible,
-                        snapshots,
-                        .descending,
-                        null,
-                    ).next();
+                    var itr = level.iterator(.visible, snapshots, .descending, null);
+                    const table: ?*const TableInfo = itr.next();
                     assert(table != null);
                     self.key_range.?.key_max = table.?.key_max;
                 }
                 if (compare_keys(exclude_range.key_min, self.key_range.?.key_min) == .eq) {
-                    const table: ?*const TableInfo = level.iterator(
-                        .visible,
-                        snapshots,
-                        .ascending,
-                        null,
-                    ).next();
+                    var itr = level.iterator(.visible, snapshots, .ascending, null);
+                    const table: ?*const TableInfo = itr.next();
                     assert(table != null);
                     self.key_range.?.key_min = table.?.key_min;
                 }

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -38,6 +38,7 @@ pub fn ManifestLevelType(
 
         pub const Tables = SegmentedArray(TableInfo, NodePool, table_count_max, .{});
 
+        // A direct reference to a TableInfo within the Tables array.
         pub const TableInfoReference = struct { table_info: *TableInfo, generation: u32 };
 
         pub const LeastOverlapTable = struct {
@@ -54,6 +55,63 @@ pub fn ManifestLevelType(
             tables: std.BoundedArray(TableInfoReference, constants.lsm_growth_factor),
         };
 
+        pub const LevelKeyRange = struct {
+            key_range: ?KeyRange,
+
+            /// Excludes the specified range from the level's key range, i.e. if the specified range
+            /// contributes to the level's key_min/key_max, find a new key_min/key_max.
+            ///
+            /// This is achieved by querying the tables visible to snapshot_latest and updating level
+            /// key_min/key_max to the key_min/key_max of the first table returned by the iterator.
+            /// The query is guaranteed to only fetch non-snapshotted tables, since
+            /// tables visible to old snapshots that users have retained would have
+            /// snapshot_max set to a non math.maxInt(u64) value. Therefore, they wouldn't
+            /// be visible to queries with snapshot_latest (math.maxInt(u64 - 1)).
+            fn exclude(self: *LevelKeyRange, exclude_range: KeyRange) void {
+                assert(self.key_range != null);
+
+                var level = @fieldParentPtr(Self, "key_range", self);
+                if (level.table_count_visible == 0) {
+                    self.key_range = null;
+                    return;
+                }
+
+                const snapshots = &[1]u64{lsm.snapshot_latest};
+                if (compare_keys(exclude_range.key_max, self.key_range.?.key_max) == .eq) {
+                    const table = level.iterator(.visible, snapshots, .descending, null).next();
+                    // Since level.table_count_visible is non-zero, we're guaranteed to find a table
+                    // visible to snapshot_latest.
+                    assert(table != null);
+                    self.key_range.?.key_max = table.?.key_max;
+                }
+                if (compare_keys(exclude_range.key_min, self.key_range.?.key_min) == .eq) {
+                    const table = level.iterator(.visible, snapshots, .ascending, null).next();
+                    assert(table != null);
+                    self.key_range.?.key_min = table.?.key_min;
+                }
+            }
+
+            fn include(self: *LevelKeyRange, include_range: KeyRange) void {
+                if (self.key_range) |*level_range| {
+                    if (compare_keys(include_range.key_min, level_range.key_min) == .lt) {
+                        level_range.key_min = include_range.key_min;
+                    }
+                    if (compare_keys(include_range.key_max, level_range.key_max) == .gt) {
+                        level_range.key_max = include_range.key_max;
+                    }
+                } else {
+                    self.key_range = include_range;
+                }
+                assert(self.key_range != null);
+            }
+
+            inline fn contains(self: *const LevelKeyRange, key: Key) bool {
+                return (self.key_range != null) and
+                    compare_keys(key, self.key_range.?.key_min) != .lt and
+                    compare_keys(key, self.key_range.?.key_max) != .gt;
+            }
+        };
+
         // These two segmented arrays are parallel. That is, the absolute indexes of maximum key
         // and corresponding TableInfo are the same. However, the number of nodes, node index, and
         // relative index into the node differ as the elements per node are different.
@@ -61,6 +119,9 @@ pub fn ManifestLevelType(
         // Ordered by ascending (maximum) key. Keys may repeat due to snapshots.
         keys: Keys,
         tables: Tables,
+
+        /// The range of keys in this level covered by tables visible to snapshot_latest.
+        key_range: LevelKeyRange = .{ .key_range = null },
 
         /// The number of tables visible to snapshot_latest.
         /// Used to enforce table_count_max_for_level().
@@ -100,27 +161,27 @@ pub fn ManifestLevelType(
         }
 
         /// Inserts the given table into the ManifestLevel.
-        pub fn insert_table(
-            level: *Self,
-            node_pool: *NodePool,
-            table: *const TableInfo,
-        ) void {
+        pub fn insert_table(level: *Self, node_pool: *NodePool, table: *const TableInfo) void {
             if (constants.verify) {
                 assert(!level.contains(table));
             }
             assert(level.keys.len() == level.tables.len());
-
             const absolute_index = level.keys.insert_element(node_pool, table.key_max);
             assert(absolute_index < level.keys.len());
 
             level.tables.insert_elements(node_pool, absolute_index, &[_]TableInfo{table.*});
-            if (constants.verify) {
-                assert(level.contains(table));
-            }
 
             if (table.visible(lsm.snapshot_latest)) level.table_count_visible += 1;
             level.generation +%= 1;
 
+            level.key_range.include(KeyRange{
+                .key_min = table.key_min,
+                .key_max = table.key_max,
+            });
+
+            if (constants.verify) {
+                assert(level.contains(table));
+            }
             assert(level.keys.len() == level.tables.len());
         }
 
@@ -130,18 +191,21 @@ pub fn ManifestLevelType(
         /// * Asserts that the table exists in the manifest.
         pub fn set_snapshot_max(level: *Self, snapshot: u64, table_ref: TableInfoReference) void {
             var table = table_ref.table_info;
-            const key_min = table.key_min;
-            const key_max = table.key_max;
+
             assert(table_ref.generation == level.generation);
             if (constants.verify) {
                 assert(level.contains(table));
             }
             assert(snapshot < lsm.snapshot_latest);
             assert(table.snapshot_max == math.maxInt(u64));
-            assert(compare_keys(key_min, key_max) != .gt);
+            assert(compare_keys(table.key_min, table.key_max) != .gt);
 
             table.snapshot_max = snapshot;
             level.table_count_visible -= 1;
+            level.key_range.exclude(KeyRange{
+                .key_min = table.key_min,
+                .key_max = table.key_max,
+            });
         }
 
         /// Remove the given table from the level assuming it's visible to `lsm.snapshot_latest`.
@@ -156,6 +220,11 @@ pub fn ManifestLevelType(
 
             level.remove_table(node_pool, table);
             level.table_count_visible -= 1;
+            level.key_range.exclude(KeyRange{
+                .key_min = table.key_min,
+                .key_max = table.key_max,
+            });
+
             return table;
         }
 
@@ -169,6 +238,19 @@ pub fn ManifestLevelType(
         ) void {
             assert(table.invisible(snapshots));
             level.remove_table(node_pool, table);
+        }
+
+        /// Returns True if the given key may be present in the ManifestLevel,
+        /// False if the key is guaranteed to not be present.
+        ///
+        /// Our key range keeps track of tables that are visible to snapshot_latest, so it cannot
+        /// be relied upon for queries to older snapshots.
+        pub fn key_range_contains(level: *const Self, snapshot: u64, key: Key) bool {
+            if (snapshot == lsm.snapshot_latest) {
+                return level.key_range.contains(key);
+            } else {
+                return true;
+            }
         }
 
         fn remove_table(level: *Self, node_pool: *NodePool, table: *const TableInfo) void {
@@ -185,7 +267,9 @@ pub fn ManifestLevelType(
                     level.keys.remove_elements(node_pool, absolute_index, 1);
                     level.tables.remove_elements(node_pool, absolute_index, 1);
                     assert(level.keys.len() == level.tables.len());
+
                     level.generation +%= 1;
+
                     return;
                 }
             }
@@ -341,8 +425,6 @@ pub fn ManifestLevelType(
         ) ?Keys.Cursor {
             assert(compare_keys(key_min, key_max) != .gt);
             assert(level.keys.len() == level.tables.len());
-
-            if (level.keys.len() == 0) return null;
 
             // Ascending:  Find the first table where table.key_max ≤ iterator.key_min.
             // Descending: Find the first table where table.key_max ≤ iterator.key_max.

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -1325,7 +1325,7 @@ test "TreeType" {
     _ = Tree.put;
     _ = Tree.remove;
     _ = Tree.lookup_from_memory;
-    _ = Tree.lookup_from_levels;
+    _ = Tree.lookup_from_levels_storage;
     _ = Tree.open;
     _ = Tree.compact;
     _ = Tree.compact_end;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -5,12 +5,13 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 const os = std.os;
+const maybe = stdx.maybe;
+const div_ceil = stdx.div_ceil;
 
 const log = std.log.scoped(.tree);
 const tracer = @import("../tracer.zig");
 
 const stdx = @import("../stdx.zig");
-const div_ceil = stdx.div_ceil;
 const constants = @import("../constants.zig");
 const eytzinger = @import("eytzinger.zig").eytzinger;
 const vsr = @import("../vsr.zig");
@@ -86,11 +87,18 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
         const Grid = @import("grid.zig").GridType(Storage);
         const Manifest = @import("manifest.zig").ManifestType(Table, Storage);
+        const KeyRange = Manifest.KeyRange;
+
         pub const TableMutable = @import("table_mutable.zig").TableMutableType(Table);
         const TableImmutable = @import("table_immutable.zig").TableImmutableType(Table);
 
         const CompactionType = @import("compaction.zig").CompactionType;
         const Compaction = CompactionType(Table, Tree, Storage);
+        pub const LookupMemoryResult = union(enum) {
+            exists: *const Value,
+            does_not_exist,
+            may_exist: u8,
+        };
 
         grid: *Grid,
         config: Config,
@@ -124,7 +132,6 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         /// (When recovering from a checkpoint, compaction_op starts at op_checkpoint).
         compaction_op: ?u64 = null,
 
-        /// The maximum snapshot which is safe to prefetch from.
         /// The minimum snapshot which can see the mutable table.
         ///
         /// This field ensures that the tree never queries the output tables of a running
@@ -157,6 +164,9 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         tracer_slot: ?tracer.SpanStart = null,
         filter_block_hits: u64 = 0,
         filter_block_misses: u64 = 0,
+
+        /// The range of keys in this tree at snapshot_latest.
+        key_range: ?KeyRange = null,
 
         /// (Constructed by the Forest.)
         pub const Config = struct {
@@ -283,13 +293,34 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             tree.table_mutable.remove(value);
         }
 
+        pub fn key_range_update(tree: *Tree, key: Key) void {
+            if (tree.key_range) |*key_range| {
+                if (compare_keys(key, key_range.key_min) == .lt) key_range.key_min = key;
+                if (compare_keys(key, key_range.key_max) == .gt) key_range.key_max = key;
+            } else {
+                tree.key_range = KeyRange{ .key_min = key, .key_max = key };
+            }
+        }
+
+        /// Returns True if the given key may be present in the Tree, False if the key is
+        /// guaranteed to not be present.
+        ///
+        /// Specifically, it checks whether the key exists within the Tree's key range.
+        pub fn key_range_contains(tree: *const Tree, snapshot: u64, key: Key) bool {
+            if (snapshot == snapshot_latest) {
+                return tree.key_range != null and
+                    compare_keys(key, tree.key_range.?.key_min) != .lt and
+                    compare_keys(key, tree.key_range.?.key_max) != .gt;
+            } else {
+                return true;
+            }
+        }
+
         /// Returns the value from the mutable or immutable table (possibly a tombstone),
         /// if one is available for the specified snapshot.
-        pub fn lookup_from_memory(tree: *Tree, snapshot: u64, key: Key) ?*const Value {
-            assert(tree.lookup_snapshot_max.? >= snapshot);
-
-            if (tree.lookup_snapshot_max.? == snapshot) {
-                if (tree.table_mutable.get(key)) |value| return value;
+        pub fn lookup_from_memory(tree: *Tree, snapshot: u64, key: Key) LookupMemoryResult {
+            if (snapshot >= tree.lookup_snapshot_max.?) {
+                if (tree.table_mutable.get(key)) |value| return .{ .exists = value };
             } else {
                 // The mutable table is converted to an immutable table when a snapshot is created.
                 // This means that a past snapshot will never be able to see the mutable table.
@@ -297,38 +328,140 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             }
 
             if (!tree.table_immutable.free and tree.table_immutable.snapshot_min <= snapshot) {
-                if (tree.table_immutable.get(key)) |value| return value;
+                if (tree.table_immutable.get(key)) |value| return .{ .exists = value };
             } else {
                 // If the immutable table is invisible, then the mutable table is also invisible.
                 assert(tree.table_immutable.free or snapshot != tree.lookup_snapshot_max.?);
             }
 
-            return null;
+            return tree.lookup_from_levels_cache(snapshot, key);
+        }
+
+        /// Returns:
+        /// - .does_not_exist if the key does not exist in the Manifest.
+        /// - .exists if the key exists in the Manifest, along with the associated value.
+        /// - .may_exist if the key may exist in the Manifest but its existence cannot be
+        ///  ascertained without IO, along with the level number at which IO must be performed.
+        ///
+        /// This function attempts to fetch the index, filter & data blocks for the tables that
+        /// could contain the key synchronously from the Grid cache. It then attempts to ascertain
+        /// the existence of the key in the filter/data block. If any of the blocks needed to
+        /// ascertain the existence of the key are not in the Grid cache, it bails out.
+        fn lookup_from_levels_cache(tree: *Tree, snapshot: u64, key: Key) LookupMemoryResult {
+            const fingerprint = bloom_filter.Fingerprint.create(stdx.hash_inline(key));
+            var iterator = tree.manifest.lookup(snapshot, key, 0);
+            while (iterator.next()) |table| {
+                const index_block = tree.grid.read_block_from_cache(
+                    table.address,
+                    table.checksum,
+                ) orelse {
+                    // Index block not in cache. We cannot rule out existence without I/O,
+                    // and therefore bail out.
+                    return .{ .may_exist = iterator.level - 1 };
+                };
+
+                const key_blocks = Table.index_blocks_for_key(index_block, key);
+                switch (tree.cached_filter_block_search(
+                    key_blocks.filter_block_address,
+                    key_blocks.filter_block_checksum,
+                    fingerprint,
+                )) {
+                    .does_not_exist => {
+                        if (constants.verify) {
+                            assert(tree.cached_data_block_search(
+                                key_blocks.data_block_address,
+                                key_blocks.data_block_checksum,
+                                key,
+                            ) != .exists);
+                        }
+                        // Filter block indicates that the key is not present in the data block,
+                        // move on to the next table that could contain the key.
+                        continue;
+                    },
+                    .may_exist, .block_not_in_cache => {
+                        // Give yourself another fighting chance to rule out the existence of
+                        // the key; search for the data block in the grid cache.
+                    },
+                }
+
+                switch (tree.cached_data_block_search(
+                    key_blocks.data_block_address,
+                    key_blocks.data_block_checksum,
+                    key,
+                )) {
+                    .does_not_exist => {},
+                    // Key present in the data block.
+                    .exists => |value| return .{ .exists = value },
+                    // Data block was not found in the grid cache. We cannot rule out
+                    // the existence of the key without I/O, and therefore bail out.
+                    .block_not_in_cache => return .{ .may_exist = iterator.level - 1 },
+                }
+            }
+            // Key not present in the Manifest.
+            return .does_not_exist;
+        }
+
+        fn cached_filter_block_search(
+            tree: *Tree,
+            address: u64,
+            checksum: u128,
+            fingerprint: bloom_filter.Fingerprint,
+        ) enum { does_not_exist, may_exist, block_not_in_cache } {
+            if (tree.grid.read_block_from_cache(address, checksum)) |filter_block| {
+                const filter_schema = schema.TableFilter.from(filter_block);
+                const filter_bytes = filter_schema.block_filter_const(filter_block);
+                if (!bloom_filter.may_contain(fingerprint, filter_bytes)) {
+                    return .does_not_exist;
+                } else {
+                    return .may_exist;
+                }
+            } else {
+                return .block_not_in_cache;
+            }
+        }
+
+        fn cached_data_block_search(
+            tree: *Tree,
+            address: u64,
+            checksum: u128,
+            key: Key,
+        ) union(enum) {
+            exists: *const Value,
+            does_not_exist,
+            block_not_in_cache,
+        } {
+            if (tree.grid.read_block_from_cache(address, checksum)) |data_block| {
+                if (Table.data_block_search(data_block, key)) |value| {
+                    return .{ .exists = value };
+                } else {
+                    return .does_not_exist;
+                }
+            } else {
+                return .block_not_in_cache;
+            }
         }
 
         /// Call this function only after checking `lookup_from_memory()`.
-        pub fn lookup_from_levels(
-            tree: *Tree,
+        pub fn lookup_from_levels_storage(tree: *Tree, parameters: struct {
             callback: *const fn (*LookupContext, ?*const Value) void,
             context: *LookupContext,
             snapshot: u64,
             key: Key,
-        ) void {
-            assert(tree.lookup_snapshot_max.? >= snapshot);
-            if (constants.verify) {
-                // The caller is responsible for checking the mutable table.
-                assert(tree.lookup_from_memory(snapshot, key) == null);
-            }
-
+            start_level: u8,
+        }) void {
             var index_block_count: u8 = 0;
             var index_block_addresses: [constants.lsm_levels]u64 = undefined;
             var index_block_checksums: [constants.lsm_levels]u128 = undefined;
             {
-                var it = tree.manifest.lookup(snapshot, key);
+                var it = tree.manifest.lookup(
+                    parameters.snapshot,
+                    parameters.key,
+                    parameters.start_level,
+                );
                 while (it.next()) |table| : (index_block_count += 1) {
-                    assert(table.visible(snapshot));
-                    assert(compare_keys(table.key_min, key) != .gt);
-                    assert(compare_keys(table.key_max, key) != .lt);
+                    assert(table.visible(parameters.snapshot));
+                    assert(compare_keys(table.key_min, parameters.key) != .gt);
+                    assert(compare_keys(table.key_max, parameters.key) != .lt);
 
                     index_block_addresses[index_block_count] = table.address;
                     index_block_checksums[index_block_count] = table.checksum;
@@ -336,28 +469,28 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             }
 
             if (index_block_count == 0) {
-                callback(context, null);
+                parameters.callback(parameters.context, null);
                 return;
             }
 
             // Hash the key to the fingerprint only once and reuse for all bloom filter checks.
-            const fingerprint = bloom_filter.Fingerprint.create(stdx.hash_inline(key));
+            const fingerprint = bloom_filter.Fingerprint.create(stdx.hash_inline(parameters.key));
 
-            context.* = .{
+            parameters.context.* = .{
                 .tree = tree,
                 .completion = undefined,
 
-                .key = key,
+                .key = parameters.key,
                 .fingerprint = fingerprint,
 
                 .index_block_count = index_block_count,
                 .index_block_addresses = index_block_addresses,
                 .index_block_checksums = index_block_checksums,
 
-                .callback = callback,
+                .callback = parameters.callback,
             };
 
-            context.read_index_block();
+            parameters.context.read_index_block();
         }
 
         pub const LookupContext = struct {
@@ -514,6 +647,11 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
             const callback = tree.open_callback.?;
             tree.open_callback = null;
+
+            assert(tree.key_range == null);
+            tree.key_range = manifest.key_range();
+            maybe(tree.key_range == null);
+
             callback(tree);
         }
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -79,6 +79,7 @@ const FuzzOp = union(enum) {
 const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
 const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Key.Value));
 const value_count_max = constants.lsm_batch_multiple * commit_entries_max;
+const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const cluster = 32;
 const replica = 4;
@@ -276,13 +277,24 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         pub fn get(env: *Environment, key: Key) ?*const Key.Value {
             env.change_state(.fuzzing, .tree_lookup);
 
-            if (env.tree.lookup_from_memory(env.tree.lookup_snapshot_max.?, key)) |value| {
-                env.change_state(.tree_lookup, .fuzzing);
-                return Tree.unwrap_tombstone(value);
-            }
-
             env.lookup_value = null;
-            env.tree.lookup_from_levels(get_callback, &env.lookup_context, env.tree.lookup_snapshot_max.?, key);
+            switch (env.tree.lookup_from_memory(snapshot_latest, key)) {
+                .exists => |value| {
+                    get_callback(&env.lookup_context, Tree.unwrap_tombstone(value));
+                },
+                .does_not_exist => {
+                    get_callback(&env.lookup_context, null);
+                },
+                .may_exist => |level| {
+                    env.tree.lookup_from_levels_storage(.{
+                        .callback = get_callback,
+                        .context = &env.lookup_context,
+                        .snapshot = env.tree.lookup_snapshot_max.?,
+                        .key = key,
+                        .start_level = level,
+                    });
+                },
+            }
             env.tick_until_state_change(.tree_lookup, .fuzzing);
             return env.lookup_value;
         }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -279,19 +279,19 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
             env.lookup_value = null;
             switch (env.tree.lookup_from_memory(snapshot_latest, key)) {
-                .exists => |value| {
-                    get_callback(&env.lookup_context, Tree.unwrap_tombstone(value));
-                },
-                .does_not_exist => {
+                .negative => {
                     get_callback(&env.lookup_context, null);
                 },
-                .may_exist => |level| {
+                .positive => |value| {
+                    get_callback(&env.lookup_context, Tree.unwrap_tombstone(value));
+                },
+                .possible => |level_min| {
                     env.tree.lookup_from_levels_storage(.{
                         .callback = get_callback,
                         .context = &env.lookup_context,
                         .snapshot = env.tree.lookup_snapshot_max.?,
                         .key = key,
-                        .start_level = level,
+                        .level_min = level_min,
                     });
                 },
             }


### PR DESCRIPTION
### Problem

While creating a new account/transfer, the state machine ascertains the existence of the account/transfer ID in the LSM tree. If the ID doesn't exist in the tree, the account/transfer can be safely created. Otherwise, the account/transfer creation must be rejected.

 To this end,  [prefetch_create_accounts](https://github.com/tigerbeetledb/tigerbeetle/blob/f7e64c970a6ff38987bc64dce92ce519ee93e64e/src/state_machine.zig#L407) & [prefetch_create_transfers](https://github.com/tigerbeetledb/tigerbeetle/blob/f7e64c970a6ff38987bc64dce92ce519ee93e64e/src/state_machine.zig#L439) invoke [prefetch_enqueue](https://github.com/tigerbeetledb/tigerbeetle/blob/f7e64c970a6ff38987bc64dce92ce519ee93e64e/src/lsm/groove.zig#L617), which involves searching for the ID in all on-disk levels of the LSM tree (if not found in the in-memory (im)mutable tables), possibly performing I/O to read index, filter & data blocks (if not found in the cache).

This is expensive, considering duplicate IDs are a rarity and would likely only be encountered if:

* The client retries a batch of requests for which it didn't receive an acknowledge
* The client generates duplicate IDs within the same batch

### Solution

prefetch_enqueue now makes makes a best-effort attempt to ascertain the existence of an ID in the IdTree without performing any I/O. If ascertaining the existence of the ID becomes intractable at any point (this point is expanded on below), it reverts to the legacy flow.

_**This is achieved by maintaining key ranges for the Tree & all levels in the LSM tree.**_ 

Note that we don't maintain a key range for the mutable table. Maintaining a key range for the mutable table would entail maintaining the minimum & maximum key across a hash map and a SetAssociativeCache. While it is feasible to track the key range in the hash map, we would have to keep a track of evictions from the cache to maintain a key range for it, which is non trivial. This would become easier to track when @cb22's changes come in since they move the cache up to the Groove layer!

This is a high-level writeup of how the prefetch negative lookup flow looks after these changes get in:

* **_If the account/transfer ID does not exist within the tree's key range_** → the account/transfer creation request can simply be processed without incurring any I/O cost 🚀
* **_If the account/transfer ID does exist in the tree's key range, we handle the following cases:_**
  * _ID doesn't exist in the (im)mutable tables_ 
    * ID doesn't exist exist within any of the key ranges of the LSM levels → The account/transfer creation request can be processed without incurring any I/O cost 🚀
    * ID exists within the key range of some LSM levels → Attempt to synchronously fetch the index, data & filter blocks of the tables that could contain the key from the cache
      *  If any of the blocks required to ascertain the existence of a key within a table are not found in the cache, revert to the legacy flow
      *  If all the blocks required to ascertain the existence of a key within a table are found in the cache, and the ID doesn't exist in any of them → The account/transfer creation request can be processed without incurring any I/O cost 🚀
  * _ID exists in the (im)mutable tables_ → Attempt to prefetch it from the (im)mutable tables. Note that this step the same as it was in the legacy flow, since it attempts to prefetch the ID from memory before checking the on-disk LSM tree levels.
