### PR TITLE
ci: smoke-run simulator on CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -213,15 +213,13 @@ jobs:
       - run: zig/zig build build_benchmark_segmented_array
       - run: zig/zig build -Dtracer-backend=tracy
 
-  # This is just a canary to make sure that the simulator compiles
-  # It would be a good idea to also _run_ a single iteration,
-  # but that currently has some false failures :-)
-  # TODO: Make so we have a single zig build simulator that does both
+  # Run simulator once for each state machine, using commit hash as a random, but also deterministic
+  # seed.
   simulate:
     if: inputs.version == ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: zig/zig build simulator -Dsimulator-state-machine=accounting
-      - run: zig/zig build simulator -Dsimulator-state-machine=testing
+      - run: zig/zig build simulator_run -Dsimulator-state-machine=accounting -Doptimize=ReleaseSafe -- ${{ github.sha }}
+      - run: zig/zig build simulator_run -Dsimulator-state-machine=testing    -Doptimize=ReleaseSafe -- ${{ github.sha }}

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -931,6 +931,19 @@ fn random_core(random: std.rand.Random, replica_count: u8, standby_count: u8) Co
 }
 
 pub fn parse_seed(bytes: []const u8) u64 {
+    if (bytes.len == 40) {
+        // Normally, a seed is specified as a base-10 integer. However, as a special case, we allow
+        // using a Git hash (a hex string 40 character long). This is used by our CI, which passes
+        // current commit hash as a seed --- that way, we run simulator on CI, we run it with
+        // different, "random" seeds, but the the failures remain reproducible just from the commit
+        // hash!
+        const commit_hash = std.fmt.parseUnsigned(u160, bytes, 16) catch |err| switch (err) {
+            error.Overflow => unreachable,
+            error.InvalidCharacter => @panic("commit hash seed contains an invalid character"),
+        };
+        return @truncate(commit_hash);
+    }
+
     return std.fmt.parseUnsigned(u64, bytes, 10) catch |err| switch (err) {
         error.Overflow => @panic("seed exceeds a 64-bit unsigned integer"),
         error.InvalidCharacter => @panic("seed contains an invalid character"),


### PR DESCRIPTION
Normally, a seed is specified as a base-10 integer. However, as a special case, we allow using a Git hash (a hex string 40 character long). This is used by our CI, which passes current commit hash as a seed --- that way, we run simulator on CI, we run it with different, "random" seeds, but the the failures remain reproducible just from the commit hash!