### PR TITLE
IO: Async disk I/O on Windows

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -134,7 +134,8 @@ pub const AOF = struct {
     }
 
     fn init(dir_fd: os.fd_t, relative_path: []const u8) !AOF {
-        const fd = try IO.open_file(dir_fd, relative_path, 0, .create_or_open, .direct_io_required);
+        const fd =
+            try IO.open_file(null, dir_fd, relative_path, 0, .create_or_open, .direct_io_required);
         errdefer os.close(fd);
 
         try os.lseek_END(fd, 0);

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -672,12 +672,15 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
+        self: ?*IO,
         dir_fd: os.fd_t,
         relative_path: []const u8,
         size: u64,
         method: enum { create, create_or_open, open },
         direct_io: DirectIO,
     ) !os.fd_t {
+        _ = self;
+
         assert(relative_path.len > 0);
         assert(size % constants.sector_size == 0);
 

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -992,12 +992,15 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
+        self: ?*IO,
         dir_fd: os.fd_t,
         relative_path: []const u8,
         size: u64,
         method: enum { create, create_or_open, open },
         direct_io: DirectIO,
     ) !os.fd_t {
+        _ = self;
+
         assert(relative_path.len > 0);
         assert(size % constants.sector_size == 0);
         // Be careful with openat(2): "If pathname is absolute, then dirfd is ignored." (man page)

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -784,7 +784,9 @@ pub const IO = struct {
             .INVALID_USER_BUFFER, .NOT_ENOUGH_MEMORY => error.SystemResources,
             .NOT_ENOUGH_QUOTA => error.SystemResources,
             .OPERATION_ABORTED => unreachable, // overlapped_fn() doesn't get cancelled.
-            .HANDLE_EOF => unreachable,
+            // ReadFile and WriteFile don't allow partial IO (acting more like readAll/writeAll)
+            // so assume the offset is correct and simulate partial IO by returning 0 bytes moved.
+            .HANDLE_EOF => return 0,
             else => |err| return os.windows.unexpectedError(err),
         };
     }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -172,8 +172,12 @@ const Command = struct {
         else
             .direct_io_required;
 
+        command.io = try IO.init(128, 0);
+        errdefer command.io.deinit();
+
         const basename = std.fs.path.basename(path);
         command.fd = try IO.open_file(
+            &command.io,
             command.dir_fd,
             basename,
             data_file_size_min,
@@ -181,9 +185,6 @@ const Command = struct {
             direct_io,
         );
         errdefer os.close(command.fd);
-
-        command.io = try IO.init(128, 0);
-        errdefer command.io.deinit();
 
         command.storage = try Storage.init(&command.io, command.fd);
         errdefer command.storage.deinit();


### PR DESCRIPTION
Enables `ReadFile` and `WriteFile` to use Overlapped IO instead of being synchronous.
```sh
info(main): 0: Allocated 3304MiB during replica init
info(main): 0: Grid cache: 1024MiB, LSM-tree manifests: 128MiB
info(main): 0: cluster=0: listening on 127.0.0.1:65448
info: Benchmark running against { 127.0.0.1:65448 }
info: Benchmark seed = 42

# main
1260 batches in 58.23 s
load offered = 1000000 tx/s
load accepted = 171742 tx/s
batch latency p1 = 0 ms
batch latency p10 = 5 ms
batch latency p20 = 6 ms
batch latency p30 = 16 ms
batch latency p40 = 23 ms
batch latency p50 = 29 ms
batch latency p60 = 50 ms
batch latency p70 = 59 ms
batch latency p80 = 67 ms
batch latency p90 = 79 ms
batch latency p95 = 105 ms
batch latency p99 = 331 ms
batch latency p100 = 352 ms

# this PR
1269 batches in 36.72 s
load offered = 1000000 tx/s
load accepted = 272351 tx/s
batch latency p1 = 0 ms
batch latency p10 = 5 ms
batch latency p20 = 6 ms
batch latency p30 = 9 ms
batch latency p40 = 16 ms
batch latency p50 = 20 ms
batch latency p60 = 26 ms
batch latency p70 = 29 ms
batch latency p80 = 32 ms
batch latency p90 = 35 ms
batch latency p95 = 41 ms
batch latency p99 = 327 ms
batch latency p100 = 345 m
```