### PR TITLE
java: improve samples

### DIFF
--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -132,10 +132,12 @@ replica. The address is read from the `TB_ADDRESS`
 environment variable and defaults to port `3000`.
 
 ```java
-var tbAddress = System.getenv("TB_ADDRESS");
+var replicaAddress = System.getenv("TB_ADDRESS");
+int clusterID = 0;
+String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
 Client client = new Client(
-  0,
-  new String[] {tbAddress.length() > 0 ? tbAddress : "3000"}
+  clusterID,
+  replicaAddresses,
 );
 ```
 
@@ -147,8 +149,6 @@ syntax:
 ```java
 try (var client = new Client(...)) {
   // Use client
-} catch (Exception e) {
-  // Handle exception
 }
 ```
 

--- a/src/clients/java/docs.zig
+++ b/src/clients/java/docs.zig
@@ -220,10 +220,12 @@ pub const JavaDocs = Docs{
     .examples = "",
 
     .client_object_example =
-    \\var tbAddress = System.getenv("TB_ADDRESS");
+    \\var replicaAddress = System.getenv("TB_ADDRESS");
+    \\int clusterID = 0;
+    \\String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
     \\Client client = new Client(
-    \\  0,
-    \\  new String[] {tbAddress.length() > 0 ? tbAddress : "3000"}
+    \\  clusterID,
+    \\  replicaAddresses,
     \\);
     ,
 
@@ -236,8 +238,6 @@ pub const JavaDocs = Docs{
     \\```java
     \\try (var client = new Client(...)) {
     \\  // Use client
-    \\} catch (Exception e) {
-    \\  // Handle exception
     \\}
     \\```
     ,

--- a/src/clients/java/samples/basic/src/main/java/Main.java
+++ b/src/clients/java/samples/basic/src/main/java/Main.java
@@ -8,11 +8,11 @@ import com.tigerbeetle.*;
 public final class Main {
 	public static void main(String[] args)
 			throws RequestException, ConcurrencyExceededException {
-		var port = System.getenv("TB_ADDRESS");
-		if (port == null || port == "") {
-			port = "3000";
-		}
-		try (var client = new Client(0, new String[] { port })) {
+		String replicaAddress = System.getenv("TB_ADDRESS");
+
+		int clusterID = 0;
+		String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
+		try (var client = new Client(clusterID, replicaAddresses)) {
 			// Create two accounts
 			AccountBatch accounts = new AccountBatch(2);
 			accounts.add();
@@ -77,8 +77,6 @@ public final class Main {
 					assert false;
 				}
 			}
-		} catch (Exception e) {
-			assert e == null;
 		}
 	}
 }

--- a/src/clients/java/samples/two-phase-many/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase-many/src/main/java/Main.java
@@ -8,12 +8,11 @@ import com.tigerbeetle.*;
 public final class Main {
 	public static void main(String[] args)
 			throws RequestException, ConcurrencyExceededException {
-		var port = System.getenv("TB_ADDRESS");
-		if (port == null || port == "") {
-			port = "3000";
-		}
+		String replicaAddress = System.getenv("TB_ADDRESS");
 
-		try (var client = new Client(0, new String[] { port })) {
+		int clusterID = 0;
+		String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
+		try (var client = new Client(clusterID, replicaAddresses)) {
 			// Create two accounts
 			AccountBatch accounts = new AccountBatch(2);
 			accounts.add();
@@ -356,8 +355,6 @@ public final class Main {
 					assert false;
 				}
 			}
-		} catch (Exception e) {
-			assert e == null;
 		}
 	}
 }

--- a/src/clients/java/samples/two-phase/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase/src/main/java/Main.java
@@ -9,12 +9,11 @@ import com.tigerbeetle.*;
 public final class Main {
 	public static void main(String[] args)
 			throws RequestException, ConcurrencyExceededException {
-		var port = System.getenv("TB_ADDRESS");
-		if (port == null || port == "") {
-			port = "3000";
-		}
+		String replicaAddress = System.getenv("TB_ADDRESS");
 
-		try (var client = new Client(0, new String[] { port })) {
+		int clusterID = 0;
+		String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
+		try (var client = new Client(clusterID, replicaAddresses)) {
 			// Create two accounts
 			AccountBatch accounts = new AccountBatch(2);
 			accounts.add();
@@ -138,8 +137,6 @@ public final class Main {
 					assert false;
 				}
 			}
-		} catch (Exception e) {
-			assert e == null;
 		}
 	}
 }

--- a/src/clients/java/src/main/java/com/tigerbeetle/Client.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Client.java
@@ -252,7 +252,7 @@ public final class Client implements AutoCloseable {
      * @see java.lang.AutoCloseable#close()
      */
     @Override
-    public void close() throws Exception {
+    public void close() {
         nativeClient.close();
     }
 }

--- a/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
@@ -49,7 +49,7 @@ final class NativeClient {
         }
     }
 
-    public void close() throws Exception {
+    public void close() {
         if (contextHandle != 0L) {
             synchronized (this) {
                 if (contextHandle != 0L) {


### PR DESCRIPTION
Two changes here, one big and one small:

* Remove "throws Exception" from our close method. As per AutoClosable docs:

     While this interface method is declared to throw Exception,
     implementers are strongly encouraged to declare concrete
     implementations of the close method to throw more specific
     exceptions, or to throw no exception at all if the close operation
     cannot fail.

  Covariant return types for the win!

* Assign `ClusterID` name to the magical `0` constant.