### PR TITLE
vsr: extra test for checksum

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -182,7 +182,6 @@ const naughty_list = [_][]const u8{
     "time.zig",
     "tracer.zig",
     "vsr.zig",
-    "vsr/checksum.zig",
     "vsr/client_replies.zig",
     "vsr/client.zig",
     "vsr/clock.zig",

--- a/src/vsr/checksum.zig
+++ b/src/vsr/checksum.zig
@@ -1,86 +1,48 @@
+//! This file implements vsr.checksum. TigerBeetle uses this checksum to:
+//!
+//! - detect bitrot in data on disk,
+//! - validate network messages before casting raw bytes to an `extern struct` type,
+//! - hash-chain prepares and client requests to have strong consistency and ordering guarantees.
+//!
+//! As this checksum is stored on disk, it is set in stone and impossible to change.
+//!
+//! We need this checksum to be fast (it's in all our hotpaths) and strong (it's our ultimate line
+//! of defense against storage failures and some classes of software bugs).
+//!
+//! Our checksum of choice is based on Aegis:
+//!
+//! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-aegis-aead/>
+//!
+//! We use the implementation from the Zig standard library, but here's the overall overview of the
+//! thing works:
+//!
+//! - AES-block is a widely supported in hardware symmetric encryption primitive (`vaesenc`,
+//!   `vaesdec` instructions). Hardware acceleration is what provides speed.
+//! - Aegis is an modern Authenticated Encryption with Associated Data (AEAD) scheme based on
+//!   AES-block.
+//! - In AEAD, the user provides, a key, a nonce, a secret message, and associated data, and gets
+//!   a ciphertext and an authentication tag back. Associated data is expected to be sent as plain
+//!   text (eg, it could be routing information). The tag authenticates _both_ the secret message
+//!   and associated data.
+//! - AEAD can be specialized to be a MAC by using an empty secret message and zero nonce. NB:
+//!   in mac mode, message to sign is treated as AD, not as a secret message.
+//! - A MAC can further be specialized to be a checksum by setting the secret key to zero.
+//!   And that's what we do here!
+
 const std = @import("std");
 const builtin = @import("builtin");
 const mem = std.mem;
 const testing = std.testing;
+const assert = std.debug.assert;
 
-// TODO(king): Replace with std.crypto.aead.aegis.Aegis128LMac_128 once Zig is updated.
-const Aegis128 = struct {
-    const AesBlock = std.crypto.core.aes.Block;
-    const State = [8]AesBlock;
-
-    fn init(key: [16]u8, nonce: [16]u8) State {
-        const c1 = AesBlock.fromBytes(&.{ 0xdb, 0x3d, 0x18, 0x55, 0x6d, 0xc2, 0x2f, 0xf1, 0x20, 0x11, 0x31, 0x42, 0x73, 0xb5, 0x28, 0xdd });
-        const c2 = AesBlock.fromBytes(&.{ 0x0, 0x1, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22, 0x37, 0x59, 0x90, 0xe9, 0x79, 0x62 });
-        const key_block = AesBlock.fromBytes(&key);
-        const nonce_block = AesBlock.fromBytes(&nonce);
-        var blocks = [8]AesBlock{
-            key_block.xorBlocks(nonce_block),
-            c1,
-            c2,
-            c1,
-            key_block.xorBlocks(nonce_block),
-            key_block.xorBlocks(c2),
-            key_block.xorBlocks(c1),
-            key_block.xorBlocks(c2),
-        };
-        var i: usize = 0;
-        while (i < 10) : (i += 1) {
-            update(&blocks, nonce_block, key_block);
-        }
-        return blocks;
-    }
-
-    inline fn update(blocks: *State, d1: AesBlock, d2: AesBlock) void {
-        const tmp = blocks[7];
-        comptime var i: usize = 7;
-        inline while (i > 0) : (i -= 1) {
-            blocks[i] = blocks[i - 1].encrypt(blocks[i]);
-        }
-        blocks[0] = tmp.encrypt(blocks[0]);
-        blocks[0] = blocks[0].xorBlocks(d1);
-        blocks[4] = blocks[4].xorBlocks(d2);
-    }
-
-    fn absorb(blocks: *State, src: *const [32]u8) void {
-        const msg0 = AesBlock.fromBytes(src[0..16]);
-        const msg1 = AesBlock.fromBytes(src[16..32]);
-        update(blocks, msg0, msg1);
-    }
-
-    fn mac(blocks: *State, adlen: usize, mlen: usize) [16]u8 {
-        var sizes: [16]u8 = undefined;
-        mem.writeIntLittle(u64, sizes[0..8], adlen * 8);
-        mem.writeIntLittle(u64, sizes[8..16], mlen * 8);
-        const tmp = AesBlock.fromBytes(&sizes).xorBlocks(blocks[2]);
-        var i: usize = 0;
-        while (i < 7) : (i += 1) {
-            update(blocks, tmp, tmp);
-        }
-        return blocks[0].xorBlocks(blocks[1]).xorBlocks(blocks[2]).xorBlocks(blocks[3]).xorBlocks(blocks[4])
-            .xorBlocks(blocks[5]).xorBlocks(blocks[6]).toBytes();
-    }
-
-    inline fn hash(blocks: *State, source: []const u8) u128 {
-        var i: usize = 0;
-        while (i + 32 <= source.len) : (i += 32) {
-            absorb(blocks, source[i..][0..32]);
-        }
-        if (source.len % 32 != 0) {
-            var src: [32]u8 align(16) = mem.zeroes([32]u8);
-            mem.copy(u8, src[0 .. source.len % 32], source[i .. i + source.len % 32]);
-            absorb(blocks, &src);
-        }
-        return @as(u128, @bitCast(mac(blocks, 0, source.len)));
-    }
-};
+const Aegis128LMac_128 = std.crypto.auth.aegis.Aegis128LMac_128;
 
 var seed_once = std.once(seed_init);
-var seed_state: Aegis128.State = undefined;
+var seed_state: Aegis128LMac_128 = undefined;
 
 fn seed_init() void {
     const key = mem.zeroes([16]u8);
-    const nonce = mem.zeroes([16]u8);
-    seed_state = Aegis128.init(key, nonce);
+    seed_state = Aegis128LMac_128.init(&key);
 }
 
 // Lazily initialize the Aegis State instead of recomputing it on each call to checksum().
@@ -88,45 +50,40 @@ fn seed_init() void {
 pub fn checksum(source: []const u8) u128 {
     seed_once.call();
     var state_copy = seed_state;
-    return Aegis128.hash(&state_copy, source);
+    state_copy.update(source);
+    var result: u128 = undefined;
+    state_copy.final(mem.asBytes(&result));
+    return result;
 }
 
-fn std_checksum(cipher: []u8, msg: []const u8) u128 {
-    std.debug.assert(cipher.len == msg.len);
-
-    const ad = [_]u8{};
-    const key: [16]u8 = [_]u8{0x00} ** 16;
-    const nonce: [16]u8 = [_]u8{0x00} ** 16;
-
-    var tag: [16]u8 = undefined;
-    std.crypto.aead.aegis.Aegis128L.encrypt(cipher, &tag, msg, &ad, nonce, key);
-    return @as(u128, @bitCast(tag));
-}
-
-test "Aegis test vectors" {
+// Note: these test vectors are not independent --- there are test vectors in AEAD papers, but they
+// don't zero all of (nonce, key, secret message). However, the as underlying AEAD implementation
+// matches those test vectors, the entries here are correct.
+//
+// They can be used to smoke-test independent implementations of TigerBeetle checksum.
+//
+// "checksum stability" test further nails down the exact behavior.
+test "checksum test vectors" {
     const TestVector = struct {
         source: []const u8,
         hash: u128,
     };
 
-    var cipher_buf: [16]u8 = undefined;
     for (&[_]TestVector{
         .{
             .source = &[_]u8{0x00} ** 16,
-            .hash = @byteSwap(@as(u128, 0xf4d997cc9b94227ada4fe4165422b1c8)),
+            .hash = @byteSwap(@as(u128, 0xf72ad48dd05dd1656133101cd4be3a26)),
         },
         .{
             .source = &[_]u8{},
             .hash = @byteSwap(@as(u128, 0x83cc600dc4e3e7e62d4055826174f149)),
         },
     }) |test_vector| {
-        const cipher = cipher_buf[0..test_vector.source.len];
         try testing.expectEqual(test_vector.hash, checksum(test_vector.source));
-        try testing.expectEqual(test_vector.hash, std_checksum(cipher, test_vector.source));
     }
 }
 
-test "Aegis simple fuzzing" {
+test "checksum simple fuzzing" {
     var prng = std.rand.DefaultPrng.init(42);
 
     const msg_min = 1;
@@ -141,13 +98,10 @@ test "Aegis simple fuzzing" {
     var i: usize = 0;
     while (i < 1_000) : (i += 1) {
         const msg_len = prng.random().intRangeAtMostBiased(usize, msg_min, msg_max);
-        const cipher = cipher_buf[0..msg_len];
         const msg = msg_buf[0..msg_len];
         prng.fill(msg);
 
-        // Make sure it matches with stdlib.
         const msg_checksum = checksum(msg);
-        try testing.expectEqual(msg_checksum, std_checksum(cipher, msg));
 
         // Sanity check that it's a pure function.
         const msg_checksum_again = checksum(msg);
@@ -156,7 +110,58 @@ test "Aegis simple fuzzing" {
         // Change the message and make sure the checksum changes.
         msg[prng.random().uintLessThan(usize, msg.len)] +%= 1;
         const changed_checksum = checksum(msg);
-        try testing.expectEqual(changed_checksum, std_checksum(cipher, msg));
         try testing.expect(changed_checksum != msg_checksum);
     }
+}
+
+// Change detector test to ensure we don't inadvertency modify our checksum function.
+test "checksum stability" {
+    var buf: [1024]u8 = undefined;
+    var cases: [896]u128 = undefined;
+    var case_index: usize = 0;
+
+    // Zeros of various lengths.
+    var subcase: usize = 0;
+    while (subcase < 128) : (subcase += 1) {
+        const message = buf[0..subcase];
+        @memset(message, 0);
+
+        cases[case_index] = checksum(message);
+        case_index += 1;
+    }
+
+    // 64 bytes with exactly one bit set.
+    subcase = 0;
+    while (subcase < 64 * 8) : (subcase += 1) {
+        const message = buf[0..64];
+        @memset(message, 0);
+        message[@divFloor(subcase, 8)] = @shlExact(@as(u8, 1), @as(u3, @intCast(subcase % 8)));
+
+        cases[case_index] = checksum(message);
+        case_index += 1;
+    }
+
+    // Pseudo-random data from a specific PRNG of various lengths.
+    var prng = std.rand.Xoshiro256.init(92);
+    subcase = 0;
+    while (subcase < 256) : (subcase += 1) {
+        const message = buf[0 .. subcase + 13];
+        prng.fill(message);
+
+        cases[case_index] = checksum(message);
+        case_index += 1;
+    }
+
+    // Sanity check that we are not getting trivial answers.
+    for (cases, 0..) |case_a, i| {
+        assert(case_a != 0);
+        assert(case_a != std.math.maxInt(u128));
+        for (cases[0..i]) |case_b| assert(case_a != case_b);
+    }
+
+    // Hash me, baby, one more time! If this final hash changes, we broke compatibility in a major
+    // way.
+    comptime assert(builtin.target.cpu.arch.endian() == .Little);
+    const hash = checksum(mem.sliceAsBytes(&cases));
+    try testing.expectEqual(hash, 0x82dcaacf4875b279446825b6830d1263);
 }


### PR DESCRIPTION
vsr.checksum is pretty important, as it cements our on-disk representation and over-the-wire protocol (so, we won't be able to easily change it).

This PR adds a "change detector" test to ensure we don't accidentally change the result. The idea of the test is basically to hash a bunch of random stuff, and then assert that the final hash has a specific value.

While we are at it, extend our fuzz test to do more sanity checking:

- allow arbitrary bitflips (rather than just +%= 1)
- also test avalanching (that every bit of input affects every bit of the output)

While doing all that, I've noticed that the results we get are actually different from the results in Zig master. That's because we treat bytes-to-hash as a secret message, rather than as associated data. Adjust our algo to do that. I've also committed&reverted test against Zig master, which passes the change-detector test with updated expected value. 