### PR TITLE
VSR/Grid: read_block(.from_local,{_or_global})

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -394,7 +394,7 @@ pub fn CompactionType(
                     .disk => |table_ref| {
                         compaction.state = .iterator_init_a;
                         compaction.context.grid.read_block(
-                            .{ .from_local_or_global= on_iterator_init_a },
+                            .{ .from_local_or_global_storage = on_iterator_init_a },
                             &compaction.read,
                             table_ref.table_info.address,
                             table_ref.table_info.checksum,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -393,8 +393,8 @@ pub fn CompactionType(
                     },
                     .disk => |table_ref| {
                         compaction.state = .iterator_init_a;
-                        compaction.context.grid.read_block_from_cluster(
-                            on_iterator_init_a,
+                        compaction.context.grid.read_block(
+                            .{ .from_local_or_global= on_iterator_init_a },
                             &compaction.read,
                             table_ref.table_info.address,
                             table_ref.table_info.checksum,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -393,12 +393,12 @@ pub fn CompactionType(
                     },
                     .disk => |table_ref| {
                         compaction.state = .iterator_init_a;
-                        compaction.context.grid.read_block_from_cache_or_storage(
+                        compaction.context.grid.read_block_from_cluster(
                             on_iterator_init_a,
                             &compaction.read,
                             table_ref.table_info.address,
                             table_ref.table_info.checksum,
-                            .index,
+                            .{ .cache_check = true, .cache_update = true },
                         );
                     },
                 }

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -398,7 +398,7 @@ pub fn CompactionType(
                             &compaction.read,
                             table_ref.table_info.address,
                             table_ref.table_info.checksum,
-                            .{ .cache_check = true, .cache_update = true },
+                            .{ .cache_read = true, .cache_write = true },
                         );
                     },
                 }

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -124,8 +124,8 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                 // Refill `table_data_iterator` before calling `table_next`.
                 const table_ref = it.context.tables[it.table_index];
                 it.callback = .{ .level_next = callback };
-                it.context.grid.read_block_from_cluster(
-                    on_level_next,
+                it.context.grid.read_block(
+                    .{ .from_local_or_global = on_level_next },
                     &it.read,
                     table_ref.table_info.address,
                     table_ref.table_info.checksum,

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -129,7 +129,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                     &it.read,
                     table_ref.table_info.address,
                     table_ref.table_info.checksum,
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             } else {
                 it.table_next(callback);

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -125,7 +125,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                 const table_ref = it.context.tables[it.table_index];
                 it.callback = .{ .level_next = callback };
                 it.context.grid.read_block(
-                    .{ .from_local_or_global = on_level_next },
+                    .{ .from_local_or_global_storage = on_level_next },
                     &it.read,
                     table_ref.table_info.address,
                     table_ref.table_info.checksum,

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -124,12 +124,12 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
                 // Refill `table_data_iterator` before calling `table_next`.
                 const table_ref = it.context.tables[it.table_index];
                 it.callback = .{ .level_next = callback };
-                it.context.grid.read_block_from_cache_or_storage(
+                it.context.grid.read_block_from_cluster(
                     on_level_next,
                     &it.read,
                     table_ref.table_info.address,
                     table_ref.table_info.checksum,
-                    .index,
+                    .{ .cache_check = true, .cache_update = true },
                 );
             } else {
                 it.table_next(callback);

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -118,12 +118,12 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                         .table_info = table_info.*,
                     },
                 };
-                it.context.grid.read_block_from_cache_or_storage(
+                it.context.grid.read_block_from_cluster(
                     on_read,
                     &it.read,
                     table_info.address,
                     table_info.checksum,
-                    .index,
+                    .{ .cache_check = true, .cache_update = true },
                 );
             } else {
                 it.callback = .{ .next_tick = callback };

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -118,8 +118,8 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                         .table_info = table_info.*,
                     },
                 };
-                it.context.grid.read_block_from_cluster(
-                    on_read,
+                it.context.grid.read_block(
+                    .{ .from_local_or_global = on_read },
                     &it.read,
                     table_info.address,
                     table_info.checksum,

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -123,7 +123,7 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                     &it.read,
                     table_info.address,
                     table_info.checksum,
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             } else {
                 it.callback = .{ .next_tick = callback };

--- a/src/lsm/level_index_iterator.zig
+++ b/src/lsm/level_index_iterator.zig
@@ -119,7 +119,7 @@ pub fn LevelIndexIteratorType(comptime Table: type, comptime Storage: type) type
                     },
                 };
                 it.context.grid.read_block(
-                    .{ .from_local_or_global = on_read },
+                    .{ .from_local_or_global_storage = on_read },
                     &it.read,
                     table_info.address,
                     table_info.checksum,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -225,7 +225,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 assert(block.address > 0);
 
                 manifest_log.grid.read_block(
-                    .{ .from_local_or_global = open_read_block_callback },
+                    .{ .from_local_or_global_storage = open_read_block_callback },
                     &manifest_log.read,
                     block.address,
                     block.checksum,
@@ -579,7 +579,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 manifest_log.read_block_reference = block;
 
                 manifest_log.grid.read_block(
-                    .{ .from_local_or_global = compact_read_block_callback },
+                    .{ .from_local_or_global_storage = compact_read_block_callback },
                     &manifest_log.read,
                     block.address,
                     block.checksum,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -224,8 +224,8 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 assert(block.tree == manifest_log.tree_id);
                 assert(block.address > 0);
 
-                manifest_log.grid.read_block_from_cluster(
-                    open_read_block_callback,
+                manifest_log.grid.read_block(
+                    .{ .from_local_or_global = open_read_block_callback },
                     &manifest_log.read,
                     block.address,
                     block.checksum,
@@ -578,8 +578,8 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 manifest_log.reading = true;
                 manifest_log.read_block_reference = block;
 
-                manifest_log.grid.read_block_from_cluster(
-                    compact_read_block_callback,
+                manifest_log.grid.read_block(
+                    .{ .from_local_or_global = compact_read_block_callback },
                     &manifest_log.read,
                     block.address,
                     block.checksum,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -224,12 +224,12 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 assert(block.tree == manifest_log.tree_id);
                 assert(block.address > 0);
 
-                manifest_log.grid.read_block_from_cache_or_storage(
+                manifest_log.grid.read_block_from_cluster(
                     open_read_block_callback,
                     &manifest_log.read,
                     block.address,
                     block.checksum,
-                    .manifest,
+                    .{ .cache_check = true, .cache_update = true },
                 );
             } else {
                 // Use next_tick because the manifest may be empty (no blocks to read).
@@ -578,12 +578,12 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                 manifest_log.reading = true;
                 manifest_log.read_block_reference = block;
 
-                manifest_log.grid.read_block_from_cache_or_storage(
+                manifest_log.grid.read_block_from_cluster(
                     compact_read_block_callback,
                     &manifest_log.read,
                     block.address,
                     block.checksum,
-                    .manifest,
+                    .{ .cache_check = true, .cache_update = true },
                 );
             } else {
                 manifest_log.read_callback = null;

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -229,7 +229,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                     &manifest_log.read,
                     block.address,
                     block.checksum,
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             } else {
                 // Use next_tick because the manifest may be empty (no blocks to read).
@@ -583,7 +583,7 @@ pub fn ManifestLogType(comptime Storage: type, comptime TableInfo: type) type {
                     &manifest_log.read,
                     block.address,
                     block.checksum,
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             } else {
                 manifest_log.read_callback = null;

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -101,7 +101,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
 
                 it.callback = .{ .read = callback };
                 it.context.grid.read_block(
-                    .{ .from_local_or_global = on_read },
+                    .{ .from_local_or_global_storage = on_read },
                     &it.read,
                     it.context.addresses[index],
                     it.context.checksums[index],

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -100,12 +100,12 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                 };
 
                 it.callback = .{ .read = callback };
-                it.context.grid.read_block_from_cache_or_storage(
+                it.context.grid.read_block_from_cluster(
                     on_read,
                     &it.read,
                     it.context.addresses[index],
                     it.context.checksums[index],
-                    .data,
+                    .{ .cache_check = true, .cache_update = true },
                 );
             } else {
                 it.callback = .{ .next_tick = callback };

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -100,8 +100,8 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                 };
 
                 it.callback = .{ .read = callback };
-                it.context.grid.read_block_from_cluster(
-                    on_read,
+                it.context.grid.read_block(
+                    .{ .from_local_or_global = on_read },
                     &it.read,
                     it.context.addresses[index],
                     it.context.checksums[index],

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -105,7 +105,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                     &it.read,
                     it.context.addresses[index],
                     it.context.checksums[index],
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             } else {
                 it.callback = .{ .next_tick = callback };

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -532,7 +532,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block_count <= constants.lsm_levels);
 
                 context.tree.grid.read_block(
-                    .{ .from_local_or_global = read_index_block_callback },
+                    .{ .from_local_or_global_storage = read_index_block_callback },
                     &context.completion,
                     context.index_block_addresses[context.index_block],
                     context.index_block_checksums[context.index_block],
@@ -556,7 +556,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 };
 
                 context.tree.grid.read_block(
-                    .{ .from_local_or_global = read_filter_block_callback },
+                    .{ .from_local_or_global_storage = read_filter_block_callback },
                     completion,
                     blocks.filter_block_address,
                     blocks.filter_block_checksum,
@@ -582,7 +582,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                     );
 
                     context.tree.grid.read_block(
-                        .{ .from_local_or_global = read_data_block_callback },
+                        .{ .from_local_or_global_storage = read_data_block_callback },
                         completion,
                         context.data_block.?.address,
                         context.data_block.?.checksum,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -536,7 +536,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                     &context.completion,
                     context.index_block_addresses[context.index_block],
                     context.index_block_checksums[context.index_block],
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             }
 
@@ -560,7 +560,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                     completion,
                     blocks.filter_block_address,
                     blocks.filter_block_checksum,
-                    .{ .cache_check = true, .cache_update = true },
+                    .{ .cache_read = true, .cache_write = true },
                 );
             }
 
@@ -586,7 +586,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                         completion,
                         context.data_block.?.address,
                         context.data_block.?.checksum,
-                        .{ .cache_check = true, .cache_update = true },
+                        .{ .cache_read = true, .cache_write = true },
                     );
                 } else {
                     context.tree.filter_block_misses += 1;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -531,8 +531,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
 
-                context.tree.grid.read_block_from_cluster(
-                    read_index_block_callback,
+                context.tree.grid.read_block(
+                    .{ .from_local_or_global = read_index_block_callback },
                     &context.completion,
                     context.index_block_addresses[context.index_block],
                     context.index_block_checksums[context.index_block],
@@ -555,8 +555,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                     .checksum = blocks.data_block_checksum,
                 };
 
-                context.tree.grid.read_block_from_cluster(
-                    read_filter_block_callback,
+                context.tree.grid.read_block(
+                    .{ .from_local_or_global = read_filter_block_callback },
                     completion,
                     blocks.filter_block_address,
                     blocks.filter_block_checksum,
@@ -581,8 +581,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                         @as(f64, @floatFromInt(context.tree.filter_block_hits)),
                     );
 
-                    context.tree.grid.read_block_from_cluster(
-                        read_data_block_callback,
+                    context.tree.grid.read_block(
+                        .{ .from_local_or_global = read_data_block_callback },
                         completion,
                         context.data_block.?.address,
                         context.data_block.?.checksum,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -392,7 +392,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             const writing = grid.writing(read.address, null);
             // If the same block faulted more than once, we should only repair once.
             if (writing == .repair) return;
-            assert(writing == .none);
+            assert(writing == .not_writing);
 
             env.grid_repair_queue.append(.{
                 .address = read.address,

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -239,7 +239,8 @@ pub fn GridType(comptime Storage: type) type {
         }
 
         /// Invoke the callback after all pending repair-writes to blocks that are about to be
-        /// released have completed.
+        /// released have completed. This guarantees that there are no outstanding writes to
+        /// (now-)free blocks when we enter the new checkpoint.
         pub fn checkpoint(grid: *Grid, callback: *const fn (*Grid) void) void {
             assert(grid.checkpointing == null);
             assert(grid.canceling == null);

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -316,6 +316,7 @@ pub fn GridType(comptime Storage: type) type {
 
         fn cancel_join_callback(grid: *Grid) void {
             assert(grid.canceling != null);
+            assert(grid.checkpointing == null);
             assert(grid.read_queue.empty());
             assert(grid.read_pending_queue.empty());
             assert(grid.read_faulty_queue.empty());

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -54,7 +54,7 @@ pub fn GridType(comptime Storage: type) type {
             repair: bool,
             block: *BlockPtr,
             /// The current checkpoint when the write began.
-            /// Used to verify that the checkpoint does not advance while the write is in progress.
+            /// Verifies that the checkpoint does not advance during the (non-repair) write.
             checkpoint_id: u128,
 
             /// Link for the Grid.write_queue linked list.
@@ -67,16 +67,26 @@ pub fn GridType(comptime Storage: type) type {
             write: *Write,
         };
 
+        const ReadBlockCallback = union(enum) {
+            /// If the local read fails, report the error.
+            local: *const fn (*Grid.Read, ReadBlockResult) void,
+            /// If the local read fails, this read will be added to a linked list, which Replica can
+            /// then interrogate each tick(). The callback passed to this function won't be called
+            /// until the block has been recovered.
+            remote: *const fn (*Grid.Read, BlockPtrConst) void,
+        };
+
         pub const Read = struct {
-            callback: *const fn (*Grid.Read, BlockPtrConst) void,
+            callback: ReadBlockCallback,
             address: u64,
             checksum: u128,
-            block_type: BlockType,
             /// The current checkpoint when the read began.
             /// Used to verify that the checkpoint does not advance while the read is in progress.
             checkpoint_id: u128,
 
-            read_cache: bool,
+            coherent: bool,
+            cache_check: bool,
+            cache_update: bool,
             pending: ReadPending = .{},
             resolves: FIFO(ReadPending) = .{ .name = null },
 
@@ -87,14 +97,17 @@ pub fn GridType(comptime Storage: type) type {
             next: ?*Read = null,
         };
 
-        pub const ReadRepair = struct {
-            callback: *const fn (*Grid.ReadRepair, error{BlockNotFound}!void) void,
-            address: u64,
-            checksum: u128,
-            block: BlockPtr,
-            grid: *Grid,
-            next_tick: Grid.NextTick = undefined,
-            completion: Storage.Read = undefined,
+        pub const ReadBlockResult = union(enum) {
+            valid: BlockPtrConst,
+            /// Checksum of block header is invalid.
+            invalid_checksum,
+            /// Checksum of block body is invalid.
+            invalid_checksum_body,
+            /// The block header is valid, but its `header.command` is not `block`.
+            /// (This is possible due to misdirected IO).
+            unexpected_command,
+            /// The block is valid, but it is not the block we expected.
+            unexpected_checksum,
         };
 
         const ReadPending = struct {
@@ -141,11 +154,6 @@ pub fn GridType(comptime Storage: type) type {
         cache: Cache,
         /// Each entry in cache has a corresponding block.
         cache_blocks: []BlockPtr,
-        /// Each entry in cache has a corresponding bit.
-        /// This bit tracks whether the cache block is definitely valid relative to the current
-        /// checkpoint (matches what should be on disk). At the conclusion of state sync, all blocks
-        /// are marked as invalid. This enables additional validation of cache consistency.
-        cache_coherent: std.DynamicBitSetUnmanaged,
 
         write_iops: IOPS(WriteIOP, write_iops_max) = .{},
         write_iop_tracer_slots: [write_iops_max]?tracer.SpanStart = .{null} ** write_iops_max,
@@ -157,7 +165,7 @@ pub fn GridType(comptime Storage: type) type {
         read_iop_tracer_slots: [read_iops_max]?tracer.SpanStart = .{null} ** read_iops_max,
         read_queue: FIFO(Read) = .{ .name = "grid_read" },
 
-        // List if Read.pending's which are in `read_queue` but also waiting for a free `read_iops`.
+        // List of Read.pending's which are in `read_queue` but also waiting for a free `read_iops`.
         read_pending_queue: FIFO(ReadPending) = .{ .name = "grid_read_pending" },
         read_faulty_queue: FIFO(Read) = .{ .name = "grid_read_faulty" },
         // True if there's a read that is resolving callbacks.
@@ -176,10 +184,6 @@ pub fn GridType(comptime Storage: type) type {
         }) !Grid {
             const cache_blocks = try allocator.alloc(BlockPtr, options.cache_blocks_count);
             errdefer allocator.free(cache_blocks);
-
-            var cache_coherent =
-                try std.DynamicBitSetUnmanaged.initEmpty(allocator, options.cache_blocks_count);
-            errdefer cache_coherent.deinit(allocator);
 
             for (cache_blocks, 0..) |*cache_block, i| {
                 errdefer for (cache_blocks[0..i]) |block| allocator.free(block);
@@ -202,7 +206,6 @@ pub fn GridType(comptime Storage: type) type {
                 .superblock = options.superblock,
                 .cache = cache,
                 .cache_blocks = cache_blocks,
-                .cache_coherent = cache_coherent,
                 .read_iop_blocks = read_iop_blocks,
                 .on_read_fault = options.on_read_fault,
             };
@@ -217,7 +220,6 @@ pub fn GridType(comptime Storage: type) type {
             for (grid.cache_blocks) |block| allocator.free(block);
             allocator.free(grid.cache_blocks);
 
-            grid.cache_coherent.deinit(allocator);
             grid.cache.deinit(allocator);
 
             grid.* = undefined;
@@ -269,11 +271,6 @@ pub fn GridType(comptime Storage: type) type {
             }
         }
 
-        pub fn cache_invalidate(grid: *Grid) void {
-            var cache_indexes = grid.cache_coherent.iterator(.{});
-            while (cache_indexes.next()) |index| grid.cache_coherent.unset(index);
-        }
-
         pub fn on_next_tick(
             grid: *Grid,
             callback: *const fn (*Grid.NextTick) void,
@@ -285,17 +282,20 @@ pub fn GridType(comptime Storage: type) type {
 
         /// Returning null indicates that there are not enough free blocks to fill the reservation.
         pub fn reserve(grid: *Grid, blocks_count: usize) ?Reservation {
+            assert(grid.canceling == null);
             return grid.superblock.free_set.reserve(blocks_count);
         }
 
         /// Forfeit a reservation.
         pub fn forfeit(grid: *Grid, reservation: Reservation) void {
+            assert(grid.canceling == null);
             return grid.superblock.free_set.forfeit(reservation);
         }
 
         /// Returns a just-allocated block.
         /// The caller is responsible for not acquiring more blocks than they reserved.
         pub fn acquire(grid: *Grid, reservation: Reservation) u64 {
+            assert(grid.canceling == null);
             return grid.superblock.free_set.acquire(reservation).?;
         }
 
@@ -309,7 +309,7 @@ pub fn GridType(comptime Storage: type) type {
         ///
         /// Asserts that the address is not currently being read from or written to.
         pub fn release(grid: *Grid, address: u64) void {
-            assert(grid.writing(address, null) != .init);
+            assert(grid.writing(address, null) != .create);
             // It's safe to release an address that is being read from,
             // because the superblock will not allow it to be overwritten before
             // the end of the measure.
@@ -335,9 +335,9 @@ pub fn GridType(comptime Storage: type) type {
             return false;
         }
 
-        const Writing = enum { init, repair, none };
+        const Writing = enum { create, repair, none };
 
-        /// If the address is being written to by a non-repair, return `.init`.
+        /// If the address is being written to by a non-repair, return `.create`.
         /// If the address is being written to by a repair, return `.repair`.
         /// Otherwise return `.none`.
         ///
@@ -352,7 +352,7 @@ pub fn GridType(comptime Storage: type) type {
                     assert(block != queued_write.block.*);
                     if (address == queued_write.address) {
                         assert(result == .none);
-                        result = if (queued_write.repair) .repair else .init;
+                        result = if (queued_write.repair) .repair else .create;
                     }
                 }
             }
@@ -362,7 +362,7 @@ pub fn GridType(comptime Storage: type) type {
                     assert(block != iop.write.block.*);
                     if (address == iop.write.address) {
                         assert(result == .none);
-                        result = if (iop.write.repair) .repair else .init;
+                        result = if (iop.write.repair) .repair else .create;
                     }
                 }
             }
@@ -373,19 +373,24 @@ pub fn GridType(comptime Storage: type) type {
         /// Assert that the block pointer is not being used for any read if non-null.
         fn assert_not_reading(grid: *Grid, address: u64, block: ?BlockPtrConst) void {
             assert(address > 0);
+
             for ([_]*const FIFO(Read){
                 &grid.read_queue,
                 &grid.read_faulty_queue,
             }) |queue| {
                 var it = queue.peek();
                 while (it) |queued_read| : (it = queued_read.next) {
-                    assert(address != queued_read.address);
+                    if (queued_read.coherent) {
+                        assert(address != queued_read.address);
+                    }
                 }
             }
             {
                 var it = grid.read_iops.iterate();
                 while (it.next()) |iop| {
-                    assert(address != iop.read.address);
+                    if (iop.read.coherent) {
+                        assert(address != iop.read.address);
+                    }
                     const iop_block = grid.read_iop_blocks[grid.read_iops.index(iop)];
                     assert(block != iop_block);
                 }
@@ -504,7 +509,6 @@ pub fn GridType(comptime Storage: type) type {
             const cache_block = &grid.cache_blocks[cache_index];
             std.mem.swap(BlockPtr, cache_block, completed_write.block);
             @memset(completed_write.block.*, 0);
-            grid.cache_coherent.set(cache_index);
 
             const write_iop_index = grid.write_iops.index(iop);
             tracer.end(
@@ -529,7 +533,7 @@ pub fn GridType(comptime Storage: type) type {
                         read.address == completed_write.address)
                     {
                         grid.read_faulty_queue.remove(read);
-                        grid.read_block_resolve(read, cache_block.*);
+                        grid.read_block_resolve(read, .{ .valid = cache_block.* });
                         break;
                     }
                 } else {
@@ -558,11 +562,18 @@ pub fn GridType(comptime Storage: type) type {
 
         /// Fetch the block synchronously from cache, if possible.
         /// The returned block pointer is only valid until the next Grid write.
-        pub fn read_block_from_cache(grid: *Grid, address: u64, checksum: u128) ?BlockPtrConst {
+        pub fn read_block_from_cache(
+            grid: *Grid,
+            address: u64,
+            checksum: u128,
+            options: struct { coherent: bool },
+        ) ?BlockPtrConst {
             assert(grid.superblock.opened);
             assert(grid.canceling == null);
-            assert(!grid.superblock.free_set.is_free(address));
-            assert(grid.writing(address, null) != .init);
+            if (options.coherent) {
+                assert(grid.writing(address, null) != .create);
+                assert(!grid.superblock.free_set.is_free(address));
+            }
 
             assert(address > 0);
 
@@ -571,117 +582,148 @@ pub fn GridType(comptime Storage: type) type {
 
             const header = schema.header_from_block(cache_block);
             assert(header.op == address);
+            assert(header.cluster == grid.superblock.working.cluster);
 
             if (header.checksum == checksum) {
-                if (constants.verify) grid.verify_read(address, cache_block);
+                if (constants.verify and options.coherent) {
+                    grid.verify_read(address, cache_block);
+                }
 
-                grid.cache_coherent.set(cache_index);
                 return cache_block;
             } else {
-                assert(!grid.cache_coherent.isSet(cache_index));
                 return null;
             }
         }
 
-        pub fn read_block_from_cache_or_storage(
+        pub fn read_block_from_replica(
+            grid: *Grid,
+            callback: *const fn (*Grid.Read, ReadBlockResult) void,
+            read: *Grid.Read,
+            address: u64,
+            checksum: u128,
+            options: struct {
+                coherent: bool,
+                cache_check: bool,
+                cache_update: bool,
+            },
+        ) void {
+            grid.read_block(.{ .local = callback }, read, address, checksum, .{
+                .coherent = options.coherent,
+                .cache_check = options.cache_check,
+                .cache_update = options.cache_update,
+            });
+        }
+
+        pub fn read_block_from_cluster(
             grid: *Grid,
             callback: *const fn (*Grid.Read, BlockPtrConst) void,
             read: *Grid.Read,
             address: u64,
             checksum: u128,
-            block_type: BlockType,
+            options: struct {
+                cache_check: bool,
+                cache_update: bool,
+            },
+        ) void {
+            grid.read_block(.{ .remote = callback }, read, address, checksum, .{
+                .coherent = true,
+                .cache_check = options.cache_check,
+                .cache_update = options.cache_update,
+            });
+        }
+
+        fn read_block(
+            grid: *Grid,
+            callback: ReadBlockCallback,
+            read: *Grid.Read,
+            address: u64,
+            checksum: u128,
+            options: struct {
+                coherent: bool,
+                cache_check: bool,
+                cache_update: bool,
+            },
         ) void {
             assert(grid.superblock.opened);
-            assert(grid.canceling == null);
-            assert(!grid.superblock.free_set.is_free(address));
-            assert(grid.writing(address, null) != .init);
-
             assert(address > 0);
-            assert(block_type != .reserved);
+
+            if (options.coherent) {
+                assert(grid.canceling == null);
+                assert(!grid.superblock.free_set.is_free(address));
+                assert(grid.writing(address, null) != .create);
+            } else {
+                maybe(grid.canceling == null);
+                // We try to read the block even when it is free — if we recently released it,
+                // it might be found on disk anyway.
+                // TODO maybe not, to unify invariants?
+                maybe(grid.superblock.free_set.is_free(address));
+                maybe(grid.writing(address, null) == .create);
+                assert(callback == .local);
+            }
 
             read.* = .{
                 .callback = callback,
                 .address = address,
                 .checksum = checksum,
-                .block_type = block_type,
-                .read_cache = true,
+                .coherent = options.coherent,
+                .cache_check = options.cache_check,
+                .cache_update = options.cache_update,
                 .checkpoint_id = grid.superblock.working.checkpoint_id(),
                 .grid = grid,
             };
 
-            grid.on_next_tick(read_block_tick_callback, &read.next_tick);
+            if (options.cache_check) {
+                grid.on_next_tick(read_block_tick_callback, &read.next_tick);
+            } else {
+                read_block_tick_callback(&read.next_tick);
+            }
         }
 
         fn read_block_tick_callback(next_tick: *Storage.NextTick) void {
             const read = @fieldParentPtr(Grid.Read, "next_tick", next_tick);
             const grid = read.grid;
-
-            grid.read_block(read);
-        }
-
-        /// This function transparently handles recovery if the checksum fails.
-        /// If necessary, this read will be added to a linked list, which Replica can then
-        /// interrogate each tick(). The callback passed to this function won't be called until the
-        /// block has been recovered.
-        pub fn read_block_from_storage(
-            grid: *Grid,
-            callback: fn (*Grid.Read, BlockPtrConst) void,
-            read: *Grid.Read,
-            address: u64,
-            checksum: u128,
-            block_type: BlockType,
-        ) void {
             assert(grid.superblock.opened);
-            assert(grid.canceling == null);
-            assert(!grid.superblock.free_set.is_free(address));
-            assert(grid.writing(address, null) != .init);
-
-            assert(address > 0);
-            assert(block_type != .reserved);
-
-            read.* = .{
-                .callback = callback,
-                .address = address,
-                .checksum = checksum,
-                .block_type = block_type,
-                .read_cache = false,
-                .checkpoint_id = grid.superblock.working.checkpoint_id(),
-                .grid = grid,
-            };
-
-            grid.read_block(read);
-        }
-
-        fn read_block(grid: *Grid, read: *Grid.Read) void {
-            assert(grid.superblock.opened);
-            assert(grid.canceling == null);
-            assert(!grid.superblock.free_set.is_free(read.address));
-            assert(grid.writing(read.address, null) != .init);
+            if (read.coherent) {
+                assert(grid.canceling == null);
+                assert(!grid.superblock.free_set.is_free(read.address));
+                assert(grid.writing(read.address, null) != .create);
+            }
 
             assert(read.address > 0);
-            assert(read.block_type != .reserved);
 
             // Check if a read is already processing/recovering and merge with it.
             for ([_]*const FIFO(Read){
                 &grid.read_queue,
                 &grid.read_faulty_queue,
             }) |queue| {
+                // Don't remote-repair repairs – the block may not belong in our current checkpoint.
+                if (read.callback == .local) {
+                    if (queue == &grid.read_faulty_queue) continue;
+                }
+
                 var it = queue.peek();
                 while (it) |queued_read| : (it = queued_read.next) {
                     if (queued_read.address == read.address) {
-                        assert(queued_read.checksum == read.checksum);
-                        assert(queued_read.block_type == read.block_type);
-                        queued_read.resolves.push(&read.pending);
-                        return;
+                        // TODO check all read options match
+                        if (queued_read.checksum == read.checksum) {
+                            queued_read.resolves.push(&read.pending);
+                            return;
+                        } else {
+                            assert(!queued_read.coherent or !read.coherent);
+                        }
                     }
                 }
             }
 
-            // When Read.read_cache is set, the caller of read_block() is responsible for calling
+            // When Read.cache_check is set, the caller of read_block() is responsible for calling
             // us via next_tick().
-            if (read.read_cache) {
-                if (grid.read_block_from_cache(read.address, read.checksum)) |cache_block| {
-                    grid.read_block_resolve(read, cache_block);
+            if (read.cache_check) {
+                if (grid.read_block_from_cache(
+                    read.address,
+                    read.checksum,
+                    .{ .coherent = read.coherent },
+                )) |cache_block| {
+                    grid.read_block_resolve(read, .{ .valid = cache_block });
                     return;
                 }
             }
@@ -742,11 +784,18 @@ pub fn GridType(comptime Storage: type) type {
             }
 
             // Insert the block into the cache, and give the evicted block to `iop`.
-            const cache_index = grid.cache.insert_index(&read.address);
-            const cache_block = &grid.cache_blocks[cache_index];
-            std.mem.swap(BlockPtr, iop_block, cache_block);
-            @memset(iop_block.*, 0);
-            grid.cache_coherent.set(cache_index);
+            const cache_index =
+                if (read.cache_update) grid.cache.insert_index(&read.address) else null;
+            const block = block: { // TODO rename "block"
+                if (read.cache_update) {
+                    const cache_block = &grid.cache_blocks[cache_index.?];
+                    std.mem.swap(BlockPtr, iop_block, cache_block);
+                    @memset(iop_block.*, 0);
+                    break :block cache_block;
+                } else {
+                    break :block iop_block;
+                }
+            };
 
             const read_iop_index = grid.read_iops.index(iop);
             tracer.end(
@@ -765,76 +814,57 @@ pub fn GridType(comptime Storage: type) type {
             // Remove the "root" read so that the address is no longer actively reading / locked.
             grid.read_queue.remove(read);
 
-            // A valid block filled by storage means the reads for the address can be resolved.
-            if (read_block_valid(cache_block.*, .{
+            const result = read_block_validate(block.*, .{
                 .address = read.address,
                 .checksum = read.checksum,
-                .block_type = read.block_type,
-            })) {
-                grid.read_block_resolve(read, cache_block.*);
+            });
+
+            if (result == .valid) {
+                grid.read_block_resolve(read, .{ .valid = block.* });
                 return;
             }
 
+            const header = mem.bytesAsValue(vsr.Header, block.*[0..@sizeOf(vsr.Header)]);
+            log.err(
+                "{s}: expected address={} checksum={}, found address={} checksum={}",
+                .{
+                    @tagName(result),
+                    read.address,
+                    read.checksum,
+                    header.op,
+                    header.checksum,
+                },
+            );
+
             // Don't cache a corrupt or incorrect block.
             grid.cache.remove(read.address);
-            grid.cache_coherent.unset(cache_index);
 
-            // On the result of an invalid block, move the "root" read (and all others it
-            // resolves) to recovery queue. Future reads on the same address will see the "root"
-            // read in the recovery queue and enqueue to it.
-            grid.read_faulty_queue.push(read);
-            if (grid.on_read_fault) |on_read_fault| {
-                on_read_fault(grid, read);
-            } else {
-                @panic("Grid.on_read_fault not set");
-            }
+            grid.read_block_resolve(read, result);
         }
 
-        fn read_block_valid(block: BlockPtrConst, expect: struct {
+        fn read_block_validate(block: BlockPtrConst, expect: struct {
             address: u64,
             checksum: u128,
-            block_type: ?BlockType,
-        }) bool {
-            const address = expect.address;
-            const checksum = expect.checksum;
-            const block_type = expect.block_type;
-
+        }) ReadBlockResult {
             const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
 
-            if (!header.valid_checksum()) {
-                log.err("invalid checksum at address {} (expected={})", .{ address, checksum });
-                return false;
-            }
+            if (!header.valid_checksum()) return .invalid_checksum;
+            if (header.command != .block) return .unexpected_command;
 
-            if (!header.valid_checksum_body(block[@sizeOf(vsr.Header)..header.size])) {
-                log.err("invalid checksum body at address {} (expected={})", .{ address, checksum });
-                return false;
-            }
+            assert(header.size >= @sizeOf(vsr.Header));
+            assert(header.size <= constants.block_size);
 
-            if (header.checksum != checksum) {
-                log.err(
-                    "expected address={} checksum={} block_type={?}, " ++
-                        "found address={} checksum={} block_type={}",
-                    .{
-                        address,
-                        checksum,
-                        block_type,
-                        header.op,
-                        header.checksum,
-                        @intFromEnum(header.operation),
-                    },
-                );
-                return false;
-            }
+            const block_body = block[@sizeOf(vsr.Header)..header.size];
+            if (!header.valid_checksum_body(block_body)) return .invalid_checksum_body;
+            if (header.checksum != expect.checksum) return .unexpected_checksum;
 
-            assert(header.op == address);
-            if (block_type) |block_type_| {
-                assert(header.operation == block_type_.operation());
-            }
-            return true;
+            assert(header.op == expect.address);
+            return .{ .valid = block };
         }
 
-        fn read_block_resolve(grid: *Grid, read: *Grid.Read, block: BlockPtrConst) void {
+        fn read_block_resolve(grid: *Grid, read: *Grid.Read, result: ReadBlockResult) void {
+            assert(grid.canceling == null);
+
             // Guard to make sure the cache cannot be updated by any read.callbacks() below.
             assert(!grid.read_resolving);
             grid.read_resolving = true;
@@ -843,134 +873,73 @@ pub fn GridType(comptime Storage: type) type {
                 grid.read_resolving = false;
             }
 
-            assert(read.checkpoint_id == grid.superblock.working.checkpoint_id());
+            if (read.coherent) {
+                assert(!grid.superblock.free_set.is_free(read.address));
+                assert(read.checkpoint_id == grid.superblock.working.checkpoint_id());
+            }
 
-            const header = schema.header_from_block(block);
-            assert(header.op == read.address);
-            assert(header.checksum == read.checksum);
+            if (result == .valid) {
+                const header = schema.header_from_block(result.valid);
+                assert(header.cluster == grid.superblock.working.cluster);
+                assert(header.op == read.address);
+                assert(header.checksum == read.checksum);
+            }
+
+            var read_remote_resolves: FIFO(ReadPending) = .{ .name = read.resolves.name };
 
             // Resolve all reads queued to the address with the block.
             while (read.resolves.pop()) |pending| {
                 const pending_read = @fieldParentPtr(Read, "pending", pending);
                 assert(pending_read.address == read.address);
                 assert(pending_read.checksum == read.checksum);
-                assert(pending_read.checkpoint_id == grid.superblock.working.checkpoint_id());
+                if (pending_read.coherent) {
+                    assert(pending_read.checkpoint_id == grid.superblock.working.checkpoint_id());
+                }
 
-                pending_read.callback(pending_read, block);
+                switch (pending_read.callback) {
+                    .local => |callback| callback(pending_read, result),
+                    .remote => |callback| {
+                        if (result == .valid) {
+                            callback(pending_read, result.valid);
+                        } else {
+                            read_remote_resolves.push(&pending_read.pending);
+                        }
+                    },
+                }
             }
 
             // Then invoke the callback with the cache block (which should be valid for the duration
             // of the callback as any nested Grid calls cannot synchronously update the cache).
-            read.callback(read, block);
-        }
-
-        /// If the block is not present (or corrupt), we do not attempt to repair it — the repair's
-        /// address/checksum is not assumed to match what "should" be in our block.
-        /// Relatedly we still attempt to read free blocks — they might still hold the requested data.
-        ///
-        /// Even though this block is the block we expected to read, we can't safely
-        /// cache this result:
-        /// 1. Replica A writes block X₁ to address X.
-        /// 2. Replica A writes block X₂ to address X (write is lost/misdirected).
-        /// 3. Replica B requests block X₁ from replica A.
-        /// It is safe for A to send back X₁, but A must not allow it to poison its cache.
-        ///
-        /// Additionally, we don't cache these reads for performance reasons:
-        /// - it would fill the cache with non-temporally-local blocks, and
-        /// - it would force an extra memcpy.
-        pub fn read_block_repair(
-            grid: *Grid,
-            callback: *const fn (*Grid.ReadRepair, error{BlockNotFound}!void) void,
-            read: *Grid.ReadRepair,
-            block: BlockPtr,
-            address: u64,
-            checksum: u128,
-        ) void {
-            assert(address > 0);
-
-            assert(grid.superblock.opened);
-            maybe(grid.canceling == null);
-            // We try to read the block even when it is free — if we recently released it,
-            // it might be found on disk anyway.
-            maybe(grid.superblock.free_set.is_free(address));
-            // The caller will not attempt to help another replica repair a block that
-            // we are already trying to repair ourselves.
-            assert(!grid.faulty(address, null));
-            maybe(grid.writing(address, null) == .init);
-
-            read.* = .{
-                .callback = callback,
-                .address = address,
-                .checksum = checksum,
-                .block = block,
-                .grid = grid,
-            };
-
-            if (grid.cache.get_index(read.address)) |cache_index| {
-                const cache_block = grid.cache_blocks[cache_index];
-
-                const header = schema.header_from_block(cache_block);
-                assert(header.op == read.address);
-
-                if (grid.cache_coherent.isSet(cache_index)) {
-                    if (constants.verify) grid.verify_read(read.address, cache_block);
-                }
-
-                if (header.checksum == read.checksum) {
-                    stdx.copy_disjoint(.inexact, u8, read.block, cache_block[0..header.size]);
-                } else {
-                    // Signal to read_block_repair_tick_callback() that we found a block,
-                    // but not the one we wanted.
-                    @memset(read.block[0..header.size], 0);
-                }
-
-                if (header.checksum == read.checksum or
-                    grid.cache_coherent.isSet(cache_index))
-                {
-                    // Use "vsr" on_next_tick() because Grid.cancel() can run concurrently with repairs.
-                    grid.superblock.storage.on_next_tick(
-                        .vsr,
-                        read_block_repair_tick_callback,
-                        &read.next_tick,
-                    );
-                    return;
-                } else {
-                    // We have a cached entry (wrong block), but the cache is not coherent.
-                    // The block we actually want may be on disk.
-                }
+            switch (read.callback) {
+                .local => |callback| callback(read, result),
+                .remote => |callback| {
+                    if (result == .valid) {
+                        callback(read, result.valid);
+                    } else {
+                        read_remote_resolves.push(&read.pending);
+                    }
+                },
             }
 
-            grid.superblock.storage.read_sectors(
-                read_block_repair_callback,
-                &read.completion,
-                read.block,
-                .grid,
-                block_offset(read.address),
-            );
-        }
+            // On the result of an invalid block, move the "root" read (and all others it
+            // resolves) to recovery queue. Future reads on the same address will see the "root"
+            // read in the recovery queue and enqueue to it.
+            if (read_remote_resolves.pop()) |read_remote_head_pending| {
+                const read_remote_head = @fieldParentPtr(Read, "pending", read_remote_head_pending);
+                assert(read_remote_head.callback == .remote);
+                assert(read_remote_head.coherent);
 
-        fn read_block_repair_tick_callback(next_tick: *Grid.NextTick) void {
-            const read = @fieldParentPtr(ReadRepair, "next_tick", next_tick);
-            const header = mem.bytesAsValue(vsr.Header, read.block[0..@sizeOf(vsr.Header)]);
+                // On the result of an invalid block, move the "root" read (and all others it
+                // resolves) to recovery queue. Future reads on the same address will see the "root"
+                // read in the recovery queue and enqueue to it.
+                read_remote_head.resolves = read_remote_resolves;
+                grid.read_faulty_queue.push(read_remote_head);
 
-            if (header.op > 0) {
-                read.callback(read, {});
-            } else {
-                read.callback(read, error.BlockNotFound);
-            }
-        }
-
-        fn read_block_repair_callback(completion: *Storage.Read) void {
-            const read = @fieldParentPtr(ReadRepair, "completion", completion);
-
-            if (read_block_valid(read.block, .{
-                .address = read.address,
-                .checksum = read.checksum,
-                .block_type = null,
-            })) {
-                read.callback(read, {});
-            } else {
-                read.callback(read, error.BlockNotFound);
+                if (grid.on_read_fault) |on_read_fault| {
+                    on_read_fault(grid, read_remote_head);
+                } else {
+                    @panic("Grid.on_read_fault not set");
+                }
             }
         }
 
@@ -981,11 +950,16 @@ pub fn GridType(comptime Storage: type) type {
         }
 
         fn verify_read(grid: *Grid, address: u64, cached_block: BlockPtrConst) void {
-            if (Storage != @import("../testing/storage.zig").Storage)
-                // Too complicated to do async verification
-                return;
+            assert(constants.verify);
+
+            const TestStorage = @import("../testing/storage.zig").Storage;
+            if (Storage != TestStorage) return;
 
             const actual_block = grid.superblock.storage.grid_block(address);
+            const actual_header = schema.header_from_block(actual_block);
+            const cached_header = schema.header_from_block(cached_block);
+            assert(cached_header.checksum == actual_header.checksum);
+
             assert(std.mem.eql(u8, cached_block, actual_block));
         }
     };

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -105,6 +105,8 @@ pub fn GridType(comptime Storage: type) type {
             next: ?*Read = null,
         };
 
+        /// Although we distinguish between the reasons why the block is invalid, we only use this
+        /// info for logging, not logic.
         pub const ReadBlockResult = union(enum) {
             valid: BlockPtrConst,
             /// Checksum of block header is invalid.

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -887,8 +887,10 @@ pub fn GridType(comptime Storage: type) type {
                 },
             );
 
-            // Don't cache a corrupt or incorrect block.
-            grid.cache.remove(read.address);
+            if (read.cache_write) {
+                // Don't cache a corrupt or incorrect block.
+                grid.cache.remove(read.address);
+            }
 
             grid.read_block_resolve(read, result);
         }

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -681,13 +681,12 @@ pub fn GridType(comptime Storage: type) type {
             address: u64,
             checksum: u128,
             options: struct {
-                coherent: bool,
                 cache_check: bool,
                 cache_update: bool,
             },
         ) void {
             grid.read_block(.{ .local = callback }, read, address, checksum, .{
-                .coherent = options.coherent,
+                .coherent = false,
                 .cache_check = options.cache_check,
                 .cache_update = options.cache_update,
             });
@@ -731,6 +730,7 @@ pub fn GridType(comptime Storage: type) type {
                 assert(grid.checkpointing == null);
                 assert(!grid.superblock.free_set.is_free(address));
                 assert(grid.writing(address, null) != .create);
+                assert(callback == .remote);
             } else {
                 maybe(grid.checkpointing == null);
                 // We try to read the block even when it is free — if we recently released it,

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -84,6 +84,14 @@ pub fn GridType(comptime Storage: type) type {
             /// Used to verify that the checkpoint does not advance while the read is in progress.
             checkpoint_id: u128,
 
+            /// When coherent=true:
+            /// - the block (address+checksum) is part of the current checkpoint.
+            /// - the read will complete before the next checkpoint occurs.
+            /// - callback == .from_local_or_global_storage
+            /// When coherent=false:
+            /// - the block (address+checksum) is not necessarily part of the current checkpoint.
+            /// - the read may complete after a future checkpoint.
+            /// - callback == .from_local_storage
             coherent: bool,
             cache_read: bool,
             cache_write: bool,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2239,7 +2239,7 @@ pub fn ReplicaType(
                 };
 
                 self.grid.read_block(
-                    .{ .from_local_storage = on_request_blocks_read_repair },
+                    .{ .from_local_storage = on_request_blocks_read_block },
                     &read.read,
                     request.block_address,
                     request.block_checksum,
@@ -2248,7 +2248,7 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_request_blocks_read_repair(
+        fn on_request_blocks_read_block(
             grid_read: *Grid.Read,
             result: Grid.ReadBlockResult,
         ) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2239,7 +2239,7 @@ pub fn ReplicaType(
                 };
 
                 self.grid.read_block(
-                    .{ .from_local = on_request_blocks_read_repair },
+                    .{ .from_local_storage = on_request_blocks_read_repair },
                     &read.read,
                     request.block_address,
                     request.block_checksum,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2238,8 +2238,8 @@ pub fn ReplicaType(
                     .message = reply.ref(),
                 };
 
-                self.grid.read_block_from_replica(
-                    on_request_blocks_read_repair,
+                self.grid.read_block(
+                    .{ .from_local = on_request_blocks_read_repair },
                     &read.read,
                     request.block_address,
                     request.block_checksum,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7713,6 +7713,8 @@ pub fn ReplicaType(
             assert(!self.solo());
             assert(self.syncing == .updating_superblock);
             assert(self.sync_message_timeout.ticking);
+            assert(self.grid.read_faulty_queue.empty());
+            assert(self.grid.write_queue.empty());
             maybe(self.state_machine_opened);
 
             const stage: *const SyncStage.UpdatingSuperBlock = &self.syncing.updating_superblock;
@@ -7739,7 +7741,10 @@ pub fn ReplicaType(
 
         fn sync_superblock_update_callback(superblock_context: *SuperBlock.Context) void {
             const self = @fieldParentPtr(Self, "superblock_context", superblock_context);
+            assert(self.grid.read_faulty_queue.empty());
+            assert(self.grid.write_queue.empty());
             assert(self.syncing == .updating_superblock);
+            assert(!self.state_machine_opened);
 
             const stage: *const SyncStage.UpdatingSuperBlock = &self.syncing.updating_superblock;
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2327,7 +2327,7 @@ pub fn ReplicaType(
                     });
                     return;
                 },
-                .none => {},
+                .not_writing => {},
             }
 
             const write = self.grid_writes.acquire() orelse {
@@ -8203,7 +8203,7 @@ pub fn ReplicaType(
             while (reads) |read| : (reads = read.next) {
                 assert(read.address > 0);
                 assert(!self.superblock.free_set.is_free(read.address));
-                if (self.grid.writing(read.address, null) != .none) continue;
+                if (self.grid.writing(read.address, null) != .not_writing) continue;
 
                 log.debug("{}: send_request_blocks: request address={} checksum={}", .{
                     self.replica,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2243,11 +2243,7 @@ pub fn ReplicaType(
                     &read.read,
                     request.block_address,
                     request.block_checksum,
-                    .{
-                        .coherent = false,
-                        .cache_check = true,
-                        .cache_update = false,
-                    },
+                    .{ .cache_check = true, .cache_update = false },
                 );
             }
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2243,7 +2243,7 @@ pub fn ReplicaType(
                     &read.read,
                     request.block_address,
                     request.block_checksum,
-                    .{ .cache_check = true, .cache_update = false },
+                    .{ .cache_read = true, .cache_write = false },
                 );
             }
         }

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -309,6 +309,11 @@ pub const FreeSet = struct {
         return !set.blocks.isSet(block);
     }
 
+    pub fn is_released(set: *const FreeSet, address: u64) bool {
+        const block = address - 1;
+        return set.staging.isSet(block);
+    }
+
     /// Leave the address allocated for now, but free it at the next checkpoint.
     /// This ensures that it will not be overwritten during the current checkpoint — the block may
     /// still be needed if we crash and recover from the current checkpoint.


### PR DESCRIPTION
(Context: The grid scrubber will use this.)

- `read_block(.{ .from_local = ... }, ...)`: Read from the disk. If there is an issue (e.g. checksum failure), pass the encountered error into the callback.
- `read_block(.{ .from_local_or_global = ... }, ...)`: Read from the disk. If there is an issue (e.g. checksum failure), queue the read into the "faulty queue" for remote repair. Don't invoke the callback until the correct block is available.

Both of these have `cache_read`/`cache_update` options:
- `cache_read` allows the scrubber to skip the cache (since it only cares about disk content).
- `cache_read` also allows the caller to skip the cache if they are handling it separately via `read_block_from_cache` as an optimization (to avoid a nexttick).
- `cache_write` allows the scrubber to avoid filling the cache with cold data.

---

Remove `cache_coherent`. `Grid.verify_read()` can now depend on the `coherent` option, which is much simpler (albeit slightly less comprehensive).
But the old `cache_coherent` strategy won't work soon (due to `fulfill_block`) and would have needed to be _much_ more complicated (depending on a whole second bitset) so this is a good compromise.