### PR TITLE
VSR/SuperBlock: SuperBlock.replica_index

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1631,12 +1631,12 @@ fn member_count(members: *const Members) u8 {
     return constants.members_max;
 }
 
-pub fn assert_valid_member(members: *const Members, replica_id: u128) void {
+pub fn member_index(members: *const Members, replica_id: u128) ?u8 {
     assert(replica_id != 0);
     assert(valid_members(members));
-    for (members) |member| {
-        if (member == replica_id) break;
-    } else unreachable;
+    for (members, 0..) |member, replica_index| {
+        if (member == replica_id) return @intCast(replica_index);
+    } else return null;
 }
 
 pub const Headers = struct {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -686,6 +686,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             options: FormatOptions,
         ) void {
             assert(!superblock.opened);
+            assert(superblock.replica_index == null);
 
             assert(options.replica_count > 0);
             assert(options.replica_count <= constants.replicas_max);
@@ -693,6 +694,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
             const members = vsr.root_members(options.cluster);
             const replica_id = members[options.replica];
+
+            superblock.replica_index = vsr.member_index(&members, replica_id);
 
             // This working copy provides the parent checksum, and will not be written to disk.
             // We therefore use zero values to make this parent checksum as stable as possible.


### PR DESCRIPTION
By convention, logs start with the prefix: `{replica_index}: ...`.
This makes it easy to distinguish and filter the cluster members in simulator debug log output.
But many components don't currently have access to the replica index.

Add it to `SuperBlock` so that `SuperBlock` itself, and also LSM and Grid, can log the replica index.