### PR TITLE
Main: Guard against integer overflow

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -148,7 +148,7 @@ const Command = struct {
             aof = try AOF.from_absolute_path(aof_path);
         }
 
-        const grid_cache_size = args.cache_grid_blocks * constants.block_size;
+        const grid_cache_size = @as(u64, args.cache_grid_blocks) * constants.block_size;
         const grid_cache_size_warn = 1024 * 1024 * 1024;
         if (grid_cache_size <= grid_cache_size_warn) {
             log_main.warn("Grid cache size of {}MB is small. See --cache-grid", .{


### PR DESCRIPTION
`args.cache_grid_blocks` is a `u32`, and `block_size` is a `comptime_int`, so `grid_cache_size` is as well. This is very easy to overflow – a maximum 4GB cache.