### PR TITLE
LSM: Remove `Tree.lookup_snapshot_max`

### DIFF
--- a/docs/internals/lsm.md
+++ b/docs/internals/lsm.md
@@ -162,9 +162,6 @@ queries against past states of the tree (unimplemented; future work).
 Consider the half-bar compaction beginning at op=`X` (`12`), with `lsm_batch_multiple=M` (`8`).
 Each half-bar contains `N=M/2` (`4`) beats. The next half-bar begins at `Y=X+N` (`16`).
 
-During the half-bar compaction `X` (op=`X…Y-1`; `12…15`), each commit prefetches from the snapshot
-[equal to its own op](#current-snapshot). As shown, they continue to query the old (input) tables.
-
 During the half-bar compaction `X`:
 - `snapshot_max` of each input table is truncated to `Y-1` (`15`).
 - `snapshot_min` of each output table is initialized to `Y` (`16`).
@@ -190,38 +187,8 @@ At this point the input tables can be removed if they are invisible to all persi
 ### Snapshot Queries
 
 Each query targets a particular snapshot, either:
-- the [current snapshot](#current-snapshot), or
+- the current snapshot (`snapshot_latest`), or
 - a [persisted snapshot](#persistent-snapshots).
-
-#### Current Snapshot
-
-Each tree tracks the highest snapshot safe to query from (`tree.lookup_snapshot_max`), to ensure that
-an ongoing compaction's incomplete output tables are not visible. Queries targeting
-`tree.lookup_snapshot_max` always read from the mutable and immutable tables — so each commit can
-see all previous commits' updates.)
-
-During typical operation, the `lookup_snapshot_max` when prefetching op `S` is snapshot `S`.
-The following chart depicts:
-- `lookup_snapshot_max` (`$`)
-- for each commit op (the left column)
-- and a compaction that began at op `12` and completed at the end of op `15`.
-
-```
-op  0   4   8  12  16  20  24  (op, snapshot)
-    ┼───┬───┼───┬───┼───┬───┼
-12  ····────────$───
-13  ····─────────$──
-14  ····──────────$─
-15  ····───────────$
-16                  $────····
-17                  ─$───····
-18                  ──$──····
-19                  ───$─····
-```
-
-However, commits in the first measure following recovery from a checkpoint prefetch from a higher
-snapshot to avoid querying tables that were deleted at the checkpoint.
-See [`lookup_snapshot_max_for_checkpoint()`](https://github.com/tigerbeetle/tigerbeetle/blob/main/src/lsm/tree.zig) for more detail.
 
 #### Persistent Snapshots
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -854,23 +854,19 @@ pub fn CompactionType(
             assert(compaction.state == .tables_writing_done);
             compaction.state = .applied_to_manifest;
 
-            // Each compaction's manifest (log) updates are deferred to the end of the last
-            // half-beat to ensure they are ordered deterministically relative to one
-            // another.
-            // TODO: If compaction is sequential, deferring manifest updates is unnecessary.
+            // Each compaction's manifest updates are deferred to the end of the last
+            // half-beat to ensure:
+            // - manifest log updates are ordered deterministically relative to one another, and
+            // - manifest updates are not visible until after the blocks are all on disk.
             const manifest = &compaction.context.tree.manifest;
             const level_b = compaction.context.level_b;
             const snapshot_max = snapshot_max_for_table_input(compaction.context.op_min);
 
-            // Update snapshot_max only if table in level A has been compacted
-            // with tables from level B. If no compaction is required, i.e.
-            // if a table in level A can simply be moved to level B, we needn't
-            // update snapshot_max.
-            // This update MUST be done before insert_table() and move_table()
-            // since it directly uses pointers to the ManifestLevel tables to
-            // perform updates. Calling insert_table() and move_table() before
-            // this update will cause these pointers to become invalid.
-            if (!compaction.move_table) {
+            if (compaction.move_table) {
+                // If no compaction is required, don't update snapshot_max.
+            } else {
+                // These updates MUST precede insert_table() and move_table() since they use
+                // references to modify the ManifestLevel in-place.
                 switch (compaction.context.table_info_a) {
                     .immutable => {},
                     .disk => |table_info| {
@@ -884,27 +880,20 @@ pub fn CompactionType(
 
             for (compaction.manifest_entries.slice()) |*entry| {
                 switch (entry.operation) {
-                    .insert_to_level_b => manifest.insert_table(
-                        level_b,
-                        &entry.table,
-                    ),
-                    .move_to_level_b => manifest.move_table(
-                        level_b - 1,
-                        level_b,
-                        &entry.table,
-                    ),
+                    .insert_to_level_b => manifest.insert_table(level_b, &entry.table),
+                    .move_to_level_b => manifest.move_table(level_b - 1, level_b, &entry.table),
                 }
             }
         }
     };
 }
 
-pub fn snapshot_max_for_table_input(op_min: u64) u64 {
-    assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
-    return op_min + @divExact(constants.lsm_batch_multiple, 2) - 1;
+fn snapshot_max_for_table_input(op_min: u64) u64 {
+    return snapshot_min_for_table_output(op_min) - 1;
 }
 
 pub fn snapshot_min_for_table_output(op_min: u64) u64 {
+    assert(op_min > 0);
     assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
     return op_min + @divExact(constants.lsm_batch_multiple, 2);
 }

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -899,12 +899,12 @@ pub fn CompactionType(
     };
 }
 
-fn snapshot_max_for_table_input(op_min: u64) u64 {
+pub fn snapshot_max_for_table_input(op_min: u64) u64 {
     assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
     return op_min + @divExact(constants.lsm_batch_multiple, 2) - 1;
 }
 
-fn snapshot_min_for_table_output(op_min: u64) u64 {
+pub fn snapshot_min_for_table_output(op_min: u64) u64 {
     assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
     return op_min + @divExact(constants.lsm_batch_multiple, 2);
 }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -15,7 +15,6 @@ const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_s
 const Fingerprint = @import("bloom_filter.zig").Fingerprint;
 
 const snapshot_latest = @import("tree.zig").snapshot_latest;
-const compaction_snapshot_for_op = @import("tree.zig").compaction_snapshot_for_op;
 const key_fingerprint = @import("tree.zig").key_fingerprint;
 
 fn ObjectTreeHelpers(comptime Object: type) type {
@@ -141,9 +140,6 @@ fn IndexTreeType(
 
 /// A Groove is a collection of LSM trees auto generated for fields on a struct type
 /// as well as custom derived fields from said struct type.
-///
-/// Invariants:
-/// - Between beats, all of a groove's trees share the same lookup_snapshot_max.
 pub fn GrooveType(
     comptime Storage: type,
     comptime Object: type,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -295,7 +295,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     env.tree.lookup_from_levels_storage(.{
                         .callback = get_callback,
                         .context = &env.lookup_context,
-                        .snapshot = env.tree.lookup_snapshot_max.?,
+                        .snapshot = snapshot_latest,
                         .key = key,
                         .fingerprint = fingerprint,
                         .level_min = level_min,


### PR DESCRIPTION
- Remove `Tree.lookup_snapshot_max`; just use `snpashot_latest`.
- Clean up some compaction logic.