### PR TITLE
VSR: Fix overflow due to zig 11 upgrade

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3894,7 +3894,8 @@ pub fn ReplicaType(
             }
 
             message.header.* = .{
-                .size = @as(u32, @intCast(@as(usize, @sizeOf(Header)) * (1 + self.view_headers.array.len))),
+                .size = @as(u32, @intCast(@as(usize, @sizeOf(Header)) *
+                    (1 + @as(usize, self.view_headers.array.len)))),
                 .command = command,
                 .cluster = self.cluster,
                 .replica = self.replica,


### PR DESCRIPTION
In Zig 0.9/0.10, `BoundedArray.len` is a `usize`.
In Zig 0.11, `BoundedArray.len` is a `std.math.IntFittingRange(0, buffer_capacity)`!

So adding `1` without first casting to `usize` can (potentially) overflow.