### PR TITLE
VSR/SuperBlock: Fix grid_blocks_max, data_file_size_min

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -124,7 +124,7 @@ pub const journal_slot_count = config.cluster.journal_slot_count;
 /// Writes within this file never extend the filesystem inode size reducing the cost of fdatasync().
 /// This enables static allocation of disk space so that appends cannot fail with ENOSPC.
 /// This also enables us to detect filesystem inode corruption that would change the journal size.
-pub const journal_size_max = journal_size_headers + journal_size_prepares;
+pub const journal_size = journal_size_headers + journal_size_prepares;
 pub const journal_size_headers = journal_slot_count * @sizeOf(vsr.Header);
 pub const journal_size_prepares = journal_slot_count * message_size_max;
 
@@ -150,7 +150,7 @@ comptime {
     // another pipeline of messages. (See op_repair_min()).
     assert(journal_slot_count >= pipeline_prepare_queue_max * 2);
 
-    assert(journal_size_max == journal_size_headers + journal_size_prepares);
+    assert(journal_size == journal_size_headers + journal_size_prepares);
 }
 
 /// The maximum number of connections that can be held open by the server at any time:

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -154,7 +154,10 @@ test "format" {
 
     var storage = try Storage.init(
         allocator,
-        superblock_zone_size + constants.journal_size_headers + constants.journal_size_prepares,
+        superblock_zone_size +
+            constants.journal_size_headers +
+            constants.journal_size_prepares +
+            constants.client_replies_size,
         .{
             .read_latency_min = 0,
             .read_latency_mean = 0,

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -154,10 +154,7 @@ test "format" {
 
     var storage = try Storage.init(
         allocator,
-        superblock_zone_size +
-            constants.journal_size_headers +
-            constants.journal_size_prepares +
-            constants.client_replies_size,
+        superblock_zone_size + constants.journal_size + constants.client_replies_size,
         .{
             .read_latency_min = 0,
             .read_latency_mean = 0,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1058,9 +1058,7 @@ const TestContext = struct {
             .replica_count = options.replica_count,
             .standby_count = options.standby_count,
             .client_count = options.client_count,
-            .storage_size_limit = vsr.sector_floor(
-                constants.storage_size_max - random.uintLessThan(u64, constants.storage_size_max / 10),
-            ),
+            .storage_size_limit = vsr.sector_floor(constants.storage_size_max),
             .seed = random.int(u64),
             .network = .{
                 .node_count = options.replica_count + options.standby_count,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -431,9 +431,9 @@ const superblock_trailer_client_sessions_size_max = blk: {
     break :blk vsr.sector_ceil(encode_size_max);
 };
 
-pub const data_file_size_min = blk: {
-    break :blk superblock_zone_size + constants.journal_size_max;
-};
+/// The size of a data file that has an empty grid.
+pub const data_file_size_min =
+    superblock_zone_size + constants.journal_size_max + constants.client_replies_size;
 
 /// The maximum number of blocks in the grid.
 pub const grid_blocks_max = blk: {
@@ -441,7 +441,8 @@ pub const grid_blocks_max = blk: {
     size -= constants.superblock_copies * @sizeOf(SuperBlockHeader);
     size -= constants.superblock_copies * superblock_trailer_client_sessions_size_max;
     size -= constants.superblock_copies * superblock_trailer_manifest_size_max;
-    size -= constants.journal_size_max;
+    size -= constants.journal_size_max; // Zone.wal_headers + Zone.wal_prepares
+    size -= constants.client_replies_size; // Zone.client_replies
     // At this point, the remainder of size is split between the grid and the freeset copies.
     // The size of a freeset is related to the number of blocks it must store.
     // Maximize the number of grid blocks.

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -433,7 +433,7 @@ const superblock_trailer_client_sessions_size_max = blk: {
 
 /// The size of a data file that has an empty grid.
 pub const data_file_size_min =
-    superblock_zone_size + constants.journal_size_max + constants.client_replies_size;
+    superblock_zone_size + constants.journal_size + constants.client_replies_size;
 
 /// The maximum number of blocks in the grid.
 pub const grid_blocks_max = blk: {
@@ -441,7 +441,7 @@ pub const grid_blocks_max = blk: {
     size -= constants.superblock_copies * @sizeOf(SuperBlockHeader);
     size -= constants.superblock_copies * superblock_trailer_client_sessions_size_max;
     size -= constants.superblock_copies * superblock_trailer_manifest_size_max;
-    size -= constants.journal_size_max; // Zone.wal_headers + Zone.wal_prepares
+    size -= constants.journal_size; // Zone.wal_headers + Zone.wal_prepares
     size -= constants.client_replies_size; // Zone.client_replies
     // At this point, the remainder of size is split between the grid and the freeset copies.
     // The size of a freeset is related to the number of blocks it must store.


### PR DESCRIPTION
`grid_blocks_max` and `data_file_size_min` were not counting the client replies.

(This was missed because we don't have any tests that fill the whole grid.) (We don't test a full grid yet since it isn't currently handled properly.)

Also, in `replica_test.zig`, use `storage_size_limit == storage_size_max`. This is needed because a test (`Cluster: recovery: grid corruption (disjoint)`) iterates over every block in the grid and marks faults.