### PR TITLE
Docs: Remove copyright notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,6 @@ Read [docs/HACKING.md](docs/HACKING.md).
 See https://github.com/tigerbeetle/tigerbeetle/issues/259.
 
 ## License
-
-Copyright 2023 TigerBeetle, Inc
-
-Copyright 2020-2022 Coil Technologies, Inc
-
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use these files except in compliance with the License. You may obtain a copy of the License at
 
 https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Chatted with @jorangreef, and we're removing these since:

1. They're not entirely accurate.
2. To make our README look more contributor friendly.