### PR TITLE
dotnet: better diagnostics when `tigerbeetle format` fails

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1128,9 +1128,16 @@ namespace TigerBeetle.Tests
         {
             CleanUp();
 
-            var format = Process.Start(TB_SERVER, FORMAT);
-            format.WaitForExit();
-            if (format.ExitCode != 0) throw new InvalidOperationException("format failed");
+            {
+                var format = new Process();
+                format.StartInfo.FileName = TB_SERVER;
+                format.StartInfo.Arguments = FORMAT;
+                format.StartInfo.RedirectStandardError = true;
+                format.Start();
+                var formatStderr = format.StandardError.ReadToEnd();
+                format.WaitForExit();
+                if (format.ExitCode != 0) throw new InvalidOperationException($"format failed, ExitCode={format.ExitCode} stderr:\n{formatStderr}");
+            }
 
             process = new Process();
             process.StartInfo.FileName = TB_SERVER;


### PR DESCRIPTION
I've seen `format` fail on CI without much info once:

https://github.com/tigerbeetle/tigerbeetle/actions/runs/6546186637/job/17776176142#step:5:96

Let's explicitly print the exit code and stderr.