### PR TITLE
vopr: avoid liveness false-positive

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -243,7 +243,7 @@ pub fn main() !void {
     // Safety: replicas crash and restart; at any given point in time arbitrarily many replicas may
     // be crashed, but each replica restarts eventually. The cluster must process all requests
     // without split-brain.
-    const ticks_max_requests = 10_000_000;
+    const ticks_max_requests = 40_000_000;
     var tick_total: u64 = 0;
     var tick: u64 = 0;
     while (tick < ticks_max_requests) : (tick += 1) {


### PR DESCRIPTION
This fixes https://github.com/tigerbeetle/tigerbeetle/issues/1266.

Its  enough to bump to 30 to get this passing, but I use 40 for some head room.