### PR TITLE
ci: explicitly use latest versions when verifying release

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -1,6 +1,7 @@
 name: "Release (validate)"
 
 on:
+  workflow_dispatch: # Manual triggering for debugging
   workflow_run:
     workflows: ["Release"]
     types:
@@ -16,9 +17,21 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.x'
+
       - uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+
       - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - uses: actions/setup-node@v3
+        with:
+          node-version: 'latest'
 
       - run: ./scripts/install_zig.sh
 


### PR DESCRIPTION
Here, we _don't_ want the build to be reproducible, rather, we want to always check that the latest versions of upstream continue to work with our code.

I hoped that just not specifying the version would do the trick, but at least some actions make the version mandatory.