### PR TITLE
ci: fix wrong working directory when unmarking release as a draft

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -447,6 +447,7 @@ fn publish(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
     }
 
     if (languages.contains(.zig)) {
+        try shell.project_root.setAsCwd();
         try shell.exec(
             \\gh release edit --draft=false
             \\  {tag}


### PR DESCRIPTION
`publish_docs` step changes the dir to that of the docs website, but that directory is removed completly when publish_docs completes.

So we end up in a non-existing working directory, which breaks git.

The proper fix here would be to bite the bullet and add some sort of misuse resitant cd API to shell, but let's just fix the bug for now.