### PR TITLE
Fuzz/LSM: Prevent static checkpoint id

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -212,6 +212,22 @@ const Environment = struct {
         const op = env.checkpoint_op.?;
         env.checkpoint_op = null;
 
+        {
+            // VSRState.monotonic() asserts that the previous_checkpoint id changes.
+            // In a normal replica this is guaranteed – even if the LSM is idle and no blocks
+            // are acquired or released, the client sessions are necessarily mutated.
+            var reply = std.mem.zeroInit(vsr.Header, .{
+                .cluster = cluster,
+                .command = .reply,
+                .op = op,
+                .commit = op,
+            });
+            reply.set_checksum_body(&.{});
+            reply.set_checksum();
+
+            _ = env.superblock.client_sessions.put(1, &reply);
+        }
+
         env.change_state(.forest_checkpoint, .superblock_checkpoint);
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
             .commit_min_checksum = env.superblock.working.vsr_state.commit_min_checksum + 1,


### PR DESCRIPTION
On checkpoint, we expect the checkpoint id to change. We assert this (somewhat obliquely) in `VSRState.monotonic()`:

    assert(old.previous_checkpoint_id != new.previous_checkpoint_id);

The checkpoint id is `hash(hash(free_set), hash(manifest), hash(client_sessions))`.

Even if the LSM is "idle" for a whole log-wrap of messages (i.e. all lookups, no inserts/updates), then we still expect the client sessions to mutate – in order to checkpoint, we must have committed. And if we committed, then there must be new replies in our sessions.

The forest and tree fuzzers weren't mutating client sessions, though.

Tree fuzzer was failing on seed `6039089230838466239`.