### PR TITLE
build: squash warning from ldd

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -401,10 +401,13 @@ pub fn build(b: *std.Build) !void {
                 // On Linux, detects the abi by calling `ldd` to check if
                 // the libjvm.so is linked against libc or musl.
                 // It's reasonable to assume that ldd will be present.
-                const ldd_result = b.exec(&.{
-                    "ldd",
-                    b.pathJoin(&.{ libjvm_path, "libjvm.so" }),
-                });
+                var exit_code: u8 = undefined;
+                const stderr_behavior = .Ignore;
+                const ldd_result = try b.execAllowFail(
+                    &.{ "ldd", b.pathJoin(&.{ libjvm_path, "libjvm.so" }) },
+                    &exit_code,
+                    stderr_behavior,
+                );
                 tests.target.abi = if (std.mem.indexOf(u8, ldd_result, "musl") != null)
                     .musl
                 else if (std.mem.indexOf(u8, ldd_result, "libc") != null)


### PR DESCRIPTION
This gets rid of

ldd: warning: you do not have execution permission for `/nix/store/njjfhnvg90czp2jz37dkfyrhr97rvlii-openjdk-19.0.2+7/lib/openjdk/lib/server/libjvm.so'

warning

I've also spend some time trying to figure out how to get rid of ldd here altogether, and didnt' find a good way :-)

I think it is true that, on a given system, both musl and glibc jvms might be present, and that we need to inspect the .so to figure out the ABI, and that we need to do this during "configure" phase of our build process.