### PR TITLE
VSR: Fix committing/view-change prepare-timeout race

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4232,7 +4232,7 @@ pub fn ReplicaType(
 
             // Don't accept more requests than will fit in the current checkpoint.
             // (The request's op hasn't been assigned yet, but it will be `self.op + 1`
-            // when primary_pipeline_next() converts the request to a prepare.)
+            // when primary_pipeline_prepare() converts the request to a prepare.)
             if (self.op + self.pipeline.queue.request_queue.count == self.op_checkpoint_trigger()) {
                 log.debug("{}: on_request: ignoring op={} (too far ahead, checkpoint={})", .{
                     self.replica,
@@ -5055,7 +5055,7 @@ pub fn ReplicaType(
 
             assert(!self.ignore_request_message(message));
 
-            log.debug("{}: primary_pipeline_next: request checksum={} client={}", .{
+            log.debug("{}: primary_pipeline_prepare: request checksum={} client={}", .{
                 self.replica,
                 message.header.checksum,
                 message.header.client,
@@ -5103,7 +5103,7 @@ pub fn ReplicaType(
             message.header.set_checksum_body(message.body());
             message.header.set_checksum();
 
-            log.debug("{}: primary_pipeline_next: prepare {}", .{ self.replica, message.header.checksum });
+            log.debug("{}: primary_pipeline_prepare: prepare {}", .{ self.replica, message.header.checksum });
 
             if (self.primary_pipeline_pending()) |_| {
                 // Do not restart the prepare timeout as it is already ticking for another prepare.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2477,6 +2477,7 @@ pub fn ReplicaType(
             // We will decide below whether to reset or backoff the timeout.
             assert(self.status == .normal);
             assert(self.primary());
+            assert(self.prepare_timeout.ticking);
 
             const prepare = self.primary_pipeline_pending().?;
 
@@ -3361,6 +3362,7 @@ pub fn ReplicaType(
                     assert(prepare.message.header.checksum == self.commit_prepare.?.header.checksum);
                     assert(prepare.message.header.op == self.commit_min);
                     assert(prepare.message.header.op == self.commit_max);
+                    assert(prepare.ok_quorum_received);
                 }
 
                 if (self.pipeline.queue.pop_request()) |request| {


### PR DESCRIPTION
### Bug

Fixes seed `8496795589850792254`.

1. R0 is primary.
2. R0 receives a quorum for prepare P1 (`ok_quorum_received=true`). (`checksum=118583213136435813326495368021576914887` in this seed).
3. R0 starts committing P1.
4. Before prefetching P1 finishes, P1 receives an SVC quorum and transitions to view-changes status.
5. (A few view changes happen...)
6. R0 is primary again. R0's pipeline is reconstructed. Since P1 isn't committed yet (still prefetching from step 3), P1 is in its new pipeline. But `ok_quorum_received=false` now!
7. R0 finally finishes prefetching P1 (`commit_op_prefetch_callback`).
8. R0 dispatches `setup_client_replies` for P1...
9. R0 finishes `setup_client_replies` for P1 (`commit_op_client_replies_ready_callback`).
10. But `self.pipeline.queue.pop_prepare().?` pops P1 from the pipeline queue. (Remember, `P1.ok_quorum_received == false`).

Surprisingly, we weren't asserting `ok_quorum_received` from the popped prepare (which would have been hit in this case)!

Instead what failed is that the `prepare_timeout` fired, only to find an empty pipeline.
(`prepare_timeout` runs iff `status=normal primary, pipeline has prepare with !ok_quorum_received`).

### Fix

New primary doesn't repair the pipeline and transition to normal status until it has finished committing.


A couple other approaches that occurred to me before this one, just because:

<details><summary>Fix (Alternate; not implemented)</summary>

Fake the `ok_quorum_received`.

At the end of `Replica.primary_repair_pipeline_done()`:

```zig
// If we were already committing the op prior to our view change, it must have a quorum.
if (self.commit_prepare) |prepare_committing| {
    if (pipeline_queue.prepare_queue.head_ptr()) |prepare_head| {
        if (prepare_head.message.header.op == prepare_committing.header.op) {
            assert(prepare_head.message.header.checksum ==
                prepare_committing.header.checksum);

            prepare_head.ok_quorum_received = true;
        } else {
            assert(prepare_head.message.header.op == prepare_committing.header.op + 1);
        }
    }
}
```

This is not an intrusive change, but feels like a kludge.
In particular, even with `ok_quorum_received=true`, `ok_from_all_replicas` would be empty, which would normally not be the case.
</details>

<details><summary>Fix (Alternate; not implemented)</summary>

Primary bump `commit_max` when it begins to prefetch, rather then when it commits.

This means that when the primary becomes primary (the second time) it won't transition to `normal` until it finishes the commit that started during its first time as primary.

This is a somewhat intrusive change due to the invariant change:
we lose the normal-primary's `self.commit_min == self.commit_max` invariant.
</details>

### And also

- Update some outdated docs and log lines.
- Add some asserts.