### PR TITLE
Binary search over ranges

### DIFF
--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -2,8 +2,10 @@ const std = @import("std");
 const assert = std.debug.assert;
 const math = std.math;
 
+const constants = @import("../constants.zig");
+
 pub const Config = struct {
-    verify: bool = false,
+    mode: enum { lower_bound, upper_bound } = .lower_bound,
 };
 
 // TODO Add prefeching when @prefetch is available: https://github.com/ziglang/zig/issues/3600.
@@ -11,15 +13,20 @@ pub const Config = struct {
 // TODO The Zig self hosted compiler will implement inlining itself before passing the IR to llvm,
 // which should eliminate the current poor codegen of key_from_value/compare_keys.
 
-/// Returns either the index of the first value equal to `key`,
+/// Returns either the index of the value equal to `key`,
 /// or if there is no such value then the index where `key` would be inserted.
 ///
 /// In other words, return `i` such that both:
 /// * key_from_value(values[i])  >= key or i == values.len
 /// * key_value_from(values[i-1]) < key or i == 0
 ///
+/// Expects `values` to be sorted by key.
+/// If `values` contains duplicated matches, then returns
+/// the first index when `Config.mode == .lower_bound`,
+/// or the last index when `Config.mode == .upper_bound`.
+/// 
 /// Doesn't perform the extra key comparison to determine if the match is exact.
-pub fn binary_search_values_raw(
+pub fn binary_search_values_upsert_index(
     comptime Key: type,
     comptime Value: type,
     comptime key_from_value: fn (*const Value) callconv(.Inline) Key,
@@ -30,7 +37,7 @@ pub fn binary_search_values_raw(
 ) u32 {
     if (values.len == 0) return 0;
 
-    if (config.verify) {
+    if (constants.verify) {
         // Input must be sorted by key.
         for (values) |_, i| {
             assert(i == 0 or
@@ -41,7 +48,7 @@ pub fn binary_search_values_raw(
     var offset: usize = 0;
     var length: usize = values.len;
     while (length > 1) {
-        if (config.verify) {
+        if (constants.verify) {
             assert(offset == 0 or
                 compare_keys(key_from_value(&values[offset - 1]), key) != .gt);
             assert(offset + length == values.len or
@@ -54,12 +61,19 @@ pub fn binary_search_values_raw(
         // This trick seems to be what's needed to get llvm to emit branchless code for this,
         // a ternary-style if expression was generated as a jump here for whatever reason.
         const next_offsets = [_]usize{ offset, mid };
-        offset = next_offsets[@boolToInt(compare_keys(key_from_value(&values[mid]), key) == .lt)];
+        offset = next_offsets[
+            // For exact matches, takes the first half if `mode == .lower_bound`,
+            // or the second half if `mode == .upper_bound`.
+            @boolToInt(switch (config.mode) {
+                .lower_bound => compare_keys(key_from_value(&values[mid]), key) == .lt,
+                .upper_bound => compare_keys(key_from_value(&values[mid]), key) != .gt,
+            })
+        ];
 
         length -= half;
     }
 
-    if (config.verify) {
+    if (constants.verify) {
         assert(length == 1);
         assert(offset == 0 or
             compare_keys(key_from_value(&values[offset - 1]), key) != .gt);
@@ -69,9 +83,15 @@ pub fn binary_search_values_raw(
 
     offset += @boolToInt(compare_keys(key_from_value(&values[offset]), key) == .lt);
 
-    if (config.verify) {
-        assert(offset == 0 or
-            compare_keys(key_from_value(&values[offset - 1]), key) == .lt);
+    if (constants.verify) {
+        assert(offset == 0 or switch (config.mode) {
+            .lower_bound => compare_keys(key_from_value(&values[offset - 1]), key) == .lt,
+            .upper_bound => compare_keys(key_from_value(&values[offset - 1]), key) != .gt,
+        });
+        assert(offset >= values.len - 1 or switch (config.mode) {
+            .lower_bound => compare_keys(key_from_value(&values[offset + 1]), key) != .lt,
+            .upper_bound => compare_keys(key_from_value(&values[offset + 1]), key) == .gt,
+        });
         assert(offset == values.len or
             compare_keys(key_from_value(&values[offset]), key) != .lt);
     }
@@ -79,14 +99,14 @@ pub fn binary_search_values_raw(
     return @intCast(u32, offset);
 }
 
-pub inline fn binary_search_keys_raw(
+pub inline fn binary_search_keys_upsert_index(
     comptime Key: type,
     comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
     keys: []const Key,
     key: Key,
     comptime config: Config,
 ) u32 {
-    return binary_search_values_raw(
+    return binary_search_values_upsert_index(
         Key,
         Key,
         struct {
@@ -115,7 +135,15 @@ pub inline fn binary_search_values(
     key: Key,
     comptime config: Config,
 ) BinarySearchResult {
-    const index = binary_search_values_raw(Key, Value, key_from_value, compare_keys, values, key, config);
+    const index = binary_search_values_upsert_index(
+        Key,
+        Value,
+        key_from_value,
+        compare_keys,
+        values,
+        key,
+        config,
+    );
     return .{
         .index = index,
         .exact = index < values.len and compare_keys(key_from_value(&values[index]), key) == .eq,
@@ -129,11 +157,156 @@ pub inline fn binary_search_keys(
     key: Key,
     comptime config: Config,
 ) BinarySearchResult {
-    const index = binary_search_keys_raw(Key, compare_keys, keys, key, config);
+    const index = binary_search_keys_upsert_index(Key, compare_keys, keys, key, config);
     return .{
         .index = index,
         .exact = index < keys.len and compare_keys(keys[index], key) == .eq,
     };
+}
+
+pub const BinarySearchRangeUpsertIndexes = struct {
+    start: u32,
+    end: u32,
+};
+
+/// Same semantics of `binary_search_values_upsert_indexes`:
+/// Returns either the indexes of the values equal to `key_min` and `key_max`,
+/// or the indexes where they would be inserted.
+/// 
+/// Expects `values` to be sorted by key.
+/// If `values` contains duplicated matches, then returns
+/// the first index for `key_min` and the last index for `key_max`.
+/// 
+/// Doesn't perform the extra key comparison to determine if the match is exact.
+pub inline fn binary_search_values_range_upsert_indexes(
+    comptime Key: type,
+    comptime Value: type,
+    comptime key_from_value: fn (*const Value) callconv(.Inline) Key,
+    comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
+    values: []const Value,
+    key_min: Key,
+    key_max: Key,
+) BinarySearchRangeUpsertIndexes {
+    assert(compare_keys(key_min, key_max) != .gt);
+
+    const start = binary_search_values_upsert_index(
+        Key,
+        Value,
+        key_from_value,
+        compare_keys,
+        values,
+        key_min,
+        .{ .mode = .lower_bound },
+    );
+
+    if (start == values.len) return .{
+        .start = start,
+        .end = start,
+    };
+
+    const end = binary_search_values_upsert_index(
+        Key,
+        Value,
+        key_from_value,
+        compare_keys,
+        values[start..],
+        key_max,
+        .{ .mode = .upper_bound },
+    );
+
+    return .{
+        .start = start,
+        .end = start + end,
+    };
+}
+
+pub inline fn binary_search_keys_range_upsert_indexes(
+    comptime Key: type,
+    comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
+    keys: []const Key,
+    key_min: Key,
+    key_max: Key,
+) BinarySearchRangeUpsertIndexes {
+    return binary_search_values_range_upsert_indexes(
+        Key,
+        Key,
+        struct {
+            inline fn key_from_key(k: *const Key) Key {
+                return k.*;
+            }
+        }.key_from_key,
+        compare_keys,
+        keys,
+        key_min,
+        key_max,
+    );
+}
+
+pub const BinarySearchRange = struct {
+    start: u32,
+    count: u32,
+};
+
+/// Returns the index of the first value greater than or equal to `key_min` and
+/// the count of elements until the last value less than or equal to `key_max`.
+/// 
+/// Expects `values` to be sorted by key.
+/// The result is always safe for slicing using the `values[start..][0..count]` idiom,
+/// even when no elements are matched.
+pub inline fn binary_search_values_range(
+    comptime Key: type,
+    comptime Value: type,
+    comptime key_from_value: fn (*const Value) callconv(.Inline) Key,
+    comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
+    values: []const Value,
+    key_min: Key,
+    key_max: Key,
+) BinarySearchRange {
+    const upsert_indexes = binary_search_values_range_upsert_indexes(
+        Key,
+        Value,
+        key_from_value,
+        compare_keys,
+        values,
+        key_min,
+        key_max,
+    );
+
+    if (upsert_indexes.start == values.len) return .{
+        .start = upsert_indexes.start -| 1,
+        .count = 0,
+    };
+
+    const inclusive = @boolToInt(
+        upsert_indexes.end < values.len and
+            compare_keys(key_max, key_from_value(&values[upsert_indexes.end])) == .eq,
+    );
+    return .{
+        .start = upsert_indexes.start,
+        .count = upsert_indexes.end - upsert_indexes.start + inclusive,
+    };
+}
+
+pub inline fn binary_search_keys_range(
+    comptime Key: type,
+    comptime compare_keys: fn (Key, Key) callconv(.Inline) math.Order,
+    keys: []const Key,
+    key_min: Key,
+    key_max: Key,
+) BinarySearchRange {
+    return binary_search_values_range(
+        Key,
+        Key,
+        struct {
+            inline fn key_from_key(k: *const Key) Key {
+                return k.*;
+            }
+        }.key_from_key,
+        compare_keys,
+        keys,
+        key_min,
+        key_max,
+    );
 }
 
 const test_binary_search = struct {
@@ -151,7 +324,7 @@ const test_binary_search = struct {
         return a < b;
     }
 
-    fn exhaustive_search(keys_count: u32) !void {
+    fn exhaustive_search(keys_count: u32, comptime mode: anytype) !void {
         const keys = try gpa.alloc(u32, keys_count);
         defer gpa.free(keys);
 
@@ -164,8 +337,9 @@ const test_binary_search = struct {
                 switch (compare_keys(key, target_key)) {
                     .lt => expect.index = @intCast(u32, i) + 1,
                     .eq => {
+                        expect.index = @intCast(u32, i);
                         expect.exact = true;
-                        break;
+                        if (mode == .lower_bound) break;
                     },
                     .gt => break,
                 }
@@ -183,7 +357,7 @@ const test_binary_search = struct {
                 compare_keys,
                 keys,
                 target_key,
-                .{ .verify = true },
+                .{ .mode = mode },
             );
 
             if (log) std.debug.print("expected: {}, actual: {}\n", .{ expect, actual });
@@ -196,6 +370,7 @@ const test_binary_search = struct {
         keys: []const u32,
         target_keys: []const u32,
         expected_results: []const BinarySearchResult,
+        comptime mode: anytype,
     ) !void {
         assert(target_keys.len == expected_results.len);
 
@@ -212,24 +387,30 @@ const test_binary_search = struct {
                 compare_keys,
                 keys,
                 target_key,
-                .{ .verify = true },
+                .{ .mode = mode },
             );
             try std.testing.expectEqual(expect.index, actual.index);
             try std.testing.expectEqual(expect.exact, actual.exact);
         }
     }
 
-    fn random_search(random: std.rand.Random, iter: usize) !void {
+    fn random_sequence(allocator: std.mem.Allocator, random: std.rand.Random, iter: usize) ![]const u32 {
         const keys_count = @minimum(
             @as(usize, 1E6),
             fuzz.random_int_exponential(random, usize, iter),
         );
 
-        const keys = try std.testing.allocator.alloc(u32, keys_count);
-        defer std.testing.allocator.free(keys);
-
+        const keys = try allocator.alloc(u32, keys_count);
         for (keys) |*key| key.* = fuzz.random_int_exponential(random, u32, 100);
         std.sort.sort(u32, keys, {}, less_than_key);
+
+        return keys;
+    }
+
+    fn random_search(random: std.rand.Random, iter: usize, comptime mode: anytype) !void {
+        const keys = try random_sequence(std.testing.allocator, random, iter);
+        defer std.testing.allocator.free(keys);
+
         const target_key = fuzz.random_int_exponential(random, u32, 100);
 
         var expect: BinarySearchResult = .{ .index = 0, .exact = false };
@@ -237,8 +418,9 @@ const test_binary_search = struct {
             switch (compare_keys(key, target_key)) {
                 .lt => expect.index = @intCast(u32, i) + 1,
                 .eq => {
+                    expect.index = @intCast(u32, i);
                     expect.exact = true;
-                    break;
+                    if (mode == .lower_bound) break;
                 },
                 .gt => break,
             }
@@ -249,93 +431,383 @@ const test_binary_search = struct {
             compare_keys,
             keys,
             target_key,
-            .{ .verify = true },
+            .{ .mode = mode },
         );
 
         if (log) std.debug.print("expected: {}, actual: {}\n", .{ expect, actual });
         try std.testing.expectEqual(expect.index, actual.index);
         try std.testing.expectEqual(expect.exact, actual.exact);
     }
+
+    pub fn explicit_range_search(
+        sequence: []const u32,
+        key_min: u32,
+        key_max: u32,
+        expected: BinarySearchRange,
+    ) !void {
+        const actual = binary_search_keys_range(
+            u32,
+            compare_keys,
+            sequence,
+            key_min,
+            key_max,
+        );
+
+        try std.testing.expectEqual(expected.start, actual.start);
+        try std.testing.expectEqual(expected.count, actual.count);
+
+        // Make sure that the index is valid for slicing using the [start..][0..count] idiom:
+        const expected_slice = sequence[expected.start..][0..expected.count];
+        const actual_slice = sequence[actual.start..][0..actual.count];
+        try std.testing.expectEqualSlices(u32, expected_slice, actual_slice);
+    }
+
+    fn random_range_search(random: std.rand.Random, iter: usize) !void {
+        const keys = try random_sequence(std.testing.allocator, random, iter);
+        defer std.testing.allocator.free(keys);
+
+        const target_range = blk: {
+            // Cover many combinations of key_min, key_max:
+            var key_min = if (keys.len > 0 and random.boolean())
+                random.intRangeAtMostBiased(u32, keys[0], keys[keys.len - 1])
+            else
+                fuzz.random_int_exponential(random, u32, 100);
+
+            var key_max = if (keys.len > 0 and random.boolean())
+                random.intRangeAtMostBiased(u32, keys[0], keys[keys.len - 1])
+            else if (random.boolean())
+                key_min
+            else
+                fuzz.random_int_exponential(random, u32, 100);
+
+            if (compare_keys(key_max, key_min) == .lt) std.mem.swap(u32, &key_min, &key_max);
+            assert(compare_keys(key_min, key_max) != .gt);
+
+            break :blk .{
+                .key_min = key_min,
+                .key_max = key_max,
+            };
+        };
+
+        var expect: BinarySearchRange = .{ .start = 0, .count = 0 };
+        var key_target: enum { key_min, key_max } = .key_min;
+        for (keys) |key| {
+            if (key_target == .key_min) {
+                switch (compare_keys(key, target_range.key_min)) {
+                    .lt => if (expect.start < keys.len - 1) {
+                        expect.start += 1;
+                    },
+                    .gt, .eq => key_target = .key_max,
+                }
+            }
+
+            if (key_target == .key_max) {
+                switch (compare_keys(key, target_range.key_max)) {
+                    .lt, .eq => expect.count += 1,
+                    .gt => break,
+                }
+            }
+        }
+
+        const actual = binary_search_keys_range(
+            u32,
+            compare_keys,
+            keys,
+            target_range.key_min,
+            target_range.key_max,
+        );
+
+        if (log) std.debug.print("expected: {?}, actual: {?}\n", .{ expect, actual });
+        try std.testing.expectEqual(expect.start, actual.start);
+        try std.testing.expectEqual(expect.count, actual.count);
+    }
 };
 
-// TODO test search on empty slice
 test "binary search: exhaustive" {
     if (test_binary_search.log) std.debug.print("\n", .{});
-    var i: u32 = 1;
-    while (i < 300) : (i += 1) {
-        try test_binary_search.exhaustive_search(i);
+    inline for (.{ .lower_bound, .upper_bound }) |mode| {
+        var i: u32 = 1;
+        while (i < 300) : (i += 1) {
+            try test_binary_search.exhaustive_search(i, mode);
+        }
     }
 }
 
 test "binary search: explicit" {
     if (test_binary_search.log) std.debug.print("\n", .{});
-    try test_binary_search.explicit_search(
-        &[_]u32{},
-        &[_]u32{0},
-        &[_]BinarySearchResult{
-            .{ .index = 0, .exact = false },
-        },
-    );
-    try test_binary_search.explicit_search(
-        &[_]u32{1},
-        &[_]u32{ 0, 1, 2 },
-        &[_]BinarySearchResult{
-            .{ .index = 0, .exact = false },
-            .{ .index = 0, .exact = true },
-            .{ .index = 1, .exact = false },
-        },
-    );
-    try test_binary_search.explicit_search(
-        &[_]u32{ 1, 3 },
-        &[_]u32{ 0, 1, 2, 3, 4 },
-        &[_]BinarySearchResult{
-            .{ .index = 0, .exact = false },
-            .{ .index = 0, .exact = true },
-            .{ .index = 1, .exact = false },
-            .{ .index = 1, .exact = true },
-            .{ .index = 2, .exact = false },
-        },
-    );
-    try test_binary_search.explicit_search(
-        &[_]u32{ 1, 3, 5, 8, 9, 11 },
-        &[_]u32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 },
-        &[_]BinarySearchResult{
-            .{ .index = 0, .exact = false },
-            .{ .index = 0, .exact = true },
-            .{ .index = 1, .exact = false },
-            .{ .index = 1, .exact = true },
-            .{ .index = 2, .exact = false },
-            .{ .index = 2, .exact = true },
-            .{ .index = 3, .exact = false },
-            .{ .index = 3, .exact = false },
-            .{ .index = 3, .exact = true },
-            .{ .index = 4, .exact = true },
-            .{ .index = 5, .exact = false },
-            .{ .index = 5, .exact = true },
-            .{ .index = 6, .exact = false },
-            .{ .index = 6, .exact = false },
-        },
-    );
+
+    inline for (.{ .lower_bound, .upper_bound }) |mode| {
+        try test_binary_search.explicit_search(
+            &[_]u32{},
+            &[_]u32{0},
+            &[_]BinarySearchResult{
+                .{ .index = 0, .exact = false },
+            },
+            mode,
+        );
+
+        try test_binary_search.explicit_search(
+            &[_]u32{4} ** 10,
+            &[_]u32{4},
+            &[_]BinarySearchResult{
+                .{
+                    .index = if (mode == .lower_bound) 0 else 9,
+                    .exact = true,
+                },
+            },
+            mode,
+        );
+
+        try test_binary_search.explicit_search(
+            &[_]u32{},
+            &[_]u32{0},
+            &[_]BinarySearchResult{
+                .{ .index = 0, .exact = false },
+            },
+            mode,
+        );
+
+        try test_binary_search.explicit_search(
+            &[_]u32{1},
+            &[_]u32{ 0, 1, 2 },
+            &[_]BinarySearchResult{
+                .{ .index = 0, .exact = false },
+                .{ .index = 0, .exact = true },
+                .{ .index = 1, .exact = false },
+            },
+            mode,
+        );
+
+        try test_binary_search.explicit_search(
+            &[_]u32{ 1, 3 },
+            &[_]u32{ 0, 1, 2, 3, 4 },
+            &[_]BinarySearchResult{
+                .{ .index = 0, .exact = false },
+                .{ .index = 0, .exact = true },
+                .{ .index = 1, .exact = false },
+                .{ .index = 1, .exact = true },
+                .{ .index = 2, .exact = false },
+            },
+            mode,
+        );
+
+        try test_binary_search.explicit_search(
+            &[_]u32{ 1, 3, 5, 8, 9, 11 },
+            &[_]u32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 },
+            &[_]BinarySearchResult{
+                .{ .index = 0, .exact = false },
+                .{ .index = 0, .exact = true },
+                .{ .index = 1, .exact = false },
+                .{ .index = 1, .exact = true },
+                .{ .index = 2, .exact = false },
+                .{ .index = 2, .exact = true },
+                .{ .index = 3, .exact = false },
+                .{ .index = 3, .exact = false },
+                .{ .index = 3, .exact = true },
+                .{ .index = 4, .exact = true },
+                .{ .index = 5, .exact = false },
+                .{ .index = 5, .exact = true },
+                .{ .index = 6, .exact = false },
+                .{ .index = 6, .exact = false },
+            },
+            mode,
+        );
+    }
 }
 
 test "binary search: duplicates" {
     if (test_binary_search.log) std.debug.print("\n", .{});
     try test_binary_search.explicit_search(
         &[_]u32{ 0, 0, 3, 3, 3, 5, 5, 5, 5 },
-        &[_]u32{ 1, 2, 4, 6 },
+        &[_]u32{ 0, 1, 2, 3, 4, 5, 6 },
         &[_]BinarySearchResult{
+            .{ .index = 0, .exact = true },
             .{ .index = 2, .exact = false },
             .{ .index = 2, .exact = false },
+            .{ .index = 2, .exact = true },
             .{ .index = 5, .exact = false },
+            .{ .index = 5, .exact = true },
             .{ .index = 9, .exact = false },
         },
+        .lower_bound,
+    );
+    try test_binary_search.explicit_search(
+        &[_]u32{ 0, 0, 3, 3, 3, 5, 5, 5, 5 },
+        &[_]u32{ 0, 1, 2, 3, 4, 5, 6 },
+        &[_]BinarySearchResult{
+            .{ .index = 1, .exact = true },
+            .{ .index = 2, .exact = false },
+            .{ .index = 2, .exact = false },
+            .{ .index = 4, .exact = true },
+            .{ .index = 5, .exact = false },
+            .{ .index = 8, .exact = true },
+            .{ .index = 9, .exact = false },
+        },
+        .upper_bound,
     );
 }
 
 test "binary search: random" {
     var rng = std.rand.DefaultPrng.init(42);
+    inline for (.{ .lower_bound, .upper_bound }) |mode| {
+        var i: usize = 0;
+        while (i < 2048) : (i += 1) {
+            try test_binary_search.random_search(rng.random(), i, mode);
+        }
+    }
+}
+
+test "binary search: explicit range" {
+    if (test_binary_search.log) std.debug.print("\n", .{});
+
+    // Exact inverval:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        3,
+        1000,
+        .{
+            .start = 0,
+            .count = 9,
+        },
+    );
+
+    // Larger inverval:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        2,
+        1001,
+        .{
+            .start = 0,
+            .count = 9,
+        },
+    );
+
+    // Inclusive key_min and exclusive key_max:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        3,
+        9,
+        .{
+            .start = 0,
+            .count = 2,
+        },
+    );
+
+    // Exclusive key_min and inclusive key_max:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        5,
+        10,
+        .{
+            .start = 2,
+            .count = 1,
+        },
+    );
+
+    // Exclusive interval:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        5,
+        14,
+        .{
+            .start = 2,
+            .count = 1,
+        },
+    );
+
+    // Inclusive interval:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        15,
+        100,
+        .{
+            .start = 3,
+            .count = 5,
+        },
+    );
+
+    // Where key_min == key_max:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        10,
+        10,
+        .{
+            .start = 2,
+            .count = 1,
+        },
+    );
+
+    // Interval smaller than the first element:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        1,
+        2,
+        .{
+            .start = 0,
+            .count = 0,
+        },
+    );
+
+    // Interval greater than the last element:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        1_001,
+        10_000,
+        .{
+            .start = 8,
+            .count = 0,
+        },
+    );
+
+    // Nonexistent interval in the middle:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
+        31,
+        99,
+        .{
+            .start = 7,
+            .count = 0,
+        },
+    );
+
+    // Empty slice:
+    try test_binary_search.explicit_range_search(
+        &[_]u32{},
+        1,
+        2,
+        .{
+            .start = 0,
+            .count = 0,
+        },
+    );
+}
+
+test "binary search: duplicated range" {
+    if (test_binary_search.log) std.debug.print("\n", .{});
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 1, 3, 3, 3, 5, 5, 5, 7 },
+        3,
+        5,
+        .{
+            .start = 1,
+            .count = 6,
+        },
+    );
+    try test_binary_search.explicit_range_search(
+        &[_]u32{ 1, 1, 1, 3, 5, 7 },
+        1,
+        1,
+        .{
+            .start = 0,
+            .count = 3,
+        },
+    );
+}
+
+test "binary search: random range" {
+    var rng = std.rand.DefaultPrng.init(42);
     var i: usize = 0;
     while (i < 2048) : (i += 1) {
-        try test_binary_search.random_search(rng.random(), i);
+        try test_binary_search.random_range_search(rng.random(), i);
     }
 }

--- a/src/lsm/eytzinger_benchmark.zig
+++ b/src/lsm/eytzinger_benchmark.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 const assert = std.debug.assert;
 const math = std.math;
 
-const binary_search_keys_raw = @import("./binary_search.zig").binary_search_keys_raw;
-const binary_search_values_raw = @import("./binary_search.zig").binary_search_values_raw;
+const binary_search_keys_upsert_index = @import("./binary_search.zig").binary_search_keys_upsert_index;
+const binary_search_values_upsert_index = @import("./binary_search.zig").binary_search_values_upsert_index;
 const eytzinger = @import("./eytzinger.zig").eytzinger;
 
 const GiB = 1 << 30;
@@ -106,7 +106,7 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: std.rand.Random) !
             const page = &pages[page_index];
             const bounds = Eytzinger.search_values(K, V, V.key_compare, &page.keys, &page.values, target);
             const hit = bounds[
-                binary_search_values_raw(
+                binary_search_values_upsert_index(
                     K,
                     V,
                     V.key_from_value,
@@ -147,7 +147,7 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: std.rand.Random) !
             const target = value_picker[v % value_picker.len];
             const page = &pages[page_picker[i % page_picker.len]];
             const hit = page.values[
-                binary_search_values_raw(
+                binary_search_values_upsert_index(
                     K,
                     V,
                     V.key_from_value,
@@ -320,7 +320,7 @@ fn binary_search_keys(
     assert(keys.len == layout.keys_count);
     assert(values.len == layout.values_count);
 
-    const key_index = binary_search_keys_raw(Key, compare_keys, keys, key, .{});
+    const key_index = binary_search_keys_upsert_index(Key, compare_keys, keys, key, .{});
     const key_stride = layout.values_count / layout.keys_count;
     const high = key_index * key_stride;
     if (key_index < keys.len and keys[key_index] == key) {

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -763,7 +763,7 @@ pub fn TestContext(
             }
 
             for (buffer[0..count]) |table| {
-                const index = binary_search.binary_search_values_raw(
+                const index = binary_search.binary_search_values_upsert_index(
                     Key,
                     TableInfo,
                     key_min_from_table,
@@ -789,7 +789,7 @@ pub fn TestContext(
 
             assert(compare_keys(new_key_min, key) == .gt);
 
-            var i = binary_search.binary_search_values_raw(
+            var i = binary_search.binary_search_values_upsert_index(
                 Key,
                 TableInfo,
                 key_min_from_table,

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -317,7 +317,7 @@ pub fn EnvironmentType(comptime table_count_max: u32, comptime node_size: u32) t
 
             // Insert the generated tables into the Environment for reference:
             for (tables) |*table| {
-                const index = binary_search.binary_search_values_raw(
+                const index = binary_search.binary_search_values_upsert_index(
                     Key,
                     TableInfo,
                     key_min_from_table,
@@ -340,7 +340,7 @@ pub fn EnvironmentType(comptime table_count_max: u32, comptime node_size: u32) t
             var new_key_min = key + env.random.uintLessThanBiased(Key, 31) + 1;
             assert(compare_keys(new_key_min, key) == .gt);
 
-            var i = binary_search.binary_search_values_raw(
+            var i = binary_search.binary_search_values_upsert_index(
                 Key,
                 TableInfo,
                 key_min_from_table,
@@ -416,7 +416,7 @@ pub fn EnvironmentType(comptime table_count_max: u32, comptime node_size: u32) t
         }
 
         fn find_exact(env: *Environment, level_table: *const TableInfo) *TableInfo {
-            const index = binary_search.binary_search_values_raw(
+            const index = binary_search.binary_search_values_upsert_index(
                 Key,
                 TableInfo,
                 key_min_from_table,

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -6,7 +6,7 @@ const mem = std.mem;
 
 const stdx = @import("../stdx.zig");
 const div_ceil = @import("../stdx.zig").div_ceil;
-const binary_search_values_raw = @import("binary_search.zig").binary_search_values_raw;
+const binary_search_values_upsert_index = @import("binary_search.zig").binary_search_values_upsert_index;
 const binary_search_keys = @import("binary_search.zig").binary_search_keys;
 const Direction = @import("direction.zig").Direction;
 
@@ -890,7 +890,7 @@ fn SegmentedArrayType(
                 const node = @intCast(u32, offset);
                 assert(node < array.node_count);
 
-                const relative_index = binary_search_values_raw(
+                const relative_index = binary_search_values_upsert_index(
                     K,
                     T,
                     key_from_value,
@@ -1225,7 +1225,7 @@ fn TestContext(
         }
 
         fn reference_index(context: *const Self, key: Key) u32 {
-            return binary_search_values_raw(
+            return binary_search_values_upsert_index(
                 Key,
                 T,
                 key_from_value,

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -693,7 +693,7 @@ pub fn TableType(
             // want to return that data block. If the search does not find an exact match
             // it returns the index of the next greatest key, which again is the index of the
             // data block that may contain the key.
-            const data_block_index = binary_search.binary_search_keys_raw(
+            const data_block_index = binary_search.binary_search_keys_upsert_index(
                 Key,
                 compare_keys,
                 Table.index_data_keys_used(index_block),


### PR DESCRIPTION
This PR adds the ability to binary search over ranges, following the same semantics of the existing `binary_search_*` functions.

- Renames `binary_search_*_raw` to `binary_search_*_upsert_index`.

- Removes `config.verify` in favor of `constants.verify`, and removes the validation if the input array is sorted.

- Introduces `config.mode = .lower_bound | .upper_bound` to define the behavior of the binary search when the array contains duplicated entries.

- Adds tests for both `.lower_bound` and `.upper_bound` modes, including new test cases for duplicated matches.

- Clarify the comments.

The new functions `binary_search_*_range` and `binary_search_*_range_upsert_indexes` will be used by the Scan API. The point of adding it now is to make the review simpler and to reduce the amount of code to rebase later.