### PR TITLE
LSM/ManifestLog: Manifest block count upper-bound

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -142,6 +142,7 @@ const ConfigCluster = struct {
     lsm_growth_factor: u32 = 8,
     lsm_batch_multiple: comptime_int = 32,
     lsm_snapshots_max: usize = 32,
+    lsm_manifest_compact_extra_blocks: comptime_int = 1,
 
     /// The WAL requires at least two sectors of redundant headers — otherwise we could lose them all to
     /// a single torn write. A replica needs at least one valid redundant header to determine an
@@ -260,6 +261,8 @@ pub const configs = struct {
             .block_size = sector_size,
             .lsm_batch_multiple = 4,
             .lsm_growth_factor = 4,
+            // (This is higher than the production default value because the block size is smaller.)
+            .lsm_manifest_compact_extra_blocks = 5,
         },
     };
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -508,6 +508,25 @@ pub const lsm_growth_factor = config.cluster.lsm_growth_factor;
 /// TODO Double-check this with our "LSM Manifest" spreadsheet.
 pub const lsm_manifest_node_size = config.process.lsm_manifest_node_size;
 
+/// The number of manifest blocks to compact *beyond the minimum*, per half-bar.
+///
+/// In the worst case, we still compact entries faster than we produce them (by a margin of
+/// "extra" blocks). This is necessary to ensure that the manifest has a bounded number of entries.
+/// (Or in other words, that Pace's recurrence relation converges.)
+///
+/// This specific choice of value is somewhat arbitrary, but yields a decent balance between
+/// "compaction work performed" and "total manifest size".
+///
+/// As this value increases, the manifest must perform more compaction work, but the manifest
+/// upper-bound shrinks (and therefore manifest recovery time decreases).
+///
+/// See ManifestLog.Pace for more detail.
+pub const lsm_manifest_compact_extra_blocks = config.cluster.lsm_manifest_compact_extra_blocks;
+
+comptime {
+    assert(lsm_manifest_compact_extra_blocks > 0);
+}
+
 /// A multiple of batch inserts that a mutable table can definitely accommodate before flushing.
 /// For example, if a message_size_max batch can contain at most 8181 transfers then a multiple of 4
 /// means that the transfer tree's mutable table will be sized to 8191 * 4 = 32764 transfers.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -13,6 +13,7 @@ const schema = @import("schema.zig");
 const GridType = @import("../vsr/grid.zig").GridType;
 const NodePool = @import("node_pool.zig").NodePool(constants.lsm_manifest_node_size, 16);
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
+const table_count_max = @import("tree.zig").table_count_max;
 
 pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
     var groove_fields: []const std.builtin.Type.StructField = &.{};
@@ -194,6 +195,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             var manifest_log = try ManifestLog.init(allocator, grid, .{
                 .tree_id_min = tree_id_range.min,
                 .tree_id_max = tree_id_range.max,
+                // TODO Make this a runtime argument (from the CLI, derived from storage-size-max if
+                // possible).
+                .forest_table_count_max = table_count_max,
             });
             errdefer manifest_log.deinit(allocator);
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -73,6 +73,7 @@ const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
 const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Value));
 const value_count_max = constants.lsm_batch_multiple * commit_entries_max;
 const snapshot_latest = @import("tree.zig").snapshot_latest;
+const table_count_max = @import("tree.zig").table_count_max;
 
 const cluster = 32;
 const replica = 4;
@@ -151,6 +152,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.manifest_log = try ManifestLog.init(allocator, &env.grid, .{
                 .tree_id_min = 1,
                 .tree_id_max = 1,
+                .forest_table_count_max = table_count_max,
             });
             defer env.manifest_log.deinit(allocator);
 


### PR DESCRIPTION

## Summary

(Borrowed from docs):

> The goals of manifest log compaction are (in no particular order):
>
> 1. Free enough manifest blocks such that there are always enough free slots in the manifest
>    trailer to accommodate the appends by table compaction.
> 2. Shrink the manifest: A smaller manifest means that fewer blocks need to be replayed during
>    recovery, or repaired during state sync.
> 3. Don't shrink the manifest too much: The more manifest compaction work is deferred, the more
>    "efficient" compaction is. Put another way: deferring manifest compaction means that more
>    entries are freed per block compacted.
> 4. Spread compaction work evenly between half-bars, to avoid latency spikes.
>
> To address goal 1, we must (on average) "remove" as many blocks from the manifest log as we add.
> But when we compact a block, only a subset of its entries can be freed/dropped – the remainder
> must be re-appended to the manifest log.
>
> The upper-bound number of manifest blocks is related to the rate at which we compact blocks.
> Put simply, the more compaction work we do, the smaller the upper bound.

Prior to this PR:
1. The maximum number of manifest blocks has been hard-coded at 65536.
2. We compact exactly one manifest block per half-bar.

But the current state of things is not ideal. In particular:
1. We had no guarantee that manifest compaction was doing enough work to avoid eventually running out of space. (It wasn't!)
2. One block per half-bar is more than enough when the forest is small, but as trees fill up their lower levels, it falls behind.

This commit solves both issues – the upper bound and compaction pacing – by leveraging the relationship between the two factors.

More specifically:
- the maximum compaction rate is now defined in terms of the number of blocks appended per half-bar
- the manifest block count upper bound is defined in terms of the compaction rate

For details, check out the (very long) explanation in `manifest_log.zig`. 

## Compaction vs Upper Bound

This chart plots the manifest upper-bound block count (Y axis) against the number of _extra_ blocks compacted per half-bar (i.e. the number of blocks compacted beyond the absolute minimum required for an upper bound to exist at all).

Caveats:
- This chart assumes a 128 KiB block size, not the 1 MiB block size that is currently in `main`.
- In order to keep the calculation (relatively) simple, several factors are ignored, resulting in the upper bound being overestimated. See `manifest_log.zig` for details.

![Screenshot 2023-10-25 at 09-57-19 Scratch](https://github.com/tigerbeetle/tigerbeetle/assets/461112/6b90d140-e364-43cf-9aba-8e60fb8cf9e3)

<details>
<summary>Data</summary>

`lsm_manifest_compact_extra_blocks` | `log_blocks_max`
--: | --:
1 | 9439
2 | 6163
3 | 4972
4 | 4330
5 | 3928
6 | 3646
7 | 3436
8 | 3277
9 | 3148
10 | 3043
11 | 2956
12 | 2884
13 | 2821
14 | 2764
15 | 2719
16 | 2677
17 | 2638
18 | 2605
19 | 2575
20 | 2548
21 | 2521
22 | 2500
23 | 2479
24 | 2458
25 | 2440
26 | 2425
27 | 2410
28 | 2395
29 | 2383

</details>

### Default

I selected `1` as the default production `constants.lsm_manifest_compact_extra_blocks`.

My reasoning is that optimizing throughput is a higher priority than optimizing time-to-recover.
