### PR TITLE
Zig 0.11.0 misc

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -435,7 +435,7 @@ const Benchmark = struct {
         );
 
         b.client.request(
-            @as(u128, @intCast(@intFromPtr(b))),
+            @intCast(@intFromPtr(b)),
             send_complete,
             operation,
             b.message.?,
@@ -470,7 +470,7 @@ const Benchmark = struct {
             else => unreachable,
         }
 
-        const b = @as(*Benchmark, @ptrFromInt(@as(u64, @intCast(user_data))));
+        const b: *Benchmark = @ptrFromInt(@as(u64, @intCast(user_data)));
 
         b.client.unref(b.message.?);
         b.message = null;

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -50,7 +50,7 @@ pub fn context_to_client(implementation: *ContextImplementation) tb_client_t {
 }
 
 fn client_to_context(tb_client: tb_client_t) *ContextImplementation {
-    return @as(*ContextImplementation, @ptrCast(@alignCast(tb_client)));
+    return @ptrCast(@alignCast(tb_client));
 }
 
 pub fn init_error_to_status(err: InitError) tb_status_t {

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -38,7 +38,7 @@ fn RequestContextType(comptime request_size_max: comptime_int) type {
             result_ptr: [*c]const u8,
             result_len: u32,
         ) callconv(.C) void {
-            var self = @as(*Self, @ptrCast(@alignCast(tb_packet.*.user_data.?)));
+            var self: *Self = @ptrCast(@alignCast(tb_packet.*.user_data.?));
             defer self.completion.complete();
 
             self.reply = .{

--- a/src/clients/java/src/jni.zig
+++ b/src/clients/java/src/jni.zig
@@ -3232,13 +3232,10 @@ fn JniInterface(comptime T: type) type {
                 functions: [*]const *const anyopaque,
             };
 
-            const vtable = @as(
-                *VTable,
-                @ptrCast(@alignCast(self)),
-            );
-            const fn_ptr = @as(*const Fn, @ptrCast(@alignCast(
+            const vtable: *VTable = @ptrCast(@alignCast(self));
+            const fn_ptr: *const Fn = @ptrCast(@alignCast(
                 vtable.functions[@intFromEnum(function)],
-            )));
+            ));
             return @call(.auto, fn_ptr, .{self} ++ args);
         }
     };

--- a/src/clients/java/src/jni_tests.zig
+++ b/src/clients/java/src/jni_tests.zig
@@ -1511,8 +1511,8 @@ test "JNI: primitive arrays" {
                         };
                         defer env.release_primitive_array_critical(array, critical, .default);
 
-                        var elements = @as([*]PrimitiveType, @ptrCast(@alignCast(critical)));
-                        for (elements[0..@as(usize, @intCast(len))], 0..) |*element, i| {
+                        var elements: [*]PrimitiveType = @ptrCast(@alignCast(critical));
+                        for (elements[0..@intCast(len)], 0..) |*element, i| {
                             element.* = cast(i + 10);
                         }
                     }
@@ -1525,8 +1525,8 @@ test "JNI: primitive arrays" {
                         };
                         defer env.release_primitive_array_critical(array, critical, .default);
 
-                        var elements = @as([*]PrimitiveType, @ptrCast(@alignCast(critical)));
-                        for (elements[0..@as(usize, @intCast(len))], 0..) |element, i| {
+                        var elements: [*]PrimitiveType = @ptrCast(@alignCast(critical));
+                        for (elements[0..@intCast(len)], 0..) |element, i| {
                             try testing.expectEqual(cast(i + 10), element);
                         }
                     }

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -59,7 +59,7 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     // state.
     translate.set_instance_data(
         env,
-        @as(*anyopaque, @ptrCast(@alignCast(global))),
+        @ptrCast(@alignCast(global)),
         Globals.destroy,
     ) catch {
         global.deinit();
@@ -117,7 +117,7 @@ const Globals = struct {
 };
 
 fn globalsCast(globals_raw: *anyopaque) *Globals {
-    return @as(*Globals, @ptrCast(@alignCast(globals_raw)));
+    return @ptrCast(@alignCast(globals_raw));
 }
 
 const Context = struct {
@@ -163,7 +163,7 @@ const Context = struct {
 };
 
 fn contextCast(context_raw: *anyopaque) !*Context {
-    return @as(*Context, @ptrCast(@alignCast(context_raw)));
+    return @ptrCast(@alignCast(context_raw));
 }
 
 fn validate_timestamp(env: c.napi_env, object: c.napi_value) !u64 {

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -70,7 +70,7 @@ pub fn ewah(comptime Word: type) type {
             var source_index: usize = 0;
             var target_index: usize = 0;
             while (source_index < source_words.len) {
-                const marker = @as(*const Marker, @ptrCast(&source_words[source_index]));
+                const marker: *const Marker = @ptrCast(&source_words[source_index]);
                 source_index += 1;
                 @memset(
                     target_words[target_index..][0..marker.uniform_word_count],

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -242,7 +242,6 @@ pub const IO = struct {
         operation_data: anytype,
         comptime OperationImpl: type,
     ) void {
-        const Context = @TypeOf(context);
         const onCompleteFn = struct {
             fn onComplete(io: *IO, _completion: *Completion) void {
                 // Perform the actual operaton
@@ -265,8 +264,9 @@ pub const IO = struct {
                 }
 
                 // Complete the Completion
+
                 return callback(
-                    @as(Context, @ptrFromInt(@intFromPtr(_completion.context))),
+                    @ptrCast(@alignCast(_completion.context)),
                     _completion,
                     result,
                 );
@@ -580,7 +580,7 @@ pub const IO = struct {
                 .callback = struct {
                     fn on_complete(_io: *IO, _completion: *Completion) void {
                         _ = _io;
-                        const _context = @as(Context, @ptrFromInt(@intFromPtr(_completion.context)));
+                        const _context: Context = @ptrCast(@alignCast(_completion.context));
                         callback(_context, _completion, {});
                     }
                 }.on_complete,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -611,9 +611,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const AcceptError!os.socket_t, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const AcceptError!os.socket_t, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -653,9 +653,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const CloseError!void, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const CloseError!void, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -704,9 +704,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const ConnectError!void, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const ConnectError!void, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -752,9 +752,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const ReadError!usize, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const ReadError!usize, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -799,9 +799,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const RecvError!usize, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const RecvError!usize, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -850,9 +850,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const SendError!usize, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const SendError!usize, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -886,9 +886,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const TimeoutError!void, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const TimeoutError!void, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -943,9 +943,9 @@ pub const IO = struct {
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque, comp: *Completion, res: *const anyopaque) void {
                     callback(
-                        @as(Context, @ptrFromInt(@intFromPtr(ctx))),
+                        @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const WriteError!usize, @ptrFromInt(@intFromPtr(res))).*,
+                        @as(*const WriteError!usize, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -731,7 +731,7 @@ pub fn ManifestLevelType(
                 // mutable. That is, the table is not in the .text or .rodata section.
                 if (range.tables.len < max_overlapping_tables) {
                     var table_info_reference = TableInfoReference{
-                        .table_info = @as(*TableInfo, @ptrFromInt(@intFromPtr(table))),
+                        .table_info = @constCast(table),
                         .generation = level.generation,
                     };
                     range.tables.appendAssumeCapacity(table_info_reference);
@@ -1047,7 +1047,7 @@ pub fn TestContext(
                 while (it.next()) |level_table| {
                     if (level_table.equal(table)) {
                         context.level.set_snapshot_max(snapshot, .{
-                            .table_info = @as(*TableInfo, @ptrFromInt(@intFromPtr(level_table))),
+                            .table_info = @constCast(level_table),
                             .generation = context.level.generation,
                         });
                         table.snapshot_max = snapshot;

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -398,7 +398,7 @@ pub fn EnvironmentType(comptime table_count_max: u32, comptime node_size: u32) t
                 assert(level_table.equal(env_table));
 
                 env.level.set_snapshot_max(env.snapshot, .{
-                    .table_info = @as(*TableInfo, @ptrFromInt(@intFromPtr(level_table))),
+                    .table_info = @constCast(level_table),
                     .generation = env.level.generation,
                 });
                 // This is required to keep the table in the fuzzer's environment consistent with

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -150,9 +150,7 @@ fn SegmentedArrayType(
             if (options.verify) array.verify();
 
             for (array.nodes[0..array.node_count]) |node| {
-                node_pool.?.release(
-                    @as(NodePool.Node, @ptrCast(@alignCast(node.?))),
-                );
+                node_pool.?.release(@ptrCast(@alignCast(node.?)));
             }
             allocator.free(array.nodes);
             allocator.free(array.indexes);
@@ -635,9 +633,7 @@ fn SegmentedArrayType(
             assert(node < array.node_count);
             assert(array.count(node) == 0);
 
-            node_pool.release(
-                @as(NodePool.Node, @ptrCast(@alignCast(array.nodes[node].?))),
-            );
+            node_pool.release(@ptrCast(@alignCast(array.nodes[node].?)));
 
             stdx.copy_left(
                 .exact,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -571,7 +571,7 @@ pub const Simulator = struct {
         reply: *Message,
     ) void {
         // TODO(Zig) Use @returnAddress to initialzie the cluster, then this can just use @fieldParentPtr().
-        const simulator = @as(*Simulator, @ptrCast(@alignCast(cluster.context.?)));
+        const simulator: *Simulator = @ptrCast(@alignCast(cluster.context.?));
         simulator.reply_sequence.insert(reply_client, request, reply);
 
         while (simulator.reply_sequence.peek()) |commit| {

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -463,7 +463,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         }
 
         fn client_on_reply(client: *Client, request_message: *Message, reply_message: *Message) void {
-            const cluster = @as(*Self, @ptrCast(@alignCast(client.on_reply_context.?)));
+            const cluster: *Self = @ptrCast(@alignCast(client.on_reply_context.?));
             assert(reply_message.header.cluster == cluster.options.cluster_id);
             assert(reply_message.header.invalid() == null);
             assert(reply_message.header.client == client.id);
@@ -479,7 +479,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         }
 
         fn on_replica_event(replica: *const Replica, event: vsr.ReplicaEvent) void {
-            const cluster = @as(*Self, @ptrCast(@alignCast(replica.test_context.?)));
+            const cluster: *Self = @ptrCast(@alignCast(replica.test_context.?));
             assert(cluster.replica_health[replica.replica] == .up);
 
             switch (event) {

--- a/src/testing/table.zig
+++ b/src/testing/table.zig
@@ -55,7 +55,7 @@ fn parse_data(comptime Data: type, tokens: *std.mem.TokenIterator(u8, .any)) Dat
                 const Field = value_field.type;
                 if (value_field.default_value) |ptr| {
                     if (eat(tokens, "_")) {
-                        const value_ptr = @as(*const Field, @ptrCast(@alignCast(ptr)));
+                        const value_ptr: *const Field = @ptrCast(@alignCast(ptr));
                         @field(data, value_field.name) = value_ptr.*;
                     } else {
                         @field(data, value_field.name) = parse_data(Field, tokens);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1150,7 +1150,7 @@ const TestContext = struct {
     fn on_client_reply(cluster: *Cluster, client: usize, request: *Message, reply: *Message) void {
         _ = request;
         _ = reply;
-        const t = @as(*TestContext, @ptrCast(@alignCast(cluster.context.?)));
+        const t: *TestContext = @ptrCast(@alignCast(cluster.context.?));
         t.client_replies[client] += 1;
     }
 


### PR DESCRIPTION
- Remove the pattern `@ptrFromInt(@intFromPtr(...))` using `@constCast` or `@ptrCast`.

- Remove unnecessary `@as`, preferring explicit types declarations instead.

Note: This is not an exhaustive `@as` replacement, in some places it may still need future work.
Only occurrences related to `@ptrCast` or `@ptrFromInt` were analyzed.