### PR TITLE
LSM: Include tree_id in table block headers

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -104,8 +104,7 @@ pub fn CompactionType(
         };
 
         // Passed by `init`.
-        tree_name: []const u8,
-        tree_id: u128,
+        tree_config: Tree.Config,
 
         // Allocated during `init`.
         iterator_a: TableDataIterator,
@@ -170,7 +169,7 @@ pub fn CompactionType(
         tracer_slot: ?tracer.SpanStart,
         iterator_tracer_slot: ?tracer.SpanStart,
 
-        pub fn init(allocator: Allocator, config: Tree.Config) !Compaction {
+        pub fn init(allocator: Allocator, tree_config: Tree.Config) !Compaction {
             var iterator_a = TableDataIterator.init();
             errdefer iterator_a.deinit();
 
@@ -195,8 +194,7 @@ pub fn CompactionType(
             errdefer table_builder.deinit(allocator);
 
             return Compaction{
-                .tree_name = config.name,
-                .tree_id = config.id,
+                .tree_config = tree_config,
 
                 .iterator_a = iterator_a,
                 .iterator_b = iterator_b,
@@ -230,8 +228,7 @@ pub fn CompactionType(
 
         pub fn reset(compaction: *Compaction) void {
             compaction.* = .{
-                .tree_name = compaction.tree_name,
-                .tree_id = compaction.tree_id,
+                .tree_config = compaction.tree_config,
 
                 .iterator_a = compaction.iterator_a,
                 .iterator_b = compaction.iterator_b,
@@ -291,7 +288,7 @@ pub fn CompactionType(
             tracer.start(
                 &compaction.tracer_slot,
                 .{ .tree_compaction = .{
-                    .tree_name = compaction.tree_name,
+                    .tree_name = compaction.tree_config.name,
                     .level_b = context.level_b,
                 } },
                 @src(),
@@ -330,8 +327,7 @@ pub fn CompactionType(
             assert(drop_tombstones or context.level_b < constants.lsm_levels - 1);
 
             compaction.* = .{
-                .tree_name = compaction.tree_name,
-                .tree_id = compaction.tree_id,
+                .tree_config = compaction.tree_config,
 
                 .iterator_a = compaction.iterator_a,
                 .iterator_b = compaction.iterator_b,
@@ -359,7 +355,7 @@ pub fn CompactionType(
 
                 log.debug(
                     "{s}: Moving table: level_b={}",
-                    .{ compaction.tree_name, context.level_b },
+                    .{ compaction.tree_config.name, context.level_b },
                 );
 
                 const snapshot_max = snapshot_max_for_table_input(context.op_min);
@@ -378,7 +374,7 @@ pub fn CompactionType(
 
                 log.debug(
                     "{s}: Merging table: level_b={}",
-                    .{ compaction.tree_name, context.level_b },
+                    .{ compaction.tree_config.name, context.level_b },
                 );
 
                 compaction.iterator_b.start(.{
@@ -412,7 +408,7 @@ pub fn CompactionType(
         fn on_iterator_init_a(read: *Grid.Read, index_block: BlockPtrConst) void {
             const compaction = @fieldParentPtr(Compaction, "read", read);
             assert(compaction.state == .iterator_init_a);
-            assert(compaction.tree_id == schema.TableIndex.tree_id(index_block));
+            assert(compaction.tree_config.id == schema.TableIndex.tree_id(index_block));
 
             // `index_block` is only valid for this callback, so copy its contents.
             // TODO(jamii) This copy can be avoided if we bypass the cache.
@@ -436,7 +432,7 @@ pub fn CompactionType(
             tracer.start(
                 &compaction.iterator_tracer_slot,
                 .{ .tree_compaction_iter = .{
-                    .tree_name = compaction.tree_name,
+                    .tree_name = compaction.tree_config.name,
                     .level_b = compaction.context.level_b,
                 } },
                 @src(),
@@ -550,7 +546,7 @@ pub fn CompactionType(
             tracer.start(
                 &tracer_slot,
                 .{ .tree_compaction_merge = .{
-                    .tree_name = compaction.tree_name,
+                    .tree_name = compaction.tree_config.name,
                     .level_b = compaction.context.level_b,
                 } },
                 @src(),
@@ -573,7 +569,7 @@ pub fn CompactionType(
             tracer.end(
                 &tracer_slot,
                 .{ .tree_compaction_merge = .{
-                    .tree_name = compaction.tree_name,
+                    .tree_name = compaction.tree_config.name,
                     .level_b = compaction.context.level_b,
                 } },
             );
@@ -719,7 +715,7 @@ pub fn CompactionType(
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
                     .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
-                    .tree_id = compaction.tree_id,
+                    .tree_id = compaction.tree_config.id,
                 });
                 WriteBlock(.data).write_block(compaction);
             }
@@ -736,7 +732,7 @@ pub fn CompactionType(
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
                     .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
-                    .tree_id = compaction.tree_id,
+                    .tree_id = compaction.tree_config.id,
                 });
                 WriteBlock(.filter).write_block(compaction);
             }
@@ -750,7 +746,7 @@ pub fn CompactionType(
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
                     .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
-                    .tree_id = compaction.tree_id,
+                    .tree_id = compaction.tree_config.id,
                 });
                 // Make this table visible at the end of this half-bar.
                 compaction.manifest_entries.appendAssumeCapacity(.{
@@ -816,7 +812,7 @@ pub fn CompactionType(
             tracer.end(
                 &compaction.iterator_tracer_slot,
                 .{ .tree_compaction_iter = .{
-                    .tree_name = compaction.tree_name,
+                    .tree_name = compaction.tree_config.name,
                     .level_b = compaction.context.level_b,
                 } },
             );
@@ -851,7 +847,7 @@ pub fn CompactionType(
             tracer.end(
                 &compaction.tracer_slot,
                 .{ .tree_compaction = .{
-                    .tree_name = compaction.tree_name,
+                    .tree_name = compaction.tree_config.name,
                     .level_b = compaction.context.level_b,
                 } },
             );

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -15,6 +15,7 @@
 //! Index block schema:
 //! │ vsr.Header                   │ operation=BlockType.index,
 //! │                              │ context=schema.TableIndex.Context,
+//! │                              │ parent=schema.TableIndex.Parent,
 //! │                              │ request=@sizeOf(Key)
 //! │                              │ timestamp=snapshot_min
 //! │ [filter_block_count_max]u128 │ checksums of filter blocks
@@ -27,6 +28,7 @@
 //! Filter block schema:
 //! │ vsr.Header │ operation=BlockType.filter,
 //! │            │ context=schema.TableFilter.context
+//! │            │ parent=schema.TableFilter.Parent,
 //! │            │ timestamp=snapshot_min
 //! │ […]u8      │ A split-block Bloom filter, "containing" every key from as many as
 //! │            │   `filter_data_block_count_max` data blocks.
@@ -34,6 +36,7 @@
 //! Data block schema:
 //! │ vsr.Header               │ operation=BlockType.data,
 //! │                          │ context=schema.TableData.context,
+//! │                          │ parent=schema.TableData.Parent,
 //! │                          │ request=values_count
 //! │                          │ timestamp=snapshot_min
 //! │ [block_key_count + 1]Key │ Eytzinger-layout keys from a subset of the values.
@@ -117,6 +120,16 @@ pub const TableIndex = struct {
         comptime {
             assert(@sizeOf(Context) == @sizeOf(u128));
             assert(stdx.no_padding(Context));
+        }
+    };
+
+    pub const Parent = extern struct {
+        // TODO u16 + padding.
+        tree_id: u128,
+
+        comptime {
+            assert(@sizeOf(Parent) == @sizeOf(u128));
+            assert(stdx.no_padding(Parent));
         }
     };
 
@@ -206,6 +219,13 @@ pub const TableIndex = struct {
             .filter_block_count_max = context.filter_block_count_max,
             .data_block_count_max = context.data_block_count_max,
         });
+    }
+
+    pub fn tree_id(index_block: BlockPtrConst) u128 {
+        const header = header_from_block(index_block);
+        assert(BlockType.from(header.operation) == .index);
+
+        return @bitCast(Parent, header.parent).tree_id;
     }
 
     pub inline fn data_addresses(index: *const TableIndex, index_block: BlockPtr) []u64 {
@@ -316,6 +336,16 @@ pub const TableFilter = struct {
         }
     };
 
+    pub const Parent = extern struct {
+        // TODO u16 + padding.
+        tree_id: u128,
+
+        comptime {
+            assert(@sizeOf(Parent) == @sizeOf(u128));
+            assert(stdx.no_padding(Parent));
+        }
+    };
+
     /// The number of data blocks summarized by a single filter block.
     data_block_count_max: u32,
 
@@ -355,6 +385,13 @@ pub const TableFilter = struct {
         return TableFilter.init(@bitCast(Context, header.context));
     }
 
+    pub fn tree_id(filter_block: BlockPtrConst) u128 {
+        const header = header_from_block(filter_block);
+        assert(BlockType.from(header.operation) == .filter);
+
+        return @bitCast(Parent, header.parent).tree_id;
+    }
+
     pub inline fn block_filter(
         filter: *const TableFilter,
         filter_block: BlockPtr,
@@ -381,6 +418,16 @@ pub const TableData = struct {
         comptime {
             assert(@sizeOf(Context) == @sizeOf(u128));
             assert(stdx.no_padding(Context));
+        }
+    };
+
+    pub const Parent = extern struct {
+        // TODO u16 + padding.
+        tree_id: u128,
+
+        comptime {
+            assert(@sizeOf(Parent) == @sizeOf(u128));
+            assert(stdx.no_padding(Parent));
         }
     };
 
@@ -439,6 +486,13 @@ pub const TableData = struct {
         assert(header.timestamp > 0);
 
         return TableData.init(@bitCast(Context, header.context));
+    }
+
+    pub fn tree_id(data_block: BlockPtrConst) u128 {
+        const header = header_from_block(data_block);
+        assert(BlockType.from(header.operation) == .data);
+
+        return @bitCast(Parent, header.parent).tree_id;
     }
 
     pub inline fn block_values_bytes(

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -14,8 +14,8 @@
 //!
 //! Index block schema:
 //! │ vsr.Header                   │ operation=BlockType.index,
-//! │                              │ context=schema.TableIndex.Context,
-//! │                              │ parent=schema.TableIndex.Parent,
+//! │                              │ context: schema.TableIndex.Context,
+//! │                              │ parent: schema.TableIndex.Parent,
 //! │                              │ request=@sizeOf(Key)
 //! │                              │ timestamp=snapshot_min
 //! │ [filter_block_count_max]u128 │ checksums of filter blocks
@@ -27,16 +27,16 @@
 //!
 //! Filter block schema:
 //! │ vsr.Header │ operation=BlockType.filter,
-//! │            │ context=schema.TableFilter.context
-//! │            │ parent=schema.TableFilter.Parent,
+//! │            │ context: schema.TableFilter.Context
+//! │            │ parent: schema.TableFilter.Parent,
 //! │            │ timestamp=snapshot_min
 //! │ […]u8      │ A split-block Bloom filter, "containing" every key from as many as
 //! │            │   `filter_data_block_count_max` data blocks.
 //!
 //! Data block schema:
 //! │ vsr.Header               │ operation=BlockType.data,
-//! │                          │ context=schema.TableData.context,
-//! │                          │ parent=schema.TableData.Parent,
+//! │                          │ context: schema.TableData.Context,
+//! │                          │ parent: schema.TableData.Parent,
 //! │                          │ request=values_count
 //! │                          │ timestamp=snapshot_min
 //! │ [block_key_count + 1]Key │ Eytzinger-layout keys from a subset of the values.

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -453,6 +453,7 @@ pub fn TableType(
                 cluster: u32,
                 address: u64,
                 snapshot_min: u64,
+                tree_id: u128,
             };
 
             pub fn data_block_finish(builder: *Builder, options: DataFinishOptions) void {
@@ -518,6 +519,7 @@ pub fn TableType(
                 const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
                 header.* = .{
                     .cluster = options.cluster,
+                    .parent = @bitCast(u128, schema.TableData.Parent{ .tree_id = options.tree_id }),
                     .context = @bitCast(u128, schema.TableData.Context{
                         .key_count = data.key_count,
                         .key_layout_size = data.key_layout_size,
@@ -574,6 +576,7 @@ pub fn TableType(
                 cluster: u32,
                 address: u64,
                 snapshot_min: u64,
+                tree_id: u128,
             };
 
             pub fn filter_block_finish(builder: *Builder, options: FilterFinishOptions) void {
@@ -584,6 +587,9 @@ pub fn TableType(
                 const header = mem.bytesAsValue(vsr.Header, builder.filter_block[0..@sizeOf(vsr.Header)]);
                 header.* = .{
                     .cluster = options.cluster,
+                    .parent = @bitCast(u128, schema.TableFilter.Parent{
+                        .tree_id = options.tree_id,
+                    }),
                     .context = @bitCast(u128, schema.TableFilter.Context{
                         .data_block_count_max = data_block_count_max,
                     }),
@@ -620,6 +626,7 @@ pub fn TableType(
                 cluster: u32,
                 address: u64,
                 snapshot_min: u64,
+                tree_id: u128,
             };
 
             pub fn index_block_finish(builder: *Builder, options: IndexFinishOptions) TableInfo {
@@ -638,6 +645,9 @@ pub fn TableType(
                 const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
                 header.* = .{
                     .cluster = options.cluster,
+                    .parent = @bitCast(u128, schema.TableIndex.Parent{
+                        .tree_id = options.tree_id,
+                    }),
                     .context = @bitCast(u128, schema.TableIndex.Context{
                         .filter_block_count = builder.filter_block_count,
                         .filter_block_count_max = index.filter_block_count_max,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -812,7 +812,6 @@ pub const Header = extern struct {
 
     fn invalid_block(self: *const Header) ?[]const u8 {
         assert(self.command == .block);
-        if (self.parent != 0) return "parent != 0";
         if (self.client != 0) return "client != 0";
         if (self.view != 0) return "view != 0";
         if (self.op == 0) return "op == 0"; // address ≠ 0


### PR DESCRIPTION
The assertions here aren't particularly powerful, but this is useful for debugging state sync's table repair.

I included the id in an `extern struct` rather than just directly using the `parent: u128` since tree id will be shrunk down to a `u16` as part of the upcoming "unified manifest" changes.