### PR TITLE
vsr: reconfigure request for simulator and client

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -366,7 +366,11 @@ pub const AOFReplayClient = struct {
                 .timestamp = header.timestamp,
             };
 
-            self.client.raw_request(@ptrToInt(self), AOFReplayClient.replay_callback, message);
+            self.client.raw_request(
+                @ptrToInt(self),
+                .{ .request = AOFReplayClient.replay_callback },
+                message,
+            );
 
             // Process messages one by one for now
             while (self.client.request_queue.count > 0) {

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -81,7 +81,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
 
             self.request_queue.push_assume_capacity(.{
                 .user_data = user_data,
-                .callback = callback,
+                .callback = .{ .request = callback },
                 .message = message.ref(),
             });
         }
@@ -109,7 +109,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
                 // callback. This necessitates a `copy_disjoint` above.
                 self.unref(inflight.message);
 
-                inflight.callback.?(
+                inflight.callback.?.request(
                     inflight.user_data,
                     reply_message.header.operation.cast(Self.StateMachine),
                     reply_message.body(),

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -460,6 +460,28 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
             _ = result;
         }
 
+        pub fn request_reconfigure(
+            cluster: *Self,
+            client_index: usize,
+            reconfiguration: *const vsr.ReconfigurationRequest,
+            request_message: *Message,
+        ) void {
+            cluster.clients[client_index].request_reconfigure(
+                undefined,
+                request_reconfigure_callback,
+                reconfiguration,
+                request_message,
+            );
+        }
+
+        fn request_reconfigure_callback(
+            user_data: u128,
+            result: vsr.ReconfigurationResult,
+        ) void {
+            _ = user_data;
+            _ = result;
+        }
+
         fn client_on_reply(client: *Client, request_message: *Message, reply_message: *Message) void {
             const cluster = @ptrCast(*Self, @alignCast(@alignOf(Self), client.on_reply_context.?));
             assert(reply_message.header.cluster == cluster.options.cluster_id);


### PR DESCRIPTION
This adds reconfiguration request to the client and simulator. 

For the client, we go with a strongly typed API -- `.requset` and `.request_reconfigure` are different functions, and they accept callbacks with different signatures. I am not entirely sure that's a good idea --- as an alternative, we could use more "dynamically-typed" API, where it is just a request, and its on the user to cast the result to ReconfigurationResult. 

Note that `request_reconfigure` accepts a `Message` argument. It _could_ aquire the message itself internally, given that it's going to memcpy ReconfigurationRequest anyway, but, as acquiring a message is a failable operation (there are only so many messages available), pushing that to the caller seems advantageous. 