### PR TITLE
vsr: align grid to block

### DIFF
--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -459,7 +459,10 @@ const superblock_trailer_client_sessions_size_max = blk: {
 
 /// The size of a data file that has an empty grid.
 pub const data_file_size_min =
-    superblock_zone_size + constants.journal_size + constants.client_replies_size;
+    superblock_zone_size +
+    constants.journal_size +
+    constants.client_replies_size +
+    vsr.Zone.size(.grid_padding).?;
 
 /// The maximum number of blocks in the grid.
 pub const grid_blocks_max = blk: {


### PR DESCRIPTION
Aligning blocks this way makes it more likely that they are aligned to the underlying physical sector size, and is plainly nicer. 

While doing that, I've noticed that we have divergent assertions between the real storage and the testing storage. While it a fun puzzle to ponder, which assertions are more important, from the testing storage, or from the real one, I decided to just merge the two :)