### PR TITLE
k_way_merge refactor

### DIFF
--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -5,7 +5,7 @@ const mem = std.mem;
 
 const Direction = @import("direction.zig").Direction;
 
-pub fn KWayMergeIterator(
+pub fn KWayMergeIteratorType(
     comptime Context: type,
     comptime Key: type,
     comptime Value: type,
@@ -14,6 +14,9 @@ pub fn KWayMergeIterator(
     comptime k_max: u32,
     /// Peek the next key in the stream identified by stream_index.
     /// For example, peek(stream_index=2) returns user_streams[2][0].
+    /// Returns Drained if the stream was consumed and
+    /// must be refilled before calling peek() again.
+    /// Returns Empty if the stream was fully consumed and reached the end.
     comptime stream_peek: fn (
         context: *const Context,
         stream_index: u32,
@@ -86,8 +89,8 @@ pub fn KWayMergeIterator(
             return it.k == 0;
         }
 
-        pub fn pop(it: *Self) ?Value {
-            while (it.pop_internal()) |value| {
+        pub fn pop(it: *Self) error{Drained}!?Value {
+            while (try it.pop_internal()) |value| {
                 const key = key_from_value(&value);
                 if (it.previous_key_popped) |previous| {
                     switch (compare_keys(previous, key)) {
@@ -104,7 +107,7 @@ pub fn KWayMergeIterator(
             return null;
         }
 
-        fn pop_internal(it: *Self) ?Value {
+        fn pop_internal(it: *Self) error{Drained}!?Value {
             if (it.k == 0) return null;
 
             // We update the heap prior to removing the value from the stream. If we updated after
@@ -114,7 +117,7 @@ pub fn KWayMergeIterator(
                 it.keys[0] = key;
                 it.down_heap();
             } else |err| switch (err) {
-                error.Drained => return null,
+                error.Drained => return error.Drained,
                 error.Empty => {
                     it.swap(0, it.k - 1);
                     it.k -= 1;
@@ -226,7 +229,7 @@ fn TestContext(comptime k_max: u32) type {
         }
 
         fn stream_peek(context: *const Self, stream_index: u32) error{ Empty, Drained }!u32 {
-            // TODO: test for Drained somehow as well
+            // TODO: test for Drained somehow as well.
             const stream = context.streams[stream_index];
             if (stream.len == 0) return error.Empty;
             return stream[0].key;
@@ -241,7 +244,7 @@ fn TestContext(comptime k_max: u32) type {
         fn stream_precedence(context: *const Self, a: u32, b: u32) bool {
             _ = context;
 
-            // Higher streams have higher precedence
+            // Higher streams have higher precedence.
             return a > b;
         }
 
@@ -250,7 +253,7 @@ fn TestContext(comptime k_max: u32) type {
             streams_keys: []const []const u32,
             expect: []const Value,
         ) !void {
-            const KWay = KWayMergeIterator(
+            const KWay = KWayMergeIteratorType(
                 Self,
                 u32,
                 Value,
@@ -281,7 +284,7 @@ fn TestContext(comptime k_max: u32) type {
             var context: Self = .{ .streams = streams };
             var kway = KWay.init(&context, @intCast(u32, streams_keys.len), direction);
 
-            while (kway.pop()) |value| {
+            while (try kway.pop()) |value| {
                 try actual.append(value);
             }
 


### PR DESCRIPTION
This PR adds support to streams that need to be refilled during iteration by `pop()`.
~Also, renames errors `Empty` and `Drained` to `EOF` and `Again`.~

The common pattern for using it in a `while` loop was kept unchanged:
```zig
while(kway.pop() catch buffer_read()) |value| {

}
```

This feature is needed by the Scan API. It's being added now to simplify the review and reduce the amount of code to be rebased later.