### PR TITLE
Test/StateMachine: Match timestamp and timeout scale

### DIFF
--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -362,7 +362,8 @@ pub const AccountingAuditor = struct {
                     });
                     self.pending_expiries.add(.{
                         .transfer = transfer.id,
-                        .timestamp = transfer_timestamp + transfer.timeout,
+                        .timestamp = transfer_timestamp +
+                            @as(u64, transfer.timeout) * std.time.ns_per_s,
                     }) catch unreachable;
                     // PriorityQueue lacks an "unmanaged" API, so verify that the workload hasn't
                     // created more pending transfers than permitted.


### PR DESCRIPTION
Since `transfer.timeout` was changed from measuring nanoseconds to seconds (while `timestamp` remains nanoseconds), we must re-scale the units.

This was triggering many `unimplemented: timeouts` exits from the VOPR.