### PR TITLE
FIFO: Assert !contains(elem) before push(elem)

### DIFF
--- a/src/fifo.zig
+++ b/src/fifo.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
+const constants = @import("./constants.zig");
 const tracer = @import("./tracer.zig");
 
 /// An intrusive first in/first out linked list.
@@ -16,6 +17,8 @@ pub fn FIFO(comptime T: type) type {
         name: ?[]const u8,
 
         pub fn push(self: *Self, elem: *T) void {
+            if (constants.verify) assert(!self.contains(elem));
+
             assert(elem.next == null);
             if (self.in) |in| {
                 in.next = elem;

--- a/src/fifo.zig
+++ b/src/fifo.zig
@@ -47,6 +47,15 @@ pub fn FIFO(comptime T: type) type {
             return self.peek() == null;
         }
 
+        /// Returns whether the linked list contains the given *exact element* (pointer comparison).
+        pub fn contains(self: *const Self, elem_needle: *const T) bool {
+            var iterator = self.peek();
+            while (iterator) |elem| : (iterator = elem.next) {
+                if (elem == elem_needle) return true;
+            }
+            return false;
+        }
+
         /// Remove an element from the FIFO. Asserts that the element is
         /// in the FIFO. This operation is O(N), if this is done often you
         /// probably want a different data structure.
@@ -83,7 +92,7 @@ pub fn FIFO(comptime T: type) type {
     };
 }
 
-test "push/pop/peek/remove/empty" {
+test "FIFO: push/pop/peek/remove/empty" {
     const testing = @import("std").testing;
 
     const Foo = struct { next: ?*@This() = null };
@@ -98,11 +107,17 @@ test "push/pop/peek/remove/empty" {
     fifo.push(&one);
     try testing.expect(!fifo.empty());
     try testing.expectEqual(@as(?*Foo, &one), fifo.peek());
+    try testing.expect(fifo.contains(&one));
+    try testing.expect(!fifo.contains(&two));
+    try testing.expect(!fifo.contains(&three));
 
     fifo.push(&two);
     fifo.push(&three);
     try testing.expect(!fifo.empty());
     try testing.expectEqual(@as(?*Foo, &one), fifo.peek());
+    try testing.expect(fifo.contains(&one));
+    try testing.expect(fifo.contains(&two));
+    try testing.expect(fifo.contains(&three));
 
     fifo.remove(&one);
     try testing.expect(!fifo.empty());
@@ -110,6 +125,9 @@ test "push/pop/peek/remove/empty" {
     try testing.expectEqual(@as(?*Foo, &three), fifo.pop());
     try testing.expectEqual(@as(?*Foo, null), fifo.pop());
     try testing.expect(fifo.empty());
+    try testing.expect(!fifo.contains(&one));
+    try testing.expect(!fifo.contains(&two));
+    try testing.expect(!fifo.contains(&three));
 
     fifo.push(&one);
     fifo.push(&two);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -287,6 +287,12 @@ pub const Storage = struct {
         callback: *const fn (next_tick: *Storage.NextTick) void,
         next_tick: *Storage.NextTick,
     ) void {
+        // The NextTick context is not already in use.
+        var next_tick_queue = storage.next_tick_queue.peek();
+        while (next_tick_queue) |next_tick_item| : (next_tick_queue = next_tick_item.next) {
+            assert(next_tick_item != next_tick);
+        }
+
         next_tick.* = .{
             .source = source,
             .callback = callback,

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -287,8 +287,6 @@ pub const Storage = struct {
         callback: *const fn (next_tick: *Storage.NextTick) void,
         next_tick: *Storage.NextTick,
     ) void {
-        assert(!storage.next_tick_queue.contains(next_tick));
-
         next_tick.* = .{
             .source = source,
             .callback = callback,

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -287,11 +287,7 @@ pub const Storage = struct {
         callback: *const fn (next_tick: *Storage.NextTick) void,
         next_tick: *Storage.NextTick,
     ) void {
-        // The NextTick context is not already in use.
-        var next_tick_queue = storage.next_tick_queue.peek();
-        while (next_tick_queue) |next_tick_item| : (next_tick_queue = next_tick_item.next) {
-            assert(next_tick_item != next_tick);
-        }
+        assert(!storage.next_tick_queue.contains(next_tick));
 
         next_tick.* = .{
             .source = source,


### PR DESCRIPTION
This is useful to be certain that e.g. `NextTick` or `Read` contexts are not used multiple times concurrently.