### PR TITLE
size: avoid needless monomorphizations

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -269,8 +269,8 @@ const Command = struct {
 
 fn print_value(
     writer: anytype,
-    comptime field: []const u8,
-    comptime value: anytype,
+    field: []const u8,
+    value: anytype,
 ) !void {
     switch (@typeInfo(@TypeOf(value))) {
         .Fn => {}, // Ignore the log() function.


### PR DESCRIPTION
By the amount of LLVM IR, Command.version is one of the larger functions we have. That's because `print_value` is monomoprihsed for each field name and distinct value (as opposed to every type).