### PR TITLE
Test/StorageChecker: Cleanup; verify grid block padding

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -18,7 +18,7 @@ const MessageBus = @import("cluster/message_bus.zig").MessageBus;
 const Network = @import("cluster/network.zig").Network;
 const NetworkOptions = @import("cluster/network.zig").NetworkOptions;
 const StateCheckerType = @import("cluster/state_checker.zig").StateCheckerType;
-const StorageCheckerType = @import("cluster/storage_checker.zig").StorageCheckerType;
+const StorageChecker = @import("cluster/storage_checker.zig").StorageChecker;
 const SyncCheckerType = @import("cluster/sync_checker.zig").SyncCheckerType;
 const GridChecker = @import("cluster/grid_checker.zig").GridChecker;
 
@@ -53,7 +53,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time, AOF);
         pub const Client = vsr.Client(StateMachine, MessageBus);
         pub const StateChecker = StateCheckerType(Client, Replica);
-        pub const StorageChecker = StorageCheckerType(Storage);
         pub const SyncChecker = SyncCheckerType(Replica);
 
         pub const Options = struct {

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -27,6 +27,7 @@ const log = std.log.scoped(.storage_checker);
 const constants = @import("../../constants.zig");
 const vsr = @import("../../vsr.zig");
 const schema = @import("../../lsm/schema.zig");
+const Storage = @import("../storage.zig").Storage;
 
 /// After each compaction half measure, save the cumulative hash of all acquired grid blocks.
 ///
@@ -52,170 +53,166 @@ const CheckpointArea = enum {
 
 const Checkpoint = std.enums.EnumArray(CheckpointArea, u128);
 
-// TODO not generic over Storage
-pub fn StorageCheckerType(comptime Storage: type) type {
-    return struct {
-        const Self = @This();
-        const SuperBlock = vsr.SuperBlockType(Storage);
+pub const StorageChecker = struct {
+    const SuperBlock = vsr.SuperBlockType(Storage);
 
-        compactions: Compactions,
-        checkpoints: Checkpoints,
+    compactions: Compactions,
+    checkpoints: Checkpoints,
 
-        free_set: SuperBlock.FreeSet,
+    free_set: SuperBlock.FreeSet,
 
-        pub fn init(allocator: std.mem.Allocator) !Self {
-            var compactions = Compactions.init(allocator);
-            errdefer compactions.deinit();
+    pub fn init(allocator: std.mem.Allocator) !StorageChecker {
+        var compactions = Compactions.init(allocator);
+        errdefer compactions.deinit();
 
-            var checkpoints = Checkpoints.init(allocator);
-            errdefer checkpoints.deinit();
+        var checkpoints = Checkpoints.init(allocator);
+        errdefer checkpoints.deinit();
 
-            var free_set = try SuperBlock.FreeSet.init(allocator, vsr.superblock.grid_blocks_max);
-            errdefer free_set.deinit(allocator);
+        var free_set = try SuperBlock.FreeSet.init(allocator, vsr.superblock.grid_blocks_max);
+        errdefer free_set.deinit(allocator);
 
-            return Self{
-                .compactions = compactions,
-                .checkpoints = checkpoints,
-                .free_set = free_set,
-            };
+        return StorageChecker{
+            .compactions = compactions,
+            .checkpoints = checkpoints,
+            .free_set = free_set,
+        };
+    }
+
+    pub fn deinit(checker: *StorageChecker, allocator: std.mem.Allocator) void {
+        checker.free_set.deinit(allocator);
+        checker.checkpoints.deinit();
+        checker.compactions.deinit();
+    }
+
+    pub fn replica_checkpoint(checker: *StorageChecker, superblock: *const SuperBlock) !void {
+        const replica_checkpoint_op = superblock.working.vsr_state.commit_min;
+
+        var checkpoint_actual = std.enums.EnumMap(CheckpointArea, u128).init(.{
+            .superblock_manifest = checksum_trailer(superblock, .manifest),
+            .superblock_free_set = checksum_trailer(superblock, .free_set),
+            .superblock_client_sessions = checksum_trailer(superblock, .client_sessions),
+        });
+
+        const syncing = superblock.working.vsr_state.sync_op_max > 0;
+        if (!syncing) {
+            checkpoint_actual.put(.client_replies, checksum_client_replies(superblock));
+            checkpoint_actual.put(.grid, checker.checksum_grid(superblock));
         }
 
-        pub fn deinit(checker: *Self, allocator: std.mem.Allocator) void {
-            checker.free_set.deinit(allocator);
-            checker.checkpoints.deinit();
-            checker.compactions.deinit();
-        }
-
-        pub fn replica_checkpoint(checker: *Self, superblock: *const SuperBlock) !void {
-            const replica_checkpoint_op = superblock.working.vsr_state.commit_min;
-
-            var checkpoint_actual = std.enums.EnumMap(CheckpointArea, u128).init(.{
-                .superblock_manifest = checksum_trailer(superblock, .manifest),
-                .superblock_free_set = checksum_trailer(superblock, .free_set),
-                .superblock_client_sessions = checksum_trailer(superblock, .client_sessions),
+        for (std.enums.values(CheckpointArea)) |area| {
+            log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={?x:0>32}", .{
+                superblock.replica_index.?,
+                replica_checkpoint_op,
+                @tagName(area),
+                checkpoint_actual.get(area),
             });
+        }
 
-            const syncing = superblock.working.vsr_state.sync_op_max > 0;
+        const checkpoint_expect = checker.checkpoints.get(replica_checkpoint_op) orelse {
             if (!syncing) {
-                checkpoint_actual.put(.client_replies, checksum_client_replies(superblock));
-                checkpoint_actual.put(.grid, checker.checksum_grid(superblock));
-            }
-
-            for (std.enums.values(CheckpointArea)) |area| {
-                log.debug("{}: replica_checkpoint: checkpoint={} area={s} value={?x:0>32}", .{
-                    superblock.replica_index.?,
-                    replica_checkpoint_op,
-                    @tagName(area),
-                    checkpoint_actual.get(area),
-                });
-            }
-
-            const checkpoint_expect = checker.checkpoints.get(replica_checkpoint_op) orelse {
-                if (!syncing) {
-                    // This replica is the first to reach op_checkpoint.
-                    // Save its state for other replicas to check themselves against.
-                    var checkpoint: Checkpoint = undefined;
-                    for (std.enums.values(CheckpointArea)) |area| {
-                        checkpoint.set(area, checkpoint_actual.get(area).?);
-                    }
-                    try checker.checkpoints.putNoClobber(replica_checkpoint_op, checkpoint);
+                // This replica is the first to reach op_checkpoint.
+                // Save its state for other replicas to check themselves against.
+                var checkpoint: Checkpoint = undefined;
+                for (std.enums.values(CheckpointArea)) |area| {
+                    checkpoint.set(area, checkpoint_actual.get(area).?);
                 }
-                return;
+                try checker.checkpoints.putNoClobber(replica_checkpoint_op, checkpoint);
+            }
+            return;
+        };
+
+        var mismatch: bool = false;
+        for (std.enums.values(CheckpointArea)) |area| {
+            const checksum_actual = checkpoint_actual.get(area) orelse continue;
+            const checksum_expect = checkpoint_expect.get(area);
+            if (checksum_expect != checksum_actual) {
+                log.warn("{}: replica_checkpoint: mismatch " ++
+                    "area={s} expect={x:0>32} actual={x:0>32}", .{
+                    superblock.replica_index.?,
+                    @tagName(area),
+                    checksum_expect,
+                    checksum_actual,
+                });
+
+                mismatch = true;
+            }
+        }
+        if (mismatch) return error.StorageMismatch;
+    }
+
+    fn checksum_trailer(superblock: *const SuperBlock, trailer: vsr.SuperBlockTrailer) u128 {
+        const trailer_size = superblock.working.trailer_size(trailer);
+        const trailer_checksum = superblock.working.trailer_checksum(trailer);
+
+        var copy: u8 = 0;
+        while (copy < constants.superblock_copies) : (copy += 1) {
+            const trailer_start = trailer.zone().start_for_copy(copy);
+
+            assert(trailer_checksum ==
+                vsr.checksum(superblock.storage.memory[trailer_start..][0..trailer_size]));
+        }
+
+        return trailer_checksum;
+    }
+
+    fn checksum_client_replies(superblock: *const SuperBlock) u128 {
+        assert(superblock.working.vsr_state.sync_op_max == 0);
+
+        var checksum: u128 = 0;
+        for (superblock.client_sessions.entries, 0..) |client_session, slot| {
+            if (client_session.session == 0) {
+                // Empty slot.
+            } else {
+                assert(client_session.header.command == .reply);
+
+                if (client_session.header.size == @sizeOf(vsr.Header)) {
+                    // ClientReplies won't store this entry.
+                } else {
+                    checksum ^= vsr.checksum(superblock.storage.area_memory(
+                        .{ .client_replies = .{ .slot = slot } },
+                    )[0..vsr.sector_ceil(client_session.header.size)]);
+                }
+            }
+        }
+        return checksum;
+    }
+
+    fn checksum_grid(checker: *StorageChecker, superblock: *const SuperBlock) u128 {
+        assert(superblock.working.vsr_state.sync_op_max == 0);
+
+        const free_set_zone = vsr.SuperBlockTrailer.free_set.zone();
+        const free_set_offset = vsr.Zone.superblock.offset(free_set_zone.start_for_copy(0));
+        const free_set_size = superblock.working.free_set_size;
+        const free_set_buffer = superblock.storage.memory[free_set_offset..][0..free_set_size];
+        assert(vsr.checksum(free_set_buffer) == superblock.working.free_set_checksum);
+
+        checker.free_set.decode(@alignCast(free_set_buffer));
+        defer checker.free_set.reset();
+
+        var stream = vsr.ChecksumStream.init();
+        var blocks_missing: usize = 0;
+        var blocks_acquired = checker.free_set.blocks.iterator(.{});
+        while (blocks_acquired.next()) |block_address_index| {
+            const block_address: u64 = block_address_index + 1;
+            const block = superblock.storage.grid_block(block_address) orelse {
+                log.err("{}: checksum_grid: missing block_address={}", .{
+                    superblock.replica_index.?,
+                    block_address,
+                });
+
+                blocks_missing += 1;
+                continue;
             };
 
-            var mismatch: bool = false;
-            for (std.enums.values(CheckpointArea)) |area| {
-                const checksum_actual = checkpoint_actual.get(area) orelse continue;
-                const checksum_expect = checkpoint_expect.get(area);
-                if (checksum_expect != checksum_actual) {
-                    log.warn("{}: replica_checkpoint: mismatch " ++
-                        "area={s} expect={x:0>32} actual={x:0>32}", .{
-                        superblock.replica_index.?,
-                        @tagName(area),
-                        checksum_expect,
-                        checksum_actual,
-                    });
+            const block_header = schema.header_from_block(block);
+            assert(block_header.op == block_address);
 
-                    mismatch = true;
-                }
-            }
-            if (mismatch) return error.StorageMismatch;
+            stream.add(block[0..block_header.size]);
+            // Extra guard against identical blocks:
+            stream.add(std.mem.asBytes(&block_address));
         }
+        assert(blocks_missing == 0);
 
-        fn checksum_trailer(superblock: *const SuperBlock, trailer: vsr.SuperBlockTrailer) u128 {
-            const trailer_size = superblock.working.trailer_size(trailer);
-            const trailer_checksum = superblock.working.trailer_checksum(trailer);
-
-            var copy: u8 = 0;
-            while (copy < constants.superblock_copies) : (copy += 1) {
-                const trailer_start = trailer.zone().start_for_copy(copy);
-
-                assert(trailer_checksum ==
-                    vsr.checksum(superblock.storage.memory[trailer_start..][0..trailer_size]));
-            }
-
-            return trailer_checksum;
-        }
-
-        fn checksum_client_replies(superblock: *const SuperBlock) u128 {
-            assert(superblock.working.vsr_state.sync_op_max == 0);
-
-            var checksum: u128 = 0;
-            for (superblock.client_sessions.entries, 0..) |client_session, slot| {
-                if (client_session.session == 0) {
-                    // Empty slot.
-                } else {
-                    assert(client_session.header.command == .reply);
-
-                    if (client_session.header.size == @sizeOf(vsr.Header)) {
-                        // ClientReplies won't store this entry.
-                    } else {
-                        checksum ^= vsr.checksum(superblock.storage.area_memory(
-                            .{ .client_replies = .{ .slot = slot } },
-                        )[0..vsr.sector_ceil(client_session.header.size)]);
-                    }
-                }
-            }
-            return checksum;
-        }
-
-        fn checksum_grid(checker: *Self, superblock: *const SuperBlock) u128 {
-            assert(superblock.working.vsr_state.sync_op_max == 0);
-
-            const free_set_zone = vsr.SuperBlockTrailer.free_set.zone();
-            const free_set_offset = vsr.Zone.superblock.offset(free_set_zone.start_for_copy(0));
-            const free_set_size = superblock.working.free_set_size;
-            const free_set_buffer = superblock.storage.memory[free_set_offset..][0..free_set_size];
-            assert(vsr.checksum(free_set_buffer) == superblock.working.free_set_checksum);
-
-            checker.free_set.decode(@alignCast(free_set_buffer));
-            defer checker.free_set.reset();
-
-            var stream = vsr.ChecksumStream.init();
-            var blocks_missing: usize = 0;
-            var blocks_acquired = checker.free_set.blocks.iterator(.{});
-            while (blocks_acquired.next()) |block_address_index| {
-                const block_address: u64 = block_address_index + 1;
-                const block = superblock.storage.grid_block(block_address) orelse {
-                    log.err("{}: checksum_grid: missing block_address={}", .{
-                        superblock.replica_index.?,
-                        block_address,
-                    });
-
-                    blocks_missing += 1;
-                    continue;
-                };
-
-                const block_header = schema.header_from_block(block);
-                assert(block_header.op == block_address);
-
-                stream.add(block[0..block_header.size]);
-                // Extra guard against identical blocks:
-                stream.add(std.mem.asBytes(&block_address));
-            }
-            assert(blocks_missing == 0);
-
-            return stream.checksum();
-        }
-    };
-}
+        return stream.checksum();
+    }
+};

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -25,6 +25,7 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.storage_checker);
 
 const constants = @import("../../constants.zig");
+const stdx = @import("../../stdx.zig");
 const vsr = @import("../../vsr.zig");
 const schema = @import("../../lsm/schema.zig");
 const Storage = @import("../storage.zig").Storage;
@@ -210,6 +211,9 @@ pub const StorageChecker = struct {
             stream.add(block[0..block_header.size]);
             // Extra guard against identical blocks:
             stream.add(std.mem.asBytes(&block_address));
+
+            // Grid block sector padding is zeroed:
+            assert(stdx.zeroed(block[block_header.size..vsr.sector_ceil(block_header.size)]));
         }
         assert(blocks_missing == 0);
 

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -615,10 +615,14 @@ pub fn GridType(comptime Storage: type) type {
                 .write = write,
             };
 
+            const write_header = schema.header_from_block(write.block.*);
+            assert(write_header.size > @sizeOf(vsr.Header));
+            assert(write_header.size <= constants.block_size);
+
             grid.superblock.storage.write_sectors(
                 write_block_callback,
                 &iop.completion,
-                write.block.*,
+                write.block.*[0..vsr.sector_ceil(write_header.size)],
                 .grid,
                 block_offset(write.address),
             );

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -957,6 +957,10 @@ pub fn GridType(comptime Storage: type) type {
             if (!header.valid_checksum_body(block_body)) return .invalid_checksum_body;
             if (header.checksum != expect.checksum) return .unexpected_checksum;
 
+            if (constants.verify) {
+                assert(stdx.zeroed(block[header.size..vsr.sector_ceil(header.size)]));
+            }
+
             assert(header.op == expect.address);
             return .{ .valid = block };
         }

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1726,9 +1726,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             const offset = Ring.prepares.offset(slot);
 
             // Assert that any sector padding has already been zeroed:
-            var sum_of_sector_padding_bytes: u8 = 0;
-            for (buffer[message.header.size..]) |byte| sum_of_sector_padding_bytes |= byte;
-            assert(sum_of_sector_padding_bytes == 0);
+            assert(stdx.zeroed(buffer[message.header.size..]));
 
             journal.prepare_inhabited[slot.index] = false;
             journal.prepare_checksums[slot.index] = 0;


### PR DESCRIPTION
I recommend reviewing the commits independently -- the first looks big because it un-indents the `StorageChecker` methods.