### PR TITLE
ci: add secret for the docs repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           NUGET_KEY: ${{ secrets.NUGET_KEY }}
           TIGERBEETLE_GO_PAT: ${{ secrets.TIGERBEETLE_GO_PAT }}
+          TIGERBEETLE_DOCS_PAT: ${{ secrets.TIGERBEETLE_DOCS_PAT }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}


### PR DESCRIPTION
Forgot to add it when adding docs publishing to release.zig