### PR TITLE
Use consistent relative path for TigerBeetle in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ First let's create two accounts. (Don't worry about the details, you
 can read about them later.)
 
 ```console
-tigerbeetle client --addresses=3000
+./tigerbeetle client --addresses=3000
 ```
 ```console
 TigerBeetle Client


### PR DESCRIPTION
All the other uses of the tigerbeetle binary in the file use `./tigerbeetle`. I missed this in the REPL pull request.