### PR TITLE
use constants.zig as a source of truth for config

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -7,7 +7,8 @@ const assert = std.debug.assert;
 const vsr = @import("vsr.zig");
 const tracer = @import("tracer.zig");
 const Config = @import("config.zig").Config;
-const config = @import("config.zig").configs.current;
+
+pub const config = @import("config.zig").configs.current;
 
 /// The maximum log level.
 /// One of: .err, .warn, .info, .debug

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -23,10 +23,10 @@ const Client = vsr.Client(StateMachine, MessageBus);
 pub const log_level: std.log.Level = .alert;
 
 pub const vsr_options = .{
-    .config_base = vsr.config.ConfigBase.default,
+    .config_base = .default,
     .config_log_level = std.log.Level.info,
-    .tracer_backend = vsr.config.TracerBackend.none,
-    .hash_log_mode = vsr.config.HashLogMode.none,
+    .tracer_backend = .none,
+    .hash_log_mode = .none,
     .config_aof_record = false,
     .config_aof_recovery = false,
 };

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -10,7 +10,7 @@ const build_options = @import("vsr_options");
 
 const vsr = @import("vsr");
 const constants = vsr.constants;
-const config = vsr.config.configs.current;
+const config = constants.config;
 const tracer = vsr.tracer;
 
 const cli = @import("cli.zig");

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -16,7 +16,6 @@ pub const storage = @import("storage.zig");
 pub const tigerbeetle = @import("tigerbeetle.zig");
 pub const time = @import("time.zig");
 pub const tracer = @import("tracer.zig");
-pub const config = @import("config.zig");
 pub const stdx = @import("stdx.zig");
 pub const superblock = @import("vsr/superblock.zig");
 pub const aof = @import("aof.zig");
@@ -1325,7 +1324,7 @@ test "quorums" {
 /// replica ids for the initial cluster deterministically.
 pub fn root_members(cluster: u32) [constants.nodes_max]u128 {
     const IdSeed = packed struct {
-        cluster_config_checksum: u128 = config.configs.current.cluster.checksum(),
+        cluster_config_checksum: u128 = constants.config.cluster.checksum(),
         cluster: u32,
         replica: u8,
     };


### PR DESCRIPTION
Couple of bits of code were using `vsr.config.configs.current` to get user-specified compile time configuration. This reads kafkaesque, and also makes it less clear what should one use config.zig or constants.zig?

To fix that, remove `pub const config` from the vsr interface, and re-export required bits from the `constants`.

As a positive side effect, we also gained an actual `config.BuildOptions` type which clearly specifies all bits that can be tweaked at compile time using build.zig options or `vsr_options` struct in the root file.