### PR TITLE
VSR: ClientReplies repair fixes

### DIFF
--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -20,6 +20,7 @@
 //! client to create a new session.
 const std = @import("std");
 const assert = std.debug.assert;
+const maybe = stdx.maybe;
 const mem = std.mem;
 const log = std.log.scoped(.client_replies);
 
@@ -85,6 +86,11 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             std.StaticBitSet(constants.clients_max).initEmpty(),
         /// Track which slots hold a corrupt reply, or are otherwise missing the reply
         /// that ClientSessions believes they should hold.
+        ///
+        /// Invariants:
+        /// - Set bits must correspond to occupied slots in ClientSessions.
+        /// - Set bits must correspond to entries in ClientSessions with
+        ///   `header.size > @sizeOf(vsr.Header)`.
         faulty: std.StaticBitSet(constants.clients_max) =
             std.StaticBitSet(constants.clients_max).initEmpty(),
 
@@ -287,6 +293,8 @@ pub fn ClientRepliesType(comptime Storage: type) type {
         }
 
         pub fn remove_reply(client_replies: *ClientReplies, slot: Slot) void {
+            maybe(client_replies.faulty.isSet(slot.index));
+
             client_replies.faulty.unset(slot.index);
         }
 
@@ -295,6 +303,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
         pub fn write_reply(client_replies: *ClientReplies, slot: Slot, message: *Message) void {
             assert(client_replies.ready_callback == null);
             assert(client_replies.writes.available() > 0);
+            maybe(client_replies.writing.isSet(slot.index));
             assert(message.header.command == .reply);
             // There is never any need to write a body-less message, since the header is
             // stored safely in the client sessions superblock trailer.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1449,7 +1449,7 @@ pub fn ReplicaType(
                 message.header.request,
             });
 
-            self.client_replies.write_reply(slot, message);
+            self.client_replies.write_reply(slot, message, .repair);
         }
 
         /// Known issue:
@@ -3761,7 +3761,7 @@ pub fn ReplicaType(
             if (reply.header.size == @sizeOf(Header)) {
                 self.client_replies.remove_reply(reply_slot);
             } else {
-                self.client_replies.write_reply(reply_slot, reply);
+                self.client_replies.write_reply(reply_slot, reply, .create);
             }
         }
 
@@ -3799,7 +3799,7 @@ pub fn ReplicaType(
                 if (entry.header.size == @sizeOf(Header)) {
                     self.client_replies.remove_reply(reply_slot);
                 } else {
-                    self.client_replies.write_reply(reply_slot, reply);
+                    self.client_replies.write_reply(reply_slot, reply, .create);
                 }
             } else {
                 // If no entry exists, then the session must have been evicted while being prepared.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3734,9 +3734,7 @@ pub fn ReplicaType(
             assert(clients <= constants.clients_max);
             if (clients == constants.clients_max) {
                 const evictee = self.client_sessions().evictee();
-                const slot = self.client_sessions().get_slot_for_client(evictee).?;
                 self.client_sessions().remove(evictee);
-                self.client_replies.remove_reply(slot);
 
                 assert(self.client_sessions().count() == constants.clients_max - 1);
 
@@ -3760,7 +3758,9 @@ pub fn ReplicaType(
             const reply_slot = self.client_sessions().put(session, reply.header);
             assert(self.client_sessions().count() <= constants.clients_max);
 
-            if (reply.header.size != @sizeOf(Header)) {
+            if (reply.header.size == @sizeOf(Header)) {
+                self.client_replies.remove_reply(reply_slot);
+            } else {
                 self.client_replies.write_reply(reply_slot, reply);
             }
         }
@@ -3794,11 +3794,12 @@ pub fn ReplicaType(
                 });
 
                 entry.header = reply.header.*;
-                if (entry.header.size != @sizeOf(Header)) {
-                    self.client_replies.write_reply(
-                        self.client_sessions().get_slot_for_header(reply.header).?,
-                        reply,
-                    );
+
+                const reply_slot = self.client_sessions().get_slot_for_header(reply.header).?;
+                if (entry.header.size == @sizeOf(Header)) {
+                    self.client_replies.remove_reply(reply_slot);
+                } else {
+                    self.client_replies.write_reply(reply_slot, reply);
                 }
             } else {
                 // If no entry exists, then the session must have been evicted while being prepared.
@@ -4444,6 +4445,7 @@ pub fn ReplicaType(
             destination_replica: ?u8,
         ) void {
             const self = @fieldParentPtr(Self, "client_replies", client_replies);
+            assert(reply_header.size > @sizeOf(Header));
             assert(destination_replica == null);
 
             const reply = reply_ orelse {
@@ -4456,6 +4458,7 @@ pub fn ReplicaType(
                 return;
             };
             assert(reply.header.checksum == reply_header.checksum);
+            assert(reply.header.size > @sizeOf(Header));
 
             log.debug("{}: on_request: repeat reply (client={} request={})", .{
                 self.replica,
@@ -5308,8 +5311,9 @@ pub fn ReplicaType(
             } else if (self.client_replies.faulty.findFirstSet()) |slot| {
                 // After we have all prepares, repair replies.
                 const entry = &self.client_sessions().entries[slot];
-                assert(entry.session != 0);
                 assert(!self.client_sessions().entries_free.isSet(slot));
+                assert(entry.session != 0);
+                assert(entry.header.size > @sizeOf(Header));
 
                 self.send_header_to_replica(self.choose_any_other_replica(), .{
                     .command = .request_reply,


### PR DESCRIPTION
- Don't repair replies with `header.size=sizeOf(Header)`.
- Allow ClientReplies repair during checkpoint/ready.

These are currently difficult (though possible) for the VOPR to hit -- replies are read so infrequently that this code path is rarely hit. Sync-repair will use `ClientReplies.faulty` immediately after state sync to force the replies to repair.