### PR TITLE
aof: line length & cleanups

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -76,7 +76,6 @@ fn find_long_line(file_text: []const u8) !?usize {
 }
 
 const naughty_list = [_][]const u8{
-    "aof.zig",
     "benchmark.zig",
     "clients/c/tb_client_header_test.zig",
     "clients/c/tb_client_header.zig",

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -282,7 +282,6 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
         /// Acquires a message from the message bus.
         ///
         /// The caller must ensure that a message is available.
-        // FIXME: change back to get_message.
         pub fn get_message(self: *Self) *Message {
             assert(self.messages_available > 0);
             self.messages_available -= 1;


### PR DESCRIPTION
Mostly line lengths, but also: 

- add blank line after `defer`, as per style guide
- add some missing defers :-)
- add full stop at the end of comments