### PR TITLE
Adds direction to table_data_iterator

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -170,10 +170,10 @@ pub fn CompactionType(
         iterator_tracer_slot: ?tracer.SpanStart,
 
         pub fn init(allocator: Allocator, tree_name: []const u8) !Compaction {
-            var iterator_a = try TableDataIterator.init();
+            var iterator_a = TableDataIterator.init();
             errdefer iterator_a.deinit();
 
-            var iterator_b = try LevelTableValueBlockIterator.init();
+            var iterator_b = LevelTableValueBlockIterator.init();
             errdefer iterator_b.deinit();
 
             const index_block_a = try allocate_block(allocator);
@@ -383,6 +383,7 @@ pub fn CompactionType(
                     .snapshot = context.op_min,
                     .tables = compaction.context.range_b.tables.constSlice(),
                     .index_block = compaction.index_block_b,
+                    .direction = .ascending,
                 });
 
                 switch (context.table_info_a) {
@@ -417,6 +418,7 @@ pub fn CompactionType(
                 .grid = compaction.context.grid,
                 .addresses = index_schema_a.data_addresses_used(compaction.index_block_a),
                 .checksums = index_schema_a.data_checksums_used(compaction.index_block_a),
+                .direction = .ascending,
             });
             compaction.release_table_blocks(compaction.index_block_a);
             compaction.state = .compacting;

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
+const schema = @import("schema.zig");
 
 const constants = @import("../constants.zig");
 
@@ -9,7 +10,7 @@ const stdx = @import("../stdx.zig");
 const ManifestType = @import("manifest.zig").ManifestType;
 const allocate_block = @import("grid.zig").allocate_block;
 const GridType = @import("grid.zig").GridType;
-const schema = @import("schema.zig");
+const Direction = @import("direction.zig").Direction;
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
 
 // Iterates over the data blocks in a level B table. References to the level B
@@ -41,6 +42,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
 
             // `tables` contains TableInfo references from ManifestLevel.
             tables: []const Manifest.TableInfoReference,
+            direction: Direction,
         };
 
         pub const IndexCallback = fn (it: *LevelTableValueBlockIterator) void;
@@ -66,8 +68,8 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
             table_next: Callback,
         },
 
-        pub fn init() !LevelTableValueBlockIterator {
-            var table_data_iterator = try TableDataIterator.init();
+        pub fn init() LevelTableValueBlockIterator {
+            var table_data_iterator = TableDataIterator.init();
             errdefer table_data_iterator.deinit();
 
             return LevelTableValueBlockIterator{
@@ -107,6 +109,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                 .grid = context.grid,
                 .addresses = &.{},
                 .checksums = &.{},
+                .direction = context.direction,
             });
         }
 
@@ -150,6 +153,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                 .grid = it.context.grid,
                 .addresses = index_schema.data_addresses_used(it.context.index_block),
                 .checksums = index_schema.data_checksums_used(it.context.index_block),
+                .direction = it.context.direction,
             });
             callback.on_index(it);
             it.table_index += 1;

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -29,6 +29,7 @@ const log = std.log.scoped(.manifest_log);
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const stdx = @import("../stdx.zig");
+const schema = @import("schema.zig");
 
 const SuperBlockType = vsr.SuperBlockType;
 const GridType = @import("grid.zig").GridType;
@@ -403,7 +404,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 const block = manifest_log.blocks.get_ptr(i).?.*;
                 verify_block(block, null, null);
 
-                const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+                const header = schema.header_from_block(block);
                 const address = Block.address(block);
                 assert(address > 0);
 
@@ -457,7 +458,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
             const block = manifest_log.blocks.head_ptr().?;
             verify_block(block.*, null, null);
 
-            const header = mem.bytesAsValue(vsr.Header, block.*[0..@sizeOf(vsr.Header)]);
+            const header = schema.header_from_block(block.*);
             const address = Block.address(block.*);
             assert(address > 0);
 
@@ -744,7 +745,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
         }
 
         fn verify_block(block: BlockPtrConst, checksum: ?u128, address: ?u64) void {
-            const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+            const header = schema.header_from_block(block);
             assert(BlockType.from(header.operation) == .manifest);
 
             if (constants.verify) {
@@ -805,8 +806,7 @@ fn ManifestLogBlockType(comptime Storage: type, comptime TableInfo: type) type {
         }
 
         pub fn entry_count(block: BlockPtrConst) u32 {
-            const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
-            assert(header.command == .block);
+            const header = schema.header_from_block(block);
 
             const labels_size = entry_count_max * @sizeOf(Label);
             const tables_size = header.size - @sizeOf(vsr.Header) - labels_size;

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -514,9 +514,7 @@ pub fn TableType(
                 const block_padding = block[data.padding_offset..][0..data.padding_size];
                 assert(compare_keys(key_from_value(&values[values.len - 1]), key_max) == .eq);
 
-                const header_bytes = block[0..@sizeOf(vsr.Header)];
-                const header = mem.bytesAsValue(vsr.Header, header_bytes);
-
+                const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
                 header.* = .{
                     .cluster = options.cluster,
                     .context = @bitCast(u128, schema.TableData.Context{
@@ -580,8 +578,7 @@ pub fn TableType(
                 assert(builder.data_block_empty());
                 assert(options.address > 0);
 
-                const header_bytes = builder.filter_block[0..@sizeOf(vsr.Header)];
-                const header = mem.bytesAsValue(vsr.Header, header_bytes);
+                const header = mem.bytesAsValue(vsr.Header, builder.filter_block[0..@sizeOf(vsr.Header)]);
                 header.* = .{
                     .cluster = options.cluster,
                     .context = @bitCast(u128, schema.TableFilter.Context{
@@ -634,10 +631,7 @@ pub fn TableType(
                 ));
 
                 const index_block = builder.index_block;
-
-                const header_bytes = index_block[0..@sizeOf(vsr.Header)];
-                const header = mem.bytesAsValue(vsr.Header, header_bytes);
-
+                const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
                 header.* = .{
                     .cluster = options.cluster,
                     .context = @bitCast(u128, schema.TableIndex.Context{
@@ -740,7 +734,7 @@ pub fn TableType(
         }
 
         pub inline fn block_address(block: BlockPtrConst) u64 {
-            const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
+            const header = schema.header_from_block(block);
             const address = header.op;
             assert(address > 0);
             return address;

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -7,6 +7,7 @@ const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const vsr = @import("../vsr.zig");
+const schema = @import("schema.zig");
 
 const log = std.log.scoped(.lsm_tree_fuzz);
 const tracer = @import("../tracer.zig");
@@ -400,8 +401,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             const actual_block = env.grid.superblock.storage.grid_block(repair.address);
             stdx.copy_disjoint(.exact, u8, block.*, actual_block);
 
-            const header_bytes = block.*[0..@sizeOf(vsr.Header)];
-            const header = std.mem.bytesAsValue(vsr.Header, header_bytes);
+            const header = schema.header_from_block(block.*);
             assert(header.op == repair.address);
             assert(header.checksum == repair.checksum);
 


### PR DESCRIPTION
This PR adds support to `direction` to `table_data_iterator.zig`, as it is needed for the Scan API, and doing it by now reduces the amount of work needed for further rebase.

Also, changes `level_data_iterator` to accept `direction` and `compaction` to pass always `ascending`.

A few non-related changes:

- Removes the error result for `TableDataIterator.init`.
- Adds `schema.header_from_block` as a helper to obtain the `vsr.Header` pointer from a block, replacing in many places `mem.bytesAsValue(...)`.