### PR TITLE
VSR/SuperBlock: Trailer IO dedup

### DIFF
--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -140,13 +140,12 @@ pub fn StorageCheckerType(comptime Replica: type) type {
                 .checksum_grid = 0,
             };
 
-            inline for (.{ .manifest, .free_set, .client_sessions }) |trailer| {
-                const trailer_area = @field(superblock.areas, @tagName(trailer));
+            inline for (comptime std.enums.values(vsr.SuperBlockTrailer)) |trailer| {
                 const trailer_size = @field(working, @tagName(trailer) ++ "_size");
                 var copy: u8 = 0;
                 while (copy < constants.superblock_copies) : (copy += 1) {
                     @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer)) |=
-                        vsr.checksum(storage.memory[trailer_area.offset(copy)..][0..trailer_size]);
+                        vsr.checksum(storage.memory[trailer.area().offset(copy)..][0..trailer_size]);
                 }
             }
 

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -144,8 +144,9 @@ pub fn StorageCheckerType(comptime Replica: type) type {
                 const trailer_size = @field(working, @tagName(trailer) ++ "_size");
                 var copy: u8 = 0;
                 while (copy < constants.superblock_copies) : (copy += 1) {
+                    const trailer_start = trailer.zone().start_for_copy(copy);
                     @field(checkpoint, "checksum_superblock_" ++ @tagName(trailer)) |=
-                        vsr.checksum(storage.memory[trailer.area().offset(copy)..][0..trailer_size]);
+                        vsr.checksum(storage.memory[trailer_start..][0..trailer_size]);
                 }
             }
 

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -502,7 +502,7 @@ pub const Storage = struct {
         copy_: u8,
     ) *const superblock.SuperBlockHeader {
         const offset = vsr.Zone.superblock.offset(superblock.Area.header.offset(copy_));
-        const bytes = storage.memory[offset..][0..superblock.Area.header.size_max()];
+        const bytes = storage.memory[offset..][0..comptime superblock.Area.header.size_max()];
         return mem.bytesAsValue(superblock.SuperBlockHeader, bytes);
     }
 

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -501,8 +501,8 @@ pub const Storage = struct {
         storage: *const Storage,
         copy_: u8,
     ) *const superblock.SuperBlockHeader {
-        const offset = vsr.Zone.superblock.offset(superblock.areas.header.offset(copy_));
-        const bytes = storage.memory[offset..][0..superblock.areas.header.size_max];
+        const offset = vsr.Zone.superblock.offset(superblock.Area.header.offset(copy_));
+        const bytes = storage.memory[offset..][0..superblock.Area.header.size_max()];
         return mem.bytesAsValue(superblock.SuperBlockHeader, bytes);
     }
 
@@ -610,8 +610,8 @@ pub const Area = union(enum) {
         switch (area) {
             .superblock => |data| SectorRange.from_zone(
                 .superblock,
-                @field(superblock.areas, data.area).offset(data.copy),
-                @field(superblock.areas, data.area).size_max,
+                data.area.offset(data.copy),
+                data.area.size_max(),
             ),
             .wal_headers => |data| SectorRange.from_zone(
                 .wal_headers,
@@ -814,10 +814,10 @@ pub const ClusterFaultAtlas = struct {
         const copy = @divFloor(offset_in_zone, superblock.superblock_copy_size);
         const offset_in_copy = offset_in_zone % superblock.superblock_copy_size;
         const area: superblock.Area = switch (offset_in_copy) {
-            superblock.areas.header.base => .header,
-            superblock.areas.manifest.base => .manifest,
-            superblock.areas.free_set.base => .free_set,
-            superblock.areas.client_sessions.base => .client_sessions,
+            superblock.Area.header.base() => .header,
+            superblock.Area.manifest.base() => .manifest,
+            superblock.Area.free_set.base() => .free_set,
+            superblock.Area.client_sessions.base() => .client_sessions,
             else => unreachable,
         };
 

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -501,8 +501,8 @@ pub const Storage = struct {
         storage: *const Storage,
         copy_: u8,
     ) *const superblock.SuperBlockHeader {
-        const offset = vsr.Zone.superblock.offset(superblock.Area.header.offset(copy_));
-        const bytes = storage.memory[offset..][0..comptime superblock.Area.header.size_max()];
+        const offset = vsr.Zone.superblock.offset(superblock.SuperBlockZone.header.start_for_copy(copy_));
+        const bytes = storage.memory[offset..][0..comptime superblock.SuperBlockZone.header.size_max()];
         return mem.bytesAsValue(superblock.SuperBlockHeader, bytes);
     }
 
@@ -600,7 +600,7 @@ fn verify_alignment(buffer: []const u8) void {
 }
 
 pub const Area = union(enum) {
-    superblock: struct { area: superblock.Area, copy: u8 },
+    superblock: struct { zone: superblock.SuperBlockZone, copy: u8 },
     wal_headers: struct { sector: usize },
     wal_prepares: struct { slot: usize },
     client_replies: struct { slot: usize },
@@ -610,8 +610,8 @@ pub const Area = union(enum) {
         switch (area) {
             .superblock => |data| SectorRange.from_zone(
                 .superblock,
-                data.area.offset(data.copy),
-                data.area.size_max(),
+                data.zone.start_for_copy(data.copy),
+                data.zone.size_max(),
             ),
             .wal_headers => |data| SectorRange.from_zone(
                 .wal_headers,
@@ -716,7 +716,7 @@ pub const ClusterFaultAtlas = struct {
     const headers_per_sector = @divExact(constants.sector_size, @sizeOf(vsr.Header));
     const header_sectors = @divExact(constants.journal_slot_count, headers_per_sector);
 
-    const FaultySuperBlockAreas = std.enums.EnumArray(superblock.Area, CopySet);
+    const FaultySuperBlockAreas = std.enums.EnumArray(superblock.SuperBlockZone, CopySet);
     const FaultyWALHeaders = std.StaticBitSet(@divExact(
         constants.journal_size_headers,
         constants.sector_size,
@@ -747,7 +747,7 @@ pub const ClusterFaultAtlas = struct {
         var atlas = ClusterFaultAtlas{ .options = options };
 
         for (&atlas.faulty_superblock_areas.values) |*copies, area| {
-            if (area == @enumToInt(superblock.Area.header)) {
+            if (area == @enumToInt(superblock.SuperBlockZone.header)) {
                 // Only inject read/write faults into trailers, not the header.
                 // This prevents the quorum from being lost like so:
                 // - copy₀: B (ok)
@@ -813,11 +813,11 @@ pub const ClusterFaultAtlas = struct {
 
         const copy = @divFloor(offset_in_zone, superblock.superblock_copy_size);
         const offset_in_copy = offset_in_zone % superblock.superblock_copy_size;
-        const area: superblock.Area = switch (offset_in_copy) {
-            superblock.Area.header.base() => .header,
-            superblock.Area.manifest.base() => .manifest,
-            superblock.Area.free_set.base() => .free_set,
-            superblock.Area.client_sessions.base() => .client_sessions,
+        const area: superblock.SuperBlockZone = switch (offset_in_copy) {
+            superblock.SuperBlockZone.header.start() => .header,
+            superblock.SuperBlockZone.manifest.start() => .manifest,
+            superblock.SuperBlockZone.free_set.start() => .free_set,
+            superblock.SuperBlockZone.client_sessions.start() => .client_sessions,
             else => unreachable,
         };
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8199,13 +8199,14 @@ pub fn ReplicaType(
             const trailer_buffer_all = self.superblock.trailer_buffer(trailer);
             const trailer_checksum = self.superblock.staging.trailer_checksum(trailer);
             const trailer_size = self.superblock.staging.trailer_size(trailer);
-            assert(trailer_size >= parameters.offset);
-            assert(trailer_size <= trailer.area().size_max());
+            assert(trailer_size > parameters.offset);
+            assert(trailer_size <= trailer.zone().size_max());
 
             const body_size = @intCast(u32, @minimum(
                 trailer_size - parameters.offset,
                 constants.sync_trailer_message_body_size_max,
             ));
+            assert(body_size > 0 or parameters.offset == 0);
             assert(body_size <= constants.message_body_size_max);
 
             stdx.copy_disjoint(

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -159,6 +159,18 @@ pub const Trailer = struct {
     done: bool = false,
     final: ?struct { size: u32, checksum: u128 } = null,
 
+    pub const requests = std.enums.EnumArray(vsr.SuperBlockTrailer, vsr.Command).init(.{
+        .manifest = .request_sync_manifest,
+        .free_set = .request_sync_free_set,
+        .client_sessions = .request_sync_client_sessions,
+    });
+
+    pub const responses = std.enums.EnumArray(vsr.SuperBlockTrailer, vsr.Command).init(.{
+        .manifest = .sync_manifest,
+        .free_set = .sync_free_set,
+        .client_sessions = .sync_client_sessions,
+    });
+
     pub fn write_chunk(
         trailer: *Trailer,
         destination: struct {


### PR DESCRIPTION
Also:
- Move the request/response command mapping from `superblock.Trailer` to `sync.Trailer`. (More relevant).
- Split `SuperBlock.trailer()` into `SuperBlock.trailer_buffer`, `SuperBlockHeader.trailer_checksum`, and `SuperBlockHeader.trailer_size`. (`.trailer()` previously always used `.staging` as its header, but now that isn't always what we want. This is more explicit too.)

The diff in `superblock.zig` makes this refactor look much more extensive than it is. 