### PR TITLE
VOPRHub Fetch owned & open issues specifically

### DIFF
--- a/src/vopr_hub/main.go
+++ b/src/vopr_hub/main.go
@@ -662,7 +662,7 @@ func get_open_issue_count() int {
 
 	res := do_github_request(
 		"GET",
-		repository_url+"/issues?filter=created",
+		repository_url+"/issues?filter=created&state=open",
 		nil,
 		nil,
 	)


### PR DESCRIPTION
Closes #1000 

The [`/issues` REST API docs](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-issues-assigned-to-the-authenticated-user) seem to say that `state=open` is implied 