### PR TITLE
VSR/Sync: Allow tables to queue for sync twice

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7947,11 +7947,21 @@ pub fn ReplicaType(
                     const table = self.grid_repair_tables.acquire().?;
                     table.* = .{ .replica = self, .table = undefined };
 
-                    self.grid.blocks_missing.enqueue_table(
+                    const enqueue_result = self.grid.blocks_missing.enqueue_table(
                         &table.table,
                         table_info.address,
                         table_info.checksum,
                     );
+
+                    switch (enqueue_result) {
+                        .insert => {},
+                        .duplicate => {
+                            // Duplicates are only possible due to move-table.
+                            assert(table_info.label.level > 0);
+
+                            self.grid_repair_tables.release(table);
+                        },
+                    }
 
                     if (self.grid_repair_tables.available() == 0) break;
                 } else {


### PR DESCRIPTION
Timeline of the VOPR seed in https://github.com/tigerbeetle/tigerbeetle/issues/1273 (seed `2812334640525749465` on commit `47c03651ff08ee547b4baefda1b5b40f7f95e191 `):

1. Replica 2: Superblock sync completes. Begin syncing LSM tables.
2. Replica 2: Queue the table `address=62 checksum=145957321580082356891479597489273601427 level=0` for sync (`GridBlocksMissing.enqueue_table()`).
3. Replica 2: LSM compaction moves the table with `address=62` to level 1.
4. Replica 2: Queue the table `address=62 checksum=145957321580082356891479597489273601427 level=1` for sync (`GridBlocksMissing.enqueue_table()`).

The `ForestTableIterator` doesn't repeat tables... except when the table in question has moved to the next level.

This commit loosens the assertion to allow for this case.

Fixes https://github.com/tigerbeetle/tigerbeetle/issues/1273.