### PR TITLE
vsr: assert that ViewChange headers are valid

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1380,8 +1380,9 @@ pub const Headers = struct {
     pub fn dvc_header_type(header: *const Header) enum { blank, valid } {
         if (std.meta.eql(header.*, Headers.dvc_blank(header.op))) return .blank;
 
-        assert(header.command == .prepare);
         if (constants.verify) assert(header.valid_checksum());
+        assert(header.command == .prepare);
+        assert(header.invalid() == null);
         return .valid;
     }
 };
@@ -1511,7 +1512,10 @@ test "Headers.ViewChangeSlice.view_for_op" {
     var headers_array = [_]Header{
         std.mem.zeroInit(Header, .{
             .checksum = undefined,
+            .client = 6,
+            .request = 7,
             .command = .prepare,
+            .operation = @intToEnum(Operation, constants.vsr_operations_reserved + 8),
             .op = 9,
             .view = 10,
             .timestamp = 11,
@@ -1520,7 +1524,10 @@ test "Headers.ViewChangeSlice.view_for_op" {
         Headers.dvc_blank(7),
         std.mem.zeroInit(Header, .{
             .checksum = undefined,
+            .client = 3,
+            .request = 4,
             .command = .prepare,
+            .operation = @intToEnum(Operation, constants.vsr_operations_reserved + 5),
             .op = 6,
             .view = 7,
             .timestamp = 8,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -344,8 +344,12 @@ const Environment = struct {
 
         var vsr_headers = vsr.Headers.Array{ .buffer = undefined };
         var vsr_head = std.mem.zeroInit(vsr.Header, .{
+            .client = 1,
+            .request = 1,
             .command = .prepare,
-            .op = env.superblock.staging.vsr_state.commit_min,
+            .operation = @intToEnum(vsr.Operation, constants.vsr_operations_reserved + 1),
+            .op = env.superblock.staging.vsr_state.commit_min + 1,
+            .timestamp = 1,
         });
         vsr_head.set_checksum_body(&.{});
         vsr_head.set_checksum();


### PR DESCRIPTION
The most interesting case here is when we load superblock from disk. We do check the overall checksum, so seeing an invalid header there would be surprising, but still feels better to double check.

Two other paths to load a header from disk are Journal.read_prepare, and Journal.redundant_headers, and we do verify `.invalid() == null` there.