### PR TITLE
testing: introduce TmpTigerBeetle

### DIFF
--- a/src/clients/run_with_tb.zig
+++ b/src/clients/run_with_tb.zig
@@ -1,14 +1,13 @@
-//
-// This script spins up a TigerBeetle server on the first available
-// TCP port and references a brand new data file. Then it runs the
-// command passed to it and shuts down the server. It cleans up all
-// resources unless told not to. It fails if the command passed to it
-// fails. It could have been a bash script except for that it works on
-// Windows as well.
-//
-// Example: (run from the repo root)
-//   ./zig/zig build run_with_tb -- node myscript.js
-//
+//! This script spins up a TigerBeetle server on an available
+//! TCP port and references a brand new data file. Then it runs the
+//! command passed to it and shuts down the server. It cleans up all
+//! resources unless told not to. It fails if the command passed to it
+//! fails. It could have been a bash script except for that it works on
+//! Windows as well.
+//!
+//! Example: (run from the repo root)
+//!   ./zig/zig build run_with_tb -- node myscript.js
+//!
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -22,84 +21,16 @@ const path_exists = @import("./shutil.zig").path_exists;
 const script_filename = @import("./shutil.zig").script_filename;
 const binary_filename = @import("./shutil.zig").binary_filename;
 const file_or_directory_exists = @import("./shutil.zig").file_or_directory_exists;
-
-fn free_port() !u16 {
-    const address = try std.net.Address.parseIp4("127.0.0.1", 0);
-
-    const server = try os.socket(address.any.family, os.SOCK.STREAM, os.IPPROTO.TCP);
-    defer os.closeSocket(server);
-
-    try os.bind(server, &address.any, address.getOsSockLen());
-
-    var client_address = std.net.Address.initIp4(undefined, undefined);
-    var client_address_len = client_address.getOsSockLen();
-    try os.getsockname(server, &client_address.any, &client_address_len);
-
-    return client_address.getPort();
-}
+const TmpTigerBeetle = @import("../testing/tmp_tigerbeetle.zig");
 
 pub fn run_with_tb(arena: *std.heap.ArenaAllocator, commands: []const []const u8, cwd: []const u8) !void {
-    const root = try git_root(arena);
-
-    std.debug.print("Moved to git root: {s}\n", .{root});
-    try std.os.chdir(root);
-    var tb_binary = try binary_filename(arena, &[_][]const u8{"tigerbeetle"});
-
-    // Build TigerBeetle
-    if (!file_or_directory_exists(tb_binary)) {
-        std.debug.print("Building TigerBeetle server\n", .{});
-        try run(arena, &[_][]const u8{
-            try script_filename(arena, &[_][]const u8{ "scripts", "install" }),
-        });
-    }
-
-    std.debug.assert(file_or_directory_exists(tb_binary));
-
-    var tmpdir = try TmpDir.init(arena);
-    defer tmpdir.deinit();
-    const wrk_dir = tmpdir.path;
-
-    const data_file = try std.fmt.allocPrint(
-        arena.allocator(),
-        "{s}/0_0.tigerbeetle",
-        .{wrk_dir},
-    );
-
-    std.debug.print("Formatting data file: {s}\n", .{data_file});
-    _ = try run(arena, &[_][]const u8{
-        tb_binary,
-        "format",
-        "--cluster=0",
-        "--replica=0",
-        "--replica-count=1",
-        data_file,
-    });
-
-    const port = try free_port();
-
-    const start_args = &[_][]const u8{
-        tb_binary,
-        "start",
-        try std.fmt.allocPrint(arena.allocator(), "--addresses={}", .{port}),
-        "--cache-grid=128MB",
-        data_file,
-    };
-    std.debug.print("Starting TigerBeetle server: {s}\n", .{start_args});
-    var cp = std.ChildProcess.init(
-        start_args,
-        arena.allocator(),
-    );
-    defer _ = cp.kill() catch {};
-    try cp.spawn();
+    var tb = try TmpTigerBeetle.init(arena.allocator());
+    defer tb.deinit();
 
     std.debug.print("Running commands: {s}\n", .{commands});
 
     try std.os.chdir(cwd);
-
-    try run_with_env(arena, commands, &[_][]const u8{
-        "TB_ADDRESS",
-        try std.fmt.allocPrint(arena.allocator(), "{}", .{port}),
-    });
+    try run_with_env(arena, commands, &[_][]const u8{ "TB_ADDRESS", tb.port_str.slice() });
 }
 
 fn error_main() !void {

--- a/src/clients/run_with_tb.zig
+++ b/src/clients/run_with_tb.zig
@@ -24,8 +24,8 @@ const file_or_directory_exists = @import("./shutil.zig").file_or_directory_exist
 const TmpTigerBeetle = @import("../testing/tmp_tigerbeetle.zig");
 
 pub fn run_with_tb(arena: *std.heap.ArenaAllocator, commands: []const []const u8, cwd: []const u8) !void {
-    var tb = try TmpTigerBeetle.init(arena.allocator());
-    defer tb.deinit();
+    var tb = try TmpTigerBeetle.init(arena.allocator(), .{});
+    defer tb.deinit(arena.allocator());
 
     std.debug.print("Running commands: {s}\n", .{commands});
 

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -427,23 +427,29 @@ test "shell: expand_argv" {
 ///
 /// Caller is responsible for closing the dir.
 fn discover_project_root() !std.fs.Dir {
-    var current = try std.fs.cwd().openDir(".", .{}); // dup cwd so that the caller can close
-    errdefer current.close();
+    if (false) { // TODO(Zig): https://github.com/ziglang/zig/issues/16779
+        var current = try std.fs.cwd().openDir(".", .{}); // dup cwd so that the caller can close
+        errdefer current.close();
 
-    var level: u32 = 0;
-    while (level < 16) : (level += 1) {
-        if (current.statFile("build.zig")) |_| {
-            assert(try subdir_exists(current, ".github"));
-            return current;
-        } else |err| switch (err) {
-            error.FileNotFound => {
-                var parent = try current.openDir("..", .{});
-                current.close();
-                current = parent;
-            },
-            else => return err,
+        var level: u32 = 0;
+        while (level < 16) : (level += 1) {
+            if (current.statFile("build.zig")) |_| {
+                assert(try subdir_exists(current, ".github"));
+                return current;
+            } else |err| switch (err) {
+                error.FileNotFound => {
+                    var parent = try current.openDir("..", .{});
+                    current.close();
+                    current = parent;
+                },
+                else => return err,
+            }
         }
-    }
 
-    return error.DiscoverProjectRootDepthExceeded;
+        return error.DiscoverProjectRootDepthExceeded;
+    } else {
+        const this_file = @src().file;
+        const root_dir = std.fs.path.dirname(std.fs.path.dirname(this_file).?).?;
+        return try std.fs.cwd().openDir(root_dir, .{});
+    }
 }

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -165,6 +165,7 @@ pub fn exec(shell: Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
 
+    echo_command(&child);
     const term = try child.spawnAndWait();
 
     switch (term) {
@@ -273,12 +274,26 @@ pub fn zig(shell: Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
 
+    echo_command(&child);
     const term = try child.spawnAndWait();
 
     switch (term) {
         .Exited => |code| if (code != 0) return error.NonZeroExitStatus,
         else => return error.CommandFailed,
     }
+}
+
+/// If we inherit `stdout` to show the output to the user, it's also helpful to echo the command
+/// itself.
+fn echo_command(child: *const std.ChildProcess) void {
+    assert(child.stdout_behavior == .Inherit);
+
+    std.debug.print("$ ", .{});
+    for (child.argv) |arg, i| {
+        if (i != 0) std.debug.print(" ", .{});
+        std.debug.print("{s}", .{arg});
+    }
+    std.debug.print("\n", .{});
 }
 
 /// Returns current git commit hash as an ASCII string.

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -1,0 +1,129 @@
+//! TmpTigerBeetle is an utility for integration tests, which spawns a single node TigerBeetle
+//! cluster in a temporary directory.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const stdx = @import("../stdx.zig");
+const Shell = @import("../shell.zig");
+
+const log = std.log.scoped(.tmptigerbeetle);
+
+const TmpTigerBeetle = @This();
+
+/// Port the TigerBeetle instance is listening on.
+port: u16,
+/// For convenience, the same port pre-converted to string.
+port_str: std.BoundedArray(u8, 8),
+
+tmp_dir: std.testing.TmpDir,
+process: std.ChildProcess,
+stderr_reader: std.Thread,
+
+pub fn init(gpa: std.mem.Allocator) !TmpTigerBeetle {
+    const shell = try Shell.create(gpa);
+    defer shell.destroy();
+
+    const tigerbeetle_exe = comptime "tigerbeetle" ++ builtin.target.exeFileExt();
+
+    // If tigerbeetle binary does not exist yet, build it.
+    // TODO: just run `zig build run` unconditionally here, when that doesn't do spurious rebuilds.
+    _ = shell.project_root.statFile(tigerbeetle_exe) catch {
+        log.info("building TigerBeetle", .{});
+        try shell.zig("build", .{});
+    };
+
+    const tigerbeetle: []const u8 = try shell.project_root.realpathAlloc(gpa, tigerbeetle_exe);
+    defer gpa.free(tigerbeetle);
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    errdefer tmp_dir.cleanup();
+
+    const tmp_dir_path = try tmp_dir.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(tmp_dir_path);
+
+    const data_file: []const u8 = try std.fs.path.join(gpa, &.{ tmp_dir_path, "0_0.tigerbeetle" });
+    defer gpa.free(data_file);
+
+    try shell.exec(
+        "{tigerbeetle} format --cluster=0 --replica=0 --replica-count=1 {data_file}",
+        .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
+    );
+
+    // Pass `--addresses=0` to let the OS pick a port for us.
+    var process = try shell.spawn(
+        "{tigerbeetle} start --cache-grid=128MB --addresses=0 {data_file}",
+        .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
+    );
+    errdefer {
+        _ = process.kill() catch {};
+        _ = process.wait() catch unreachable;
+    }
+
+    // Parse stderr to learn the assigned port. After that, spawn a dedicated thread to read the
+    // rest of stderr to avoid blocking stderr. No need to read stdout as we don't print there.
+    var buf: [4096]u8 = undefined;
+    var buf_cursor: usize = 0;
+    var limit: u32 = 0;
+    const port = while (limit < 32) : (limit += 1) {
+        buf_cursor += try process.stderr.?.read(buf[buf_cursor..]);
+        if (parse_port(buf[0..buf_cursor])) |port| break port;
+    } else {
+        log.err("can't start TigerBeetle", .{});
+        std.debug.print("stderr:\n{s}\n", .{buf[0..buf_cursor]});
+        return error.NoPort;
+    };
+
+    var port_str: std.BoundedArray(u8, 8) = .{};
+    std.fmt.formatInt(port, 10, .lower, .{}, port_str.writer()) catch unreachable;
+
+    const stderr_reader = try read_stderr_in_background(&process);
+    errdefer stderr_reader.join();
+
+    return TmpTigerBeetle{
+        .tmp_dir = tmp_dir,
+        .process = process,
+        .port = port,
+        .port_str = port_str,
+        .stderr_reader = stderr_reader,
+    };
+}
+
+pub fn deinit(tb: *TmpTigerBeetle) void {
+    _ = tb.process.kill() catch {};
+    tb.stderr_reader.join();
+    _ = tb.process.wait() catch unreachable;
+    tb.tmp_dir.cleanup();
+}
+
+fn parse_port(stderr_log: []const u8) ?u16 {
+    var result = stderr_log;
+    result = (stdx.cut(result, "listening on ") orelse return null).suffix;
+    result = (stdx.cut(result, "\n") orelse return null).prefix;
+    result = (stdx.cut(result, ":") orelse return null).suffix;
+    const port = std.fmt.parseInt(u16, result, 10) catch return null;
+    return port;
+}
+
+test parse_port {
+    try std.testing.expectEqual(
+        parse_port("info(main): 0: cluster=1: listening on 127.0.0.1:39047\n"),
+        39047,
+    );
+}
+
+fn read_stderr_in_background(process: *const std.ChildProcess) !std.Thread {
+    return try std.Thread.spawn(
+        .{},
+        struct {
+            fn read_stderr(stderr: std.fs.File) void {
+                var buf: [4096]u8 = undefined;
+                while (true) {
+                    const n = stderr.read(&buf) catch return;
+                    if (n == 0) return;
+                }
+            }
+        }.read_stderr,
+        .{process.stderr.?},
+    );
+}

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -111,9 +111,10 @@ pub fn deinit(tb: *TmpTigerBeetle, gpa: std.mem.Allocator) void {
     // Signal to the `stderr_reader_thread` that it can exit
     // TODO(Zig) https://github.com/ziglang/zig/issues/16820
     if (builtin.os.tag == .windows) {
-        std.os.windows.TerminateProcess(tb.process.handle, 1) catch {};
+        const exit_code = 1;
+        std.os.windows.TerminateProcess(tb.process.id, exit_code) catch {};
     } else {
-        std.os.kill(tb.process.pid, std.os.SIG.TERM) catch {};
+        std.os.kill(tb.process.id, std.os.SIG.TERM) catch {};
     }
 
     tb.stderr_reader_thread.join();

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -37,6 +37,7 @@ test {
     _ = @import("testing/id.zig");
     _ = @import("testing/storage.zig");
     _ = @import("testing/table.zig");
+    _ = @import("testing/tmp_tigerbeetle.zig");
 
     _ = @import("vsr.zig");
     _ = @import("vsr/clock.zig");


### PR DESCRIPTION
TmpTigerBeetle is an utility for integration tests, which spawns a single node TigerBeetle
cluster in a temporary directory. This generalizes `run_with_tb` a bit.

Backstory: I am looking into simplifying how we do cilent doc generation. This is one intermediate step, but it seems pretty valuable as is --- it actually is surprising that we went so far without "tmpdir, but for tigerbeetle" utility. Guess that shows the extent we prefer simulation tests over, you know, real tests :D 