### PR TITLE
VSR: 256-byte headers; Header specialization

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -210,13 +210,11 @@ pub const AOF = struct {
                 }
 
                 const header = target.header();
-                if (!header.frame_const().valid_checksum()) {
+                if (!header.valid_checksum()) {
                     return error.AOFChecksumMismatch;
                 }
 
-                if (!header.frame_const().valid_checksum_body(
-                    target.message[@sizeOf(Header)..header.size],
-                )) {
+                if (!header.valid_checksum_body(target.message[@sizeOf(Header)..header.size])) {
                     return error.AOFBodyChecksumMismatch;
                 }
 
@@ -536,13 +534,11 @@ pub fn aof_merge(
         }
 
         const header = target.header();
-        if (!header.frame_const().valid_checksum()) {
+        if (!header.valid_checksum()) {
             @panic("unexpected checksum error while merging");
         }
 
-        if (!header.frame_const().valid_checksum_body(
-            target.message[@sizeOf(Header)..header.size],
-        )) {
+        if (!header.valid_checksum_body(target.message[@sizeOf(Header)..header.size])) {
             @panic("unexpected body checksum error while merging");
         }
 
@@ -621,8 +617,8 @@ test "aof write / read" {
     };
 
     stdx.copy_disjoint(.exact, u8, demo_message.body(), demo_payload);
-    demo_message.header.frame().set_checksum_body(demo_payload);
-    demo_message.header.frame().set_checksum();
+    demo_message.header.set_checksum_body(demo_payload);
+    demo_message.header.set_checksum();
 
     try aof.write(demo_message, .{ .replica = 1, .primary = 1 });
     aof.close();

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -58,18 +58,18 @@ pub const AOFEntry = extern struct {
         return vsr.sector_ceil(unaligned_size);
     }
 
-    pub fn header(self: *AOFEntry) *Header.Type(.prepare) {
+    pub fn header(self: *AOFEntry) *Header.Prepare {
         return @ptrCast(&self.message);
     }
 
     /// Turn an AOFEntry back into a Message.
-    pub fn to_message(self: *AOFEntry, target: Message.Type(.prepare)) void {
+    pub fn to_message(self: *AOFEntry, target: Message.Prepare) void {
         stdx.copy_disjoint(.inexact, u8, target.base.buffer, self.message[0..self.header().size]);
     }
 
     pub fn from_message(
         self: *AOFEntry,
-        message: Message.Type(.prepare),
+        message: Message.Prepare,
         options: struct { replica: u64, primary: u64 },
         last_checksum: *?u128,
     ) void {
@@ -158,7 +158,7 @@ pub const AOF = struct {
     /// We don't bother returning a count of how much we wrote. Not being
     /// able to fully write the entire payload is an error, not an expected
     /// condition.
-    pub fn write(self: *AOF, message: Message.Type(.prepare), options: struct {
+    pub fn write(self: *AOF, message: Message.Prepare, options: struct {
         replica: u64,
         primary: u64,
     }) !void {
@@ -292,7 +292,7 @@ pub const AOFReplayClient = struct {
     client: *Client,
     io: *IO,
     message_pool: *MessagePool,
-    inflight_message: ?Message.Type(.request) = null,
+    inflight_message: ?Message.Request = null,
 
     pub fn init(allocator: std.mem.Allocator, raw_addresses: []const u8) !Self {
         var addresses = try vsr.parse_addresses(allocator, raw_addresses, constants.replicas_max);

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -115,7 +115,9 @@ pub fn ContextType(
             errdefer allocator.destroy(context);
 
             context.allocator = allocator;
-            context.client_id = std.crypto.random.int(u128);
+            context.client_id = std.crypto.random.int(u128) +| 1;
+            assert(context.client_id != 0);
+
             log.debug("{}: init: initializing", .{context.client_id});
 
             if (concurrency_max == 0 or concurrency_max > 4096) {

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -105,7 +105,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
         fn reply(self: *Self) void {
             while (self.request_queue.pop()) |inflight| {
                 const reply_message = self.message_pool.get_message(.request);
-                defer self.message_pool.unref(reply_message.base);
+                defer self.message_pool.unref(reply_message.base());
 
                 stdx.copy_disjoint(
                     .exact,
@@ -116,7 +116,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
 
                 // Similarly to the real client, release the request message before invoking the
                 // callback. This necessitates a `copy_disjoint` above.
-                self.release(inflight.message.base);
+                self.release(inflight.message.base());
 
                 inflight.callback.?(
                     inflight.user_data,

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -70,7 +70,9 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
             message: *Message,
             message_body_size: usize,
         ) void {
-            message.header.* = .{
+            const message_request = message.build(.request);
+
+            message_request.header.* = .{
                 .client = 0,
                 .request = 0,
                 .cluster = 0,
@@ -84,7 +86,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
             self.request_queue.push_assume_capacity(.{
                 .user_data = user_data,
                 .callback = callback,
-                .message = message,
+                .message = message_request,
             });
         }
 
@@ -102,13 +104,19 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
 
         fn reply(self: *Self) void {
             while (self.request_queue.pop()) |inflight| {
-                const reply_message = self.message_pool.get_message();
-                defer self.message_pool.unref(reply_message);
+                const reply_message = self.message_pool.get_message().build(.request);
+                defer self.message_pool.unref(reply_message.base);
 
-                stdx.copy_disjoint(.exact, u8, reply_message.buffer, inflight.message.buffer);
+                stdx.copy_disjoint(
+                    .exact,
+                    u8,
+                    reply_message.base.buffer,
+                    inflight.message.base.buffer,
+                );
+
                 // Similarly to the real client, release the request message before invoking the
                 // callback. This necessitates a `copy_disjoint` above.
-                self.release(inflight.message);
+                self.release(inflight.message.base);
 
                 inflight.callback.?(
                     inflight.user_data,

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -93,7 +93,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
         pub fn get_message(self: *Self) *Message {
             assert(self.messages_available > 0);
             self.messages_available -= 1;
-            return self.message_pool.get_message();
+            return self.message_pool.get_message(null);
         }
 
         pub fn release(self: *Self, message: *Message) void {
@@ -104,14 +104,14 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
 
         fn reply(self: *Self) void {
             while (self.request_queue.pop()) |inflight| {
-                const reply_message = self.message_pool.get_message().build(.request);
+                const reply_message = self.message_pool.get_message(.request);
                 defer self.message_pool.unref(reply_message.base);
 
                 stdx.copy_disjoint(
                     .exact,
                     u8,
-                    reply_message.base.buffer,
-                    inflight.message.base.buffer,
+                    reply_message.buffer,
+                    inflight.message.buffer,
                 );
 
                 // Similarly to the real client, release the request message before invoking the

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -405,7 +405,7 @@ pub fn CompactionType(
         fn on_iterator_init_a(read: *Grid.Read, index_block: BlockPtrConst) void {
             const compaction = @fieldParentPtr(Compaction, "read", read);
             assert(compaction.state == .iterator_init_a);
-            assert(compaction.tree_config.id == schema.TableIndex.tree_id(index_block));
+            assert(compaction.tree_config.id == schema.TableIndex.metadata(index_block).tree_id);
 
             // `index_block` is only valid for this callback, so copy its contents.
             // TODO(jamii) This copy can be avoided if we bypass the cache.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -544,9 +544,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
                 const block = forest.grid.superblock.storage.grid_block(block_address).?;
                 const block_header = schema.header_from_block(block);
-                assert(block_header.op == block_address);
+                assert(block_header.address == block_address);
                 assert(block_header.checksum == block_checksum);
-                assert(schema.BlockType.from(block_header.operation) == .manifest);
+                assert(block_header.block_type == .manifest);
 
                 const block_schema = schema.ManifestNode.from(block);
                 assert(block_schema.entry_count > 0);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -219,14 +219,14 @@ const Environment = struct {
             // VSRState.monotonic() asserts that the previous_checkpoint id changes.
             // In a normal replica this is guaranteed – even if the LSM is idle and no blocks
             // are acquired or released, the client sessions are necessarily mutated.
-            var reply = std.mem.zeroInit(vsr.Header, .{
+            var reply = std.mem.zeroInit(vsr.Header.Type(.reply), .{
                 .cluster = cluster,
                 .command = .reply,
                 .op = op,
                 .commit = op,
             });
-            reply.set_checksum_body(&.{});
-            reply.set_checksum();
+            reply.frame().set_checksum_body(&.{});
+            reply.frame().set_checksum();
 
             _ = env.superblock.client_sessions.put(1, &reply);
         }

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -219,7 +219,7 @@ const Environment = struct {
             // VSRState.monotonic() asserts that the previous_checkpoint id changes.
             // In a normal replica this is guaranteed – even if the LSM is idle and no blocks
             // are acquired or released, the client sessions are necessarily mutated.
-            var reply = std.mem.zeroInit(vsr.Header.Type(.reply), .{
+            var reply = std.mem.zeroInit(vsr.Header.Reply, .{
                 .cluster = cluster,
                 .command = .reply,
                 .op = op,

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -225,8 +225,8 @@ const Environment = struct {
                 .op = op,
                 .commit = op,
             });
-            reply.frame().set_checksum_body(&.{});
-            reply.frame().set_checksum();
+            reply.set_checksum_body(&.{});
+            reply.set_checksum();
 
             _ = env.superblock.client_sessions.put(1, &reply);
         }

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -514,7 +514,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             block_builder_schema.tables(block)[entry] = table.*;
 
             const block_header =
-                mem.bytesAsValue(vsr.Header.Type(.block), block[0..@sizeOf(vsr.Header)]);
+                mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
             const block_address = block_header.address;
 
             switch (table.label.event) {
@@ -893,7 +893,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             const block: BlockPtr = manifest_log.blocks.tail().?;
             const block_address = manifest_log.grid.acquire(manifest_log.grid_reservation.?);
 
-            const header = mem.bytesAsValue(vsr.Header.Type(.block), block[0..@sizeOf(vsr.Header)]);
+            const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
             header.* = .{
                 .cluster = manifest_log.superblock.working.cluster,
                 .address = block_address,
@@ -919,7 +919,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(entry_count <= schema.ManifestNode.entry_count_max);
 
             const block_schema = schema.ManifestNode{ .entry_count = entry_count };
-            const header = mem.bytesAsValue(vsr.Header.Type(.block), block[0..@sizeOf(vsr.Header)]);
+            const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
             assert(header.cluster == manifest_log.superblock.working.cluster);
             assert(header.command == .block);
             assert(header.address > 0);

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -936,8 +936,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
             // Zero padding:
             @memset(block[header.size..], 0);
 
-            header.frame().set_checksum_body(block[@sizeOf(vsr.Header)..header.size]);
-            header.frame().set_checksum();
+            header.set_checksum_body(block[@sizeOf(vsr.Header)..header.size]);
+            header.set_checksum();
             verify_block(block, null, null);
 
             manifest_log.log_block_checksums.push_assume_capacity(header.checksum);

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -83,6 +83,7 @@ pub const TableIndex = struct {
 
         comptime {
             assert(stdx.no_padding(Metadata));
+            assert(@sizeOf(Metadata) == vsr.Header.Block.metadata_size);
         }
     };
 
@@ -226,6 +227,7 @@ pub const TableData = struct {
 
         comptime {
             assert(stdx.no_padding(Metadata));
+            assert(@sizeOf(Metadata) == vsr.Header.Block.metadata_size);
         }
     };
 
@@ -294,6 +296,9 @@ pub const TableData = struct {
         assert(header_metadata.value_count <= header_metadata.value_count_max);
         assert(header_metadata.tree_id > 0);
         assert(stdx.zeroed(&header_metadata.reserved));
+        assert(@sizeOf(vsr.Header) + header_metadata.value_size * header_metadata.value_count ==
+            header.size);
+
         return header_metadata;
     }
 
@@ -363,6 +368,7 @@ pub const ManifestNode = struct {
 
         comptime {
             assert(stdx.no_padding(Metadata));
+            assert(@sizeOf(Metadata) == vsr.Header.Block.metadata_size);
         }
     };
 

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -36,8 +36,8 @@ const block_body_size = block_size - @sizeOf(vsr.Header);
 const BlockPtr = *align(constants.sector_size) [block_size]u8;
 const BlockPtrConst = *align(constants.sector_size) const [block_size]u8;
 
-pub inline fn header_from_block(block: BlockPtrConst) *const vsr.Header.Type(.block) {
-    const header = mem.bytesAsValue(vsr.Header.Type(.block), block[0..@sizeOf(vsr.Header)]);
+pub inline fn header_from_block(block: BlockPtrConst) *const vsr.Header.Block {
+    const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
     assert(header.command == .block);
     assert(header.address > 0);
     assert(header.size >= @sizeOf(vsr.Header)); // Every block has a header.

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -306,8 +306,8 @@ pub fn TableType(
                 assert(builder.value_count > 0);
 
                 const block = builder.data_block;
-                const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
-                header.* = @bitCast(vsr.Header.Block{
+                const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
+                header.* = .{
                     .cluster = options.cluster,
                     .metadata_bytes = @bitCast(schema.TableData.Metadata{
                         .value_count_max = data.value_count_max,
@@ -320,7 +320,7 @@ pub fn TableType(
                     .size = @sizeOf(vsr.Header) + builder.value_count * @sizeOf(Value),
                     .command = .block,
                     .block_type = .data,
-                });
+                };
 
                 header.set_checksum_body(block[@sizeOf(vsr.Header)..header.size]);
                 header.set_checksum();
@@ -405,8 +405,9 @@ pub fn TableType(
                 assert(builder.value_count == 0);
 
                 const index_block = builder.index_block;
-                const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
-                header.* = @bitCast(vsr.Header.Block{
+                const header =
+                    mem.bytesAsValue(vsr.Header.Block, index_block[0..@sizeOf(vsr.Header)]);
+                header.* = .{
                     .cluster = options.cluster,
                     .metadata_bytes = @bitCast(schema.TableIndex.Metadata{
                         .data_block_count = builder.data_block_count,
@@ -419,7 +420,7 @@ pub fn TableType(
                     .size = index.size,
                     .command = .block,
                     .block_type = .index,
-                });
+                };
                 header.set_checksum_body(index_block[@sizeOf(vsr.Header)..header.size]);
                 header.set_checksum();
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -307,7 +307,7 @@ pub fn TableType(
 
                 const block = builder.data_block;
                 const header = mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
-                header.* = @bitCast(vsr.Header.Type(.block){
+                header.* = @bitCast(vsr.Header.Block{
                     .cluster = options.cluster,
                     .metadata_bytes = @bitCast(schema.TableData.Metadata{
                         .value_count_max = data.value_count_max,
@@ -406,7 +406,7 @@ pub fn TableType(
 
                 const index_block = builder.index_block;
                 const header = mem.bytesAsValue(vsr.Header, index_block[0..@sizeOf(vsr.Header)]);
-                header.* = @bitCast(vsr.Header.Type(.block){
+                header.* = @bitCast(vsr.Header.Block{
                     .cluster = options.cluster,
                     .metadata_bytes = @bitCast(schema.TableIndex.Metadata{
                         .data_block_count = builder.data_block_count,

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -125,7 +125,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                 .ascending => {
                     if (constants.verify) {
                         const header = schema.header_from_block(block);
-                        assert(header.op == it.context.addresses[0]);
+                        assert(header.address == it.context.addresses[0]);
                         assert(header.checksum == it.context.checksums[0]);
                     }
 
@@ -136,7 +136,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                     const index_last = it.context.checksums.len - 1;
                     if (constants.verify) {
                         const header = schema.header_from_block(block);
-                        assert(header.op == it.context.addresses[index_last]);
+                        assert(header.address == it.context.addresses[index_last]);
                         assert(header.checksum == it.context.checksums[index_last]);
                     }
 

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -456,7 +456,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block < context.index_block_count);
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
-                assert(schema.TableIndex.tree_id(index_block) == context.tree.config.id);
+                assert(schema.TableIndex.metadata(index_block).tree_id == context.tree.config.id);
 
                 const blocks = Table.index_blocks_for_key(index_block, context.key) orelse {
                     // The key is not present in this table, check the next level.
@@ -484,7 +484,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block < context.index_block_count);
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
-                assert(schema.TableData.tree_id(data_block) == context.tree.config.id);
+                assert(schema.TableData.metadata(data_block).tree_id == context.tree.config.id);
 
                 if (Table.data_block_search(data_block, context.key)) |value| {
                     context.callback(context, unwrap_tombstone(value));

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -270,14 +270,14 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 // VSRState.monotonic() asserts that the previous_checkpoint id changes.
                 // In a normal replica this is guaranteed – even if the LSM is idle and no blocks
                 // are acquired or released, the client sessions are necessarily mutated.
-                var reply = std.mem.zeroInit(vsr.Header, .{
+                var reply = std.mem.zeroInit(vsr.Header.Type(.reply), .{
                     .cluster = cluster,
                     .command = .reply,
                     .op = op,
                     .commit = op,
                 });
-                reply.set_checksum_body(&.{});
-                reply.set_checksum();
+                reply.frame().set_checksum_body(&.{});
+                reply.frame().set_checksum();
 
                 _ = env.superblock.client_sessions.put(1, &reply);
             }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -276,8 +276,8 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     .op = op,
                     .commit = op,
                 });
-                reply.frame().set_checksum_body(&.{});
-                reply.frame().set_checksum();
+                reply.set_checksum_body(&.{});
+                reply.set_checksum();
 
                 _ = env.superblock.client_sessions.put(1, &reply);
             }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -270,7 +270,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 // VSRState.monotonic() asserts that the previous_checkpoint id changes.
                 // In a normal replica this is guaranteed – even if the LSM is idle and no blocks
                 // are acquired or released, the client sessions are necessarily mutated.
-                var reply = std.mem.zeroInit(vsr.Header.Type(.reply), .{
+                var reply = std.mem.zeroInit(vsr.Header.Reply, .{
                     .cluster = cluster,
                     .command = .reply,
                     .op = op,

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -371,11 +371,17 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             bus.process.accept_connection.?.on_accept(bus, fd);
         }
 
-        pub fn get_message(bus: *Self) *Message {
-            return bus.pool.get_message();
+        pub fn get_message(
+            bus: *Self,
+            comptime command: ?vsr.Command,
+        ) MessagePool.GetMessageType(command) {
+            return bus.pool.get_message(command);
         }
 
-        pub fn unref(bus: *Self, message: *Message) void {
+        /// `@TypeOf(message)` is one of:
+        /// - `*Message`
+        /// - `MessageType(command)` for any `command`.
+        pub fn unref(bus: *Self, message: anytype) void {
             bus.pool.unref(message);
         }
 
@@ -777,7 +783,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 // `references` and `header` metadata.
                 if (connection.recv_progress == header.size) return connection.recv_message.?.ref();
 
-                const message = bus.get_message();
+                const message = bus.get_message(null);
                 stdx.copy_disjoint(.inexact, u8, message.buffer, data[0..header.size]);
                 return message;
             }
@@ -871,7 +877,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                     return;
                 }
 
-                const new_message = bus.get_message();
+                const new_message = bus.get_message(null);
                 defer bus.unref(new_message);
 
                 if (connection.recv_message) |recv_message| {

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -820,8 +820,8 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
                 const header_peer: Connection.Peer = switch (header.peer_type()) {
                     .unknown => return true,
-                    .replica => .{ .replica = header.replica },
-                    .client => .{ .client = header.client },
+                    .replica => |replica| .{ .replica = replica },
+                    .client => |client| .{ .client = client },
                 };
 
                 if (connection.peer != .unknown) {

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -66,7 +66,33 @@ comptime {
 /// initialization and reused thereafter. The messages_max values determine the size of this pool.
 pub const MessagePool = struct {
     pub const Message = struct {
-        pub const Type = MessageType;
+        pub const Reserved = MessageType(.reserved);
+        pub const Ping = MessageType(.ping);
+        pub const Pong = MessageType(.pong);
+        pub const PingClient = MessageType(.ping_client);
+        pub const PongClient = MessageType(.pong_client);
+        pub const Request = MessageType(.request);
+        pub const Prepare = MessageType(.prepare);
+        pub const PrepareOk = MessageType(.prepare_ok);
+        pub const Reply = MessageType(.reply);
+        pub const Commit = MessageType(.commit);
+        pub const StartViewChange = MessageType(.start_view_change);
+        pub const DoViewChange = MessageType(.do_view_change);
+        pub const StartView = MessageType(.start_view);
+        pub const RequestStartView = MessageType(.request_start_view);
+        pub const RequestHeaders = MessageType(.request_headers);
+        pub const RequestPrepare = MessageType(.request_prepare);
+        pub const RequestReply = MessageType(.request_reply);
+        pub const Headers = MessageType(.headers);
+        pub const Eviction = MessageType(.eviction);
+        pub const RequestBlocks = MessageType(.request_blocks);
+        pub const Block = MessageType(.block);
+        pub const RequestSyncCheckpoint = MessageType(.request_sync_checkpoint);
+        pub const SyncCheckpoint = MessageType(.sync_checkpoint);
+        pub const RequestSyncFreeSet = MessageType(.request_sync_free_set);
+        pub const RequestSyncClientSessions = MessageType(.request_sync_client_sessions);
+        pub const SyncFreeSet = MessageType(.sync_free_set);
+        pub const SyncClientSessions = MessageType(.sync_client_sessions);
 
         // TODO: replace this with a header() function to save memory
         header: *Header,

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -509,7 +509,7 @@ pub const Simulator = struct {
     //
     // When generating a FaultAtlas, we don't try to protect core from excessive errors. Instead,
     // if the core gets stuck, we verify that this is indeed due to storage faults.
-    pub fn core_missing_prepare(simulator: *const Simulator) ?vsr.Header.Type(.prepare) {
+    pub fn core_missing_prepare(simulator: *const Simulator) ?vsr.Header.Prepare {
         assert(simulator.core.count() > 0);
 
         var missing_op: ?u64 = null;
@@ -666,8 +666,8 @@ pub const Simulator = struct {
     fn on_cluster_reply(
         cluster: *Cluster,
         reply_client: usize,
-        request: Message.Type(.request),
-        reply: Message.Type(.reply),
+        request: Message.Request,
+        reply: Message.Reply,
     ) void {
         // TODO(Zig) Use @returnAddress to initialzie the cluster, then this can just use @fieldParentPtr().
         const simulator: *Simulator = @ptrCast(@alignCast(cluster.context.?));
@@ -833,7 +833,7 @@ pub const Simulator = struct {
             const headers_size = vsr.Zone.wal_headers.size().?;
             const headers_bytes = replica_storage.memory[headers_offset..][0..headers_size];
             for (
-                mem.bytesAsSlice(vsr.Header.Type(.prepare), headers_bytes),
+                mem.bytesAsSlice(vsr.Header.Prepare, headers_bytes),
                 replica_storage.wal_prepares(),
             ) |*wal_header, *wal_prepare| {
                 if (wal_header.checksum == 0) {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -666,8 +666,8 @@ pub const Simulator = struct {
     fn on_cluster_reply(
         cluster: *Cluster,
         reply_client: usize,
-        request: Message.Request,
-        reply: Message.Reply,
+        request: *Message.Request,
+        reply: *Message.Reply,
     ) void {
         // TODO(Zig) Use @returnAddress to initialzie the cluster, then this can just use @fieldParentPtr().
         const simulator: *Simulator = @ptrCast(@alignCast(cluster.context.?));
@@ -677,13 +677,13 @@ pub const Simulator = struct {
             defer simulator.reply_sequence.next();
 
             const commit_client = simulator.cluster.clients[commit.client_index];
-            assert(commit.reply.base.references == 1);
+            assert(commit.reply.references == 1);
             assert(commit.reply.header.command == .reply);
             assert(commit.reply.header.client == commit_client.id);
             assert(commit.reply.header.request == commit.request.header.request);
             assert(commit.reply.header.operation == commit.request.header.operation);
 
-            assert(commit.request.base.references == 1);
+            assert(commit.request.references == 1);
             assert(commit.request.header.command == .request);
             assert(commit.request.header.client == commit_client.id);
 
@@ -759,7 +759,7 @@ pub const Simulator = struct {
         );
         // Since we already checked the client's request queue for free space, `client.request()`
         // should always queue the request.
-        assert(request_message == client.request_queue.tail_ptr().?.message.base);
+        assert(request_message == client.request_queue.tail_ptr().?.message.base());
         assert(request_message.header.size == @sizeOf(vsr.Header) + request_metadata.size);
         assert(request_message.header.into(.request).?.operation.cast(StateMachine) ==
             request_metadata.operation);

--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -107,7 +107,7 @@ pub const AOF = struct {
 
     pub fn write(
         self: *AOF,
-        message: Message.Type(.prepare),
+        message: Message.Prepare,
         options: struct { replica: u8, primary: u8 },
     ) !void {
         var entry: AOFEntry align(constants.sector_size) = undefined;

--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -105,7 +105,11 @@ pub const AOF = struct {
         }
     }
 
-    pub fn write(self: *AOF, message: *const Message, options: struct { replica: u8, primary: u8 }) !void {
+    pub fn write(
+        self: *AOF,
+        message: Message.Type(.prepare),
+        options: struct { replica: u8, primary: u8 },
+    ) !void {
         var entry: AOFEntry align(constants.sector_size) = undefined;
         entry.from_message(message, .{ .replica = options.replica, .primary = options.primary }, &self.last_checksum);
 

--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -107,7 +107,7 @@ pub const AOF = struct {
 
     pub fn write(
         self: *AOF,
-        message: Message.Prepare,
+        message: *const Message.Prepare,
         options: struct { replica: u8, primary: u8 },
     ) !void {
         var entry: AOFEntry align(constants.sector_size) = undefined;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -76,8 +76,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         on_client_reply: *const fn (
             cluster: *Self,
             client: usize,
-            request: Message.Type(.request),
-            reply: Message.Type(.reply),
+            request: Message.Request,
+            reply: Message.Reply,
         ) void,
 
         network: *Network,
@@ -111,8 +111,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             on_client_reply: *const fn (
                 cluster: *Self,
                 client: usize,
-                request: Message.Type(.request),
-                reply: Message.Type(.reply),
+                request: Message.Request,
+                reply: Message.Reply,
             ) void,
             options: Options,
         ) !*Self {
@@ -487,8 +487,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
         fn client_on_reply(
             client: *Client,
-            request_message: Message.Type(.request),
-            reply_message: Message.Type(.reply),
+            request_message: Message.Request,
+            reply_message: Message.Reply,
         ) void {
             const cluster: *Self = @ptrCast(@alignCast(client.on_reply_context.?));
             assert(reply_message.header.frame_const().invalid() == null);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -491,7 +491,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             reply_message: Message.Reply,
         ) void {
             const cluster: *Self = @ptrCast(@alignCast(client.on_reply_context.?));
-            assert(reply_message.header.frame_const().invalid() == null);
+            assert(reply_message.header.invalid() == null);
             assert(reply_message.header.cluster == cluster.options.cluster_id);
             assert(reply_message.header.client == client.id);
             assert(reply_message.header.request == request_message.header.request);
@@ -632,7 +632,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 var wal_op_min: u64 = std.math.maxInt(u64);
                 var wal_op_max: u64 = 0;
                 for (cluster.storages[replica_index].wal_prepares()) |*prepare| {
-                    if (prepare.header.frame_const().valid_checksum() and
+                    if (prepare.header.valid_checksum() and
                         prepare.header.command == .prepare)
                     {
                         if (wal_op_min > prepare.header.op) wal_op_min = prepare.header.op;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -76,8 +76,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         on_client_reply: *const fn (
             cluster: *Self,
             client: usize,
-            request: Message.Request,
-            reply: Message.Reply,
+            request: *Message.Request,
+            reply: *Message.Reply,
         ) void,
 
         network: *Network,
@@ -111,8 +111,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             on_client_reply: *const fn (
                 cluster: *Self,
                 client: usize,
-                request: Message.Request,
-                reply: Message.Reply,
+                request: *Message.Request,
+                reply: *Message.Reply,
             ) void,
             options: Options,
         ) !*Self {
@@ -487,8 +487,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
         fn client_on_reply(
             client: *Client,
-            request_message: Message.Request,
-            reply_message: Message.Reply,
+            request_message: *Message.Request,
+            reply_message: *Message.Reply,
         ) void {
             const cluster: *Self = @ptrCast(@alignCast(client.on_reply_context.?));
             assert(reply_message.header.invalid() == null);

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -3,8 +3,9 @@ const assert = std.debug.assert;
 
 const MessagePool = @import("../../message_pool.zig").MessagePool;
 const Message = MessagePool.Message;
-const Header = @import("../../vsr.zig").Header;
-const ProcessType = @import("../../vsr.zig").ProcessType;
+const vsr = @import("../../vsr.zig");
+const Header = vsr.Header;
+const ProcessType = vsr.ProcessType;
 
 const Network = @import("network.zig").Network;
 
@@ -51,11 +52,17 @@ pub const MessageBus = struct {
 
     pub fn tick(_: *MessageBus) void {}
 
-    pub fn get_message(bus: *MessageBus) *Message {
-        return bus.pool.get_message();
+    pub fn get_message(
+        bus: *MessageBus,
+        comptime command: ?vsr.Command,
+    ) MessagePool.GetMessageType(command) {
+        return bus.pool.get_message(command);
     }
 
-    pub fn unref(bus: *MessageBus, message: *Message) void {
+    /// `@TypeOf(message)` is one of:
+    /// - `*Message`
+    /// - `MessageType(command)` for any `command`.
+    pub fn unref(bus: *MessageBus, message: anytype) void {
         bus.pool.unref(message);
     }
 

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -218,7 +218,7 @@ pub const Network = struct {
             message.header.command,
         });
 
-        const network_message = network.message_pool.get_message();
+        const network_message = network.message_pool.get_message(null);
         defer network.message_pool.unref(network_message);
 
         stdx.copy_disjoint(.exact, u8, network_message.buffer, message.buffer);
@@ -271,7 +271,7 @@ pub const Network = struct {
         }
 
         const target_bus = network.buses.items[path.target];
-        const target_message = target_bus.get_message();
+        const target_message = target_bus.get_message(null);
         defer target_bus.unref(target_message);
 
         stdx.copy_disjoint(.exact, u8, target_message.buffer, packet.message.buffer);

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -11,7 +11,7 @@ const Message = MessagePool.Message;
 
 const ReplicaSet = std.StaticBitSet(constants.members_max);
 const Commits = std.ArrayList(struct {
-    header: vsr.Header,
+    header: vsr.Header.Type(.prepare),
     replicas: ReplicaSet = ReplicaSet.initEmpty(),
 });
 
@@ -46,7 +46,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             replicas: []const Replica,
             clients: []const Client,
         }) !Self {
-            const root_prepare = vsr.Header.root_prepare(options.cluster_id);
+            const root_prepare = vsr.Header.Type(.prepare).root(options.cluster_id);
 
             var commits = Commits.init(allocator);
             errdefer commits.deinit();
@@ -79,13 +79,13 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
         }
 
         pub fn on_message(state_checker: *Self, message: *const Message) void {
-            if (message.header.command == .prepare_ok) {
-                const head = &state_checker.replica_head_max[message.header.replica];
-                if (message.header.view > head.view or
-                    (message.header.view == head.view and message.header.op > head.op))
+            if (message.header.into_const(.prepare_ok)) |header| {
+                const head = &state_checker.replica_head_max[header.replica];
+                if (header.view > head.view or
+                    (header.view == head.view and header.op > head.op))
                 {
-                    head.view = message.header.view;
-                    head.op = message.header.op;
+                    head.view = header.view;
+                    head.op = header.op;
                 }
             }
         }
@@ -204,7 +204,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             }
         }
 
-        pub fn header_with_op(state_checker: *Self, op: u64) vsr.Header {
+        pub fn header_with_op(state_checker: *Self, op: u64) vsr.Header.Type(.prepare) {
             const commit = &state_checker.commits.items[op];
             assert(commit.header.op == op);
             assert(commit.replicas.count() > 0);

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -11,7 +11,7 @@ const Message = MessagePool.Message;
 
 const ReplicaSet = std.StaticBitSet(constants.members_max);
 const Commits = std.ArrayList(struct {
-    header: vsr.Header.Type(.prepare),
+    header: vsr.Header.Prepare,
     replicas: ReplicaSet = ReplicaSet.initEmpty(),
 });
 
@@ -46,7 +46,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             replicas: []const Replica,
             clients: []const Client,
         }) !Self {
-            const root_prepare = vsr.Header.Type(.prepare).root(options.cluster_id);
+            const root_prepare = vsr.Header.Prepare.root(options.cluster_id);
 
             var commits = Commits.init(allocator);
             errdefer commits.deinit();
@@ -204,7 +204,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             }
         }
 
-        pub fn header_with_op(state_checker: *Self, op: u64) vsr.Header.Type(.prepare) {
+        pub fn header_with_op(state_checker: *Self, op: u64) vsr.Header.Prepare {
             const commit = &state_checker.commits.items[op];
             assert(commit.header.op == op);
             assert(commit.replicas.count() > 0);

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -254,7 +254,7 @@ pub const StorageChecker = struct {
             };
 
             const block_header = schema.header_from_block(block);
-            assert(block_header.op == block_address);
+            assert(block_header.address == block_address);
 
             stream.add(block[0..block_header.size]);
             // Extra guard against identical blocks:

--- a/src/testing/reply_sequence.zig
+++ b/src/testing/reply_sequence.zig
@@ -87,10 +87,10 @@ pub const ReplySequence = struct {
         request_message: Message.Request,
         reply_message: Message.Reply,
     ) void {
-        assert(request_message.header.frame_const().invalid() == null);
+        assert(request_message.header.invalid() == null);
         assert(request_message.header.command == .request);
 
-        assert(reply_message.header.frame_const().invalid() == null);
+        assert(reply_message.header.invalid() == null);
         assert(reply_message.header.request == request_message.header.request);
         assert(reply_message.header.op >= sequence.stalled_op);
         assert(reply_message.header.command == .reply);

--- a/src/testing/reply_sequence.zig
+++ b/src/testing/reply_sequence.zig
@@ -131,7 +131,7 @@ pub const ReplySequence = struct {
     ///
     /// Returns the ReplySequence's message.
     fn clone_message(sequence: *ReplySequence, message_client: *const Message) *Message {
-        const message_sequence = sequence.message_pool.get_message();
+        const message_sequence = sequence.message_pool.get_message(null);
         stdx.copy_disjoint(.exact, u8, message_sequence.buffer, message_client.buffer);
         return message_sequence;
     }

--- a/src/testing/reply_sequence.zig
+++ b/src/testing/reply_sequence.zig
@@ -17,8 +17,8 @@ const PriorityQueue = std.PriorityQueue;
 /// Both messages belong to the ReplySequence's `MessagePool`.
 const PendingReply = struct {
     client_index: usize,
-    request: Message.Type(.request),
-    reply: Message.Type(.reply),
+    request: Message.Request,
+    reply: Message.Reply,
 
     /// `PendingReply`s are ordered by ascending reply op.
     fn compare(context: void, a: PendingReply, b: PendingReply) std.math.Order {
@@ -84,8 +84,8 @@ pub const ReplySequence = struct {
     pub fn insert(
         sequence: *ReplySequence,
         client_index: usize,
-        request_message: Message.Type(.request),
-        reply_message: Message.Type(.reply),
+        request_message: Message.Request,
+        reply_message: Message.Reply,
     ) void {
         assert(request_message.header.frame_const().invalid() == null);
         assert(request_message.header.command == .request);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -548,11 +548,11 @@ pub const Storage = struct {
         return @alignCast(mem.bytesAsValue(superblock.SuperBlockHeader, bytes));
     }
 
-    pub fn wal_headers(storage: *const Storage) []const vsr.Header.Type(.prepare) {
+    pub fn wal_headers(storage: *const Storage) []const vsr.Header.Prepare {
         const offset = vsr.Zone.wal_headers.offset(0);
         const size = vsr.Zone.wal_headers.size().?;
         return @alignCast(mem.bytesAsSlice(
-            vsr.Header.Type(.prepare),
+            vsr.Header.Prepare,
             storage.memory[offset..][0..size],
         ));
     }

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -548,32 +548,44 @@ pub const Storage = struct {
         return @alignCast(mem.bytesAsValue(superblock.SuperBlockHeader, bytes));
     }
 
-    pub fn wal_headers(storage: *const Storage) []const vsr.Header {
+    pub fn wal_headers(storage: *const Storage) []const vsr.Header.Type(.prepare) {
         const offset = vsr.Zone.wal_headers.offset(0);
         const size = vsr.Zone.wal_headers.size().?;
-        return @alignCast(mem.bytesAsSlice(vsr.Header, storage.memory[offset..][0..size]));
+        return @alignCast(mem.bytesAsSlice(
+            vsr.Header.Type(.prepare),
+            storage.memory[offset..][0..size],
+        ));
     }
 
-    const MessageRaw = extern struct {
-        header: vsr.Header,
-        body: [constants.message_size_max - @sizeOf(vsr.Header)]u8,
+    fn MessageRawType(comptime command: vsr.Command) type {
+        return extern struct {
+            const MessageRaw = @This();
+            header: vsr.Header.Type(command),
+            body: [constants.message_size_max - @sizeOf(vsr.Header)]u8,
 
-        comptime {
-            assert(@sizeOf(MessageRaw) == constants.message_size_max);
-            assert(stdx.no_padding(MessageRaw));
-        }
-    };
+            comptime {
+                assert(@sizeOf(MessageRaw) == constants.message_size_max);
+                assert(stdx.no_padding(MessageRaw));
+            }
+        };
+    }
 
-    pub fn wal_prepares(storage: *const Storage) []const MessageRaw {
+    pub fn wal_prepares(storage: *const Storage) []const MessageRawType(.prepare) {
         const offset = vsr.Zone.wal_prepares.offset(0);
         const size = vsr.Zone.wal_prepares.size().?;
-        return @alignCast(mem.bytesAsSlice(MessageRaw, storage.memory[offset..][0..size]));
+        return @alignCast(mem.bytesAsSlice(
+            MessageRawType(.prepare),
+            storage.memory[offset..][0..size],
+        ));
     }
 
-    pub fn client_replies(storage: *const Storage) []const MessageRaw {
+    pub fn client_replies(storage: *const Storage) []const MessageRawType(.reply) {
         const offset = vsr.Zone.client_replies.offset(0);
         const size = vsr.Zone.client_replies.size().?;
-        return @alignCast(mem.bytesAsSlice(MessageRaw, storage.memory[offset..][0..size]));
+        return @alignCast(mem.bytesAsSlice(
+            MessageRawType(.reply),
+            storage.memory[offset..][0..size],
+        ));
     }
 
     pub fn grid_block(
@@ -586,7 +598,7 @@ pub const Storage = struct {
         if (storage.memory_written.isSet(@divExact(block_offset, constants.sector_size))) {
             const block_buffer = storage.memory[block_offset..][0..constants.block_size];
             const block_header = schema.header_from_block(@alignCast(block_buffer));
-            assert(block_header.op == address);
+            assert(block_header.address == address);
 
             return @alignCast(block_buffer);
         } else {
@@ -646,9 +658,9 @@ pub const Storage = struct {
         const index_block = storage.grid_block(index_address).?;
         const index_schema = schema.TableIndex.from(index_block);
         const index_block_header = schema.header_from_block(index_block);
-        assert(index_block_header.op == index_address);
+        assert(index_block_header.address == index_address);
         assert(index_block_header.checksum == index_checksum);
-        assert(schema.BlockType.from(index_block_header.operation) == .index);
+        assert(index_block_header.block_type == .index);
 
         for (
             index_schema.data_addresses_used(index_block),
@@ -657,9 +669,9 @@ pub const Storage = struct {
             const data_block = storage.grid_block(address).?;
             const data_block_header = schema.header_from_block(data_block);
 
-            assert(data_block_header.op == address);
+            assert(data_block_header.address == address);
             assert(data_block_header.checksum == checksum);
-            assert(schema.BlockType.from(data_block_header.operation) == .data);
+            assert(data_block_header.block_type == .data);
         }
     }
 };

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const math = std.math;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
+const maybe = stdx.maybe;
 const log = std.log.scoped(.vsr);
 
 // vsr.zig is the root of a zig package, reexport all public APIs.
@@ -51,10 +52,11 @@ pub const VSRState = superblock.SuperBlockHeader.VSRState;
 pub const CheckpointState = superblock.SuperBlockHeader.CheckpointState;
 pub const checksum = @import("vsr/checksum.zig").checksum;
 pub const ChecksumStream = @import("vsr/checksum.zig").ChecksumStream;
+pub const Header = @import("vsr/message_header.zig").Header;
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).
-pub const Version: u8 = 0;
+pub const Version: u16 = 0;
 
 pub const ProcessType = enum { replica, client };
 
@@ -265,715 +267,6 @@ pub const Operation = enum(u8) {
                 }
             }
         }
-    }
-};
-
-/// Network message and journal entry header:
-/// We reuse the same header for both so that prepare messages from the primary can simply be
-/// journalled as is by the backups without requiring any further modification.
-pub const Header = extern struct {
-    /// Aegis128 (used by checksum) uses hardware accelerated AES via inline asm which isn't
-    /// available at comptime. Use a hard-coded value instead and verify via a test.
-    const checksum_body_empty: u128 = 0x49F174618255402DE6E7E3C40D60CC83;
-    test "empty checksum" {
-        assert(checksum_body_empty == checksum(&.{}));
-    }
-
-    /// A checksum covering only the remainder of this header.
-    /// This allows the header to be trusted without having to recv() or read() the associated body.
-    /// This checksum is enough to uniquely identify a network message or journal entry.
-    checksum: u128 = 0,
-
-    /// A checksum covering only the associated body after this header.
-    checksum_body: u128 = 0,
-
-    /// A backpointer to the previous request or prepare checksum for hash chain verification.
-    /// This provides a cryptographic guarantee for linearizability:
-    /// 1. across our distributed log of prepares, and
-    /// 2. across a client's requests and our replies.
-    /// This may also be used as the initialization vector for AEAD encryption at rest, provided
-    /// that the primary ratchets the encryption key every view change to ensure that prepares
-    /// reordered through a view change never repeat the same IV for the same encryption key.
-    ///
-    /// * A `prepare_ok` sets this to the checkpoint id. (TODO(Big headers): Use a separate field.)
-    /// * A `commit` sets this to the checkpoint id. (Possibly uncanonical.)
-    /// * A `ping` sets this to the checkpoint id. (Possibly uncanonical.)
-    /// * A `request_sync_checkpoint` sets this to the requested checkpoint id.
-    /// * A `request_sync_free_set` sets this to the requested checkpoint id.
-    /// * A `request_sync_client_sessions` sets this to the requested checkpoint id.
-    /// * A `sync_checkpoint` sets this to the checkpoint id.
-    /// * A `sync_free_set` sets this to the checkpoint id.
-    /// * A `sync_client_sessions` sets this to the checkpoint id.
-    parent: u128 = 0,
-
-    /// Each client process generates a unique, random and ephemeral client ID at initialization.
-    /// The client ID identifies connections made by the client to the cluster for the sake of
-    /// routing messages back to the client.
-    ///
-    /// With the client ID in hand, the client then registers a monotonically increasing session
-    /// number (committed through the cluster) to allow the client's session to be evicted safely
-    /// from the client table if too many concurrent clients cause the client table to overflow.
-    /// The monotonically increasing session number prevents duplicate client requests from being
-    /// replayed.
-    ///
-    /// The problem of routing is therefore solved by the 128-bit client ID, and the problem of
-    /// detecting whether a session has been evicted is solved by the session number.
-    ///
-    /// * A `request_reply` sets this to the client of the reply being requested.
-    /// * A `do_view_change` sets this to a bitset of "present" prepares. If a bit is set, then
-    ///   the corresponding header is not "blank", the replica has the prepare, and the prepare
-    ///   is not known to be faulty.
-    client: u128 = 0,
-
-    /// The checksum of the message to which this message refers.
-    ///
-    /// We use this cryptographic context in various ways, for example:
-    ///
-    /// * A `request` sets this to the client's session number.
-    /// * A `reply` sets this to a "stable" checksum.
-    ///   Replies for a specific op may have different views (and checksums),
-    ///   but are guaranteed to have the same context.
-    /// * A `prepare` sets this to the checksum of the client's request.
-    /// * A `prepare_ok` sets this to the checksum of the prepare being acked.
-    /// * A `commit` sets this to the checksum of the latest committed prepare.
-    /// * A `do_view_change` sets this to a bitset, with set bits indicating headers
-    ///   in the message body which it has definitely not prepared (i.e. "nack").
-    ///   The corresponding header may be an actual prepare header, or it may be a "blank" header.
-    /// * A `request_start_view` sets this to a unique nonce, to detect outdated SVs.
-    /// * A `start_view` sets this to zero for a new view, and to a nonce from an RSV when
-    ///   responding to the RSV.
-    /// * A `request_prepare` sets this to the checksum of the prepare being requested.
-    /// * A `request_reply` sets this to the checksum of the reply being requested.
-    /// * A `sync_free_set` sets this to the complete FreeSet's checksum.
-    /// * A `sync_client_sessions` sets this to the complete ClientSessions's checksum.
-    ///
-    /// This allows for cryptographic guarantees beyond request, op, and commit numbers, which have
-    /// low entropy and may otherwise collide in the event of any correctness bugs.
-    context: u128 = 0,
-
-    /// Each request is given a number by the client and later requests must have larger numbers
-    /// than earlier ones. The request number is used by the replicas to avoid running requests more
-    /// than once; it is also used by the client to discard duplicate responses to its requests.
-    /// A client is allowed to have at most one request inflight at a time.
-    ///
-    /// * A `do_view_change` sets this to its latest log_view number.
-    /// * A `request_sync_free_set` sets this to the requested offset within the encoded FreeSet.
-    /// * A `request_sync_client_sessions` sets this to the requested offset within the encoded ClientSessions.
-    /// * A `sync_free_set` sets this to the offset within the encoded FreeSet.
-    /// * A `sync_client_sessions` sets this to the offset within the encoded ClientSessions.
-    request: u32 = 0,
-
-    /// The cluster number binds intention into the header, so that a client or replica can indicate
-    /// the cluster it believes it is speaking to, instead of accidentally talking to the wrong
-    /// cluster (for example, staging vs production).
-    cluster: u32,
-
-    /// The cluster reconfiguration epoch number (for future use).
-    epoch: u32 = 0,
-
-    /// Every message sent from one replica to another contains the sending replica's current view.
-    /// A `u32` allows for a minimum lifetime of 136 years at a rate of one view change per second.
-    view: u32 = 0,
-
-    /// The op number of the latest prepare that may or may not yet be committed. Uncommitted ops
-    /// may be replaced by different ops if they do not survive through a view change.
-    ///
-    /// * A `commit` sets this to its checkpoint op.
-    /// * A `ping` sets this to its checkpoint op.
-    /// * A `request_headers` sets this to the maximum op requested (inclusive).
-    /// * A `request_prepare` sets this to the requested op.
-    /// * A `request_reply` sets this to the requested op.
-    /// * A `request_sync_checkpoint` sets this to the requested checkpoint op.
-    /// * A `request_sync_free_set` sets this to the requested checkpoint op.
-    /// * A `request_sync_client_sessions` sets this to the requested checkpoint op.
-    /// * A `sync_checkpoint` sets this to the checkpoint op.
-    /// * A `sync_free_set` sets this to the checkpoint op.
-    /// * A `sync_client_sessions` sets this to the checkpoint op.
-    op: u64 = 0,
-
-    /// The commit number of the latest committed prepare. Committed ops are immutable.
-    ///
-    /// * A `do_view_change` sets this to `commit_min`, to indicate the sending replica's progress.
-    ///   The sending replica may continue to commit after sending the DVC.
-    /// * A `start_view` sets this to `commit_min`/`commit_max` (they are the same).
-    /// * A `request_headers` sets this to the minimum op requested (inclusive).
-    /// * A `sync_free_set` sets this to the complete FreeSet's size.
-    /// * A `sync_client_sessions` sets this to the complete ClientSessions's size.
-    /// * A `ping` sets this to its monotonic timestamp.
-    /// * A `pong` echoes the ping's monotonic timestamp.
-    commit: u64 = 0,
-
-    /// This field is used in various ways:
-    ///
-    /// * A `prepare` sets this to the primary's state machine `prepare_timestamp`.
-    ///   For `create_accounts` and `create_transfers` this is the batch's highest timestamp.
-    /// * A `reply` sets this to the corresponding `prepare`'s timestamp.
-    ///   This allows the test workload to verify transfer timeouts.
-    /// * A `pong` sets this to the sender's wall clock value.
-    /// * A `commit` message sets this to the replica's monotonic timestamp.
-    /// * A `do_view_change` and `start_view` set this to the replica's `op_checkpoint`.
-    timestamp: u64 = 0,
-
-    /// The size of the Header structure (always), plus any associated body.
-    size: u32 = @sizeOf(Header),
-
-    /// The index of the replica in the cluster configuration array that authored this message.
-    /// This identifies only the ultimate author because messages may be forwarded amongst replicas.
-    replica: u8 = 0,
-
-    /// The Viewstamped Replication protocol command for this message.
-    command: Command,
-
-    /// The state machine operation to apply.
-    operation: Operation = .reserved,
-
-    /// The version of the protocol implementation that originated this message.
-    version: u8 = Version,
-
-    reserved: [128]u8 = [_]u8{0} ** 128,
-
-    comptime {
-        assert(@sizeOf(Header) == 256);
-        assert(stdx.no_padding(Header));
-    }
-
-    pub fn calculate_checksum(self: *const Header) u128 {
-        const checksum_size = @sizeOf(@TypeOf(self.checksum));
-        assert(checksum_size == 16);
-        const checksum_value = checksum(std.mem.asBytes(self)[checksum_size..]);
-        assert(@TypeOf(checksum_value) == @TypeOf(self.checksum));
-        return checksum_value;
-    }
-
-    pub fn calculate_checksum_body(self: *const Header, body: []const u8) u128 {
-        assert(self.size == @sizeOf(Header) + body.len);
-        const checksum_size = @sizeOf(@TypeOf(self.checksum_body));
-        assert(checksum_size == 16);
-        const checksum_value = checksum(body);
-        assert(@TypeOf(checksum_value) == @TypeOf(self.checksum_body));
-        return checksum_value;
-    }
-
-    /// This must be called only after set_checksum_body() so that checksum_body is also covered:
-    pub fn set_checksum(self: *Header) void {
-        self.checksum = self.calculate_checksum();
-    }
-
-    pub fn set_checksum_body(self: *Header, body: []const u8) void {
-        self.checksum_body = self.calculate_checksum_body(body);
-    }
-
-    pub fn valid_checksum(self: *const Header) bool {
-        return self.checksum == self.calculate_checksum();
-    }
-
-    pub fn valid_checksum_body(self: *const Header, body: []const u8) bool {
-        return self.checksum_body == self.calculate_checksum_body(body);
-    }
-
-    /// Returns null if all fields are set correctly according to the command, or else a warning.
-    /// This does not verify that checksum is valid, and expects that this has already been done.
-    pub fn invalid(self: *const Header) ?[]const u8 {
-        if (self.version != Version) return "version != Version";
-        if (self.size < @sizeOf(Header)) return "size < @sizeOf(Header)";
-        if (self.epoch != 0) return "epoch != 0";
-        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
-        return switch (self.command) {
-            .reserved => self.invalid_reserved(),
-            .ping => self.invalid_ping(),
-            .pong => self.invalid_pong(),
-            .ping_client => self.invalid_ping_client(),
-            .pong_client => self.invalid_pong_client(),
-            .request => self.invalid_request(),
-            .prepare => self.invalid_prepare(),
-            .prepare_ok => self.invalid_prepare_ok(),
-            .reply => self.invalid_reply(),
-            .commit => self.invalid_commit(),
-            .start_view_change => self.invalid_start_view_change(),
-            .do_view_change => self.invalid_do_view_change(),
-            .start_view => self.invalid_start_view(),
-            .request_start_view => self.invalid_request_start_view(),
-            .request_headers => self.invalid_request_headers(),
-            .request_prepare => self.invalid_request_prepare(),
-            .request_reply => self.invalid_request_reply(),
-            .request_blocks => self.invalid_request_blocks(),
-            .headers => self.invalid_headers(),
-            .eviction => self.invalid_eviction(),
-            .block => self.invalid_block(),
-            .request_sync_checkpoint => self.invalid_request_sync_checkpoint(),
-            .sync_checkpoint => self.invalid_sync_checkpoint(),
-            .request_sync_free_set => self.invalid_request_sync_free_set(),
-            .request_sync_client_sessions => self.invalid_request_sync_client_sessions(),
-            .sync_free_set => self.invalid_sync_free_set(),
-            .sync_client_sessions => self.invalid_sync_client_sessions(),
-            // The `Command` enum is exhaustive, so we can't write an "else" branch here. An unknown
-            // command is a possibility, but that means that someone has send us a message with
-            // matching cluster, matching version, correct checksum, and a command we don't know
-            // about. Ignoring unknown commands might be unsafe, so the replica intentionally
-            // crashes here, which is guaranteed by Zig's ReleaseSafe semantics.
-            //
-            // _ => unreachable
-        };
-    }
-
-    fn invalid_reserved(self: *const Header) ?[]const u8 {
-        assert(self.command == .reserved);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.replica != 0) return "replica != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_ping(self: *const Header) ?[]const u8 {
-        assert(self.command == .ping);
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_pong(self: *const Header) ?[]const u8 {
-        assert(self.command == .pong);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.timestamp == 0) return "timestamp == 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_ping_client(self: *const Header) ?[]const u8 {
-        assert(self.command == .ping_client);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client == 0) return "client == 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.replica != 0) return "replica != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_pong_client(self: *const Header) ?[]const u8 {
-        assert(self.command == .pong_client);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request(self: *const Header) ?[]const u8 {
-        assert(self.command == .request);
-        if (self.client == 0) return "client == 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0 and !constants.aof_recovery) return "timestamp != 0";
-        if (self.replica != 0) return "replica != 0";
-        switch (self.operation) {
-            .reserved => return "operation == .reserved",
-            .root => return "operation == .root",
-            .register => {
-                // The first request a client makes must be to register with the cluster:
-                if (self.parent != 0) return "register: parent != 0";
-                if (self.context != 0) return "register: context != 0";
-                if (self.request != 0) return "register: request != 0";
-                // The .register operation carries no payload:
-                if (self.checksum_body != checksum_body_empty) return "register: checksum_body != expected";
-                if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-            },
-            else => {
-                if (self.operation == .reconfigure) {
-                    if (self.size != @sizeOf(Header) + @sizeOf(ReconfigurationRequest)) {
-                        return "size != @sizeOf(Header) + @sizeOf(ReconfigurationRequest)";
-                    }
-                } else if (@intFromEnum(self.operation) < constants.vsr_operations_reserved) {
-                    return "operation is reserved";
-                }
-                // Thereafter, the client must provide the session number in the context:
-                // These requests should set `parent` to the `checksum` of the previous reply.
-                if (self.context == 0) return "context == 0";
-                if (self.request == 0) return "request == 0";
-            },
-        }
-        return null;
-    }
-
-    fn invalid_prepare(self: *const Header) ?[]const u8 {
-        assert(self.command == .prepare);
-        switch (self.operation) {
-            .reserved => return "operation == .reserved",
-            .root => {
-                if (self.parent != 0) return "root: parent != 0";
-                if (self.client != 0) return "root: client != 0";
-                if (self.context != 0) return "root: context != 0";
-                if (self.request != 0) return "root: request != 0";
-                if (self.view != 0) return "root: view != 0";
-                if (self.op != 0) return "root: op != 0";
-                if (self.commit != 0) return "root: commit != 0";
-                if (self.timestamp != 0) return "root: timestamp != 0";
-                if (self.checksum_body != checksum_body_empty) return "root: checksum_body != expected";
-                if (self.size != @sizeOf(Header)) return "root: size != @sizeOf(Header)";
-                if (self.replica != 0) return "root: replica != 0";
-            },
-            else => {
-                if (self.client == 0) return "client == 0";
-                if (self.op == 0) return "op == 0";
-                if (self.op <= self.commit) return "op <= commit";
-                if (self.timestamp == 0) return "timestamp == 0";
-                if (self.operation == .register) {
-                    // Client session numbers are replaced by the reference to the previous prepare.
-                    if (self.request != 0) return "request != 0";
-                } else {
-                    // Client session numbers are replaced by the reference to the previous prepare.
-                    if (self.request == 0) return "request == 0";
-                }
-            },
-        }
-        return null;
-    }
-
-    fn invalid_prepare_ok(self: *const Header) ?[]const u8 {
-        assert(self.command == .prepare_ok);
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        switch (self.operation) {
-            .reserved => return "operation == .reserved",
-            .root => {
-                const root_checksum = Header.root_prepare(self.cluster).checksum;
-                if (self.client != 0) return "root: client != 0";
-                if (self.context != root_checksum) return "root: context != expected";
-                if (self.request != 0) return "root: request != 0";
-                if (self.op != 0) return "root: op != 0";
-                if (self.commit != 0) return "root: commit != 0";
-                if (self.timestamp != 0) return "root: timestamp != 0";
-            },
-            else => {
-                if (self.client == 0) return "client == 0";
-                if (self.op == 0) return "op == 0";
-                if (self.op <= self.commit) return "op <= commit";
-                if (self.timestamp == 0) return "timestamp == 0";
-                if (self.operation == .register) {
-                    if (self.request != 0) return "request != 0";
-                } else {
-                    if (self.request == 0) return "request == 0";
-                }
-            },
-        }
-        return null;
-    }
-
-    fn invalid_reply(self: *const Header) ?[]const u8 {
-        assert(self.command == .reply);
-        // Initialization within `client.zig` asserts that client `id` is greater than zero:
-        if (self.client == 0) return "client == 0";
-        if (self.op != self.commit) return "op != commit";
-        if (self.timestamp == 0) return "timestamp == 0";
-        if (self.operation == .register) {
-            // In this context, the commit number is the newly registered session number.
-            // The `0` commit number is reserved for cluster initialization.
-            if (self.commit == 0) return "commit == 0";
-            if (self.request != 0) return "request != 0";
-        } else {
-            if (self.commit == 0) return "commit == 0";
-            if (self.request == 0) return "request == 0";
-        }
-        return null;
-    }
-
-    fn invalid_commit(self: *const Header) ?[]const u8 {
-        assert(self.command == .commit);
-        if (self.client != 0) return "client != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.timestamp == 0) return "timestamp == 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_start_view_change(self: *const Header) ?[]const u8 {
-        assert(self.command == .start_view_change);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_do_view_change(self: *const Header) ?[]const u8 {
-        assert(self.command == .do_view_change);
-        if (self.parent != 0) return "parent != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_start_view(self: *const Header) ?[]const u8 {
-        assert(self.command == .start_view);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_start_view(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_start_view);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_headers(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_headers);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.commit > self.op) return "op_min > op_max";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_prepare(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_prepare);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_reply(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_reply);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client == 0) return "client == 0";
-        if (self.request != 0) return "request != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_blocks(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_blocks);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.size == @sizeOf(Header)) return "size == @sizeOf(Header)";
-        if ((self.size - @sizeOf(Header)) % @sizeOf(BlockRequest) != 0) {
-            return "size multiple invalid";
-        }
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_headers(self: *const Header) ?[]const u8 {
-        assert(self.command == .headers);
-        if (self.parent != 0) return "parent != 0";
-        if (self.client != 0) return "client != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_eviction(self: *const Header) ?[]const u8 {
-        assert(self.command == .eviction);
-        if (self.parent != 0) return "parent != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.op != 0) return "op != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_block(self: *const Header) ?[]const u8 {
-        assert(self.command == .block);
-        if (self.size > constants.block_size) return "size > block_size";
-        if (self.size == @sizeOf(Header)) return "size = @sizeOf(Header)";
-        if (self.client != 0) return "client != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.op == 0) return "op == 0"; // address ≠ 0
-        if (self.replica != 0) return "replica != 0";
-        if (self.operation == .reserved) return "operation == .reserved";
-        return null;
-    }
-
-    fn invalid_request_sync_checkpoint(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_sync_checkpoint);
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_sync_checkpoint(self: *const Header) ?[]const u8 {
-        assert(self.command == .sync_checkpoint);
-        if (self.size != @sizeOf(Header) + @sizeOf(CheckpointState)) {
-            return "size != @sizeOf(Header) + @sizeOf(CheckpointState)";
-        }
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.request != 0) return "request != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_sync_free_set(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_sync_free_set);
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_request_sync_client_sessions(self: *const Header) ?[]const u8 {
-        assert(self.command == .request_sync_client_sessions);
-        if (self.client != 0) return "client != 0";
-        if (self.context != 0) return "context != 0";
-        if (self.view != 0) return "view != 0";
-        if (self.commit != 0) return "commit != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_sync_free_set(self: *const Header) ?[]const u8 {
-        assert(self.command == .sync_free_set);
-        if (self.size - @sizeOf(Header) > constants.sync_trailer_message_body_size_max) return "size > max";
-        if (self.view != 0) return "view != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    fn invalid_sync_client_sessions(self: *const Header) ?[]const u8 {
-        assert(self.command == .sync_client_sessions);
-        if (self.size - @sizeOf(Header) > constants.sync_trailer_message_body_size_max) return "size > max";
-        if (self.view != 0) return "view != 0";
-        if (self.timestamp != 0) return "timestamp != 0";
-        if (self.operation != .reserved) return "operation != .reserved";
-        return null;
-    }
-
-    /// Returns whether the immediate sender is a replica or client (if this can be determined).
-    /// Some commands such as .request or .prepare may be forwarded on to other replicas so that
-    /// Header.replica or Header.client only identifies the ultimate origin, not the latest peer.
-    pub fn peer_type(self: *const Header) enum { unknown, replica, client } {
-        switch (self.command) {
-            .reserved => unreachable,
-            // These messages cannot always identify the peer as they may be forwarded:
-            .request => switch (self.operation) {
-                // However, we do not forward the first .register request sent by a client:
-                .register => return .client,
-                else => return .unknown,
-            },
-            .prepare => return .unknown,
-            // These messages identify the peer as either a replica or a client:
-            .ping_client => return .client,
-            // All other messages identify the peer as a replica:
-            else => return .replica,
-        }
-    }
-
-    pub fn reserved(cluster: u32, slot: u64) Header {
-        assert(slot < constants.journal_slot_count);
-
-        var header = Header{
-            .command = .reserved,
-            .cluster = cluster,
-            .op = slot,
-        };
-        header.set_checksum_body(&[0]u8{});
-        header.set_checksum();
-        assert(header.invalid() == null);
-        return header;
-    }
-
-    pub fn root_prepare(cluster: u32) Header {
-        var header = Header{
-            .cluster = cluster,
-            .size = @sizeOf(Header),
-            .command = .prepare,
-            .operation = .root,
-        };
-        header.set_checksum_body(&[0]u8{});
-        header.set_checksum();
-        assert(header.invalid() == null);
-        return header;
     }
 };
 
@@ -1741,7 +1034,7 @@ pub fn member_index(members: *const Members, replica_id: u128) ?u8 {
 }
 
 pub const Headers = struct {
-    pub const Array = stdx.BoundedArray(Header, constants.view_change_headers_max);
+    pub const Array = stdx.BoundedArray(Header.Type(.prepare), constants.view_change_headers_max);
     /// The SuperBlock's persisted VSR headers.
     /// One of the following:
     ///
@@ -1750,20 +1043,29 @@ pub const Headers = struct {
     pub const ViewChangeSlice = ViewChangeHeadersSlice;
     pub const ViewChangeArray = ViewChangeHeadersArray;
 
-    fn dvc_blank(op: u64) Header {
-        var header: Header = undefined;
-        @memset(std.mem.asBytes(&header), 0);
-        header.command = .reserved;
-        header.op = op;
-        return header;
+    fn dvc_blank(op: u64) Header.Type(.prepare) {
+        return .{
+            .command = .prepare,
+            .operation = .reserved,
+            .op = op,
+            .cluster = 0,
+            .view = 0,
+            .context = 0,
+            .parent = 0,
+            .client = 0,
+            .commit = 0,
+            .timestamp = 0,
+            .request = 0,
+        };
     }
 
-    pub fn dvc_header_type(header: *const Header) enum { blank, valid } {
+    pub fn dvc_header_type(header: *const Header.Type(.prepare)) enum { blank, valid } {
         if (std.meta.eql(header.*, Headers.dvc_blank(header.op))) return .blank;
 
-        if (constants.verify) assert(header.valid_checksum());
+        if (constants.verify) assert(header.frame_const().valid_checksum());
         assert(header.command == .prepare);
-        assert(header.invalid() == null);
+        assert(header.operation != .reserved);
+        assert(header.frame_const().invalid() == null);
         return .valid;
     }
 };
@@ -1773,9 +1075,12 @@ pub const ViewChangeCommand = enum { do_view_change, start_view };
 const ViewChangeHeadersSlice = struct {
     command: ViewChangeCommand,
     /// Headers are ordered from high-to-low op.
-    slice: []const Header,
+    slice: []const Header.Type(.prepare),
 
-    pub fn init(command: ViewChangeCommand, slice: []const Header) ViewChangeHeadersSlice {
+    pub fn init(
+        command: ViewChangeCommand,
+        slice: []const Header.Type(.prepare),
+    ) ViewChangeHeadersSlice {
         const headers = ViewChangeHeadersSlice{
             .command = command,
             .slice = slice,
@@ -1803,7 +1108,8 @@ const ViewChangeHeadersSlice = struct {
         var child = head;
         for (headers.slice[1..], 0..) |*header, i| {
             const index = i + 1;
-            assert(header.command == .prepare or header.command == .reserved);
+            assert(header.command == .prepare);
+            maybe(header.operation == .reserved);
             assert(header.op < child.op);
 
             // DVC: Ops are consecutive (with explicit blank headers).
@@ -1890,8 +1196,8 @@ const ViewChangeHeadersSlice = struct {
 };
 
 test "Headers.ViewChangeSlice.view_for_op" {
-    var headers_array = [_]Header{
-        std.mem.zeroInit(Header, .{
+    var headers_array = [_]Header.Type(.prepare){
+        std.mem.zeroInit(Header.Type(.prepare), .{
             .checksum = undefined,
             .client = 6,
             .request = 7,
@@ -1903,7 +1209,7 @@ test "Headers.ViewChangeSlice.view_for_op" {
         }),
         Headers.dvc_blank(8),
         Headers.dvc_blank(7),
-        std.mem.zeroInit(Header, .{
+        std.mem.zeroInit(Header.Type(.prepare), .{
             .checksum = undefined,
             .client = 3,
             .request = 4,
@@ -1916,8 +1222,8 @@ test "Headers.ViewChangeSlice.view_for_op" {
         Headers.dvc_blank(5),
     };
 
-    headers_array[0].set_checksum();
-    headers_array[3].set_checksum();
+    headers_array[0].frame().set_checksum();
+    headers_array[3].frame().set_checksum();
 
     const headers = Headers.ViewChangeSlice.init(.do_view_change, &headers_array);
     try std.testing.expect(std.meta.eql(headers.view_for_op(11, 12), .{ .min = 12, .max = 12 }));
@@ -1937,13 +1243,13 @@ const ViewChangeHeadersArray = struct {
 
     pub fn root(cluster: u32) ViewChangeHeadersArray {
         return ViewChangeHeadersArray.init_from_slice(.start_view, &.{
-            Header.root_prepare(cluster),
+            Header.Type(.prepare).root(cluster),
         });
     }
 
     pub fn init_from_slice(
         command: ViewChangeCommand,
-        slice: []const Header,
+        slice: []const Header.Type(.prepare),
     ) ViewChangeHeadersArray {
         const headers = ViewChangeHeadersArray{
             .command = command,
@@ -1983,6 +1289,7 @@ const ViewChangeHeadersArray = struct {
         );
         const commit_max_header = headers.array.get(headers.array.get(0).op - commit_max);
         assert(commit_max_header.command == .prepare);
+        assert(commit_max_header.operation != .reserved);
         assert(commit_max_header.op == commit_max);
 
         // SVs may include more headers than DVC:
@@ -1999,7 +1306,7 @@ const ViewChangeHeadersArray = struct {
     pub fn replace(
         headers: *ViewChangeHeadersArray,
         command: ViewChangeCommand,
-        slice: []const Header,
+        slice: []const Header.Type(.prepare),
     ) void {
         headers.command = command;
         headers.array.clear();
@@ -2007,7 +1314,7 @@ const ViewChangeHeadersArray = struct {
         headers.verify();
     }
 
-    pub fn append(headers: *ViewChangeHeadersArray, header: *const Header) void {
+    pub fn append(headers: *ViewChangeHeadersArray, header: *const Header.Type(.prepare)) void {
         // We don't do comprehensive validation here — assume that verify() will be called
         // after any series of appends.
         headers.array.append_assume_capacity(header.*);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1034,7 +1034,7 @@ pub fn member_index(members: *const Members, replica_id: u128) ?u8 {
 }
 
 pub const Headers = struct {
-    pub const Array = stdx.BoundedArray(Header.Type(.prepare), constants.view_change_headers_max);
+    pub const Array = stdx.BoundedArray(Header.Prepare, constants.view_change_headers_max);
     /// The SuperBlock's persisted VSR headers.
     /// One of the following:
     ///
@@ -1043,7 +1043,7 @@ pub const Headers = struct {
     pub const ViewChangeSlice = ViewChangeHeadersSlice;
     pub const ViewChangeArray = ViewChangeHeadersArray;
 
-    fn dvc_blank(op: u64) Header.Type(.prepare) {
+    fn dvc_blank(op: u64) Header.Prepare {
         return .{
             .command = .prepare,
             .operation = .reserved,
@@ -1059,7 +1059,7 @@ pub const Headers = struct {
         };
     }
 
-    pub fn dvc_header_type(header: *const Header.Type(.prepare)) enum { blank, valid } {
+    pub fn dvc_header_type(header: *const Header.Prepare) enum { blank, valid } {
         if (std.meta.eql(header.*, Headers.dvc_blank(header.op))) return .blank;
 
         if (constants.verify) assert(header.frame_const().valid_checksum());
@@ -1075,11 +1075,11 @@ pub const ViewChangeCommand = enum { do_view_change, start_view };
 const ViewChangeHeadersSlice = struct {
     command: ViewChangeCommand,
     /// Headers are ordered from high-to-low op.
-    slice: []const Header.Type(.prepare),
+    slice: []const Header.Prepare,
 
     pub fn init(
         command: ViewChangeCommand,
-        slice: []const Header.Type(.prepare),
+        slice: []const Header.Prepare,
     ) ViewChangeHeadersSlice {
         const headers = ViewChangeHeadersSlice{
             .command = command,
@@ -1196,8 +1196,8 @@ const ViewChangeHeadersSlice = struct {
 };
 
 test "Headers.ViewChangeSlice.view_for_op" {
-    var headers_array = [_]Header.Type(.prepare){
-        std.mem.zeroInit(Header.Type(.prepare), .{
+    var headers_array = [_]Header.Prepare{
+        std.mem.zeroInit(Header.Prepare, .{
             .checksum = undefined,
             .client = 6,
             .request = 7,
@@ -1209,7 +1209,7 @@ test "Headers.ViewChangeSlice.view_for_op" {
         }),
         Headers.dvc_blank(8),
         Headers.dvc_blank(7),
-        std.mem.zeroInit(Header.Type(.prepare), .{
+        std.mem.zeroInit(Header.Prepare, .{
             .checksum = undefined,
             .client = 3,
             .request = 4,
@@ -1243,13 +1243,13 @@ const ViewChangeHeadersArray = struct {
 
     pub fn root(cluster: u32) ViewChangeHeadersArray {
         return ViewChangeHeadersArray.init_from_slice(.start_view, &.{
-            Header.Type(.prepare).root(cluster),
+            Header.Prepare.root(cluster),
         });
     }
 
     pub fn init_from_slice(
         command: ViewChangeCommand,
-        slice: []const Header.Type(.prepare),
+        slice: []const Header.Prepare,
     ) ViewChangeHeadersArray {
         const headers = ViewChangeHeadersArray{
             .command = command,
@@ -1306,7 +1306,7 @@ const ViewChangeHeadersArray = struct {
     pub fn replace(
         headers: *ViewChangeHeadersArray,
         command: ViewChangeCommand,
-        slice: []const Header.Type(.prepare),
+        slice: []const Header.Prepare,
     ) void {
         headers.command = command;
         headers.array.clear();
@@ -1314,7 +1314,7 @@ const ViewChangeHeadersArray = struct {
         headers.verify();
     }
 
-    pub fn append(headers: *ViewChangeHeadersArray, header: *const Header.Type(.prepare)) void {
+    pub fn append(headers: *ViewChangeHeadersArray, header: *const Header.Prepare) void {
         // We don't do comprehensive validation here — assume that verify() will be called
         // after any series of appends.
         headers.array.append_assume_capacity(header.*);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1062,10 +1062,10 @@ pub const Headers = struct {
     pub fn dvc_header_type(header: *const Header.Prepare) enum { blank, valid } {
         if (std.meta.eql(header.*, Headers.dvc_blank(header.op))) return .blank;
 
-        if (constants.verify) assert(header.frame_const().valid_checksum());
+        if (constants.verify) assert(header.valid_checksum());
         assert(header.command == .prepare);
         assert(header.operation != .reserved);
-        assert(header.frame_const().invalid() == null);
+        assert(header.invalid() == null);
         return .valid;
     }
 };
@@ -1222,8 +1222,8 @@ test "Headers.ViewChangeSlice.view_for_op" {
         Headers.dvc_blank(5),
     };
 
-    headers_array[0].frame().set_checksum();
-    headers_array[3].frame().set_checksum();
+    headers_array[0].set_checksum();
+    headers_array[3].set_checksum();
 
     const headers = Headers.ViewChangeSlice.init(.do_view_change, &headers_array);
     try std.testing.expect(std.meta.eql(headers.view_for_op(11, 12), .{ .min = 12, .max = 12 }));

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -430,8 +430,10 @@ pub const Header = extern struct {
     /// The version of the protocol implementation that originated this message.
     version: u8 = Version,
 
+    reserved: [128]u8 = [_]u8{0} ** 128,
+
     comptime {
-        assert(@sizeOf(Header) == 128);
+        assert(@sizeOf(Header) == 256);
         assert(stdx.no_padding(Header));
     }
 
@@ -475,6 +477,7 @@ pub const Header = extern struct {
         if (self.version != Version) return "version != Version";
         if (self.size < @sizeOf(Header)) return "size < @sizeOf(Header)";
         if (self.epoch != 0) return "epoch != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
         return switch (self.command) {
             .reserved => self.invalid_reserved(),
             .ping => self.invalid_ping(),

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -293,7 +293,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(self.messages_available > 0);
             self.messages_available -= 1;
 
-            return self.message_bus.get_message();
+            return self.message_bus.get_message(null);
         }
 
         /// Releases a message back to the message bus.
@@ -489,7 +489,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(header.cluster == self.cluster);
             assert(header.size == @sizeOf(Header));
 
-            const message = self.message_bus.get_message();
+            const message = self.message_bus.get_message(null);
             defer self.message_bus.unref(message);
 
             message.header.* = header;
@@ -504,7 +504,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             if (self.request_number > 0) return;
 
             const message = self.get_message().build(.request);
-            errdefer self.release(message.base);
+            errdefer self.release(message);
 
             // We will set parent, session, view and checksums only when sending for the first time:
             message.header.* = .{

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -351,8 +351,8 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
         fn on_reply(self: *Self, reply: Message.Reply) void {
             // We check these checksums again here because this is the last time we get to downgrade
             // a correctness bug into a liveness bug, before we return data back to the application.
-            assert(reply.header.frame_const().valid_checksum());
-            assert(reply.header.frame_const().valid_checksum_body(reply.body()));
+            assert(reply.header.valid_checksum());
+            assert(reply.header.valid_checksum_body(reply.body()));
             assert(reply.header.command == .reply);
 
             if (reply.header.client != self.id) {
@@ -590,8 +590,8 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             // to be sent for the first time. However, beyond that, it is not necessary to update
             // the view number again, for example if it should change between now and resending.
             message.header.view = self.view;
-            message.header.frame().set_checksum_body(message.body());
-            message.header.frame().set_checksum();
+            message.header.set_checksum_body(message.body());
+            message.header.set_checksum();
 
             // The checksum of this request becomes the parent of our next reply:
             self.parent = message.header.checksum;

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -227,8 +227,8 @@ pub fn ClientRepliesType(comptime Storage: type) type {
                 client_replies.write_reply_next();
             }
 
-            if (!message.header.frame_const().valid_checksum() or
-                !message.header.frame_const().valid_checksum_body(message.body()))
+            if (!message.header.valid_checksum() or
+                !message.header.valid_checksum_body(message.body()))
             {
                 log.warn("{}: read_reply: corrupt reply (client={} reply={})", .{
                     client_replies.replica,

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -54,14 +54,14 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             completion: Storage.Read,
             callback: *const fn (
                 client_replies: *ClientReplies,
-                reply_header: *const vsr.Header.Type(.reply),
-                reply: ?Message.Type(.reply),
+                reply_header: *const vsr.Header.Reply,
+                reply: ?Message.Reply,
                 destination_replica: ?u8,
             ) void,
             slot: Slot,
-            message: Message.Type(.reply),
+            message: Message.Reply,
             /// The header of the expected reply.
-            header: vsr.Header.Type(.reply),
+            header: vsr.Header.Reply,
             destination_replica: ?u8,
         };
 
@@ -69,7 +69,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             client_replies: *ClientReplies,
             completion: Storage.Write,
             slot: Slot,
-            message: Message.Type(.reply),
+            message: Message.Reply,
         };
 
         const WriteQueue = RingBuffer(*Write, .{
@@ -133,7 +133,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             client_replies: *ClientReplies,
             slot: Slot,
             session: *const ClientSessions.Entry,
-        ) ?Message.Type(.reply) {
+        ) ?Message.Reply {
             const client = session.header.client;
 
             if (client_replies.writing.isSet(slot.index)) {
@@ -166,8 +166,8 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             session: *const ClientSessions.Entry,
             callback: *const fn (
                 *ClientReplies,
-                *const vsr.Header.Type(.reply),
-                ?Message.Type(.reply),
+                *const vsr.Header.Reply,
+                ?Message.Reply,
                 ?u8,
             ) void,
             destination_replica: ?u8,
@@ -299,7 +299,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
         pub fn write_reply(
             client_replies: *ClientReplies,
             slot: Slot,
-            message: Message.Type(.reply),
+            message: Message.Reply,
             trigger: enum { commit, repair },
         ) void {
             assert(client_replies.ready_sync());

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -55,11 +55,11 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             callback: *const fn (
                 client_replies: *ClientReplies,
                 reply_header: *const vsr.Header.Reply,
-                reply: ?Message.Reply,
+                reply: ?*Message.Reply,
                 destination_replica: ?u8,
             ) void,
             slot: Slot,
-            message: Message.Reply,
+            message: *Message.Reply,
             /// The header of the expected reply.
             header: vsr.Header.Reply,
             destination_replica: ?u8,
@@ -69,7 +69,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             client_replies: *ClientReplies,
             completion: Storage.Write,
             slot: Slot,
-            message: Message.Reply,
+            message: *Message.Reply,
         };
 
         const WriteQueue = RingBuffer(*Write, .{
@@ -133,7 +133,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             client_replies: *ClientReplies,
             slot: Slot,
             session: *const ClientSessions.Entry,
-        ) ?Message.Reply {
+        ) ?*Message.Reply {
             const client = session.header.client;
 
             if (client_replies.writing.isSet(slot.index)) {
@@ -167,7 +167,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             callback: *const fn (
                 *ClientReplies,
                 *const vsr.Header.Reply,
-                ?Message.Reply,
+                ?*Message.Reply,
                 ?u8,
             ) void,
             destination_replica: ?u8,
@@ -299,7 +299,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
         pub fn write_reply(
             client_replies: *ClientReplies,
             slot: Slot,
-            message: Message.Reply,
+            message: *Message.Reply,
             trigger: enum { commit, repair },
         ) void {
             assert(client_replies.ready_sync());

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -925,7 +925,7 @@ pub fn GridType(comptime Storage: type) type {
 
             if (result != .valid) {
                 const header =
-                    mem.bytesAsValue(vsr.Header.Type(.block), block.*[0..@sizeOf(vsr.Header)]);
+                    mem.bytesAsValue(vsr.Header.Block, block.*[0..@sizeOf(vsr.Header)]);
                 log.err(
                     "{}: {s}: expected address={} checksum={}, found address={} checksum={}",
                     .{
@@ -952,7 +952,7 @@ pub fn GridType(comptime Storage: type) type {
             address: u64,
             checksum: u128,
         }) ReadBlockResult {
-            const header = mem.bytesAsValue(vsr.Header.Type(.block), block[0..@sizeOf(vsr.Header)]);
+            const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
 
             if (!header.frame_const().valid_checksum()) return .invalid_checksum;
             if (header.command != .block) return .unexpected_command;

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -954,14 +954,14 @@ pub fn GridType(comptime Storage: type) type {
         }) ReadBlockResult {
             const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);
 
-            if (!header.frame_const().valid_checksum()) return .invalid_checksum;
+            if (!header.valid_checksum()) return .invalid_checksum;
             if (header.command != .block) return .unexpected_command;
 
             assert(header.size >= @sizeOf(vsr.Header));
             assert(header.size <= constants.block_size);
 
             const block_body = block[@sizeOf(vsr.Header)..header.size];
-            if (!header.frame_const().valid_checksum_body(block_body)) {
+            if (!header.valid_checksum_body(block_body)) {
                 return .invalid_checksum_body;
             }
 

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -329,10 +329,10 @@ pub const GridBlocksMissing = struct {
 
     pub fn repair_complete(queue: *GridBlocksMissing, block: BlockPtrConst) void {
         const block_header = schema.header_from_block(block);
-        const fault_index = queue.faulty_blocks.getIndex(block_header.op).?;
+        const fault_index = queue.faulty_blocks.getIndex(block_header.address).?;
         const fault_address = queue.faulty_blocks.entries.items(.key)[fault_index];
         const fault: FaultyBlock = queue.faulty_blocks.entries.items(.value)[fault_index];
-        assert(fault_address == block_header.op);
+        assert(fault_address == block_header.address);
         assert(fault.checksum == block_header.checksum);
         assert(fault.state == .aborting or fault.state == .writing);
 
@@ -388,9 +388,9 @@ pub const GridBlocksMissing = struct {
 
         const index_schema = schema.TableIndex.from(index_block_data);
         const index_block_header = schema.header_from_block(index_block_data);
-        assert(index_block_header.op == table.index_address);
+        assert(index_block_header.address == table.index_address);
         assert(index_block_header.checksum == table.index_checksum);
-        assert(schema.BlockType.from(index_block_header.operation) == .index);
+        assert(index_block_header.block_type == .index);
 
         table.table_blocks_total = index_schema.data_blocks_used(index_block_data) + 1;
 

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -141,11 +141,11 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             completion: Storage.Read,
             callback: *const fn (
                 replica: *Replica,
-                prepare: ?Message.Prepare,
+                prepare: ?*Message.Prepare,
                 destination_replica: ?u8,
             ) void,
 
-            message: Message.Prepare,
+            message: *Message.Prepare,
             op: u64,
             checksum: u128,
             destination_replica: ?u8,
@@ -157,11 +157,11 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             journal: *Journal,
             callback: *const fn (
                 replica: *Replica,
-                wrote: ?Message.Prepare,
+                wrote: ?*Message.Prepare,
                 trigger: Trigger,
             ) void,
 
-            message: Message.Prepare,
+            message: *Message.Prepare,
             trigger: Trigger,
 
             /// True if this Write has acquired a lock on a sector of headers.
@@ -716,7 +716,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             journal: *Journal,
             callback: *const fn (
                 replica: *Replica,
-                prepare: ?Message.Prepare,
+                prepare: ?*Message.Prepare,
                 destination_replica: ?u8,
             ) void,
             op: u64,
@@ -757,7 +757,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             journal: *Journal,
             callback: *const fn (
                 replica: *Replica,
-                prepare: ?Message.Prepare,
+                prepare: ?*Message.Prepare,
                 destination_replica: ?u8,
             ) void,
             op: u64,
@@ -1069,7 +1069,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         }
 
         fn recover_headers_buffer(
-            message: Message.Prepare,
+            message: *Message.Prepare,
             offset: u64,
         ) []align(@alignOf(Header)) u8 {
             const max = @min(constants.message_size_max, headers_size - offset);
@@ -1713,10 +1713,10 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             journal: *Journal,
             callback: *const fn (
                 journal: *Replica,
-                wrote: ?Message.Prepare,
+                wrote: ?*Message.Prepare,
                 trigger: Write.Trigger,
             ) void,
-            message: Message.Prepare,
+            message: *Message.Prepare,
             trigger: Journal.Write.Trigger,
         ) void {
             const replica = @fieldParentPtr(Replica, "journal", journal);
@@ -1914,7 +1914,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         fn write_prepare_release(
             journal: *Journal,
             write: *Journal.Write,
-            wrote: ?Message.Prepare,
+            wrote: ?*Message.Prepare,
         ) void {
             const replica = @fieldParentPtr(Replica, "journal", journal);
             const write_callback = write.callback;
@@ -1951,7 +1951,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
         fn offset_logical_in_headers_for_message(
             journal: *const Journal,
-            message: Message.Prepare,
+            message: *const Message.Prepare,
         ) u64 {
             return Ring.headers.offset(journal.slot_for_header(message.header));
         }

--- a/src/vsr/journal_format_fuzz.zig
+++ b/src/vsr/journal_format_fuzz.zig
@@ -97,9 +97,9 @@ pub fn fuzz_format_wal_prepares(write_size_max: usize) !void {
 }
 
 fn verify_slot_header(slot: usize, header: vsr.Header.Prepare) !void {
-    try std.testing.expect(header.frame_const().valid_checksum());
-    try std.testing.expect(header.frame_const().valid_checksum_body(&[0]u8{}));
-    try std.testing.expectEqual(header.frame_const().invalid(), null);
+    try std.testing.expect(header.valid_checksum());
+    try std.testing.expect(header.valid_checksum_body(&[0]u8{}));
+    try std.testing.expectEqual(header.invalid(), null);
     try std.testing.expectEqual(header.cluster, cluster);
     try std.testing.expectEqual(header.op, slot);
     try std.testing.expectEqual(header.size, @sizeOf(vsr.Header));

--- a/src/vsr/journal_format_fuzz.zig
+++ b/src/vsr/journal_format_fuzz.zig
@@ -42,7 +42,7 @@ pub fn fuzz_format_wal_headers(write_size_max: usize) !void {
         const write_size = journal.format_wal_headers(cluster, offset, write);
         defer offset += write_size;
 
-        const write_headers = std.mem.bytesAsSlice(vsr.Header.Type(.prepare), write[0..write_size]);
+        const write_headers = std.mem.bytesAsSlice(vsr.Header.Prepare, write[0..write_size]);
         for (write_headers, 0..) |header, i| {
             const slot = @divExact(offset, @sizeOf(vsr.Header)) + i;
             try verify_slot_header(slot, header);
@@ -76,7 +76,7 @@ pub fn fuzz_format_wal_prepares(write_size_max: usize) !void {
                 // Message header.
                 const slot = @divExact(offset + offset_checked, constants.message_size_max);
                 const header_bytes = write[offset_checked..][0..@sizeOf(vsr.Header)];
-                const header = std.mem.bytesToValue(vsr.Header.Type(.prepare), header_bytes);
+                const header = std.mem.bytesToValue(vsr.Header.Prepare, header_bytes);
 
                 try verify_slot_header(slot, header);
                 offset_checked += @sizeOf(vsr.Header);
@@ -96,7 +96,7 @@ pub fn fuzz_format_wal_prepares(write_size_max: usize) !void {
     assert(offset == constants.journal_size_prepares);
 }
 
-fn verify_slot_header(slot: usize, header: vsr.Header.Type(.prepare)) !void {
+fn verify_slot_header(slot: usize, header: vsr.Header.Prepare) !void {
     try std.testing.expect(header.frame_const().valid_checksum());
     try std.testing.expect(header.frame_const().valid_checksum_body(&[0]u8{}));
     try std.testing.expectEqual(header.frame_const().invalid(), null);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1,0 +1,1430 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const constants = @import("../constants.zig");
+const stdx = @import("../stdx.zig");
+const vsr = @import("../vsr.zig");
+const Command = vsr.Command;
+const Operation = vsr.Operation;
+const schema = @import("../lsm/schema.zig");
+
+/// Aegis128 (used by checksum) uses hardware accelerated AES via inline asm which isn't
+/// available at comptime. Use a hard-coded value instead and verify via a test.
+const checksum_body_empty: u128 = 0x49F174618255402DE6E7E3C40D60CC83;
+
+test "empty checksum" {
+    assert(checksum_body_empty == vsr.checksum(&.{}));
+}
+
+/// Network message and journal entry header:
+/// We reuse the same header for both so that prepare messages from the primary can simply be
+/// journalled as is by the backups without requiring any further modification.
+pub const Header = extern struct {
+    /// A checksum covering only the remainder of this header.
+    /// This allows the header to be trusted without having to recv() or read() the associated body.
+    /// This checksum is enough to uniquely identify a network message or journal entry.
+    checksum: u128,
+
+    /// A checksum covering only the associated body after this header.
+    checksum_body: u128,
+
+    /// Reserved for future use by AEAD.
+    reserved_nonce: u128,
+
+    /// The cluster number binds intention into the header, so that a client or replica can indicate
+    /// the cluster it believes it is speaking to, instead of accidentally talking to the wrong
+    /// cluster (for example, staging vs production).
+    cluster: u32,
+
+    /// The size of the Header structure (always), plus any associated body.
+    size: u32,
+
+    /// The cluster reconfiguration epoch number (for future use).
+    epoch: u32,
+
+    /// Every message sent from one replica to another contains the sending replica's current view.
+    /// A `u32` allows for a minimum lifetime of 136 years at a rate of one view change per second.
+    view: u32,
+
+    /// The version of the protocol implementation that originated this message.
+    version: u16,
+
+    /// The Viewstamped Replication protocol command for this message.
+    command: Command,
+
+    /// The index of the replica in the cluster configuration array that authored this message.
+    /// This identifies only the ultimate author because messages may be forwarded amongst replicas.
+    replica: u8,
+
+    /// Reserved for future use by the header frame (i.e. to be shared by all message types).
+    reserved_frame: [12]u8,
+
+    /// This data's schema is different depending on the `Header.command`.
+    /// (No default value – `Header`s should not be constructed directly.)
+    reserved_command: [176]u8,
+
+    comptime {
+        assert(@sizeOf(Header) == 256);
+        assert(stdx.no_padding(Header));
+        assert(@offsetOf(Header, "reserved_command") % @alignOf(u128) == 0);
+    }
+
+    pub fn Type(comptime command: Command) type {
+        return switch (command) {
+            .reserved => Reserved,
+            .ping => Ping,
+            .pong => Pong,
+            .ping_client => PingClient,
+            .pong_client => PongClient,
+            .request => Request,
+            .prepare => Prepare,
+            .prepare_ok => PrepareOk,
+            .reply => Reply,
+            .commit => Commit,
+            .start_view_change => StartViewChange,
+            .do_view_change => DoViewChange,
+            .start_view => StartView,
+            .request_start_view => RequestStartView,
+            .request_headers => RequestHeaders,
+            .request_prepare => RequestPrepare,
+            .request_reply => RequestReply,
+            .headers => Headers,
+            .eviction => Eviction,
+            .request_blocks => RequestBlocks,
+            .block => Block,
+            .request_sync_checkpoint => RequestSyncCheckpoint,
+            .sync_checkpoint => SyncCheckpoint,
+            .request_sync_free_set => RequestSyncFreeSet,
+            .request_sync_client_sessions => RequestSyncClientSessions,
+            .sync_free_set => SyncFreeSet,
+            .sync_client_sessions => SyncClientSessions,
+        };
+    }
+
+    pub fn calculate_checksum(self: *const Header) u128 {
+        const checksum_size = @sizeOf(@TypeOf(self.checksum));
+        assert(checksum_size == 16);
+        const checksum_value = vsr.checksum(std.mem.asBytes(self)[checksum_size..]);
+        assert(@TypeOf(checksum_value) == @TypeOf(self.checksum));
+        return checksum_value;
+    }
+
+    pub fn calculate_checksum_body(self: *const Header, body: []const u8) u128 {
+        assert(self.size == @sizeOf(Header) + body.len);
+        const checksum_size = @sizeOf(@TypeOf(self.checksum_body));
+        assert(checksum_size == 16);
+        const checksum_value = vsr.checksum(body);
+        assert(@TypeOf(checksum_value) == @TypeOf(self.checksum_body));
+        return checksum_value;
+    }
+
+    /// This must be called only after set_checksum_body() so that checksum_body is also covered:
+    pub fn set_checksum(self: *Header) void {
+        self.checksum = self.calculate_checksum();
+    }
+
+    pub fn set_checksum_body(self: *Header, body: []const u8) void {
+        self.checksum_body = self.calculate_checksum_body(body);
+    }
+
+    pub fn valid_checksum(self: *const Header) bool {
+        return self.checksum == self.calculate_checksum();
+    }
+
+    pub fn valid_checksum_body(self: *const Header, body: []const u8) bool {
+        return self.checksum_body == self.calculate_checksum_body(body);
+    }
+
+    pub const AnyHeaderPointer = stdx.EnumUnionType(Command, struct {
+        fn PointerForCommand(comptime variant: Command) type {
+            return *const Type(variant);
+        }
+    }.PointerForCommand);
+
+    pub fn into_any(self: *const Header) AnyHeaderPointer {
+        switch (self.command) {
+            inline else => |command| {
+                return @unionInit(AnyHeaderPointer, @tagName(command), self.into_const(command).?);
+            },
+        }
+    }
+
+    pub fn into(self: *Header, comptime command: Command) ?*Type(command) {
+        if (self.command != command) return null;
+        return std.mem.bytesAsValue(Type(command), std.mem.asBytes(self));
+    }
+
+    pub fn into_const(self: *const Header, comptime command: Command) ?*const Type(command) {
+        if (self.command != command) return null;
+        return std.mem.bytesAsValue(Type(command), std.mem.asBytes(self));
+    }
+
+    /// Returns null if all fields are set correctly according to the command, or else a warning.
+    /// This does not verify that checksum is valid, and expects that this has already been done.
+    pub fn invalid(self: *const Header) ?[]const u8 {
+        if (self.version != vsr.Version) return "version != Version";
+        if (self.size < @sizeOf(Header)) return "size < @sizeOf(Header)";
+        if (self.epoch != 0) return "epoch != 0";
+        if (!stdx.zeroed(&self.reserved_frame)) return "reserved_frame != 0";
+
+        switch (self.into_any()) {
+            inline else => |command_header| return command_header.invalid(),
+            // The `Command` enum is exhaustive, so we can't write an "else" branch here. An unknown
+            // command is a possibility, but that means that someone has send us a message with
+            // matching cluster, matching version, correct checksum, and a command we don't know
+            // about. Ignoring unknown commands might be unsafe, so the replica intentionally
+            // crashes here, which is guaranteed by Zig's ReleaseSafe semantics.
+            //
+            // _ => unreachable
+        }
+    }
+
+    /// Returns whether the immediate sender is a replica or client (if this can be determined).
+    /// Some commands such as .request or .prepare may be forwarded on to other replicas so that
+    /// Header.replica or Header.client only identifies the ultimate origin, not the latest peer.
+    pub fn peer_type(self: *const Header) union(enum) {
+        unknown,
+        replica: u8,
+        client: u128,
+    } {
+        switch (self.into_any()) {
+            .reserved => unreachable,
+            // These messages cannot always identify the peer as they may be forwarded:
+            .request => |request| {
+                switch (request.operation) {
+                    // However, we do not forward the first .register request sent by a client:
+                    .register => return .{ .client = request.client },
+                    else => return .unknown,
+                }
+            },
+            .prepare => return .unknown,
+            // These messages identify the peer as either a replica or a client:
+            .ping_client => |ping| return .{ .client = ping.client },
+            // All other messages identify the peer as a replica:
+            else => return .{ .replica = self.replica },
+        }
+    }
+};
+
+// Verify each Command's header type.
+comptime {
+    @setEvalBranchQuota(20000);
+
+    for (std.enums.values(Command)) |command| {
+        const CommandHeader = Header.Type(command);
+        assert(@sizeOf(CommandHeader) == @sizeOf(Header));
+        assert(@alignOf(CommandHeader) == @alignOf(Header));
+        assert(@typeInfo(CommandHeader) == .Struct);
+        assert(@typeInfo(CommandHeader).Struct.layout == .Extern);
+        assert(stdx.no_padding(CommandHeader));
+
+        // Verify that the command's header's frame is identical to Header's.
+        for (std.meta.fields(Header)) |header_field| {
+            if (std.mem.eql(u8, header_field.name, "reserved_command")) {
+                assert(std.meta.fieldIndex(CommandHeader, header_field.name) == null);
+            } else {
+                const command_field_index = std.meta.fieldIndex(CommandHeader, header_field.name).?;
+                const command_field = std.meta.fields(CommandHeader)[command_field_index];
+                assert(command_field.type == header_field.type);
+                assert(command_field.alignment == header_field.alignment);
+                assert(@offsetOf(CommandHeader, command_field.name) ==
+                    @offsetOf(Header, header_field.name));
+            }
+        }
+    }
+}
+
+/// This type isn't ever actually a constructed, but makes Type() simpler by providing a header type
+/// for each command.
+const Reserved = extern struct {
+    checksum: u128,
+    checksum_body: u128,
+    reserved_nonce: u128,
+    cluster: u32,
+    size: u32,
+    epoch: u32 = 0,
+    view: u32 = 0,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8 = 0,
+    reserved_frame: [12]u8,
+
+    reserved: [176]u8 = [_]u8{0} ** 176,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .reserved);
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Ping = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// Current checkpoint id (possibly uncanonical).
+    checkpoint_id: u128,
+    /// Current checkpoint op (possibly uncanonical).
+    checkpoint_op: u64,
+
+    ping_timestamp_monotonic: u64,
+
+    reserved: [144]u8 = [_]u8{0} ** 144,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .ping);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.view != 0) return "view != 0";
+        if (self.ping_timestamp_monotonic == 0) return "ping_timestamp_monotonic != expected";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Pong = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8 = 0,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    ping_timestamp_monotonic: u64,
+    pong_timestamp_wall: u64,
+
+    reserved: [160]u8 = [_]u8{0} ** 160,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .pong);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.view != 0) return "view != 0";
+        if (self.ping_timestamp_monotonic == 0) return "ping_timestamp_monotonic == 0";
+        if (self.pong_timestamp_wall == 0) return "pong_timestamp_wall == 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const PingClient = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8 = 0, // Always 0.
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    client: u128,
+    reserved: [160]u8 = [_]u8{0} ** 160,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .ping_client);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.replica != 0) return "replica != 0";
+        if (self.view != 0) return "view != 0";
+        if (self.client == 0) return "client == 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const PongClient = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    reserved: [176]u8 = [_]u8{0} ** 176,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .pong_client);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Request = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8 = 0, // Always 0.
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// Clients hash-chain their requests to verify linearizability:
+    /// - A session's first request (operation=register) sets `parent=0`.
+    /// - A session's subsequent requests (operation≠register) set `parent` to the checksum of the
+    ///   preceding request.
+    parent: u128 = 0,
+    /// Each client process generates a unique, random and ephemeral client ID at
+    /// initialization. The client ID identifies connections made by the client to the cluster
+    /// for the sake of routing messages back to the client.
+    ///
+    /// With the client ID in hand, the client then registers a monotonically increasing session
+    /// number (committed through the cluster) to allow the client's session to be evicted
+    /// safely from the client table if too many concurrent clients cause the client table to
+    /// overflow. The monotonically increasing session number prevents duplicate client requests
+    /// from being replayed.
+    ///
+    /// The problem of routing is therefore solved by the 128-bit client ID, and the problem of
+    /// detecting whether a session has been evicted is solved by the session number.
+    client: u128,
+    /// When operation=register, this is zero.
+    /// When operation≠register, this is the commit number of register.
+    session: u64 = 0,
+    /// Only nonzero during AOF recovery.
+    /// TODO: Use this for bulk-import to state machine?
+    timestamp: u64 = 0,
+    /// Each request is given a number by the client and later requests must have larger numbers
+    /// than earlier ones. The request number is used by the replicas to avoid running requests
+    /// more than once; it is also used by the client to discard duplicate replies to its requests.
+    /// A client is allowed to have at most one request inflight at a time.
+    request: u32,
+    operation: Operation,
+    reserved: [123]u8 = [_]u8{0} ** 123,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request);
+        if (self.replica != 0) return "replica != 0";
+        if (self.client == 0) return "client == 0";
+        if (self.timestamp != 0 and !constants.aof_recovery) return "timestamp != 0";
+        switch (self.operation) {
+            .reserved => return "operation == .reserved",
+            .root => return "operation == .root",
+            .register => {
+                // The first request a client makes must be to register with the cluster:
+                if (self.parent != 0) return "register: parent != 0";
+                if (self.session != 0) return "register: session != 0";
+                if (self.request != 0) return "register: request != 0";
+                // The .register operation carries no payload:
+                if (self.checksum_body != checksum_body_empty) {
+                    return "register: checksum_body != expected";
+                }
+                if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+            },
+            else => {
+                if (self.operation == .reconfigure) {
+                    if (self.size != @sizeOf(Header) + @sizeOf(vsr.ReconfigurationRequest)) {
+                        return "size != @sizeOf(Header) + @sizeOf(ReconfigurationRequest)";
+                    }
+                } else if (@intFromEnum(self.operation) < constants.vsr_operations_reserved) {
+                    return "operation is reserved";
+                }
+                // Thereafter, the client must provide the session number:
+                // These requests should set `parent` to the `checksum` of the previous reply.
+                if (self.session == 0) return "session == 0";
+                if (self.request == 0) return "request == 0";
+            },
+        }
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Prepare = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8 = 0,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// A backpointer to the previous request or prepare checksum for hash chain verification.
+    /// This provides a cryptographic guarantee for linearizability:
+    /// 1. across our distributed log of prepares, and
+    /// 2. across a client's requests and our replies.
+    /// This may also be used as the initialization vector for AEAD encryption at rest, provided
+    /// that the primary ratchets the encryption key every view change to ensure that prepares
+    /// reordered through a view change never repeat the same IV for the same encryption key.
+    parent: u128,
+    client: u128,
+    /// The checksum of the client's request.
+    context: u128,
+    /// The op number of the latest prepare that may or may not yet be committed. Uncommitted
+    /// ops may be replaced by different ops if they do not survive through a view change.
+    op: u64,
+    /// The commit number of the latest committed prepare. Committed ops are immutable.
+    commit: u64,
+    /// The primary's state machine `prepare_timestamp`.
+    /// For `create_accounts` and `create_transfers` this is the batch's highest timestamp.
+    timestamp: u64,
+    request: u32,
+    /// The state machine operation to apply.
+    operation: Operation,
+    reserved: [99]u8 = [_]u8{0} ** 99,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const Prepare) ?[]const u8 {
+        assert(self.command == .prepare);
+        switch (self.operation) {
+            .reserved => {
+                if (self.parent != 0) return "reserved: parent != 0";
+                if (self.client != 0) return "reserved: client != 0";
+                if (self.context != 0) return "reserved: context != 0";
+                if (self.request != 0) return "reserved: request != 0";
+                if (self.view != 0) return "reserved: view != 0";
+                if (self.commit != 0) return "reserved: commit != 0";
+                if (self.timestamp != 0) return "reserved: timestamp != 0";
+                if (self.size != @sizeOf(Header)) return "reserved: size != @sizeOf(Header)";
+                if (self.replica != 0) return "reserved: replica != 0";
+                if (self.checksum_body != checksum_body_empty) {
+                    return "reserved: checksum_body != expected";
+                }
+            },
+            .root => {
+                if (self.parent != 0) return "root: parent != 0";
+                if (self.client != 0) return "root: client != 0";
+                if (self.context != 0) return "root: context != 0";
+                if (self.request != 0) return "root: request != 0";
+                if (self.view != 0) return "root: view != 0";
+                if (self.op != 0) return "root: op != 0";
+                if (self.commit != 0) return "root: commit != 0";
+                if (self.timestamp != 0) return "root: timestamp != 0";
+                if (self.size != @sizeOf(Header)) return "root: size != @sizeOf(Header)";
+                if (self.replica != 0) return "root: replica != 0";
+                if (self.checksum_body != checksum_body_empty) {
+                    return "root: checksum_body != expected";
+                }
+            },
+            else => {
+                if (self.client == 0) return "client == 0";
+                if (self.op == 0) return "op == 0";
+                if (self.op <= self.commit) return "op <= commit";
+                if (self.timestamp == 0) return "timestamp == 0";
+                if (self.operation == .register) {
+                    // Client session numbers are replaced by the reference to the previous prepare.
+                    if (self.request != 0) return "request != 0";
+                } else {
+                    // Client session numbers are replaced by the reference to the previous prepare.
+                    if (self.request == 0) return "request == 0";
+                }
+            },
+        }
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+
+    pub fn reserved(cluster: u32, slot: u64) Prepare {
+        assert(slot < constants.journal_slot_count);
+
+        var header = Prepare{
+            .command = .prepare,
+            .cluster = cluster,
+            .op = slot,
+            .operation = .reserved,
+            .view = 0,
+            .context = 0,
+            .parent = 0,
+            .client = 0,
+            .commit = 0,
+            .timestamp = 0,
+            .request = 0,
+        };
+        header.frame().set_checksum_body(&[0]u8{});
+        header.frame().set_checksum();
+        assert(header.frame().invalid() == null);
+        return header;
+    }
+
+    pub fn root(cluster: u32) Prepare {
+        var header = Prepare{
+            .cluster = cluster,
+            .size = @sizeOf(Header),
+            .command = .prepare,
+            .operation = .root,
+            .op = 0,
+            .view = 0,
+            .context = 0,
+            .parent = 0,
+            .client = 0,
+            .commit = 0,
+            .timestamp = 0,
+            .request = 0,
+        };
+        header.frame().set_checksum_body(&[0]u8{});
+        header.frame().set_checksum();
+        assert(header.frame().invalid() == null);
+        return header;
+    }
+};
+
+const PrepareOk = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    checkpoint_id: u128,
+    parent: u128,
+    client: u128,
+    prepare_checksum: u128,
+    op: u64,
+    commit: u64,
+    timestamp: u64,
+    request: u32,
+    operation: Operation = .reserved,
+    reserved: [83]u8 = [_]u8{0} ** 83,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .prepare_ok);
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        switch (self.operation) {
+            .reserved => return "operation == .reserved",
+            .root => {
+                const root_checksum = Header.Type(.prepare).root(self.cluster).checksum;
+                if (self.parent != 0) return "root: parent != 0";
+                if (self.client != 0) return "root: client != 0";
+                if (self.prepare_checksum != root_checksum) {
+                    return "root: prepare_checksum != expected";
+                }
+                if (self.request != 0) return "root: request != 0";
+                if (self.op != 0) return "root: op != 0";
+                if (self.commit != 0) return "root: commit != 0";
+                if (self.timestamp != 0) return "root: timestamp != 0";
+            },
+            else => {
+                if (self.client == 0) return "client == 0";
+                if (self.op == 0) return "op == 0";
+                if (self.op <= self.commit) return "op <= commit";
+                if (self.timestamp == 0) return "timestamp == 0";
+                if (self.operation == .register) {
+                    if (self.request != 0) return "request != 0";
+                } else {
+                    if (self.request == 0) return "request == 0";
+                }
+            },
+        }
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Reply = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    parent: u128,
+    client: u128,
+    /// The checksum of the prepare message to which this message refers.
+    /// This allows for cryptographic guarantees beyond request, op, and commit numbers, which
+    /// have low entropy and may otherwise collide in the event of any correctness bugs.
+    context: u128 = 0,
+    op: u64,
+    commit: u64,
+    /// The corresponding `prepare`'s timestamp.
+    /// This allows the test workload to verify transfer timeouts.
+    timestamp: u64,
+    request: u32,
+    operation: Operation = .reserved,
+    reserved: [99]u8 = [_]u8{0} ** 99,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .reply);
+        // Initialization within `client.zig` asserts that client `id` is greater than zero:
+        if (self.client == 0) return "client == 0";
+        if (self.op != self.commit) return "op != commit";
+        if (self.timestamp == 0) return "timestamp == 0";
+        if (self.operation == .register) {
+            // In this context, the commit number is the newly registered session number.
+            // The `0` commit number is reserved for cluster initialization.
+            if (self.commit == 0) return "commit == 0";
+            if (self.request != 0) return "request != 0";
+        } else {
+            if (self.commit == 0) return "commit == 0";
+            if (self.request == 0) return "request == 0";
+        }
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Commit = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// Current checkpoint id (possibly uncanonical).
+    checkpoint_id: u128,
+
+    /// The latest committed prepare's checksum.
+    commit_checksum: u128,
+
+    /// Current checkpoint op (possibly uncanonical).
+    checkpoint_op: u64,
+
+    /// The latest committed prepare's op.
+    commit: u64,
+
+    timestamp_monotonic: u64,
+
+    reserved: [120]u8 = [_]u8{0} ** 120,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .commit);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.timestamp_monotonic == 0) return "timestamp_monotonic == 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const StartViewChange = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    reserved: [176]u8 = [_]u8{0} ** 176,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .start_view_change);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const DoViewChange = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// A bitset of "present" prepares. If a bit is set, then the corresponding header is not
+    /// "blank", the replica has the prepare, and the prepare is not known to be faulty.
+    present_bitset: u128,
+    /// A bitset, with set bits indicating headers in the message body which it has definitely not
+    /// prepared (i.e. "nack"). The corresponding header may be an actual prepare header, or it may
+    /// be a "blank" header.
+    nack_bitset: u128,
+    op: u64,
+    /// Set to `commit_min`, to indicate the sending replica's progress.
+    /// The sending replica may continue to commit after sending the DVC.
+    commit_min: u64,
+    checkpoint_op: u64,
+    log_view: u32,
+    reserved: [116]u8 = [_]u8{0} ** 116,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .do_view_change);
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const StartView = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// Set to zero for a new view, and to a nonce from an RSV when responding to the RSV.
+    nonce: u128,
+    op: u64,
+    /// Set to `commit_min`/`commit_max` (they are the same).
+    commit: u64,
+    /// The replica's `op_checkpoint`.
+    checkpoint_op: u64,
+    reserved: [136]u8 = [_]u8{0} ** 136,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .start_view);
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestStartView = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    nonce: u128,
+    reserved: [160]u8 = [_]u8{0} ** 160,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_start_view);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestHeaders = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    /// The minimum op requested (inclusive).
+    op_min: u64,
+    /// The maximum op requested (inclusive).
+    op_max: u64,
+    reserved: [160]u8 = [_]u8{0} ** 160,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_headers);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.op_min > self.op_max) return "op_min > op_max";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestPrepare = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    prepare_checksum: u128,
+    prepare_op: u64,
+    reserved: [152]u8 = [_]u8{0} ** 152,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_prepare);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestReply = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    reply_client: u128,
+    reply_checksum: u128,
+    reply_op: u64,
+    reserved: [136]u8 = [_]u8{0} ** 136,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_reply);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.reply_client == 0) return "reply_client == 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Headers = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    reserved: [176]u8 = [_]u8{0} ** 176,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .headers);
+        if (self.size == @sizeOf(Header)) return "size == @sizeOf(Header)";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Eviction = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32,
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    client: u128,
+    reserved: [160]u8 = [_]u8{0} ** 160,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .eviction);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestBlocks = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    reserved: [176]u8 = [_]u8{0} ** 176,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_blocks);
+        if (self.view != 0) return "view != 0";
+        if (self.size == @sizeOf(Header)) return "size == @sizeOf(Header)";
+        if ((self.size - @sizeOf(Header)) % @sizeOf(vsr.BlockRequest) != 0) {
+            return "size multiple invalid";
+        }
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const Block = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8 = 0, // Always 0.
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    // Schema is determined by `block_type`.
+    metadata_bytes: [144]u8,
+
+    // Fields shared by all block types:
+    address: u64,
+    snapshot: u64,
+    block_type: schema.BlockType,
+    reserved_block: [15]u8 = [_]u8{0} ** 15,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .block);
+        if (self.size > constants.block_size) return "size > block_size";
+        if (self.size == @sizeOf(Header)) return "size = @sizeOf(Header)";
+        if (self.view != 0) return "view != 0";
+        if (self.replica != 0) return "replica != 0";
+        if (self.address == 0) return "address == 0"; // address ≠ 0
+        if (!self.block_type.valid()) return "block_type invalid";
+        if (self.block_type == .reserved) return "block_type == .reserved";
+        // TODO When manifest blocks include a snapshot, verify that snapshot≠0.
+        return null;
+    }
+};
+
+const RequestSyncCheckpoint = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    checkpoint_id: u128,
+    checkpoint_op: u64,
+    reserved: [152]u8 = [_]u8{0} ** 152,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_sync_checkpoint);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.view != 0) return "view != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const SyncCheckpoint = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    checkpoint_id: u128,
+    checkpoint_op: u64,
+    reserved: [152]u8 = [_]u8{0} ** 152,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .sync_checkpoint);
+        if (self.size != @sizeOf(Header) + @sizeOf(vsr.CheckpointState)) {
+            return "size != @sizeOf(Header) + @sizeOf(CheckpointState)";
+        }
+        if (self.view != 0) return "view != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestSyncFreeSet = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    checkpoint_id: u128,
+    checkpoint_op: u64,
+    trailer_offset: u32,
+    reserved: [148]u8 = [_]u8{0} ** 148,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_sync_free_set);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.view != 0) return "view != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const RequestSyncClientSessions = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    checkpoint_id: u128,
+    checkpoint_op: u64,
+    trailer_offset: u32 = 0,
+    reserved: [148]u8 = [_]u8{0} ** 148,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .request_sync_client_sessions);
+        if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
+        if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
+        if (self.view != 0) return "view != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const SyncFreeSet = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    trailer_checksum: u128,
+    checkpoint_id: u128,
+    checkpoint_op: u64,
+    trailer_size: u32,
+    trailer_offset: u32,
+    reserved: [128]u8 = [_]u8{0} ** 128,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .sync_free_set);
+        if (self.size - @sizeOf(Header) > constants.sync_trailer_message_body_size_max) {
+            return "size > max";
+        }
+        if (self.view != 0) return "view != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};
+
+const SyncClientSessions = extern struct {
+    checksum: u128 = 0,
+    checksum_body: u128 = 0,
+    reserved_nonce: u128 = 0,
+    cluster: u32,
+    size: u32 = @sizeOf(Header),
+    epoch: u32 = 0,
+    view: u32 = 0, // Always 0.
+    version: u16 = vsr.Version,
+    command: Command,
+    replica: u8,
+    reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+    trailer_checksum: u128,
+    checkpoint_id: u128,
+    checkpoint_op: u64,
+    trailer_size: u32,
+    trailer_offset: u32,
+    reserved: [128]u8 = [_]u8{0} ** 128,
+
+    pub fn frame(header: *@This()) *Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    pub fn frame_const(header: *const @This()) *const Header {
+        return std.mem.bytesAsValue(Header, std.mem.asBytes(header));
+    }
+
+    fn invalid(self: *const @This()) ?[]const u8 {
+        assert(self.command == .sync_client_sessions);
+        if (self.size - @sizeOf(Header) > constants.sync_trailer_message_body_size_max) {
+            return "size > max";
+        }
+        if (self.view != 0) return "view != 0";
+        if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+        return null;
+    }
+};

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1076,6 +1076,7 @@ pub const Header = extern struct {
 
     pub const Block = extern struct {
         pub usingnamespace HeaderFunctions(@This());
+        pub const metadata_size = 144;
 
         checksum: u128 = 0,
         checksum_body: u128 = 0,
@@ -1090,7 +1091,7 @@ pub const Header = extern struct {
         reserved_frame: [12]u8 = [_]u8{0} ** 12,
 
         // Schema is determined by `block_type`.
-        metadata_bytes: [144]u8,
+        metadata_bytes: [metadata_size]u8,
 
         // Fields shared by all block types:
         address: u64,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -95,7 +95,7 @@ const Nonce = u128;
 
 const Prepare = struct {
     /// The current prepare message (used to cross-check prepare_ok messages, and for resending).
-    message: *Message,
+    message: Message.Type(.prepare),
 
     /// Unique prepare_ok messages for the same view, op number and checksum from ALL replicas.
     ok_from_all_replicas: QuorumCounter = quorum_counter_null,
@@ -105,12 +105,12 @@ const Prepare = struct {
 };
 
 const Request = struct {
-    message: *Message, // header.command == .request
+    message: Message.Type(.request),
     realtime: i64,
 };
 
-const QuorumMessages = [constants.replicas_max]?*Message;
-const quorum_messages_null = [_]?*Message{null} ** constants.replicas_max;
+const DVCQuorumMessages = [constants.replicas_max]?Message.Type(.do_view_change);
+const dvc_quorum_messages_null = [_]?Message.Type(.do_view_change){null} ** constants.replicas_max;
 
 const QuorumCounter = std.StaticBitSet(constants.replicas_max);
 const quorum_counter_null = QuorumCounter.initEmpty();
@@ -137,7 +137,7 @@ pub fn ReplicaType(
             read: Grid.Read,
             replica: *Self,
             destination: u8,
-            message: *Message,
+            message: Message.Type(.block),
         };
 
         const BlockWrite = struct {
@@ -354,7 +354,7 @@ pub fn ReplicaType(
         start_view_change_from_all_replicas: QuorumCounter = quorum_counter_null,
 
         /// Unique do_view_change messages for the same view from ALL replicas (including ourself).
-        do_view_change_from_all_replicas: QuorumMessages = quorum_messages_null,
+        do_view_change_from_all_replicas: DVCQuorumMessages = dvc_quorum_messages_null,
 
         /// Whether the primary has received a quorum of do_view_change messages for the view change:
         /// Determines whether the primary may effect repairs according to the CTRL protocol.
@@ -439,7 +439,7 @@ pub fn ReplicaType(
         event_callback: ?*const fn (replica: *const Self, event: ReplicaEvent) void = null,
 
         /// The prepare message being committed.
-        commit_prepare: ?*Message = null,
+        commit_prepare: ?Message.Type(.prepare) = null,
 
         tracer_slot_commit: ?tracer.SpanStart = null,
         tracer_slot_checkpoint: ?tracer.SpanStart = null,
@@ -550,7 +550,8 @@ pub fn ReplicaType(
 
             if (self.log_view == self.view) {
                 for (self.journal.headers) |*header| {
-                    if (header.command == .prepare) {
+                    assert(header.command == .prepare);
+                    if (header.operation != .reserved) {
                         assert(header.op <= self.op_checkpoint_next_trigger());
                         assert(header.view <= self.log_view);
 
@@ -982,17 +983,17 @@ pub fn ReplicaType(
 
             if (self.commit_prepare) |message| {
                 assert(self.commit_stage != .idle);
-                self.message_bus.unref(message);
+                self.message_bus.unref(message.base);
                 self.commit_prepare = null;
             }
 
             var grid_reads = self.grid_reads.iterate();
-            while (grid_reads.next()) |read| self.message_bus.unref(read.message);
+            while (grid_reads.next()) |read| self.message_bus.unref(read.message.base);
 
             for (self.grid_repair_write_blocks) |block| allocator.free(block);
 
             for (self.do_view_change_from_all_replicas) |message| {
-                if (message) |m| self.message_bus.unref(m);
+                if (message) |m| self.message_bus.unref(m.base);
             }
         }
 
@@ -1060,12 +1061,17 @@ pub fn ReplicaType(
             assert(self.loopback_queue == null);
             assert(message.references > 0);
 
-            log.debug("{}: on_message: view={} status={} {}", .{
-                self.replica,
-                self.view,
-                self.status,
-                message.header,
-            });
+            // Switch on the header type so that we don't log opaque bytes for the per-command data.
+            switch (message.header.into_any()) {
+                inline else => |header| {
+                    log.debug("{}: on_message: view={} status={} {}", .{
+                        self.replica,
+                        self.view,
+                        self.status,
+                        header,
+                    });
+                },
+            }
 
             if (message.header.invalid()) |reason| {
                 log.err("{}: on_message: invalid (command={}, {s})", .{
@@ -1092,27 +1098,27 @@ pub fn ReplicaType(
             self.jump_sync_target(message.header);
 
             assert(message.header.replica < self.node_count);
-            switch (message.header.command) {
-                .ping => self.on_ping(message),
-                .pong => self.on_pong(message),
-                .ping_client => self.on_ping_client(message),
-                .request => self.on_request(message),
-                .prepare => self.on_prepare(message),
-                .prepare_ok => self.on_prepare_ok(message),
-                .reply => self.on_reply(message),
-                .commit => self.on_commit(message),
-                .start_view_change => self.on_start_view_change(message),
-                .do_view_change => self.on_do_view_change(message),
-                .start_view => self.on_start_view(message),
-                .request_start_view => self.on_request_start_view(message),
-                .request_prepare => self.on_request_prepare(message),
-                .request_headers => self.on_request_headers(message),
-                .request_reply => self.on_request_reply(message),
-                .headers => self.on_headers(message),
-                .request_blocks => self.on_request_blocks(message),
-                .block => self.on_block(message),
-                .request_sync_checkpoint => self.on_request_sync_checkpoint(message),
-                .sync_checkpoint => self.on_sync_checkpoint(message),
+            switch (message.into_any()) {
+                .ping => |m| self.on_ping(m),
+                .pong => |m| self.on_pong(m),
+                .ping_client => |m| self.on_ping_client(m),
+                .request => |m| self.on_request(m),
+                .prepare => |m| self.on_prepare(m),
+                .prepare_ok => |m| self.on_prepare_ok(m),
+                .reply => |m| self.on_reply(m),
+                .commit => |m| self.on_commit(m),
+                .start_view_change => |m| self.on_start_view_change(m),
+                .do_view_change => |m| self.on_do_view_change(m),
+                .start_view => |m| self.on_start_view(m),
+                .request_start_view => |m| self.on_request_start_view(m),
+                .request_prepare => |m| self.on_request_prepare(m),
+                .request_headers => |m| self.on_request_headers(m),
+                .request_reply => |m| self.on_request_reply(m),
+                .headers => |m| self.on_headers(m),
+                .request_blocks => |m| self.on_request_blocks(m),
+                .block => |m| self.on_block(m),
+                .request_sync_checkpoint => |m| self.on_request_sync_checkpoint(m),
+                .sync_checkpoint => |m| self.on_sync_checkpoint(m),
                 .request_sync_free_set => self.on_request_sync_trailer(message),
                 .request_sync_client_sessions => self.on_request_sync_trailer(message),
                 .sync_free_set => self.on_sync_trailer(.free_set, message),
@@ -1141,7 +1147,7 @@ pub fn ReplicaType(
         }
 
         /// Pings are used by replicas to synchronise cluster time and to probe for network connectivity.
-        fn on_ping(self: *Self, message: *const Message) void {
+        fn on_ping(self: *Self, message: Message.Type(.ping)) void {
             assert(message.header.command == .ping);
             if (self.status != .normal and self.status != .view_change) return;
 
@@ -1154,17 +1160,17 @@ pub fn ReplicaType(
 
             // TODO Drop pings that were not addressed to us.
 
-            self.send_header_to_replica(message.header.replica, .{
+            self.send_header_to_replica(message.header.replica, @bitCast(Header.Type(.pong){
                 .command = .pong,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 // Copy the ping's monotonic timestamp to our pong and add our wall clock sample:
-                .commit = message.header.commit,
-                .timestamp = @as(u64, @bitCast(self.clock.realtime())),
-            });
+                .ping_timestamp_monotonic = message.header.ping_timestamp_monotonic,
+                .pong_timestamp_wall = @as(u64, @bitCast(self.clock.realtime())),
+            }));
         }
 
-        fn on_pong(self: *Self, message: *const Message) void {
+        fn on_pong(self: *Self, message: Message.Type(.pong)) void {
             assert(message.header.command == .pong);
             if (message.header.replica == self.replica) {
                 log.warn("{}: on_pong: misdirected message (self)", .{self.replica});
@@ -1174,26 +1180,26 @@ pub fn ReplicaType(
             // Ignore clocks of standbys.
             if (message.header.replica >= self.replica_count) return;
 
-            const m0 = message.header.commit;
-            const t1 = @as(i64, @bitCast(message.header.timestamp));
+            const m0 = message.header.ping_timestamp_monotonic;
+            const t1 = @as(i64, @bitCast(message.header.pong_timestamp_wall));
             const m2 = self.clock.monotonic();
 
             self.clock.learn(message.header.replica, m0, t1, m2);
         }
 
         /// Pings are used by clients to learn about the current view.
-        fn on_ping_client(self: *Self, message: *const Message) void {
+        fn on_ping_client(self: *Self, message: Message.Type(.ping_client)) void {
             assert(message.header.command == .ping_client);
             assert(message.header.client != 0);
 
             if (self.ignore_ping_client(message)) return;
 
-            self.send_header_to_client(message.header.client, .{
+            self.send_header_to_client(message.header.client, @bitCast(Header.Type(.pong_client){
                 .command = .pong_client,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
-            });
+            }));
         }
 
         /// When there is free space in the pipeline's prepare queue:
@@ -1205,7 +1211,7 @@ pub fn ReplicaType(
         /// Otherwise, when there is room in the pipeline's request queue:
         ///   The request is queued, and will be dequeued & prepared when the pipeline head commits.
         /// Otherwise, drop the request.
-        fn on_request(self: *Self, message: *Message) void {
+        fn on_request(self: *Self, message: Message.Type(.request)) void {
             if (self.ignore_request_message(message)) return;
 
             assert(self.status == .normal);
@@ -1215,6 +1221,8 @@ pub fn ReplicaType(
             assert(self.commit_max + self.pipeline.queue.prepare_queue.count == self.op);
 
             assert(message.header.command == .request);
+            assert(message.header.operation != .reserved);
+            assert(message.header.operation != .root);
             assert(message.header.view <= self.view); // The client's view may be behind ours.
 
             const realtime = self.clock.realtime_synchronized() orelse {
@@ -1259,9 +1267,10 @@ pub fn ReplicaType(
         /// The remaining problem then is tail latency tolerance for network latency spikes.
         /// If the next replica is down or partitioned, then the primary's prepare timeout will fire,
         /// and the primary will resend but to another replica, until it receives enough prepare_ok's.
-        fn on_prepare(self: *Self, message: *Message) void {
+        fn on_prepare(self: *Self, message: Message.Type(.prepare)) void {
             assert(message.header.command == .prepare);
             assert(message.header.replica < self.replica_count);
+            assert(message.header.operation != .reserved);
 
             if (self.is_repair(message)) {
                 log.debug("{}: on_prepare: ignoring (repair)", .{self.replica});
@@ -1343,7 +1352,7 @@ pub fn ReplicaType(
             self.append(message);
         }
 
-        fn on_prepare_ok(self: *Self, message: *Message) void {
+        fn on_prepare_ok(self: *Self, message: Message.Type(.prepare_ok)) void {
             assert(message.header.command == .prepare_ok);
             if (self.ignore_prepare_ok(message)) return;
 
@@ -1357,18 +1366,18 @@ pub fn ReplicaType(
                 log.debug("{}: on_prepare_ok: not preparing ok={} checksum={}", .{
                     self.replica,
                     message.header.op,
-                    message.header.context,
+                    message.header.prepare_checksum,
                 });
                 return;
             };
 
-            assert(prepare.message.header.checksum == message.header.context);
+            assert(prepare.message.header.checksum == message.header.prepare_checksum);
             assert(prepare.message.header.op >= self.commit_max + 1);
             assert(prepare.message.header.op <= self.commit_max +
                 self.pipeline.queue.prepare_queue.count);
             assert(prepare.message.header.op <= self.op);
 
-            const checkpoint_id = message.header.parent;
+            const checkpoint_id = message.header.checkpoint_id;
             if (checkpoint_id != self.checkpoint_id_for_op(prepare.message.header.op).?) {
                 // If this is hit, there is a storage determinism problem.
                 // One of these replicas will need to state sync.
@@ -1428,7 +1437,7 @@ pub fn ReplicaType(
             self.commit_pipeline();
         }
 
-        fn on_reply(self: *Self, message: *Message) void {
+        fn on_reply(self: *Self, message: Message.Type(.reply)) void {
             assert(message.header.command == .reply);
             assert(message.header.replica < self.replica_count);
 
@@ -1482,7 +1491,7 @@ pub fn ReplicaType(
         /// TODO The primary should stand down if it sees too many retries in on_prepare_timeout().
         /// It's possible for the network to be one-way partitioned so that backups don't see the
         /// primary as down, but neither can the primary hear from the backups.
-        fn on_commit(self: *Self, message: *const Message) void {
+        fn on_commit(self: *Self, message: Message.Type(.commit)) void {
             assert(message.header.command == .commit);
             assert(message.header.replica < self.replica_count);
 
@@ -1512,8 +1521,8 @@ pub fn ReplicaType(
             assert(message.header.replica == self.primary_index(message.header.view));
 
             // Old/duplicate heartbeats don't count.
-            if (self.heartbeat_timestamp < message.header.timestamp) {
-                self.heartbeat_timestamp = message.header.timestamp;
+            if (self.heartbeat_timestamp < message.header.timestamp_monotonic) {
+                self.heartbeat_timestamp = message.header.timestamp_monotonic;
                 self.normal_heartbeat_timeout.reset();
                 if (!self.standby()) {
                     self.start_view_change_from_all_replicas.unset(self.replica);
@@ -1522,7 +1531,7 @@ pub fn ReplicaType(
 
             // We may not always have the latest commit entry but if we do our checksum must match:
             if (self.journal.header_with_op(message.header.commit)) |commit_entry| {
-                if (commit_entry.checksum == message.header.context) {
+                if (commit_entry.checksum == message.header.commit_checksum) {
                     log.debug("{}: on_commit: checksum verified", .{self.replica});
                 } else if (self.valid_hash_chain("on_commit")) {
                     @panic("commit checksum verification failed");
@@ -1535,7 +1544,7 @@ pub fn ReplicaType(
             self.commit_journal(message.header.commit);
         }
 
-        fn on_repair(self: *Self, message: *Message) void {
+        fn on_repair(self: *Self, message: Message.Type(.prepare)) void {
             assert(message.header.command == .prepare);
 
             if (self.status != .normal and self.status != .view_change) {
@@ -1592,7 +1601,7 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_start_view_change(self: *Self, message: *Message) void {
+        fn on_start_view_change(self: *Self, message: Message.Type(.start_view_change)) void {
             assert(message.header.command == .start_view_change);
             if (self.ignore_start_view_change_message(message)) return;
 
@@ -1651,9 +1660,9 @@ pub fn ReplicaType(
         ///
         /// When a new backup receives a do_view_change message for a new view, it transitions to
         /// that new view in view-change status and begins to broadcast its own DVC.
-        fn on_do_view_change(self: *Self, message: *Message) void {
+        fn on_do_view_change(self: *Self, message: Message.Type(.do_view_change)) void {
             assert(message.header.command == .do_view_change);
-            if (self.ignore_view_change_message(message)) return;
+            if (self.ignore_view_change_message(message.base)) return;
 
             assert(!self.solo());
             assert(self.status == .view_change);
@@ -1667,7 +1676,7 @@ pub fn ReplicaType(
 
             // Wait until we have a quorum of messages (including ourself):
             assert(self.do_view_change_from_all_replicas[self.replica] != null);
-            assert(self.do_view_change_from_all_replicas[self.replica].?.header.timestamp <=
+            assert(self.do_view_change_from_all_replicas[self.replica].?.header.checkpoint_op <=
                 self.op_checkpoint());
             DVCQuorum.verify(self.do_view_change_from_all_replicas);
 
@@ -1748,7 +1757,7 @@ pub fn ReplicaType(
                     if (self.do_view_change_from_all_replicas[next_primary]) |dvc| {
                         assert(dvc.header.replica == next_primary);
 
-                        const dvc_checkpoint = dvc.header.timestamp;
+                        const dvc_checkpoint = dvc.header.checkpoint_op;
                         if (dvc_checkpoint == op_checkpoint_max) break next_view;
                     }
                 } else unreachable;
@@ -1808,9 +1817,9 @@ pub fn ReplicaType(
         /// they send a ⟨prepare_ok v, n, i⟩ message to the primary; here n is the op-number. Then
         /// they execute all operations known to be committed that they haven’t executed previously,
         /// advance their commit number, and update the information in their client table.
-        fn on_start_view(self: *Self, message: *const Message) void {
+        fn on_start_view(self: *Self, message: Message.Type(.start_view)) void {
             assert(message.header.command == .start_view);
-            if (self.ignore_view_change_message(message)) return;
+            if (self.ignore_view_change_message(message.base)) return;
 
             assert(self.status == .view_change or
                 self.status == .normal or
@@ -1818,8 +1827,8 @@ pub fn ReplicaType(
             assert(message.header.view >= self.view);
             assert(message.header.replica != self.replica);
             assert(message.header.replica == self.primary_index(message.header.view));
-            assert(message.header.commit >= message.header.timestamp);
-            assert(message.header.commit - message.header.timestamp <=
+            assert(message.header.commit >= message.header.checkpoint_op);
+            assert(message.header.commit - message.header.checkpoint_op <=
                 constants.journal_slot_count);
             assert(message.header.op >= message.header.commit);
             assert(message.header.op - message.header.commit <=
@@ -1851,7 +1860,7 @@ pub fn ReplicaType(
             }
             assert(self.view == message.header.view);
 
-            const view_headers = message_body_as_view_headers(message);
+            const view_headers = message_body_as_view_headers(message.base);
             assert(view_headers.command == .start_view);
             assert(view_headers.slice[0].op == message.header.op);
 
@@ -1921,9 +1930,12 @@ pub fn ReplicaType(
             self.repair();
         }
 
-        fn on_request_start_view(self: *Self, message: *const Message) void {
+        fn on_request_start_view(
+            self: *Self,
+            message: Message.Type(.request_start_view),
+        ) void {
             assert(message.header.command == .request_start_view);
-            if (self.ignore_repair_message(message)) return;
+            if (self.ignore_repair_message(message.base)) return;
 
             assert(self.status == .normal);
             assert(self.view == self.log_view);
@@ -1931,16 +1943,16 @@ pub fn ReplicaType(
             assert(message.header.replica != self.replica);
             assert(self.primary());
 
-            const start_view = self.create_view_change_message(.start_view, message.header.context);
-            defer self.message_bus.unref(start_view);
+            const start_view = self.create_start_view_message(message.header.nonce);
+            defer self.message_bus.unref(start_view.base);
 
-            assert(start_view.references == 1);
+            assert(start_view.base.references == 1);
             assert(start_view.header.command == .start_view);
             assert(start_view.header.view == self.view);
             assert(start_view.header.op == self.op);
             assert(start_view.header.commit == self.commit_max);
 
-            self.send_message_to_replica(message.header.replica, start_view);
+            self.send_message_to_replica(message.header.replica, start_view.base);
         }
 
         /// If the requested prepare has been guaranteed by this replica:
@@ -1952,18 +1964,18 @@ pub fn ReplicaType(
         /// to the cluster. The cluster sees the replica as an underwriter of a guaranteed
         /// prepare. If a guaranteed prepare is found to by faulty, the replica must repair it
         /// to restore durability.
-        fn on_request_prepare(self: *Self, message: *const Message) void {
+        fn on_request_prepare(self: *Self, message: Message.Type(.request_prepare)) void {
             assert(message.header.command == .request_prepare);
-            if (self.ignore_repair_message(message)) return;
+            if (self.ignore_repair_message(message.base)) return;
 
             assert(self.node_count > 1);
             maybe(self.status == .recovering_head);
             maybe(message.header.view != self.view);
             assert(message.header.replica != self.replica);
 
-            const op = message.header.op;
+            const op = message.header.prepare_op;
             const slot = self.journal.slot_for_op(op);
-            const checksum = message.header.context;
+            const checksum = message.header.prepare_checksum;
 
             // Try to serve the message directly from the pipeline.
             // This saves us from going to disk. And we don't need to worry that the WAL's copy
@@ -1974,7 +1986,7 @@ pub fn ReplicaType(
                     op,
                     checksum,
                 });
-                self.send_message_to_replica(message.header.replica, prepare);
+                self.send_message_to_replica(message.header.replica, prepare.base);
                 return;
             }
 
@@ -2013,11 +2025,16 @@ pub fn ReplicaType(
             });
         }
 
-        fn on_request_prepare_read(self: *Self, prepare: ?*Message, destination_replica: ?u8) void {
+        fn on_request_prepare_read(
+            self: *Self,
+            prepare: ?Message.Type(.prepare),
+            destination_replica: ?u8,
+        ) void {
             const message = prepare orelse {
                 log.debug("{}: on_request_prepare_read: prepare=null", .{self.replica});
                 return;
             };
+            assert(message.header.command == .prepare);
 
             log.debug("{}: on_request_prepare_read: op={} checksum={} sending to replica={}", .{
                 self.replica,
@@ -2027,12 +2044,12 @@ pub fn ReplicaType(
             });
 
             assert(destination_replica.? != self.replica);
-            self.send_message_to_replica(destination_replica.?, message);
+            self.send_message_to_replica(destination_replica.?, message.base);
         }
 
-        fn on_request_headers(self: *Self, message: *const Message) void {
+        fn on_request_headers(self: *Self, message: Message.Type(.request_headers)) void {
             assert(message.header.command == .request_headers);
-            if (self.ignore_repair_message(message)) return;
+            if (self.ignore_repair_message(message.base)) return;
 
             maybe(self.status == .recovering_head);
             maybe(message.header.view == self.view);
@@ -2041,17 +2058,15 @@ pub fn ReplicaType(
             const response = self.message_bus.get_message();
             defer self.message_bus.unref(response);
 
-            response.header.* = .{
+            response.build(.headers).header.* = .{
                 .command = .headers,
-                // We echo the context back to the replica so that they can match up our response:
-                .context = message.header.context,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
             };
 
-            const op_min = message.header.commit;
-            const op_max = message.header.op;
+            const op_min = message.header.op_min;
+            const op_max = message.header.op_max;
             assert(op_max >= op_min);
 
             // We must add 1 because op_max and op_min are both inclusive:
@@ -2062,7 +2077,7 @@ pub fn ReplicaType(
                 op_min,
                 op_max,
                 std.mem.bytesAsSlice(
-                    Header,
+                    Header.Type(.prepare),
                     response.buffer[@sizeOf(Header)..][0 .. @sizeOf(Header) * count_max],
                 ),
             );
@@ -2082,35 +2097,35 @@ pub fn ReplicaType(
             response.header.set_checksum();
 
             // Assert that the headers are valid.
-            _ = message_body_as_headers(response);
+            _ = message_body_as_prepare_headers(response);
 
             self.send_message_to_replica(message.header.replica, response);
         }
 
-        fn on_request_reply(self: *Self, message: *const Message) void {
+        fn on_request_reply(self: *Self, message: Message.Type(.request_reply)) void {
             assert(message.header.command == .request_reply);
-            assert(message.header.client != 0);
+            assert(message.header.reply_client != 0);
 
-            if (self.ignore_repair_message(message)) return;
+            if (self.ignore_repair_message(message.base)) return;
             assert(message.header.replica != self.replica);
 
-            const entry = self.client_sessions().get(message.header.client) orelse {
+            const entry = self.client_sessions().get(message.header.reply_client) orelse {
                 log.debug("{}: on_request_reply: ignoring, client not in table", .{self.replica});
                 return;
             };
-            assert(entry.header.client == message.header.client);
+            assert(entry.header.client == message.header.reply_client);
 
-            if (entry.header.checksum != message.header.context) {
+            if (entry.header.checksum != message.header.reply_checksum) {
                 log.debug("{}: on_request_reply: ignoring, reply not in table " ++
                     "(requested={} stored={})", .{
                     self.replica,
-                    message.header.context,
+                    message.header.reply_checksum,
                     entry.header.checksum,
                 });
                 return;
             }
             assert(entry.header.size != @sizeOf(Header));
-            assert(entry.header.op == message.header.op);
+            assert(entry.header.op == message.header.reply_op);
 
             const slot = self.client_sessions().get_slot_for_header(&entry.header).?;
             if (self.client_replies.read_reply_sync(slot, entry)) |reply| {
@@ -2138,8 +2153,8 @@ pub fn ReplicaType(
 
         fn on_request_reply_read_callback(
             client_replies: *ClientReplies,
-            reply_header: *const Header,
-            reply_: ?*Message,
+            reply_header: *const Header.Type(.reply),
+            reply_: ?Message.Type(.reply),
             destination_replica: ?u8,
         ) void {
             const self = @fieldParentPtr(Self, "client_replies", client_replies);
@@ -2165,12 +2180,12 @@ pub fn ReplicaType(
                 reply_header.checksum,
             });
 
-            self.send_message_to_replica(destination_replica.?, reply);
+            self.send_message_to_replica(destination_replica.?, reply.base);
         }
 
-        fn on_headers(self: *Self, message: *const Message) void {
+        fn on_headers(self: *Self, message: Message.Type(.headers)) void {
             assert(message.header.command == .headers);
-            if (self.ignore_repair_message(message)) return;
+            if (self.ignore_repair_message(message.base)) return;
 
             assert(self.status == .normal or self.status == .view_change);
             maybe(message.header.view == self.view);
@@ -2181,7 +2196,7 @@ pub fn ReplicaType(
 
             var op_min: ?u64 = null;
             var op_max: ?u64 = null;
-            for (message_body_as_headers(message)) |*h| {
+            for (message_body_as_prepare_headers(message.base)) |*h| {
                 if (op_min == null or h.op < op_min.?) op_min = h.op;
                 if (op_max == null or h.op > op_max.?) op_max = h.op;
                 _ = self.repair_header(h);
@@ -2191,7 +2206,7 @@ pub fn ReplicaType(
             self.repair();
         }
 
-        fn on_request_blocks(self: *Self, message: *const Message) void {
+        fn on_request_blocks(self: *Self, message: Message.Type(.request_blocks)) void {
             assert(message.header.command == .request_blocks);
 
             if (message.header.replica == self.replica) {
@@ -2260,7 +2275,7 @@ pub fn ReplicaType(
                     .replica = self,
                     .destination = message.header.replica,
                     .read = undefined,
-                    .message = reply.ref(),
+                    .message = reply.ref().build(.block),
                 };
 
                 self.grid.read_block(
@@ -2280,7 +2295,7 @@ pub fn ReplicaType(
             const read = @fieldParentPtr(BlockRead, "read", grid_read);
             const self = read.replica;
             defer {
-                self.message_bus.unref(read.message);
+                self.message_bus.unref(read.message.base);
                 self.grid_reads.release(read);
             }
 
@@ -2305,50 +2320,50 @@ pub fn ReplicaType(
                 grid_read.checksum,
             });
 
-            stdx.copy_disjoint(.inexact, u8, read.message.buffer, result.valid);
+            stdx.copy_disjoint(.inexact, u8, read.message.base.buffer, result.valid);
 
             assert(read.message.header.command == .block);
-            assert(read.message.header.op == grid_read.address);
+            assert(read.message.header.address == grid_read.address);
             assert(read.message.header.checksum == grid_read.checksum);
             assert(read.message.header.size <= constants.block_size);
 
-            self.send_message_to_replica(read.destination, read.message);
+            self.send_message_to_replica(read.destination, read.message.base);
         }
 
-        fn on_block(self: *Self, message: *const Message) void {
+        fn on_block(self: *Self, message: Message.Type(.block)) void {
             maybe(self.state_machine_opened);
             assert(message.header.command == .block);
             assert(message.header.size <= constants.block_size);
-            assert(message.header.op > 0); // op holds the block's address.
+            assert(message.header.address > 0);
 
             if (self.grid.canceling) |_| {
                 assert(self.grid.read_global_queue.count == 0);
 
                 log.debug("{}: on_block: ignoring; grid is canceling (address={} checksum={})", .{
                     self.replica,
-                    message.header.op,
+                    message.header.address,
                     message.header.checksum,
                 });
                 return;
             }
 
-            const block = message.buffer[0..constants.block_size];
+            const block = message.base.buffer[0..constants.block_size];
 
             const grid_fulfill = self.grid.fulfill_block(block);
             if (grid_fulfill) {
-                assert(!self.superblock.free_set.is_free(message.header.op));
+                assert(!self.superblock.free_set.is_free(message.header.address));
 
                 log.debug("{}: on_block: fulfilled address={} checksum={}", .{
                     self.replica,
-                    message.header.op,
+                    message.header.address,
                     message.header.checksum,
                 });
             }
 
             const grid_repair =
-                self.grid.repair_block_waiting(message.header.op, message.header.checksum);
+                self.grid.repair_block_waiting(message.header.address, message.header.checksum);
             if (grid_repair) {
-                assert(!self.superblock.free_set.is_free(message.header.op));
+                assert(!self.superblock.free_set.is_free(message.header.address));
 
                 if (self.grid_repair_writes.acquire()) |write| {
                     const write_index = self.grid_repair_writes.index(write);
@@ -2356,7 +2371,7 @@ pub fn ReplicaType(
 
                     log.debug("{}: on_block: repairing address={} checksum={}", .{
                         self.replica,
-                        message.header.op,
+                        message.header.address,
                         message.header.checksum,
                     });
 
@@ -2364,7 +2379,7 @@ pub fn ReplicaType(
                         .inexact,
                         u8,
                         write_block.*,
-                        message.buffer[0..message.header.size],
+                        message.base.buffer[0..message.header.size],
                     );
                     assert(stdx.zeroed(write_block.*[message.header.size..]));
 
@@ -2374,7 +2389,7 @@ pub fn ReplicaType(
                     log.debug("{}: on_block: ignoring; no write available " ++
                         "(address={} checksum={})", .{
                         self.replica,
-                        message.header.op,
+                        message.header.address,
                         message.header.checksum,
                     });
                 }
@@ -2383,7 +2398,7 @@ pub fn ReplicaType(
             if (!grid_fulfill and !grid_repair) {
                 log.debug("{}: on_block: ignoring; block not needed (address={} checksum={})", .{
                     self.replica,
-                    message.header.op,
+                    message.header.address,
                     message.header.checksum,
                 });
             }
@@ -2402,24 +2417,27 @@ pub fn ReplicaType(
             self.sync_reclaim_tables();
         }
 
-        fn on_request_sync_checkpoint(self: *Self, message: *Message) void {
+        fn on_request_sync_checkpoint(
+            self: *Self,
+            message: Message.Type(.request_sync_checkpoint),
+        ) void {
             assert(message.header.command == .request_sync_checkpoint);
-            if (self.ignore_sync_request_message(message)) return;
+            if (self.ignore_sync_request_message(message.base)) return;
 
-            assert(message.header.op ==
+            assert(message.header.checkpoint_op ==
                 self.superblock.staging.vsr_state.checkpoint.commit_min);
-            assert(message.header.parent == self.superblock.staging.checkpoint_id());
+            assert(message.header.checkpoint_id == self.superblock.staging.checkpoint_id());
 
             self.send_sync_checkpoint(.{ .replica = message.header.replica });
         }
 
-        fn on_sync_checkpoint(self: *Self, message: *const Message) void {
+        fn on_sync_checkpoint(self: *Self, message: Message.Type(.sync_checkpoint)) void {
             assert(message.header.replica < self.replica_count);
             assert(message.header.command == .sync_checkpoint);
-            if (self.ignore_sync_response_message(message)) return;
+            if (self.ignore_sync_response_message(message.base)) return;
 
             const stage: *const SyncStage.RequestingTrailers = &self.syncing.requesting_trailers;
-            assert(stage.target.checkpoint_id == message.header.parent);
+            assert(stage.target.checkpoint_id == message.header.checkpoint_id);
 
             log.debug("{}: on_sync_checkpoint: checkpoint_op={} checkpoint_id={x:0>32}", .{
                 self.replica,
@@ -2442,14 +2460,21 @@ pub fn ReplicaType(
                 message.header.command == .request_sync_client_sessions);
             if (self.ignore_sync_request_message(message)) return;
 
-            assert(message.header.op ==
-                self.superblock.staging.vsr_state.checkpoint.commit_min);
-            assert(message.header.parent == self.superblock.staging.checkpoint_id());
+            switch (message.header.into_any()) {
+                inline .request_sync_client_sessions,
+                .request_sync_free_set,
+                => |message_header, command| {
+                    assert(message_header.checkpoint_op ==
+                        self.superblock.staging.vsr_state.checkpoint.commit_min);
+                    assert(message_header.checkpoint_id == self.superblock.staging.checkpoint_id());
 
-            self.send_sync_trailer(message.header.command, .{
-                .offset = message.header.request,
-                .replica = message.header.replica,
-            });
+                    self.send_sync_trailer(command, .{
+                        .offset = message_header.trailer_offset,
+                        .replica = message_header.replica,
+                    });
+                },
+                else => unreachable,
+            }
         }
 
         fn on_sync_trailer(
@@ -2461,50 +2486,56 @@ pub fn ReplicaType(
             assert(message.header.command == SyncTrailer.responses.get(trailer));
             if (self.ignore_sync_response_message(message)) return;
 
-            const stage: *SyncStage.RequestingTrailers = &self.syncing.requesting_trailers;
-            assert(stage.target.checkpoint_id == message.header.parent);
+            switch (message.header.into_any()) {
+                inline .sync_client_sessions,
+                .sync_free_set,
+                => |message_header| {
+                    const stage: *SyncStage.RequestingTrailers = &self.syncing.requesting_trailers;
+                    assert(stage.target.checkpoint_id == message_header.checkpoint_id);
 
-            log.debug("{}: on_{s}: checkpoint_op={} checkpoint_id={x:0>32}", .{
-                self.replica,
-                @tagName(message.header.command),
-                stage.target.checkpoint_op,
-                stage.target.checkpoint_id,
-            });
+                    log.debug("{}: on_{s}: checkpoint_op={} checkpoint_id={x:0>32}", .{
+                        self.replica,
+                        @tagName(message.header.command),
+                        stage.target.checkpoint_op,
+                        stage.target.checkpoint_id,
+                    });
 
-            const target_buffer = self.superblock.trailer_buffer(trailer);
-            const target_size = @as(u32, @intCast(message.header.commit));
-            const progress = stage.trailers.getPtr(trailer).write_chunk(.{
-                .buffer = target_buffer,
-                .size = target_size,
-                .checksum = message.header.context,
-            }, .{
-                .chunk = message.body(),
-                .chunk_offset = message.header.request,
-            });
+                    const target_buffer = self.superblock.trailer_buffer(trailer);
+                    const progress = stage.trailers.getPtr(trailer).write_chunk(.{
+                        .buffer = target_buffer,
+                        .size = message_header.trailer_size,
+                        .checksum = message_header.trailer_checksum,
+                    }, .{
+                        .chunk = message.body(),
+                        .chunk_offset = message_header.trailer_offset,
+                    });
 
-            log.debug("{}: on_{s}: {s} ({}/{})", .{
-                self.replica,
-                @tagName(message.header.command),
-                @tagName(progress),
-                stage.trailers.get(trailer).offset,
-                target_size,
-            });
+                    log.debug("{}: on_{s}: {s} ({}/{})", .{
+                        self.replica,
+                        @tagName(message.header.command),
+                        @tagName(progress),
+                        stage.trailers.get(trailer).offset,
+                        message_header.trailer_size,
+                    });
+                },
+                else => unreachable,
+            }
         }
 
         fn on_ping_timeout(self: *Self) void {
             self.ping_timeout.reset();
 
-            var ping = Header{
+            var ping = Header.Type(.ping){
                 .command = .ping,
                 .cluster = self.cluster,
                 .replica = self.replica,
-                .commit = self.clock.monotonic(),
+                .ping_timestamp_monotonic = self.clock.monotonic(),
                 // Checkpoint information:
-                .parent = self.superblock.working.checkpoint_id(),
-                .op = self.op_checkpoint(),
+                .checkpoint_id = self.superblock.working.checkpoint_id(),
+                .checkpoint_op = self.op_checkpoint(),
             };
 
-            self.send_header_to_other_replicas_and_standbys(ping);
+            self.send_header_to_other_replicas_and_standbys(ping.frame_const().*);
         }
 
         fn on_prepare_timeout(self: *Self) void {
@@ -2594,7 +2625,7 @@ pub fn ReplicaType(
                 self.replica,
                 replica,
             });
-            self.send_message_to_replica(replica, prepare.message);
+            self.send_message_to_replica(replica, prepare.message.base);
         }
 
         fn on_primary_abdicate_timeout(self: *Self) void {
@@ -2649,17 +2680,17 @@ pub fn ReplicaType(
                 }
             };
 
-            self.send_header_to_other_replicas_and_standbys(.{
+            self.send_header_to_other_replicas_and_standbys(@bitCast(Header.Type(.commit){
                 .command = .commit,
-                .context = latest_committed_entry,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
                 .commit = self.commit_max,
-                .timestamp = self.clock.monotonic(),
-                .op = self.superblock.working.vsr_state.checkpoint.commit_min,
-                .parent = self.superblock.working.checkpoint_id(),
-            });
+                .commit_checksum = latest_committed_entry,
+                .timestamp_monotonic = self.clock.monotonic(),
+                .checkpoint_op = self.superblock.working.vsr_state.checkpoint.commit_min,
+                .checkpoint_id = self.superblock.working.checkpoint_id(),
+            }));
         }
 
         fn on_normal_heartbeat_timeout(self: *Self) void {
@@ -2734,13 +2765,16 @@ pub fn ReplicaType(
                 self.replica,
                 self.view,
             });
-            self.send_header_to_replica(self.primary_index(self.view), .{
-                .command = .request_start_view,
-                .cluster = self.cluster,
-                .replica = self.replica,
-                .view = self.view,
-                .context = self.nonce,
-            });
+            self.send_header_to_replica(
+                self.primary_index(self.view),
+                @bitCast(Header.Type(.request_start_view){
+                    .command = .request_start_view,
+                    .cluster = self.cluster,
+                    .replica = self.replica,
+                    .view = self.view,
+                    .nonce = self.nonce,
+                }),
+            );
         }
 
         fn on_repair_timeout(self: *Self) void {
@@ -2859,7 +2893,10 @@ pub fn ReplicaType(
             }
         }
 
-        fn primary_receive_do_view_change(self: *Self, message: *Message) void {
+        fn primary_receive_do_view_change(
+            self: *Self,
+            message: Message.Type(.do_view_change),
+        ) void {
             assert(!self.solo());
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
@@ -2886,27 +2923,27 @@ pub fn ReplicaType(
                 // if it was checkpointing/committing originally.
                 // Keep the one with the highest checkpoint, then commit.
                 // This is *not* necessary for correctness.
-                if (m.header.timestamp < message.header.timestamp or
-                    (m.header.timestamp == message.header.timestamp and
-                    m.header.commit < message.header.commit))
+                if (m.header.checkpoint_op < message.header.checkpoint_op or
+                    (m.header.checkpoint_op == message.header.checkpoint_op and
+                    m.header.commit_min < message.header.commit_min))
                 {
                     log.debug("{}: on_{s}: replacing " ++
                         "(newer message replica={} checkpoint={}..{} commit={}..{})", .{
                         self.replica,
                         command,
                         message.header.replica,
-                        m.header.timestamp,
-                        message.header.timestamp,
-                        m.header.commit,
-                        message.header.commit,
+                        m.header.checkpoint_op,
+                        message.header.checkpoint_op,
+                        m.header.commit_min,
+                        message.header.commit_min,
                     });
                     // TODO(Buggify): skip updating the DVC, since it isn't required for correctness.
-                    self.message_bus.unref(m);
+                    self.message_bus.unref(m.base);
                     self.do_view_change_from_all_replicas[message.header.replica] = message.ref();
-                } else if (m.header.timestamp != message.header.timestamp or
-                    m.header.commit != message.header.commit or
-                    m.header.context != message.header.context or
-                    m.header.client != message.header.client)
+                } else if (m.header.checkpoint_op != message.header.checkpoint_op or
+                    m.header.commit_min != message.header.commit_min or
+                    m.header.nack_bitset != message.header.nack_bitset or
+                    m.header.present_bitset != message.header.present_bitset)
                 {
                     log.debug("{}: on_{s}: ignoring (older message replica={})", .{
                         self.replica,
@@ -2932,7 +2969,7 @@ pub fn ReplicaType(
         fn count_message_and_receive_quorum_exactly_once(
             self: *Self,
             counter: *QuorumCounter,
-            message: *Message,
+            message: Message.Type(.prepare_ok),
             threshold: u32,
         ) ?usize {
             assert(threshold >= 1);
@@ -2993,9 +3030,10 @@ pub fn ReplicaType(
             return count;
         }
 
-        fn append(self: *Self, message: *Message) void {
+        fn append(self: *Self, message: Message.Type(.prepare)) void {
             assert(self.status == .normal);
             assert(message.header.command == .prepare);
+            assert(message.header.operation != .reserved);
             assert(message.header.view == self.view);
             assert(message.header.op == self.op);
             assert(message.header.op <= self.op_checkpoint_next_trigger());
@@ -3019,11 +3057,13 @@ pub fn ReplicaType(
 
         /// Returns whether `b` succeeds `a` by having a newer view or same view and newer op.
         fn ascending_viewstamps(
-            a: *const Header,
-            b: *const Header,
+            a: *const Header.Type(.prepare),
+            b: *const Header.Type(.prepare),
         ) bool {
             assert(a.command == .prepare);
             assert(b.command == .prepare);
+            assert(a.operation != .reserved);
+            assert(b.operation != .reserved);
 
             if (a.view < b.view) {
                 // We do not assert b.op >= a.op, ops may be reordered during a view change.
@@ -3235,7 +3275,11 @@ pub fn ReplicaType(
             }
         }
 
-        fn commit_journal_next_callback(self: *Self, prepare: ?*Message, destination_replica: ?u8) void {
+        fn commit_journal_next_callback(
+            self: *Self,
+            prepare: ?Message.Type(.prepare),
+            destination_replica: ?u8,
+        ) void {
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(self.commit_stage == .next_journal);
@@ -3347,8 +3391,9 @@ pub fn ReplicaType(
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(self.commit_stage == .prefetch_state_machine);
-            assert(self.commit_prepare.?.header.operation != .root);
             assert(self.commit_prepare.?.header.command == .prepare);
+            assert(self.commit_prepare.?.header.operation != .root);
+            assert(self.commit_prepare.?.header.operation != .reserved);
             assert(self.commit_prepare.?.header.op == self.commit_min + 1);
             assert(self.commit_prepare.?.header.op <= self.op);
 
@@ -3399,7 +3444,7 @@ pub fn ReplicaType(
             if (self.status == .normal and self.primary()) {
                 {
                     const prepare = self.pipeline.queue.pop_prepare().?;
-                    defer self.message_bus.unref(prepare.message);
+                    defer self.message_bus.unref(prepare.message.base);
 
                     assert(prepare.message.header.command == .prepare);
                     assert(prepare.message.header.checksum == self.commit_prepare.?.header.checksum);
@@ -3589,7 +3634,7 @@ pub fn ReplicaType(
 
             const op = self.commit_prepare.?.header.op;
 
-            self.message_bus.unref(self.commit_prepare.?);
+            self.message_bus.unref(self.commit_prepare.?.base);
             self.commit_prepare = null;
 
             tracer.end(
@@ -3600,15 +3645,16 @@ pub fn ReplicaType(
             self.commit_dispatch(.next);
         }
 
-        fn commit_op(self: *Self, prepare: *const Message) void {
+        fn commit_op(self: *Self, prepare: Message.Type(.prepare)) void {
             // TODO Can we add more checks around allowing commit_op() during a view change?
             assert(self.commit_stage == .setup_client_replies);
-            assert(self.commit_prepare.? == prepare);
+            assert(self.commit_prepare.?.base == prepare.base);
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(self.client_replies.writes.available() > 0);
             assert(prepare.header.command == .prepare);
             assert(prepare.header.operation != .root);
+            assert(prepare.header.operation != .reserved);
             assert(prepare.header.op == self.commit_min + 1);
             assert(prepare.header.op <= self.op);
 
@@ -3637,8 +3683,8 @@ pub fn ReplicaType(
                 prepare.header.operation.tag_name(StateMachine),
             });
 
-            const reply = self.message_bus.get_message();
-            defer self.message_bus.unref(reply);
+            const reply = self.message_bus.get_message().build(.reply);
+            defer self.message_bus.unref(reply.base);
 
             log.debug("{}: commit_op: commit_timestamp={} prepare.header.timestamp={}", .{
                 self.replica,
@@ -3672,14 +3718,17 @@ pub fn ReplicaType(
             const reply_body_size = switch (prepare.header.operation) {
                 .reserved, .root => unreachable,
                 .register => 0,
-                .reconfigure => self.commit_reconfiguration(prepare, reply.buffer[@sizeOf(Header)..]),
+                .reconfigure => self.commit_reconfiguration(
+                    prepare,
+                    reply.base.buffer[@sizeOf(Header)..],
+                ),
                 else => self.state_machine.commit(
                     prepare.header.client,
                     prepare.header.op,
                     prepare.header.timestamp,
                     prepare.header.operation.cast(StateMachine),
-                    prepare.buffer[@sizeOf(Header)..prepare.header.size],
-                    reply.buffer[@sizeOf(Header)..],
+                    prepare.base.buffer[@sizeOf(Header)..prepare.header.size],
+                    reply.base.buffer[@sizeOf(Header)..],
                 ),
             };
 
@@ -3708,10 +3757,10 @@ pub fn ReplicaType(
             };
             assert(reply.header.epoch == 0);
 
-            reply.header.set_checksum_body(reply.body());
+            reply.header.frame().set_checksum_body(reply.body());
             // See `send_reply_message_to_client` for why we compute the checksum twice.
-            reply.header.context = reply.header.calculate_checksum();
-            reply.header.set_checksum();
+            reply.header.context = reply.header.frame_const().calculate_checksum();
+            reply.header.frame().set_checksum();
 
             if (self.superblock.working.vsr_state.op_compacted(prepare.header.op)) {
                 // We are recovering from a checkpoint. Prior to the crash, the client table was
@@ -3749,11 +3798,11 @@ pub fn ReplicaType(
         // Here, we just copy over the result.
         fn commit_reconfiguration(
             self: *Self,
-            prepare: *const Message,
+            prepare: Message.Type(.prepare),
             output_buffer: *align(16) [constants.message_body_size_max]u8,
         ) usize {
             assert(self.commit_stage == .setup_client_replies);
-            assert(self.commit_prepare.? == prepare);
+            assert(self.commit_prepare.?.base == prepare.base);
             assert(prepare.header.command == .prepare);
             assert(prepare.header.operation == .reconfigure);
             assert(prepare.header.size == @sizeOf(vsr.Header) + @sizeOf(vsr.ReconfigurationRequest));
@@ -3778,7 +3827,7 @@ pub fn ReplicaType(
         /// Creates an entry in the client table when registering a new client session.
         /// Asserts that the new session does not yet exist.
         /// Evicts another entry deterministically, if necessary, to make space for the insert.
-        fn client_table_entry_create(self: *Self, reply: *Message) void {
+        fn client_table_entry_create(self: *Self, reply: Message.Type(.reply)) void {
             assert(reply.header.command == .reply);
             assert(reply.header.operation == .register);
             assert(reply.header.client > 0);
@@ -3836,7 +3885,7 @@ pub fn ReplicaType(
             }
         }
 
-        fn client_table_entry_update(self: *Self, reply: *Message) void {
+        fn client_table_entry_update(self: *Self, reply: Message.Type(.reply)) void {
             assert(reply.header.command == .reply);
             assert(reply.header.operation != .register);
             assert(reply.header.client > 0);
@@ -3878,125 +3927,44 @@ pub fn ReplicaType(
             }
         }
 
-        /// Construct a SV/DVC message, including attached headers from the current log_view.
-        ///
+        /// Construct a SV message, including attached headers from the current log_view.
         /// The caller owns the returned message, if any, which has exactly 1 reference.
-        fn create_view_change_message(self: *Self, command: Command, nonce: ?u128) *Message {
-            assert(self.status == .normal or self.status == .view_change);
-            assert((self.status == .normal) == (command == .start_view));
-            assert((self.status == .view_change) == (command == .do_view_change));
-            assert((command == .do_view_change) == (nonce == null));
+        fn create_start_view_message(self: *Self, nonce: u128) Message.Type(.start_view) {
+            assert(self.status == .normal);
+            assert(self.replica == self.primary_index(self.view));
+            assert(self.commit_min == self.commit_max);
             assert(self.view >= self.view_durable());
             assert(self.log_view >= self.log_view_durable());
-            assert((self.log_view < self.view) == (command == .do_view_change));
-            assert((self.log_view == self.view) == (command == .start_view));
-            assert(self.log_view < self.view or self.replica == self.primary_index(self.view));
+            assert(self.log_view == self.view);
 
-            const message = self.message_bus.get_message();
-            defer self.message_bus.unref(message);
-
-            switch (command) {
-                // The DVC headers are already up to date, either via:
-                // - transition_to_view_change_status(), or
-                // - superblock's vsr_headers (after recovery).
-                .do_view_change => {
-                    assert(self.view_headers.command == .do_view_change);
-                    assert(self.view_headers.array.get(0).op >= self.op);
-                },
-                .start_view => {
-                    self.primary_update_view_headers();
-                    assert(self.view_headers.command == .start_view);
-                    assert(self.view_headers.array.get(0).op == self.op);
-                },
-                else => unreachable,
-            }
+            self.primary_update_view_headers();
+            assert(self.view_headers.command == .start_view);
+            assert(self.view_headers.array.get(0).op == self.op);
             self.view_headers.verify();
 
-            const BitSet = std.bit_set.IntegerBitSet(128);
-            comptime assert(BitSet.MaskInt == std.meta.fieldInfo(Header, .context).type);
-
-            // Collect nack and presence bits for the headers, so that the new primary can run CTRL
-            // protocol to truncate uncommitted headers. When:
-            // - a header has quorum of nacks -- the header is truncated
-            // - a header isn't truncated and is present -- the header gets into the next view
-            // - a header is neither truncated nor present -- the primary waits for more
-            //   DVC messages to decide whether to keep or truncate the header.
-            var nacks = BitSet.initEmpty();
-            var present = BitSet.initEmpty();
-            if (command == .do_view_change) {
-                for (self.view_headers.array.const_slice(), 0..) |*header, i| {
-                    const slot = self.journal.slot_for_op(header.op);
-                    const journal_header = self.journal.header_for_op(header.op);
-                    const dirty = self.journal.dirty.bit(slot);
-                    const faulty = self.journal.faulty.bit(slot);
-
-                    // Case 1: We have this header in memory, but haven't persisted it to disk yet.
-                    if (journal_header != null and journal_header.?.checksum == header.checksum and
-                        dirty and !faulty)
-                    {
-                        nacks.set(i);
-                    }
-
-                    // Case 2: We have a _different_ prepare — safe to nack even if it is faulty.
-                    if (journal_header != null and journal_header.?.checksum != header.checksum) {
-                        nacks.set(i);
-                    }
-
-                    // Case 3: We don't have a prepare at all, and that's not due to a fault.
-                    if (journal_header == null and !faulty) {
-                        nacks.set(i);
-                    }
-
-                    // Presence bit: the prepare is on disk, is being written to disk, or is cached
-                    // in memory. These conditions mirror logic in `on_request_prepare` and imply
-                    // that we can help the new primary to repair this prepare.
-                    if ((self.journal.prepare_inhabited[slot.index] and
-                        self.journal.prepare_checksums[slot.index] == header.checksum) or
-                        self.journal.writing(header.op, header.checksum) or
-                        self.pipeline_prepare_by_op_and_checksum(header.op, header.checksum) != null)
-                    {
-                        if (journal_header != null) {
-                            assert(journal_header.?.checksum == header.checksum);
-                        }
-                        maybe(nacks.isSet(i));
-                        present.set(i);
-                    }
-                }
-            }
+            const message = self.message_bus.get_message().build(.start_view);
+            defer self.message_bus.unref(message.base);
 
             message.header.* = .{
                 .size = @sizeOf(Header) * (1 + self.view_headers.array.count_as(u32)),
-                .command = command,
+                .command = .start_view,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
-                // The latest normal view (as specified in the 2012 paper) is different to the view
-                // number contained in the prepare headers we include in the body. The former shows
-                // how recent a view change the replica participated in, which may be much higher.
-                // We use the `request` field to send this in addition to the current view number:
-                .request = if (command == .do_view_change) self.log_view else 0,
-                .timestamp = self.op_checkpoint(),
-                // This is usually the head op, but for DVCs it may be farther ahead if we are
-                // lagging behind a checkpoint. (In which case the op is inherited from the SV).
-                .op = self.view_headers.array.get(0).op,
-                // For command=start_view, commit_min=commit_max.
-                // For command=do_view_change, the new primary uses this op to trust extra headers
-                // from non-canonical DVCs.
-                .commit = self.commit_min,
-                // DVC: Signal which headers correspond to definitely not-prepared messages.
-                .context = if (command == .do_view_change) nacks.mask else nonce.?,
-                // DVC: Signal which headers correspond to locally available prepares.
-                .client = present.mask,
+                .checkpoint_op = self.op_checkpoint(),
+                .op = self.op,
+                .commit = self.commit_min, // (Same as commit_max.)
+                .nonce = nonce,
             };
 
             stdx.copy_disjoint(
                 .exact,
-                Header,
-                std.mem.bytesAsSlice(Header, message.body()),
+                Header.Type(.prepare),
+                std.mem.bytesAsSlice(Header.Type(.prepare), message.body()),
                 self.view_headers.array.const_slice(),
             );
-            message.header.set_checksum_body(message.body());
-            message.header.set_checksum();
+            message.header.frame().set_checksum_body(message.body());
+            message.header.frame().set_checksum();
 
             return message.ref();
         }
@@ -4128,7 +4096,7 @@ pub fn ReplicaType(
             assert(self.loopback_queue == null);
         }
 
-        fn ignore_ping_client(self: *const Self, message: *const Message) bool {
+        fn ignore_ping_client(self: *const Self, message: Message.Type(.ping_client)) bool {
             assert(message.header.command == .ping_client);
             assert(message.header.client != 0);
 
@@ -4148,7 +4116,7 @@ pub fn ReplicaType(
             return false;
         }
 
-        fn ignore_prepare_ok(self: *Self, message: *const Message) bool {
+        fn ignore_prepare_ok(self: *Self, message: Message.Type(.prepare_ok)) bool {
             assert(message.header.command == .prepare_ok);
             assert(message.header.replica < self.replica_count);
 
@@ -4299,9 +4267,7 @@ pub fn ReplicaType(
             return false;
         }
 
-        fn ignore_request_message(self: *Self, message: *Message) bool {
-            assert(message.header.command == .request);
-
+        fn ignore_request_message(self: *Self, message: Message.Type(.request)) bool {
             if (self.standby()) {
                 log.warn("{}: on_request: misdirected message (standby)", .{self.replica});
                 return true;
@@ -4383,7 +4349,7 @@ pub fn ReplicaType(
 
         /// Returns whether the request is stale, or a duplicate of the latest committed request.
         /// Resends the reply to the latest request if the request has been committed.
-        fn ignore_request_message_duplicate(self: *Self, message: *const Message) bool {
+        fn ignore_request_message_duplicate(self: *Self, message: Message.Type(.request)) bool {
             assert(self.status == .normal);
             assert(self.primary());
             assert(self.syncing == .idle);
@@ -4391,7 +4357,7 @@ pub fn ReplicaType(
             assert(message.header.command == .request);
             assert(message.header.client > 0);
             assert(message.header.view <= self.view); // See ignore_request_message_backup().
-            assert(message.header.context == 0 or message.header.operation != .register);
+            assert(message.header.session == 0 or message.header.operation != .register);
             assert(message.header.request == 0 or message.header.operation != .register);
 
             if (self.client_sessions().get(message.header.client)) |entry| {
@@ -4400,11 +4366,11 @@ pub fn ReplicaType(
 
                 if (message.header.operation == .register) {
                     // Fall through below to check if we should resend the .register session reply.
-                } else if (entry.session > message.header.context) {
+                } else if (entry.session > message.header.session) {
                     // The client must not reuse the ephemeral client ID when registering a new session.
                     log.err("{}: on_request: ignoring older session (client bug)", .{self.replica});
                     return true;
-                } else if (entry.session < message.header.context) {
+                } else if (entry.session < message.header.session) {
                     // This cannot be because of a partition since we check the client's view number.
                     log.err("{}: on_request: ignoring newer session (client bug)", .{self.replica});
                     return true;
@@ -4467,7 +4433,7 @@ pub fn ReplicaType(
 
         fn on_request_repeat_reply(
             self: *Self,
-            message: *const Message,
+            message: Message.Type(.request),
             entry: *const ClientSessions.Entry,
         ) void {
             assert(self.status == .normal);
@@ -4476,14 +4442,14 @@ pub fn ReplicaType(
             assert(message.header.command == .request);
             assert(message.header.client > 0);
             assert(message.header.view <= self.view); // See ignore_request_message_backup().
-            assert(message.header.context == 0 or message.header.operation != .register);
+            assert(message.header.session == 0 or message.header.operation != .register);
             assert(message.header.request == 0 or message.header.operation != .register);
             assert(message.header.checksum == entry.header.parent);
             assert(message.header.request == entry.header.request);
 
             if (entry.header.size == @sizeOf(Header)) {
-                const reply = self.create_message_from_header(entry.header);
-                defer self.message_bus.unref(reply);
+                const reply = self.create_message_from_header(@bitCast(entry.header)).into(.reply).?;
+                defer self.message_bus.unref(reply.base);
 
                 self.send_reply_message_to_client(reply);
                 return;
@@ -4515,8 +4481,8 @@ pub fn ReplicaType(
 
         fn on_request_repeat_reply_callback(
             client_replies: *ClientReplies,
-            reply_header: *const Header,
-            reply_: ?*Message,
+            reply_header: *const Header.Type(.reply),
+            reply_: ?Message.Type(.reply),
             destination_replica: ?u8,
         ) void {
             const self = @fieldParentPtr(Self, "client_replies", client_replies);
@@ -4547,7 +4513,7 @@ pub fn ReplicaType(
         /// Returns whether the replica is eligible to process this request as the primary.
         /// Takes the client's perspective into account if the client is aware of a newer view.
         /// Forwards requests to the primary if the client has an older view.
-        fn ignore_request_message_backup(self: *Self, message: *Message) bool {
+        fn ignore_request_message_backup(self: *Self, message: Message.Type(.request)) bool {
             assert(self.status == .normal);
             assert(message.header.command == .request);
 
@@ -4571,7 +4537,7 @@ pub fn ReplicaType(
                 // Since the client is already connected to all replicas, the client may yet receive the
                 // reply from the new primary directly.
                 log.debug("{}: on_request: forwarding (backup)", .{self.replica});
-                self.send_message_to_replica(self.primary_index(self.view), message);
+                self.send_message_to_replica(self.primary_index(self.view), message.base);
             } else {
                 assert(message.header.view == self.view);
                 // The client has the correct view, but has retried against a backup.
@@ -4589,7 +4555,7 @@ pub fn ReplicaType(
             return true;
         }
 
-        fn ignore_request_message_preparing(self: *Self, message: *const Message) bool {
+        fn ignore_request_message_preparing(self: *Self, message: Message.Type(.request)) bool {
             assert(self.status == .normal);
             assert(self.primary());
 
@@ -4598,23 +4564,28 @@ pub fn ReplicaType(
             assert(message.header.view <= self.view); // See ignore_request_message_backup().
 
             if (self.pipeline.queue.message_by_client(message.header.client)) |pipeline_message| {
-                assert(pipeline_message.header.client == message.header.client);
                 assert(pipeline_message.header.command == .request or
                     pipeline_message.header.command == .prepare);
 
-                if (pipeline_message.header.command == .request and
-                    pipeline_message.header.checksum == message.header.checksum)
-                {
-                    log.debug("{}: on_request: ignoring (already queued)", .{self.replica});
-                    return true;
-                }
+                switch (pipeline_message.header.into_any()) {
+                    .request => |pipeline_message_header| {
+                        assert(pipeline_message_header.client == message.header.client);
 
-                if (pipeline_message.header.command == .prepare and
-                    pipeline_message.header.context == message.header.checksum)
-                {
-                    assert(pipeline_message.header.op > self.commit_max);
-                    log.debug("{}: on_request: ignoring (already preparing)", .{self.replica});
-                    return true;
+                        if (pipeline_message.header.checksum == message.header.checksum) {
+                            log.debug("{}: on_request: ignoring (already queued)", .{self.replica});
+                            return true;
+                        }
+                    },
+                    .prepare => |pipeline_message_header| {
+                        assert(pipeline_message_header.client == message.header.client);
+
+                        if (pipeline_message_header.context == message.header.checksum) {
+                            assert(pipeline_message_header.op > self.commit_max);
+                            log.debug("{}: on_request: ignoring (already preparing)", .{self.replica});
+                            return true;
+                        }
+                    },
+                    else => unreachable,
                 }
 
                 log.err("{}: on_request: ignoring (client forked)", .{self.replica});
@@ -4629,7 +4600,10 @@ pub fn ReplicaType(
             return false;
         }
 
-        fn ignore_start_view_change_message(self: *const Self, message: *const Message) bool {
+        fn ignore_start_view_change_message(
+            self: *const Self,
+            message: Message.Type(.start_view_change),
+        ) bool {
             assert(message.header.command == .start_view_change);
             assert(message.header.replica < self.replica_count);
 
@@ -4681,8 +4655,8 @@ pub fn ReplicaType(
                 return true;
             }
 
-            switch (message.header.command) {
-                .start_view => {
+            switch (message.header.into_any()) {
+                .start_view => |message_header| {
                     // This may be caused by faults in the network topology.
                     if (message.header.replica == self.replica) {
                         log.warn("{}: on_{s}: misdirected message (self)", .{ self.replica, command });
@@ -4690,9 +4664,9 @@ pub fn ReplicaType(
                     }
 
                     if (self.status == .recovering_head) {
-                        if (message.header.view > self.view or
-                            message.header.op >= self.op_checkpoint_next_trigger() or
-                            message.header.context == self.nonce)
+                        if (message_header.view > self.view or
+                            message_header.op >= self.op_checkpoint_next_trigger() or
+                            message_header.nonce == self.nonce)
                         {
                             // This SV is guaranteed to have originated after the replica crash,
                             // it is safe to use to determine the head op.
@@ -4707,7 +4681,7 @@ pub fn ReplicaType(
 
                     // Syncing replicas must be careful about receiving SV messages, since they
                     // may have fast-forwarded their commit_max via their checkpoint target.
-                    if (message.header.commit < self.op_checkpoint()) {
+                    if (message_header.commit < self.op_checkpoint()) {
                         log.debug("{}: on_{s}: ignoring (older checkpoint)", .{
                             self.replica,
                             command,
@@ -4760,6 +4734,8 @@ pub fn ReplicaType(
             return false;
         }
 
+        // TODO Once trailers are removed, this can take a Message.Type(.request_sync_checkpoint)
+        // (or just be inlined into on_request_sync_checkpoint).
         fn ignore_sync_request_message(self: *const Self, message: *const Message) bool {
             assert(message.header.command == .request_sync_checkpoint or
                 message.header.command == .request_sync_free_set or
@@ -4785,30 +4761,42 @@ pub fn ReplicaType(
                 return true;
             }
 
-            if (self.superblock.staging.vsr_state.checkpoint.commit_min != message.header.op) {
-                log.debug("{}: on_{s}: ignoring different checkpoint (local={} message={})", .{
-                    self.replica,
-                    command,
-                    self.op_checkpoint(),
-                    message.header.op,
-                });
-                return true;
-            }
+            switch (message.header.command) {
+                inline .request_sync_checkpoint,
+                .request_sync_client_sessions,
+                .request_sync_free_set,
+                => |command_comptime| {
+                    const message_header = message.header.into_const(command_comptime).?;
 
-            if (self.superblock.staging.checkpoint_id() != message.header.parent) {
-                log.warn("{}: on_{s}: ignoring divergent checkpoint (local={x:0>32} message={x:0>32} remote={})", .{
-                    self.replica,
-                    command,
-                    self.superblock.staging.checkpoint_id(),
-                    message.header.parent,
-                    message.header.replica,
-                });
-                return true;
+                    if (self.superblock.staging.vsr_state.checkpoint.commit_min != message_header.checkpoint_op) {
+                        log.debug("{}: on_{s}: ignoring different checkpoint (local={} message={})", .{
+                            self.replica,
+                            command,
+                            self.op_checkpoint(),
+                            message_header.checkpoint_op,
+                        });
+                        return true;
+                    }
+
+                    if (self.superblock.staging.checkpoint_id() != message_header.checkpoint_id) {
+                        log.warn("{}: on_{s}: ignoring divergent checkpoint (local={x:0>32} message={x:0>32} remote={})", .{
+                            self.replica,
+                            command,
+                            self.superblock.staging.checkpoint_id(),
+                            message_header.checkpoint_id,
+                            message_header.replica,
+                        });
+                        return true;
+                    }
+                },
+                else => unreachable,
             }
 
             return false;
         }
 
+        // TODO Once trailers are removed, this can take a Message.Type(.sync_checkpoint)
+        // (or just be inlined into on_sync_checkpoint).
         fn ignore_sync_response_message(self: *const Self, message: *const Message) bool {
             assert(message.header.command == .sync_checkpoint or
                 message.header.command == .sync_free_set or
@@ -4827,30 +4815,36 @@ pub fn ReplicaType(
 
             const stage: *const SyncStage.RequestingTrailers = &self.syncing.requesting_trailers;
 
-            if (message.header.op != stage.target.checkpoint_op) {
-                log.debug("{}: on_{s}: ignoring, wrong op (got={} want={})", .{
-                    self.replica,
-                    @tagName(message.header.command),
-                    message.header.op,
-                    stage.target.checkpoint_op,
-                });
-                return true;
-            }
+            switch (message.header.command) {
+                inline .sync_checkpoint, .sync_client_sessions, .sync_free_set => |command| {
+                    const message_header = message.header.into_const(command).?;
 
-            if (message.header.parent != stage.target.checkpoint_id) {
-                log.debug("{}: on_{s}: ignoring, wrong op (got={x:0>32} want={x:0>32})", .{
-                    self.replica,
-                    @tagName(message.header.command),
-                    message.header.parent,
-                    stage.target.checkpoint_id,
-                });
-                return true;
-            }
+                    if (message_header.checkpoint_op != stage.target.checkpoint_op) {
+                        log.debug("{}: on_{s}: ignoring, wrong op (got={} want={})", .{
+                            self.replica,
+                            @tagName(message_header.command),
+                            message_header.checkpoint_op,
+                            stage.target.checkpoint_op,
+                        });
+                        return true;
+                    }
 
+                    if (message_header.checkpoint_id != stage.target.checkpoint_id) {
+                        log.debug("{}: on_{s}: ignoring, wrong op (got={x:0>32} want={x:0>32})", .{
+                            self.replica,
+                            @tagName(message_header.command),
+                            message_header.checkpoint_id,
+                            stage.target.checkpoint_id,
+                        });
+                        return true;
+                    }
+                },
+                else => unreachable,
+            }
             return false;
         }
 
-        fn is_repair(self: *const Self, message: *const Message) bool {
+        fn is_repair(self: *const Self, message: Message.Type(.prepare)) bool {
             assert(message.header.command == .prepare);
 
             if (self.status == .normal) {
@@ -4904,7 +4898,10 @@ pub fn ReplicaType(
         /// Advances `op` to where we need to be before `header` can be processed as a prepare.
         ///
         /// This function temporarily violates the "replica.op must exist in WAL" invariant.
-        fn jump_to_newer_op_in_normal_status(self: *Self, header: *const Header) void {
+        fn jump_to_newer_op_in_normal_status(
+            self: *Self,
+            header: *const Header.Type(.prepare),
+        ) void {
             assert(self.status == .normal);
             assert(self.backup());
             assert(header.view == self.view);
@@ -4991,7 +4988,7 @@ pub fn ReplicaType(
             return true;
         }
 
-        /// The op of the highest checkpointed message.
+        /// The op of the highest checkpointed prepare.
         pub fn op_checkpoint(self: *const Self) u64 {
             return self.superblock.working.vsr_state.checkpoint.commit_min;
         }
@@ -5108,15 +5105,15 @@ pub fn ReplicaType(
         /// Assumes gaps and does not require that a precedes b.
         fn panic_if_hash_chain_would_break_in_the_same_view(
             self: *const Self,
-            a: *const Header,
-            b: *const Header,
+            a: *const Header.Type(.prepare),
+            b: *const Header.Type(.prepare),
         ) void {
             assert(a.command == .prepare);
             assert(b.command == .prepare);
             assert(a.cluster == b.cluster);
             if (a.view == b.view and a.op + 1 == b.op and a.checksum != b.parent) {
-                assert(a.valid_checksum());
-                assert(b.valid_checksum());
+                assert(a.frame_const().valid_checksum());
+                assert(b.frame_const().valid_checksum());
                 log.err("{}: panic_if_hash_chain_would_break: a: {}", .{ self.replica, a });
                 log.err("{}: panic_if_hash_chain_would_break: b: {}", .{ self.replica, b });
                 @panic("hash chain would break");
@@ -5131,15 +5128,12 @@ pub fn ReplicaType(
             assert(!self.pipeline.queue.prepare_queue.full());
             self.pipeline.queue.verify();
 
-            const message = request.message;
-            defer self.message_bus.unref(message);
-
-            assert(!self.ignore_request_message(message));
+            assert(!self.ignore_request_message(request.message));
 
             log.debug("{}: primary_pipeline_prepare: request checksum={} client={}", .{
                 self.replica,
-                message.header.checksum,
-                message.header.client,
+                request.message.header.checksum,
+                request.message.header.client,
             });
 
             // Guard against the wall clock going backwards by taking the max with timestamps issued:
@@ -5154,38 +5148,54 @@ pub fn ReplicaType(
             );
             assert(self.state_machine.prepare_timestamp > self.state_machine.commit_timestamp);
 
-            switch (message.header.operation) {
+            switch (request.message.header.operation) {
                 .reserved, .root => unreachable,
                 .register => {},
-                .reconfigure => self.primary_prepare_reconfiguration(message),
+                .reconfigure => self.primary_prepare_reconfiguration(request.message),
                 else => self.state_machine.prepare(
-                    message.header.operation.cast(StateMachine),
-                    message.body(),
+                    request.message.header.operation.cast(StateMachine),
+                    request.message.body(),
                 ),
             }
             const prepare_timestamp = self.state_machine.prepare_timestamp;
 
+            // Reuse the Request message as a Prepare message by replacing the header.
+            const message = request.message.base.build(.prepare);
+            defer self.message_bus.unref(message.base);
+
+            // Copy the header to the stack before overwriting it to avoid UB.
+            const request_header: Header.Type(.request) = request.message.header.*;
+
             const latest_entry = self.journal.header_with_op(self.op).?;
-            message.header.parent = latest_entry.checksum;
-            message.header.context = message.header.checksum;
-            message.header.view = self.view;
-            message.header.op = self.op + 1;
-            message.header.commit = self.commit_max;
-
-            // When running in AOF recovery mode, we allow clients to set a timestamp explicitly, but
-            // they can still pass in 0.
-            if (constants.aof_recovery) {
-                if (message.header.timestamp == 0) {
-                    message.header.timestamp = prepare_timestamp;
-                }
-            } else {
-                message.header.timestamp = prepare_timestamp;
-            }
-            message.header.replica = self.replica;
-            message.header.command = .prepare;
-
-            message.header.set_checksum_body(message.body());
-            message.header.set_checksum();
+            message.header.* = Header.Type(.prepare){
+                .cluster = self.cluster,
+                .size = request_header.size,
+                .view = self.view,
+                .command = .prepare,
+                .replica = self.replica,
+                .parent = latest_entry.checksum,
+                .client = request_header.client,
+                .context = request_header.checksum,
+                .op = self.op + 1,
+                .commit = self.commit_max,
+                .timestamp = timestamp: {
+                    // When running in AOF recovery mode, we allow clients to set a timestamp
+                    // explicitly, but they can still pass in 0.
+                    if (constants.aof_recovery) {
+                        if (request_header.timestamp == 0) {
+                            break :timestamp prepare_timestamp;
+                        } else {
+                            break :timestamp request_header.timestamp;
+                        }
+                    } else {
+                        break :timestamp prepare_timestamp;
+                    }
+                },
+                .request = request_header.request,
+                .operation = request_header.operation,
+            };
+            message.header.frame().set_checksum_body(message.body());
+            message.header.frame().set_checksum();
 
             log.debug("{}: primary_pipeline_prepare: prepare {}", .{ self.replica, message.header.checksum });
 
@@ -5209,7 +5219,10 @@ pub fn ReplicaType(
             assert(self.op == message.header.op);
         }
 
-        fn primary_prepare_reconfiguration(self: *const Self, request: *Message) void {
+        fn primary_prepare_reconfiguration(
+            self: *const Self,
+            request: Message.Type(.request),
+        ) void {
             assert(self.primary());
             assert(request.header.command == .request);
             assert(request.header.operation == .reconfigure);
@@ -5245,7 +5258,11 @@ pub fn ReplicaType(
             }
         }
 
-        fn pipeline_prepare_by_op_and_checksum(self: *Self, op: u64, checksum: u128) ?*Message {
+        fn pipeline_prepare_by_op_and_checksum(
+            self: *Self,
+            op: u64,
+            checksum: u128,
+        ) ?Message.Type(.prepare) {
             return switch (self.pipeline) {
                 .cache => |*cache| cache.prepare_by_op_and_checksum(op, checksum),
                 .queue => |*queue| if (queue.prepare_by_op_and_checksum(op, checksum)) |prepare|
@@ -5309,13 +5326,16 @@ pub fn ReplicaType(
                     },
                 );
 
-                self.send_header_to_replica(self.primary_index(self.view), .{
-                    .command = .request_start_view,
-                    .cluster = self.cluster,
-                    .replica = self.replica,
-                    .view = self.view,
-                    .context = self.nonce,
-                });
+                self.send_header_to_replica(
+                    self.primary_index(self.view),
+                    @bitCast(Header.Type(.request_start_view){
+                        .command = .request_start_view,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .view = self.view,
+                        .nonce = self.nonce,
+                    }),
+                );
                 return;
             }
 
@@ -5341,14 +5361,17 @@ pub fn ReplicaType(
                     },
                 );
 
-                self.send_header_to_replica(self.choose_any_other_replica(), .{
-                    .command = .request_headers,
-                    .cluster = self.cluster,
-                    .replica = self.replica,
-                    .view = self.view,
-                    .commit = range.op_min,
-                    .op = range.op_max,
-                });
+                self.send_header_to_replica(
+                    self.choose_any_other_replica(),
+                    @bitCast(Header.Type(.request_headers){
+                        .command = .request_headers,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .view = self.view,
+                        .op_min = range.op_min,
+                        .op_max = range.op_max,
+                    }),
+                );
                 return;
             }
             assert(self.valid_hash_chain_between(self.op_repair_min(), self.op));
@@ -5363,15 +5386,18 @@ pub fn ReplicaType(
                 assert(entry.session != 0);
                 assert(entry.header.size > @sizeOf(Header));
 
-                self.send_header_to_replica(self.choose_any_other_replica(), .{
-                    .command = .request_reply,
-                    .cluster = self.cluster,
-                    .replica = self.replica,
-                    .view = self.view,
-                    .client = entry.header.client,
-                    .op = entry.header.op,
-                    .context = entry.header.checksum,
-                });
+                self.send_header_to_replica(
+                    self.choose_any_other_replica(),
+                    @bitCast(Header.Type(.request_reply){
+                        .command = .request_reply,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .view = self.view,
+                        .reply_client = entry.header.client,
+                        .reply_op = entry.header.op,
+                        .reply_checksum = entry.header.checksum,
+                    }),
+                );
             }
 
             if (self.commit_min < self.commit_max) {
@@ -5442,10 +5468,10 @@ pub fn ReplicaType(
         /// * Do not replace an op belonging to the current WAL wrap with an op belonging to a
         ///   previous wrap. In other words, don't repair checkpointed ops.
         ///
-        fn repair_header(self: *Self, header: *const Header) bool {
+        fn repair_header(self: *Self, header: *const Header.Type(.prepare)) bool {
             assert(self.status == .normal or self.status == .view_change);
-            assert(header.valid_checksum());
-            assert(header.invalid() == null);
+            assert(header.frame_const().valid_checksum());
+            assert(header.frame_const().invalid() == null);
             assert(header.command == .prepare);
 
             if (header.view > self.view) {
@@ -5571,7 +5597,10 @@ pub fn ReplicaType(
         /// This would violate our quorum replication commitment to the primary.
         /// The mistake in this example was not that we ignored the break to the left, which we must
         /// do to repair reordered ops, but that we did not check for connection to the right.
-        fn repair_header_would_connect_hash_chain(self: *Self, header: *const Header) bool {
+        fn repair_header_would_connect_hash_chain(
+            self: *Self,
+            header: *const Header.Type(.prepare),
+        ) bool {
             var entry = header;
 
             while (entry.op < self.op) {
@@ -5695,7 +5724,7 @@ pub fn ReplicaType(
 
         fn repair_pipeline_read_callback(
             self: *Self,
-            prepare: ?*Message,
+            prepare: ?Message.Type(.prepare),
             destination_replica: ?u8,
         ) void {
             assert(destination_replica == null);
@@ -5752,7 +5781,7 @@ pub fn ReplicaType(
             });
 
             const prepare_evicted = self.pipeline.cache.insert(prepare.?.ref());
-            if (prepare_evicted) |message_evicted| self.message_bus.unref(message_evicted);
+            if (prepare_evicted) |message_evicted| self.message_bus.unref(message_evicted.base);
 
             if (self.primary_repair_pipeline_op()) |_| {
                 assert(!self.pipeline_repairing);
@@ -5782,8 +5811,8 @@ pub fn ReplicaType(
                     assert(slot.index == op);
 
                     if (self.journal.faulty.bit(slot)) {
-                        assert(self.journal.headers[op].command == .reserved);
-                        assert(self.journal.headers_redundant[op].command == .reserved);
+                        assert(self.journal.headers[op].operation == .reserved);
+                        assert(self.journal.headers_redundant[op].operation == .reserved);
                         self.journal.dirty.clear(slot);
                         self.journal.faulty.clear(slot);
                         log.debug("{}: repair_prepares: remove slot={} " ++
@@ -5924,13 +5953,13 @@ pub fn ReplicaType(
                 return true;
             }
 
-            const request_prepare = Header{
+            const request_prepare = Header.Type(.request_prepare){
                 .command = .request_prepare,
-                .context = checksum,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
-                .op = op,
+                .prepare_op = op,
+                .prepare_checksum = checksum,
             };
 
             if (self.status == .view_change and op > self.commit_max) {
@@ -5948,8 +5977,7 @@ pub fn ReplicaType(
                     },
                 );
 
-                assert(request_prepare.context == checksum);
-                self.send_header_to_other_replicas(request_prepare);
+                self.send_header_to_other_replicas(@bitCast(request_prepare));
             } else {
                 const nature = if (op > self.commit_max) "uncommitted" else "committed";
                 const reason = if (self.journal.faulty.bit(slot)) "faulty" else "dirty";
@@ -5961,8 +5989,10 @@ pub fn ReplicaType(
                     reason,
                 });
 
-                assert(request_prepare.context == checksum);
-                self.send_header_to_replica(self.choose_any_other_replica(), request_prepare);
+                self.send_header_to_replica(
+                    self.choose_any_other_replica(),
+                    @bitCast(request_prepare),
+                );
             }
 
             return true;
@@ -5985,13 +6015,13 @@ pub fn ReplicaType(
 
         /// Replaces the header if the header is different and at least op_repair_min.
         /// The caller must ensure that the header is trustworthy (part of the current view's log).
-        fn replace_header(self: *Self, header: *const Header) void {
+        fn replace_header(self: *Self, header: *const Header.Type(.prepare)) void {
             assert(self.status == .normal or self.status == .view_change or
                 self.status == .recovering_head);
             assert(self.op_checkpoint() <= self.commit_min);
 
-            assert(header.valid_checksum());
-            assert(header.invalid() == null);
+            assert(header.frame_const().valid_checksum());
+            assert(header.frame_const().invalid() == null);
             assert(header.command == .prepare);
             assert(header.view <= self.view);
             assert(header.op <= self.op); // Never advance the op.
@@ -6015,7 +6045,7 @@ pub fn ReplicaType(
         /// Does not flood the network with prepares that have already committed.
         /// Replication to standbys works similarly, jumping off the replica just before primary.
         /// TODO Use recent heartbeat data for next replica to leapfrog if faulty (optimization).
-        fn replicate(self: *Self, message: *Message) void {
+        fn replicate(self: *Self, message: Message.Type(.prepare)) void {
             assert(self.status == .normal);
             assert(message.header.command == .prepare);
             assert(message.header.view == self.view);
@@ -6052,7 +6082,7 @@ pub fn ReplicaType(
             if (self.standby()) assert(next >= self.replica_count);
 
             log.debug("{}: replicate: replicating to replica {}", .{ self.replica, next });
-            self.send_message_to_replica(next, message);
+            self.send_message_to_replica(next, message.base);
         }
 
         /// Conversions between usual `self.replica` and "nth standby" coordinate spaces.
@@ -6069,7 +6099,7 @@ pub fn ReplicaType(
             return replica - self.replica_count;
         }
 
-        fn reset_quorum_messages(self: *Self, messages: *QuorumMessages, command: Command) void {
+        fn reset_quorum_messages(self: *Self, messages: *DVCQuorumMessages, command: Command) void {
             assert(messages.len == constants.replicas_max);
             var view: ?u32 = null;
             var count: usize = 0;
@@ -6087,7 +6117,7 @@ pub fn ReplicaType(
                         view = message.header.view;
                     }
 
-                    self.message_bus.unref(message);
+                    self.message_bus.unref(message.base);
                     count += 1;
                 }
                 received.* = null;
@@ -6125,7 +6155,7 @@ pub fn ReplicaType(
             self.reset_quorum_counter(&self.start_view_change_from_all_replicas);
         }
 
-        fn send_prepare_ok(self: *Self, header: *const Header) void {
+        fn send_prepare_ok(self: *Self, header: *const Header.Type(.prepare)) void {
             assert(header.command == .prepare);
             assert(header.cluster == self.cluster);
             assert(header.replica == self.primary_index(header.view));
@@ -6182,22 +6212,25 @@ pub fn ReplicaType(
 
                 // We therefore only ever send to the primary of the current view, never to the
                 // primary of the prepare header's view:
-                self.send_header_to_replica(self.primary_index(self.view), .{
-                    .command = .prepare_ok,
-                    // TODO 256-byte headers: Send `header.parent` as the parent.
-                    .parent = checkpoint_id,
-                    .client = header.client,
-                    .context = header.checksum,
-                    .request = header.request,
-                    .cluster = self.cluster,
-                    .replica = self.replica,
-                    .epoch = header.epoch,
-                    .view = self.view,
-                    .op = header.op,
-                    .commit = header.commit,
-                    .timestamp = header.timestamp,
-                    .operation = header.operation,
-                });
+                self.send_header_to_replica(
+                    self.primary_index(self.view),
+                    @bitCast(Header.Type(.prepare_ok){
+                        .command = .prepare_ok,
+                        .checkpoint_id = checkpoint_id,
+                        .parent = header.parent,
+                        .client = header.client,
+                        .prepare_checksum = header.checksum,
+                        .request = header.request,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .epoch = header.epoch,
+                        .view = self.view,
+                        .op = header.op,
+                        .commit = header.commit,
+                        .timestamp = header.timestamp,
+                        .operation = header.operation,
+                    }),
+                );
             } else {
                 log.debug("{}: send_prepare_ok: not sending (dirty)", .{self.replica});
                 return;
@@ -6226,17 +6259,17 @@ pub fn ReplicaType(
 
             if (self.standby()) return;
 
-            const header: Header = .{
+            const header = Header.Type(.start_view_change){
                 .command = .start_view_change,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
             };
 
-            self.send_header_to_other_replicas(header);
+            self.send_header_to_other_replicas(header.frame_const().*);
 
             if (!self.start_view_change_from_all_replicas.isSet(self.replica)) {
-                self.send_header_to_replica(self.replica, header);
+                self.send_header_to_replica(self.replica, header.frame_const().*);
                 defer self.flush_loopback_queue();
             }
         }
@@ -6245,16 +6278,107 @@ pub fn ReplicaType(
             assert(self.status == .view_change);
             assert(!self.solo());
             assert(self.view > self.log_view);
+            assert(self.view >= self.view_durable());
+            assert(self.log_view >= self.log_view_durable());
             assert(!self.do_view_change_quorum);
+            // The DVC headers are already up to date, either via:
+            // - transition_to_view_change_status(), or
+            // - superblock's vsr_headers (after recovery).
+            assert(self.view_headers.command == .do_view_change);
+            assert(self.view_headers.array.get(0).op >= self.op);
+            self.view_headers.verify();
 
-            const message = self.create_view_change_message(.do_view_change, null);
-            defer self.message_bus.unref(message);
+            const BitSet = std.bit_set.IntegerBitSet(128);
+            comptime assert(BitSet.MaskInt ==
+                std.meta.fieldInfo(Header.Type(.do_view_change), .present_bitset).type);
+            comptime assert(BitSet.MaskInt ==
+                std.meta.fieldInfo(Header.Type(.do_view_change), .nack_bitset).type);
 
-            assert(message.references == 1);
-            assert(message.header.command == .do_view_change);
-            assert(message.header.view == self.view);
+            // Collect nack and presence bits for the headers, so that the new primary can run CTRL
+            // protocol to truncate uncommitted headers. When:
+            // - a header has quorum of nacks -- the header is truncated
+            // - a header isn't truncated and is present -- the header gets into the next view
+            // - a header is neither truncated nor present -- the primary waits for more
+            //   DVC messages to decide whether to keep or truncate the header.
+            var nacks = BitSet.initEmpty();
+            var present = BitSet.initEmpty();
+            for (self.view_headers.array.const_slice(), 0..) |*header, i| {
+                const slot = self.journal.slot_for_op(header.op);
+                const journal_header = self.journal.header_for_op(header.op);
+                const dirty = self.journal.dirty.bit(slot);
+                const faulty = self.journal.faulty.bit(slot);
+
+                // Case 1: We have this header in memory, but haven't persisted it to disk yet.
+                if (journal_header != null and journal_header.?.checksum == header.checksum and
+                    dirty and !faulty)
+                {
+                    nacks.set(i);
+                }
+
+                // Case 2: We have a _different_ prepare — safe to nack even if it is faulty.
+                if (journal_header != null and journal_header.?.checksum != header.checksum) {
+                    nacks.set(i);
+                }
+
+                // Case 3: We don't have a prepare at all, and that's not due to a fault.
+                if (journal_header == null and !faulty) {
+                    nacks.set(i);
+                }
+
+                // Presence bit: the prepare is on disk, is being written to disk, or is cached
+                // in memory. These conditions mirror logic in `on_request_prepare` and imply
+                // that we can help the new primary to repair this prepare.
+                if ((self.journal.prepare_inhabited[slot.index] and
+                    self.journal.prepare_checksums[slot.index] == header.checksum) or
+                    self.journal.writing(header.op, header.checksum) or
+                    self.pipeline_prepare_by_op_and_checksum(header.op, header.checksum) != null)
+                {
+                    if (journal_header != null) {
+                        assert(journal_header.?.checksum == header.checksum);
+                    }
+                    maybe(nacks.isSet(i));
+                    present.set(i);
+                }
+            }
+
+            const message = self.message_bus.get_message().build(.do_view_change);
+            defer self.message_bus.unref(message.base);
+
+            message.header.* = .{
+                .size = @sizeOf(Header) * (1 + self.view_headers.array.count_as(u32)),
+                .command = .do_view_change,
+                .cluster = self.cluster,
+                .replica = self.replica,
+                .view = self.view,
+                // The latest normal view (as specified in the 2012 paper) is different to the view
+                // number contained in the prepare headers we include in the body. The former shows
+                // how recent a view change the replica participated in, which may be much higher.
+                // We use the `request` field to send this in addition to the current view number:
+                .log_view = self.log_view,
+                .checkpoint_op = self.op_checkpoint(),
+                // This is usually the head op, but it may be farther ahead if we are lagging behind
+                // a checkpoint. (In which case the op is inherited from the SV).
+                .op = self.view_headers.array.get(0).op,
+                // For command=start_view, commit_min=commit_max.
+                // For command=do_view_change, the new primary uses this op to trust extra headers
+                // from non-canonical DVCs.
+                .commit_min = self.commit_min,
+                // Signal which headers correspond to definitely not-prepared messages.
+                .nack_bitset = nacks.mask,
+                // Signal which headers correspond to locally available prepares.
+                .present_bitset = present.mask,
+            };
+
+            stdx.copy_disjoint(
+                .exact,
+                Header.Type(.prepare),
+                std.mem.bytesAsSlice(Header.Type(.prepare), message.body()),
+                self.view_headers.array.const_slice(),
+            );
+            message.header.frame().set_checksum_body(message.body());
+            message.header.frame().set_checksum();
+
             assert(message.header.op >= self.op);
-            assert(message.header.op == message_body_as_view_headers(message).slice[0].op);
             // Each replica must advertise its own commit number, so that the new primary can know
             // which headers must be replaced in its log. Otherwise, a gap in the log may prevent
             // the new primary from repairing its log, resulting in the log being forked if the new
@@ -6262,17 +6386,17 @@ pub fn ReplicaType(
             // It is also safe not to use `commit_max` here because the new primary will assume that
             // operations after the highest `commit_min` may yet have been committed before the old
             // primary crashed. The new primary will use the NACK protocol to be sure of a discard.
-            assert(message.header.commit == self.commit_min);
+            assert(message.header.commit_min == self.commit_min);
             DVCQuorum.verify_message(message);
 
             if (self.standby()) return;
 
-            self.send_message_to_other_replicas(message);
+            self.send_message_to_other_replicas(message.base);
 
             if (self.replica == self.primary_index(self.view) and
                 self.do_view_change_from_all_replicas[self.replica] == null)
             {
-                self.send_message_to_replica(self.replica, message);
+                self.send_message_to_replica(self.replica, message.base);
                 defer self.flush_loopback_queue();
             }
         }
@@ -6286,16 +6410,16 @@ pub fn ReplicaType(
                 client,
             });
 
-            self.send_header_to_client(client, .{
+            self.send_header_to_client(client, @bitCast(Header.Type(.eviction){
                 .command = .eviction,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
                 .client = client,
-            });
+            }));
         }
 
-        fn send_reply_message_to_client(self: *Self, reply: *Message) void {
+        fn send_reply_message_to_client(self: *Self, reply: Message.Type(.reply)) void {
             assert(reply.header.command == .reply);
             assert(reply.header.view <= self.view);
 
@@ -6309,12 +6433,12 @@ pub fn ReplicaType(
 
             if (reply.header.view == self.view) {
                 // Hot path: no need to clone the message if the view is the same.
-                self.message_bus.send_message_to_client(reply.header.client, reply);
+                self.message_bus.send_message_to_client(reply.header.client, reply.base);
                 return;
             }
 
-            const reply_copy = self.message_bus.get_message();
-            defer self.message_bus.unref(reply_copy);
+            const reply_copy = self.message_bus.get_message().build(.reply);
+            defer self.message_bus.unref(reply_copy.base);
 
             // Copy the message and update the view.
             // We could optimize this by using in-place modification if `reply.references == 1`.
@@ -6323,13 +6447,13 @@ pub fn ReplicaType(
             stdx.copy_disjoint(
                 .inexact,
                 u8,
-                reply_copy.buffer,
-                reply.buffer[0..reply.header.size],
+                reply_copy.base.buffer,
+                reply.base.buffer[0..reply.header.size],
             );
             reply_copy.header.view = self.view;
-            reply_copy.header.set_checksum();
+            reply_copy.header.frame().set_checksum();
 
-            self.message_bus.send_message_to_client(reply.header.client, reply_copy);
+            self.message_bus.send_message_to_client(reply.header.client, reply_copy.base);
         }
 
         fn send_header_to_client(self: *Self, client: u128, header: Header) void {
@@ -6383,12 +6507,17 @@ pub fn ReplicaType(
         }
 
         fn send_message_to_replica(self: *Self, replica: u8, message: *Message) void {
-            log.debug("{}: sending {s} to replica {}: {}", .{
-                self.replica,
-                @tagName(message.header.command),
-                replica,
-                message.header,
-            });
+            // Switch on the header type so that we don't log opaque bytes for the per-command data.
+            switch (message.header.into_any()) {
+                inline else => |header| {
+                    log.debug("{}: sending {s} to replica {}: {}", .{
+                        self.replica,
+                        @tagName(message.header.command),
+                        replica,
+                        header,
+                    });
+                },
+            }
 
             if (message.header.invalid()) |reason| {
                 log.err("{}: send_message_to_replica: invalid ({s})", .{ self.replica, reason });
@@ -6398,7 +6527,7 @@ pub fn ReplicaType(
             assert(message.header.cluster == self.cluster);
 
             // TODO According to message.header.command, assert on the destination replica.
-            switch (message.header.command) {
+            switch (message.header.into_any()) {
                 .reserved => unreachable,
                 .request => {
                     assert(!self.standby());
@@ -6406,7 +6535,7 @@ pub fn ReplicaType(
                     assert(self.status == .normal);
                     assert(message.header.view <= self.view);
                 },
-                .prepare => {
+                .prepare => |header| {
                     maybe(self.standby());
                     assert(self.replica != replica);
                     // Do not assert message.header.replica because we forward .prepare messages.
@@ -6416,23 +6545,24 @@ pub fn ReplicaType(
                         // These are replies to a request_prepare:
                         else => assert(message.header.view <= self.view),
                     }
+                    assert(header.operation != .reserved);
                 },
-                .prepare_ok => {
+                .prepare_ok => |header| {
                     assert(!self.standby());
                     assert(self.status == .normal);
                     assert(self.syncing == .idle);
-                    assert(message.header.view == self.view);
-                    assert(message.header.op <= self.op_checkpoint_next_trigger());
+                    assert(header.view == self.view);
+                    assert(header.op <= self.op_checkpoint_next_trigger());
                     // We must only ever send a prepare_ok to the latest primary of the active view:
                     // We must never straddle views by sending to a primary in an older view.
                     // Otherwise, we would be enabling a partitioned primary to commit.
                     assert(replica == self.primary_index(self.view));
-                    assert(message.header.replica == self.replica);
+                    assert(header.replica == self.replica);
                 },
-                .reply => {
+                .reply => |header| {
                     assert(!self.standby());
-                    assert(message.header.view <= self.view);
-                    assert(message.header.op <= self.op_checkpoint_next_trigger());
+                    assert(header.view <= self.view);
+                    assert(header.op <= self.op_checkpoint_next_trigger());
                 },
                 .start_view_change => {
                     assert(!self.standby());
@@ -6440,30 +6570,30 @@ pub fn ReplicaType(
                     assert(message.header.view == self.view);
                     assert(message.header.replica == self.replica);
                 },
-                .do_view_change => {
+                .do_view_change => |header| {
                     assert(!self.standby());
                     assert(self.status == .view_change);
                     assert(self.view > self.log_view);
                     assert(!self.do_view_change_quorum);
-                    assert(message.header.view == self.view);
-                    assert(message.header.replica == self.replica);
-                    maybe(message.header.op == self.op);
-                    assert(message.header.op >= self.op);
-                    assert(message.header.commit == self.commit_min);
-                    assert(message.header.timestamp == self.op_checkpoint());
-                    assert(message.header.request == self.log_view);
+                    assert(header.view == self.view);
+                    assert(header.replica == self.replica);
+                    maybe(header.op == self.op);
+                    assert(header.op >= self.op);
+                    assert(header.commit_min == self.commit_min);
+                    assert(header.checkpoint_op == self.op_checkpoint());
+                    assert(header.log_view == self.log_view);
                 },
-                .start_view => {
+                .start_view => |header| {
                     assert(!self.standby());
                     assert(self.status == .normal);
                     assert(!self.do_view_change_quorum);
                     assert(self.syncing == .idle);
-                    assert(message.header.view == self.view);
-                    assert(message.header.replica == self.replica);
-                    assert(message.header.replica != replica);
-                    assert(message.header.commit == self.commit_min);
-                    assert(message.header.commit == self.commit_max);
-                    assert(message.header.timestamp == self.op_checkpoint());
+                    assert(header.view == self.view);
+                    assert(header.replica == self.replica);
+                    assert(header.replica != replica);
+                    assert(header.commit == self.commit_min);
+                    assert(header.commit == self.commit_max);
+                    assert(header.checkpoint_op == self.op_checkpoint());
                 },
                 .headers => {
                     assert(!self.standby());
@@ -6763,10 +6893,10 @@ pub fn ReplicaType(
                     // Only replies to `request_start_view` need a nonce,
                     // to guarantee freshness of the message.
                     const nonce = 0;
-                    const start_view = self.create_view_change_message(.start_view, nonce);
-                    defer self.message_bus.unref(start_view);
+                    const start_view = self.create_start_view_message(nonce);
+                    defer self.message_bus.unref(start_view.base);
 
-                    self.send_message_to_other_replicas(start_view);
+                    self.send_message_to_other_replicas(start_view.base);
                 } else {
                     self.send_prepare_oks_after_view_change();
                 }
@@ -6898,7 +7028,7 @@ pub fn ReplicaType(
                     // Any ops in the next checkpoint are definitely uncommitted — otherwise,
                     // we would have forfeited to favor a different primary.
                     for (dvcs_all.const_slice()) |dvc| {
-                        assert(dvc.header.timestamp <= self.op_checkpoint());
+                        assert(dvc.header.checkpoint_op <= self.op_checkpoint());
                     }
                 } else {
                     break header;
@@ -6911,7 +7041,7 @@ pub fn ReplicaType(
             assert(header_head.op >= self.commit_min);
             assert(header_head.op >= self.commit_max);
             assert(header_head.op <= self.op_checkpoint_next_trigger());
-            for (dvcs_all.const_slice()) |dvc| assert(header_head.op >= dvc.header.commit);
+            for (dvcs_all.const_slice()) |dvc| assert(header_head.op >= dvc.header.commit_min);
 
             // When computing the new commit_max, we cannot simply rely on the fact that our own
             // commit_min is attached to our own DVC in the quorum.
@@ -6927,7 +7057,7 @@ pub fn ReplicaType(
                 DVCQuorum.commit_max(self.do_view_change_from_all_replicas),
             );
             assert(self.commit_min >=
-                self.do_view_change_from_all_replicas[self.replica].?.header.commit);
+                self.do_view_change_from_all_replicas[self.replica].?.header.commit_min);
 
             {
                 // "`replica.op` exists" invariant may be broken briefly between
@@ -6951,13 +7081,13 @@ pub fn ReplicaType(
             const dvcs_uncanonical =
                 DVCQuorum.dvcs_uncanonical(self.do_view_change_from_all_replicas);
             for (dvcs_uncanonical.const_slice()) |message| {
-                const message_headers = message_body_as_view_headers(message);
+                const message_headers = message_body_as_view_headers(message.base);
                 for (message_headers.slice) |*header| {
                     if (vsr.Headers.dvc_header_type(header) != .valid) continue;
 
                     // We must trust headers that other replicas have committed, because
                     // repair_header() will not repair a header if the hash chain has a gap.
-                    if (header.op <= message.header.commit) {
+                    if (header.op <= message.header.commit_min) {
                         log.debug(
                             "{}: on_do_view_change: committed: replica={} op={} checksum={}",
                             .{
@@ -6991,16 +7121,17 @@ pub fn ReplicaType(
                         self.replica,
                         context,
                         dvc.header.replica,
-                        dvc.header.request, // The `log_view` of the replica.
+                        dvc.header.log_view,
                         dvc.header.op,
-                        dvc.header.commit, // The `commit_min` of the replica.
-                        dvc.header.timestamp, // The `op_checkpoint` of the replica.
+                        dvc.header.commit_min,
+                        dvc.header.checkpoint_op,
                     },
                 );
 
-                const dvc_headers = message_body_as_view_headers(dvc);
-                const dvc_nacks = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.context };
-                const dvc_present = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.client };
+                const BitSet = std.bit_set.IntegerBitSet(128);
+                const dvc_headers = message_body_as_view_headers(dvc.base);
+                const dvc_nacks = BitSet{ .mask = dvc.header.nack_bitset };
+                const dvc_present = BitSet{ .mask = dvc.header.present_bitset };
                 for (dvc_headers.slice, 0..) |*header, i| {
                     log.debug("{}: {s}: dvc: header: " ++
                         "replica={} op={} checksum={} nack={} present={} type={s}", .{
@@ -7701,16 +7832,16 @@ pub fn ReplicaType(
             if (self.commit_stage == .idle) {
                 assert(self.commit_prepare == null);
             } else {
-                if (self.commit_prepare) |prepare| self.message_bus.unref(prepare);
+                if (self.commit_prepare) |prepare| self.message_bus.unref(prepare.base);
                 self.commit_prepare = null;
                 self.commit_stage = .idle;
             }
 
             var grid_reads = self.grid_reads.iterate();
             while (grid_reads.next()) |grid_read| {
-                assert(grid_read.message.references == 1);
+                assert(grid_read.message.base.references == 1);
 
-                self.message_bus.unref(grid_read.message);
+                self.message_bus.unref(grid_read.message.base);
                 self.grid_reads.release(grid_read);
             }
 
@@ -8162,13 +8293,16 @@ pub fn ReplicaType(
                     // TODO Debounce and decouple this from `on_message()` by moving into `tick()`:
                     // (Using request_start_view_message_timeout).
                     log.debug("{}: jump_view: requesting start_view message", .{self.replica});
-                    self.send_header_to_replica(self.primary_index(header.view), .{
-                        .command = .request_start_view,
-                        .cluster = self.cluster,
-                        .replica = self.replica,
-                        .view = header.view,
-                        .context = self.nonce,
-                    });
+                    self.send_header_to_replica(
+                        self.primary_index(header.view),
+                        @bitCast(Header.Type(.request_start_view){
+                            .command = .request_start_view,
+                            .cluster = self.cluster,
+                            .replica = self.replica,
+                            .view = header.view,
+                            .nonce = self.nonce,
+                        }),
+                    );
                 },
                 .view_change => {
                     assert(self.status == .normal or self.status == .view_change);
@@ -8190,21 +8324,22 @@ pub fn ReplicaType(
                 assert(self.sync_target_quorum.candidates[self.replica] == null);
             }
 
+            if (header.into_const(.commit)) |h| assert(h.commit >= h.checkpoint_op);
+
             if (header.replica >= self.replica_count) return; // Ignore messages from standbys.
             if (header.replica == self.replica) return; // Ignore messages from self (misdirected).
 
             // TODO(256-byte headers) Prepares also need to include a checkpoint id,
             // so that backups cannot diverge by >1 checkpoint when they are (somehow)
             // partitioned from command=commit and command=ping messages.
-            switch (header.command) {
-                .commit => assert(header.commit >= header.op),
-                .ping => {},
+            const candidate: SyncTargetCandidate = switch (header.into_any()) {
+                inline .commit,
+                .ping,
+                => |h| .{
+                    .checkpoint_id = h.checkpoint_id,
+                    .checkpoint_op = h.checkpoint_op,
+                },
                 else => return,
-            }
-
-            const candidate = SyncTargetCandidate{
-                .checkpoint_id = header.parent,
-                .checkpoint_op = header.op,
             };
 
             if (candidate.checkpoint_op == 0) return;
@@ -8223,9 +8358,9 @@ pub fn ReplicaType(
             const candidate_canonical = canonical: {
                 const candidate_trigger = vsr.Checkpoint.trigger_for_checkpoint(candidate.checkpoint_op).?;
 
-                if (header.command == .commit and header.commit > candidate_trigger) {
+                if (header.into_const(.commit)) |h| {
                     // Normal case: The primary has committed atop the checkpoint.
-                    break :canonical true;
+                    if (h.commit > candidate_trigger) break :canonical true;
                 }
 
                 if (header.command == .commit and
@@ -8332,12 +8467,17 @@ pub fn ReplicaType(
             }
         }
 
-        fn write_prepare(self: *Self, message: *Message, trigger: Journal.Write.Trigger) void {
+        fn write_prepare(
+            self: *Self,
+            message: Message.Type(.prepare),
+            trigger: Journal.Write.Trigger,
+        ) void {
             assert(self.status == .normal or self.status == .view_change);
             assert(self.status == .normal or self.primary_index(self.view) == self.replica);
             assert(self.status == .normal or self.do_view_change_quorum);
-            assert(message.references > 0);
+            assert(message.base.references > 0);
             assert(message.header.command == .prepare);
+            assert(message.header.operation != .reserved);
             assert(message.header.view <= self.view);
             assert(message.header.op <= self.op);
             assert(message.header.op >= self.op_repair_min());
@@ -8369,7 +8509,7 @@ pub fn ReplicaType(
                 self.commit_min < message.header.op)
             {
                 const prepare_evicted = self.pipeline.cache.insert(message.ref());
-                if (prepare_evicted) |m| self.message_bus.unref(m);
+                if (prepare_evicted) |m| self.message_bus.unref(m.base);
             }
 
             self.journal.write_prepare(write_prepare_callback, message, trigger);
@@ -8377,7 +8517,7 @@ pub fn ReplicaType(
 
         fn write_prepare_callback(
             self: *Self,
-            wrote: ?*Message,
+            wrote: ?Message.Type(.prepare),
             trigger: Journal.Write.Trigger,
         ) void {
             // `null` indicates that we did not complete the write for some reason.
@@ -8401,12 +8541,12 @@ pub fn ReplicaType(
             assert(self.grid.canceling == null);
             maybe(self.state_machine_opened);
 
-            var message = self.message_bus.get_message();
-            defer self.message_bus.unref(message);
+            var message = self.message_bus.get_message().build(.request_blocks);
+            defer self.message_bus.unref(message.base);
 
             const requests = std.mem.bytesAsSlice(
                 vsr.BlockRequest,
-                message.buffer[@sizeOf(Header)..],
+                message.base.buffer[@sizeOf(Header)..],
             )[0..constants.grid_repair_request_max];
             assert(requests.len > 0);
 
@@ -8429,10 +8569,10 @@ pub fn ReplicaType(
                 .replica = self.replica,
                 .size = @sizeOf(Header) + requests_count * @sizeOf(vsr.BlockRequest),
             };
-            message.header.set_checksum_body(message.body());
-            message.header.set_checksum();
+            message.header.frame().set_checksum_body(message.body());
+            message.header.frame().set_checksum();
 
-            self.send_message_to_replica(self.choose_any_other_replica(), message);
+            self.send_message_to_replica(self.choose_any_other_replica(), message.base);
         }
 
         fn send_request_sync_checkpoint(self: *Self) void {
@@ -8442,14 +8582,17 @@ pub fn ReplicaType(
 
             const stage: *const SyncStage.RequestingTrailers = &self.syncing.requesting_trailers;
 
-            self.send_header_to_replica(self.choose_any_other_replica(), .{
-                .command = .request_sync_checkpoint,
-                .cluster = self.cluster,
-                .replica = self.replica,
-                .size = @sizeOf(Header),
-                .parent = stage.target.checkpoint_id,
-                .op = stage.target.checkpoint_op,
-            });
+            self.send_header_to_replica(
+                self.choose_any_other_replica(),
+                @bitCast(Header.Type(.request_sync_checkpoint){
+                    .command = .request_sync_checkpoint,
+                    .cluster = self.cluster,
+                    .replica = self.replica,
+                    .size = @sizeOf(Header),
+                    .checkpoint_id = stage.target.checkpoint_id,
+                    .checkpoint_op = stage.target.checkpoint_op,
+                }),
+            );
         }
 
         fn send_sync_checkpoint(self: *Self, parameters: struct { replica: u8 }) void {
@@ -8457,16 +8600,16 @@ pub fn ReplicaType(
             assert(self.syncing == .idle);
             assert(self.replica != parameters.replica);
 
-            const reply = self.message_bus.get_message();
-            defer self.message_bus.unref(reply);
+            const reply = self.message_bus.get_message().build(.sync_checkpoint);
+            defer self.message_bus.unref(reply.base);
 
             reply.header.* = .{
                 .command = .sync_checkpoint,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .size = @sizeOf(Header) + @sizeOf(vsr.CheckpointState),
-                .parent = self.superblock.working.checkpoint_id(),
-                .op = self.op_checkpoint(),
+                .checkpoint_id = self.superblock.working.checkpoint_id(),
+                .checkpoint_op = self.op_checkpoint(),
             };
 
             stdx.copy_disjoint(
@@ -8476,12 +8619,12 @@ pub fn ReplicaType(
                 std.mem.asBytes(&self.superblock.working.vsr_state.checkpoint),
             );
 
-            reply.header.set_checksum_body(reply.body());
-            reply.header.set_checksum();
+            reply.header.frame().set_checksum_body(reply.body());
+            reply.header.frame().set_checksum();
 
             // Note that our checkpoint may not be canonical — that is the syncing replica's
             // responsibility to check.
-            self.send_message_to_replica(parameters.replica, reply);
+            self.send_message_to_replica(parameters.replica, reply.base);
         }
 
         fn send_request_sync_trailer(self: *Self, command: vsr.Command, offset: u32) void {
@@ -8496,22 +8639,30 @@ pub fn ReplicaType(
             const message = self.message_bus.get_message();
             defer self.message_bus.unref(message);
 
-            message.header.* = .{
-                .command = command,
-                .cluster = self.cluster,
-                .replica = self.replica,
-                .size = @sizeOf(Header),
-                .parent = stage.target.checkpoint_id,
-                .op = stage.target.checkpoint_op,
-                .request = offset,
-            };
+            switch (command) {
+                inline .request_sync_free_set,
+                .request_sync_client_sessions,
+                => |command_comptime| {
+                    message.header.* = @bitCast(Header.Type(command_comptime){
+                        .command = command,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .size = @sizeOf(Header),
+                        .checkpoint_id = stage.target.checkpoint_id,
+                        .checkpoint_op = stage.target.checkpoint_op,
+                        .trailer_offset = offset,
+                    });
+                },
+                else => unreachable,
+            }
+
             message.header.set_checksum_body(message.body());
             message.header.set_checksum();
 
             self.send_message_to_replica(self.choose_any_other_replica(), message);
         }
 
-        fn send_sync_trailer(self: *Self, command: vsr.Command, parameters: struct {
+        fn send_sync_trailer(self: *Self, comptime command: vsr.Command, parameters: struct {
             offset: u32,
             replica: u8,
         }) void {
@@ -8521,12 +8672,12 @@ pub fn ReplicaType(
             assert(command == .request_sync_free_set or
                 command == .request_sync_client_sessions);
 
-            const reply = self.message_bus.get_message();
-            defer self.message_bus.unref(reply);
-
-            const trailer = for (comptime std.enums.values(vsr.SuperBlockTrailer)) |trailer| {
+            const trailer = comptime for (std.enums.values(vsr.SuperBlockTrailer)) |trailer| {
                 if (command == SyncTrailer.requests.get(trailer)) break trailer;
             } else unreachable;
+
+            const reply = self.message_bus.get_message().build(SyncTrailer.responses.get(trailer));
+            defer self.message_bus.unref(reply.base);
 
             const trailer_buffer_all = self.superblock.trailer_buffer(trailer);
             const trailer_checksum = self.superblock.staging.trailer_checksum(trailer);
@@ -8545,7 +8696,7 @@ pub fn ReplicaType(
             stdx.copy_disjoint(
                 .inexact,
                 u8,
-                reply.buffer[@sizeOf(Header)..],
+                reply.base.buffer[@sizeOf(Header)..],
                 trailer_buffer_all[parameters.offset..][0..body_size],
             );
 
@@ -8558,18 +8709,18 @@ pub fn ReplicaType(
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .size = @sizeOf(Header) + body_size,
-                .parent = self.superblock.staging.checkpoint_id(),
-                .op = self.op_checkpoint(),
-                .request = parameters.offset,
-                .context = trailer_checksum,
-                .commit = trailer_size,
+                .checkpoint_id = self.superblock.staging.checkpoint_id(),
+                .checkpoint_op = self.op_checkpoint(),
+                .trailer_offset = parameters.offset,
+                .trailer_checksum = trailer_checksum,
+                .trailer_size = trailer_size,
             };
-            reply.header.set_checksum_body(reply.body());
-            reply.header.set_checksum();
+            reply.header.frame().set_checksum_body(reply.body());
+            reply.header.frame().set_checksum();
 
             // Note that our checkpoint may not be canonical — that is the syncing replica's
             // responsibility to check.
-            self.send_message_to_replica(parameters.replica, reply);
+            self.send_message_to_replica(parameters.replica, reply.base);
         }
     };
 }
@@ -8672,19 +8823,19 @@ pub fn ReplicaType(
 /// - uncommitted — if the header is chosen, but cannot be recovered from any replica, then
 ///   it will be discarded by the nack protocol.
 const DVCQuorum = struct {
-    const DVCArray = stdx.BoundedArray(*const Message, constants.replicas_max);
+    const DVCArray = stdx.BoundedArray(Message.Type(.do_view_change), constants.replicas_max);
 
-    fn verify(dvc_quorum: QuorumMessages) void {
+    fn verify(dvc_quorum: DVCQuorumMessages) void {
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |message| verify_message(message);
 
         // Verify that DVCs with the same log_view do not conflict.
         for (dvcs.const_slice(), 0..) |dvc_a, i| {
             for (dvcs.const_slice()[0..i]) |dvc_b| {
-                if (dvc_a.header.request != dvc_b.header.request) continue;
+                if (dvc_a.header.log_view != dvc_b.header.log_view) continue;
 
-                const headers_a = message_body_as_view_headers(dvc_a);
-                const headers_b = message_body_as_view_headers(dvc_b);
+                const headers_a = message_body_as_view_headers(dvc_a.base);
+                const headers_b = message_body_as_view_headers(dvc_b.base);
                 // Find the intersection of the ops covered by each DVC.
                 const op_max = @min(dvc_a.header.op, dvc_b.header.op);
                 const op_min = @max(
@@ -8708,38 +8859,38 @@ const DVCQuorum = struct {
         }
     }
 
-    fn verify_message(message: *const Message) void {
+    fn verify_message(message: Message.Type(.do_view_change)) void {
         assert(message.header.command == .do_view_change);
-        assert(message.header.commit <= message.header.op);
+        assert(message.header.commit_min <= message.header.op);
 
-        const checkpoint = message.header.timestamp;
-        assert(checkpoint <= message.header.commit);
+        const checkpoint = message.header.checkpoint_op;
+        assert(checkpoint <= message.header.commit_min);
 
         // The log_view:
         // * may be higher than the view in any of the prepare headers.
         // * must be lower than the view of this view change.
-        const log_view = message.header.request;
+        const log_view = message.header.log_view;
         assert(log_view < message.header.view);
 
         // Ignore the result, init() verifies the headers.
-        const headers = message_body_as_view_headers(message);
+        const headers = message_body_as_view_headers(message.base);
         assert(headers.slice.len >= 1);
         assert(headers.slice.len <= constants.pipeline_prepare_queue_max + 1);
         assert(headers.slice[0].op == message.header.op);
         assert(headers.slice[0].view <= log_view);
 
-        const nacks = message.header.context;
+        const nacks = message.header.nack_bitset;
         comptime assert(@TypeOf(nacks) == u128);
         assert(@popCount(nacks) <= headers.slice.len);
         assert(@clz(nacks) + headers.slice.len >= @bitSizeOf(u128));
 
-        const present = message.header.client;
+        const present = message.header.present_bitset;
         comptime assert(@TypeOf(present) == u128);
         assert(@popCount(present) <= headers.slice.len);
         assert(@clz(present) + headers.slice.len >= @bitSizeOf(u128));
     }
 
-    fn dvcs_all(dvc_quorum: QuorumMessages) DVCArray {
+    fn dvcs_all(dvc_quorum: DVCQuorumMessages) DVCArray {
         var array = DVCArray{};
         for (dvc_quorum, 0..) |received, replica| {
             if (received) |message| {
@@ -8752,42 +8903,40 @@ const DVCQuorum = struct {
         return array;
     }
 
-    fn dvcs_canonical(dvc_quorum: QuorumMessages) DVCArray {
+    fn dvcs_canonical(dvc_quorum: DVCQuorumMessages) DVCArray {
         return dvcs_with_log_view(dvc_quorum, DVCQuorum.log_view_max(dvc_quorum));
     }
 
-    fn dvcs_with_log_view(dvc_quorum: QuorumMessages, log_view: u32) DVCArray {
+    fn dvcs_with_log_view(dvc_quorum: DVCQuorumMessages, log_view: u32) DVCArray {
         var array = DVCArray{};
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |message| {
-            const message_log_view = message.header.request;
-            if (message_log_view == log_view) {
+            if (message.header.log_view == log_view) {
                 array.append_assume_capacity(message);
             }
         }
         return array;
     }
 
-    fn dvcs_uncanonical(dvc_quorum: QuorumMessages) DVCArray {
+    fn dvcs_uncanonical(dvc_quorum: DVCQuorumMessages) DVCArray {
         const log_view_max_ = DVCQuorum.log_view_max(dvc_quorum);
         var array = DVCArray{};
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |message| {
-            const log_view = message.header.request;
-            assert(log_view <= log_view_max_);
+            assert(message.header.log_view <= log_view_max_);
 
-            if (log_view < log_view_max_) {
+            if (message.header.log_view < log_view_max_) {
                 array.append_assume_capacity(message);
             }
         }
         return array;
     }
 
-    fn op_checkpoint_max(dvc_quorum: QuorumMessages) u64 {
+    fn op_checkpoint_max(dvc_quorum: DVCQuorumMessages) u64 {
         var checkpoint_max: ?u64 = null;
         const dvcs = dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |dvc| {
-            const dvc_checkpoint = dvc.header.timestamp;
+            const dvc_checkpoint = dvc.header.checkpoint_op;
             if (checkpoint_max == null or checkpoint_max.? < dvc_checkpoint) {
                 checkpoint_max = dvc_checkpoint;
             }
@@ -8799,30 +8948,29 @@ const DVCQuorum = struct {
     ///
     /// The headers bundled with DVCs with the highest `log_view` are canonical, since
     /// the replica has knowledge of previous view changes in which headers were replaced.
-    fn log_view_max(dvc_quorum: QuorumMessages) u32 {
+    fn log_view_max(dvc_quorum: DVCQuorumMessages) u32 {
         var log_view_max_: ?u32 = null;
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |message| {
-            // The view when this replica was last in normal status, which:
+            // `log_view` is the view when this replica was last in normal status, which:
             // * may be higher than the view in any of the prepare headers.
             // * must be lower than the view of this view change.
-            const log_view = message.header.request;
-            assert(log_view < message.header.view);
+            assert(message.header.log_view < message.header.view);
 
-            if (log_view_max_ == null or log_view_max_.? < log_view) {
-                log_view_max_ = log_view;
+            if (log_view_max_ == null or log_view_max_.? < message.header.log_view) {
+                log_view_max_ = message.header.log_view;
             }
         }
         return log_view_max_.?;
     }
 
-    fn commit_max(dvc_quorum: QuorumMessages) u64 {
+    fn commit_max(dvc_quorum: DVCQuorumMessages) u64 {
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         assert(dvcs.count() > 0);
 
         var commit_max_: u64 = 0;
         for (dvcs.const_slice()) |dvc| {
-            const dvc_headers = message_body_as_view_headers(dvc);
+            const dvc_headers = message_body_as_view_headers(dvc.base);
             // DVC generation stops when a header with op ≤ commit_max is appended.
             const dvc_commit_max_tail = dvc_headers.slice[dvc_headers.slice.len - 1].op;
             // An op cannot be uncommitted if it is definitely outside the pipeline.
@@ -8833,18 +8981,18 @@ const DVCQuorum = struct {
 
             commit_max_ = @max(commit_max_, dvc_commit_max_tail);
             commit_max_ = @max(commit_max_, dvc_commit_max_pipeline);
-            commit_max_ = @max(commit_max_, dvc.header.commit);
+            commit_max_ = @max(commit_max_, dvc.header.commit_min);
             commit_max_ = @max(commit_max_, dvc_headers.slice[0].commit);
         }
         return commit_max_;
     }
 
     /// Returns the highest `timestamp` from any replica.
-    fn timestamp_max(dvc_quorum: QuorumMessages) u64 {
+    fn timestamp_max(dvc_quorum: DVCQuorumMessages) u64 {
         var timestamp_max_: ?u64 = null;
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |dvc| {
-            const dvc_headers = message_body_as_view_headers(dvc);
+            const dvc_headers = message_body_as_view_headers(dvc.base);
             const dvc_head = &dvc_headers.slice[0];
             if (timestamp_max_ == null or timestamp_max_.? < dvc_head.timestamp) {
                 timestamp_max_ = dvc_head.timestamp;
@@ -8853,7 +9001,7 @@ const DVCQuorum = struct {
         return timestamp_max_.?;
     }
 
-    fn op_max_canonical(dvc_quorum: QuorumMessages) u64 {
+    fn op_max_canonical(dvc_quorum: DVCQuorumMessages) u64 {
         var op_max: ?u64 = null;
         const dvcs = DVCQuorum.dvcs_canonical(dvc_quorum);
         for (dvcs.const_slice()) |message| {
@@ -8869,7 +9017,7 @@ const DVCQuorum = struct {
     ///   The first header returned is the new head message.
     /// Otherwise:
     /// - Return the reason the view cannot begin.
-    fn quorum_headers(dvc_quorum: QuorumMessages, options: struct {
+    fn quorum_headers(dvc_quorum: DVCQuorumMessages, options: struct {
         quorum_nack_prepare: u8,
         quorum_view_change: u8,
         replica_count: u8,
@@ -8916,7 +9064,7 @@ const DVCQuorum = struct {
                 // This DVC is canonical, but lagging far behind.
                 if (dvc.header.op < op) continue;
 
-                const headers = message_body_as_view_headers(dvc);
+                const headers = message_body_as_view_headers(dvc.base);
                 const header_index = dvc.header.op - op;
                 assert(header_index <= headers.slice.len);
 
@@ -8934,7 +9082,7 @@ const DVCQuorum = struct {
                     continue;
                 }
 
-                const headers = message_body_as_view_headers(dvc);
+                const headers = message_body_as_view_headers(dvc.base);
                 const header_index = dvc.header.op - op;
                 if (header_index >= headers.slice.len) {
                     nacks += 1;
@@ -8944,8 +9092,8 @@ const DVCQuorum = struct {
                 const header = &headers.slice[header_index];
                 assert(header.op == op);
 
-                const header_nacks = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.context };
-                const header_present = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.client };
+                const header_nacks = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.nack_bitset };
+                const header_present = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.present_bitset };
 
                 if (vsr.Headers.dvc_header_type(header) == .valid and
                     header_present.isSet(header_index) and
@@ -9004,7 +9152,7 @@ const DVCQuorum = struct {
         child_op: ?u64 = null,
         child_parent: ?u128 = null,
 
-        fn next(iterator: *HeaderIterator) ?*const Header {
+        fn next(iterator: *HeaderIterator) ?*const Header.Type(.prepare) {
             assert(iterator.dvcs.count() > 0);
             assert(iterator.op_min <= iterator.op_max);
             assert((iterator.child_op == null) == (iterator.child_parent == null));
@@ -9013,15 +9161,15 @@ const DVCQuorum = struct {
 
             const op = (iterator.child_op orelse (iterator.op_max + 1)) - 1;
 
-            var header: ?*const Header = null;
+            var header: ?*const Header.Type(.prepare) = null;
 
-            const log_view = iterator.dvcs.get(0).header.request;
+            const log_view = iterator.dvcs.get(0).header.log_view;
             for (iterator.dvcs.const_slice()) |dvc| {
-                assert(log_view == dvc.header.request);
+                assert(log_view == dvc.header.log_view);
 
                 if (op > dvc.header.op) continue;
 
-                const dvc_headers = message_body_as_view_headers(dvc);
+                const dvc_headers = message_body_as_view_headers(dvc.base);
                 const dvc_header_index = dvc.header.op - op;
                 if (dvc_header_index >= dvc_headers.slice.len) continue;
 
@@ -9063,15 +9211,15 @@ fn message_body_as_view_headers(message: *const Message) vsr.Headers.ViewChangeS
 
 /// Asserts that the headers are in descending op order.
 /// The headers may contain gaps and/or breaks.
-fn message_body_as_headers(message: *const Message) []const Header {
+fn message_body_as_prepare_headers(message: *const Message) []const Header.Type(.prepare) {
     assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
     assert(message.header.command == .start_view or
         message.header.command == .headers);
 
     const headers = message_body_as_headers_unchecked(message);
-    var child: ?*const Header = null;
+    var child: ?*const Header.Type(.prepare) = null;
     for (headers) |*header| {
-        if (constants.verify) assert(header.valid_checksum());
+        if (constants.verify) assert(header.frame_const().valid_checksum());
         assert(header.command == .prepare);
         assert(header.cluster == message.header.cluster);
         assert(header.view <= message.header.view);
@@ -9087,14 +9235,14 @@ fn message_body_as_headers(message: *const Message) []const Header {
     return headers;
 }
 
-fn message_body_as_headers_unchecked(message: *const Message) []const Header {
+fn message_body_as_headers_unchecked(message: *const Message) []const Header.Type(.prepare) {
     assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
     assert(message.header.command == .do_view_change or
         message.header.command == .start_view or
         message.header.command == .headers);
 
     return std.mem.bytesAsSlice(
-        Header,
+        Header.Type(.prepare),
         message.buffer[@sizeOf(Header)..message.header.size],
     );
 }
@@ -9127,8 +9275,8 @@ const PipelineQueue = struct {
     request_queue: RequestQueue = RequestQueue.init(),
 
     fn deinit(pipeline: *PipelineQueue, message_pool: *MessagePool) void {
-        while (pipeline.request_queue.pop()) |r| message_pool.unref(r.message);
-        while (pipeline.prepare_queue.pop()) |p| message_pool.unref(p.message);
+        while (pipeline.request_queue.pop()) |r| message_pool.unref(r.message.base);
+        while (pipeline.prepare_queue.pop()) |p| message_pool.unref(p.message.base);
     }
 
     fn verify(pipeline: PipelineQueue) void {
@@ -9144,6 +9292,7 @@ const PipelineQueue = struct {
             var prepare_iterator = pipeline.prepare_queue.iterator();
             while (prepare_iterator.next_ptr()) |prepare| {
                 assert(prepare.message.header.command == .prepare);
+                assert(prepare.message.header.operation != .reserved);
                 assert(prepare.message.header.op == op);
                 assert(prepare.message.header.parent == parent);
 
@@ -9189,14 +9338,15 @@ const PipelineQueue = struct {
 
     /// Searches the pipeline for a prepare matching the given ack.
     /// Asserts that the returned prepare corresponds to the prepare_ok.
-    fn prepare_by_prepare_ok(pipeline: *PipelineQueue, ok: *const Message) ?*Prepare {
+    fn prepare_by_prepare_ok(pipeline: *PipelineQueue, ok: Message.Type(.prepare_ok)) ?*Prepare {
         assert(ok.header.command == .prepare_ok);
 
         const prepare = pipeline.prepare_by_op_and_checksum(
             ok.header.op,
-            ok.header.context,
+            ok.header.prepare_checksum,
         ) orelse return null;
         assert(prepare.message.header.command == .prepare);
+        assert(prepare.message.header.parent == ok.header.parent);
         assert(prepare.message.header.client == ok.header.client);
         assert(prepare.message.header.request == ok.header.request);
         assert(prepare.message.header.cluster == ok.header.cluster);
@@ -9207,7 +9357,6 @@ const PipelineQueue = struct {
         assert(prepare.message.header.commit == ok.header.commit);
         assert(prepare.message.header.timestamp == ok.header.timestamp);
         assert(prepare.message.header.operation == ok.header.operation);
-        // "ok.parent" stores the checkpoint id, so don't compare it.
 
         return prepare;
     }
@@ -9222,12 +9371,12 @@ const PipelineQueue = struct {
         var message: ?*const Message = null;
         var prepare_iterator = pipeline.prepare_queue.iterator();
         while (prepare_iterator.next_ptr()) |prepare| {
-            if (prepare.message.header.client == client_id) message = prepare.message;
+            if (prepare.message.header.client == client_id) message = prepare.message.base;
         }
 
         var request_iterator = pipeline.request_queue.iterator();
         while (request_iterator.next()) |request| {
-            if (request.message.header.client == client_id) message = request.message;
+            if (request.message.header.client == client_id) message = request.message.base;
         }
         return message;
     }
@@ -9260,8 +9409,9 @@ const PipelineQueue = struct {
         if (constants.verify) pipeline.verify();
     }
 
-    fn push_prepare(pipeline: *PipelineQueue, message: *Message) void {
+    fn push_prepare(pipeline: *PipelineQueue, message: Message.Type(.prepare)) void {
         assert(message.header.command == .prepare);
+        assert(message.header.operation != .reserved);
         if (pipeline.prepare_queue.tail()) |tail| {
             assert(message.header.op == tail.message.header.op + 1);
             assert(message.header.parent == tail.message.header.checksum);
@@ -9285,7 +9435,8 @@ const PipelineCache = struct {
         constants.pipeline_prepare_queue_max +
         constants.pipeline_request_queue_max;
 
-    prepares: [prepares_max]?*Message = [_]?*Message{null} ** prepares_max,
+    prepares: [prepares_max]?Message.Type(.prepare) =
+        [_]?Message.Type(.prepare){null} ** prepares_max,
 
     /// Converting a PipelineQueue to a PipelineCache discards all accumulated acks.
     /// "prepare_ok"s from previous views are not valid, even if the pipeline entry is reused
@@ -9307,7 +9458,7 @@ const PipelineCache = struct {
     fn deinit(pipeline: *PipelineCache, message_pool: *MessagePool) void {
         for (&pipeline.prepares) |*entry| {
             if (entry.*) |m| {
-                message_pool.unref(m);
+                message_pool.unref(m.base);
                 entry.* = null;
             }
         }
@@ -9320,8 +9471,9 @@ const PipelineCache = struct {
         return false;
     }
 
-    fn contains_header(pipeline: *const PipelineCache, header: *const Header) bool {
+    fn contains_header(pipeline: *const PipelineCache, header: *const Header.Type(.prepare)) bool {
         assert(header.command == .prepare);
+        assert(header.operation != .reserved);
 
         const slot = header.op % prepares_max;
         const prepare = pipeline.prepares[slot] orelse return false;
@@ -9330,7 +9482,11 @@ const PipelineCache = struct {
 
     /// Unlike the PipelineQueue, cached messages may not belong to the current view.
     /// Thus, a matching checksum is required.
-    fn prepare_by_op_and_checksum(pipeline: *PipelineCache, op: u64, checksum: u128) ?*Message {
+    fn prepare_by_op_and_checksum(
+        pipeline: *PipelineCache,
+        op: u64,
+        checksum: u128,
+    ) ?Message.Type(.prepare) {
         const slot = op % prepares_max;
         const prepare = pipeline.prepares[slot] orelse return null;
         if (prepare.header.op != op) return null;
@@ -9339,8 +9495,9 @@ const PipelineCache = struct {
     }
 
     /// Returns the message evicted from the cache, if any.
-    fn insert(pipeline: *PipelineCache, prepare: *Message) ?*Message {
+    fn insert(pipeline: *PipelineCache, prepare: Message.Type(.prepare)) ?Message.Type(.prepare) {
         assert(prepare.header.command == .prepare);
+        assert(prepare.header.operation != .reserved);
 
         const slot = prepare.header.op % prepares_max;
         const prepare_evicted = pipeline.prepares[slot];

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1970,7 +1970,6 @@ pub fn ReplicaType(
 
             assert(self.node_count > 1);
             maybe(self.status == .recovering_head);
-            maybe(message.header.view != self.view);
             assert(message.header.replica != self.replica);
 
             const op = message.header.prepare_op;
@@ -2052,7 +2051,6 @@ pub fn ReplicaType(
             if (self.ignore_repair_message(message.base)) return;
 
             maybe(self.status == .recovering_head);
-            maybe(message.header.view == self.view);
             assert(message.header.replica != self.replica);
 
             const response = self.message_bus.get_message();
@@ -4015,6 +4013,9 @@ pub fn ReplicaType(
             assert(
                 header.view == self.view or
                     header.command == .request_start_view or
+                    header.command == .request_headers or
+                    header.command == .request_prepare or
+                    header.command == .request_reply or
                     header.command == .request_sync_checkpoint or
                     header.command == .reply or
                     header.command == .ping or header.command == .pong,
@@ -5367,7 +5368,6 @@ pub fn ReplicaType(
                         .command = .request_headers,
                         .cluster = self.cluster,
                         .replica = self.replica,
-                        .view = self.view,
                         .op_min = range.op_min,
                         .op_max = range.op_max,
                     }),
@@ -5392,7 +5392,6 @@ pub fn ReplicaType(
                         .command = .request_reply,
                         .cluster = self.cluster,
                         .replica = self.replica,
-                        .view = self.view,
                         .reply_client = entry.header.client,
                         .reply_op = entry.header.op,
                         .reply_checksum = entry.header.checksum,
@@ -5957,7 +5956,6 @@ pub fn ReplicaType(
                 .command = .request_prepare,
                 .cluster = self.cluster,
                 .replica = self.replica,
-                .view = self.view,
                 .prepare_op = op,
                 .prepare_checksum = checksum,
             };
@@ -6632,18 +6630,15 @@ pub fn ReplicaType(
                 },
                 .request_headers => {
                     maybe(self.standby());
-                    assert(message.header.view == self.view);
                     assert(message.header.replica == self.replica);
                     assert(message.header.replica != replica);
                 },
                 .request_prepare => {
                     maybe(self.standby());
-                    assert(message.header.view == self.view);
                     assert(message.header.replica == self.replica);
                     assert(message.header.replica != replica);
                 },
                 .request_reply => {
-                    assert(message.header.view == self.view);
                     assert(message.header.replica == self.replica);
                     assert(message.header.replica != replica);
                 },

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -85,8 +85,8 @@ fn ReplicaFormatType(comptime Storage: type) type {
                         // This is a Prepare's header.
                         assert(header.valid_checksum());
 
-                        if (header.operation == .root) {
-                            assert(header.op == 0);
+                        if (header.op == 0) {
+                            assert(header.operation == .root);
                         } else {
                             assert(header.operation == .reserved);
                         }
@@ -115,8 +115,8 @@ fn ReplicaFormatType(comptime Storage: type) type {
                 for (std.mem.bytesAsSlice(Header.Prepare, wal_buffer[0..size])) |*header| {
                     assert(header.valid_checksum());
 
-                    if (header.operation == .root) {
-                        assert(header.op == 0);
+                    if (header.op == 0) {
+                        assert(header.operation == .root);
                     } else {
                         assert(header.operation == .reserved);
                     }

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -83,7 +83,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                         // This is the (empty) body of a reserved or root Prepare.
                     } else {
                         // This is a Prepare's header.
-                        assert(header.frame_const().valid_checksum());
+                        assert(header.valid_checksum());
 
                         if (header.operation == .root) {
                             assert(header.op == 0);
@@ -113,7 +113,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                 assert(size > 0);
 
                 for (std.mem.bytesAsSlice(Header.Prepare, wal_buffer[0..size])) |*header| {
-                    assert(header.frame_const().valid_checksum());
+                    assert(header.valid_checksum());
 
                     if (header.operation == .root) {
                         assert(header.op == 0);
@@ -266,9 +266,9 @@ test "format" {
     for (storage.wal_headers(), storage.wal_prepares(), 0..) |header, *message, slot| {
         try std.testing.expect(std.meta.eql(header, message.header));
 
-        try std.testing.expect(header.frame_const().valid_checksum());
-        try std.testing.expect(header.frame_const().valid_checksum_body(&[0]u8{}));
-        try std.testing.expectEqual(header.frame_const().invalid(), null);
+        try std.testing.expect(header.valid_checksum());
+        try std.testing.expect(header.valid_checksum_body(&[0]u8{}));
+        try std.testing.expectEqual(header.invalid(), null);
         try std.testing.expectEqual(header.cluster, cluster);
         try std.testing.expectEqual(header.op, slot);
         try std.testing.expectEqual(header.size, @sizeOf(vsr.Header));

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -78,7 +78,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                 const size = format_wal_prepares(cluster, wal_offset, wal_buffer);
                 assert(size > 0);
 
-                for (std.mem.bytesAsSlice(Header.Type(.prepare), wal_buffer[0..size])) |*header| {
+                for (std.mem.bytesAsSlice(Header.Prepare, wal_buffer[0..size])) |*header| {
                     if (std.mem.eql(u8, std.mem.asBytes(header), &header_zeroes)) {
                         // This is the (empty) body of a reserved or root Prepare.
                     } else {
@@ -112,7 +112,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                 const size = format_wal_headers(cluster, wal_offset, wal_buffer);
                 assert(size > 0);
 
-                for (std.mem.bytesAsSlice(Header.Type(.prepare), wal_buffer[0..size])) |*header| {
+                for (std.mem.bytesAsSlice(Header.Prepare, wal_buffer[0..size])) |*header| {
                     assert(header.frame_const().valid_checksum());
 
                     if (header.operation == .root) {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1163,8 +1163,8 @@ const TestContext = struct {
     fn on_client_reply(
         cluster: *Cluster,
         client: usize,
-        request: Message.Type(.request),
-        reply: Message.Type(.reply),
+        request: Message.Request,
+        reply: Message.Reply,
     ) void {
         _ = request;
         _ = reply;

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -37,7 +37,7 @@ const log_level = std.log.Level.err;
 
 comptime {
     // The tests are written for these configuration values in particular.
-    assert(constants.journal_slot_count == 64);
+    assert(constants.journal_slot_count == 32);
     assert(constants.lsm_batch_multiple == 4);
 }
 
@@ -104,7 +104,7 @@ test "Cluster: recovery: WAL prepare corruption (R=3, corrupt checkpoint…head)
     try c.request(checkpoint_1_trigger, checkpoint_1_trigger);
     t.replica(.R0).stop();
 
-    // Corrupt op_checkpoint (59) and all ops that follow.
+    // Corrupt op_checkpoint (27) and all ops that follow.
     var slot: usize = slot_count - constants.lsm_batch_multiple - 1;
     while (slot < slot_count) : (slot += 1) {
         t.replica(.R0).corrupt(.{ .wal_prepare = slot });
@@ -299,9 +299,9 @@ test "Cluster: network: partition 2-1 (isolate backup, symmetric)" {
     var c = t.clients(0, t.cluster.clients.len);
     try c.request(20, 20);
     t.replica(.B2).drop_all(.__, .bidirectional);
-    try c.request(40, 40);
-    try expectEqual(t.replica(.A0).commit(), 40);
-    try expectEqual(t.replica(.B1).commit(), 40);
+    try c.request(30, 30);
+    try expectEqual(t.replica(.A0).commit(), 30);
+    try expectEqual(t.replica(.B1).commit(), 30);
     try expectEqual(t.replica(.B2).commit(), 20);
 }
 
@@ -312,9 +312,9 @@ test "Cluster: network: partition 2-1 (isolate backup, asymmetric, send-only)" {
     var c = t.clients(0, t.cluster.clients.len);
     try c.request(20, 20);
     t.replica(.B2).drop_all(.__, .incoming);
-    try c.request(40, 40);
-    try expectEqual(t.replica(.A0).commit(), 40);
-    try expectEqual(t.replica(.B1).commit(), 40);
+    try c.request(30, 30);
+    try expectEqual(t.replica(.A0).commit(), 30);
+    try expectEqual(t.replica(.B1).commit(), 30);
     try expectEqual(t.replica(.B2).commit(), 20);
 }
 
@@ -325,9 +325,9 @@ test "Cluster: network: partition 2-1 (isolate backup, asymmetric, receive-only)
     var c = t.clients(0, t.cluster.clients.len);
     try c.request(20, 20);
     t.replica(.B2).drop_all(.__, .outgoing);
-    try c.request(40, 40);
-    try expectEqual(t.replica(.A0).commit(), 40);
-    try expectEqual(t.replica(.B1).commit(), 40);
+    try c.request(30, 30);
+    try expectEqual(t.replica(.A0).commit(), 30);
+    try expectEqual(t.replica(.B1).commit(), 30);
     // B2 may commit some ops, but at some point is will likely fall behind.
     // Prepares may be reordered by the network, and if B1 receives X+1 then X,
     // it will not forward X on, as it is a "repair".
@@ -389,8 +389,8 @@ test "Cluster: network: partition client-primary (symmetric)" {
 
     t.replica(.A0).drop_all(.C_, .bidirectional);
     // TODO: https://github.com/tigerbeetle/tigerbeetle/issues/444
-    // try c.request(40, 40);
-    try c.request(40, 20);
+    // try c.request(30, 30);
+    try c.request(30, 20);
 }
 
 test "Cluster: network: partition client-primary (asymmetric, drop requests)" {
@@ -403,8 +403,8 @@ test "Cluster: network: partition client-primary (asymmetric, drop requests)" {
 
     t.replica(.A0).drop_all(.C_, .incoming);
     // TODO: https://github.com/tigerbeetle/tigerbeetle/issues/444
-    // try c.request(40, 40);
-    try c.request(40, 20);
+    // try c.request(30, 40);
+    try c.request(30, 20);
 }
 
 test "Cluster: network: partition client-primary (asymmetric, drop replies)" {
@@ -417,8 +417,8 @@ test "Cluster: network: partition client-primary (asymmetric, drop replies)" {
 
     t.replica(.A0).drop_all(.C_, .outgoing);
     // TODO: https://github.com/tigerbeetle/tigerbeetle/issues/444
-    // try c.request(40, 40);
-    try c.request(40, 20);
+    // try c.request(30, 30);
+    try c.request(30, 20);
 }
 
 test "Cluster: repair: partition 2-1, then backup fast-forward 1 checkpoint" {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1163,8 +1163,8 @@ const TestContext = struct {
     fn on_client_reply(
         cluster: *Cluster,
         client: usize,
-        request: Message.Request,
-        reply: Message.Reply,
+        request: *Message.Request,
+        reply: *Message.Reply,
     ) void {
         _ = request;
         _ = reply;

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1160,7 +1160,12 @@ const TestContext = struct {
         return commits_before != t.cluster.state_checker.commits.items.len;
     }
 
-    fn on_client_reply(cluster: *Cluster, client: usize, request: *Message, reply: *Message) void {
+    fn on_client_reply(
+        cluster: *Cluster,
+        client: usize,
+        request: Message.Type(.request),
+        reply: Message.Type(.reply),
+    ) void {
         _ = request;
         _ = reply;
         const t: *TestContext = @ptrCast(@alignCast(cluster.context.?));

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -111,7 +111,7 @@ pub const SuperBlockHeader = extern struct {
     ///
     /// When `vsr_state.log_view < vsr_state.view`, the headers are for a DVC.
     /// When `vsr_state.log_view = vsr_state.view`, the headers are for a SV.
-    vsr_headers_all: [constants.view_change_headers_max]vsr.Header.Type(.prepare),
+    vsr_headers_all: [constants.view_change_headers_max]vsr.Header.Prepare,
     vsr_headers_reserved: [vsr_headers_reserved_size]u8 =
         [_]u8{0} ** vsr_headers_reserved_size,
 
@@ -176,7 +176,7 @@ pub const SuperBlockHeader = extern struct {
             return .{
                 .checkpoint = .{
                     .previous_checkpoint_id = 0,
-                    .commit_min_checksum = vsr.Header.Type(.prepare).root(options.cluster).checksum,
+                    .commit_min_checksum = vsr.Header.Prepare.root(options.cluster).checksum,
                     .commit_min = 0,
                     .snapshots_block_checksum = 0,
                     .snapshots_block_address = 0,
@@ -385,7 +385,7 @@ pub const SuperBlockHeader = extern struct {
         if (a.free_set_size != b.free_set_size) return false;
         if (a.vsr_headers_count != b.vsr_headers_count) return false;
         if (!stdx.equal_bytes(
-            [constants.view_change_headers_max]vsr.Header.Type(.prepare),
+            [constants.view_change_headers_max]vsr.Header.Prepare,
             &a.vsr_headers_all,
             &b.vsr_headers_all,
         )) return false;
@@ -784,7 +784,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .client_sessions_size = 0,
                 .vsr_headers_count = 0,
                 .vsr_headers_all = mem.zeroes(
-                    [constants.view_change_headers_max]vsr.Header.Type(.prepare),
+                    [constants.view_change_headers_max]vsr.Header.Prepare,
                 ),
             };
 
@@ -1006,13 +1006,13 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 superblock.staging.vsr_headers_count = headers.array.count_as(u32);
                 stdx.copy_disjoint(
                     .exact,
-                    vsr.Header.Type(.prepare),
+                    vsr.Header.Prepare,
                     superblock.staging.vsr_headers_all[0..headers.array.count()],
                     headers.array.const_slice(),
                 );
                 @memset(
                     superblock.staging.vsr_headers_all[headers.array.count()..],
-                    std.mem.zeroes(vsr.Header.Type(.prepare)),
+                    std.mem.zeroes(vsr.Header.Prepare),
                 );
             } else {
                 assert(!context.caller.updates_vsr_headers());
@@ -1311,7 +1311,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     assert(working.free_set_size == 0);
                     assert(working.client_sessions_size == ClientSessions.encode_size_max);
                     assert(working.vsr_state.checkpoint.commit_min_checksum ==
-                        vsr.Header.Type(.prepare).root(working.cluster).checksum);
+                        vsr.Header.Prepare.root(working.cluster).checksum);
                     assert(working.vsr_state.checkpoint.commit_min == 0);
                     assert(working.vsr_state.commit_max == 0);
                     assert(working.vsr_state.log_view == 0);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -111,7 +111,7 @@ pub const SuperBlockHeader = extern struct {
     ///
     /// When `vsr_state.log_view < vsr_state.view`, the headers are for a DVC.
     /// When `vsr_state.log_view = vsr_state.view`, the headers are for a SV.
-    vsr_headers_all: [constants.view_change_headers_max]vsr.Header,
+    vsr_headers_all: [constants.view_change_headers_max]vsr.Header.Type(.prepare),
     vsr_headers_reserved: [vsr_headers_reserved_size]u8 =
         [_]u8{0} ** vsr_headers_reserved_size,
 
@@ -176,7 +176,7 @@ pub const SuperBlockHeader = extern struct {
             return .{
                 .checkpoint = .{
                     .previous_checkpoint_id = 0,
-                    .commit_min_checksum = vsr.Header.root_prepare(options.cluster).checksum,
+                    .commit_min_checksum = vsr.Header.Type(.prepare).root(options.cluster).checksum,
                     .commit_min = 0,
                     .snapshots_block_checksum = 0,
                     .snapshots_block_address = 0,
@@ -385,7 +385,7 @@ pub const SuperBlockHeader = extern struct {
         if (a.free_set_size != b.free_set_size) return false;
         if (a.vsr_headers_count != b.vsr_headers_count) return false;
         if (!stdx.equal_bytes(
-            [constants.view_change_headers_max]vsr.Header,
+            [constants.view_change_headers_max]vsr.Header.Type(.prepare),
             &a.vsr_headers_all,
             &b.vsr_headers_all,
         )) return false;
@@ -783,7 +783,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .free_set_size = 0,
                 .client_sessions_size = 0,
                 .vsr_headers_count = 0,
-                .vsr_headers_all = mem.zeroes([constants.view_change_headers_max]vsr.Header),
+                .vsr_headers_all = mem.zeroes(
+                    [constants.view_change_headers_max]vsr.Header.Type(.prepare),
+                ),
             };
 
             superblock.working.set_checksum();
@@ -1004,13 +1006,13 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 superblock.staging.vsr_headers_count = headers.array.count_as(u32);
                 stdx.copy_disjoint(
                     .exact,
-                    vsr.Header,
+                    vsr.Header.Type(.prepare),
                     superblock.staging.vsr_headers_all[0..headers.array.count()],
                     headers.array.const_slice(),
                 );
                 @memset(
                     superblock.staging.vsr_headers_all[headers.array.count()..],
-                    std.mem.zeroes(vsr.Header),
+                    std.mem.zeroes(vsr.Header.Type(.prepare)),
                 );
             } else {
                 assert(!context.caller.updates_vsr_headers());
@@ -1309,7 +1311,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     assert(working.free_set_size == 0);
                     assert(working.client_sessions_size == ClientSessions.encode_size_max);
                     assert(working.vsr_state.checkpoint.commit_min_checksum ==
-                        vsr.Header.root_prepare(working.cluster).checksum);
+                        vsr.Header.Type(.prepare).root(working.cluster).checksum);
                     assert(working.vsr_state.checkpoint.commit_min == 0);
                     assert(working.vsr_state.commit_max == 0);
                     assert(working.vsr_state.log_view == 0);

--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -34,7 +34,7 @@ pub const ClientSessions = struct {
         session: u64,
 
         /// The header of the reply corresponding to the client's latest committed request.
-        header: vsr.Header,
+        header: vsr.Header.Type(.reply),
     };
 
     /// Values are indexes into `entries`.
@@ -130,7 +130,7 @@ pub const ClientSessions = struct {
         assert(client_sessions.entries_free.count() == constants.clients_max);
         for (client_sessions.entries) |*entry| {
             assert(entry.session == 0);
-            assert(std.meta.eql(entry.header, std.mem.zeroes(vsr.Header)));
+            assert(stdx.zeroed(std.mem.asBytes(&entry.header)));
         }
 
         var size: u64 = 0;
@@ -139,8 +139,8 @@ pub const ClientSessions = struct {
 
         assert(@alignOf(vsr.Header) == 16);
         size = std.mem.alignForward(usize, size, 16);
-        const headers: []const vsr.Header = @alignCast(mem.bytesAsSlice(
-            vsr.Header,
+        const headers: []const vsr.Header.Type(.reply) = @alignCast(mem.bytesAsSlice(
+            vsr.Header.Type(.reply),
             source[size..][0 .. constants.clients_max * @sizeOf(vsr.Header)],
         ));
         size += mem.sliceAsBytes(headers).len;
@@ -158,9 +158,9 @@ pub const ClientSessions = struct {
         for (headers, 0..) |*header, i| {
             const session = sessions[i];
             if (session == 0) {
-                assert(std.meta.eql(header.*, std.mem.zeroes(vsr.Header)));
+                assert(stdx.zeroed(std.mem.asBytes(header)));
             } else {
-                assert(header.valid_checksum());
+                assert(header.frame_const().valid_checksum());
                 assert(header.command == .reply);
                 assert(header.commit >= session);
 
@@ -202,7 +202,7 @@ pub const ClientSessions = struct {
 
     pub fn get_slot_for_header(
         client_sessions: *const ClientSessions,
-        header: *const vsr.Header,
+        header: *const vsr.Header.Type(.reply),
     ) ?ReplySlot {
         if (client_sessions.entries_by_client.get(header.client)) |entry_index| {
             const entry = &client_sessions.entries[entry_index];
@@ -218,7 +218,7 @@ pub const ClientSessions = struct {
     pub fn put(
         client_sessions: *ClientSessions,
         session: u64,
-        header: *const vsr.Header,
+        header: *const vsr.Header.Type(.reply),
     ) ReplySlot {
         assert(session != 0);
         assert(header.command == .reply);
@@ -266,7 +266,7 @@ pub const ClientSessions = struct {
         assert(client_sessions.entries_free.count() == 0);
         assert(client_sessions.count() == constants.clients_max);
 
-        var evictee_: ?*const vsr.Header = null;
+        var evictee_: ?*const vsr.Header.Type(.reply) = null;
         var iterated: usize = 0;
         var entries = client_sessions.iterator();
         while (entries.next()) |entry| : (iterated += 1) {

--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -34,7 +34,7 @@ pub const ClientSessions = struct {
         session: u64,
 
         /// The header of the reply corresponding to the client's latest committed request.
-        header: vsr.Header.Type(.reply),
+        header: vsr.Header.Reply,
     };
 
     /// Values are indexes into `entries`.
@@ -139,8 +139,8 @@ pub const ClientSessions = struct {
 
         assert(@alignOf(vsr.Header) == 16);
         size = std.mem.alignForward(usize, size, 16);
-        const headers: []const vsr.Header.Type(.reply) = @alignCast(mem.bytesAsSlice(
-            vsr.Header.Type(.reply),
+        const headers: []const vsr.Header.Reply = @alignCast(mem.bytesAsSlice(
+            vsr.Header.Reply,
             source[size..][0 .. constants.clients_max * @sizeOf(vsr.Header)],
         ));
         size += mem.sliceAsBytes(headers).len;
@@ -202,7 +202,7 @@ pub const ClientSessions = struct {
 
     pub fn get_slot_for_header(
         client_sessions: *const ClientSessions,
-        header: *const vsr.Header.Type(.reply),
+        header: *const vsr.Header.Reply,
     ) ?ReplySlot {
         if (client_sessions.entries_by_client.get(header.client)) |entry_index| {
             const entry = &client_sessions.entries[entry_index];
@@ -218,7 +218,7 @@ pub const ClientSessions = struct {
     pub fn put(
         client_sessions: *ClientSessions,
         session: u64,
-        header: *const vsr.Header.Type(.reply),
+        header: *const vsr.Header.Reply,
     ) ReplySlot {
         assert(session != 0);
         assert(header.command == .reply);
@@ -266,7 +266,7 @@ pub const ClientSessions = struct {
         assert(client_sessions.entries_free.count() == 0);
         assert(client_sessions.count() == constants.clients_max);
 
-        var evictee_: ?*const vsr.Header.Type(.reply) = null;
+        var evictee_: ?*const vsr.Header.Reply = null;
         var iterated: usize = 0;
         var entries = client_sessions.iterator();
         while (entries.next()) |entry| : (iterated += 1) {

--- a/src/vsr/superblock_client_sessions.zig
+++ b/src/vsr/superblock_client_sessions.zig
@@ -160,7 +160,7 @@ pub const ClientSessions = struct {
             if (session == 0) {
                 assert(stdx.zeroed(std.mem.asBytes(header)));
             } else {
-                assert(header.frame_const().valid_checksum());
+                assert(header.valid_checksum());
                 assert(header.command == .reply);
                 assert(header.commit >= session);
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -288,7 +288,7 @@ const Environment = struct {
         });
 
         var vsr_headers = vsr.Headers.Array{};
-        vsr_headers.append_assume_capacity(vsr.Header.root_prepare(cluster));
+        vsr_headers.append_assume_capacity(vsr.Header.Type(.prepare).root(cluster));
 
         assert(env.sequence_states.items.len == 0);
         try env.sequence_states.append(undefined); // skip sequence=0
@@ -345,7 +345,7 @@ const Environment = struct {
         };
 
         var vsr_headers = vsr.Headers.Array{};
-        var vsr_head = std.mem.zeroInit(vsr.Header, .{
+        var vsr_head = std.mem.zeroInit(vsr.Header.Type(.prepare), .{
             .client = 1,
             .request = 1,
             .command = .prepare,
@@ -353,8 +353,8 @@ const Environment = struct {
             .op = env.superblock.staging.vsr_state.checkpoint.commit_min + 1,
             .timestamp = 1,
         });
-        vsr_head.set_checksum_body(&.{});
-        vsr_head.set_checksum();
+        vsr_head.frame().set_checksum_body(&.{});
+        vsr_head.frame().set_checksum();
         vsr_headers.append_assume_capacity(vsr_head);
 
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);
@@ -414,14 +414,14 @@ const Environment = struct {
         // To mimic the replica, ClientSessions mutates between every checkpoint.
         // This ensures that sequential checkpoint ids are never identical.
         const session: u64 = 1;
-        var reply = vsr.Header{
+        var reply = std.mem.zeroInit(vsr.Header.Type(.reply), .{
             .cluster = cluster,
             .command = .reply,
             .client = 456,
             .commit = vsr_state.checkpoint.commit_min,
-        };
-        reply.set_checksum_body(&.{});
-        reply.set_checksum();
+        });
+        reply.frame().set_checksum_body(&.{});
+        reply.frame().set_checksum();
 
         _ = env.superblock.client_sessions.put(session, &reply);
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -288,7 +288,7 @@ const Environment = struct {
         });
 
         var vsr_headers = vsr.Headers.Array{};
-        vsr_headers.append_assume_capacity(vsr.Header.Type(.prepare).root(cluster));
+        vsr_headers.append_assume_capacity(vsr.Header.Prepare.root(cluster));
 
         assert(env.sequence_states.items.len == 0);
         try env.sequence_states.append(undefined); // skip sequence=0
@@ -345,7 +345,7 @@ const Environment = struct {
         };
 
         var vsr_headers = vsr.Headers.Array{};
-        var vsr_head = std.mem.zeroInit(vsr.Header.Type(.prepare), .{
+        var vsr_head = std.mem.zeroInit(vsr.Header.Prepare, .{
             .client = 1,
             .request = 1,
             .command = .prepare,
@@ -414,7 +414,7 @@ const Environment = struct {
         // To mimic the replica, ClientSessions mutates between every checkpoint.
         // This ensures that sequential checkpoint ids are never identical.
         const session: u64 = 1;
-        var reply = std.mem.zeroInit(vsr.Header.Type(.reply), .{
+        var reply = std.mem.zeroInit(vsr.Header.Reply, .{
             .cluster = cluster,
             .command = .reply,
             .client = 456,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -353,8 +353,8 @@ const Environment = struct {
             .op = env.superblock.staging.vsr_state.checkpoint.commit_min + 1,
             .timestamp = 1,
         });
-        vsr_head.frame().set_checksum_body(&.{});
-        vsr_head.frame().set_checksum();
+        vsr_head.set_checksum_body(&.{});
+        vsr_head.set_checksum();
         vsr_headers.append_assume_capacity(vsr_head);
 
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);
@@ -420,8 +420,8 @@ const Environment = struct {
             .client = 456,
             .commit = vsr_state.checkpoint.commit_min,
         });
-        reply.frame().set_checksum_body(&.{});
-        reply.frame().set_checksum();
+        reply.set_checksum_body(&.{});
+        reply.set_checksum();
 
         _ = env.superblock.client_sessions.put(session, &reply);
 


### PR DESCRIPTION
## 256-byte headers

The extra space is mostly just reserved space for now. (See "Next Steps".)

#### Aside:

Counter-intuitively, when we double the header size, we can _halve_ the minimum WAL size.
This is because the minimum journal size is driven by the redundant headers -- we need at least 2 sectors of them.
Doubling the header size means those 2 sectors hold half as many headers. (See `journal_slot_count_min`).

Thus, a VOPR run of the same number of commits will checkpoint twice as often!

## Header Specialization

### Context

Presently, we have a single header type (`vsr.Header`) which serves as the header of all message types (i.e. "commands") – including all grid block types.

Some fields are common across all message types – e.g. `checksum` or `cluster`.
But not all message types need to store the same information.

Consider `Header.context`:

```
const Header = extern struct {
    ...
    /// The checksum of the message to which this message refers.
    ///
    /// We use this cryptographic context in various ways, for example:
    ///
    /// * A `request` sets this to the client's session number.
    /// * A `reply` sets this to a "stable" checksum.
    ///   Replies for a specific op may have different views (and checksums),
    ///   but are guaranteed to have the same context.
    /// * A `prepare` sets this to the checksum of the client's request.
    /// * A `prepare_ok` sets this to the checksum of the prepare being acked.
    /// * A `commit` sets this to the checksum of the latest committed prepare.
    /// * A `do_view_change` sets this to a bitset, with set bits indicating headers
    ///   in the message body which it has definitely not prepared (i.e. "nack").
    ///   The corresponding header may be an actual prepare header, or it may be a "blank" header.
    /// * A `request_start_view` sets this to a unique nonce, to detect outdated SVs.
    /// * A `start_view` sets this to zero for a new view, and to a nonce from an RSV when
    ///   responding to the RSV.
    /// * A `request_prepare` sets this to the checksum of the prepare being requested.
    /// * A `request_reply` sets this to the checksum of the reply being requested.
    /// * A `sync_free_set` sets this to the complete FreeSet's checksum.
    /// * A `sync_client_sessions` sets this to the complete ClientSessions's checksum.
    ///
    /// This allows for cryptographic guarantees beyond request, op, and commit numbers, which have
    /// low entropy and may otherwise collide in the event of any correctness bugs.
    context: u128 = 0,
    ...
};
```

The field's name applies to `prepare` and `reply`. All of the other message types reuse the field because they need a `u128`. The documentation specifying these uses easily gets out of sync, though. (Grid blocks also use `context` – and each block type encodes data into `context` with a different schema.)

### Solution

- Some fields are shared by all (or most) messages – these are called the _frame_ fields.
- `Header` still exists as a "generic" header (it may hold any message type). But it holds the frame fields, and then a `reserved_command: [...]u8` slice of bytes which are command-specific.
- For each `Command`, add a new `extern struct` header type:
    - Exposed via `Header.Type(command)`.
    - The frame fields are identical in all header types (in both type and offset).
    - In place of `reserved_command`, each header type defines its own specific fields. For example, `Header.Type(.request_prepare)` has a `prepare_checksum` field instead of `context`.
- There is a corresponding `Message.Type(command)`, which has `message.header: *Header.Type(command)`. This means that most functions (e.g. message handlers) don't need to cast headers at all.
- For grid blocks, there is a `Header.Type(.block)` shared by all block types, with a `block_type: BlockType` field (no more reusing `Operation`!) and `reserved_block` bytes, which are decoded by each block schema (see `schema.zig`).
- To avoid duplicating methods like `set_checksum()` onto each header type, every header type has a `frame()` and `frame_const()` method, which casts to a base `Header`.
- Casts from the base header type to a specific header use one of:
    - `pub fn into(self: *Header, comptime command: Command) ?*Type(command)`
        - Returns `null` if the command doesn't match `header.command`.
        - The caller almost always writes `header.into(...).?` -- it makes the assertion explicit at the call site.
    - `pub fn into_const(self: *const Header, comptime command: Command) ?*const Type(command)`
    - `pub fn into_any(self: *const Header) AnyHeaderPointer`
        - (returns a `union(Command) { command → *const Type(command) }`).
- Note that there are some frame fields that are unused by some message types. (e.g. `view`, `replica`).

### Polymorphism

This approach raises the question of how to handle message polymorphism – code which operates over multiple specific header/message types.

On a case-by-case basis:

- WAL prepares and reserved prepares: Instead of using `command=reserved` for reserved prepares, use `command=prepare operation=reserved`. No more polymorphism needed here.
- DVC prepares and gaps: Same as the WAL.
- Superblock trailer sync messages: These are going to removed anyway, so for now the split just uses code generation for each command.
- Different block types: Each block type uses `Header.Type(.block)`. Some fields (e.g. `address`, `block_type`) are shared by all block types. For fields that are block-type-specific (e.g. "how many values are in this data block"), there is `metadata_bytes: [...]u8`, which is cast to block-type-specific `Metadata` structs.

### Misc

Also included in this commit:

- Remove many default fields from header types – now that we can simply remove extraneous fields from headers that don't use them, default values are a bit of a footgun (since you can forget to set a required field).
- Change `Header.version` from a `u8` to a `u16`.
- In the `Header(*).invalid()` functions, when we are verifying that a header has no body, we test both `size == @sizeof(Header)` and `checksum_body == checksum(.{})`. Previously we checked the checksum first, but now we check the size first. I _think_ this would provide a little more information if one of them found an error.

The frame/header schemas used in this commit is very much not final, but this diff is big enough already:

## Next Steps

(In follow-up PRs).

- Double the checksum size so that we can use the checksum as an AEAD tag eventually.
- Add checkpoint id to `prepare`s. (As mentioned in the [state sync PR](https://github.com/tigerbeetle/tigerbeetle/pull/834).)