### PR TITLE
Use integer keys

### DIFF
--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -88,7 +88,6 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: std.rand.Random) !
                     K,
                     V,
                     V.key_from_value,
-                    V.key_compare,
                     page.values[0..],
                     target,
                     .{ .prefetch = prefetch },
@@ -139,10 +138,6 @@ fn Value(comptime layout: Layout) type {
 
         inline fn key_from_value(self: *const Self) Key {
             return self.key;
-        }
-
-        inline fn key_compare(a: Key, b: Key) math.Order {
-            return math.order(a, b);
         }
     };
 }

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -28,7 +28,6 @@ pub fn CacheMapType(
     comptime Value: type,
     comptime key_from_value: fn (*const Value) callconv(.Inline) Key,
     comptime hash_from_key: fn (Key) callconv(.Inline) u64,
-    comptime equal: fn (Key, Key) callconv(.Inline) bool,
     comptime tombstone_from_key: fn (Key) callconv(.Inline) Value,
     comptime tombstone: fn (*const Value) callconv(.Inline) bool,
 ) type {
@@ -37,7 +36,6 @@ pub fn CacheMapType(
         Value,
         key_from_value,
         hash_from_key,
-        equal,
         .{},
     );
 
@@ -45,7 +43,7 @@ pub fn CacheMapType(
         const Self = @This();
 
         pub inline fn eql(_: Self, a: Value, b: Value) bool {
-            return equal(key_from_value(&a), key_from_value(&b));
+            return key_from_value(&a) == key_from_value(&b);
         }
 
         pub inline fn hash(_: Self, value: Value) u64 {
@@ -350,10 +348,6 @@ pub const TestTable = struct {
     pub inline fn hash(key: TestTable.Key) u64 {
         return stdx.hash_inline(key);
     }
-
-    pub inline fn equal(a: TestTable.Key, b: TestTable.Key) bool {
-        return a == b;
-    }
 };
 
 pub const TestCacheMap = CacheMapType(
@@ -361,7 +355,6 @@ pub const TestCacheMap = CacheMapType(
     TestTable.Value,
     TestTable.key_from_value,
     TestTable.hash,
-    TestTable.equal,
     TestTable.tombstone_from_key,
     TestTable.tombstone,
 );

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -4,67 +4,63 @@ const math = std.math;
 
 const stdx = @import("../stdx.zig");
 
-pub fn CompositeKey(comptime Field: type) type {
-    assert(Field == u128 or Field == u64);
+pub fn CompositeKeyType(comptime Field: type) type {
+    // The type if zeroed padding is needed.
+    const pad = switch (Field) {
+        u128 => @as(u64, 0),
+        // [0]u8 as zero-sized-type workaround for https://github.com/ziglang/zig/issues/16394.
+        u64 => [0]u8{},
+        else => @compileError("invalid Field for CompositeKey: " ++ @typeName(Field)),
+    };
+    const Pad = @TypeOf(pad);
 
     return extern struct {
         const Self = @This();
 
-        pub const sentinel_key: Self = .{
+        pub const sentinel_key: Key = key_from_value(&.{
             .field = math.maxInt(Field),
             .timestamp = math.maxInt(u64),
-        };
+        });
 
-        const tombstone_bit = 1 << 63;
-
-        // The type if zeroed padding is needed after the timestamp field.
-        const pad = switch (Field) {
-            u128 => @as(u64, 0),
-            u64 => [0]u8{},
-            else => @compileError("invalid Field for CompositeKey: " ++ @typeName(Field)),
-        };
+        const tombstone_bit: u64 = 1 << 63;
 
         // u128 may be aligned to 8 instead of the expected 16.
         const field_bitsize_alignment = @divExact(@bitSizeOf(Field), 8);
 
-        pub const Value = Self;
+        pub const Key = std.meta.Int(
+            .unsigned,
+            @bitSizeOf(u64) + @bitSizeOf(Field) + @bitSizeOf(Pad),
+        );
 
         field: Field align(field_bitsize_alignment),
         /// The most significant bit must be unset as it is used to indicate a tombstone.
         timestamp: u64,
-        /// [0]u8 as zero-sized-type workaround for https://github.com/ziglang/zig/issues/16394.
-        padding: @TypeOf(pad) = pad,
+        padding: Pad = pad,
 
         comptime {
             assert(@sizeOf(Self) == @sizeOf(Field) * 2);
+            assert(@sizeOf(Self) == @sizeOf(Key));
             assert(@alignOf(Self) >= @alignOf(Field));
             assert(@alignOf(Self) == field_bitsize_alignment);
             assert(stdx.no_padding(Self));
         }
 
-        pub inline fn compare_keys(a: Self, b: Self) math.Order {
-            var order = std.math.order(a.field, b.field);
-            if (order == .eq) {
-                order = std.math.order(a.timestamp, b.timestamp);
-            }
-            return order;
+        pub inline fn key_from_value(value: *const Self) Key {
+            return @as(Key, value.timestamp & ~tombstone_bit) | (@as(Key, value.field) << 64);
         }
 
-        pub inline fn key_from_value(value: *const Value) Self {
-            return .{
-                .field = value.field,
-                .timestamp = @as(u63, @truncate(value.timestamp)),
-            };
-        }
-
-        pub inline fn tombstone(value: *const Value) bool {
+        pub inline fn tombstone(value: *const Self) bool {
             return (value.timestamp & tombstone_bit) != 0;
         }
 
-        pub inline fn tombstone_from_key(key: Self) Value {
+        pub inline fn tombstone_from_key(key: Key) Self {
+            const timestamp: u64 = @truncate(key);
+            const field: Field = @truncate(key >> 64);
+            assert(timestamp & tombstone_bit == 0);
+
             return .{
-                .field = key.field,
-                .timestamp = key.timestamp | tombstone_bit,
+                .field = field,
+                .timestamp = timestamp | tombstone_bit,
             };
         }
     };

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -89,11 +89,6 @@ pub fn main() !void {
                     return value.key;
                 }
             }.key_from_value,
-            struct {
-                inline fn compare_keys(a: Key, b: Key) std.math.Order {
-                    return std.math.order(a, b);
-                }
-            }.compare_keys,
             .{ .verify = false },
         );
 

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -32,7 +32,6 @@ pub fn SetAssociativeCacheType(
     comptime Value: type,
     comptime key_from_value: fn (*const Value) callconv(.Inline) Key,
     comptime hash: fn (Key) callconv(.Inline) u64,
-    comptime equal: fn (Key, Key) callconv(.Inline) bool,
     comptime layout: Layout,
 ) type {
     assert(math.isPowerOfTwo(@sizeOf(Key)));
@@ -266,7 +265,7 @@ pub fn SetAssociativeCacheType(
             var it = BitIterator(Ways){ .bits = ways };
             while (it.next()) |way| {
                 const count = self.counts.get(set.offset + way);
-                if (count > 0 and equal(key_from_value(&set.values[way]), key)) {
+                if (count > 0 and key_from_value(&set.values[way]) == key) {
                     return way;
                 }
             }
@@ -437,7 +436,6 @@ fn set_associative_cache_test(
         Value,
         context.key_from_value,
         context.hash,
-        context.equal,
         layout,
     );
 
@@ -562,9 +560,6 @@ test "SetAssociativeCache: eviction" {
         }
         inline fn hash(key: Key) u64 {
             return key;
-        }
-        inline fn equal(a: Key, b: Key) bool {
-            return a == b;
         }
     };
 
@@ -822,7 +817,6 @@ fn search_tags_test(comptime Key: type, comptime Value: type, comptime layout: L
         Value,
         context.key_from_value,
         context.hash,
-        context.equal,
         layout,
     );
 

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -10,7 +10,6 @@ pub fn TableMemoryType(comptime Table: type) type {
     const Key = Table.Key;
     const Value = Table.Value;
     const value_count_max = Table.value_count_max;
-    const compare_keys = Table.compare_keys;
     const key_from_value = Table.key_from_value;
 
     return struct {
@@ -83,10 +82,8 @@ pub fn TableMemoryType(comptime Table: type) type {
 
             if (table.value_context.sorted) {
                 table.value_context.sorted = table.value_context.count == 0 or
-                    compare_keys(
-                    key_from_value(&table.values[table.value_context.count - 1]),
-                    key_from_value(value),
-                ).compare(.lte);
+                    key_from_value(&table.values[table.value_context.count - 1]) <=
+                    key_from_value(value);
             } else {
                 assert(table.value_context.count > 0);
             }
@@ -117,14 +114,13 @@ pub fn TableMemoryType(comptime Table: type) type {
                 Key,
                 Value,
                 key_from_value,
-                compare_keys,
                 table.values_used(),
                 key,
                 .{ .mode = .upper_bound },
             );
             if (result.exact) {
                 const value = &table.values[result.index];
-                assert(compare_keys(key, key_from_value(value)) == .eq);
+                assert(key == key_from_value(value));
                 return value;
             }
 
@@ -169,7 +165,7 @@ pub fn TableMemoryType(comptime Table: type) type {
         }
 
         fn sort_values_by_key_in_ascending_order(_: void, a: Value, b: Value) bool {
-            return compare_keys(key_from_value(&a), key_from_value(&b)) == .lt;
+            return key_from_value(&a) < key_from_value(&b);
         }
 
         pub fn key_min(table: *const TableMemory) Key {

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -20,6 +20,7 @@ test {
     _ = @import("lsm/binary_search.zig");
     _ = @import("lsm/bloom_filter.zig");
     _ = @import("lsm/cache_map.zig");
+    _ = @import("lsm/composite_key.zig");
     _ = @import("lsm/forest.zig");
     _ = @import("lsm/forest_table_iterator.zig");
     _ = @import("lsm/groove.zig");

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -141,10 +141,6 @@ pub fn GridType(comptime Storage: type) type {
                 assert(address > 0);
                 return stdx.hash_inline(address);
             }
-
-            inline fn equal_addresses(a: u64, b: u64) bool {
-                return a == b;
-            }
         };
 
         const set_associative_cache_ways = 16;
@@ -154,7 +150,6 @@ pub fn GridType(comptime Storage: type) type {
             u64,
             cache_interface.address_from_address,
             cache_interface.hash_address,
-            cache_interface.equal_addresses,
             .{
                 .ways = set_associative_cache_ways,
                 .value_alignment = @alignOf(u64),


### PR DESCRIPTION
### This PR

Makes `Table.Key` always an integer type, removing the need for the `compare_keys` function.

**Rationale:** 

Removes unnecessary extra comparisons performed by `std.math.order` when we need to check only one condition, e.g. `a > b` instead of `std.math.order(a, b) == .gt`.

Future benefits may be explored when dealing with integer keys.

**Results:**

- Binary size decreased from 11757K to 10934K. Removing the inline function resulted in a **823K** smaller binary.

- Slightly better performance for both sequential and random IDs:

<table>
<th>
<td>Before</td><td>After</td>
</th>
<tr>
<td>Sequential IDs</td>
<td>
<pre>
Benchmarking...
info: Benchmark running against { 127.0.0.1:44605 }
info(message_bus): connected to replica 0
1226 batches in 59.76 s
load offered = 1000000 tx/s
load accepted = 167324 tx/s
batch latency p00 = 0 ms
batch latency p10 = 13 ms
batch latency p20 = 14 ms
batch latency p30 = 19 ms
batch latency p40 = 19 ms
batch latency p50 = 20 ms
batch latency p60 = 23 ms
batch latency p70 = 23 ms
batch latency p80 = 24 ms
batch latency p90 = 25 ms
batch latency p100 = 2494 ms
transfer latency p00 = 0 ms
transfer latency p10 = 3242 ms
transfer latency p20 = 6370 ms
transfer latency p30 = 10733 ms
transfer latency p40 = 15543 ms
transfer latency p50 = 20723 ms
transfer latency p60 = 26259 ms
transfer latency p70 = 31955 ms
transfer latency p80 = 38095 ms
transfer latency p90 = 44121 ms
transfer latency p100 = 49773 ms
</pre>
</td>
<td>
<pre>
Benchmarking...
info: Benchmark running against { 127.0.0.1:47107 }
info(message_bus): connected to replica 0
1226 batches in 58.06 s
load offered = 1000000 tx/s
load accepted = 172247 tx/s
batch latency p00 = 0 ms
batch latency p10 = 12 ms
batch latency p20 = 13 ms
batch latency p30 = 15 ms
batch latency p40 = 19 ms
batch latency p50 = 20 ms
batch latency p60 = 22 ms
batch latency p70 = 23 ms
batch latency p80 = 24 ms
batch latency p90 = 25 ms
batch latency p100 = 2684 ms
transfer latency p00 = 0 ms
transfer latency p10 = 2675 ms
transfer latency p20 = 5603 ms
transfer latency p30 = 9744 ms
transfer latency p40 = 14511 ms
transfer latency p50 = 19412 ms
transfer latency p60 = 25255 ms
transfer latency p70 = 30772 ms
transfer latency p80 = 36665 ms
transfer latency p90 = 42643 ms
transfer latency p100 = 48067 ms
</pre>
</td>
</tr>
<tr>
<td>Random IDs</td>
<td>
<pre>
Benchmarking...
info: Benchmark running against { 127.0.0.1:36915 }
info(message_bus): connected to replica 0
1226 batches in 68.28 s
load offered = 1000000 tx/s
load accepted = 146456 tx/s
batch latency p00 = 0 ms
batch latency p10 = 18 ms
batch latency p20 = 19 ms
batch latency p30 = 22 ms
batch latency p40 = 26 ms
batch latency p50 = 28 ms
batch latency p60 = 30 ms
batch latency p70 = 31 ms
batch latency p80 = 32 ms
batch latency p90 = 34 ms
batch latency p100 = 2824 ms
transfer latency p00 = 0 ms
transfer latency p10 = 3396 ms
transfer latency p20 = 6709 ms
transfer latency p30 = 12640 ms
transfer latency p40 = 18089 ms
transfer latency p50 = 24672 ms
transfer latency p60 = 30580 ms
transfer latency p70 = 37002 ms
transfer latency p80 = 44130 ms
transfer latency p90 = 51227 ms
transfer latency p100 = 58288 ms
</pre>
</td>
<td>
<pre>
Benchmarking...
info: Benchmark running against { 127.0.0.1:45447 }
info(message_bus): connected to replica 0
1226 batches in 66.87 s
load offered = 1000000 tx/s
load accepted = 149544 tx/s
batch latency p00 = 0 ms
batch latency p10 = 17 ms
batch latency p20 = 19 ms
batch latency p30 = 23 ms
batch latency p40 = 26 ms
batch latency p50 = 28 ms
batch latency p60 = 29 ms
batch latency p70 = 31 ms
batch latency p80 = 32 ms
batch latency p90 = 34 ms
batch latency p100 = 2506 ms
transfer latency p00 = 0 ms
transfer latency p10 = 3035 ms
transfer latency p20 = 6561 ms
transfer latency p30 = 11519 ms
transfer latency p40 = 16549 ms
transfer latency p50 = 23144 ms
transfer latency p60 = 29478 ms
transfer latency p70 = 35383 ms
transfer latency p80 = 42422 ms
transfer latency p90 = 49794 ms
transfer latency p100 = 56878 ms
</pre>
</td>
</tr>
</table>










 