### PR TITLE
vsr: avoid memcpy

### DIFF
--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -102,7 +102,7 @@ pub const ClientSessions = struct {
         std.mem.set(u8, target[size..new_size], 0);
         size = new_size;
 
-        for (client_sessions.entries) |entry| {
+        for (client_sessions.entries) |*entry| {
             stdx.copy_disjoint(.inexact, u8, target[size..], mem.asBytes(&entry.header));
             size += @sizeOf(vsr.Header);
         }
@@ -112,7 +112,7 @@ pub const ClientSessions = struct {
         std.mem.set(u8, target[size..new_size], 0);
         size = new_size;
 
-        for (client_sessions.entries) |entry| {
+        for (client_sessions.entries) |*entry| {
             stdx.copy_disjoint(.inexact, u8, target[size..], mem.asBytes(&entry.session));
             size += @sizeOf(u64);
         }


### PR DESCRIPTION
entry holds a vsr.Header, no need to memcpy that.

Curiously, we already do that in the decode path.   