### PR TITLE
Fix bootstrap.{sh,ps1} asset paths

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -19,7 +19,7 @@ if ($build) {
     echo "Downloading pre-built TigerBeetle binary for your machine."
     echo ""
 
-    curl.exe -Lo tigerbeetle.zip "https://github.com/tigerbeetle/tigerbeetle/releases/download/$version/tigerbeetle-x86_64-windows-$version.zip"
+    curl.exe -Lo tigerbeetle.zip "https://github.com/tigerbeetle/tigerbeetle/releases/download/$version/tigerbeetle-x86_64-windows.zip"
     unzip -qo tigerbeetle.zip
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,8 +33,8 @@
 	    exit 1
 	fi
 
-	curl -sLO "https://github.com/tigerbeetle/tigerbeetle/releases/download/$version/tigerbeetle-$arch-$os-$version.zip"
-	unzip -qo "tigerbeetle-$arch-$os-$version.zip"
+	curl -sLO "https://github.com/tigerbeetle/tigerbeetle/releases/download/$version/tigerbeetle-$arch-$os.zip"
+	unzip -qo "tigerbeetle-$arch-$os.zip"
 	chmod +x tigerbeetle
     else
 	echo "Building TigerBeetle binary from source for your machine."


### PR DESCRIPTION
Thanks @rbino for reporting.

With our new release process, the assets no longer have the version number in them.