### PR TITLE
Include version in `needs:` so that we can reference it in `run:`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
   finalize_release:
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [release, version]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
... should be the final PR in this series :)