### PR TITLE
Refactor tree_id to u16.

### DIFF
--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -123,8 +123,8 @@ pub const TableIndex = struct {
     };
 
     pub const Parent = extern struct {
-        // TODO u16 + padding.
-        tree_id: u128,
+        tree_id: u16,
+        padding: [14]u8 = [_]u8{0} ** 14,
 
         comptime {
             assert(@sizeOf(Parent) == @sizeOf(u128));
@@ -336,8 +336,8 @@ pub const TableFilter = struct {
     };
 
     pub const Parent = extern struct {
-        // TODO u16 + padding.
-        tree_id: u128,
+        tree_id: u16,
+        padding: [14]u8 = [_]u8{0} ** 14,
 
         comptime {
             assert(@sizeOf(Parent) == @sizeOf(u128));

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -479,7 +479,7 @@ pub fn TableType(
                 cluster: u32,
                 address: u64,
                 snapshot_min: u64,
-                tree_id: u128,
+                tree_id: u16,
             };
 
             pub fn filter_block_finish(builder: *Builder, options: FilterFinishOptions) void {
@@ -529,7 +529,7 @@ pub fn TableType(
                 cluster: u32,
                 address: u64,
                 snapshot_min: u64,
-                tree_id: u128,
+                tree_id: u16,
             };
 
             pub fn index_block_finish(builder: *Builder, options: IndexFinishOptions) TableInfo {


### PR DESCRIPTION
Refactors the `// TODO u16 + padding.` at `schema.zig`.
This refactor was started by #1145, but it left two places still as `u128`.