### PR TITLE
ci: more robust handling of directories in shell.zig 

### DIFF
--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -9,6 +9,8 @@ const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
+    assert(shell.file_exists("go.mod"));
+
     // No unit tests for Go :-(
 
     // `go build`  won't compile the native library automatically, we need to do that ourselves.
@@ -31,10 +33,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     };
 
     inline for (.{ "basic", "two-phase", "two-phase-many" }) |sample| {
-        var sample_dir = try shell.project_root.openDir("src/clients/go/samples/" ++ sample, .{});
-        defer sample_dir.close();
-
-        try sample_dir.setAsCwd();
+        try shell.pushd("./samples/" ++ sample);
+        defer shell.popd();
 
         var tmp_beetle = try TmpTigerBeetle.init(gpa, .{});
         defer tmp_beetle.deinit(gpa);

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -8,6 +8,8 @@ const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
+    assert(shell.file_exists("pom.xml"));
+
     // Java's maven doesn't support a separate test command, or a way to add dependency on a
     // project (as opposed to a compiled jar file).
     //
@@ -17,10 +19,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     try shell.exec("mvn --batch-mode --file pom.xml --quiet install", .{});
 
     inline for (.{ "basic", "two-phase", "two-phase-many" }) |sample| {
-        var sample_dir = try shell.project_root.openDir("src/clients/java/samples/" ++ sample, .{});
-        defer sample_dir.close();
-
-        try sample_dir.setAsCwd();
+        try shell.pushd("./samples/" ++ sample);
+        defer shell.popd();
 
         var tmp_beetle = try TmpTigerBeetle.init(gpa, .{});
         defer tmp_beetle.deinit(gpa);

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -9,6 +9,8 @@ const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
+    assert(shell.file_exists("package.json"));
+
     // We have some unit-tests for node, but they are likely bitrotted, as they are not run on CI.
 
     // Integration tests.
@@ -18,10 +20,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     try shell.exec("npm pack --quiet", .{});
 
     inline for (.{ "basic", "two-phase", "two-phase-many" }) |sample| {
-        var sample_dir = try shell.project_root.openDir("src/clients/node/samples/" ++ sample, .{});
-        defer sample_dir.close();
-
-        try sample_dir.setAsCwd();
+        try shell.pushd("./samples/" ++ sample);
+        defer shell.popd();
 
         var tmp_beetle = try TmpTigerBeetle.init(gpa, .{});
         defer tmp_beetle.deinit(gpa);
@@ -33,10 +33,6 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
 
     // Container smoke tests.
     if (builtin.target.os.tag == .linux) {
-        var client_dir = try shell.project_root.openDir("src/clients/node/", .{});
-        defer client_dir.close();
-
-        try client_dir.setAsCwd();
 
         // Installing node through <https://github.com/nodesource/distributions>.
 

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -60,15 +60,12 @@ pub fn main() !void {
                 var section = try shell.open_section(@tagName(language) ++ " ci");
                 defer section.close();
 
-                var client_src_dir = try shell.project_root.openDir(
-                    "src/clients/" ++ @tagName(language),
-                    .{},
-                );
-                defer client_src_dir.close();
+                {
+                    try shell.pushd("./src/clients/" ++ @tagName(language));
+                    defer shell.popd();
 
-                try client_src_dir.setAsCwd();
-
-                try ci.tests(shell, gpa);
+                    try ci.tests(shell, gpa);
+                }
 
                 // Piggy back on node client testing to verify our docs, as we use node to generate
                 // them anyway.
@@ -86,13 +83,8 @@ pub fn main() !void {
 }
 
 fn build_docs(shell: *Shell) !void {
-    var docs_dir = try shell.project_root.openDir(
-        "src/docs_website",
-        .{},
-    );
-    defer docs_dir.close();
-
-    try docs_dir.setAsCwd();
+    try shell.pushd("./src/docs_website");
+    defer shell.popd();
 
     try shell.exec("npm install", .{});
     try shell.exec("npm run build", .{});


### PR DESCRIPTION
We use shell.zig for various "scripting" tasks. One problem there is
managing environment --- current directory and environmental variables.

So far, the strategy was to avoid doing anything special about it and
just use std API to mutate global process state. That's not great, for
two reasons:

- First, mutating process state is inherently fragile. For example,
  calling setenv in a multithreaded program is almost always UB

- Second, mutating global state might lead to logical errors. For
  example, we had a bug recently where `foo` called `bar`, `bar` changed
  process working directory, and, upon return, `foo` ended up in an
  unexpected state. (https://github.com/tigerbeetle/tigerbeetle/pull/1272)

To fix the issues, this PR phases our global API in favor of `Shell.cwd`
field.

Trivia: in most other languages, adding a second cwd would be quite
confusing, as that would make the `std` API behave in unexpected ways.
However in Zig the cwd is not ambient, but rather passed explicitly to
almost all APIs:

    std.fs.cwd().readFle("Readme.me")

So there's no confusion!