### PR TITLE
Add info about other subcommands when none are passed.

### DIFF
--- a/src/flags.zig
+++ b/src/flags.zig
@@ -619,7 +619,11 @@ test "flags" {
     try t.check(&.{}, snap(@src(),
         \\status: 1
         \\stderr:
-        \\error: subcommand required
+        \\error: subcommand required.
+        \\
+        \\Expected one of: empty, prefix, pos, required, values.
+        \\
+        \\Or use -h, --help for more information.
         \\
     ));
 

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -75,7 +75,7 @@ pub fn parse_commands(args: *std.process.ArgIterator, comptime Commands: type) C
     const first_arg = args.next() orelse {
         const fields = comptime blk: {
             var fields: [:0]const u8 = "";
-            inline for (std.meta.fields(Commands)) |field, i| {
+            for (std.meta.fields(Commands)) |field, i| {
                 if (i > 0) {
                     fields = fields ++ ", ";
                 }


### PR DESCRIPTION
Before switching to src/flags.zig we used to have a little more information about what is available if you pass in incorrect or missing arguments.

Though this still doesn't help the user very much yet if they do something like `./tigerbeetle what`.

```
./tigerbeetle
error: subcommand required.

Expected one of: format, start, version, client.

Or use -h, --help for more information.
```