### PR TITLE
LSM: Revert groove to use update + insert and vendor hasUniqueRepresentation

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -283,13 +283,17 @@ const Environment = struct {
         }
     }
 
-    fn put_account(env: *Environment, a: *const Account) void {
-        env.forest.grooves.accounts.upsert(a);
+    fn put_account(env: *Environment, a: *const Account, maybe_old: ?*const Account) void {
+        if (maybe_old) |old| {
+            env.forest.grooves.accounts.update(.{ .old = old, .new = a });
+        } else {
+            env.forest.grooves.accounts.insert(a);
+        }
     }
 
-    fn get_account(env: *Environment, id: u128) ?Account {
+    fn get_account(env: *Environment, id: u128) ?*const Account {
         const account = env.forest.grooves.accounts.get(id) orelse return null;
-        return account.*;
+        return account;
     }
 
     // The forest should behave like a simple key-value data-structure.
@@ -441,8 +445,7 @@ const Environment = struct {
                             env.forest.grooves.accounts.objects_cache.options.map_value_count_max;
 
                         if (log_index % groove_map_value_count_max == 0) {
-                            env.forest.grooves.accounts_immutable.objects_cache.compact();
-                            env.forest.grooves.accounts_mutable.objects_cache.compact();
+                            env.forest.grooves.accounts.objects_cache.compact();
                         }
                     }
                 }
@@ -463,7 +466,8 @@ const Environment = struct {
             .put_account => |put| {
                 // The forest requires prefetch before put.
                 try env.prefetch_account(put.account.id);
-                env.put_account(&put.account);
+                const lsm_account = env.get_account(put.account.id);
+                env.put_account(&put.account, lsm_account);
                 try model.put_account(&put.account, put.op);
             },
             .get_account => |id| {

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -890,7 +890,13 @@ pub fn GrooveType(
 
         /// Update the value. Requires the old object to be provided.
         /// Update the object and index trees by diff'ing the old and new values.
-        pub fn update(groove: *Groove, new: *const Object, old: *const Object) void {
+        pub fn update(
+            groove: *Groove,
+            values: struct { old: *const Object, new: *const Object },
+        ) void {
+            const old = values.old;
+            const new = values.new;
+
             if (constants.verify) {
                 const old_from_cache = groove.objects_cache.get(@field(old, primary_field)).?;
                 assert(@field(old_from_cache, primary_field) == @field(old, primary_field));

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -910,9 +910,7 @@ pub fn GrooveType(
             // Sanity check to ensure the caller didn't accidentally pass in an alias.
             assert(new != old);
 
-            if (has_id) {
-                assert(old.id == new.id);
-            }
+            if (has_id) assert(old.id == new.id);
             assert(old.timestamp == new.timestamp);
 
             // The ID can't change, so no need to update the ID tree. Update the object tree entry
@@ -950,8 +948,8 @@ pub fn GrooveType(
 
             // Putting the objects_cache upsert after the index tree updates is critical:
             // We diff the old and new objects, but the old object will be a pointer into the
-            // objects_cache. If we upsert first, old.* == new.* and no secondary indexes will
-            // be updated!
+            // objects_cache. If we upsert first, there's a high chance old.* == new.* (always,
+            // unless old comes from the stash) and no secondary indexes will be updated!
             groove.objects_cache.upsert(new);
             groove.objects.put(new);
         }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1398,16 +1398,16 @@ fn check(test_table: []const u8) !void {
             .setup => |b| {
                 assert(operation == null);
 
-                var account = context.state_machine.forest.grooves.accounts.get(b.account).?.*;
-                var account_new = account;
+                var account = context.state_machine.forest.grooves.accounts.get(b.account).?;
+                var account_new = account.*;
 
                 account_new.debits_pending = b.debits_pending;
                 account_new.debits_posted = b.debits_posted;
                 account_new.credits_pending = b.credits_pending;
                 account_new.credits_posted = b.credits_posted;
-                if (!stdx.equal_bytes(Account, &account_new, &account)) {
+                if (!stdx.equal_bytes(Account, &account_new, account)) {
                     context.state_machine.forest.grooves.accounts.update(.{
-                        .old = &account,
+                        .old = account,
                         .new = &account_new,
                     });
                 }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -876,8 +876,8 @@ pub fn StateMachineType(
                 dr_account_new.debits_posted += amount;
                 cr_account_new.credits_posted += amount;
             }
-            self.forest.grooves.accounts.update(&dr_account_new, dr_account);
-            self.forest.grooves.accounts.update(&cr_account_new, cr_account);
+            self.forest.grooves.accounts.update(.{ .old = dr_account, .new = &dr_account_new });
+            self.forest.grooves.accounts.update(.{ .old = cr_account, .new = &cr_account_new });
 
             self.commit_timestamp = t.timestamp;
             return .ok;
@@ -1006,8 +1006,8 @@ pub fn StateMachineType(
                 cr_account_new.credits_posted += amount;
             }
 
-            self.forest.grooves.accounts.update(&dr_account_new, dr_account);
-            self.forest.grooves.accounts.update(&cr_account_new, cr_account);
+            self.forest.grooves.accounts.update(.{ .old = dr_account, .new = &dr_account_new });
+            self.forest.grooves.accounts.update(.{ .old = cr_account, .new = &cr_account_new });
 
             self.commit_timestamp = t.timestamp;
             return .ok;
@@ -1406,7 +1406,10 @@ fn check(test_table: []const u8) !void {
                 account_new.credits_pending = b.credits_pending;
                 account_new.credits_posted = b.credits_posted;
                 if (!stdx.equal_bytes(Account, &account_new, &account)) {
-                    context.state_machine.forest.grooves.accounts.update(&account_new, &account);
+                    context.state_machine.forest.grooves.accounts.update(.{
+                        .old = &account,
+                        .new = &account_new,
+                    });
                 }
             },
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1405,7 +1405,9 @@ fn check(test_table: []const u8) !void {
                 account_new.debits_posted = b.debits_posted;
                 account_new.credits_pending = b.credits_pending;
                 account_new.credits_posted = b.credits_posted;
-                context.state_machine.forest.grooves.accounts.update(&account_new, &account);
+                if (!stdx.equal_bytes(Account, &account_new, &account)) {
+                    context.state_machine.forest.grooves.accounts.update(&account_new, &account);
+                }
             },
 
             .tick => |ticks| {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -876,8 +876,8 @@ pub fn StateMachineType(
                 dr_account_new.debits_posted += amount;
                 cr_account_new.credits_posted += amount;
             }
-            self.forest.grooves.accounts.upsert(&dr_account_new);
-            self.forest.grooves.accounts.upsert(&cr_account_new);
+            self.forest.grooves.accounts.update(&dr_account_new, dr_account);
+            self.forest.grooves.accounts.update(&cr_account_new, cr_account);
 
             self.commit_timestamp = t.timestamp;
             return .ok;
@@ -1006,8 +1006,8 @@ pub fn StateMachineType(
                 cr_account_new.credits_posted += amount;
             }
 
-            self.forest.grooves.accounts.upsert(&dr_account_new);
-            self.forest.grooves.accounts.upsert(&cr_account_new);
+            self.forest.grooves.accounts.update(&dr_account_new, dr_account);
+            self.forest.grooves.accounts.update(&cr_account_new, cr_account);
 
             self.commit_timestamp = t.timestamp;
             return .ok;
@@ -1399,11 +1399,13 @@ fn check(test_table: []const u8) !void {
                 assert(operation == null);
 
                 var account = context.state_machine.forest.grooves.accounts.get(b.account).?.*;
-                account.debits_pending = b.debits_pending;
-                account.debits_posted = b.debits_posted;
-                account.credits_pending = b.credits_pending;
-                account.credits_posted = b.credits_posted;
-                context.state_machine.forest.grooves.accounts.upsert(&account);
+                var account_new = account;
+
+                account_new.debits_pending = b.debits_pending;
+                account_new.debits_posted = b.debits_posted;
+                account_new.credits_pending = b.credits_pending;
+                account_new.credits_posted = b.credits_posted;
+                context.state_machine.forest.grooves.accounts.update(&account_new, &account);
             },
 
             .tick => |ticks| {

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -545,7 +545,7 @@ pub fn has_unique_representation(comptime T: type) bool {
         .Struct => |info| {
             // Only consider packed structs unique if they are byte aligned.
             if (info.backing_integer) |backing_integer| {
-                return @sizeOf(@Type(.{ .Struct = info })) * 8 == @bitSizeOf(backing_integer);
+                return @sizeOf(T) * 8 == @bitSizeOf(backing_integer);
             }
 
             var sum_size = @as(usize, 0);

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -242,7 +242,7 @@ else
 ///   - `T` doesn't have any non-deterministic padding,
 ///   - `T` doesn't embed any pointers.
 pub fn equal_bytes(comptime T: type, a: *const T, b: *const T) bool {
-    comptime assert(hasUniqueRepresentation(T));
+    comptime assert(has_unique_representation(T));
     comptime assert(!has_pointers(T));
     comptime assert(@sizeOf(T) * 8 == @bitSizeOf(T));
 
@@ -339,7 +339,7 @@ test no_padding {
 pub inline fn hash_inline(value: anytype) u64 {
     comptime {
         assert(no_padding(@TypeOf(value)));
-        assert(hasUniqueRepresentation(@TypeOf(value)));
+        assert(has_unique_representation(@TypeOf(value)));
     }
     return low_level_hash(0, switch (@typeInfo(@TypeOf(value))) {
         .Struct, .Int => std.mem.asBytes(&value),
@@ -524,7 +524,7 @@ pub fn fstatfs(fd: i32, statfs_buf: *StatFs) usize {
 // TODO(Zig): https://github.com/ziglang/zig/issues/17592.
 /// True if every value of the type `T` has a unique bit pattern representing it.
 /// In other words, `T` has no unused bits and no padding.
-pub fn hasUniqueRepresentation(comptime T: type) bool {
+pub fn has_unique_representation(comptime T: type) bool {
     switch (@typeInfo(T)) {
         else => return false, // TODO can we know if it's true for some of these types ?
 
@@ -540,26 +540,133 @@ pub fn hasUniqueRepresentation(comptime T: type) bool {
 
         .Pointer => |info| return info.size != .Slice,
 
-        .Array => |info| return comptime hasUniqueRepresentation(info.child),
+        .Array => |info| return comptime has_unique_representation(info.child),
 
         .Struct => |info| {
-            // Packed structs are always unique.
-            if (info.backing_integer != null) {
-                return true;
+            // Only consider packed structs unique if they are byte aligned.
+            if (info.backing_integer) |backing_integer| {
+                return @sizeOf(@Type(.{ .Struct = info })) * 8 == @bitSizeOf(backing_integer);
             }
 
             var sum_size = @as(usize, 0);
 
             inline for (info.fields) |field| {
                 const FieldType = field.type;
-                if (comptime !hasUniqueRepresentation(FieldType)) return false;
+                if (comptime !has_unique_representation(FieldType)) return false;
                 sum_size += @sizeOf(FieldType);
             }
 
             return @sizeOf(T) == sum_size;
         },
 
-        .Vector => |info| return comptime hasUniqueRepresentation(info.child) and
+        .Vector => |info| return comptime has_unique_representation(info.child) and
             @sizeOf(T) == @sizeOf(info.child) * info.len,
     }
+}
+
+// Test vectors mostly from upstream, with some added to test the packed struct case.
+test "has_unique_representation" {
+    const TestStruct1 = struct {
+        a: u32,
+        b: u32,
+    };
+
+    try std.testing.expect(has_unique_representation(TestStruct1));
+
+    const TestStruct2 = struct {
+        a: u32,
+        b: u16,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestStruct2));
+
+    const TestStruct3 = struct {
+        a: u32,
+        b: u32,
+    };
+
+    try std.testing.expect(has_unique_representation(TestStruct3));
+
+    const TestStruct4 = struct { a: []const u8 };
+
+    try std.testing.expect(!has_unique_representation(TestStruct4));
+
+    const TestStruct5 = struct { a: TestStruct4 };
+
+    try std.testing.expect(!has_unique_representation(TestStruct5));
+
+    const TestStruct6 = packed struct {
+        a: u32,
+        b: u31,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestStruct6));
+
+    const TestStruct7 = struct {
+        a: u64,
+        b: TestStruct6,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestStruct7));
+
+    const TestStruct8 = packed struct {
+        a: u32,
+        b: u32,
+    };
+
+    try std.testing.expect(has_unique_representation(TestStruct8));
+
+    const TestStruct9 = struct {
+        a: u64,
+        b: TestStruct8,
+    };
+
+    try std.testing.expect(has_unique_representation(TestStruct9));
+
+    const TestStruct10 = packed struct {
+        a: TestStruct8,
+        b: TestStruct8,
+    };
+
+    try std.testing.expect(has_unique_representation(TestStruct10));
+
+    const TestUnion1 = packed union {
+        a: u32,
+        b: u16,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestUnion1));
+
+    const TestUnion2 = extern union {
+        a: u32,
+        b: u16,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestUnion2));
+
+    const TestUnion3 = union {
+        a: u32,
+        b: u16,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestUnion3));
+
+    const TestUnion4 = union(enum) {
+        a: u32,
+        b: u16,
+    };
+
+    try std.testing.expect(!has_unique_representation(TestUnion4));
+
+    inline for ([_]type{ i0, u8, i16, u32, i64 }) |T| {
+        try std.testing.expect(has_unique_representation(T));
+    }
+    inline for ([_]type{ i1, u9, i17, u33, i24 }) |T| {
+        try std.testing.expect(!has_unique_representation(T));
+    }
+
+    try std.testing.expect(!has_unique_representation([]u8));
+    try std.testing.expect(!has_unique_representation([]const u8));
+
+    try std.testing.expect(has_unique_representation(@Vector(4, u16)));
 }

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -167,7 +167,7 @@ pub fn StateMachineType(
                     const thing = state_machine.forest.grooves.things.get(op);
                     assert(thing == null);
 
-                    state_machine.forest.grooves.things.upsert(&.{
+                    state_machine.forest.grooves.things.insert(&.{
                         .timestamp = timestamp,
                         .id = op,
                         .value = @as(u64, @truncate(vsr.checksum(input))),

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -64,6 +64,11 @@ fn banned(source: []const u8) ?[]const u8 {
     if (std.mem.indexOf(u8, source, "std." ++ "BoundedArray") != null) {
         return "use stdx." ++ "BoundedArray instead of std version";
     }
+
+    if (std.mem.indexOf(u8, source, "trait." ++ "hasUniqueRepresentation") != null) {
+        return "use stdx." ++ "hasUniqueRepresentation instead of std version";
+    }
+
     return null;
 }
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -66,7 +66,7 @@ fn banned(source: []const u8) ?[]const u8 {
     }
 
     if (std.mem.indexOf(u8, source, "trait." ++ "hasUniqueRepresentation") != null) {
-        return "use stdx." ++ "hasUniqueRepresentation instead of std version";
+        return "use stdx." ++ "has_unique_representation instead of std version";
     }
 
     return null;


### PR DESCRIPTION
# Motivation
Whenever we update an object, we always have the old object around. Previously, we used to do a lookup to find the old one in any case, to give a simpler `upsert` function signature to the state machine - but this was resulting in duplicated work.

# Changes
Revert that, going back to having an explicit `update` and `insert` with the state machine choosing which is better for its needs. Additionally, switch to using `stdx.equal_bytes` in the Groove `update` hot path. This required vendoring a small fix for https://github.com/ziglang/zig/issues/17592.



# Benchmarks
These two things combined give a nice performance bump:

```sh
# on tmpfs
./scripts/benchmark.sh --print-batch-timings --transfer-count=10_000_000 --account-count=10 --id-order=sequential
```

Before:
```
1362 batches in 29.25 s
load offered = 1000000 tx/s
load accepted = 341867 tx/s
```

After:
```
1356 batches in 25.52 s
load offered = 1000000 tx/s
load accepted = 391846 tx/s
```