### PR TITLE
Add --cluster=0 to tigerbeetle client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ First let's create two accounts. (Don't worry about the details, you
 can read about them later.)
 
 ```console
-./tigerbeetle client --addresses=3000
+./tigerbeetle client --cluster=0 --addresses=3000
 ```
 ```console
 TigerBeetle Client

--- a/docs/quick-start/cli-client.md
+++ b/docs/quick-start/cli-client.md
@@ -11,7 +11,7 @@ First let's create two accounts. (Don't worry about the details, you
 can read about them later.)
 
 ```console
-tigerbeetle client --addresses=3000
+./tigerbeetle client --cluster=0 --addresses=3000
 ```
 ```
 TigerBeetle Client

--- a/docs/quick-start/single-binary.md
+++ b/docs/quick-start/single-binary.md
@@ -25,7 +25,7 @@ Want to build from source locally? Add `-build` as an argument to the bootstrap 
 Now create the TigerBeetle data file.
 
 ```console
-tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
 ```
 ```console
 info(io): creating "0_0.tigerbeetle"...
@@ -35,7 +35,7 @@ info(io): allocating 660.140625MiB...
 And start the server.
 
 ```console
-tigerbeetle start --addresses=3000 0_0.tigerbeetle
+./tigerbeetle start --addresses=3000 0_0.tigerbeetle
 ```
 ```console
 info(io): opening "0_0.tigerbeetle"...


### PR DESCRIPTION
Also is consistent about `./tigerbeetle` not `tigerbeetle` in the single binary quickstart (which is basically a copy of the top-level README.md).