### PR TITLE
LSM: Don't specialize TreeType on tree_name; explicit tree ids

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -55,6 +55,22 @@ pub fn ForestType(comptime Storage: type, comptime groove_config: anytype) type 
         },
     });
 
+    {
+        // Verify that every tree id is unique.
+        comptime var ids: []const u128 = &.{};
+
+        inline for (std.meta.fields(Grooves)) |groove_field| {
+            const Groove = groove_field.field_type;
+
+            for (std.meta.fields(@TypeOf(Groove.config.ids))) |field| {
+                const id = @field(Groove.config.ids, field.name);
+
+                assert(std.mem.indexOfScalar(u128, ids, id) == null);
+                ids = ids ++ [_]u128{id};
+            }
+        }
+    }
+
     return struct {
         const Forest = @This();
 

--- a/src/lsm/grid.zig
+++ b/src/lsm/grid.zig
@@ -153,7 +153,6 @@ pub fn GridType(comptime Storage: type) type {
                 .ways = set_associative_cache_ways,
                 .value_alignment = @alignOf(u64),
             },
-            "grid",
         );
 
         superblock: *SuperBlock,
@@ -207,7 +206,7 @@ pub fn GridType(comptime Storage: type) type {
             }
             errdefer for (cache_blocks) |block| allocator.free(block);
 
-            var cache = try Cache.init(allocator, options.cache_blocks_count);
+            var cache = try Cache.init(allocator, options.cache_blocks_count, .{ .name = "grid" });
             errdefer cache.deinit(allocator);
 
             var read_iop_blocks: [read_iops_max]BlockPtr = undefined;

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -119,7 +119,6 @@ comptime {
 fn IndexTreeType(
     comptime Storage: type,
     comptime Field: type,
-    comptime tree_name: [:0]const u8,
     comptime value_count_max: usize,
 ) type {
     const Key = CompositeKey(IndexCompositeKeyType(Field));
@@ -135,7 +134,7 @@ fn IndexTreeType(
         .secondary_index,
     );
 
-    return TreeType(Table, Storage, tree_name);
+    return TreeType(Table, Storage);
 }
 
 /// A Groove is a collection of LSM trees auto generated for fields on a struct type
@@ -147,6 +146,10 @@ pub fn GrooveType(
     comptime Storage: type,
     comptime Object: type,
     /// An anonymous struct instance which contains the following:
+    ///
+    /// - ids: { .tree = u128 }:
+    ///     An anonymous struct which maps each of the groove's trees to a stable, forest-unique,
+    ///     tree identifier.
     ///
     /// - value_count_max: { .field = usize }:
     ///     An anonymous struct which contains, for each field of `Object`,
@@ -184,11 +187,9 @@ pub fn GrooveType(
         }
 
         if (!ignored) {
-            const tree_name = @typeName(Object) ++ "." ++ field.name;
             const IndexTree = IndexTreeType(
                 Storage,
                 field.field_type,
-                tree_name,
                 @field(groove_options.value_count_max, field.name),
             );
             index_fields = index_fields ++ [_]std.builtin.TypeInfo.StructField{
@@ -230,12 +231,7 @@ pub fn GrooveType(
         // Create an IndexTree for the DerivedType:
         const tree_name = @typeName(Object) ++ "." ++ field.name;
         const DerivedType = @typeInfo(derive_return_type).Optional.child;
-        const IndexTree = IndexTreeType(
-            Storage,
-            DerivedType,
-            tree_name,
-            @field(groove_options.value_count_max, field.name),
-        );
+        const IndexTree = IndexTreeType(Storage, DerivedType, tree_name);
 
         index_fields = index_fields ++ &.{
             .{
@@ -274,9 +270,7 @@ pub fn GrooveType(
             groove_options.value_count_max.timestamp,
             .general,
         );
-
-        const tree_name = @typeName(Object);
-        break :blk TreeType(Table, Storage, tree_name);
+        break :blk TreeType(Table, Storage);
     };
 
     const _IdTree = if (!has_id) void else blk: {
@@ -291,9 +285,7 @@ pub fn GrooveType(
             groove_options.value_count_max.id,
             .general,
         );
-
-        const tree_name = @typeName(Object) ++ ".id";
-        break :blk TreeType(Table, Storage, tree_name);
+        break :blk TreeType(Table, Storage);
     };
 
     const _IndexTrees = @Type(.{
@@ -312,21 +304,6 @@ pub fn GrooveType(
             .is_tuple = false,
         },
     });
-
-    // Verify no hash collisions between all the trees:
-    comptime var hashes: []const u128 = &.{_ObjectTree.hash};
-
-    if (has_id) {
-        const hash: []const u128 = &.{_IdTree.hash};
-        assert(std.mem.indexOf(u128, hashes, hash) == null);
-        hashes = hashes ++ hash;
-    }
-    inline for (std.meta.fields(_IndexTrees)) |field| {
-        const IndexTree = @TypeOf(@field(@as(_IndexTrees, undefined), field.name));
-        const hash: []const u128 = &.{IndexTree.hash};
-        assert(std.mem.indexOf(u128, hashes, hash) == null);
-        hashes = hashes ++ hash;
-    }
 
     // Verify groove index count:
     const indexes_count_actual = std.meta.fields(_IndexTrees).len;
@@ -397,6 +374,7 @@ pub fn GrooveType(
         pub const ObjectTree = _ObjectTree;
         pub const IdTree = _IdTree;
         pub const IndexTrees = _IndexTrees;
+        pub const config = groove_options;
 
         const Grid = GridType(Storage);
 
@@ -469,11 +447,14 @@ pub fn GrooveType(
             grid: *Grid,
             options: Options,
         ) !Groove {
-            // Intialize the object LSM tree.
             var object_tree = try ObjectTree.init(
                 allocator,
                 node_pool,
                 grid,
+                .{
+                    .id = @field(groove_options.ids, "timestamp"),
+                    .name = @typeName(Object),
+                },
                 options.tree_options_object,
             );
             errdefer object_tree.deinit(allocator);
@@ -482,6 +463,10 @@ pub fn GrooveType(
                 allocator,
                 node_pool,
                 grid,
+                .{
+                    .id = @field(groove_options.ids, "id"),
+                    .name = @typeName(Object) ++ ".id",
+                },
                 options.tree_options_id,
             ));
             errdefer if (has_id) id_tree.deinit(allocator);
@@ -505,6 +490,10 @@ pub fn GrooveType(
                     allocator,
                     node_pool,
                     grid,
+                    .{
+                        .id = @field(groove_options.ids, field.name),
+                        .name = @typeName(Object) ++ "." ++ field.name,
+                    },
                     @field(options.tree_options_index, field.name),
                 );
                 index_trees_initialized += 1;
@@ -1057,6 +1046,17 @@ test "Groove" {
         Storage,
         Transfer,
         .{
+            .ids = .{
+                .timestamp = 1,
+                .id = 2,
+                .debit_account_id = 3,
+                .credit_account_id = 4,
+                .pending_id = 5,
+                .timeout = 6,
+                .ledger = 7,
+                .code = 8,
+                .amount = 9,
+            },
             // Doesn't matter for this test.
             .value_count_max = .{
                 .timestamp = 1,

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -153,7 +153,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
-            tree_hash: u128,
+            tree_id: u128,
         ) !Manifest {
             var levels: [constants.lsm_levels]Level = undefined;
             for (levels) |*level, i| {
@@ -162,7 +162,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             }
             errdefer for (levels) |*level| level.deinit(allocator, node_pool);
 
-            var manifest_log = try ManifestLog.init(allocator, grid, tree_hash);
+            var manifest_log = try ManifestLog.init(allocator, grid, tree_id);
             errdefer manifest_log.deinit(allocator);
 
             return Manifest{

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -297,11 +297,11 @@ const Environment = struct {
         var manifest_log_model = try ManifestLogModel.init(allocator);
         errdefer manifest_log_model.deinit();
 
-        const tree_hash = std.math.maxInt(u128);
-        var manifest_log = try ManifestLog.init(allocator, options.grid, tree_hash);
+        const tree_id = std.math.maxInt(u128);
+        var manifest_log = try ManifestLog.init(allocator, options.grid, tree_id);
         errdefer manifest_log.deinit(allocator);
 
-        var manifest_log_verify = try ManifestLog.init(allocator, options.grid_verify, tree_hash);
+        var manifest_log_verify = try ManifestLog.init(allocator, options.grid_verify, tree_id);
         errdefer manifest_log_verify.deinit(allocator);
 
         return Environment{
@@ -478,7 +478,7 @@ const Environment = struct {
             test_manifest_log.* = try ManifestLog.init(
                 env.allocator,
                 test_grid,
-                env.manifest_log.tree_hash,
+                env.manifest_log.tree_id,
             );
         }
 

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -30,7 +30,6 @@ pub fn SetAssociativeCache(
     comptime hash: fn (Key) callconv(.Inline) u64,
     comptime equal: fn (Key, Key) callconv(.Inline) bool,
     comptime layout: Layout,
-    comptime name: [:0]const u8,
 ) type {
     assert(math.isPowerOfTwo(@sizeOf(Key)));
     assert(math.isPowerOfTwo(@sizeOf(Value)));
@@ -95,6 +94,7 @@ pub fn SetAssociativeCache(
         /// follows from a multiple which will satisfy all asserts.
         pub const value_count_max_multiple = layout.cache_line_size * layout.ways * layout.clock_bits;
 
+        name: []const u8,
         sets: u64,
 
         hits: u64 = 0,
@@ -132,7 +132,9 @@ pub fn SetAssociativeCache(
         ///   https://en.wikipedia.org/wiki/Page_replacement_algorithm.
         clocks: PackedUnsignedIntegerArray(Clock),
 
-        pub fn init(allocator: mem.Allocator, value_count_max: u64) !Self {
+        pub const Options = struct { name: []const u8 };
+
+        pub fn init(allocator: mem.Allocator, value_count_max: u64, options: Options) !Self {
             const sets = @divExact(value_count_max, layout.ways);
 
             assert(value_count_max > 0);
@@ -171,6 +173,7 @@ pub fn SetAssociativeCache(
             errdefer allocator.free(clocks);
 
             var self = Self{
+                .name = options.name,
                 .sets = sets,
                 .tags = tags,
                 .values = values,
@@ -203,13 +206,19 @@ pub fn SetAssociativeCache(
             const set = self.associate(key);
             if (self.search(set, key)) |way| {
                 self.hits += 1;
-                tracer.plot(.{ .cache_hits = .{ .cache_name = name } }, @intToFloat(f64, self.hits));
+                tracer.plot(
+                    .{ .cache_hits = .{ .cache_name = self.name } },
+                    @intToFloat(f64, self.hits),
+                );
                 const count = self.counts.get(set.offset + way);
                 self.counts.set(set.offset + way, count +| 1);
                 return set.offset + way;
             } else {
                 self.misses += 1;
-                tracer.plot(.{ .cache_misses = .{ .cache_name = name } }, @intToFloat(f64, self.misses));
+                tracer.plot(
+                    .{ .cache_misses = .{ .cache_name = self.name } },
+                    @intToFloat(f64, self.misses),
+                );
                 return null;
             }
         }
@@ -402,7 +411,6 @@ fn set_associative_cache_test(
         context.hash,
         context.equal,
         layout,
-        "test",
     );
 
     return struct {
@@ -410,7 +418,7 @@ fn set_associative_cache_test(
             if (log) SAC.inspect();
 
             // TODO Add a nice calculator method to help solve the minimum value_count_max required:
-            var sac = try SAC.init(testing.allocator, 16 * 16 * 8);
+            var sac = try SAC.init(testing.allocator, 16 * 16 * 8, .{ .name = "test" });
             defer sac.deinit(testing.allocator);
 
             for (sac.tags) |tag| try testing.expectEqual(@as(SAC.Tag, 0), tag);
@@ -788,7 +796,6 @@ fn search_tags_test(comptime Key: type, comptime Value: type, comptime layout: L
         context.hash,
         context.equal,
         layout,
-        "test",
     );
 
     const reference = struct {

--- a/src/lsm/table_mutable.zig
+++ b/src/lsm/table_mutable.zig
@@ -8,7 +8,7 @@ const constants = @import("../constants.zig");
 const SetAssociativeCache = @import("set_associative_cache.zig").SetAssociativeCache;
 
 /// Range queries are not supported on the TableMutable, it must first be made immutable.
-pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) type {
+pub fn TableMutableType(comptime Table: type) type {
     const Key = Table.Key;
     const Value = Table.Value;
     const compare_keys = Table.compare_keys;
@@ -44,7 +44,6 @@ pub fn TableMutableType(comptime Table: type, comptime tree_name: [:0]const u8) 
                 }
             }.equal,
             .{},
-            tree_name,
         );
 
         values: Values = .{},

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -102,7 +102,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
     return struct {
         const Environment = @This();
 
-        const Tree = @import("tree.zig").TreeType(Table, Storage, "Key.Value");
+        const Tree = @import("tree.zig").TreeType(Table, Storage);
         const Table = TableType(
             Key,
             Key.Value,
@@ -204,7 +204,10 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.superblock.open(superblock_open_callback, &env.superblock_context);
 
             env.tick_until_state_change(.superblock_open, .tree_init);
-            env.tree = try Tree.init(allocator, &env.node_pool, &env.grid, tree_options);
+            env.tree = try Tree.init(allocator, &env.node_pool, &env.grid, .{
+                .id = 1,
+                .name = "Key.Value",
+            }, tree_options);
             defer env.tree.deinit(allocator);
 
             env.change_state(.tree_init, .tree_open);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -136,6 +136,13 @@ pub fn StateMachineType(
             Storage,
             AccountImmutable,
             .{
+                .ids = .{
+                    .timestamp = 1,
+                    .id = 2,
+                    .user_data = 3,
+                    .ledger = 4,
+                    .code = 5,
+                },
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * math.max(
                         constants.batch_max.create_accounts,
@@ -156,6 +163,13 @@ pub fn StateMachineType(
             Storage,
             AccountMutable,
             .{
+                .ids = .{
+                    .timestamp = 6,
+                    .debits_pending = 7,
+                    .debits_posted = 8,
+                    .credits_pending = 9,
+                    .credits_posted = 10,
+                },
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * math.max(
                         constants.batch_max.create_accounts,
@@ -194,6 +208,18 @@ pub fn StateMachineType(
             Storage,
             Transfer,
             .{
+                .ids = .{
+                    .timestamp = 11,
+                    .id = 12,
+                    .debit_account_id = 13,
+                    .credit_account_id = 14,
+                    .user_data = 15,
+                    .pending_id = 16,
+                    .timeout = 17,
+                    .ledger = 18,
+                    .code = 19,
+                    .amount = 20,
+                },
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * constants.batch_max.create_transfers,
                     .id = config.lsm_batch_multiple * constants.batch_max.create_transfers,
@@ -215,6 +241,7 @@ pub fn StateMachineType(
             Storage,
             PostedGrooveValue,
             .{
+                .ids = .{ .timestamp = 21 },
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * constants.batch_max.create_transfers,
                     .fulfillment = config.lsm_batch_multiple * constants.batch_max.create_transfers,
@@ -1299,7 +1326,7 @@ pub fn StateMachineType(
                     .tree_options_object = .{
                         .cache_entries_max = options.cache_entries_accounts,
                     },
-                    .tree_options_id = {}, // No ID tree as there's one already for AccountsMutable.
+                    .tree_options_id = {}, // No ID tree as there's one already for AccountsImmutable.
                     .tree_options_index = .{
                         .debits_pending = .{},
                         .debits_posted = .{},

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -61,6 +61,41 @@ pub fn StateMachineType(
                     ));
                 }
             };
+
+            pub const tree_ids = struct {
+                pub const accounts_immutable = .{
+                    .timestamp = 1,
+                    .id = 2,
+                    .user_data = 3,
+                    .ledger = 4,
+                    .code = 5,
+                };
+
+                pub const accounts_mutable = .{
+                    .timestamp = 6,
+                    .debits_pending = 7,
+                    .debits_posted = 8,
+                    .credits_pending = 9,
+                    .credits_posted = 10,
+                };
+
+                pub const transfers = .{
+                    .timestamp = 11,
+                    .id = 12,
+                    .debit_account_id = 13,
+                    .credit_account_id = 14,
+                    .user_data = 15,
+                    .pending_id = 16,
+                    .timeout = 17,
+                    .ledger = 18,
+                    .code = 19,
+                    .amount = 20,
+                };
+
+                pub const posted = .{
+                    .timestamp = 21,
+                };
+            };
         };
 
         pub const AccountImmutable = extern struct {
@@ -136,13 +171,7 @@ pub fn StateMachineType(
             Storage,
             AccountImmutable,
             .{
-                .ids = .{
-                    .timestamp = 1,
-                    .id = 2,
-                    .user_data = 3,
-                    .ledger = 4,
-                    .code = 5,
-                },
+                .ids = constants.tree_ids.accounts_immutable,
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * math.max(
                         constants.batch_max.create_accounts,
@@ -163,13 +192,7 @@ pub fn StateMachineType(
             Storage,
             AccountMutable,
             .{
-                .ids = .{
-                    .timestamp = 6,
-                    .debits_pending = 7,
-                    .debits_posted = 8,
-                    .credits_pending = 9,
-                    .credits_posted = 10,
-                },
+                .ids = constants.tree_ids.accounts_mutable,
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * math.max(
                         constants.batch_max.create_accounts,
@@ -208,18 +231,7 @@ pub fn StateMachineType(
             Storage,
             Transfer,
             .{
-                .ids = .{
-                    .timestamp = 11,
-                    .id = 12,
-                    .debit_account_id = 13,
-                    .credit_account_id = 14,
-                    .user_data = 15,
-                    .pending_id = 16,
-                    .timeout = 17,
-                    .ledger = 18,
-                    .code = 19,
-                    .amount = 20,
-                },
+                .ids = constants.tree_ids.transfers,
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * constants.batch_max.create_transfers,
                     .id = config.lsm_batch_multiple * constants.batch_max.create_transfers,
@@ -241,7 +253,7 @@ pub fn StateMachineType(
             Storage,
             PostedGrooveValue,
             .{
-                .ids = .{ .timestamp = 21 },
+                .ids = constants.tree_ids.posted,
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * constants.batch_max.create_transfers,
                     .fulfillment = config.lsm_batch_multiple * constants.batch_max.create_transfers,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -32,6 +32,11 @@ pub fn StateMachineType(
             Storage,
             Thing,
             .{
+                .ids = .{
+                    .timestamp = 1,
+                    .id = 2,
+                    .value = 3,
+                },
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple,
                     .id = config.lsm_batch_multiple,


### PR DESCRIPTION
###  Motivation

This improves compile times slightly (~10%) and shrinks the binary from 18M to 13M.
Possibly this could marginally improve benchmarks due to better instruction caching, but I didn't measure it. (Probably not significant.)
None of those reasons are too important... but there's no particular reason to specialize based on tree name in the first place. ("Avoid unnecessary specialization" seems like a good rule of thumb.)

### Other Changes

- Rename "tree hash" to "tree id".
- Instead of assigning tree ids as `hash(tree_name)`, the `StateMachine` is responsible for setting explicit unique ids.
  This better matches how other identifiers are assigned (e.g. `Operation`, `Command`).
  And it makes it obvious that changing the id would be a breaking change (i.e. backwards incompatible with the storage format).
  (Previously, renaming a tree would change the id, breaking the layout.)
- Fix: Previously the tree hashes were only checked for uniqueness *within the context of a each Groove*.
  That is, collisions between grooves were possible.
  Uniqueness is now properly verified (still at comptime) across the entire forest.