### PR TITLE
LSM/Grid: Split read_block_from_{cache,storage,cache_or_storage}

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -393,7 +393,7 @@ pub fn CompactionType(
                     },
                     .disk => |table_ref| {
                         compaction.state = .iterator_init_a;
-                        compaction.context.grid.read_block(
+                        compaction.context.grid.read_block_from_cache_or_storage(
                             on_iterator_init_a,
                             &compaction.read,
                             table_ref.table_info.address,

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -124,7 +124,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                 // Refill `table_data_iterator` before calling `table_next`.
                 const table_ref = it.context.tables[it.table_index];
                 it.callback = .{ .level_next = callback };
-                it.context.grid.read_block(
+                it.context.grid.read_block_from_cache_or_storage(
                     on_level_next,
                     &it.read,
                     table_ref.table_info.address,

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -118,7 +118,7 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                         .table_info = table_info.*,
                     },
                 };
-                it.context.grid.read_block(
+                it.context.grid.read_block_from_cache_or_storage(
                     on_read,
                     &it.read,
                     table_info.address,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -224,7 +224,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 assert(block.tree == manifest_log.tree_id);
                 assert(block.address > 0);
 
-                manifest_log.grid.read_block(
+                manifest_log.grid.read_block_from_cache_or_storage(
                     open_read_block_callback,
                     &manifest_log.read,
                     block.address,
@@ -578,7 +578,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 manifest_log.reading = true;
                 manifest_log.read_block_reference = block;
 
-                manifest_log.grid.read_block(
+                manifest_log.grid.read_block_from_cache_or_storage(
                     compact_read_block_callback,
                     &manifest_log.read,
                     block.address,

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -100,7 +100,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                 };
 
                 it.callback = .{ .read = callback };
-                it.context.grid.read_block(
+                it.context.grid.read_block_from_cache_or_storage(
                     on_read,
                     &it.read,
                     it.context.addresses[index],

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -389,7 +389,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
 
-                context.tree.grid.read_block(
+                context.tree.grid.read_block_from_cache_or_storage(
                     read_index_block_callback,
                     &context.completion,
                     context.index_block_addresses[context.index_block],
@@ -412,7 +412,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                     .checksum = blocks.data_block_checksum,
                 };
 
-                context.tree.grid.read_block(
+                context.tree.grid.read_block_from_cache_or_storage(
                     read_filter_block_callback,
                     completion,
                     blocks.filter_block_address,
@@ -437,7 +437,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                         @intToFloat(f64, context.tree.filter_block_hits),
                     );
 
-                    context.tree.grid.read_block(
+                    context.tree.grid.read_block_from_cache_or_storage(
                         read_data_block_callback,
                         completion,
                         context.data_block.?.address,


### PR DESCRIPTION
Currently all callers use `read_block_from_cache_or_storage`, which is equivalent to the old behavior (next tick, cache, storage). But the new APIs allow for reading synchronously from the cache (useful for prefetch optimization), or skipping the cache entirely (useful for prefetch optimization and disk scrubbing).