### PR TITLE
ci: fix docker publish

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -653,8 +653,11 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
         }
         try shell.exec(
             \\docker buildx build --file tools/docker/Dockerfile . --platform linux/amd64,linux/arm64
-            \\   --tag ghcr.io/tigerbeetle/tigerbeetle:{version} --push
-        , .{ .version = info.version });
+            \\   --tag ghcr.io/tigerbeetle/tigerbeetle:{version}{debug} --push
+        , .{
+            .version = info.version,
+            .debug = if (debug) "-debug" else "",
+        });
 
         // Sadly, there isn't an easy way to locally build & test a multiplatform image without
         // pushing it out to the registry first. As docker testing isn't covered under not rocket


### PR DESCRIPTION
- include `-debug` in the image tag if appropriate
- don't fail due to `0.14.155: Pulling from tigerbeetle/tigerbeetle` output on stderr from Docker over here:

  https://github.com/tigerbeetle/tigerbeetle/blob/468007a0a37c3646f2bb6ace5cabe27ed7eba7b8/src/scripts/release.zig#L662-L666