### PR TITLE
CI validate: Reuse existing message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
       - run: |
           hub release edit \
             --draft=false \
+            -m "" \
             "${{ needs.version.outputs.version }}"
 
         # Propagate token into environment


### PR DESCRIPTION
`hub release edit` to mark as published was trying to open `EDITOR`, which was failing