### PR TITLE
Switch release process for binaries to use gh cli rather than curl

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -78,14 +78,10 @@ jobs:
       if: ${{ inputs.dry-run != 'true' }}
       run: |
         export GIT_TAG="${{ needs.version.outputs.version }}" && \
-        export RELEASE_ID=`curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/tigerbeetledb/tigerbeetle/releases/tags/${GIT_TAG}" | jq '.id'` && \
         export BINARY="$([ ${{ matrix.target }} = x86_64-windows ] && echo tigerbeetle.exe || echo tigerbeetle)" && \
-        zip -9 tigerbeetle-${{ matrix.target }}-${GIT_TAG}${{ matrix.debug }}.zip $BINARY && \
-        curl --fail \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Content-Type: application/zip" \
-          --data-binary @./tigerbeetle-${{ matrix.target }}-${GIT_TAG}${{ matrix.debug }}.zip \
-          "https://uploads.github.com/repos/tigerbeetledb/tigerbeetle/releases/$RELEASE_ID/assets?name=tigerbeetle-${{ matrix.target }}-${GIT_TAG}${{ matrix.debug }}.zip"
+        export ZIP_NAME="tigerbeetle-${{ matrix.target }}-${GIT_TAG}${{ matrix.debug }}.zip" && \
+        zip -9 "${ZIP_NAME}" "${BINARY}" && \
+        gh release upload "${GIT_TAG}" "${ZIP_NAME}"
 
   # Split out the macOS building from the step above, so we can build a universal binary.
   # This means 2 less binaries (one for debug, one for release) on the release page,
@@ -128,14 +124,10 @@ jobs:
       if: ${{ inputs.dry-run != 'true' }}
       run: |
         export GIT_TAG="${{ needs.version.outputs.version }}" && \
-        export RELEASE_ID=`curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/tigerbeetledb/tigerbeetle/releases/tags/${GIT_TAG}" | jq '.id'` && \
         export BINARY="tigerbeetle" && \
-        zip -9 tigerbeetle-universal-macos-${GIT_TAG}${{ matrix.debug }}.zip $BINARY && \
-        curl --fail \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Content-Type: application/zip" \
-          --data-binary @./tigerbeetle-universal-macos-${GIT_TAG}${{ matrix.debug }}.zip \
-          "https://uploads.github.com/repos/tigerbeetledb/tigerbeetle/releases/$RELEASE_ID/assets?name=tigerbeetle-universal-macos-${GIT_TAG}${{ matrix.debug }}.zip"
+        export ZIP_NAME="tigerbeetle-universal-macos-${GIT_TAG}${{ matrix.debug }}.zip" && \
+        zip -9 "${ZIP_NAME}" "${BINARY}" && \
+        gh release upload "${GIT_TAG}" "${ZIP_NAME}"
 
   # Publish all clients and Docker image.
   client-dotnet:


### PR DESCRIPTION
This was failing silently (!) because of our repo name change, which was causing the `curl` to fail. To be followed up by a separate PR that validates our release completed successfully.