### PR TITLE
superblock: clarify what storage_size means

### DIFF
--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -586,12 +586,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
         storage: *Storage,
 
-        /// The first logical offset that may be written to the superblock storage zone.
-        storage_offset: u64 = 0,
-
-        /// The total size of the superblock storage zone after this physical offset.
-        storage_size: u64 = superblock_zone_size,
-
         /// The superblock that was recovered at startup after a crash or that was last written.
         working: *align(constants.sector_size) SuperBlockHeader,
 
@@ -633,6 +627,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
         /// Whether the superblock has been opened. An open superblock may not be formatted.
         opened: bool = false,
         block_count_limit: usize,
+        /// Runtime limit on the size of the datafile.
         storage_size_limit: u64,
 
         /// There may only be a single caller queued at a time, to ensure that the VSR protocol is
@@ -1044,6 +1039,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 staging.storage_size += address * constants.block_size;
             }
             assert(staging.storage_size >= data_file_size_min);
+            maybe(staging.storage_size_max > superblock.storage_size_limit);
             assert(staging.storage_size <= staging.storage_size_max);
             assert(staging.storage_size <= superblock.storage_size_limit);
 
@@ -1124,7 +1120,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 offset,
             });
 
-            superblock.assert_bounds(offset, buffer.len);
+            SuperBlock.assert_bounds(offset, buffer.len);
 
             if (buffer.len == 0) {
                 write_trailer_callback(&context.write);
@@ -1185,7 +1181,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 offset,
             });
 
-            superblock.assert_bounds(offset, buffer.len);
+            SuperBlock.assert_bounds(offset, buffer.len);
 
             superblock.storage.write_sectors(
                 write_header_callback,
@@ -1262,7 +1258,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 offset,
             });
 
-            superblock.assert_bounds(offset, buffer.len);
+            SuperBlock.assert_bounds(offset, buffer.len);
 
             superblock.storage.read_sectors(
                 read_header_callback,
@@ -1377,6 +1373,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         header.checksum,
                     });
                 }
+                assert(superblock.working.storage_size <= superblock.storage_size_limit);
+                maybe(superblock.working.storage_size_max > superblock.storage_size_limit);
 
                 if (context.caller == .open) {
                     if (context.repairs) |_| {
@@ -1428,7 +1426,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 offset,
             });
 
-            superblock.assert_bounds(offset, buffer.len);
+            SuperBlock.assert_bounds(offset, buffer.len);
 
             if (buffer.len == 0) {
                 read_trailer_callback(&context.read);
@@ -1620,9 +1618,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
             context.callback(context);
         }
 
-        fn assert_bounds(superblock: *SuperBlock, offset: u64, size: u64) void {
-            assert(offset >= superblock.storage_offset);
-            assert(offset + size <= superblock.storage_offset + superblock.storage_size);
+        fn assert_bounds(offset: u64, size: u64) void {
+            assert(offset + size <= superblock_zone_size);
         }
 
         /// We use flexible quorums for even quorums with write quorum > read quorum, for example:


### PR DESCRIPTION
- remove `SuperBlock.storage_size` which can be confused with `SuperBlockHeader.storage_size` and is a comptime constant anyway.

  The former is the size of the supreblock itself, the latter is the size of the entire datafile.

- remove `SuperBlock.storage_offset` for the same reason.

- Add docs and maybes to `SuperBlock.storage_size_limit`. After removal of the other two sizes, it is much less confusing, but extra clarification wouldn't hurt!

I was soooo confused by `storage_size` until I realized there are two different ones! 