### PR TITLE
Make sure version is set

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -65,7 +65,7 @@ jobs:
         fetch-depth: 0
 
     - name: Build tigerbeetle
-      run: ./scripts/install.sh ${{ matrix.debug }}
+      run: ./scripts/install.sh ${{ matrix.debug }} -Dversion=${{ needs.version.outputs.version }}
       env:
         TARGET: ${{ matrix.target }}
         CPU: ${{ matrix.target == 'aarch64-linux' && 'baseline+aes+neon' || matrix.target == 'aarch64-macos' && 'baseline+aes+neon' || 'x86_64_v3+aes' }}
@@ -107,13 +107,13 @@ jobs:
         fetch-depth: 0
 
     - name: Build tigerbeetle (aarch64)
-      run: ./scripts/install.sh ${{ matrix.debug }} && mv tigerbeetle tigerbeetle-aarch64
+      run: ./scripts/install.sh ${{ matrix.debug }} -Dversion=${{ needs.version.outputs.version }} && mv tigerbeetle tigerbeetle-aarch64
       env:
         TARGET: aarch64-macos
         CPU: baseline+aes+neon
 
     - name: Build tigerbeetle (x86_64)
-      run: ./scripts/install.sh ${{ matrix.debug }} && mv tigerbeetle tigerbeetle-x86_64
+      run: ./scripts/install.sh ${{ matrix.debug }} -Dversion=${{ needs.version.outputs.version }} && mv tigerbeetle tigerbeetle-x86_64
       env:
         TARGET: x86_64-macos
         CPU: x86_64_v3+aes

--- a/build.zig
+++ b/build.zig
@@ -21,7 +21,12 @@ pub fn build(b: *std.build.Builder) void {
         "git_commit",
         if (shell.git_commit()) |commit| @as([]const u8, &commit) else |_| null,
     );
-    options.addOption(?[]const u8, "git_tag", shell.git_tag() catch null);
+    options.addOption(
+        ?[]const u8,
+        "git_tag",
+        b.option([]const u8, "version", "Version to embed in binary.") orelse
+            (shell.git_tag() catch null),
+    );
 
     options.addOption(
         config.ConfigBase,


### PR DESCRIPTION
I'm not sure why, but the version in releases has stopped being accurate:

```
$ curl -LO https://github.com/tigerbeetle/tigerbeetle/releases/download/0.13.71/tigerbeetle-universal-macos-0.13.71.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1226k  100 1226k    0     0  2099k      0 --:--:-- --:--:-- --:--:-- 2099k
$ unzip tigerbeetle-universal-macos-0.13.71.zip
Archive:  tigerbeetle-universal-macos-0.13.71.zip
replace tigerbeetle? [y]es, [n]o, [A]ll, [N]one, [r]ename: y
  inflating: tigerbeetle
$ ./tigerbeetle version
TigerBeetle version experimental%
```

So this PR makes it a little more explicit.

```
$ ./scripts/build.sh -Dversion=GREAT
$ ./tigerbeetle version
TigerBeetle version GREAT%
```