### PR TITLE
ci: pass GITHUB_TOKEN for release validation

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -36,6 +36,9 @@ jobs:
       - run: ./scripts/install_zig.sh
 
       - run: ./zig/zig build ci -- --validate-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   alert_failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We use `gh` to download releases, and, somewhat surprisingly, it needs a token even for public operations like fetching a release.