### PR TITLE
VSR: Fix committing/view-change race assertion

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5284,7 +5284,8 @@ pub fn ReplicaType(
                         // If we still have a commit running, we started it the last time we were
                         // primary, and its still running. Wait for it to finish before repairing
                         // the pipeline so that it doesn't wind up in the new pipeline.
-                        assert(self.commit_prepare.?.header.op == self.commit_min + 1);
+                        assert(self.commit_prepare.?.header.op >= self.commit_min);
+                        assert(self.commit_prepare.?.header.op <= self.commit_min + 1);
                         assert(self.commit_prepare.?.header.view < self.view);
                         return;
                     }


### PR DESCRIPTION
Fixes seed 2921910364699353307.

Depending on the commit stage, the `commit_min` may or may not have advanced.

(Bug introduced by https://github.com/tigerbeetle/tigerbeetle/pull/1005)