### PR TITLE
vopr: fix false assertion in liveness mode

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -502,7 +502,6 @@ pub const Simulator = struct {
         for (simulator.cluster.replicas) |replica| {
             if (simulator.core.isSet(replica.replica)) {
                 assert(simulator.cluster.replica_health[replica.replica] == .up);
-                assert(replica.status == .normal);
                 if (replica.commit_min < replica.op) {
                     if (missing_op == null or missing_op.? > replica.commit_min + 1) {
                         missing_op = replica.commit_min + 1;


### PR DESCRIPTION
See: https://github.com/tigerbeetle/tigerbeetle/issues/931

The situation is as follows:

```
0   \ v          8852V 162/198C 120:183Jo  0/_2J!  99:183Wo   44504Gf
1   \  .           23V 198/198C 135:198Jo  0/_0J! 135:198Wo   44399Gf
2   /   v        8852V 198/198C 135:198Jo  2/_2J! 135:198Wo   44399Gf
```

What happens here is that the core is missing a prepare, and is also in a view change, which can't complete, because the primary can't finish its own repair (op=163 is the problematic one). So the cluster is correctly stuck cycling view changes.

While burning through view numbers _can_ indicate a bug, it isn't _always_ a bug, so just remove the assertion about normal state.

commit: b584e0398a6821a87abd8997cb38f4a75f79b461
SEED: 14466114105889386407


closes: https://github.com/tigerbeetle/tigerbeetle/issues/910
closes: https://github.com/tigerbeetle/tigerbeetle/issues/931