### PR TITLE
Minor fingerprint improvements

### DIFF
--- a/src/lsm/bloom_filter.zig
+++ b/src/lsm/bloom_filter.zig
@@ -11,7 +11,7 @@ pub const Fingerprint = struct {
     /// Hash value used to map key to block.
     hash: u32,
     /// Mask of bits set in the block for the key.
-    mask: meta.Vector(8, u32),
+    mask: @Vector(8, u32),
 
     pub fn create(hash: u64) Fingerprint {
         const hash_lower = @truncate(u32, hash);
@@ -20,7 +20,7 @@ pub const Fingerprint = struct {
         // TODO These constants are from the paper and we understand them to be arbitrary odd
         // integers. Experimentally compare the performance of these with other randomly chosen
         // odd integers to verify/improve our understanding.
-        const odd_integers: meta.Vector(8, u32) = [8]u32{
+        const odd_integers: @Vector(8, u32) = [8]u32{
             0x47b6137b,
             0x44974d91,
             0x8824ad5b,
@@ -36,7 +36,7 @@ pub const Fingerprint = struct {
 
         return .{
             .hash = hash_upper,
-            .mask = @splat(8, @as(u32, 1)) << @intCast(meta.Vector(8, u5), bit_indexes),
+            .mask = @splat(8, @as(u32, 1)) << @intCast(@Vector(8, u5), bit_indexes),
         };
     }
 };
@@ -44,37 +44,37 @@ pub const Fingerprint = struct {
 /// Add the key with the given fingerprint to the filter.
 /// filter.len must be a multiple of 32.
 pub fn add(fingerprint: Fingerprint, filter: []u8) void {
-    comptime assert(@sizeOf(meta.Vector(8, u32)) == 32);
+    comptime assert(@sizeOf(@Vector(8, u32)) == 32);
 
     assert(filter.len > 0);
-    assert(filter.len % @sizeOf(meta.Vector(8, u32)) == 0);
+    assert(filter.len % @sizeOf(@Vector(8, u32)) == 0);
 
     const blocks = mem.bytesAsSlice([8]u32, filter);
     const index = block_index(fingerprint.hash, filter.len);
 
-    const current: meta.Vector(8, u32) = blocks[index];
+    const current: @Vector(8, u32) = blocks[index];
     blocks[index] = current | fingerprint.mask;
 }
 
 /// Check if the key with the given fingerprint may have been added to the filter.
 /// filter.len must be a multiple of 32.
 pub fn may_contain(fingerprint: Fingerprint, filter: []const u8) bool {
-    comptime assert(@sizeOf(meta.Vector(8, u32)) == 32);
+    comptime assert(@sizeOf(@Vector(8, u32)) == 32);
 
     assert(filter.len > 0);
-    assert(filter.len % @sizeOf(meta.Vector(8, u32)) == 0);
+    assert(filter.len % @sizeOf(@Vector(8, u32)) == 0);
 
     const blocks = mem.bytesAsSlice([8]u32, filter);
     const index = block_index(fingerprint.hash, filter.len);
 
-    const current: meta.Vector(8, u32) = blocks[index];
+    const current: @Vector(8, u32) = blocks[index];
     return @reduce(.Or, ~current & fingerprint.mask) == 0;
 }
 
 inline fn block_index(hash: u32, size: usize) u32 {
     assert(size > 0);
 
-    const block_count = @divExact(size, @sizeOf(meta.Vector(8, u32)));
+    const block_count = @divExact(size, @sizeOf(@Vector(8, u32)));
     return @intCast(u32, (@as(u64, hash) * block_count) >> 32);
 }
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -12,6 +12,7 @@ const stdx = @import("../stdx.zig");
 const div_ceil = stdx.div_ceil;
 const eytzinger = @import("eytzinger.zig").eytzinger;
 const snapshot_latest = @import("tree.zig").snapshot_latest;
+const key_fingerprint = @import("tree.zig").key_fingerprint;
 
 const BlockType = @import("grid.zig").BlockType;
 const allocate_block = @import("grid.zig").allocate_block;
@@ -476,7 +477,7 @@ pub fn TableType(
                 const filter_bytes = filter.block_filter(builder.filter_block);
                 for (values) |*value| {
                     const key = key_from_value(value);
-                    const fingerprint = bloom_filter.Fingerprint.create(stdx.hash_inline(key));
+                    const fingerprint = key_fingerprint(key);
                     bloom_filter.add(fingerprint, filter_bytes);
                 }
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -22,6 +22,7 @@ const allocate_block = @import("grid.zig").allocate_block;
 const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 const TableUsage = @import("table.zig").TableUsage;
 const TableType = @import("table.zig").TableType;
+const key_fingerprint = @import("tree.zig").key_fingerprint;
 
 const Grid = GridType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
@@ -280,9 +281,10 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         pub fn get(env: *Environment, key: Key) ?*const Key.Value {
             env.change_state(.fuzzing, .tree_lookup);
-
             env.lookup_value = null;
-            switch (env.tree.lookup_from_memory(snapshot_latest, key)) {
+
+            const fingerprint = key_fingerprint(key);
+            switch (env.tree.lookup_from_memory(snapshot_latest, key, fingerprint)) {
                 .negative => {
                     get_callback(&env.lookup_context, null);
                 },
@@ -295,6 +297,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                         .context = &env.lookup_context,
                         .snapshot = env.tree.lookup_snapshot_max.?,
                         .key = key,
+                        .fingerprint = fingerprint,
                         .level_min = level_min,
                     });
                 },


### PR DESCRIPTION
- Change the fingerprint for composite keys, taking only the prefix, not the entire key.
Rationale: We don't use composite keys for lookups. However, the bloom filter can be useful for scans with equality conditions by prefix.

- Propagate the key's fingerprint during the prefetch path.
Rationale: Hashing the key only once.

- Change PrefetchKeys' implementation from HashMap to ArrayHashMap.
Rationale: It's better for iteration.
