### PR TITLE
VOPRHub: Filter by created issues

### DIFF
--- a/src/vopr_hub/main.go
+++ b/src/vopr_hub/main.go
@@ -662,7 +662,7 @@ func get_open_issue_count() int {
 
 	res := do_github_request(
 		"GET",
-		repository_url+"/issues?filter=created&state=open",
+		repository_url+"/issues?state=open&creator=tigerbeetle-vopr",
 		nil,
 		nil,
 	)


### PR DESCRIPTION
To avoid spurious "There are too many open GitHub issues."