### PR TITLE
Changed exception type to ArgumentOutOfRangeException

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -100,14 +100,14 @@ namespace TigerBeetle.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void ConstructorWithZeroConcurrencyMax()
         {
             _ = new Client(0, new string[] { "3000" }, 0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void ConstructorWithNegativeConcurrencyMax()
         {
             _ = new Client(0, new string[] { "3000" }, -1);

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -60,7 +60,7 @@ namespace TigerBeetle
 
         private static NativeClient CallInit(InitFunction initFunction, uint clusterID, string[] addresses, int concurrencyMax)
         {
-            if (concurrencyMax <= 0) throw new ArgumentException("Concurrency must be positive", nameof(concurrencyMax));
+            if (concurrencyMax <= 0) throw new ArgumentOutOfRangeException(nameof(concurrencyMax), "Concurrency must be positive");
 
             var addresses_byte = GetBytes(addresses);
             unsafe


### PR DESCRIPTION
`ArgumentOutOfRangeException` is a more specific about the failure reason than generalized `ArgumentException` and from which it derives. It suits better in the current place due to `concurrencyMax` having a range starting from zero.