### PR TITLE
Add lookup return code enums

### DIFF
--- a/src/tigerbeetle/repl.zig
+++ b/src/tigerbeetle/repl.zig
@@ -789,7 +789,10 @@ pub fn ReplType(comptime MessageBus: type) type {
                     );
 
                     if (lookup_account_results.len == 0) {
-                        try repl.fail("No such account or accounts exists.\n", .{});
+                        try repl.fail(
+                            "Failed to lookup account: {any}\n",
+                            .{LookupAccountResult.account_not_found},
+                        );
                     } else {
                         for (lookup_account_results) |*account| {
                             try repl.display_object(account);
@@ -818,7 +821,10 @@ pub fn ReplType(comptime MessageBus: type) type {
                     );
 
                     if (lookup_transfer_results.len == 0) {
-                        try repl.fail("No such transfer or transfers exists.\n", .{});
+                        try repl.fail(
+                            "Failed to lookup transfer: {any}\n",
+                            .{LookupTransferResult.transfer_not_found},
+                        );
                     } else {
                         for (lookup_transfer_results) |*transfer| {
                             try repl.display_object(transfer);
@@ -844,3 +850,23 @@ pub fn ReplType(comptime MessageBus: type) type {
         }
     };
 }
+
+pub const LookupAccountResult = enum(u32) {
+    ok = 0,
+    account_not_found = 1,
+    comptime {
+        for (std.enums.values(LookupAccountResult), 0..) |result, index| {
+            assert(@intFromEnum(result) == index);
+        }
+    }
+};
+
+pub const LookupTransferResult = enum(u32) {
+    ok = 0,
+    transfer_not_found = 1,
+    comptime {
+        for (std.enums.values(LookupTransferResult), 0..) |result, index| {
+            assert(@intFromEnum(result) == index);
+        }
+    }
+};


### PR DESCRIPTION
This commit addresses issue https://github.com/tigerbeetle/tigerbeetle/issues/1184

Lookup REPL actions currently return hardcoded error strings. Create enums for looking up accounts and transfers, and refactor the error message to reference them.

The actual lookup functions still return Account and Transfer structs, as a wrapper struct around them to also house the error code seemed like overkill given there is currently only one error mode supported. This could be added in the future if needed