### PR TITLE
LSM: Table{Index,Filter,Data}Schema

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -412,7 +412,7 @@ pub fn CompactionType(
             // TODO(jamii) This copy can be avoided if we bypass the cache.
             stdx.copy_disjoint(.exact, u8, compaction.index_block_a, index_block);
 
-            const index_schema_a = schema.TableIndex.from_index_block(compaction.index_block_a);
+            const index_schema_a = schema.TableIndex.from(compaction.index_block_a);
             compaction.iterator_a.start(.{
                 .grid = compaction.context.grid,
                 .addresses = index_schema_a.data_addresses_used(compaction.index_block_a),
@@ -475,7 +475,7 @@ pub fn CompactionType(
             // a copy of the index block for the Level A table being compacted.
 
             const grid = compaction.context.grid;
-            const index_schema = schema.TableIndex.from_index_block(index_block);
+            const index_schema = schema.TableIndex.from(index_block);
             for (index_schema.data_addresses_used(index_block)) |address| grid.release(address);
             for (index_schema.filter_addresses_used(index_block)) |address| grid.release(address);
             grid.release(Table.block_address(index_block));

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -46,7 +46,7 @@ const GridType = @import("grid.zig").GridType;
 const allocate_block = @import("grid.zig").allocate_block;
 const TableInfoType = @import("manifest.zig").TableInfoType;
 const ManifestType = @import("manifest.zig").ManifestType;
-const TableIndexSchema = @import("table.zig").TableIndexSchema;
+const schema = @import("schema.zig");
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
 const LevelTableValueBlockIteratorType = @import("level_data_iterator.zig").LevelTableValueBlockIteratorType;
 
@@ -412,11 +412,11 @@ pub fn CompactionType(
             // TODO(jamii) This copy can be avoided if we bypass the cache.
             stdx.copy_disjoint(.exact, u8, compaction.index_block_a, index_block);
 
-            const index_a = TableIndexSchema.from_index_block(compaction.index_block_a);
+            const index_schema_a = schema.TableIndex.from_index_block(compaction.index_block_a);
             compaction.iterator_a.start(.{
                 .grid = compaction.context.grid,
-                .addresses = index_a.data_addresses_used(compaction.index_block_a),
-                .checksums = index_a.data_checksums_used(compaction.index_block_a),
+                .addresses = index_schema_a.data_addresses_used(compaction.index_block_a),
+                .checksums = index_schema_a.data_checksums_used(compaction.index_block_a),
             });
             compaction.release_table_blocks(compaction.index_block_a);
             compaction.state = .compacting;
@@ -475,9 +475,9 @@ pub fn CompactionType(
             // a copy of the index block for the Level A table being compacted.
 
             const grid = compaction.context.grid;
-            const index = TableIndexSchema.from_index_block(index_block);
-            for (index.data_addresses_used(index_block)) |address| grid.release(address);
-            for (index.filter_addresses_used(index_block)) |address| grid.release(address);
+            const index_schema = schema.TableIndex.from_index_block(index_block);
+            for (index_schema.data_addresses_used(index_block)) |address| grid.release(address);
+            for (index_schema.filter_addresses_used(index_block)) |address| grid.release(address);
             grid.release(Table.block_address(index_block));
         }
 

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -9,6 +9,7 @@ const stdx = @import("../stdx.zig");
 const ManifestType = @import("manifest.zig").ManifestType;
 const allocate_block = @import("grid.zig").allocate_block;
 const GridType = @import("grid.zig").GridType;
+const TableIndexSchema = @import("table.zig").TableIndexSchema;
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
 
 // Iterates over the data blocks in a level B table. References to the level B
@@ -139,12 +140,10 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             read: *Grid.Read,
             index_block: BlockPtrConst,
         ) void {
-            const it = @fieldParentPtr(
-                LevelTableValueBlockIterator,
-                "read",
-                read,
-            );
+            const it = @fieldParentPtr(LevelTableValueBlockIterator, "read", read);
             assert(it.table_data_iterator.empty());
+
+            const index = TableIndexSchema.from_index_block(index_block);
             const callback = it.callback.level_next;
             it.callback = .none;
             // `index_block` is only valid for this callback, so copy it's contents.
@@ -152,8 +151,8 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             stdx.copy_disjoint(.exact, u8, it.context.index_block, index_block);
             it.table_data_iterator.start(.{
                 .grid = it.context.grid,
-                .addresses = Table.index_data_addresses_used(it.context.index_block),
-                .checksums = Table.index_data_checksums_used(it.context.index_block),
+                .addresses = index.data_addresses_used(it.context.index_block),
+                .checksums = index.data_checksums_used(it.context.index_block),
             });
             callback.on_index(it);
             it.table_index += 1;
@@ -170,7 +169,11 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             table_data_iterator: *TableDataIterator,
             data_block: ?Grid.BlockPtrConst,
         ) void {
-            const it = @fieldParentPtr(LevelTableValueBlockIterator, "table_data_iterator", table_data_iterator);
+            const it = @fieldParentPtr(
+                LevelTableValueBlockIterator,
+                "table_data_iterator",
+                table_data_iterator,
+            );
             const callback = it.callback.table_next;
             it.callback = .none;
             callback.on_data(it, data_block);

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -143,7 +143,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             const it = @fieldParentPtr(LevelTableValueBlockIterator, "read", read);
             assert(it.table_data_iterator.empty());
 
-            const index_schema = schema.TableIndex.from_index_block(index_block);
+            const index_schema = schema.TableIndex.from(index_block);
             const callback = it.callback.level_next;
             it.callback = .none;
             // `index_block` is only valid for this callback, so copy it's contents.

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -9,7 +9,7 @@ const stdx = @import("../stdx.zig");
 const ManifestType = @import("manifest.zig").ManifestType;
 const allocate_block = @import("grid.zig").allocate_block;
 const GridType = @import("grid.zig").GridType;
-const TableIndexSchema = @import("table.zig").TableIndexSchema;
+const schema = @import("schema.zig");
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
 
 // Iterates over the data blocks in a level B table. References to the level B
@@ -143,7 +143,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             const it = @fieldParentPtr(LevelTableValueBlockIterator, "read", read);
             assert(it.table_data_iterator.empty());
 
-            const index = TableIndexSchema.from_index_block(index_block);
+            const index_schema = schema.TableIndex.from_index_block(index_block);
             const callback = it.callback.level_next;
             it.callback = .none;
             // `index_block` is only valid for this callback, so copy it's contents.
@@ -151,8 +151,8 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             stdx.copy_disjoint(.exact, u8, it.context.index_block, index_block);
             it.table_data_iterator.start(.{
                 .grid = it.context.grid,
-                .addresses = index.data_addresses_used(it.context.index_block),
-                .checksums = index.data_checksums_used(it.context.index_block),
+                .addresses = index_schema.data_addresses_used(it.context.index_block),
+                .checksums = index_schema.data_checksums_used(it.context.index_block),
             });
             callback.on_index(it);
             it.table_index += 1;

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -150,7 +150,7 @@ pub const TableIndex = struct {
         };
     }
 
-    pub fn from_index_block(index_block: BlockPtrConst) TableIndex {
+    pub fn from(index_block: BlockPtrConst) TableIndex {
         const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
         assert(header.command == .block);
         assert(BlockType.from(header.operation) == .index);
@@ -304,7 +304,7 @@ pub const TableFilter = struct {
         };
     }
 
-    pub fn from_filter_block(filter_block: BlockPtrConst) TableFilter {
+    pub fn from(filter_block: BlockPtrConst) TableFilter {
         const header = mem.bytesAsValue(vsr.Header, filter_block[0..@sizeOf(vsr.Header)]);
         assert(header.command == .block);
         assert(BlockType.from(header.operation) == .filter);
@@ -389,7 +389,7 @@ pub const TableData = struct {
         };
     }
 
-    pub fn from_data_block(data_block: BlockPtrConst) TableData {
+    pub fn from(data_block: BlockPtrConst) TableData {
         const header = mem.bytesAsValue(vsr.Header, data_block[0..@sizeOf(vsr.Header)]);
         assert(header.command == .block);
         assert(BlockType.from(header.operation) == .data);

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -1,0 +1,429 @@
+//! Decode grid blocks.
+//!
+//! Rather than switching between specialized decoders depending on the tree, each schema encodes
+//! relevant parameters directly into the block's header. This allows the decoders to not be
+//! generic. This is convenient for compaction, but critical for the scrubber and repair queue.
+//!
+//! Every block begins with a `vsr.Header` that includes:
+//!
+//! * `checksum`, `checksum_body` verify the data integrity.
+//! * `cluster` is the cluster id.
+//! * `command` is `.block`.
+//! * `op` is the block address.
+//! * `size` is the block size excluding padding.
+//!
+//! Index block schema:
+//! │ vsr.Header                   │ operation=BlockType.index,
+//! │                              │ context=schema.TableIndex.Context,
+//! │                              │ request=@sizeOf(Key)
+//! │                              │ timestamp=snapshot_min
+//! │ [filter_block_count_max]u128 │ checksums of filter blocks
+//! │ [data_block_count_max]u128   │ checksums of data blocks
+//! │ [data_block_count_max]Key    │ the maximum/last key in the respective data block
+//! │ [filter_block_count_max]u64  │ addresses of filter blocks
+//! │ [data_block_count_max]u64    │ addresses of data blocks
+//! │ […]u8{0}                     │ padding (to end of block)
+//!
+//! Filter block schema:
+//! │ vsr.Header │ operation=BlockType.filter,
+//! │            │ context=schema.TableFilter.context
+//! │ […]u8      │ A split-block Bloom filter, "containing" every key from as many as
+//! │            │   `filter_data_block_count_max` data blocks.
+//!
+//! Data block schema:
+//! │ vsr.Header               │ operation=BlockType.data,
+//! │                          │ context=schema.TableData.context,
+//! │                          │ request=values_count
+//! │ [block_key_count + 1]Key │ Eytzinger-layout keys from a subset of the values.
+//! │ [≤value_count_max]Value  │ At least one value (no empty tables).
+//! │ […]u8{0}                 │ padding (to end of block)
+//!
+//! TODO(Unified manifest) Import the manifest log block too.
+const std = @import("std");
+const mem = std.mem;
+const assert = std.debug.assert;
+
+const constants = @import("../constants.zig");
+const vsr = @import("../vsr.zig");
+
+const stdx = @import("../stdx.zig");
+const BlockType = @import("grid.zig").BlockType;
+
+const address_size = @sizeOf(u64);
+const checksum_size = @sizeOf(u128);
+
+const block_size = constants.block_size;
+const block_body_size = block_size - @sizeOf(vsr.Header);
+
+const BlockPtr = *align(constants.sector_size) [block_size]u8;
+const BlockPtrConst = *align(constants.sector_size) const [block_size]u8;
+
+pub const TableIndex = struct {
+    /// Every table has exactly one index block.
+    const index_block_count = 1;
+
+    /// Stored in every index block's header's `context` field.
+    ///
+    /// The max-counts are stored in the header despite being available (per-tree) at comptime:
+    /// - Encoding schema parameters enables schema evolution.
+    /// - Tables can be decoded without per-tree specialized decoders.
+    ///   (In particular, this is useful for the scrubber and the grid repair queue).
+    pub const Context = extern struct {
+        filter_block_count: u32,
+        filter_block_count_max: u32,
+        data_block_count: u32,
+        data_block_count_max: u32,
+
+        comptime {
+            assert(@sizeOf(Context) == @sizeOf(u128));
+            assert(@bitSizeOf(Context) == @sizeOf(Context) * 8);
+        }
+    };
+
+    key_size: u32,
+    filter_block_count_max: u32,
+    data_block_count_max: u32,
+
+    size: u32,
+    filter_checksums_offset: u32,
+    filter_checksums_size: u32,
+    data_checksums_offset: u32,
+    data_checksums_size: u32,
+    keys_offset: u32,
+    keys_size: u32,
+    filter_addresses_offset: u32,
+    filter_addresses_size: u32,
+    data_addresses_offset: u32,
+    data_addresses_size: u32,
+    padding_offset: u32,
+    padding_size: u32,
+
+    const Parameters = struct {
+        key_size: u32,
+        filter_block_count_max: u32,
+        data_block_count_max: u32,
+    };
+
+    pub fn init(parameters: Parameters) TableIndex {
+        assert(parameters.key_size > 0);
+        assert(parameters.filter_block_count_max > 0);
+        assert(parameters.data_block_count_max > 0);
+
+        const filter_checksums_offset = @sizeOf(vsr.Header);
+        const filter_checksums_size = parameters.filter_block_count_max * checksum_size;
+
+        const data_checksums_offset = filter_checksums_offset + filter_checksums_size;
+        const data_checksums_size = parameters.data_block_count_max * checksum_size;
+
+        const keys_offset = data_checksums_offset + data_checksums_size;
+        const keys_size = parameters.data_block_count_max * parameters.key_size;
+
+        const filter_addresses_offset = keys_offset + keys_size;
+        const filter_addresses_size = parameters.filter_block_count_max * address_size;
+
+        const data_addresses_offset = filter_addresses_offset + filter_addresses_size;
+        const data_addresses_size = parameters.data_block_count_max * address_size;
+
+        const padding_offset = data_addresses_offset + data_addresses_size;
+        const padding_size = constants.block_size - padding_offset;
+
+        const size = @sizeOf(vsr.Header) + filter_checksums_size + data_checksums_size +
+            keys_size + filter_addresses_size + data_addresses_size;
+
+        return .{
+            .key_size = parameters.key_size,
+            .filter_block_count_max = parameters.filter_block_count_max,
+            .data_block_count_max = parameters.data_block_count_max,
+            .size = size,
+            .filter_checksums_offset = filter_checksums_offset,
+            .filter_checksums_size = filter_checksums_size,
+            .data_checksums_offset = data_checksums_offset,
+            .data_checksums_size = data_checksums_size,
+            .keys_offset = keys_offset,
+            .keys_size = keys_size,
+            .filter_addresses_offset = filter_addresses_offset,
+            .filter_addresses_size = filter_addresses_size,
+            .data_addresses_offset = data_addresses_offset,
+            .data_addresses_size = data_addresses_size,
+            .padding_offset = padding_offset,
+            .padding_size = padding_size,
+        };
+    }
+
+    pub fn from_index_block(index_block: BlockPtrConst) TableIndex {
+        const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
+        assert(header.command == .block);
+        assert(BlockType.from(header.operation) == .index);
+        assert(header.op > 0);
+
+        const context = @bitCast(Context, header.context);
+        assert(context.filter_block_count <= context.filter_block_count_max);
+        assert(context.data_block_count <= context.data_block_count_max);
+
+        return TableIndex.init(.{
+            .key_size = header.request,
+            .filter_block_count_max = context.filter_block_count_max,
+            .data_block_count_max = context.data_block_count_max,
+        });
+    }
+
+    pub inline fn data_addresses(index: *const TableIndex, index_block: BlockPtr) []u64 {
+        return mem.bytesAsSlice(
+            u64,
+            index_block[index.data_addresses_offset..][0..index.data_addresses_size],
+        );
+    }
+
+    pub inline fn data_addresses_used(
+        index: *const TableIndex,
+        index_block: BlockPtrConst,
+    ) []const u64 {
+        const slice = mem.bytesAsSlice(
+            u64,
+            index_block[index.data_addresses_offset..][0..index.data_addresses_size],
+        );
+        return slice[0..index.data_blocks_used(index_block)];
+    }
+
+    pub inline fn data_checksums(index: *const TableIndex, index_block: BlockPtr) []u128 {
+        return mem.bytesAsSlice(
+            u128,
+            index_block[index.data_checksums_offset..][0..index.data_checksums_size],
+        );
+    }
+
+    pub inline fn data_checksums_used(
+        index: *const TableIndex,
+        index_block: BlockPtrConst,
+    ) []const u128 {
+        const slice = mem.bytesAsSlice(
+            u128,
+            index_block[index.data_checksums_offset..][0..index.data_checksums_size],
+        );
+        return slice[0..index.data_blocks_used(index_block)];
+    }
+
+    pub inline fn filter_addresses(index: *const TableIndex, index_block: BlockPtr) []u64 {
+        return mem.bytesAsSlice(
+            u64,
+            index_block[index.filter_addresses_offset..][0..index.filter_addresses_size],
+        );
+    }
+
+    pub inline fn filter_addresses_used(
+        index: *const TableIndex,
+        index_block: BlockPtrConst,
+    ) []const u64 {
+        const slice = mem.bytesAsSlice(
+            u64,
+            index_block[index.filter_addresses_offset..][0..index.filter_addresses_size],
+        );
+        return slice[0..index.filter_blocks_used(index_block)];
+    }
+
+    pub inline fn filter_checksums(index: *const TableIndex, index_block: BlockPtr) []u128 {
+        return mem.bytesAsSlice(
+            u128,
+            index_block[index.filter_checksums_offset..][0..index.filter_checksums_size],
+        );
+    }
+
+    pub inline fn filter_checksums_used(
+        index: *const TableIndex,
+        index_block: BlockPtrConst,
+    ) []const u128 {
+        const slice = mem.bytesAsSlice(
+            u128,
+            index_block[index.filter_checksums_offset..][0..index.filter_checksums_size],
+        );
+        return slice[0..index.filter_blocks_used(index_block)];
+    }
+
+    inline fn blocks_used(index: *const TableIndex, index_block: BlockPtrConst) u32 {
+        return index_block_count + index.filter_blocks_used(index_block) +
+            data_blocks_used(index_block);
+    }
+
+    inline fn filter_blocks_used(index: *const TableIndex, index_block: BlockPtrConst) u32 {
+        const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
+        const context = @bitCast(Context, header.context);
+        const value = @intCast(u32, context.filter_block_count);
+        assert(value > 0);
+        assert(value <= index.filter_block_count_max);
+        return value;
+    }
+
+    pub inline fn data_blocks_used(index: *const TableIndex, index_block: BlockPtrConst) u32 {
+        const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
+        const context = @bitCast(Context, header.context);
+        const value = @intCast(u32, context.data_block_count);
+        assert(value > 0);
+        assert(value <= index.data_block_count_max);
+        return value;
+    }
+};
+
+pub const TableFilter = struct {
+    /// Stored in every filter block's header's `context` field.
+    pub const Context = extern struct {
+        data_block_count_max: u32,
+        reserved: [12]u8 = [_]u8{0} ** 12,
+
+        comptime {
+            assert(@sizeOf(Context) == @sizeOf(u128));
+            assert(@bitSizeOf(Context) == @sizeOf(Context) * 8);
+        }
+    };
+
+    /// The number of data blocks summarized by a single filter block.
+    data_block_count_max: u32,
+
+    filter_offset: u32,
+    filter_size: u32,
+    padding_offset: u32,
+    padding_size: u32,
+
+    pub fn init(parameters: Context) TableFilter {
+        assert(parameters.data_block_count_max > 0);
+        assert(stdx.zeroed(&parameters.reserved));
+
+        const filter_offset = @sizeOf(vsr.Header);
+        const filter_size = constants.block_size - filter_offset;
+        assert(filter_size == block_body_size);
+
+        const padding_offset = filter_offset + filter_size;
+        const padding_size = constants.block_size - padding_offset;
+        assert(padding_size == 0);
+
+        return .{
+            .data_block_count_max = parameters.data_block_count_max,
+            .filter_offset = filter_offset,
+            .filter_size = filter_size,
+            .padding_offset = padding_offset,
+            .padding_size = padding_size,
+        };
+    }
+
+    pub fn from_filter_block(filter_block: BlockPtrConst) TableFilter {
+        const header = mem.bytesAsValue(vsr.Header, filter_block[0..@sizeOf(vsr.Header)]);
+        assert(header.command == .block);
+        assert(BlockType.from(header.operation) == .filter);
+        assert(header.op > 0);
+
+        return TableFilter.init(@bitCast(Context, header.context));
+    }
+
+    pub inline fn block_filter(
+        filter: *const TableFilter,
+        filter_block: BlockPtr,
+    ) []u8 {
+        return filter_block[filter.filter_offset..][0..filter.filter_size];
+    }
+
+    pub inline fn block_filter_const(
+        filter: *const TableFilter,
+        filter_block: BlockPtrConst,
+    ) []const u8 {
+        return filter_block[filter.filter_offset..][0..filter.filter_size];
+    }
+};
+
+pub const TableData = struct {
+    /// Stored in every data block's header's `context` field.
+    pub const Context = extern struct {
+        key_count: u32,
+        key_layout_size: u32,
+        value_count_max: u32,
+        value_size: u32,
+
+        comptime {
+            assert(@sizeOf(Context) == @sizeOf(u128));
+            assert(@bitSizeOf(Context) == @sizeOf(Context) * 8);
+        }
+    };
+
+    // The number of keys in the Eytzinger layout per data block.
+    key_count: u32,
+    // @sizeOf(Table.Value)
+    value_size: u32,
+    // The maximum number of values in a data block.
+    value_count_max: u32,
+
+    key_layout_offset: u32,
+    // The number of bytes used by the keys in the data block.
+    key_layout_size: u32,
+
+    values_offset: u32,
+    values_size: u32,
+
+    padding_offset: u32,
+    padding_size: u32,
+
+    pub fn init(parameters: Context) TableData {
+        assert(parameters.value_count_max > 0);
+        assert(parameters.value_size > 0);
+        assert(std.math.isPowerOfTwo(parameters.value_size));
+
+        const key_count = parameters.key_count;
+        const value_count_max = parameters.value_count_max;
+
+        const key_layout_offset = @sizeOf(vsr.Header);
+        const key_layout_size = parameters.key_layout_size;
+
+        const values_offset = key_layout_offset + key_layout_size;
+        const values_size = parameters.value_count_max * parameters.value_size;
+
+        const padding_offset = values_offset + values_size;
+        const padding_size = constants.block_size - padding_offset;
+
+        return .{
+            .key_count = key_count,
+            .value_size = parameters.value_size,
+            .value_count_max = value_count_max,
+            .key_layout_offset = key_layout_offset,
+            .key_layout_size = key_layout_size,
+            .values_offset = values_offset,
+            .values_size = values_size,
+            .padding_offset = padding_offset,
+            .padding_size = padding_size,
+        };
+    }
+
+    pub fn from_data_block(data_block: BlockPtrConst) TableData {
+        const header = mem.bytesAsValue(vsr.Header, data_block[0..@sizeOf(vsr.Header)]);
+        assert(header.command == .block);
+        assert(BlockType.from(header.operation) == .data);
+        assert(header.op > 0);
+
+        return TableData.init(@bitCast(Context, header.context));
+    }
+
+    pub inline fn block_values_bytes(
+        schema: *const TableData,
+        data_block: BlockPtr,
+    ) []align(16) u8 {
+        return data_block[schema.values_offset..][0..schema.values_size];
+    }
+
+    pub inline fn block_values_bytes_const(
+        schema: *const TableData,
+        data_block: BlockPtrConst,
+    ) []align(16) const u8 {
+        return data_block[schema.values_offset..][0..schema.values_size];
+    }
+
+    pub inline fn block_values_used_bytes(
+        schema: *const TableData,
+        data_block: BlockPtrConst,
+    ) []align(16) const u8 {
+        const header = mem.bytesAsValue(vsr.Header, data_block[0..@sizeOf(vsr.Header)]);
+        // TODO we should be able to cross-check this with the header size
+        // for more safety.
+        const used_values = @intCast(u32, header.request);
+        assert(used_values > 0);
+        assert(used_values <= schema.value_count_max);
+
+        const used_bytes = used_values * schema.value_size;
+        return schema.block_values_bytes_const(data_block)[0..used_bytes];
+    }
+};

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -16,6 +16,7 @@ const snapshot_latest = @import("tree.zig").snapshot_latest;
 const BlockType = @import("grid.zig").BlockType;
 const allocate_block = @import("grid.zig").allocate_block;
 const TableInfoType = @import("manifest.zig").TableInfoType;
+const schema = @import("schema.zig");
 
 pub const TableUsage = enum {
     /// General purpose table.
@@ -44,41 +45,6 @@ const BlockPtrConst = *align(constants.sector_size) const [block_size]u8;
 ///   Each filter block summarizes the keys for several adjacent (in terms of key) data blocks.
 /// * Data blocks (at least one, at most `data_block_count_max`)
 ///   Store the actual keys/values, along with a small index of the keys to optimize lookups.
-///
-///
-/// Every block begins with a `vsr.Header` that includes:
-///
-/// * `checksum`, `checksum_body` verify the data integrity.
-/// * `cluster` is the cluster id.
-/// * `command` is `.block`.
-/// * `op` is the block address.
-/// * `size` is the block size excluding padding.
-///
-/// Index block schema:
-/// │ vsr.Header                   │ operation=BlockType.index,
-/// │                              │ context=TableIndexSchema.Context,
-/// │                              │ request=@sizeOf(Key)
-/// │                              │ timestamp=snapshot_min
-/// │ [filter_block_count_max]u128 │ checksums of filter blocks
-/// │ [data_block_count_max]u128   │ checksums of data blocks
-/// │ [data_block_count_max]Key    │ the maximum/last key in the respective data block
-/// │ [filter_block_count_max]u64  │ addresses of filter blocks
-/// │ [data_block_count_max]u64    │ addresses of data blocks
-/// │ […]u8{0}                     │ padding (to end of block)
-///
-/// Filter block schema:
-/// │ vsr.Header │ operation=BlockType.filter,
-/// │            │ context=TableFilterSchema.context
-/// │ […]u8      │ A split-block Bloom filter, "containing" every key from as many as
-/// │            │   `filter_data_block_count_max` data blocks.
-///
-/// Data block schema:
-/// │ vsr.Header               │ operation=BlockType.data,
-/// │                          │ context=TableDataSchema.context,
-/// │                          │ request=values_count
-/// │ [block_key_count + 1]Key │ Eytzinger-layout keys from a subset of the values.
-/// │ [≤value_count_max]Value  │ At least one value (no empty tables).
-/// │ […]u8{0}                 │ padding (to end of block)
 pub fn TableType(
     comptime TableKey: type,
     comptime TableValue: type,
@@ -243,17 +209,17 @@ pub fn TableType(
         pub const block_count_max =
             index_block_count + filter_block_count_max + data_block_count_max;
 
-        const index = TableIndexSchema.init(.{
+        const index = schema.TableIndex.init(.{
             .key_size = key_size,
             .filter_block_count_max = filter_block_count_max,
             .data_block_count_max = data_block_count_max,
         });
 
-        const filter = TableFilterSchema.init(.{
+        const filter = schema.TableFilter.init(.{
             .data_block_count_max = layout.filter_data_block_count_max,
         });
 
-        pub const data = TableDataSchema.init(.{
+        pub const data = schema.TableData.init(.{
             .key_count = layout.block_key_count,
             .key_layout_size = layout.block_key_layout_size,
             .value_count_max = layout.block_value_count_max,
@@ -553,7 +519,7 @@ pub fn TableType(
 
                 header.* = .{
                     .cluster = options.cluster,
-                    .context = @bitCast(u128, TableDataSchema.Context{
+                    .context = @bitCast(u128, schema.TableData.Context{
                         .key_count = data.key_count,
                         .key_layout_size = data.key_layout_size,
                         .value_count_max = data.value_count_max,
@@ -618,7 +584,7 @@ pub fn TableType(
                 const header = mem.bytesAsValue(vsr.Header, header_bytes);
                 header.* = .{
                     .cluster = options.cluster,
-                    .context = @bitCast(u128, TableFilterSchema.Context{
+                    .context = @bitCast(u128, schema.TableFilter.Context{
                         .data_block_count_max = data_block_count_max,
                     }),
                     .op = options.address,
@@ -674,7 +640,7 @@ pub fn TableType(
 
                 header.* = .{
                     .cluster = options.cluster,
-                    .context = @bitCast(u128, TableIndexSchema.Context{
+                    .context = @bitCast(u128, schema.TableIndex.Context{
                         .filter_block_count = builder.filter_block_count,
                         .filter_block_count_max = index.filter_block_count_max,
                         .data_block_count = builder.data_block_count,
@@ -866,376 +832,6 @@ pub fn TableType(
         }
     };
 }
-
-pub const TableIndexSchema = struct {
-    /// Every table has exactly one index block.
-    const index_block_count = 1;
-
-    /// Stored in every index block's header's `context` field.
-    ///
-    /// The max-counts are stored in the header despite being available (per-tree) at comptime:
-    /// - Encoding schema parameters enables schema evolution.
-    /// - Tables can be decoded without per-tree specialized decoders.
-    ///   (In particular, this is useful for the scrubber and the grid repair queue).
-    const Context = extern struct {
-        filter_block_count: u32,
-        filter_block_count_max: u32,
-        data_block_count: u32,
-        data_block_count_max: u32,
-
-        comptime {
-            assert(@sizeOf(Context) == @sizeOf(u128));
-            assert(@bitSizeOf(Context) == @sizeOf(Context) * 8);
-        }
-    };
-
-    key_size: u32,
-    filter_block_count_max: u32,
-    data_block_count_max: u32,
-
-    size: u32,
-    filter_checksums_offset: u32,
-    filter_checksums_size: u32,
-    data_checksums_offset: u32,
-    data_checksums_size: u32,
-    keys_offset: u32,
-    keys_size: u32,
-    filter_addresses_offset: u32,
-    filter_addresses_size: u32,
-    data_addresses_offset: u32,
-    data_addresses_size: u32,
-    padding_offset: u32,
-    padding_size: u32,
-
-    const Parameters = struct {
-        key_size: u32,
-        filter_block_count_max: u32,
-        data_block_count_max: u32,
-    };
-
-    pub fn init(parameters: Parameters) TableIndexSchema {
-        assert(parameters.key_size > 0);
-        assert(parameters.filter_block_count_max > 0);
-        assert(parameters.data_block_count_max > 0);
-
-        const filter_checksums_offset = @sizeOf(vsr.Header);
-        const filter_checksums_size = parameters.filter_block_count_max * checksum_size;
-
-        const data_checksums_offset = filter_checksums_offset + filter_checksums_size;
-        const data_checksums_size = parameters.data_block_count_max * checksum_size;
-
-        const keys_offset = data_checksums_offset + data_checksums_size;
-        const keys_size = parameters.data_block_count_max * parameters.key_size;
-
-        const filter_addresses_offset = keys_offset + keys_size;
-        const filter_addresses_size = parameters.filter_block_count_max * address_size;
-
-        const data_addresses_offset = filter_addresses_offset + filter_addresses_size;
-        const data_addresses_size = parameters.data_block_count_max * address_size;
-
-        const padding_offset = data_addresses_offset + data_addresses_size;
-        const padding_size = block_size - padding_offset;
-
-        const size = @sizeOf(vsr.Header) + filter_checksums_size + data_checksums_size +
-            keys_size + filter_addresses_size + data_addresses_size;
-
-        return .{
-            .key_size = parameters.key_size,
-            .filter_block_count_max = parameters.filter_block_count_max,
-            .data_block_count_max = parameters.data_block_count_max,
-            .size = size,
-            .filter_checksums_offset = filter_checksums_offset,
-            .filter_checksums_size = filter_checksums_size,
-            .data_checksums_offset = data_checksums_offset,
-            .data_checksums_size = data_checksums_size,
-            .keys_offset = keys_offset,
-            .keys_size = keys_size,
-            .filter_addresses_offset = filter_addresses_offset,
-            .filter_addresses_size = filter_addresses_size,
-            .data_addresses_offset = data_addresses_offset,
-            .data_addresses_size = data_addresses_size,
-            .padding_offset = padding_offset,
-            .padding_size = padding_size,
-        };
-    }
-
-    pub fn from_index_block(index_block: BlockPtrConst) TableIndexSchema {
-        const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
-        assert(header.command == .block);
-        assert(BlockType.from(header.operation) == .index);
-        assert(header.op > 0);
-
-        const context = @bitCast(Context, header.context);
-        assert(context.filter_block_count <= context.filter_block_count_max);
-        assert(context.data_block_count <= context.data_block_count_max);
-
-        return TableIndexSchema.init(.{
-            .key_size = header.request,
-            .filter_block_count_max = context.filter_block_count_max,
-            .data_block_count_max = context.data_block_count_max,
-        });
-    }
-
-    pub inline fn data_addresses(index: *const TableIndexSchema, index_block: BlockPtr) []u64 {
-        return mem.bytesAsSlice(
-            u64,
-            index_block[index.data_addresses_offset..][0..index.data_addresses_size],
-        );
-    }
-
-    pub inline fn data_addresses_used(
-        index: *const TableIndexSchema,
-        index_block: BlockPtrConst,
-    ) []const u64 {
-        const slice = mem.bytesAsSlice(
-            u64,
-            index_block[index.data_addresses_offset..][0..index.data_addresses_size],
-        );
-        return slice[0..index.data_blocks_used(index_block)];
-    }
-
-    pub inline fn data_checksums(index: *const TableIndexSchema, index_block: BlockPtr) []u128 {
-        return mem.bytesAsSlice(
-            u128,
-            index_block[index.data_checksums_offset..][0..index.data_checksums_size],
-        );
-    }
-
-    pub inline fn data_checksums_used(
-        index: *const TableIndexSchema,
-        index_block: BlockPtrConst,
-    ) []const u128 {
-        const slice = mem.bytesAsSlice(
-            u128,
-            index_block[index.data_checksums_offset..][0..index.data_checksums_size],
-        );
-        return slice[0..index.data_blocks_used(index_block)];
-    }
-
-    inline fn filter_addresses(index: *const TableIndexSchema, index_block: BlockPtr) []u64 {
-        return mem.bytesAsSlice(
-            u64,
-            index_block[index.filter_addresses_offset..][0..index.filter_addresses_size],
-        );
-    }
-
-    pub inline fn filter_addresses_used(
-        index: *const TableIndexSchema,
-        index_block: BlockPtrConst,
-    ) []const u64 {
-        const slice = mem.bytesAsSlice(
-            u64,
-            index_block[index.filter_addresses_offset..][0..index.filter_addresses_size],
-        );
-        return slice[0..index.filter_blocks_used(index_block)];
-    }
-
-    inline fn filter_checksums(index: *const TableIndexSchema, index_block: BlockPtr) []u128 {
-        return mem.bytesAsSlice(
-            u128,
-            index_block[index.filter_checksums_offset..][0..index.filter_checksums_size],
-        );
-    }
-
-    pub inline fn filter_checksums_used(
-        index: *const TableIndexSchema,
-        index_block: BlockPtrConst,
-    ) []const u128 {
-        const slice = mem.bytesAsSlice(
-            u128,
-            index_block[index.filter_checksums_offset..][0..index.filter_checksums_size],
-        );
-        return slice[0..index.filter_blocks_used(index_block)];
-    }
-
-    inline fn blocks_used(index: *const TableIndexSchema, index_block: BlockPtrConst) u32 {
-        return index_block_count + index.filter_blocks_used(index_block) +
-            data_blocks_used(index_block);
-    }
-
-    inline fn filter_blocks_used(index: *const TableIndexSchema, index_block: BlockPtrConst) u32 {
-        const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
-        const context = @bitCast(Context, header.context);
-        const value = @intCast(u32, context.filter_block_count);
-        assert(value > 0);
-        assert(value <= index.filter_block_count_max);
-        return value;
-    }
-
-    pub inline fn data_blocks_used(index: *const TableIndexSchema, index_block: BlockPtrConst) u32 {
-        const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
-        const context = @bitCast(Context, header.context);
-        const value = @intCast(u32, context.data_block_count);
-        assert(value > 0);
-        assert(value <= index.data_block_count_max);
-        return value;
-    }
-};
-
-pub const TableFilterSchema = struct {
-    /// Stored in every filter block's header's `context` field.
-    const Context = extern struct {
-        data_block_count_max: u32,
-        reserved: [12]u8 = [_]u8{0} ** 12,
-
-        comptime {
-            assert(@sizeOf(Context) == @sizeOf(u128));
-            assert(@bitSizeOf(Context) == @sizeOf(Context) * 8);
-        }
-    };
-
-    /// The number of data blocks summarized by a single filter block.
-    data_block_count_max: u32,
-
-    filter_offset: u32,
-    filter_size: u32,
-    padding_offset: u32,
-    padding_size: u32,
-
-    fn init(parameters: Context) TableFilterSchema {
-        assert(parameters.data_block_count_max > 0);
-        assert(stdx.zeroed(&parameters.reserved));
-
-        const filter_offset = @sizeOf(vsr.Header);
-        const filter_size = block_size - filter_offset;
-        assert(filter_size == block_body_size);
-
-        const padding_offset = filter_offset + filter_size;
-        const padding_size = block_size - padding_offset;
-        assert(padding_size == 0);
-
-        return .{
-            .data_block_count_max = parameters.data_block_count_max,
-            .filter_offset = filter_offset,
-            .filter_size = filter_size,
-            .padding_offset = padding_offset,
-            .padding_size = padding_size,
-        };
-    }
-
-    pub fn from_filter_block(filter_block: BlockPtrConst) TableFilterSchema {
-        const header = mem.bytesAsValue(vsr.Header, filter_block[0..@sizeOf(vsr.Header)]);
-        assert(header.command == .block);
-        assert(BlockType.from(header.operation) == .filter);
-        assert(header.op > 0);
-
-        return TableFilterSchema.init(@bitCast(Context, header.context));
-    }
-
-    pub inline fn block_filter(
-        filter: *const TableFilterSchema,
-        filter_block: BlockPtr,
-    ) []u8 {
-        return filter_block[filter.filter_offset..][0..filter.filter_size];
-    }
-
-    pub inline fn block_filter_const(
-        filter: *const TableFilterSchema,
-        filter_block: BlockPtrConst,
-    ) []const u8 {
-        return filter_block[filter.filter_offset..][0..filter.filter_size];
-    }
-};
-
-pub const TableDataSchema = struct {
-    /// Stored in every data block's header's `context` field.
-    const Context = extern struct {
-        key_count: u32,
-        key_layout_size: u32,
-        value_count_max: u32,
-        value_size: u32,
-
-        comptime {
-            assert(@sizeOf(Context) == @sizeOf(u128));
-            assert(@bitSizeOf(Context) == @sizeOf(Context) * 8);
-        }
-    };
-
-    // The number of keys in the Eytzinger layout per data block.
-    key_count: u32,
-    // @sizeOf(Table.Value)
-    value_size: u32,
-    // The maximum number of values in a data block.
-    value_count_max: u32,
-
-    key_layout_offset: u32,
-    // The number of bytes used by the keys in the data block.
-    key_layout_size: u32,
-
-    values_offset: u32,
-    values_size: u32,
-
-    padding_offset: u32,
-    padding_size: u32,
-
-    fn init(parameters: Context) TableDataSchema {
-        assert(parameters.value_count_max > 0);
-        assert(parameters.value_size > 0);
-        assert(std.math.isPowerOfTwo(parameters.value_size));
-
-        const key_count = parameters.key_count;
-        const value_count_max = parameters.value_count_max;
-
-        const key_layout_offset = @sizeOf(vsr.Header);
-        const key_layout_size = parameters.key_layout_size;
-
-        const values_offset = key_layout_offset + key_layout_size;
-        const values_size = parameters.value_count_max * parameters.value_size;
-
-        const padding_offset = values_offset + values_size;
-        const padding_size = block_size - padding_offset;
-
-        return .{
-            .key_count = key_count,
-            .value_size = parameters.value_size,
-            .value_count_max = value_count_max,
-            .key_layout_offset = key_layout_offset,
-            .key_layout_size = key_layout_size,
-            .values_offset = values_offset,
-            .values_size = values_size,
-            .padding_offset = padding_offset,
-            .padding_size = padding_size,
-        };
-    }
-
-    pub fn from_data_block(data_block: BlockPtrConst) TableDataSchema {
-        const header = mem.bytesAsValue(vsr.Header, data_block[0..@sizeOf(vsr.Header)]);
-        assert(header.command == .block);
-        assert(BlockType.from(header.operation) == .data);
-        assert(header.op > 0);
-
-        return TableDataSchema.init(@bitCast(Context, header.context));
-    }
-
-    pub inline fn block_values_bytes(
-        schema: *const TableDataSchema,
-        data_block: BlockPtr,
-    ) []align(16) u8 {
-        return data_block[schema.values_offset..][0..schema.values_size];
-    }
-
-    pub inline fn block_values_bytes_const(
-        schema: *const TableDataSchema,
-        data_block: BlockPtrConst,
-    ) []align(16) const u8 {
-        return data_block[schema.values_offset..][0..schema.values_size];
-    }
-
-    pub inline fn block_values_used_bytes(
-        schema: *const TableDataSchema,
-        data_block: BlockPtrConst,
-    ) []align(16) const u8 {
-        const header = mem.bytesAsValue(vsr.Header, data_block[0..@sizeOf(vsr.Header)]);
-        // TODO we should be able to cross-check this with the header size
-        // for more safety.
-        const used_values = @intCast(u32, header.request);
-        assert(used_values > 0);
-        assert(used_values <= schema.value_count_max);
-
-        const used_bytes = used_values * schema.value_size;
-        return schema.block_values_bytes_const(data_block)[0..used_bytes];
-    }
-};
 
 test "Table" {
     const Key = @import("composite_key.zig").CompositeKey(u128);

--- a/src/lsm/table_immutable.zig
+++ b/src/lsm/table_immutable.zig
@@ -83,7 +83,7 @@ pub fn TableImmutableType(comptime Table: type) type {
             assert(sorted_values.ptr == table.values.ptr);
             assert(sorted_values.len > 0);
             assert(sorted_values.len <= value_count_max);
-            assert(sorted_values.len <= Table.data.block_value_count_max * Table.data_block_count_max);
+            assert(sorted_values.len <= Table.data.value_count_max * Table.data_block_count_max);
 
             if (constants.verify) {
                 var i: usize = 1;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -423,7 +423,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
 
-                const filter_schema = schema.TableFilter.from_filter_block(filter_block);
+                const filter_schema = schema.TableFilter.from(filter_block);
                 const filter_bytes = filter_schema.block_filter_const(filter_block);
                 if (bloom_filter.may_contain(context.fingerprint, filter_bytes)) {
                     context.tree.filter_block_hits += 1;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -19,7 +19,7 @@ const bloom_filter = @import("bloom_filter.zig");
 const CompositeKey = @import("composite_key.zig").CompositeKey;
 const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
-const TableFilterSchema = @import("table.zig").TableFilterSchema;
+const schema = @import("schema.zig");
 
 /// We reserve maxInt(u64) to indicate that a table has not been deleted.
 /// Tables that have not been deleted have snapshot_max of maxInt(u64).
@@ -423,7 +423,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
 
-                const filter_schema = TableFilterSchema.from_filter_block(filter_block);
+                const filter_schema = schema.TableFilter.from_filter_block(filter_block);
                 const filter_bytes = filter_schema.block_filter_const(filter_block);
                 if (bloom_filter.may_contain(context.fingerprint, filter_bytes)) {
                     context.tree.filter_block_hits += 1;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -19,6 +19,7 @@ const bloom_filter = @import("bloom_filter.zig");
 const CompositeKey = @import("composite_key.zig").CompositeKey;
 const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
+const TableFilterSchema = @import("table.zig").TableFilterSchema;
 
 /// We reserve maxInt(u64) to indicate that a table has not been deleted.
 /// Tables that have not been deleted have snapshot_max of maxInt(u64).
@@ -422,7 +423,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
 
-                const filter_bytes = Table.filter_block_filter_const(filter_block);
+                const filter_schema = TableFilterSchema.from_filter_block(filter_block);
+                const filter_bytes = filter_schema.block_filter_const(filter_block);
                 if (bloom_filter.may_contain(context.fingerprint, filter_bytes)) {
                     context.tree.filter_block_hits += 1;
                     tracer.plot(

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -795,9 +795,9 @@ pub const Header = extern struct {
         assert(self.command == .block);
         if (self.parent != 0) return "parent != 0";
         if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
         if (self.view != 0) return "view != 0";
         if (self.op == 0) return "op == 0"; // address ≠ 0
+        if (self.commit != 0) return "commit != 0";
         if (self.replica != 0) return "replica != 0";
         if (self.operation == .reserved) return "operation == .reserved";
         return null;


### PR DESCRIPTION
(This PR has lots of lines changed, but for the most part they are just moved.)

### Motivation

The scrubber and `GridRepairQueue` will need to decode table index blocks.
(Specifically, they need to enumerate all referenced filter/data blocks in an index block).

But the scrubber and the `GridRepairQueue` are not specialized per-tree.

## Overview

Rather than switching between decoders based on the tree id (which would be complicated -- each `Table`/`Tree` is a different specialized type), encode the schema's parameters directly into the table index block.

Then the scrubber/repair-queue constructs the relevant decoder schema at runtime.
This change also lends itself well to backwards-compatible table layout changes.

(Aside: Functions that use `Key` are still specialized. The scrubber/repair-queue don't need these anyway.)