### PR TITLE
Node client support on Windows

### DIFF
--- a/.github/workflows/clients-node.yml
+++ b/.github/workflows/clients-node.yml
@@ -94,8 +94,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        # Windows not yet supported.
-        os: [ubuntu-latest, macos-latest, [self-hosted, ARM64, macos-12.6], [self-hosted, ARM64, macos-13.2]]
+        os: [ubuntu-latest, macos-latest, windows-latest, [self-hosted, ARM64, macos-12.6], [self-hosted, ARM64, macos-13.2]]
         sample: [basic, two-phase, two-phase-many]
 
     defaults:
@@ -124,8 +123,7 @@ jobs:
 
     strategy:
       matrix:
-        # Windows not yet supported.
-        os: [ubuntu-latest, macos-latest, [self-hosted, ARM64, macos-12.6], [self-hosted, ARM64, macos-13.2]]
+        os: [ubuntu-latest, macos-latest, windows-latest, [self-hosted, ARM64, macos-12.6], [self-hosted, ARM64, macos-13.2]]
 
     defaults:
       run:

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -11,7 +11,7 @@ The TigerBeetle client for Node.js.
 ### Prerequisites
 
 Linux >= 5.6 is the only production environment we
-support. But for ease of development we also support macOS. Windows is not yet supported.
+support. But for ease of development we also support macOS and Windows.
 * NodeJS >= `14`
 
 ## Setup
@@ -615,4 +615,14 @@ npm pack
 
 ### On Windows
 
-Not yet supported.
+In PowerShell run:
+
+```console
+git clone https://github.com/tigerbeetle/tigerbeetle
+cd tigerbeetle
+git submodule update --init --recursive
+.\scripts\install_zig.bat
+cd src/clients/node
+npm install --include dev
+npm pack
+```

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -88,7 +88,10 @@ pub const NodeDocs = Docs{
     ,
 
     .install_commands = "npm install tigerbeetle-node",
-    .build_commands = "npm install typescript @types/node && npx tsc --allowJs --noEmit main.js",
+    .build_commands =
+    \\npm install typescript @types/node
+    \\npx tsc --allowJs --noEmit main.js
+    ,
     .run_commands = "node main.js",
 
     .current_commit_install_commands_hook = null,
@@ -503,7 +506,11 @@ pub const NodeDocs = Docs{
 
     // Extra steps to determine commit and repo so this works in
     // CI against forks and pull requests.
-    .developer_setup_pwsh_commands = "",
+    .developer_setup_pwsh_commands =
+    \\cd src/clients/node
+    \\npm install --include dev
+    \\npm pack
+    ,
     .test_main_prefix =
     \\const {
     \\  createClient,

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -26,11 +26,11 @@
   "scripts": {
     "benchmark": "./scripts/benchmark.sh",
     "test": "node dist/test",
-    "build": "npm run build_tsc && npm run build_lib",
-    "build_tsc": "./node_modules/typescript/bin/tsc",
-    "build_lib": "node scripts/build_lib.js",
-    "prepack": "npm run build && find dist/bin \\( -iname \\*.so -o -iname \\*.dylib -o -iname \\*.dll \\) -printf \"mv '%h/%f' '%h/client.node'\\n\" | sh",
-    "clean": "rm -rf build dist node_modules src/zig-cache zig"
+    "build": "node ./scripts/build.js",
+    "build_tsc": "node ./node_modules/typescript/bin/tsc",
+    "build_lib": "node ./scripts/build_lib.js",
+    "prepack": "node ./scripts/prepack.js",
+    "clean": "node ./scripts/clean.js"
   },
   "author": "TigerBeetle, Inc",
   "license": "Apache-2.0",

--- a/src/clients/node/samples/basic/README.md
+++ b/src/clients/node/samples/basic/README.md
@@ -8,7 +8,7 @@ Code for this sample is in [./main.js](./main.js).
 ## Prerequisites
 
 Linux >= 5.6 is the only production environment we
-support. But for ease of development we also support macOS. Windows is not yet supported.
+support. But for ease of development we also support macOS and Windows.
 * NodeJS >= `14`
 
 ## Setup

--- a/src/clients/node/samples/basic/package.json
+++ b/src/clients/node/samples/basic/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tigerbeetle-node": "^0.12.52"
+    "tigerbeetle-node": "^0.13"
   }
 }

--- a/src/clients/node/samples/two-phase-many/README.md
+++ b/src/clients/node/samples/two-phase-many/README.md
@@ -8,7 +8,7 @@ Code for this sample is in [./main.js](./main.js).
 ## Prerequisites
 
 Linux >= 5.6 is the only production environment we
-support. But for ease of development we also support macOS. Windows is not yet supported.
+support. But for ease of development we also support macOS and Windows.
 * NodeJS >= `14`
 
 ## Setup

--- a/src/clients/node/samples/two-phase-many/package.json
+++ b/src/clients/node/samples/two-phase-many/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tigerbeetle-node": "^0.12.52"
+    "tigerbeetle-node": "^0.13"
   }
 }

--- a/src/clients/node/samples/two-phase/README.md
+++ b/src/clients/node/samples/two-phase/README.md
@@ -8,7 +8,7 @@ Code for this sample is in [./main.js](./main.js).
 ## Prerequisites
 
 Linux >= 5.6 is the only production environment we
-support. But for ease of development we also support macOS. Windows is not yet supported.
+support. But for ease of development we also support macOS and Windows.
 * NodeJS >= `14`
 
 ## Setup

--- a/src/clients/node/samples/two-phase/package.json
+++ b/src/clients/node/samples/two-phase/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tigerbeetle-node": "^0.12.52"
+    "tigerbeetle-node": "^0.13"
   }
 }

--- a/src/clients/node/scripts/build.js
+++ b/src/clients/node/scripts/build.js
@@ -1,0 +1,4 @@
+const { execSync } = require('child_process')
+
+execSync('npm run build_tsc')
+execSync('npm run build_lib')

--- a/src/clients/node/scripts/build_lib.js
+++ b/src/clients/node/scripts/build_lib.js
@@ -22,10 +22,10 @@ for (const ver of Object.values(headers.symbols)) {
 const defFile = path.resolve(__dirname, '../node.def')
 const libFile = path.resolve(__dirname, '../node.lib')
 const allSymbolsArr = Array.from(allSymbols)
-fs.writeFileSync(defFile, 'LIBRARY node\nEXPORTS\n' + allSymbolsArr.join('\n'))
+fs.writeFileSync(defFile, 'EXPORTS\n    ' + allSymbolsArr.join('\n    '))
 
 // Compile '.def' file to '.lib' file for zig build node_client to link to.
-execSync(`${zig} dlltool -m i386:x86-64 -d ${defFile} -l ${libFile}`)
+execSync(`${zig} dlltool -m i386:x86-64 -D node.exe -d ${defFile} -l ${libFile}`)
 
 // Build the tigerbeetle node client.
 process.chdir(path.resolve('../../../'))

--- a/src/clients/node/scripts/clean.js
+++ b/src/clients/node/scripts/clean.js
@@ -1,0 +1,22 @@
+const fs = require('fs')
+const path = require('path')
+
+rmdir(path.resolve(__dirname, '../build'));
+rmdir(path.resolve(__dirname, '../dist'));
+rmdir(path.resolve(__dirname, '../node_modules'));
+rmdir(path.resolve(__dirname, '../src/zig-cache'));
+rmdir(path.resolve(__dirname, '../zig'));
+
+function rmdir(dir) {
+    if (fs.existsSync(dir)) {
+        for (const file of fs.readdirSync(dir)) {
+            const current_path = path.join(dir, file);
+            if (fs.lstatSync(current_path).isDirectory()) {
+                rmdir(current_path);
+            } else {
+                fs.unlinkSync(current_path);
+            }
+        }
+        fs.rmdirSync(dir);
+    }
+}

--- a/src/clients/node/scripts/prepack.js
+++ b/src/clients/node/scripts/prepack.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
+
+execSync('npm run build')
+const bin_path = path.resolve(__dirname, '../dist/bin');
+const libs = get_libs(bin_path);
+
+for (const lib of libs) {
+    fs.renameSync(lib , path.join(path.dirname(lib), 'client.node'))
+}
+
+function get_libs(dir) {
+    const entries = fs.readdirSync(dir);
+    const files = [];
+
+    for (const entry of entries) {
+        const full_path = path.join(dir, entry);
+        const stats = fs.statSync(full_path);
+        
+        if (stats.isFile()) {
+            const extname = path.extname(entry);
+            if (extname === '.so' || extname === '.dylib' || extname === '.dll') {
+                files.push(full_path);
+            }
+        } else if (stats.isDirectory()) {
+            const subFiles = get_libs(full_path);
+            files.push(...subFiles);
+        }
+    }
+
+    return files;
+}

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -17,7 +17,8 @@ function getBinding (): Binding {
 
   const platformMap = {
     "linux": "linux",
-    "darwin": "macos"
+    "darwin": "macos",
+    "win32" : "windows",
   }
 
   if (! (arch in archMap)) {

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -71,7 +71,7 @@ test('can return error on account', async (): Promise<void> => {
   const errors = await client.createAccounts([accountA, accountB])
 
   assert.strictEqual(errors.length, 1)
-  assert.deepStrictEqual(errors[0], { index: 0, code: CreateAccountError.exists })
+  assert.deepStrictEqual(errors[0], { index: 0, result: CreateAccountError.exists })
 })
 
 test('throws error if timestamp is not set to 0n on account', async (): Promise<void> => {
@@ -310,8 +310,8 @@ test('can link transfers', async (): Promise<void> => {
 
   const errors = await client.createTransfers([transfer1, transfer2])
   assert.strictEqual(errors.length, 2)
-  assert.deepStrictEqual(errors[0], { index: 0, code: CreateTransferError.linked_event_failed })
-  assert.deepStrictEqual(errors[1], { index: 1, code: CreateTransferError.exists_with_different_flags })
+  assert.deepStrictEqual(errors[0], { index: 0, result: CreateTransferError.linked_event_failed })
+  assert.deepStrictEqual(errors[1], { index: 1, result: CreateTransferError.exists_with_different_flags })
 
   const accounts = await client.lookupAccounts([accountA.id, accountB.id])
   assert.strictEqual(accounts.length, 2)


### PR DESCRIPTION
This PR is a continuation of #1154 

- Adds `win32` to `platformMap` fixing the error `Unsupported platform: win32`.
- Fixes the `.lib` file that was generated pointing to node.dll instead of node.exe, causing the `dlopen` to fail trying to load `node.dll` that does not exist.
- Converts the `sh` scripts to `js` for cross-platform compatibility.
- Adds `windows-latest` to the CI tests.