### PR TITLE
dotnet: include native libraries into .nupkg archive

### DIFF
--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -9,26 +9,27 @@
     <AssemblyName>TigerBeetle</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RollForward>LatestMajor</RollForward>
-  </PropertyGroup> 
+  </PropertyGroup>
   <PropertyGroup>
     <OS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</OS>
   </PropertyGroup>
   <Target Name="BuildZig" BeforeTargets="DispatchToInnerBuilds">
     <Exec Command=".\zig\zig build dotnet_client -Doptimize=ReleaseSafe -Dconfig=production" WorkingDirectory="$(MSBuildProjectDirectory)\..\..\..\.." Condition="'$(OS)'=='Windows'" />
     <Exec Command="./zig/zig build dotnet_client -Doptimize=ReleaseSafe -Dconfig=production" WorkingDirectory="$(MSBuildProjectDirectory)/../../../.." Condition="'$(OS)'!='Windows'" />
+
+    <ItemGroup>
+      <Content Include="runtimes\**\*.so">
+        <PackagePath>runtimes</PackagePath>
+        <Pack>true</Pack>
+      </Content>
+      <Content Include="runtimes\**\*.dylib">
+        <PackagePath>runtimes</PackagePath>
+        <Pack>true</Pack>
+      </Content>
+      <Content Include="runtimes\**\*.dll">
+        <PackagePath>runtimes</PackagePath>
+        <Pack>true</Pack>
+      </Content>
+    </ItemGroup>
   </Target>
-  <ItemGroup>
-    <Content Include="runtimes\**\*.so">
-      <PackagePath>%(Identity)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="runtimes\**\*.dylib">
-      <PackagePath>%(Identity)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="runtimes\**\*.dll">
-      <PackagePath>%(Identity)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
At the moment, our dotnet packages doesn't actually include TigerBeetle native libraries. Unfortunate!

I think I've debugged this, the explanation is found here:

<https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-builds-for-generated-files?view=vs-2022>

> Files generated during execution don't exist during the evaluation
> phase, therefore they aren't included in the build process.

I think that's exactly what happens here: as written, msbuild expands the glob from `<Content Include="runtimes\**\*.so">` in evaluation phase, that is, before we run the code to generate those files. So, it happily includes an empty set of files!

We need to force MS Build to expand the glob _after_ the generation task is run. Apparently, including the `ItemGroup` into the task is the way to go here?