### PR TITLE
docs: make concurrency advice more clear

### DIFF
--- a/src/clients/docs_generate.zig
+++ b/src/clients/docs_generate.zig
@@ -473,9 +473,8 @@ const Generator = struct {
             \\ID and replica addresses are both chosen by the system that
             \\starts the TigerBeetle cluster.
             \\
-            \\Clients are thread-safe. But for better
-            \\performance, a single instance should be shared between
-            \\multiple concurrent tasks.
+            \\Clients are thread-safe and a single instance should be shared
+            \\between multiple concurrent tasks.
             \\
             \\Multiple clients are useful when connecting to more than
             \\one TigerBeetle cluster.

--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -68,9 +68,8 @@ addresses for all replicas in the cluster. The cluster
 ID and replica addresses are both chosen by the system that
 starts the TigerBeetle cluster.
 
-Clients are thread-safe. But for better
-performance, a single instance should be shared between
-multiple concurrent tasks.
+Clients are thread-safe and a single instance should be shared
+between multiple concurrent tasks.
 
 Multiple clients are useful when connecting to more than
 one TigerBeetle cluster.

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -90,9 +90,8 @@ addresses for all replicas in the cluster. The cluster
 ID and replica addresses are both chosen by the system that
 starts the TigerBeetle cluster.
 
-Clients are thread-safe. But for better
-performance, a single instance should be shared between
-multiple concurrent tasks.
+Clients are thread-safe and a single instance should be shared
+between multiple concurrent tasks.
 
 Multiple clients are useful when connecting to more than
 one TigerBeetle cluster.

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -119,9 +119,8 @@ addresses for all replicas in the cluster. The cluster
 ID and replica addresses are both chosen by the system that
 starts the TigerBeetle cluster.
 
-Clients are thread-safe. But for better
-performance, a single instance should be shared between
-multiple concurrent tasks.
+Clients are thread-safe and a single instance should be shared
+between multiple concurrent tasks.
 
 Multiple clients are useful when connecting to more than
 one TigerBeetle cluster.

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -74,9 +74,8 @@ addresses for all replicas in the cluster. The cluster
 ID and replica addresses are both chosen by the system that
 starts the TigerBeetle cluster.
 
-Clients are thread-safe. But for better
-performance, a single instance should be shared between
-multiple concurrent tasks.
+Clients are thread-safe and a single instance should be shared
+between multiple concurrent tasks.
 
 Multiple clients are useful when connecting to more than
 one TigerBeetle cluster.


### PR DESCRIPTION
~~Clients are thread safe because we want to provide hard-to-mess-up API for the users. However, each client is inherently sequential inside, as there could be only one request in flight for each particular client. So, if you want max throughput, you need to have multiple clients (but note that you loose relative ordering between requests of different clients).~~

Each client is spawns a thread, so creating many clients would be pretty bad. So let's rephrase this by removing the but. 