### PR TITLE
Enable all LSM tests under unit_tests.zig

### DIFF
--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -13,10 +13,19 @@ test {
     _ = @import("clients/java/java_bindings.zig");
     _ = @import("clients/node/node_bindings.zig");
 
-    // TODO Add remaining unit tests from lsm namespace.
+    _ = @import("lsm/binary_search.zig");
+    _ = @import("lsm/bloom_filter.zig");
+    _ = @import("lsm/eytzinger.zig");
     _ = @import("lsm/forest.zig");
+    _ = @import("lsm/groove.zig");
+    _ = @import("lsm/k_way_merge.zig");
     _ = @import("lsm/manifest_level.zig");
+    _ = @import("lsm/node_pool.zig");
+    _ = @import("lsm/posted_groove.zig");
     _ = @import("lsm/segmented_array.zig");
+    _ = @import("lsm/set_associative_cache.zig");
+    _ = @import("lsm/table.zig");
+    _ = @import("lsm/tree.zig");
 
     _ = @import("state_machine.zig");
     _ = @import("state_machine/auditor.zig");


### PR DESCRIPTION
The only test that wasn't actually running was the `k_way_merge` - everything else was pulled in via imports. 

Figured it would be a good idea to make it explicit, however.