### PR TITLE
LSM: Approximate pacing

### DIFF
--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -36,7 +36,7 @@ rm -f aof-test.tigerbeetle
 rm -f aof-test.tigerbeetle.aof
 
 ./tigerbeetle-aof format --cluster=0 --replica=0 --replica-count=1 aof-test.tigerbeetle > aof.log 2>&1
-./tigerbeetle-aof start --cache-grid=256MB --addresses=3001 aof-test.tigerbeetle >> aof.log 2>&1 &
+./tigerbeetle-aof start --cache-grid=512MB --addresses=3001 aof-test.tigerbeetle >> aof.log 2>&1 &
 
 # Wait for replicas to start, listen and connect:
 sleep 1
@@ -58,12 +58,12 @@ rm -rf 1 2
 
 mkdir 1 && cd 1
 ../tigerbeetle-aof-recovery format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MB --addresses=3001,3002 aof-test.tigerbeetle >> aof.log 2>&1 &
+../tigerbeetle-aof-recovery start --cache-grid=512MB --addresses=3001,3002 aof-test.tigerbeetle >> aof.log 2>&1 &
 cd ..
 
 mkdir 2 && cd 2
 ../tigerbeetle-aof-recovery format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MB --addresses=3001,3002 aof-test.tigerbeetle >> aof.log 2>&1 &
+../tigerbeetle-aof-recovery start --cache-grid=512MB --addresses=3001,3002 aof-test.tigerbeetle >> aof.log 2>&1 &
 cd ..
 
 # mkdir 3 && cd 3

--- a/docs/quick-start/with-docker-compose.md
+++ b/docs/quick-start/with-docker-compose.md
@@ -122,7 +122,7 @@ Podman for macOS), try increasing the virtual machine memory limit.
 
 Alternatively, in a development environment, you can lower the size of
 the cache so TigerBeetle uses less memory. For example, set
-`--cache-grid=256MB` when running `tigerbeetle start`.
+`--cache-grid=512MB` when running `tigerbeetle start`.
 
 ## Debugging panics
 

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1118,7 +1118,7 @@ namespace TigerBeetle.Tests
         private const string TB_FILE = "dotnet-tests.tigerbeetle";
         private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
         private const string FORMAT = $"format --cluster=0 --replica=0 --replica-count=1 ./" + TB_FILE;
-        private const string START = $"start --addresses=0  --cache-grid=256MB ./" + TB_FILE;
+        private const string START = $"start --addresses=0  --cache-grid=512MB ./" + TB_FILE;
 
         private readonly Process process;
 

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -37,7 +37,7 @@ func WithClient(s testing.TB, withClient func(Client)) {
 	}
 
 	addressArg := "--addresses=" + TIGERBEETLE_PORT
-	cacheSizeArg := "--cache-grid=256MB"
+	cacheSizeArg := "--cache-grid=512MB"
 	replicaArg := fmt.Sprintf("--replica=%d", TIGERBEETLE_REPLICA_ID)
 	replicaCountArg := fmt.Sprintf("--replica-count=%d", TIGERBEETLE_REPLICA_COUNT)
 	clusterArg := fmt.Sprintf("--cluster=%d", TIGERBEETLE_CLUSTER_ID)

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1367,7 +1367,7 @@ public class IntegrationTest {
             }
 
             this.process = new ProcessBuilder().command(
-                    new String[] {exe, "start", "--addresses=0", TB_FILE, "--cache-grid=256MB"})
+                    new String[] {exe, "start", "--addresses=0", TB_FILE, "--cache-grid=512MB"})
                     .redirectError(Redirect.PIPE).start();
 
             if (process.waitFor(100, TimeUnit.MILLISECONDS))

--- a/src/config.zig
+++ b/src/config.zig
@@ -137,10 +137,10 @@ const ConfigCluster = struct {
     message_size_max: usize = 1 * 1024 * 1024,
     superblock_copies: comptime_int = 4,
     storage_size_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
-    block_size: comptime_int = 128 * 1024,
+    block_size: comptime_int = 1024 * 1024,
     lsm_levels: u6 = 7,
     lsm_growth_factor: u32 = 8,
-    lsm_batch_multiple: comptime_int = 64,
+    lsm_batch_multiple: comptime_int = 32,
     lsm_snapshots_max: usize = 32,
 
     /// The WAL requires at least two sectors of redundant headers — otherwise we could lose them all to

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -68,7 +68,7 @@ pub fn init(
 
     // Pass `--addresses=0` to let the OS pick a port for us.
     var process = try shell.spawn(
-        "{tigerbeetle} start --cache-grid=256MB --addresses=0 {data_file}",
+        "{tigerbeetle} start --cache-grid=512MB --addresses=0 {data_file}",
         .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
     );
     errdefer {

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -152,6 +152,10 @@ pub fn GridType(comptime Storage: type) type {
             cache_interface.hash_address,
             .{
                 .ways = set_associative_cache_ways,
+                // TODO: This is temporary, until compaction pacing is merged. Use a sub-optimal
+                // cache line size, since combined with the large block size of 1MB, we would
+                // require a 2GB grid cache minimum otherwise.
+                .cache_line_size = 16,
                 .value_alignment = @alignOf(u64),
             },
         );


### PR DESCRIPTION
Until compaction IO pacing lands, we'll show higher p100 latencies than we should, since we're not properly distributing work across the bar.

In the meantime, bump up our block size to 1MB and decrease `lsm_batch_multiple` to 32. This has the effect of approximating pacing; since {1-3} blocks are done per beat regardless. The end result is a nice decrease in p100 latencies, at least until a few levels have filled up. The only remaining spikes are due to CPU compaction and checkpoint work.

## Grid cache impact
With the new, (very) large block size, we also need to make a compromise on our Grid cache - otherwise with the current minimum size of 2048 objects, it would require at least 2GB of RAM for the Grid cache alone. 

Lower the `cache_line_size` to a sub-optimal 16; it has less impact on performance (~2%)  than lowering the number of ways.

# Benchmarks
```
# On NVMe
./scripts/benchmark.sh --print-batch-timings --transfer-count=10_000_000 --account-count=10 --id-order=sequential
```

## Before
```
1266 batches in 48.07 s
load offered = 1000000 tx/s
load accepted = 208011 tx/s
batch latency p00 = 0 ms
batch latency p10 = 5 ms
batch latency p20 = 5 ms
batch latency p30 = 6 ms
batch latency p40 = 7 ms
batch latency p50 = 7 ms
batch latency p60 = 8 ms
batch latency p70 = 9 ms
batch latency p80 = 10 ms
batch latency p90 = 12 ms
batch latency p100 = 2954 ms
transfer latency p00 = 0 ms
transfer latency p10 = 1169 ms
transfer latency p20 = 4141 ms
transfer latency p30 = 7364 ms
transfer latency p40 = 11636 ms
transfer latency p50 = 16378 ms
transfer latency p60 = 21089 ms
transfer latency p70 = 26211 ms
transfer latency p80 = 31996 ms
transfer latency p90 = 33857 ms
transfer latency p100 = 38091 ms
```

## After
```
1243 batches in 41.73 s
load offered = 1000000 tx/s
load accepted = 239645 tx/s
batch latency p00 = 1 ms
batch latency p10 = 5 ms
batch latency p20 = 6 ms
batch latency p30 = 8 ms
batch latency p40 = 13 ms
batch latency p50 = 15 ms
batch latency p60 = 17 ms
batch latency p70 = 19 ms
batch latency p80 = 21 ms
batch latency p90 = 25 ms
batch latency p100 = 829 ms
transfer latency p00 = 1 ms
transfer latency p10 = 1762 ms
transfer latency p20 = 4226 ms
transfer latency p30 = 7265 ms
transfer latency p40 = 10305 ms
transfer latency p50 = 12667 ms
transfer latency p60 = 16133 ms
transfer latency p70 = 20150 ms
transfer latency p80 = 24443 ms
transfer latency p90 = 28760 ms
transfer latency p100 = 31738 ms
```
