### PR TITLE
ci: skip release validation for failed releases

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
We already get a message when release fails, no need to duplicate it. 