### PR TITLE
Zig: Zig 11 fixes: overflow; custom log function/level

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -28,7 +28,9 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 const panic = std.debug.panic;
 const log = std.log;
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 const constants = @import("constants.zig");
 const stdx = @import("stdx.zig");

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -24,8 +24,10 @@ const vsr = @import("../../../vsr.zig");
 const Header = vsr.Header;
 const Client = vsr.Client(StateMachine, MessageBus);
 
-// Since this is running in application space, log only critical messages to reduce noise.
-pub const log_level: std.log.Level = .err;
+pub const std_options = struct {
+    // Since this is running in application space, log only critical messages to reduce noise.
+    pub const log_level: std.log.Level = .err;
+};
 
 /// N-API will call this constructor automatically to register the module.
 export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi_value {

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -35,7 +35,9 @@ const flags = @import("./flags.zig");
 const assert = std.debug.assert;
 
 const log = std.log;
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 const CliArgs = union(enum) {
     memcpy: struct { bytes: u32 },

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -20,7 +20,9 @@ const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state
 const Header = vsr.Header;
 const Client = vsr.Client(StateMachine, MessageBus);
 
-pub const log_level: std.log.Level = .alert;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .alert;
+};
 
 pub const vsr_options = .{
     .config_base = .default,

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -575,14 +575,14 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                 .pending => {
                     transfer.flags = .{ .pending = true };
                     // Bound the timeout to ensure we never hit `overflows_timeout`.
-                    transfer.timeout = 1 + @min(
+                    transfer.timeout = 1 + @as(u64, @min(
                         std.math.maxInt(u64) / 2,
                         fuzz.random_int_exponential(
                             self.random,
                             u64,
                             self.options.pending_timeout_mean,
                         ),
-                    );
+                    ));
                 },
                 .post_pending, .void_pending => {
                     // Don't depend on `HashMap.keyIterator()` being deterministic.

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -31,8 +31,10 @@ const SuperBlock = vsr.SuperBlockType(Storage);
 const superblock_zone_size = vsr.superblock.superblock_zone_size;
 const data_file_size_min = vsr.superblock.data_file_size_min;
 
-pub const log_level: std.log.Level = constants.log_level;
-pub const log = constants.log;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = constants.log_level;
+    pub const logFn = constants.log;
+};
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);


### PR DESCRIPTION
Fixes for zig 11 upgrade.

---

The log "API" changed.
Example from `std/log.zig`:

```zig
//! pub const std_options = struct {
//!     // Set the log level to info
//!     pub const log_level = .info;
//!
//!     // Define logFn to override the std implementation
//!     pub const logFn = myLogFn;
//! };
```

---

Also fixes a sneaky overview due to how `@min()` shrinks the integer type.
