### PR TITLE
LSM/SegmentedArray: SA.iterator_from_cursor(SA.search, ascending)

### DIFF
--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -806,11 +806,30 @@ fn SegmentedArrayType(
                 assert(cursor.node == 0);
                 assert(cursor.relative_index == 0);
 
-                return Iterator{
+                return .{
                     .array = array,
                     .direction = direction,
                     .cursor = .{ .node = 0, .relative_index = 0 },
                     .done = true,
+                };
+            } else if (cursor.node == array.node_count - 1 and
+                cursor.relative_index == array.count(cursor.node))
+            {
+                return switch (direction) {
+                    .ascending => .{
+                        .array = array,
+                        .direction = direction,
+                        .cursor = cursor,
+                        .done = true,
+                    },
+                    .descending => .{
+                        .array = array,
+                        .direction = direction,
+                        .cursor = .{
+                            .node = cursor.node,
+                            .relative_index = cursor.relative_index - 1,
+                        },
+                    },
                 };
             } else {
                 assert(cursor.node < array.node_count);
@@ -855,10 +874,7 @@ fn SegmentedArrayType(
         pub usingnamespace if (Key) |K| struct {
             /// Returns a cursor to the index of the key either exactly equal to the target key or,
             /// if there is no exact match, the next greatest key.
-            pub fn search(
-                array: *const Self,
-                key: K,
-            ) Cursor {
+            pub fn search(array: *const Self, key: K) Cursor {
                 if (array.node_count == 0) {
                     return .{
                         .node = 0,
@@ -1221,6 +1237,14 @@ fn TestContext(
                     context.reference_index(query),
                     context.array.absolute_index_for_cursor(context.array.search(query)),
                 );
+            }
+
+            {
+                var iterator_end = context.array.iterator_from_cursor(
+                    context.array.search(math.maxInt(Key)),
+                    .ascending,
+                );
+                try testing.expectEqual(iterator_end.next(), null);
             }
         }
 


### PR DESCRIPTION
Correctly handle cursors at the very end of the SegmentedArray.

This is analogous to beginning to forward-iterate an N-element array from index N. That is, no elements should be iterated. (Previously this panicked).

I think this isn't actually reachable at the moment. But the `ForestTableIterator` (not part of this changeset) needs this, since it passes the result of `SegmentedArray.search()` to `SegmentedArray.iterator_from_cursor(_, .ascending)`.