### PR TITLE
vsr: explicitly crash on unknown commands

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -464,6 +464,13 @@ pub const Header = extern struct {
             .sync_manifest => self.invalid_sync_manifest(),
             .sync_free_set => self.invalid_sync_free_set(),
             .sync_client_sessions => self.invalid_sync_client_sessions(),
+            // The `Command` enum is exhaustive, so we can't write an "else" branch here. An unknown
+            // command is a possibility, but that means that someone has send us a message with
+            // matching cluster, matching version, correct checksum, and a command we don't know
+            // about. Ignoring unknown commands might be unsafe, so the replica intentionally
+            // crashes here, which is guaranteed by Zig's ReleaseSafe semantics.
+            //
+            // _ => unreachable
         };
     }
 


### PR DESCRIPTION
Racked my brain a bit here, but I  think this is the lesser of two weevils!

First, I am moderately strongly convinced that a crash is a right behavior here, as ignoring unknown commands might lead us to not doing something we _must_ do, which could be a data loss. 

It might seem that just dropping a message would be fine, because if we hit this it might mean that a "new" replica (or a "new" client) accidentally joined the cluster, and we don't want to let this bring the whole cluster down. 

_However_, and alternative scenario is that _we_ are an "old" replica, which joins a newer cluster. So everyone can understand our messages, but we might not understand all of the cluster messages. In this scenario, shutting ourselves down seems safer. 

It _might_ be a good idea to emit a better error message, and avoid materializing invalid enum values of questionable legality. I tried that in https://github.com/tigerbeetle/tigerbeetle/commit/d02a3eda9c694f2aac0d9b7ce3e4b95f1d1f4d59 by adding `_` and I don't really like the result. It needs a bunch of code for pretty much the same outcome. What's more, having `_` in enums feels scary to me, as it, eg, makes `@tagName` non-total (its CIB to invoke `@tagName` on a non-explicit value of non-exhaustive enum). 

Alternatively, we can do that on the message bus level by poking at the right byte, but I don't like that either, because: 

- we also get headers from disk, and I want the logic to be applied there as well
- we want to check `version` and `cluster` _before_ we check command, and we don't check `version` in message bus, and check `cluster` only after the problematic cast
- message bus is not a part of the vopr