### PR TITLE
LSM/ManifestNode: Move Label into TableInfo

### DIFF
--- a/src/lsm/forest_table_iterator.zig
+++ b/src/lsm/forest_table_iterator.zig
@@ -87,7 +87,7 @@ pub fn ForestTableIteratorType(comptime Forest: type) type {
                                     // Dummy event, doesn't really mean anything in this context.
                                     // (We are reusing the schema's TableInfo type since it is
                                     // shared by all Tree types.)
-                                    .event = .insert,
+                                    .event = .reserved,
                                 });
                             }
                         },

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -369,6 +369,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 entry -= 1;
 
                 const table = &tables_used[entry];
+                assert(table.label.event != .reserved);
                 assert(table.tree_id >= manifest_log.options.tree_id_min);
                 assert(table.tree_id <= manifest_log.options.tree_id_max);
                 assert(table.address > 0);
@@ -458,6 +459,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(!manifest_log.writing);
 
             switch (table.label.event) {
+                .reserved => unreachable,
                 .insert => assert(manifest_log.table_extents.get(table.address) == null),
                 // For updates + removes, the table must have previously been inserted into the log:
                 .update => assert(manifest_log.table_extents.get(table.address) != null),
@@ -515,6 +517,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             const block_address = block_header.op;
 
             switch (table.label.event) {
+                .reserved => unreachable,
                 .insert,
                 .update,
                 => {
@@ -749,6 +752,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             ) |*table, entry_index| {
                 const entry: u32 = @intCast(entry_index);
                 switch (table.label.event) {
+                    .reserved => unreachable,
                     // Append the table, updating the table extent:
                     .insert,
                     .update,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -56,11 +56,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
 
         pub const Callback = *const fn (manifest_log: *ManifestLog) void;
 
-        pub const OpenEvent = *const fn (
-            manifest_log: *ManifestLog,
-            level: u6,
-            table: *const TableInfo,
-        ) void;
+        pub const OpenEvent = *const fn (manifest_log: *ManifestLog, table: *const TableInfo) void;
 
         const Write = struct {
             manifest_log: *ManifestLog,
@@ -364,7 +360,6 @@ pub fn ManifestLogType(comptime Storage: type) type {
             verify_block(block, block_checksum, block_address);
 
             const block_schema = schema.ManifestNode.from(block);
-            const labels_used = block_schema.labels_const(block);
             const tables_used = block_schema.tables_const(block);
             assert(block_schema.entry_count > 0);
             assert(block_schema.entry_count <= schema.ManifestNode.entry_count_max);
@@ -373,19 +368,18 @@ pub fn ManifestLogType(comptime Storage: type) type {
             while (entry > 0) {
                 entry -= 1;
 
-                const label = labels_used[entry];
                 const table = &tables_used[entry];
                 assert(table.tree_id >= manifest_log.options.tree_id_min);
                 assert(table.tree_id <= manifest_log.options.tree_id_max);
                 assert(table.address > 0);
 
-                if (label.event == .remove) {
+                if (table.label.event == .remove) {
                     const table_removed =
                         manifest_log.tables_removed.fetchPutAssumeCapacity(table.address, {});
                     assert(table_removed == null);
                 } else {
                     if (manifest_log.tables_removed.get(table.address)) |_| {
-                        if (label.event == .insert) {
+                        if (table.label.event == .insert) {
                             assert(manifest_log.tables_removed.remove(table.address));
                         }
                     } else {
@@ -393,7 +387,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                             manifest_log.table_extents.getOrPutAssumeCapacity(table.address);
                         if (!extent.found_existing) {
                             extent.value_ptr.* = .{ .block = block_address, .entry = entry };
-                            manifest_log.open_event(manifest_log, label.level, table);
+                            manifest_log.open_event(manifest_log, table);
                         }
                     }
                 }
@@ -454,47 +448,37 @@ pub fn ManifestLogType(comptime Storage: type) type {
             callback(manifest_log);
         }
 
-        /// Appends an insert of a table to a level.
-        pub fn insert(manifest_log: *ManifestLog, level: u6, table: *const TableInfo) void {
-            maybe(manifest_log.opened);
-            maybe(manifest_log.reading);
-            assert(!manifest_log.writing);
-            assert(manifest_log.table_extents.get(table.address) == null);
-
-            manifest_log.append(.{ .level = level, .event = .insert }, table);
-        }
-
-        /// Appends an update or a direct move of a table to a level.
+        /// Appends an insert/update/remove of a table to a level.
+        ///
         /// A move is only recorded as an update, there is no remove from the previous level, since
         /// this is safer (no potential to get the event order wrong) and reduces fragmentation.
-        pub fn update(manifest_log: *ManifestLog, level: u6, table: *const TableInfo) void {
+        pub fn append(manifest_log: *ManifestLog, table: *const TableInfo) void {
             maybe(manifest_log.opened);
             maybe(manifest_log.reading);
             assert(!manifest_log.writing);
-            assert(manifest_log.table_extents.get(table.address) != null);
 
-            manifest_log.append(.{ .level = level, .event = .update }, table);
-        }
+            switch (table.label.event) {
+                .insert => assert(manifest_log.table_extents.get(table.address) == null),
+                // For updates + removes, the table must have previously been inserted into the log:
+                .update => assert(manifest_log.table_extents.get(table.address) != null),
+                .remove => assert(manifest_log.table_extents.get(table.address) != null),
+            }
 
-        /// Appends the removal of a table from a level.
-        /// The table must have previously been inserted to the manifest log.
-        pub fn remove(manifest_log: *ManifestLog, level: u6, table: *const TableInfo) void {
-            assert(manifest_log.opened);
-            assert(!manifest_log.reading);
-            assert(!manifest_log.writing);
-            assert(manifest_log.table_extents.get(table.address) != null);
-
-            manifest_log.append(.{ .level = level, .event = .remove }, table);
+            manifest_log.append_internal(table);
         }
 
         /// The table extent must be updated immediately when appending, without delay.
         /// Otherwise, ManifestLog.compact() may append a stale version over the latest.
-        fn append(manifest_log: *ManifestLog, label: Label, table: *const TableInfo) void {
+        ///
+        /// append_internal() is used for both:
+        /// - External appends, e.g. events created due to table compaction.
+        /// - Internal appends, e.g. events recycled by manifest compaction.
+        fn append_internal(manifest_log: *ManifestLog, table: *const TableInfo) void {
             assert(manifest_log.opened);
             assert(!manifest_log.writing);
             maybe(manifest_log.reading);
             assert(manifest_log.grid_reservation != null);
-            assert(label.level < constants.lsm_levels);
+            assert(table.label.level < constants.lsm_levels);
             assert(table.address > 0);
             assert(table.snapshot_min > 0);
             assert(table.snapshot_max > table.snapshot_min);
@@ -513,8 +497,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 "{}: {s}: level={} tree={} checksum={} address={} snapshot={}..{}",
                 .{
                     manifest_log.superblock.replica_index.?,
-                    @tagName(label.event),
-                    label.level,
+                    @tagName(table.label.event),
+                    table.label.level,
                     table.tree_id,
                     table.checksum,
                     table.address,
@@ -525,21 +509,20 @@ pub fn ManifestLogType(comptime Storage: type) type {
 
             const block: BlockPtr = manifest_log.blocks.tail().?;
             const entry = manifest_log.entry_count;
-            block_builder_schema.labels(block)[entry] = label;
             block_builder_schema.tables(block)[entry] = table.*;
 
             const block_header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
             const block_address = block_header.op;
 
-            switch (label.event) {
+            switch (table.label.event) {
                 .insert,
                 .update,
                 => {
                     var extent = manifest_log.table_extents.getOrPutAssumeCapacity(table.address);
                     if (extent.found_existing) {
-                        maybe(label.event == .insert); // (Compaction.)
+                        maybe(table.label.event == .insert); // (Compaction.)
                     } else {
-                        assert(label.event == .insert);
+                        assert(table.label.event == .insert);
                     }
                     extent.value_ptr.* = .{ .block = block_address, .entry = entry };
                 },
@@ -761,12 +744,11 @@ pub fn ManifestLogType(comptime Storage: type) type {
 
             var frees: u32 = 0;
             for (
-                block_schema.labels_const(block),
                 block_schema.tables_const(block),
                 0..block_schema.entry_count,
-            ) |label, *table, entry_index| {
+            ) |*table, entry_index| {
                 const entry: u32 = @intCast(entry_index);
-                switch (label.event) {
+                switch (table.label.event) {
                     // Append the table, updating the table extent:
                     .insert,
                     .update,
@@ -779,7 +761,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                             .{ .block = oldest_address, .entry = entry },
                         )) {
                             // Append the table, updating the table extent:
-                            manifest_log.append(label, table);
+                            manifest_log.append_internal(table);
                         } else {
                             // Either:
                             // - This is not the latest insert for this table, so it can be dropped.
@@ -944,17 +926,6 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(address > 0);
             header.size = block_schema.size();
             header.context = @bitCast(schema.ManifestNode.Context{ .entry_count = entry_count });
-
-            if (entry_count < schema.ManifestNode.entry_count_max) {
-                // Copy the labels backwards, since the block-builder schema assumed that the block
-                // would be full, and it is not.
-                stdx.copy_left(
-                    .exact,
-                    Label,
-                    block_schema.labels(block),
-                    block_builder_schema.labels(block)[0..entry_count],
-                );
-            }
 
             // Zero padding:
             @memset(block[header.size..], 0);

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -421,9 +421,10 @@ pub const ManifestNode = struct {
     };
 
     pub const Event = enum(u2) {
-        insert = 0,
-        update = 1,
-        remove = 2,
+        reserved = 0,
+        insert = 1,
+        update = 2,
+        remove = 3,
     };
 
     pub const Label = packed struct(u8) {

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -531,14 +531,16 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
         pub fn open_table(
             tree: *Tree,
-            level: u8,
             table: *const schema.ManifestNode.TableInfo,
         ) void {
             assert(tree.compaction_op == null);
             assert(tree.key_range == null);
 
             const tree_table = Manifest.TreeTableInfo.decode(table);
-            tree.manifest.levels[level].insert_table(tree.manifest.node_pool, &tree_table);
+            tree.manifest.levels[table.label.level].insert_table(
+                tree.manifest.node_pool,
+                &tree_table,
+            );
         }
 
         pub fn open_complete(tree: *Tree) void {

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -217,11 +217,9 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         fn manifest_log_open_event(
             manifest_log: *ManifestLog,
-            level: u6,
             table: *const schema.ManifestNode.TableInfo,
         ) void {
             _ = manifest_log;
-            _ = level;
             _ = table;
 
             // This ManifestLog is only opened during setup, when it has no blocks.

--- a/src/testing/cluster/manifest_checker.zig
+++ b/src/testing/cluster/manifest_checker.zig
@@ -61,7 +61,11 @@ pub fn ManifestCheckerType(comptime Forest: type) type {
                     checksum_stream.add(std.mem.asBytes(&tree_id));
                     checksum_stream.add(std.mem.asBytes(&tree_level.table_count_visible));
                     while (tree_tables.next()) |tree_table| {
-                        checksum_stream.add(std.mem.asBytes(&tree_table.encode(tree_id)));
+                        checksum_stream.add(std.mem.asBytes(&tree_table.encode(.{
+                            .tree_id = tree_id,
+                            .event = .insert, // (Placeholder event).
+                            .level = @intCast(level),
+                        })));
                     }
                 }
             }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7928,7 +7928,7 @@ pub fn ReplicaType(
             const sync_op_max = self.superblock.working.vsr_state.sync_op_max;
             while (self.sync_tables.?.next(&self.state_machine.forest)) |table_info| {
                 assert(self.grid_repair_tables.available() > 0);
-                assert(table_info.label.event == .insert); // Dummy event.
+                assert(table_info.label.event == .reserved);
 
                 if (table_info.snapshot_min >= snapshot_from_commit(sync_op_min) and
                     table_info.snapshot_min <= snapshot_from_commit(sync_op_max))

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7926,10 +7926,10 @@ pub fn ReplicaType(
             const snapshot_from_commit = vsr.Snapshot.readable_at_commit;
             const sync_op_min = self.superblock.working.vsr_state.sync_op_min;
             const sync_op_max = self.superblock.working.vsr_state.sync_op_max;
-            while (self.sync_tables.?.next(&self.state_machine.forest)) |table_item| {
+            while (self.sync_tables.?.next(&self.state_machine.forest)) |table_info| {
                 assert(self.grid_repair_tables.available() > 0);
+                assert(table_info.label.event == .insert); // Dummy event.
 
-                const table_info = &table_item.table;
                 if (table_info.snapshot_min >= snapshot_from_commit(sync_op_min) and
                     table_info.snapshot_min <= snapshot_from_commit(sync_op_max))
                 {
@@ -7938,7 +7938,7 @@ pub fn ReplicaType(
                         self.replica,
                         table_info.address,
                         table_info.checksum,
-                        table_item.level,
+                        table_info.label.level,
                         table_info.snapshot_min,
                         snapshot_from_commit(sync_op_min),
                         snapshot_from_commit(sync_op_max),


### PR DESCRIPTION
Context:

The Manifest block schema previously arranged the `Label`s (level + event) and `TableInfo`s in a SoA. This choice dates back to the pre-unified manifest – the schema's `TableInfo` was also used in memory for `ManifestLevel`s. But with the unified manifest, the `ManifestLevel`'s `TableInfo` type is a separate type.

In this PR:

Replace the SoA with AoS -- that is, an array of `TableInfo` structs, each of which has the `Label` embedded within. 

As a bonus simplification: Including the `Label` in `TableInfo` removes the `copy_left` from ManifestLog's block encoding.

Worth mentioning: This change bubbles up to the `ManifestLog`'s API. Previously it had `ManifestLog.{insert,remove,update}(level, table_info)`. But now it is just `ManifestLog.append(table_info)`, since `table_info` includes the insert/remove/update event (and level).