### PR TITLE
Reduce cache-grid for integration tests

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -986,7 +986,7 @@ namespace TigerBeetle.Tests
         private const string TB_FILE = "dotnet-tests.tigerbeetle";
         private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
         private const string FORMAT = $"format --cluster=0 --replica=0 --replica-count=1 ./" + TB_FILE;
-        private const string START = $"start --addresses=" + TB_PORT + " ./" + TB_FILE;
+        private const string START = $"start --addresses=" + TB_PORT + " --cache-grid=128MB ./" + TB_FILE;
 
         private readonly Process process;
 

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -37,6 +37,7 @@ func WithClient(s testing.TB, withClient func(Client)) {
 	}
 
 	addressArg := "--addresses=" + TIGERBEETLE_PORT
+	cacheSizeArg := "--cache-grid=128MB"
 	replicaArg := fmt.Sprintf("--replica=%d", TIGERBEETLE_REPLICA_ID)
 	replicaCountArg := fmt.Sprintf("--replica-count=%d", TIGERBEETLE_REPLICA_COUNT)
 	clusterArg := fmt.Sprintf("--cluster=%d", TIGERBEETLE_CLUSTER_ID)
@@ -57,7 +58,7 @@ func WithClient(s testing.TB, withClient func(Client)) {
 		_ = os.Remove(fileName)
 	})
 
-	tbStart := exec.Command(tigerbeetlePath, "start", addressArg, fileName)
+	tbStart := exec.Command(tigerbeetlePath, "start", addressArg, cacheSizeArg, fileName)
 	if err := tbStart.Start(); err != nil {
 		s.Fatal(err)
 	}

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -417,13 +417,15 @@ public class AsyncRequestTest {
         var callback =
                 new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
                         Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 500);
+                        PacketStatus.Ok.value, 5000);
 
         Future<TransferBatch> future = callback.request.getFuture();
         callback.start();
 
         try {
-            // Should not be ready yet
+            // Our goal is just to test the future timeout.
+            // The timeout is much smaller than the delay,
+            // to avoid flaky results due to thread scheduling.
             future.get(5, TimeUnit.MILLISECONDS);
             assert false;
 
@@ -461,14 +463,17 @@ public class AsyncRequestTest {
         var callback =
                 new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
                         Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 500);
+                        PacketStatus.Ok.value, 5);
 
         Future<TransferBatch> future = callback.request.getFuture();
         callback.start();
 
         try {
 
-            var result = future.get(1000, TimeUnit.MILLISECONDS);
+            // Our goal is just to test the future completion.
+            // The timeout is much bigger than the delay,
+            // to avoid flaky results due to thread scheduling.
+            var result = future.get(5000, TimeUnit.MILLISECONDS);
             assertEquals(2, result.getLength());
 
             assertTrue(result.next());

--- a/src/clients/run_with_tb.zig
+++ b/src/clients/run_with_tb.zig
@@ -82,6 +82,7 @@ pub fn run_with_tb(arena: *std.heap.ArenaAllocator, commands: []const []const u8
         tb_binary,
         "start",
         try std.fmt.allocPrint(arena.allocator(), "--addresses={}", .{port}),
+        "--cache-grid=128MB",
         data_file,
     };
     std.debug.print("Starting TigerBeetle server: {s}\n", .{start_args});


### PR DESCRIPTION
This PR sets the flag `--cache-grid=128MB` for all integration tests.
We start many ephemeral TB instances in this use case, so we want low memory usage rather than a large cache for performance, especially when running by CI.

Also, it changes one of the Java tests to avoid [flaky results](https://github.com/tigerbeetle/tigerbeetle/actions/runs/5468389491/jobs/9956628305?pr=957) on slow machines.

