### PR TITLE
LSM/ManifestLevel: Order tables by (key, snapshot_min) instead of (key)

### DIFF
--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
+const maybe = stdx.maybe;
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
@@ -37,7 +38,39 @@ pub fn ManifestLevelType(
             .{},
         );
 
-        pub const Tables = SegmentedArray(TableInfo, NodePool, table_count_max, .{});
+        pub const Tables = SortedSegmentedArray(
+            TableInfo,
+            NodePool,
+            table_count_max,
+            KeyAndSnapshot,
+            struct {
+                inline fn key_from_value(table_info: *const TableInfo) KeyAndSnapshot {
+                    return .{
+                        .key_max = table_info.key_max,
+                        .snapshot_min = table_info.snapshot_min,
+                    };
+                }
+            }.key_from_value,
+            struct {
+                inline fn compare_key_and_snapshot(
+                    key_a: KeyAndSnapshot,
+                    key_b: KeyAndSnapshot,
+                ) math.Order {
+                    const order = compare_keys(key_a.key_max, key_b.key_max);
+                    if (order == .eq) {
+                        return std.math.order(key_a.snapshot_min, key_b.snapshot_min);
+                    } else {
+                        return order;
+                    }
+                }
+            }.compare_key_and_snapshot,
+            .{},
+        );
+
+        const KeyAndSnapshot = struct {
+            key_max: Key,
+            snapshot_min: u64,
+        };
 
         // A direct reference to a TableInfo within the Tables array.
         pub const TableInfoReference = struct { table_info: *TableInfo, generation: u32 };
@@ -172,10 +205,16 @@ pub fn ManifestLevelType(
                 assert(!level.contains(table));
             }
             assert(level.keys.len() == level.tables.len());
-            const absolute_index = level.keys.insert_element(node_pool, table.key_max);
-            assert(absolute_index < level.keys.len());
 
-            level.tables.insert_elements(node_pool, absolute_index, &[_]TableInfo{table.*});
+            const absolute_index_keys = level.keys.insert_element(node_pool, table.key_max);
+            assert(absolute_index_keys < level.keys.len());
+
+            const absolute_index_tables = level.tables.insert_element(node_pool, table.*);
+            assert(absolute_index_tables < level.tables.len());
+
+            // `keys` may have duplicate entries due to tables with the same key_max, but different
+            // snapshots.
+            maybe(absolute_index_keys != absolute_index_tables);
 
             if (table.visible(lsm.snapshot_latest)) level.table_count_visible += 1;
             level.generation +%= 1;

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -46,6 +46,7 @@ pub const Options = struct {
     verify: bool = false,
 };
 
+// TODO Check whether this would be faster if compare_keys() passed `*const K` values.
 fn SegmentedArrayType(
     comptime T: type,
     comptime NodePool: type,
@@ -213,11 +214,16 @@ fn SegmentedArrayType(
             ) u32 {
                 if (options.verify) array.verify();
 
+                const count_before = array.len();
+
                 const cursor = array.search(key_from_value(&element));
                 const absolute_index = array.absolute_index_for_cursor(cursor);
                 array.insert_elements_at_absolute_index(node_pool, absolute_index, &[_]T{element});
 
                 if (options.verify) array.verify();
+
+                const count_after = array.len();
+                assert(count_after == count_before + 1);
 
                 return absolute_index;
             }
@@ -230,11 +236,16 @@ fn SegmentedArrayType(
             ) void {
                 if (options.verify) array.verify();
 
+                const count_before = array.len();
+
                 array.insert_elements_at_absolute_index(
                     node_pool,
                     absolute_index,
                     elements,
                 );
+
+                const count_after = array.len();
+                assert(count_after == count_before + elements.len);
 
                 if (options.verify) array.verify();
             }


### PR DESCRIPTION
Previously tables with the same key (specifically `key_max`) but a different `snapshot_min` were not ordered. Ordering them properly will enable the `ForestTableIterator` (not part of this changeset) to use a `(key, snapshot)` tuple as a cursor for iteration interleaved with mutations without skipping tables.

This has no measurable performance impact.