### PR TITLE
Pass Context.table by reference.

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -380,7 +380,7 @@ pub fn CompactionType(
                     .grid = context.grid,
                     .level = context.level_b,
                     .snapshot = context.op_min,
-                    .tables = context.range_b.tables,
+                    .tables = compaction.context.range_b.tables.constSlice(),
                     .index_block = compaction.index_block_b,
                 });
 

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -39,10 +39,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             index_block: BlockPtr,
 
             // `tables` contains TableInfo references from ManifestLevel.
-            tables: std.BoundedArray(
-                Manifest.TableInfoReference,
-                constants.lsm_growth_factor,
-            ),
+            tables: []const Manifest.TableInfoReference,
         };
 
         pub const IndexCallback = fn (it: *LevelTableValueBlockIterator) void;
@@ -121,7 +118,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             // a null data block.
             if (it.table_data_iterator.empty() and it.table_index < it.context.tables.len) {
                 // Refill `table_data_iterator` before calling `table_next`.
-                const table_ref = it.context.tables.slice()[it.table_index];
+                const table_ref = it.context.tables[it.table_index];
                 it.callback = .{ .level_next = callback };
                 it.context.grid.read_block(
                     on_level_next,


### PR DESCRIPTION
`LevelTableValueBlockIterator.Context.table` has been updated as a slice instead of a bounded array. 

Rationale:

- To avoid taking a copy of the array.
- To make the caller responsible for sizing the array (future use case for Scans).


