### PR TITLE
LSM/Schema: Include `timestamp=table.snapshot_min` in Filter and Data blocks

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -713,6 +713,7 @@ pub fn CompactionType(
                 table_builder.data_block_finish(.{
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
+                    .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
                 });
                 WriteBlock(.data).write_block(compaction);
             }
@@ -728,6 +729,7 @@ pub fn CompactionType(
                 table_builder.filter_block_finish(.{
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
+                    .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
                 });
                 WriteBlock(.filter).write_block(compaction);
             }

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -27,6 +27,7 @@
 //! Filter block schema:
 //! │ vsr.Header │ operation=BlockType.filter,
 //! │            │ context=schema.TableFilter.context
+//! │            │ timestamp=snapshot_min
 //! │ […]u8      │ A split-block Bloom filter, "containing" every key from as many as
 //! │            │   `filter_data_block_count_max` data blocks.
 //!
@@ -34,6 +35,7 @@
 //! │ vsr.Header               │ operation=BlockType.data,
 //! │                          │ context=schema.TableData.context,
 //! │                          │ request=values_count
+//! │                          │ timestamp=snapshot_min
 //! │ [block_key_count + 1]Key │ Eytzinger-layout keys from a subset of the values.
 //! │ [≤value_count_max]Value  │ At least one value (no empty tables).
 //! │ […]u8{0}                 │ padding (to end of block)
@@ -184,6 +186,7 @@ pub const TableIndex = struct {
         assert(header.command == .block);
         assert(BlockType.from(header.operation) == .index);
         assert(header.op > 0);
+        assert(header.timestamp > 0);
 
         const context = @bitCast(Context, header.context);
         assert(context.filter_block_count <= context.filter_block_count_max);
@@ -338,6 +341,7 @@ pub const TableFilter = struct {
         assert(header.command == .block);
         assert(BlockType.from(header.operation) == .filter);
         assert(header.op > 0);
+        assert(header.timestamp > 0);
 
         return TableFilter.init(@bitCast(Context, header.context));
     }
@@ -423,6 +427,7 @@ pub const TableData = struct {
         assert(header.command == .block);
         assert(BlockType.from(header.operation) == .data);
         assert(header.op > 0);
+        assert(header.timestamp > 0);
 
         return TableData.init(@bitCast(Context, header.context));
     }

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -63,7 +63,10 @@ pub inline fn header_from_block(block: BlockPtrConst) *const vsr.Header {
     const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
     assert(header.command == .block);
     assert(header.op > 0);
+    assert(header.size >= @sizeOf(vsr.Header));
     assert(header.size <= block.len);
+    assert(BlockType.valid(header.operation));
+    assert(BlockType.from(header.operation) != .reserved);
     return header;
 }
 
@@ -79,6 +82,12 @@ pub const BlockType = enum(u8) {
     index = 2,
     filter = 3,
     data = 4,
+
+    pub fn valid(vsr_operation: vsr.Operation) bool {
+        _ = std.meta.intToEnum(BlockType, @enumToInt(vsr_operation)) catch return false;
+
+        return true;
+    }
 
     pub inline fn from(vsr_operation: vsr.Operation) BlockType {
         return @intToEnum(BlockType, @enumToInt(vsr_operation));

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -452,6 +452,7 @@ pub fn TableType(
             const DataFinishOptions = struct {
                 cluster: u32,
                 address: u64,
+                snapshot_min: u64,
             };
 
             pub fn data_block_finish(builder: *Builder, options: DataFinishOptions) void {
@@ -524,6 +525,7 @@ pub fn TableType(
                         .value_size = value_size,
                     }),
                     .op = options.address,
+                    .timestamp = options.snapshot_min,
                     .request = builder.value_count,
                     .size = block_size - @intCast(u32, values_padding.len + block_padding.len),
                     .command = .block,
@@ -571,6 +573,7 @@ pub fn TableType(
             const FilterFinishOptions = struct {
                 cluster: u32,
                 address: u64,
+                snapshot_min: u64,
             };
 
             pub fn filter_block_finish(builder: *Builder, options: FilterFinishOptions) void {
@@ -585,6 +588,7 @@ pub fn TableType(
                         .data_block_count_max = data_block_count_max,
                     }),
                     .op = options.address,
+                    .timestamp = options.snapshot_min,
                     .size = block_size - filter.padding_size,
                     .command = .block,
                     .operation = schema.BlockType.filter.operation(),


### PR DESCRIPTION
(Table index blocks already set `timestamp=snapshot_min`).

This additional information is useful for troubleshooting missing blocks following a state sync + table repair.

---
Also add some simple validation to `header_from_block()`.