### PR TITLE
Factor out account assertions for Go two-phase sample

### DIFF
--- a/src/clients/go/samples/two-phase/main.go
+++ b/src/clients/go/samples/two-phase/main.go
@@ -26,6 +26,39 @@ func assert(a, b interface{}, field string) {
 	}
 }
 
+func assertAccountBalances(client tb.Client, accounts []tb_types.Account, debugMsg string) {
+	ids := []tb_types.Uint128{}
+	for _, account := range accounts {
+		ids = append(ids, account.ID)
+	}
+	found, err := client.LookupAccounts(ids)
+	if err != nil {
+		log.Fatalf("Could not fetch accounts: %s", err)
+	}
+	assert(len(found), len(accounts), "accounts")
+
+	for _, account_found := range found {
+		requested := false
+		for _, account := range accounts {
+			if account.ID == account_found.ID {
+				requested = true
+				assert(account.DebitsPosted, account_found.DebitsPosted,
+					fmt.Sprintf("account %s debits, %s", account.ID, debugMsg))
+				assert(account.CreditsPosted, account_found.DebitsPosted,
+					fmt.Sprintf("account %s credits, %s", account.ID, debugMsg))
+				assert(account.DebitsPending, account_found.DebitsPosted,
+					fmt.Sprintf("account %s debits pending, %s", account.ID, debugMsg))
+				assert(account.CreditsPending, account_found.DebitsPosted,
+					fmt.Sprintf("account %s credits pending, %s", account.ID, debugMsg))
+			}
+		}
+
+		if !requested {
+			log.Fatalf("Unexpected account: %s", account_found.ID)
+		}
+	}
+}
+
 func main() {
 	port := os.Getenv("TB_ADDRESS")
 	if port == "" {
@@ -80,27 +113,22 @@ func main() {
 	}
 
 	// Validate accounts pending and posted debits/credits before finishing the two-phase transfer
-	accounts, err := client.LookupAccounts([]tb_types.Uint128{uint128("1"), uint128("2")})
-	if err != nil {
-		log.Fatalf("Could not fetch accounts: %s", err)
-	}
-	assert(len(accounts), 2, "accounts")
-
-	for _, account := range accounts {
-		if account.ID == uint128("1") {
-			assert(account.DebitsPosted, uint64(0), "account 1 debits, before posted")
-			assert(account.CreditsPosted, uint64(0), "account 1 credits, before posted")
-			assert(account.DebitsPending, uint64(500), "account 1 debits pending, before posted")
-			assert(account.CreditsPending, uint64(0), "account 1 credits pending, before posted")
-		} else if account.ID == uint128("2") {
-			assert(account.DebitsPosted, uint64(0), "account 2 debits, before posted")
-			assert(account.CreditsPosted, uint64(0), "account 2 credits, before posted")
-			assert(account.DebitsPending, uint64(0), "account 2 debits pending, before posted")
-			assert(account.CreditsPending, uint64(500), "account 2 credits pending, before posted")
-		} else {
-			log.Fatalf("Unexpected account: %s", account.ID)
-		}
-	}
+	assertAccountBalances(client, []tb_types.Account{
+		{
+			ID:             uint128("1"),
+			DebitsPosted:   uint64(0),
+			CreditsPosted:  uint64(0),
+			DebitsPending:  uint64(500),
+			CreditsPending: uint64(0),
+		},
+		{
+			ID:             uint128("2"),
+			DebitsPosted:   uint64(0),
+			CreditsPosted:  uint64(0),
+			DebitsPending:  uint64(0),
+			CreditsPending: uint64(500),
+		},
+	}, "before posted")
 
 	// Create a second transfer simply posting the first transfer
 	transferRes, err = client.CreateTransfers([]tb_types.Transfer{
@@ -143,27 +171,22 @@ func main() {
 	}
 
 	// Validate accounts pending and posted debits/credits after finishing the two-phase transfer
-	accounts, err = client.LookupAccounts([]tb_types.Uint128{uint128("1"), uint128("2")})
-	if err != nil {
-		log.Fatalf("Could not fetch accounts: %s", err)
-	}
-	assert(len(accounts), 2, "accounts")
-
-	for _, account := range accounts {
-		if account.ID == uint128("1") {
-			assert(account.DebitsPosted, uint64(500), "account 1 debits")
-			assert(account.CreditsPosted, uint64(0), "account 1 credits")
-			assert(account.DebitsPending, uint64(0), "account 1 debits pending")
-			assert(account.CreditsPending, uint64(0), "account 1 credits pending")
-		} else if account.ID == uint128("2") {
-			assert(account.DebitsPosted, uint64(0), "account 2 debits")
-			assert(account.CreditsPosted, uint64(500), "account 2 credits")
-			assert(account.DebitsPending, uint64(0), "account 2 debits pending")
-			assert(account.CreditsPending, uint64(0), "account 2 credits pending")
-		} else {
-			log.Fatalf("Unexpected account: %s", account.ID)
-		}
-	}
+	assertAccountBalances(client, []tb_types.Account{
+		{
+			ID:             uint128("1"),
+			DebitsPosted:   uint64(500),
+			CreditsPosted:  uint64(0),
+			DebitsPending:  uint64(0),
+			CreditsPending: uint64(0),
+		},
+		{
+			ID:             uint128("2"),
+			DebitsPosted:   uint64(0),
+			CreditsPosted:  uint64(500),
+			DebitsPending:  uint64(0),
+			CreditsPending: uint64(0),
+		},
+	}, "before posted")
 
 	fmt.Println("ok")
 }


### PR DESCRIPTION
I'm going to be adding a bunch more assertions in a new sample for https://github.com/tigerbeetle/tigerbeetle/issues/943 so refactoring this in the original two-phase project to keep the PRs smaller.