### PR TITLE
CI: tag the published docker image as 'latest'

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -651,10 +651,16 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
         }
         try shell.exec(
             \\docker buildx build --file tools/docker/Dockerfile . --platform linux/amd64,linux/arm64
-            \\   --tag ghcr.io/tigerbeetle/tigerbeetle:{version}{debug} --push
+            \\   --tag ghcr.io/tigerbeetle/tigerbeetle:{version}{debug}
+            \\   {tag_latest}
+            \\   --push
         , .{
             .version = info.version,
             .debug = if (debug) "-debug" else "",
+            .tag_latest = @as(
+                []const []const u8,
+                if (debug) &.{} else &.{ "--tag", "ghcr.io/tigerbeetle/tigerbeetle:latest" },
+            ),
         });
 
         // Sadly, there isn't an easy way to locally build & test a multiplatform image without


### PR DESCRIPTION
Another regression introduced in the new release process! The current latest release is the one from a month ago. 

I am not fully familiar with how `:latest` is implemented in docker, so I am not sure that this is the right fix, but I've verified manually that at least passing `--tag` twice doesn't immediately return an error. 