### PR TITLE
Simplifies the pattern for holding multiple contexts inside a union.

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -701,7 +701,6 @@ pub fn GrooveType(
         };
 
         pub const PrefetchWorker = struct {
-
             // Since lookup contexts are used one at a time, it's safe to access
             // the union's fields and reuse the same memory for all context instances.
             // Can't use extern/packed union as the LookupContextes aren't ABI compliant.
@@ -709,20 +708,22 @@ pub fn GrooveType(
                 id: if (has_id) IdTree.LookupContext else void,
                 object: ObjectTree.LookupContext,
 
-                // TODO(Zig): No need for this function once Zig is upgraded
-                // and @fieldParentPtr() can be used for unions.
-                // See: https://github.com/ziglang/zig/issues/6611.
-                pub inline fn parent(
-                    comptime field: std.meta.Tag(LookupContext),
-                    completion: anytype,
-                ) *PrefetchWorker {
-                    var stub = @unionInit(LookupContext, @tagName(field), undefined);
-                    const stub_field_ptr = &@field(stub, @tagName(field));
-                    comptime assert(@TypeOf(stub_field_ptr) == @TypeOf(completion));
+                pub const Field = std.meta.FieldEnum(LookupContext);
+                pub fn FieldType(comptime field: Field) type {
+                    return std.meta.fieldInfo(LookupContext, field).field_type;
+                }
 
-                    const offset = @ptrToInt(stub_field_ptr) - @ptrToInt(&stub);
-                    const lookup_ptr = @intToPtr(*LookupContext, @ptrToInt(completion) - offset);
-                    return @fieldParentPtr(PrefetchWorker, "lookup", lookup_ptr);
+                pub inline fn parent(
+                    comptime field: Field,
+                    completion: *FieldType(field),
+                ) *PrefetchWorker {
+                    const lookup = stdx.union_field_parent_ptr(LookupContext, field, completion);
+                    return @fieldParentPtr(PrefetchWorker, "lookup", lookup);
+                }
+
+                pub inline fn get(self: *LookupContext, comptime field: Field) *FieldType(field) {
+                    self.* = @unionInit(LookupContext, @tagName(field), undefined);
+                    return &@field(self, @tagName(field));
                 }
             };
 
@@ -740,12 +741,10 @@ pub fn GrooveType(
                 // from disk and added to the auxiliary prefetch_objects hash map.
                 switch (prefetch_key.key) {
                     .id => |id| {
-                        // Set the union tag so access via &worker.lookup.id doesn't trap.
-                        worker.lookup = .{ .id = undefined };
                         if (has_id) {
                             worker.context.groove.ids.lookup_from_levels_storage(.{
                                 .callback = lookup_id_callback,
-                                .context = &worker.lookup.id,
+                                .context = worker.lookup.get(.id),
                                 .snapshot = worker.context.snapshot,
                                 .key = id,
                                 .level_min = prefetch_key.level,
@@ -753,11 +752,9 @@ pub fn GrooveType(
                         } else unreachable;
                     },
                     .timestamp => |timestamp| {
-                        // Set the union tag so access via &worker.lookup.id doesn't trap.
-                        worker.lookup = .{ .object = undefined };
                         worker.context.groove.objects.lookup_from_levels_storage(.{
                             .callback = lookup_object_callback,
-                            .context = &worker.lookup.object,
+                            .context = worker.lookup.get(.object),
                             .snapshot = worker.context.snapshot,
                             .key = timestamp,
                             .level_min = prefetch_key.level,
@@ -784,8 +781,6 @@ pub fn GrooveType(
             }
 
             fn lookup_by_timestamp(worker: *PrefetchWorker, timestamp: u64) void {
-                // Set the union tag so access via &worker.lookup.object doesn't trap.
-                worker.lookup = .{ .object = undefined };
                 switch (worker.context.groove.objects.lookup_from_memory(
                     worker.context.snapshot,
                     timestamp,
@@ -799,7 +794,7 @@ pub fn GrooveType(
                     .possible => |level_min| {
                         worker.context.groove.objects.lookup_from_levels_storage(.{
                             .callback = lookup_object_callback,
-                            .context = &worker.lookup.object,
+                            .context = worker.lookup.get(.object),
                             .snapshot = worker.context.snapshot,
                             .key = timestamp,
                             .level_min = level_min,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -312,20 +312,22 @@ pub fn StateMachineType(
             transfers: TransfersGroove.PrefetchContext,
             posted: PostedGroove.PrefetchContext,
 
-            // TODO(Zig): No need for this function once Zig is upgraded
-            // and @fieldParentPtr() can be used for unions.
-            // See: https://github.com/ziglang/zig/issues/6611.
-            pub inline fn parent(
-                comptime field: std.meta.Tag(PrefetchContext),
-                completion: anytype,
-            ) *StateMachine {
-                var stub = @unionInit(PrefetchContext, @tagName(field), undefined);
-                const stub_field_ptr = &@field(stub, @tagName(field));
-                comptime assert(@TypeOf(stub_field_ptr) == @TypeOf(completion));
+            pub const Field = std.meta.FieldEnum(PrefetchContext);
+            pub fn FieldType(comptime field: Field) type {
+                return std.meta.fieldInfo(PrefetchContext, field).field_type;
+            }
 
-                const offset = @ptrToInt(stub_field_ptr) - @ptrToInt(&stub);
-                const context_ptr = @intToPtr(*PrefetchContext, @ptrToInt(completion) - offset);
-                return @fieldParentPtr(StateMachine, "prefetch_context", context_ptr);
+            pub inline fn parent(
+                comptime field: Field,
+                completion: *FieldType(field),
+            ) *StateMachine {
+                const context = stdx.union_field_parent_ptr(PrefetchContext, field, completion);
+                return @fieldParentPtr(StateMachine, "prefetch_context", context);
+            }
+
+            pub inline fn get(self: *PrefetchContext, comptime field: Field) *FieldType(field) {
+                self.* = @unionInit(PrefetchContext, @tagName(field), undefined);
+                return &@field(self, @tagName(field));
             }
         };
 
@@ -486,12 +488,9 @@ pub fn StateMachineType(
                 self.forest.grooves.accounts_immutable.prefetch_enqueue(a.id);
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .accounts_immutable = undefined };
-
             self.forest.grooves.accounts_immutable.prefetch(
                 prefetch_create_accounts_immutable_callback,
-                &self.prefetch_context.accounts_immutable,
+                self.prefetch_context.get(.accounts_immutable),
             );
         }
 
@@ -504,12 +503,9 @@ pub fn StateMachineType(
             // is all that is needed to check for pre-existing accounts before creating one.
             // We still call prefetch() anyway to keep a valid/expected Groove state for commit().
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .accounts_mutable = undefined };
-
             self.forest.grooves.accounts_mutable.prefetch(
                 prefetch_create_accounts_mutable_callback,
-                &self.prefetch_context.accounts_mutable,
+                self.prefetch_context.get(.accounts_mutable),
             );
         }
 
@@ -529,12 +525,9 @@ pub fn StateMachineType(
                 }
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .transfers = undefined };
-
             self.forest.grooves.transfers.prefetch(
                 prefetch_create_transfers_callback_transfers,
-                &self.prefetch_context.transfers,
+                self.prefetch_context.get(.transfers),
             );
         }
 
@@ -554,12 +547,9 @@ pub fn StateMachineType(
                 }
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .accounts_immutable = undefined };
-
             self.forest.grooves.accounts_immutable.prefetch(
                 prefetch_create_transfers_callback_accounts_immutable,
-                &self.prefetch_context.accounts_immutable,
+                self.prefetch_context.get(.accounts_immutable),
             );
         }
 
@@ -591,24 +581,18 @@ pub fn StateMachineType(
                 }
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .accounts_mutable = undefined };
-
             self.forest.grooves.accounts_mutable.prefetch(
                 prefetch_create_transfers_callback_accounts_mutable,
-                &self.prefetch_context.accounts_mutable,
+                self.prefetch_context.get(.accounts_mutable),
             );
         }
 
         fn prefetch_create_transfers_callback_accounts_mutable(completion: *AccountsMutableGroove.PrefetchContext) void {
             const self = PrefetchContext.parent(.accounts_mutable, completion);
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .posted = undefined };
-
             self.forest.grooves.posted.prefetch(
                 prefetch_create_transfers_callback_posted,
-                &self.prefetch_context.posted,
+                self.prefetch_context.get(.posted),
             );
         }
 
@@ -623,12 +607,9 @@ pub fn StateMachineType(
                 self.forest.grooves.accounts_immutable.prefetch_enqueue(id);
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .accounts_immutable = undefined };
-
             self.forest.grooves.accounts_immutable.prefetch(
                 prefetch_lookup_accounts_immutable_callback,
-                &self.prefetch_context.accounts_immutable,
+                self.prefetch_context.get(.accounts_immutable),
             );
         }
 
@@ -642,12 +623,9 @@ pub fn StateMachineType(
                 }
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .accounts_mutable = undefined };
-
             self.forest.grooves.accounts_mutable.prefetch(
                 prefetch_lookup_accounts_mutable_callback,
-                &self.prefetch_context.accounts_mutable,
+                self.prefetch_context.get(.accounts_mutable),
             );
         }
 
@@ -662,12 +640,9 @@ pub fn StateMachineType(
                 self.forest.grooves.transfers.prefetch_enqueue(id);
             }
 
-            // Set the active union tag so access via &self.prefetch_context.* doesn't trap.
-            self.prefetch_context = .{ .transfers = undefined };
-
             self.forest.grooves.transfers.prefetch(
                 prefetch_lookup_transfers_callback,
-                &self.prefetch_context.transfers,
+                self.prefetch_context.get(.transfers),
             );
         }
 


### PR DESCRIPTION
- Adds the function `get()`, so it's not necessary to initialize the tag.

- Moves `union_field_parent_ptr` to `stdx`, making it more generic and comptime checking if we can use a simple cast instead of doing pointer arithmetic.

- Adds unit tests.