### PR TITLE
Fix broken release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
   finalize_release:
+    runs-on: ubuntu-latest
     needs: [release]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Was missing a `runs-on: ubuntu-latest`