### PR TITLE
Fixes the Node.js client validation messages.

### DIFF
--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -372,8 +372,7 @@ fn decode_array(comptime Event: type, env: c.napi_env, array: c.napi_value, even
                     const value = try @field(translate, @typeName(FieldInt) ++ "_from_object")(
                         env,
                         object,
-                        // Use `comptimePrint` to ensure the sentinel terminated string.
-                        std.fmt.comptimePrint("{s}", .{field.name}),
+                        add_trailing_null(field.name),
                     );
 
                     if (std.mem.eql(u8, field.name, "timestamp") and value != 0) {
@@ -440,6 +439,15 @@ fn encode_array(comptime Result: type, env: c.napi_env, results: []const Result)
     }
 
     return array;
+}
+
+fn add_trailing_null(comptime input: []const u8) [:0]const u8 {
+    // Concatenating `[]const u8` with an empty string `[0:0]const u8`,
+    // gives us a null-terminated string `[:0]const u8`.
+    const output = input ++ "";
+    comptime assert(output.len == input.len);
+    comptime assert(output[output.len] == 0);
+    return output;
 }
 
 /// Each packet allocates enough room to hold both its Events and its Results.

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -372,7 +372,8 @@ fn decode_array(comptime Event: type, env: c.napi_env, array: c.napi_value, even
                     const value = try @field(translate, @typeName(FieldInt) ++ "_from_object")(
                         env,
                         object,
-                        @ptrCast(field.name ++ "\x00"),
+                        // Use `comptimePrint` to ensure the sentinel terminated string.
+                        std.fmt.comptimePrint("{s}", .{field.name}),
                     );
 
                     if (std.mem.eql(u8, field.name, "timestamp") and value != 0) {

--- a/src/clients/node/src/translate.zig
+++ b/src/clients/node/src/translate.zig
@@ -92,7 +92,7 @@ pub fn slice_from_object(
     comptime key: [:0]const u8,
 ) ![]const u8 {
     var property: c.napi_value = undefined;
-    if (c.napi_get_named_property(env, object, @as([*c]const u8, @ptrCast(key)), &property) != c.napi_ok) {
+    if (c.napi_get_named_property(env, object, key, &property) != c.napi_ok) {
         return throw(env, key ++ " must be defined");
     }
 
@@ -120,7 +120,7 @@ pub fn slice_from_value(
 
 pub fn u128_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]const u8) !u128 {
     var property: c.napi_value = undefined;
-    if (c.napi_get_named_property(env, object, @as([*c]const u8, @ptrCast(key)), &property) != c.napi_ok) {
+    if (c.napi_get_named_property(env, object, key, &property) != c.napi_ok) {
         return throw(env, key ++ " must be defined");
     }
 
@@ -129,7 +129,7 @@ pub fn u128_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0
 
 pub fn u64_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]const u8) !u64 {
     var property: c.napi_value = undefined;
-    if (c.napi_get_named_property(env, object, @as([*c]const u8, @ptrCast(key)), &property) != c.napi_ok) {
+    if (c.napi_get_named_property(env, object, key, &property) != c.napi_ok) {
         return throw(env, key ++ " must be defined");
     }
 
@@ -138,7 +138,7 @@ pub fn u64_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]
 
 pub fn u32_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]const u8) !u32 {
     var property: c.napi_value = undefined;
-    if (c.napi_get_named_property(env, object, @as([*c]const u8, @ptrCast(key)), &property) != c.napi_ok) {
+    if (c.napi_get_named_property(env, object, key, &property) != c.napi_ok) {
         return throw(env, key ++ " must be defined");
     }
 
@@ -147,7 +147,7 @@ pub fn u32_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]
 
 pub fn u16_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]const u8) !u16 {
     const result = try u32_from_object(env, object, key);
-    if (result > 65535) {
+    if (result > std.math.maxInt(u16)) {
         return throw(env, key ++ " must be a u16.");
     }
 


### PR DESCRIPTION
Fixes the Node.js client validation messages.

We added an extra sentinel to the field's name `field.name ++ "\x00"` causing the message to be incorrectly concatenated like `"code\0x00 must be a u16."` and therefore printed as just `"code"` at Node's side.

Closes #1290