### PR TITLE
message_pool: fix wrong alignment in free

### DIFF
--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -123,7 +123,7 @@ pub const MessagePool = struct {
         var free_count: usize = 0;
         while (pool.free_list) |message| {
             pool.free_list = message.next;
-            allocator.free(@as([]const u8, message.buffer));
+            allocator.free(message.buffer);
             allocator.destroy(message);
             free_count += 1;
         }


### PR DESCRIPTION
We must pass the same alignment in free as the one used in AlignedAlloc. Removing the cast should fix the  issue