### PR TITLE
Consistent directory and print binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ First, download a prebuilt copy of TigerBeetle.
 On macOS/Linux:
 
 ```console
-git clone https://github.com/tigerbeetle/tigerbeetle; ./tigerbeetle/bootstrap.sh
+git clone https://github.com/tigerbeetle/tigerbeetle; cd tigerbeetle; ./bootstrap.sh
 ```
 
 On Windows:
 
 ```console
-git clone https://github.com/tigerbeetle/tigerbeetle; .\tigerbeetle\bootstrap.ps1
+git clone https://github.com/tigerbeetle/tigerbeetle; cd tigerbeetle; .\bootstrap.ps1
 ```
 
 Want to build from source locally? Add `-build` as an argument to the bootstrap script.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -24,7 +24,7 @@ if ($build) {
 }
 
 echo @"
-Successfully set up $(./tigerbeetle version) at .\tigerbeetle.exe.
+Successfully set up $(./tigerbeetle version) at $(pwd)\tigerbeetle.exe.
 
 To get started running TigerBeetle and interacting with it, see:
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -24,7 +24,7 @@ if ($build) {
 }
 
 echo @"
-Successfully set up $(./tigerbeetle version).
+Successfully set up $(./tigerbeetle version) at .\tigerbeetle.exe.
 
 To get started running TigerBeetle and interacting with it, see:
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,7 +44,7 @@
 	./scripts/install.sh
     fi
 
-    echo "Successfully set up $(./tigerbeetle version).
+    echo "Successfully set up $(./tigerbeetle version) at ./tigerbeetle.
 
 To get started running TigerBeetle and interacting with it, see:
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,7 +44,7 @@
 	./scripts/install.sh
     fi
 
-    echo "Successfully set up $(./tigerbeetle version) at ./tigerbeetle.
+    echo "Successfully set up $(./tigerbeetle version) at $(pwd)/tigerbeetle.
 
 To get started running TigerBeetle and interacting with it, see:
 


### PR DESCRIPTION
I was confused since the Powershell version did keep you in the new directory but the bash version did not. So just make them both explicitly enter the TigerBeetle directory.

Also, it's confusing to see the success message but then not know where/what the binary is for sure. So this prints out the binary name.