### PR TITLE
dotnet_client: reduce build verbosity

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -120,7 +120,7 @@ var accounts = new[] {
     Ledger = 1,
     Code = 718,
     Flags = AccountFlags.None,
-  },     
+  },
 };
 
 var createAccountsError = client.CreateAccounts(accounts);
@@ -426,7 +426,7 @@ $ git submodule update --init --recursive
 $ ./scripts/install_zig.sh
 $ cd src/clients/dotnet
 $ dotnet restore
-$ dotnet clean
+$ dotnet clean --verbosity minimal
 $ dotnet build
 $ if [ "$TEST" = "true" ]; then dotnet test; else echo "Skipping client unit tests"; fi
 ```
@@ -442,8 +442,7 @@ $ git submodule update --init --recursive
 $ .\scripts\install_zig.bat
 $ cd src/clients/dotnet
 $ dotnet restore
-$ dotnet clean
+$ dotnet clean --verbosity minimal
 $ dotnet build
 $ if ($env:TEST -eq 'true') { dotnet test } else { echo "Skipping client unit test" }
 ```
-

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -70,7 +70,7 @@ pub const DotnetDocs = Docs{
     ,
     .build_commands = 
     \\dotnet restore
-    \\dotnet clean
+    \\dotnet clean --verbosity minimal
     \\dotnet build
     ,
     .run_commands = "dotnet run",
@@ -116,7 +116,7 @@ pub const DotnetDocs = Docs{
     \\    Ledger = 1,
     \\    Code = 718,
     \\    Flags = AccountFlags.None,
-    \\  },     
+    \\  },
     \\};
     \\
     \\var createAccountsError = client.CreateAccounts(accounts);
@@ -291,7 +291,7 @@ pub const DotnetDocs = Docs{
     .developer_setup_sh_commands = 
     \\cd src/clients/dotnet
     \\dotnet restore
-    \\dotnet clean
+    \\dotnet clean --verbosity minimal
     \\dotnet build
     \\if [ "$TEST" = "true" ]; then dotnet test; else echo "Skipping client unit tests"; fi
     ,
@@ -299,7 +299,7 @@ pub const DotnetDocs = Docs{
     .developer_setup_pwsh_commands = 
     \\cd src/clients/dotnet
     \\dotnet restore
-    \\dotnet clean
+    \\dotnet clean --verbosity minimal
     \\dotnet build
     \\if ($env:TEST -eq 'true') { dotnet test } else { echo "Skipping client unit test" }
     ,


### PR DESCRIPTION
By default `dotnet clean` prints every file deleted, which drowns out most of the signal in the output.