### PR TITLE
[Java client] Fix test coverage

### DIFF
--- a/src/clients/java/src/main/java/com/tigerbeetle/Batch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Batch.java
@@ -284,15 +284,4 @@ public abstract class Batch {
             throw new IllegalArgumentException("Value must be a 16-bit unsigned integer");
         buffer.putShort(index, (short) value);
     }
-
-    protected final byte[] getArray(final int index, final int len) {
-        byte[] array = new byte[len];
-        buffer.position(index).get(array);
-        return array;
-    }
-
-    protected final void putArray(final int index, final byte[] value) {
-        Objects.requireNonNull(value);
-        buffer.position(index).put(value);
-    }
 }

--- a/src/clients/java/src/test/java/com/tigerbeetle/AccountTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AccountTest.java
@@ -97,6 +97,11 @@ public class AccountTest {
 
         accounts.setCreditsPending(999);
         assertEquals(BigInteger.valueOf(999), accounts.getCreditsPending());
+
+        accounts.setCreditsPending(999, 1);
+        assertEquals(UInt128.asBigInteger(999, 1), accounts.getCreditsPending());
+        assertEquals(999L, accounts.getCreditsPending(UInt128.LeastSignificant));
+        assertEquals(1L, accounts.getCreditsPending(UInt128.MostSignificant));
     }
 
     @Test
@@ -116,6 +121,11 @@ public class AccountTest {
 
         accounts.setCreditsPosted(999);
         assertEquals(BigInteger.valueOf(999), accounts.getCreditsPosted());
+
+        accounts.setCreditsPosted(999, 1);
+        assertEquals(UInt128.asBigInteger(999, 1), accounts.getCreditsPosted());
+        assertEquals(999L, accounts.getCreditsPosted(UInt128.LeastSignificant));
+        assertEquals(1L, accounts.getCreditsPosted(UInt128.MostSignificant));
     }
 
     @Test
@@ -135,6 +145,11 @@ public class AccountTest {
 
         accounts.setDebitsPosted(999);
         assertEquals(BigInteger.valueOf(999), accounts.getDebitsPosted());
+
+        accounts.setDebitsPosted(999, 1);
+        assertEquals(UInt128.asBigInteger(999, 1), accounts.getDebitsPosted());
+        assertEquals(999L, accounts.getDebitsPosted(UInt128.LeastSignificant));
+        assertEquals(1L, accounts.getDebitsPosted(UInt128.MostSignificant));
     }
 
     @Test
@@ -154,6 +169,11 @@ public class AccountTest {
 
         accounts.setDebitsPending(999);
         assertEquals(BigInteger.valueOf(999), accounts.getDebitsPending());
+
+        accounts.setDebitsPending(999, 1);
+        assertEquals(UInt128.asBigInteger(999, 1), accounts.getDebitsPending());
+        assertEquals(999L, accounts.getDebitsPending(UInt128.LeastSignificant));
+        assertEquals(1L, accounts.getDebitsPending(UInt128.MostSignificant));
     }
 
     @Test

--- a/src/clients/java/src/test/java/com/tigerbeetle/TransferTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/TransferTest.java
@@ -201,6 +201,11 @@ public class TransferTest {
 
         transfers.setAmount(999);
         assertEquals(BigInteger.valueOf(999), transfers.getAmount());
+
+        transfers.setAmount(999, 1);
+        assertEquals(UInt128.asBigInteger(999, 1), transfers.getAmount());
+        assertEquals(999L, transfers.getAmount(UInt128.LeastSignificant));
+        assertEquals(1L, transfers.getAmount(UInt128.MostSignificant));
     }
 
     @Test


### PR DESCRIPTION
Methods get/set for u128 amounts as BigInteger were not tested, reducing the code coverage to 94%.

After this fix, we have 98% of code coverage.
Currently our minimal threshold is 95%.

Note: `mvn package` fails with a warning, but I don't know why our CI is passing.

```
[INFO] --- jacoco-maven-plugin:0.8.8:check (jacoco-check) @ tigerbeetle-java ---
[INFO] Loading execution data file /home/batiati/tigerbeetle-clients-benchmarks/tigerbeetle/src/clients/java/target/jacoco.exec
[INFO] Analyzed bundle 'tigerbeetle-java' with 19 classes
[WARNING] Rule violated for bundle tigerbeetle-java: instructions covered ratio is 0.94, but expected minimum is 0.95
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:20 min
[INFO] Finished at: 2023-10-03T09:01:51-03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.8:check (jacoco-check) on project tigerbeetle-java: Coverage checks have not been met. See log for details. -> [Help 1]
```