### PR TITLE
message_bus: log actual port number if port 0 is used

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -207,7 +207,7 @@ const Command = struct {
         log_main.info("{}: cluster={}: listening on {}", .{
             replica.replica,
             replica.cluster,
-            args.addresses[replica.replica],
+            replica.message_bus.process.accept_address,
         });
 
         if (constants.aof_recovery) {


### PR DESCRIPTION
                                      v we pass 0 here,
    $ ./tigerbeetle start --addresses=0 --cache-grid=128MB 0_0.tigerbeetle
    info(io): opening "tb.db"...
    warning(main): Grid cache size of 128MB is small. See --cache-grid
    info(main): 0: Allocated 2721MB in 13 regions during replica init (Grid Cache: 128MB)
    info(main): 0: cluster=1: listening on 127.0.0.1:39047
                                                     ^^^^^  but get the real port number here!

This is mainly intended for concurrent tests, where you might want to spin up a replica on _some_ port, without coordinating with the rest of the system on which port that would be.

closes #1086