### PR TITLE
docs: simplify website folder layout

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -723,7 +723,7 @@ fn publish_docs(shell: *Shell, info: VersionInfo) !void {
                 shell.arena.allocator(),
                 file,
                 "src/docs_website/build",
-                "tigerbeetle-docs/docs",
+                "tigerbeetle-docs/",
             ),
         );
     }


### PR DESCRIPTION
Originally, we had the `/docs` folder with the rendered website, and the docusaurus stuff at `/` to actually generate `/docs`. Now with docusaurus moved into the main repo, we no longer need this extra level of `/docs` anymore.

On the day of the next release, I'll change the config on the docs repo to serve the content from the root.