### PR TITLE
client: correctly limit the number of outstanding requests

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -365,10 +365,10 @@ pub const AOFReplayClient = struct {
     fn replay_callback(
         user_data: u128,
         operation: StateMachine.Operation,
-        result: Client.Error![]const u8,
+        result: []const u8,
     ) void {
         _ = operation;
-        _ = result catch @panic("Client returned error");
+        _ = result;
 
         const self = @intToPtr(*AOFReplayClient, @intCast(u64, user_data));
 

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -414,18 +414,13 @@ const Benchmark = struct {
     fn send_complete(
         user_data: u128,
         operation: StateMachine.Operation,
-        result: Client.Error![]const u8,
+        result: []const u8,
     ) void {
-        _ = operation;
-
-        const result_payload = result catch |err|
-            panic("Client returned error: {}", .{err});
-
         switch (operation) {
             .create_accounts => {
                 const create_accounts_results = std.mem.bytesAsSlice(
                     tb.CreateAccountsResult,
-                    result_payload,
+                    result,
                 );
                 if (create_accounts_results.len > 0) {
                     panic("CreateAccountsResults: {any}", .{create_accounts_results});
@@ -434,7 +429,7 @@ const Benchmark = struct {
             .create_transfers => {
                 const create_transfers_results = std.mem.bytesAsSlice(
                     tb.CreateTransfersResult,
-                    result_payload,
+                    result,
                 );
                 if (create_transfers_results.len > 0) {
                     panic("CreateTransfersResults: {any}", .{create_transfers_results});

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -17,40 +17,6 @@ pub const Packet = extern struct {
         invalid_data_size,
     };
 
-    /// Non thread-safe linked list.
-    pub const List = extern struct {
-        head: ?*Packet = null,
-        tail: ?*Packet = null,
-
-        pub fn from(packet: *Packet) List {
-            packet.next = null;
-            return List{
-                .head = packet,
-                .tail = packet,
-            };
-        }
-
-        pub fn push(self: *List, list: List) void {
-            const prev = if (self.tail) |tail| &tail.next else &self.head;
-            prev.* = list.head orelse return;
-            self.tail = list.tail orelse unreachable;
-        }
-
-        pub fn peek(self: List) ?*Packet {
-            return self.head orelse {
-                assert(self.tail == null);
-                return null;
-            };
-        }
-
-        pub fn pop(self: *List) ?*Packet {
-            const packet = self.head orelse return null;
-            self.head = packet.next;
-            if (self.head == null) self.tail = null;
-            return packet;
-        }
-    };
-
     /// Thread-safe stack optimized for 1 consumer (io thread) and N producers (client threads),
     /// `push` uses a spin lock, and `pop` is not thread-safe.
     pub const SubmissionStack = struct {

--- a/src/clients/c/tb_client/thread.zig
+++ b/src/clients/c/tb_client/thread.zig
@@ -80,7 +80,7 @@ pub fn ThreadType(
             }
 
             // Process packets from either pending or submitted as long as we have messages.
-            while (self.context.messages_available > 0) {
+            while (self.context.client.messages_available > 0) {
                 const packet = pending.pop() orelse self.submitted.pop() orelse break;
                 self.context.request(packet);
             }

--- a/src/clients/c/tb_client/thread.zig
+++ b/src/clients/c/tb_client/thread.zig
@@ -14,7 +14,6 @@ pub fn ThreadType(
 
         context: *Context,
 
-        retry: Packet.List,
         submitted: Packet.SubmissionStack,
 
         signal: Signal,
@@ -25,7 +24,6 @@ pub fn ThreadType(
             context: *Context,
         ) !void {
             self.context = context;
-            self.retry = .{};
             self.submitted = .{};
 
             log.debug("{}: init: initializing signal", .{context.client_id});
@@ -65,23 +63,9 @@ pub fn ThreadType(
             const self = @fieldParentPtr(Self, "signal", signal);
             self.context.tick();
 
-            // Consume all of retry here to avoid infinite loop
-            // if the code below pushes to self.retry while we're dequeueing.
-            var pending = self.retry;
-            self.retry = .{};
-
-            // The loop below can exit early without processing all of pending
-            // if available_messages becomes zero.
-            // In such a case we need to restore self.retry we consumed above
-            // with those that weren't processed.
-            defer {
-                pending.push(self.retry);
-                self.retry = pending;
-            }
-
             // Process packets from either pending or submitted as long as we have messages.
             while (self.context.client.messages_available > 0) {
-                const packet = pending.pop() orelse self.submitted.pop() orelse break;
+                const packet = self.submitted.pop() orelse break;
                 self.context.request(packet);
             }
         }

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -205,7 +205,7 @@ func (c *c_client) doRequest(
 			// but allow an invalid opcode to be passed to emulate a client nop
 			return 0, errors.ErrInvalidOperation{}
 		case C.TB_PACKET_INVALID_DATA_SIZE:
-			panic("unreachable") // we contorl what type of data is given
+			panic("unreachable") // we control what type of data is given
 		default:
 			panic("tb_client_submit(): returned packet with invalid status")
 		}

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -89,6 +89,7 @@ export type TransferID = bigint // u128
 
 export type Event = Account | Transfer | AccountID | TransferID
 export type Result = CreateAccountsError | CreateTransfersError | Account | Transfer
+// Note: as of #990, the error is always `undefined` here.
 export type ResultCallback = (error: undefined | Error, results: Result[]) => void
 
 export interface Client {

--- a/src/clients/node/src/translate.zig
+++ b/src/clients/node/src/translate.zig
@@ -426,23 +426,6 @@ pub fn delete_reference(env: c.napi_env, reference: c.napi_ref) !void {
     }
 }
 
-pub fn create_error(
-    env: c.napi_env,
-    comptime message: [:0]const u8,
-) TranslationError!c.napi_value {
-    var napi_string: c.napi_value = undefined;
-    if (c.napi_create_string_utf8(env, message, std.mem.len(message), &napi_string) != c.napi_ok) {
-        return TranslationError.ExceptionThrown;
-    }
-
-    var napi_error: c.napi_value = undefined;
-    if (c.napi_create_error(env, null, napi_string, &napi_error) != c.napi_ok) {
-        return TranslationError.ExceptionThrown;
-    }
-
-    return napi_error;
-}
-
 pub fn call_function(
     env: c.napi_env,
     this: c.napi_value,

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -37,7 +37,7 @@ pub fn request(
     on_reply: fn (
         user_data: u128,
         operation: StateMachine.Operation,
-        results: Client.Error![]const u8,
+        results: []const u8,
     ) void,
 ) !void {
     const allocator = std.heap.page_allocator;
@@ -87,7 +87,7 @@ pub fn request(
 pub fn on_create_accounts(
     user_data: u128,
     operation: StateMachine.Operation,
-    results: Client.Error![]const u8,
+    results: []const u8,
 ) void {
     _ = user_data;
     _ = operation;
@@ -98,7 +98,7 @@ pub fn on_create_accounts(
 pub fn on_lookup_accounts(
     user_data: u128,
     operation: StateMachine.Operation,
-    results: Client.Error![]const u8,
+    results: []const u8,
 ) void {
     _ = user_data;
     _ = operation;
@@ -109,7 +109,7 @@ pub fn on_lookup_accounts(
 pub fn on_lookup_transfers(
     user_data: u128,
     operation: StateMachine.Operation,
-    results: Client.Error![]const u8,
+    results: []const u8,
 ) void {
     _ = user_data;
     _ = operation;
@@ -120,7 +120,7 @@ pub fn on_lookup_transfers(
 pub fn on_create_transfers(
     user_data: u128,
     operation: StateMachine.Operation,
-    results: Client.Error![]const u8,
+    results: []const u8,
 ) void {
     _ = user_data;
     _ = operation;
@@ -128,9 +128,8 @@ pub fn on_create_transfers(
     print_results(CreateTransfersResult, results);
 }
 
-fn print_results(comptime Results: type, results: Client.Error![]const u8) void {
-    const body = results catch unreachable;
-    const slice = std.mem.bytesAsSlice(Results, body);
+fn print_results(comptime Results: type, results: []const u8) void {
+    const slice = std.mem.bytesAsSlice(Results, results);
     for (slice) |result| {
         std.debug.print("{}\n", .{result});
     }

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -453,13 +453,11 @@ pub fn ClusterType(comptime StateMachineType: fn (comptime Storage: type, compti
         fn request_callback(
             user_data: u128,
             operation: StateMachine.Operation,
-            result: Client.Error![]const u8,
+            result: []const u8,
         ) void {
             _ = user_data;
             _ = operation;
-            _ = result catch |err| switch (err) {
-                error.TooManyOutstandingRequests => unreachable,
-            };
+            _ = result;
         }
 
         fn client_on_reply(client: *Client, request_message: *Message, reply_message: *Message) void {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1527,6 +1527,7 @@ const TestClients = struct {
                 if (client.request_queue.empty() and
                     t.context.client_requests[c] > client.request_number)
                 {
+                    assert(client.messages_available == constants.client_request_queue_max);
                     const message = client.get_message();
                     defer client.unref(message);
 


### PR DESCRIPTION
Before, we used `TooManyOutstandingRequests` to signal this condition. The problem with that is that by the time we get to invoking user's callback, its already too late --- the code might have blown up with an assertion in `get_message`.

To fix this, check the number of outstanding requests in `get_message` instead. This also allows us to remove the error condition from the request callback altogether.