### PR TITLE
vsr: remove needles alignCasts

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -681,10 +681,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                     return null;
                 }
 
-                const header = mem.bytesAsValue(
-                    Header,
-                    @alignCast(@alignOf(Header), data[0..@sizeOf(Header)]),
-                );
+                const header = mem.bytesAsValue(Header, data[0..@sizeOf(Header)]);
 
                 if (!connection.recv_checked_header) {
                     if (!header.valid_checksum()) {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -647,10 +647,7 @@ pub const Simulator = struct {
 
         const request_metadata = simulator.workload.build_request(
             client_index,
-            @alignCast(
-                @alignOf(vsr.Header),
-                request_message.buffer[@sizeOf(vsr.Header)..constants.message_size_max],
-            ),
+            request_message.buffer[@sizeOf(vsr.Header)..constants.message_size_max],
         );
         assert(request_metadata.size <= constants.message_size_max - @sizeOf(vsr.Header));
 


### PR DESCRIPTION
Message.buffer carries proper alignment in its type, so we statically get the right alignment here.