### PR TITLE
VSR: Change cluster id from u32 to u128

### DIFF
--- a/docs/design/client-requests.md
+++ b/docs/design/client-requests.md
@@ -24,10 +24,10 @@ In the default configuration, the batch sizes are:
 
 | Operation          | Batch Size |
 | ------------------ | ---------: |
-| `lookup_accounts`  | 8191       |
-| `lookup_transfers` | 8191       |
-| `create_accounts`  | 8191       |
-| `create_transfers` | 8191       |
+| `lookup_accounts`  | 8190       |
+| `lookup_transfers` | 8190       |
+| `create_accounts`  | 8190       |
+| `create_transfers` | 8190       |
 
 Presently the client application is responsible for batching events, but only as a stopgap
 because this has not yet been implemented within the clients themselves.

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -105,7 +105,7 @@ pub fn main() !void {
     );
 
     const client_id = std.crypto.random.int(u128);
-    const cluster_id: u32 = 0;
+    const cluster_id: u128 = 0;
 
     var io = try IO.init(32, 0);
 

--- a/src/clients/c/samples/main.c
+++ b/src/clients/c/samples/main.c
@@ -15,7 +15,7 @@
 #include "../tb_client.h"
 
 // config.message_size_max - @sizeOf(vsr.Header):
-#define MAX_MESSAGE_SIZE (1024 * 1024) - 128
+#define MAX_MESSAGE_SIZE (1024 * 1024) - 256
 
 // Synchronization context between the callback and the main thread.
 typedef struct completion_context {

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -201,7 +201,7 @@ typedef enum TB_STATUS {
 
 TB_STATUS tb_client_init(
     tb_client_t* out_client,
-    uint32_t cluster_id,
+    tb_uint128_t cluster_id,
     const char* address_ptr,
     uint32_t address_len,
     uint32_t packets_count,
@@ -211,7 +211,7 @@ TB_STATUS tb_client_init(
 
 TB_STATUS tb_client_init_echo(
     tb_client_t* out_client,
-    uint32_t cluster_id,
+    tb_uint128_t cluster_id,
     const char* address_ptr,
     uint32_t address_len,
     uint32_t packets_count,

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -67,7 +67,7 @@ pub fn init_error_to_status(err: InitError) tb_status_t {
 
 pub fn init(
     allocator: std.mem.Allocator,
-    cluster_id: u32,
+    cluster_id: u128,
     addresses: []const u8,
     packets_count: u32,
     on_completion_ctx: usize,
@@ -87,7 +87,7 @@ pub fn init(
 
 pub fn init_echo(
     allocator: std.mem.Allocator,
-    cluster_id: u32,
+    cluster_id: u128,
     addresses: []const u8,
     packets_count: u32,
     on_completion_ctx: usize,

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -105,7 +105,7 @@ pub fn ContextType(
 
         pub fn init(
             allocator: std.mem.Allocator,
-            cluster_id: u32,
+            cluster_id: u128,
             addresses: []const u8,
             concurrency_max: u32,
             completion_ctx: usize,
@@ -162,7 +162,7 @@ pub fn ContextType(
             context.message_pool = try MessagePool.init(allocator, .client);
             errdefer context.message_pool.deinit(context.allocator);
 
-            log.debug("{}: init: initializing client (cluster_id={}, addresses={any})", .{
+            log.debug("{}: init: initializing client (cluster_id={x:0>32}, addresses={any})", .{
                 context.client_id,
                 cluster_id,
                 context.addresses,

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -36,7 +36,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
         pub fn init(
             allocator: mem.Allocator,
             id: u128,
-            cluster: u32,
+            cluster: u128,
             replica_count: u8,
             message_pool: *MessagePool,
             message_bus_options: MessageBus.Options,

--- a/src/clients/c/tb_client_exports.zig
+++ b/src/clients/c/tb_client_exports.zig
@@ -18,7 +18,7 @@ comptime {
 
 fn init(
     out_client: *tb.tb_client_t,
-    cluster_id: u32,
+    cluster_id: u128,
     addresses_ptr: [*:0]const u8,
     addresses_len: u32,
     packets_count: u32,
@@ -41,7 +41,7 @@ fn init(
 
 fn init_echo(
     out_client: *tb.tb_client_t,
-    cluster_id: u32,
+    cluster_id: u128,
     addresses_ptr: [*:0]const u8,
     addresses_len: u32,
     packets_count: u32,

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -189,7 +189,7 @@ pub fn main() !void {
     try buffer.writer().print(
         \\TB_STATUS tb_client_init(
         \\    tb_client_t* out_client,
-        \\    uint32_t cluster_id,
+        \\    tb_uint128_t cluster_id,
         \\    const char* address_ptr,
         \\    uint32_t address_len,
         \\    uint32_t packets_count,
@@ -199,7 +199,7 @@ pub fn main() !void {
         \\
         \\TB_STATUS tb_client_init_echo(
         \\    tb_client_t* out_client,
-        \\    uint32_t cluster_id,
+        \\    tb_uint128_t cluster_id,
         \\    const char* address_ptr,
         \\    uint32_t address_len,
         \\    uint32_t packets_count,

--- a/src/clients/docs_generate.zig
+++ b/src/clients/docs_generate.zig
@@ -590,7 +590,7 @@ const Generator = struct {
             \\potential. Instead, **always batch what you can**.
             \\
             \\The maximum batch size is set in the TigerBeetle server. The default
-            \\is 8191.
+            \\is 8190.
         );
         mw.code(language.markdown_name, language.batch_example);
 

--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -84,7 +84,7 @@ environment variable and defaults to port `3000`.
 ```cs
 var tbAddress = Environment.GetEnvironmentVariable("TB_ADDRESS");
 var client = new Client(
-  clusterID: 0,
+  clusterID: UInt128.Zero,
   addresses: new[] {tbAddress != null ? tbAddress : "3000"}
 );
 ```

--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -265,10 +265,10 @@ But the insert rate will be a *fraction* of
 potential. Instead, **always batch what you can**.
 
 The maximum batch size is set in the TigerBeetle server. The default
-is 8191.
+is 8190.
 
 ```cs
-var BATCH_SIZE = 8191;
+var BATCH_SIZE = 8190;
 for (int i = 0; i < transfers.Length; i += BATCH_SIZE) {
   var batchSize = BATCH_SIZE;
   if (i + BATCH_SIZE > transfers.Length) {

--- a/src/clients/dotnet/TigerBeetle.Benchmarks/Benchmark.cs
+++ b/src/clients/dotnet/TigerBeetle.Benchmarks/Benchmark.cs
@@ -12,7 +12,7 @@ namespace TigerBeetle.Benchmarks
     {
         private const bool IS_ASYNC = false;
         private const int BATCHES_COUNT = 100;
-        private const int MAX_MESSAGE_SIZE = (1024 * 1024) - 128; // config.message_size_max - @sizeOf(vsr.Header)
+        private const int MAX_MESSAGE_SIZE = (1024 * 1024) - 256; // config.message_size_max - @sizeOf(vsr.Header)
         private const int TRANSFERS_PER_BATCH = (MAX_MESSAGE_SIZE / Transfer.SIZE);
         private const int MAX_TRANSFERS = BATCHES_COUNT * TRANSFERS_PER_BATCH;
 

--- a/src/clients/dotnet/TigerBeetle.Tests/EchoTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/EchoTests.cs
@@ -11,7 +11,7 @@ namespace TigerBeetle.Tests
     [TestClass]
     public class EchoTests
     {
-        private const int HEADER_SIZE = 128; // @sizeOf(vsr.Header)
+        private const int HEADER_SIZE = 256; // @sizeOf(vsr.Header)
         private const int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
         private static readonly int TRANSFER_SIZE = Marshal.SizeOf(typeof(Transfer));
         private static readonly int ITEMS_PER_BATCH = (MESSAGE_SIZE_MAX - HEADER_SIZE) / TRANSFER_SIZE;

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -779,7 +779,7 @@ namespace TigerBeetle
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern InitializationStatus tb_client_init(
             IntPtr* out_client,
-            uint cluster_id,
+            UInt128 cluster_id,
             byte* address_ptr,
             uint address_len,
             uint num_packets,
@@ -796,7 +796,7 @@ namespace TigerBeetle
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern InitializationStatus tb_client_init_echo(
             IntPtr* out_client,
-            uint cluster_id,
+            UInt128 cluster_id,
             byte* address_ptr,
             uint address_len,
             uint num_packets,

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -779,7 +779,7 @@ namespace TigerBeetle
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern InitializationStatus tb_client_init(
             IntPtr* out_client,
-            UInt128 cluster_id,
+            UInt128Extensions.UnsafeU128 cluster_id,
             byte* address_ptr,
             uint address_len,
             uint num_packets,
@@ -796,7 +796,7 @@ namespace TigerBeetle
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern InitializationStatus tb_client_init_echo(
             IntPtr* out_client,
-            UInt128 cluster_id,
+            UInt128Extensions.UnsafeU128 cluster_id,
             byte* address_ptr,
             uint address_len,
             uint num_packets,

--- a/src/clients/dotnet/TigerBeetle/Client.cs
+++ b/src/clients/dotnet/TigerBeetle/Client.cs
@@ -11,10 +11,10 @@ namespace TigerBeetle
     {
         private const int DEFAULT_CONCURRENCY_MAX = 32;
 
-        private readonly uint clusterID;
+        private readonly UInt128 clusterID;
         private readonly NativeClient nativeClient;
 
-        public Client(uint clusterID, string[] addresses, int concurrencyMax = DEFAULT_CONCURRENCY_MAX)
+        public Client(UInt128 clusterID, string[] addresses, int concurrencyMax = DEFAULT_CONCURRENCY_MAX)
         {
             this.nativeClient = NativeClient.Init(clusterID, addresses, concurrencyMax);
             this.clusterID = clusterID;
@@ -29,7 +29,7 @@ namespace TigerBeetle
             }
         }
 
-        public uint ClusterID => clusterID;
+        public UInt128 ClusterID => clusterID;
 
         public CreateAccountResult CreateAccount(Account account)
         {

--- a/src/clients/dotnet/TigerBeetle/EchoClient.cs
+++ b/src/clients/dotnet/TigerBeetle/EchoClient.cs
@@ -8,7 +8,7 @@ namespace TigerBeetle
     {
         private readonly NativeClient nativeClient;
 
-        public EchoClient(uint clusterID, string[] addresses, int concurrencyMax)
+        public EchoClient(UInt128 clusterID, string[] addresses, int concurrencyMax)
         {
             this.nativeClient = NativeClient.InitEcho(clusterID, addresses, concurrencyMax);
         }

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -14,7 +14,7 @@ namespace TigerBeetle
 
         private unsafe delegate InitializationStatus InitFunction(
                     IntPtr* out_client,
-                    UInt128 cluster_id,
+                    UInt128Extensions.UnsafeU128 cluster_id,
                     byte* address_ptr,
                     uint address_len,
                     uint num_packets,
@@ -58,7 +58,7 @@ namespace TigerBeetle
             }
         }
 
-        private static NativeClient CallInit(InitFunction initFunction, UInt128 clusterID, string[] addresses, int concurrencyMax)
+        private static NativeClient CallInit(InitFunction initFunction, UInt128Extensions.UnsafeU128 clusterID, string[] addresses, int concurrencyMax)
         {
             if (concurrencyMax <= 0) throw new ArgumentOutOfRangeException(nameof(concurrencyMax), "Concurrency must be positive");
 

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -14,7 +14,7 @@ namespace TigerBeetle
 
         private unsafe delegate InitializationStatus InitFunction(
                     IntPtr* out_client,
-                    uint cluster_id,
+                    UInt128 cluster_id,
                     byte* address_ptr,
                     uint address_len,
                     uint num_packets,
@@ -42,7 +42,7 @@ namespace TigerBeetle
             return Encoding.UTF8.GetBytes(string.Join(',', addresses) + "\0");
         }
 
-        public static NativeClient Init(uint clusterID, string[] addresses, int concurrencyMax)
+        public static NativeClient Init(UInt128 clusterID, string[] addresses, int concurrencyMax)
         {
             unsafe
             {
@@ -50,7 +50,7 @@ namespace TigerBeetle
             }
         }
 
-        public static NativeClient InitEcho(uint clusterID, string[] addresses, int concurrencyMax)
+        public static NativeClient InitEcho(UInt128 clusterID, string[] addresses, int concurrencyMax)
         {
             unsafe
             {
@@ -58,7 +58,7 @@ namespace TigerBeetle
             }
         }
 
-        private static NativeClient CallInit(InitFunction initFunction, uint clusterID, string[] addresses, int concurrencyMax)
+        private static NativeClient CallInit(InitFunction initFunction, UInt128 clusterID, string[] addresses, int concurrencyMax)
         {
             if (concurrencyMax <= 0) throw new ArgumentOutOfRangeException(nameof(concurrencyMax), "Concurrency must be positive");
 

--- a/src/clients/dotnet/TigerBeetle/UInt128.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128.cs
@@ -13,6 +13,22 @@ namespace TigerBeetle
     /// </summary>
     public static class UInt128Extensions
     {
+        /// <summary>
+        /// Unsafe representation of a tb_uint128_t used only internally
+        /// for P/Invove in methods marked with the [DllImport] attribute.
+        /// It's necessary only because P/Invoke's marshaller does not support System.UInt128.
+        /// </summary>
+        [StructLayout(LayoutKind.Explicit, Size = SIZE)]
+        internal unsafe struct UnsafeU128 {
+            [FieldOffset(0)]
+            fixed byte raw[SIZE];
+
+            /// <summary>
+            /// Reinterprets memory, casting the managed UInt128 directly to the unsafe representation.
+            /// </summary>
+            public static implicit operator UnsafeU128(UInt128 value) => *(UnsafeU128*)&value;
+        }
+
         internal const int SIZE = 16;
 
         public static Guid ToGuid(this UInt128 value)

--- a/src/clients/dotnet/TigerBeetle/UInt128.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128.cs
@@ -19,7 +19,8 @@ namespace TigerBeetle
         /// It's necessary only because P/Invoke's marshaller does not support System.UInt128.
         /// </summary>
         [StructLayout(LayoutKind.Explicit, Size = SIZE)]
-        internal unsafe struct UnsafeU128 {
+        internal unsafe struct UnsafeU128
+        {
             [FieldOffset(0)]
             fixed byte raw[SIZE];
 

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -71,9 +71,10 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 \\dotnet add package tigerbeetle --source /host > /dev/null
                 \\cat <<EOF > Program.cs
                 \\using System;
+                \\using TigerBeetle;
                 \\public class Program {
                 \\  public static void Main() {
-                \\    new TigerBeetle.Client(0, new [] {"3001"}).Dispose();
+                \\    new Client(UInt128.Zero, new [] {"3001"}).Dispose();
                 \\    Console.WriteLine("SUCCESS");
                 \\  }
                 \\}

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -325,7 +325,7 @@ pub const DotnetDocs = Docs{
     ,
 
     .batch_example =
-    \\var BATCH_SIZE = 8191;
+    \\var BATCH_SIZE = 8190;
     \\for (int i = 0; i < transfers.Length; i += BATCH_SIZE) {
     \\  var batchSize = BATCH_SIZE;
     \\  if (i + BATCH_SIZE > transfers.Length) {

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -202,7 +202,7 @@ pub const DotnetDocs = Docs{
     .client_object_example =
     \\var tbAddress = Environment.GetEnvironmentVariable("TB_ADDRESS");
     \\var client = new Client(
-    \\  clusterID: 0,
+    \\  clusterID: UInt128.Zero,
     \\  addresses: new[] {tbAddress != null ? tbAddress : "3000"}
     \\);
     ,

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -432,7 +432,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         \\        public static unsafe extern InitializationStatus tb_client_init(
         \\            IntPtr* out_client,
-        \\            uint cluster_id,
+        \\            UInt128 cluster_id,
         \\            byte* address_ptr,
         \\            uint address_len,
         \\            uint num_packets,
@@ -449,7 +449,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         \\        public static unsafe extern InitializationStatus tb_client_init_echo(
         \\            IntPtr* out_client,
-        \\            uint cluster_id,
+        \\            UInt128 cluster_id,
         \\            byte* address_ptr,
         \\            uint address_len,
         \\            uint num_packets,

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -432,7 +432,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         \\        public static unsafe extern InitializationStatus tb_client_init(
         \\            IntPtr* out_client,
-        \\            UInt128 cluster_id,
+        \\            UInt128Extensions.UnsafeU128 cluster_id,
         \\            byte* address_ptr,
         \\            uint address_len,
         \\            uint num_packets,
@@ -449,7 +449,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         \\        public static unsafe extern InitializationStatus tb_client_init_echo(
         \\            IntPtr* out_client,
-        \\            UInt128 cluster_id,
+        \\            UInt128Extensions.UnsafeU128 cluster_id,
         \\            byte* address_ptr,
         \\            uint address_len,
         \\            uint num_packets,

--- a/src/clients/dotnet/samples/basic/Program.cs
+++ b/src/clients/dotnet/samples/basic/Program.cs
@@ -5,7 +5,7 @@ using TigerBeetle;
 
 var tbAddress = Environment.GetEnvironmentVariable("TB_ADDRESS");
 using (var client = new Client(
-       clusterID: 0,
+       clusterID: UInt128.Zero,
        addresses: new[] { tbAddress != null ? tbAddress : "3000" }
        ))
 {

--- a/src/clients/dotnet/samples/two-phase-many/Program.cs
+++ b/src/clients/dotnet/samples/two-phase-many/Program.cs
@@ -5,7 +5,7 @@ using TigerBeetle;
 
 var tbAddress = Environment.GetEnvironmentVariable("TB_ADDRESS");
 using (var client = new Client(
-       clusterID: 0,
+       clusterID: UInt128.Zero,
        addresses: new[] { tbAddress != null ? tbAddress : "3000" }
        ))
 {

--- a/src/clients/dotnet/samples/two-phase/Program.cs
+++ b/src/clients/dotnet/samples/two-phase/Program.cs
@@ -5,7 +5,7 @@ using TigerBeetle;
 
 var tbAddress = Environment.GetEnvironmentVariable("TB_ADDRESS");
 using (var client = new Client(
-       clusterID: 0,
+       clusterID: UInt128.Zero,
        addresses: new[] { tbAddress != null ? tbAddress : "3000" }
        ))
 {

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -91,7 +91,7 @@ tbAddress := os.Getenv("TB_ADDRESS")
 if len(tbAddress) == 0 {
   tbAddress = "3000"
 }
-client, err := NewClient(0, []string{tbAddress}, 32)
+client, err := NewClient(ToUint128(0), []string{tbAddress}, 32)
 if err != nil {
 	log.Printf("Error creating client: %s", err)
 	return

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -298,10 +298,10 @@ But the insert rate will be a *fraction* of
 potential. Instead, **always batch what you can**.
 
 The maximum batch size is set in the TigerBeetle server. The default
-is 8191.
+is 8190.
 
 ```go
-BATCH_SIZE := 8191
+BATCH_SIZE := 8190
 for i := 0; i < len(transfers); i += BATCH_SIZE {
 	batch := BATCH_SIZE
 	if i + BATCH_SIZE > len(transfers) {

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -297,7 +297,7 @@ pub const GoDocs = Docs{
     ,
 
     .batch_example =
-    \\BATCH_SIZE := 8191
+    \\BATCH_SIZE := 8190
     \\for i := 0; i < len(transfers); i += BATCH_SIZE {
     \\	batch := BATCH_SIZE
     \\	if i + BATCH_SIZE > len(transfers) {

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -153,7 +153,7 @@ pub const GoDocs = Docs{
     \\if len(tbAddress) == 0 {
     \\  tbAddress = "3000"
     \\}
-    \\client, err := NewClient(0, []string{tbAddress}, 32)
+    \\client, err := NewClient(ToUint128(0), []string{tbAddress}, 32)
     \\if err != nil {
     \\	log.Printf("Error creating client: %s", err)
     \\	return

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -201,7 +201,7 @@ typedef enum TB_STATUS {
 
 TB_STATUS tb_client_init(
     tb_client_t* out_client,
-    uint32_t cluster_id,
+    tb_uint128_t cluster_id,
     const char* address_ptr,
     uint32_t address_len,
     uint32_t packets_count,
@@ -211,7 +211,7 @@ TB_STATUS tb_client_init(
 
 TB_STATUS tb_client_init_echo(
     tb_client_t* out_client,
-    uint32_t cluster_id,
+    tb_uint128_t cluster_id,
     const char* address_ptr,
     uint32_t address_len,
     uint32_t packets_count,

--- a/src/clients/go/samples/basic/main.go
+++ b/src/clients/go/samples/basic/main.go
@@ -24,7 +24,7 @@ func main() {
 		port = "3000"
 	}
 
-	client, err := NewClient(0, []string{port}, 32)
+	client, err := NewClient(ToUint128(0), []string{port}, 32)
 	if err != nil {
 		log.Fatalf("Error creating client: %s", err)
 	}

--- a/src/clients/go/samples/two-phase-many/main.go
+++ b/src/clients/go/samples/two-phase-many/main.go
@@ -57,7 +57,7 @@ func main() {
 		port = "3000"
 	}
 
-	client, err := NewClient(0, []string{port}, 32)
+	client, err := NewClient(ToUint128(0), []string{port}, 32)
 	if err != nil {
 		log.Fatalf("Error creating client: %s", err)
 	}

--- a/src/clients/go/samples/two-phase/main.go
+++ b/src/clients/go/samples/two-phase/main.go
@@ -24,7 +24,7 @@ func main() {
 		port = "3000"
 	}
 
-	client, err := NewClient(0, []string{port}, 32)
+	client, err := NewClient(ToUint128(0), []string{port}, 32)
 	if err != nil {
 		log.Fatalf("Error creating client: %s", err)
 	}

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -58,7 +58,7 @@ type c_client struct {
 }
 
 func NewClient(
-	clusterID uint32,
+	clusterID types.Uint128,
 	addresses []string,
 	concurrencyMax uint,
 ) (Client, error) {
@@ -72,7 +72,7 @@ func NewClient(
 	// Create the tb_client.
 	status := C.tb_client_init(
 		&tb_client,
-		C.uint32_t(clusterID),
+		C.tb_uint128_t(clusterID),
 		c_addresses,
 		C.uint32_t(len(addresses_raw)),
 		C.uint32_t(concurrencyMax),

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -71,7 +71,7 @@ func WithClient(s testing.TB, withClient func(Client)) {
 
 	addresses := []string{"127.0.0.1:" + TIGERBEETLE_PORT}
 	concurrencyMax := uint(32)
-	client, err := NewClient(TIGERBEETLE_CLUSTER_ID, addresses, concurrencyMax)
+	client, err := NewClient(ToUint128(TIGERBEETLE_CLUSTER_ID), addresses, concurrencyMax)
 	if err != nil {
 		s.Fatal(err)
 	}

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -133,7 +133,7 @@ environment variable and defaults to port `3000`.
 
 ```java
 var replicaAddress = System.getenv("TB_ADDRESS");
-int clusterID = 0;
+byte[] clusterID = UInt128.asBytes(0);
 String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
 Client client = new Client(
   clusterID,

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -363,10 +363,10 @@ But the insert rate will be a *fraction* of
 potential. Instead, **always batch what you can**.
 
 The maximum batch size is set in the TigerBeetle server. The default
-is 8191.
+is 8190.
 
 ```java
-var BATCH_SIZE = 8191;
+var BATCH_SIZE = 8190;
 for (int i = 0; i < transferIds.length; i += BATCH_SIZE) {
   TransferBatch batch = new TransferBatch(BATCH_SIZE);
 

--- a/src/clients/java/docs.zig
+++ b/src/clients/java/docs.zig
@@ -393,7 +393,7 @@ pub const JavaDocs = Docs{
     ,
 
     .batch_example =
-    \\var BATCH_SIZE = 8191;
+    \\var BATCH_SIZE = 8190;
     \\for (int i = 0; i < transferIds.length; i += BATCH_SIZE) {
     \\  TransferBatch batch = new TransferBatch(BATCH_SIZE);
     \\

--- a/src/clients/java/docs.zig
+++ b/src/clients/java/docs.zig
@@ -221,7 +221,7 @@ pub const JavaDocs = Docs{
 
     .client_object_example =
     \\var replicaAddress = System.getenv("TB_ADDRESS");
-    \\int clusterID = 0;
+    \\byte[] clusterID = UInt128.asBytes(0);
     \\String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
     \\Client client = new Client(
     \\  clusterID,

--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -561,7 +561,7 @@ fn emit_batch_accessors(
     }
 }
 
-// We offer multiple APIs for dealing with Uint128 in Java:
+// We offer multiple APIs for dealing with UInt128 in Java:
 // - A byte array, heap-allocated, for ids and user_data;
 // - A BigInteger, heap-allocated, for balances and amounts;
 // - Two 64-bit integers (long), stack-allocated, for both cases;

--- a/src/clients/java/samples/basic/src/main/java/Main.java
+++ b/src/clients/java/samples/basic/src/main/java/Main.java
@@ -10,7 +10,7 @@ public final class Main {
 			throws RequestException, ConcurrencyExceededException {
 		String replicaAddress = System.getenv("TB_ADDRESS");
 
-		int clusterID = 0;
+		byte[] clusterID = UInt128.asBytes(0);
 		String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
 		try (var client = new Client(clusterID, replicaAddresses)) {
 			// Create two accounts

--- a/src/clients/java/samples/two-phase-many/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase-many/src/main/java/Main.java
@@ -10,7 +10,7 @@ public final class Main {
 			throws RequestException, ConcurrencyExceededException {
 		String replicaAddress = System.getenv("TB_ADDRESS");
 
-		int clusterID = 0;
+		byte[] clusterID = UInt128.asBytes(0);
 		String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
 		try (var client = new Client(clusterID, replicaAddresses)) {
 			// Create two accounts

--- a/src/clients/java/samples/two-phase/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase/src/main/java/Main.java
@@ -11,7 +11,7 @@ public final class Main {
 			throws RequestException, ConcurrencyExceededException {
 		String replicaAddress = System.getenv("TB_ADDRESS");
 
-		int clusterID = 0;
+		byte[] clusterID = UInt128.asBytes(0);
 		String[] replicaAddresses = new String[] {replicaAddress == null ? "3000" : replicaAddress};
 		try (var client = new Client(clusterID, replicaAddresses)) {
 			// Create two accounts

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -48,7 +48,7 @@ const NativeClient = struct {
     fn client_init(
         comptime echo_client: bool,
         env: *jni.JNIEnv,
-        cluster_id: u32,
+        cluster_id: u128,
         addresses_obj: jni.JString,
         max_concurrency: u32,
     ) ?*Context {
@@ -194,15 +194,20 @@ comptime {
         fn client_init(
             env: *jni.JNIEnv,
             class: jni.JClass,
-            cluster_id: jni.JInt,
+            cluster_id: jni.JByteArray,
             addresses: jni.JString,
             max_concurrency: jni.JInt,
         ) callconv(jni.JNICALL) jni.JLong {
             _ = class;
+            assert(env.get_array_length(cluster_id) == 16);
+
+            const cluster_id_elements = env.get_byte_array_elements(cluster_id, null).?;
+            defer env.release_byte_array_elements(cluster_id, cluster_id_elements, .abort);
+
             var context = NativeClient.client_init(
                 false,
                 env,
-                @as(u32, @bitCast(cluster_id)),
+                @as(u128, @bitCast(cluster_id_elements[0..16].*)),
                 addresses,
                 @as(u32, @bitCast(max_concurrency)),
             );
@@ -212,15 +217,20 @@ comptime {
         fn client_init_echo(
             env: *jni.JNIEnv,
             class: jni.JClass,
-            cluster_id: jni.JInt,
+            cluster_id: jni.JByteArray,
             addresses: jni.JString,
             max_concurrency: jni.JInt,
         ) callconv(jni.JNICALL) jni.JLong {
             _ = class;
+            assert(env.get_array_length(cluster_id) == 16);
+
+            const cluster_id_elements = env.get_byte_array_elements(cluster_id, null).?;
+            defer env.release_byte_array_elements(cluster_id, cluster_id_elements, .abort);
+
             var context = NativeClient.client_init(
                 true,
                 env,
-                @as(u32, @bitCast(cluster_id)),
+                @as(u128, @bitCast(cluster_id_elements[0..16].*)),
                 addresses,
                 @as(u32, @bitCast(max_concurrency)),
             );

--- a/src/clients/java/src/main/java/benchmark/Benchmark.java
+++ b/src/clients/java/src/main/java/benchmark/Benchmark.java
@@ -39,7 +39,7 @@ public class Benchmark {
                 return;
             }
 
-            final int HEADER_SIZE = 128; // @sizeOf(vsr.Header)
+            final int HEADER_SIZE = 256; // @sizeOf(vsr.Header)
             final int TRANSFER_SIZE = 128; // @sizeOf(Transfer)
             final int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
 

--- a/src/clients/java/src/main/java/benchmark/Benchmark.java
+++ b/src/clients/java/src/main/java/benchmark/Benchmark.java
@@ -6,7 +6,7 @@ import com.tigerbeetle.*;
 public class Benchmark {
 
     public static void main(String[] args) {
-        try (var client = new Client(0, new String[] {"127.0.0.1:3001"})) {
+        try (var client = new Client(UInt128.asBytes(0), new String[] {"127.0.0.1:3001"})) {
 
             var accounts = new AccountBatch(2);
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/Client.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Client.java
@@ -8,7 +8,7 @@ public final class Client implements AutoCloseable {
 
     private static final int DEFAULT_MAX_CONCURRENCY = 32;
 
-    private final int clusterID;
+    private final byte[] clusterID;
     private final NativeClient nativeClient;
 
     /**
@@ -25,16 +25,19 @@ public final class Client implements AutoCloseable {
      * @throws InitializationException if an error occurred initializing this client. See
      *         {@link InitializationStatus} for more details.
      *
-     * @throws IllegalArgumentException if {@code clusterID} is negative.
+     * @throws NullPointerException if {@code clusterID} is null.
+     * @throws IllegalArgumentException if {@code clusterID} is not a UInt128.
      * @throws IllegalArgumentException if {@code replicaAddresses} is empty or presented in
      *         incorrect format.
      * @throws NullPointerException if {@code replicaAddresses} is null or any element in the array
      *         is null.
      * @throws IllegalArgumentException if {@code concurrencyMax} is zero or negative.
      */
-    public Client(final int clusterID, final String[] replicaAddresses, final int concurrencyMax) {
-        if (clusterID < 0)
-            throw new IllegalArgumentException("ClusterID must be positive");
+    public Client(final byte[] clusterID, final String[] replicaAddresses,
+            final int concurrencyMax) {
+        Objects.requireNonNull(clusterID, "ClusterID cannot be null");
+        if (clusterID.length != UInt128.SIZE)
+            throw new IllegalArgumentException("ClusterID must be 16 bytes long");
 
         if (concurrencyMax <= 0)
             throw new IllegalArgumentException("Invalid concurrencyMax");
@@ -73,7 +76,7 @@ public final class Client implements AutoCloseable {
      * @throws NullPointerException if {@code replicaAddresses} is null or any element in the array
      *         is null.
      */
-    public Client(final int clusterID, final String[] replicaAddresses) {
+    public Client(final byte[] clusterID, final String[] replicaAddresses) {
         this(clusterID, replicaAddresses, DEFAULT_MAX_CONCURRENCY);
     }
 
@@ -82,7 +85,7 @@ public final class Client implements AutoCloseable {
      *
      * @return clusterID
      */
-    public int getClusterID() {
+    public byte[] getClusterID() {
         return clusterID;
     }
 
@@ -97,7 +100,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public CreateAccountResultBatch createAccounts(final AccountBatch batch)
@@ -117,7 +120,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public CompletableFuture<CreateAccountResultBatch> createAccountsAsync(final AccountBatch batch)
@@ -136,7 +139,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public AccountBatch lookupAccounts(final IdBatch batch)
@@ -155,7 +158,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public CompletableFuture<AccountBatch> lookupAccountsAsync(final IdBatch batch)
@@ -176,7 +179,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public CreateTransferResultBatch createTransfers(final TransferBatch batch)
@@ -195,7 +198,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public CompletableFuture<CreateTransferResultBatch> createTransfersAsync(
@@ -215,7 +218,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public TransferBatch lookupTransfers(final IdBatch batch)
@@ -234,7 +237,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalArgumentException if {@code batch} is empty.
      * @throws NullPointerException if {@code batch} is null.
      * @throws ConcurrencyExceededException if there are more concurrent requests than defined at
-     *         {@link #Client(int, String[], int) concurrencyMax} parameter.
+     *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
     public CompletableFuture<TransferBatch> lookupTransfersAsync(final IdBatch batch)

--- a/src/clients/java/src/main/java/com/tigerbeetle/EchoClient.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/EchoClient.java
@@ -6,7 +6,7 @@ public final class EchoClient implements AutoCloseable {
 
     private final NativeClient nativeClient;
 
-    public EchoClient(final int clusterID, final String replicaAddresses,
+    public EchoClient(final byte[] clusterID, final String replicaAddresses,
             final int concurrencyMax) {
         this.nativeClient = NativeClient.initEcho(clusterID, replicaAddresses, concurrencyMax);
     }

--- a/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
@@ -9,23 +9,23 @@ final class NativeClient {
 
     private volatile long contextHandle;
 
-    public static NativeClient init(final int clusterID, final String addresses,
+    public static NativeClient init(final byte[] clusterID, final String addresses,
             final int concurrencyMax) {
         assertArgs(clusterID, addresses, concurrencyMax);
         final long contextHandle = clientInit(clusterID, addresses, concurrencyMax);
         return new NativeClient(contextHandle);
     }
 
-    public static NativeClient initEcho(final int clusterID, final String addresses,
+    public static NativeClient initEcho(final byte[] clusterID, final String addresses,
             final int concurrencyMax) {
         assertArgs(clusterID, addresses, concurrencyMax);
         final long contextHandle = clientInitEcho(clusterID, addresses, concurrencyMax);
         return new NativeClient(contextHandle);
     }
 
-    private static void assertArgs(final int clusterID, final String addresses,
+    private static void assertArgs(final byte[] clusterID, final String addresses,
             final int concurrencyMax) {
-        assertTrue(clusterID >= 0, "ClusterID must be positive");
+        assertTrue(clusterID.length == 16, "ClusterID must be a UInt128");
         assertTrue(addresses != null, "Replica addresses cannot be null");
         assertTrue(concurrencyMax > 0, "Invalid concurrencyMax");
     }
@@ -63,9 +63,10 @@ final class NativeClient {
 
     private static native int submit(long contextHandle, Request<?> request);
 
-    private static native long clientInit(int clusterID, String addresses, int concurrencyMax);
+    private static native long clientInit(byte[] clusterID, String addresses, int concurrencyMax);
 
-    private static native long clientInitEcho(int clusterID, String addresses, int concurrencyMax);
+    private static native long clientInitEcho(byte[] clusterID, String addresses,
+            int concurrencyMax);
 
     private static native void clientDeinit(long contextHandle);
 }

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -545,7 +545,7 @@ public class AsyncRequestTest {
     }
 
     private static NativeClient getDummyClient() {
-        return NativeClient.initEcho(0, "3000", 1);
+        return NativeClient.initEcho(UInt128.asBytes(0), "3000", 1);
     }
 
     private class CallbackSimulator<T extends Batch> extends Thread {

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -455,7 +455,7 @@ public class BlockingRequestTest {
     }
 
     private static NativeClient getDummyClient() {
-        return NativeClient.initEcho(0, "3000", 1);
+        return NativeClient.initEcho(UInt128.asBytes(0), "3000", 1);
     }
 
     private class CallbackSimulator<T extends Batch> extends Thread {

--- a/src/clients/java/src/test/java/com/tigerbeetle/EchoTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/EchoTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 public class EchoTest {
 
-    static final int HEADER_SIZE = 128; // @sizeOf(vsr.Header)
+    static final int HEADER_SIZE = 256; // @sizeOf(vsr.Header)
     static final int TRANSFER_SIZE = 128; // @sizeOf(Transfer)
     static final int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
     static final int ITEMS_PER_BATCH = (MESSAGE_SIZE_MAX - HEADER_SIZE) / TRANSFER_SIZE;

--- a/src/clients/java/src/test/java/com/tigerbeetle/EchoTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/EchoTest.java
@@ -24,7 +24,7 @@ public class EchoTest {
     @Test(expected = AssertionError.class)
     public void testConstructorNullReplicaAddresses() throws Throwable {
 
-        try (var client = new EchoClient(0, null, 1)) {
+        try (var client = new EchoClient(UInt128.asBytes(0), null, 1)) {
 
         } catch (Throwable any) {
             throw any;
@@ -32,8 +32,9 @@ public class EchoTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testConstructorNegativeCluster() throws Throwable {
-        try (var client = new EchoClient(-1, "3000", 1)) {
+    public void testConstructorInvalidCluster() throws Throwable {
+        var clusterInvalid = new byte[] {1, 2, 3};
+        try (var client = new EchoClient(clusterInvalid, "3000", 1)) {
 
         } catch (Throwable any) {
             throw any;
@@ -42,7 +43,7 @@ public class EchoTest {
 
     @Test(expected = AssertionError.class)
     public void testConstructorNegativeConcurrencyMax() throws Throwable {
-        try (var client = new EchoClient(0, "3000", -1)) {
+        try (var client = new EchoClient(UInt128.asBytes(0), "3000", -1)) {
 
         } catch (Throwable any) {
             throw any;
@@ -53,7 +54,7 @@ public class EchoTest {
     public void testEchoAccounts() throws Throwable {
         final Random rnd = new Random(1);
 
-        try (var client = new EchoClient(0, "3000", 32)) {
+        try (var client = new EchoClient(UInt128.asBytes(0), "3000", 32)) {
             final var batch = new AccountBatch(getRandomData(rnd, AccountBatch.Struct.SIZE));
             final var reply = client.echo(batch);
             assertBatchesEqual(batch, reply);
@@ -64,7 +65,7 @@ public class EchoTest {
     public void testEchoTransfers() throws Throwable {
         final Random rnd = new Random(2);
 
-        try (var client = new EchoClient(0, "3000", 32)) {
+        try (var client = new EchoClient(UInt128.asBytes(0), "3000", 32)) {
             final var batch = new TransferBatch(getRandomData(rnd, TransferBatch.Struct.SIZE));
             final var future = client.echoAsync(batch);
             final var reply = future.join();
@@ -81,7 +82,7 @@ public class EchoTest {
         };
 
         final Random rnd = new Random(3);
-        try (var client = new EchoClient(0, "3000", concurrencyMax)) {
+        try (var client = new EchoClient(UInt128.asBytes(0), "3000", concurrencyMax)) {
             for (int repetition = 0; repetition < repetitionsMax; repetition++) {
 
                 final var list = new ArrayList<AsyncContext>();
@@ -141,7 +142,7 @@ public class EchoTest {
         }
 
         final Random rnd = new Random(4);
-        try (var client = new EchoClient(0, "3000", concurrencyMax)) {
+        try (var client = new EchoClient(UInt128.asBytes(0), "3000", concurrencyMax)) {
             for (int repetition = 0; repetition < repetitionsMax; repetition++) {
 
                 final var list = new ArrayList<ThreadContext>();

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -27,12 +27,14 @@ public class IntegrationTest {
     private static final AccountBatch accounts;
     private static final IdBatch accountIds;
 
+    private static final byte[] clusterId;
     private static final byte[] account1Id;
     private static final byte[] account2Id;
     private static final byte[] transfer1Id;
     private static final byte[] transfer2Id;
 
     static {
+        clusterId = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
         account1Id = new byte[] {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
@@ -71,7 +73,7 @@ public class IntegrationTest {
     @Test(expected = NullPointerException.class)
     public void testConstructorNullReplicaAddresses() throws Throwable {
 
-        try (var client = new Client(0, null)) {
+        try (var client = new Client(clusterId, null)) {
 
         } catch (Throwable any) {
             throw any;
@@ -82,7 +84,7 @@ public class IntegrationTest {
     public void testConstructorNullElementReplicaAddresses() throws Throwable {
 
         var replicaAddresses = new String[] {"3001", null};
-        try (var client = new Client(0, replicaAddresses)) {
+        try (var client = new Client(clusterId, replicaAddresses)) {
 
         } catch (Throwable any) {
             throw any;
@@ -93,7 +95,7 @@ public class IntegrationTest {
     public void testConstructorEmptyReplicaAddresses() throws Throwable {
 
         var replicaAddresses = new String[0];
-        try (var client = new Client(0, replicaAddresses)) {
+        try (var client = new Client(clusterId, replicaAddresses)) {
 
         } catch (Throwable any) {
             throw any;
@@ -106,7 +108,7 @@ public class IntegrationTest {
         for (int i = 0; i < replicaAddresses.length; i++)
             replicaAddresses[i] = "3000";
 
-        try (var client = new Client(0, replicaAddresses)) {
+        try (var client = new Client(clusterId, replicaAddresses)) {
             assert false;
         } catch (InitializationException initializationException) {
             assertEquals(InitializationStatus.AddressLimitExceeded.value,
@@ -117,7 +119,7 @@ public class IntegrationTest {
     @Test
     public void testConstructorEmptyStringReplicaAddresses() throws Throwable {
         var replicaAddresses = new String[] {"", "", ""};
-        try (var client = new Client(0, replicaAddresses)) {
+        try (var client = new Client(clusterId, replicaAddresses)) {
             assert false;
         } catch (InitializationException initializationException) {
             assertEquals(InitializationStatus.AddressInvalid.value,
@@ -129,7 +131,7 @@ public class IntegrationTest {
     public void testConstructorInvalidReplicaAddresses() throws Throwable {
 
         var replicaAddresses = new String[] {"127.0.0.1:99999"};
-        try (var client = new Client(0, replicaAddresses)) {
+        try (var client = new Client(clusterId, replicaAddresses)) {
             assert false;
         } catch (InitializationException initializationException) {
             assertEquals(InitializationStatus.AddressInvalid.value,
@@ -138,10 +140,11 @@ public class IntegrationTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testConstructorNegativeCluster() throws Throwable {
+    public void testConstructorInvalidCluster() throws Throwable {
 
+        var clusterIdInvalid = new byte[] {0, 0, 0};
         var replicaAddresses = new String[] {"3001"};
-        try (var client = new Client(-1, replicaAddresses)) {
+        try (var client = new Client(clusterIdInvalid, replicaAddresses)) {
 
         } catch (Throwable any) {
             throw any;
@@ -153,7 +156,7 @@ public class IntegrationTest {
 
         var replicaAddresses = new String[] {"3001"};
         var concurrencyMax = -1;
-        try (var client = new Client(0, replicaAddresses, concurrencyMax)) {
+        try (var client = new Client(clusterId, replicaAddresses, concurrencyMax)) {
 
         } catch (Throwable any) {
             throw any;
@@ -164,7 +167,7 @@ public class IntegrationTest {
     public void testCreateAccounts() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 accounts.beforeFirst();
 
@@ -195,7 +198,7 @@ public class IntegrationTest {
     public void testCreateInvalidAccount() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 var zeroedAccounts = new AccountBatch(1);
                 zeroedAccounts.add();
@@ -224,7 +227,7 @@ public class IntegrationTest {
     public void testCreateAccountsAsync() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 accounts.beforeFirst();
 
@@ -261,7 +264,7 @@ public class IntegrationTest {
     public void testCreateTransfers() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 // Creating the accounts.
                 var createAccountErrors = client.createAccounts(accounts);
@@ -334,7 +337,7 @@ public class IntegrationTest {
     public void testCreateTransfersAsync() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 // Creating the accounts.
                 CompletableFuture<CreateAccountResultBatch> future =
@@ -416,7 +419,7 @@ public class IntegrationTest {
     public void testCreateInvalidTransfer() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 var zeroedTransfers = new TransferBatch(1);
                 zeroedTransfers.add();
@@ -445,7 +448,7 @@ public class IntegrationTest {
     public void testCreatePendingTransfers() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 // Creating the accounts.
                 var errors = client.createAccounts(accounts);
@@ -572,7 +575,7 @@ public class IntegrationTest {
     public void testCreatePendingTransfersAndVoid() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 // Creating the accounts.
                 var errors = client.createAccounts(accounts);
@@ -700,7 +703,7 @@ public class IntegrationTest {
     public void testCreateLinkedTransfers() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 var errors = client.createAccounts(accounts);
                 assertTrue(errors.getLength() == 0);
@@ -783,7 +786,7 @@ public class IntegrationTest {
     public void testCreateAccountTooMuchData() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 final int TOO_MUCH_DATA = 10000;
                 var accounts = new AccountBatch(TOO_MUCH_DATA);
@@ -818,7 +821,7 @@ public class IntegrationTest {
     public void testCreateAccountTooMuchDataAsync() throws Throwable {
 
         try (var server = new Server()) {
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 final int TOO_MUCH_DATA = 10000;
                 var accounts = new AccountBatch(TOO_MUCH_DATA);
@@ -862,7 +865,7 @@ public class IntegrationTest {
 
         try (var server = new Server()) {
 
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 final int TOO_MUCH_DATA = 10000;
                 var transfers = new TransferBatch(TOO_MUCH_DATA);
@@ -899,7 +902,7 @@ public class IntegrationTest {
 
         try (var server = new Server()) {
 
-            try (var client = new Client(0, new String[] {server.getAddress()})) {
+            try (var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
                 final int TOO_MUCH_DATA = 10000;
                 var transfers = new TransferBatch(TOO_MUCH_DATA);
@@ -953,7 +956,8 @@ public class IntegrationTest {
             final int tasks_qty = max_concurrency;
             final var barrier = new CountDownLatch(tasks_qty);
 
-            try (var client = new Client(0, new String[] {server.getAddress()}, max_concurrency)) {
+            try (var client =
+                    new Client(clusterId, new String[] {server.getAddress()}, max_concurrency)) {
 
                 var errors = client.createAccounts(accounts);
                 assertTrue(errors.getLength() == 0);
@@ -1016,7 +1020,8 @@ public class IntegrationTest {
             final int max_concurrency = 2;
             final var barrier = new CountDownLatch(tasks_qty);
 
-            try (var client = new Client(0, new String[] {server.getAddress()}, max_concurrency)) {
+            try (var client =
+                    new Client(clusterId, new String[] {server.getAddress()}, max_concurrency)) {
 
                 var errors = client.createAccounts(accounts);
                 assertTrue(errors.getLength() == 0);
@@ -1101,7 +1106,8 @@ public class IntegrationTest {
             final var enterBarrier = new CountDownLatch(tasks_qty);
             final var exitBarrier = new CountDownLatch(1);
 
-            try (var client = new Client(0, new String[] {server.getAddress()}, max_concurrency)) {
+            try (var client =
+                    new Client(clusterId, new String[] {server.getAddress()}, max_concurrency)) {
 
                 var errors = client.createAccounts(accounts);
                 assertTrue(errors.getLength() == 0);
@@ -1168,7 +1174,7 @@ public class IntegrationTest {
         try (var server = new Server()) {
             // As we call client.close() explicitly,
             // we don't need to use a try-with-resources block here.
-            var client = new Client(0, new String[] {server.getAddress()});
+            var client = new Client(clusterId, new String[] {server.getAddress()});
 
             // Creating accounts.
             var createAccountErrors = client.createAccounts(accounts);
@@ -1209,7 +1215,8 @@ public class IntegrationTest {
             final int tasks_qty = 100;
             final int concurrency_max = tasks_qty;
 
-            try (var client = new Client(0, new String[] {server.getAddress()}, concurrency_max)) {
+            try (var client =
+                    new Client(clusterId, new String[] {server.getAddress()}, concurrency_max)) {
 
                 var errors = client.createAccounts(accounts);
                 assertTrue(errors.getLength() == 0);

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -347,10 +347,10 @@ But the insert rate will be a *fraction* of
 potential. Instead, **always batch what you can**.
 
 The maximum batch size is set in the TigerBeetle server. The default
-is 8191.
+is 8190.
 
 ```javascript
-const BATCH_SIZE = 8191;
+const BATCH_SIZE = 8190;
 for (let i = 0; i < transfers.length; i += BATCH_SIZE) {
   const transferErrors = await client.createTransfers(transfers.slice(i, Math.min(transfers.length, BATCH_SIZE)));
   // error handling omitted

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -79,7 +79,7 @@ environment variable and defaults to port `3000`.
 
 ```javascript
 const client = createClient({
-  cluster_id: 0,
+  cluster_id: 0n,
   replica_addresses: [process.env.TB_ADDRESS || '3000']
 });
 ```

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -318,7 +318,7 @@ pub const NodeDocs = Docs{
     ,
 
     .batch_example =
-    \\const BATCH_SIZE = 8191;
+    \\const BATCH_SIZE = 8190;
     \\for (let i = 0; i < transfers.length; i += BATCH_SIZE) {
     \\  const transferErrors = await client.createTransfers(transfers.slice(i, Math.min(transfers.length, BATCH_SIZE)));
     \\  // error handling omitted

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -118,7 +118,7 @@ pub const NodeDocs = Docs{
 
     .client_object_example =
     \\const client = createClient({
-    \\  cluster_id: 0,
+    \\  cluster_id: 0n,
     \\  replica_addresses: [process.env.TB_ADDRESS || '3000']
     \\});
     ,

--- a/src/clients/node/samples/basic/main.js
+++ b/src/clients/node/samples/basic/main.js
@@ -7,7 +7,7 @@ const {
 } = require("tigerbeetle-node");
 
 const client = createClient({
-  cluster_id: 0,
+  cluster_id: 0n,
   replica_addresses: [process.env.TB_ADDRESS || '3000'],
 });
 

--- a/src/clients/node/samples/two-phase-many/main.js
+++ b/src/clients/node/samples/two-phase-many/main.js
@@ -8,7 +8,7 @@ const {
 } = require("tigerbeetle-node");
 
 const client = createClient({
-  cluster_id: 0,
+  cluster_id: 0n,
   replica_addresses: [process.env.TB_ADDRESS || '3000'],
 });
 

--- a/src/clients/node/samples/two-phase/main.js
+++ b/src/clients/node/samples/two-phase/main.js
@@ -8,7 +8,7 @@ const {
 } = require("tigerbeetle-node");
 
 const client = createClient({
-  cluster_id: 0,
+  cluster_id: 0n,
   replica_addresses: [process.env.TB_ADDRESS || '3000'],
 });
 

--- a/src/clients/node/src/benchmark.ts
+++ b/src/clients/node/src/benchmark.ts
@@ -15,7 +15,7 @@ const PREVIOUS_BENCHMARK = IS_TWO_PHASE_TRANSFER ? 150000 : 310000
 const TOLERANCE = 10 // percent that the benchmark is allowed to deviate from the previous benchmark
 
 const client = createClient({
-  cluster_id: 0,
+  cluster_id: 0n,
   replica_addresses: ['3001']
 })
 

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -70,7 +70,7 @@ export type Result = CreateAccountsError | CreateTransfersError | Account | Tran
 export type ResultCallback = (error: Error | null, results: Result[] | null) => void
 
 interface BindingInitArgs {
-  cluster_id: number, // u32
+  cluster_id: bigint, // u128
   concurrency: number, // u32
   replica_addresses: Buffer,
 }
@@ -82,7 +82,7 @@ interface Binding {
 }
 
 export interface ClientInitArgs {
-  cluster_id: number, // u32
+  cluster_id: bigint, // u128
   concurrency_max?: number, // u32
   replica_addresses: Array<string | number>,
 }

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -48,7 +48,7 @@ fn init(env: c.napi_env, info: c.napi_callback_info) callconv(.C) c.napi_value {
         .function = "init",
     }) catch return null;
 
-    const cluster = translate.u32_from_object(env, args[0], "cluster_id") catch return null;
+    const cluster = translate.u128_from_object(env, args[0], "cluster_id") catch return null;
     const concurrency = translate.u32_from_object(env, args[0], "concurrency") catch return null;
     const addresses = translate.slice_from_object(
         env,
@@ -108,7 +108,7 @@ fn submit(env: c.napi_env, info: c.napi_callback_info) callconv(.C) c.napi_value
 
 // tb_client Logic
 
-fn create(env: c.napi_env, cluster_id: u32, concurrency: u32, addresses: []const u8) !c.napi_value {
+fn create(env: c.napi_env, cluster_id: u128, concurrency: u32, addresses: []const u8) !c.napi_value {
     var tsfn_name: c.napi_value = undefined;
     if (c.napi_create_string_utf8(env, "tb_client", c.NAPI_AUTO_LENGTH, &tsfn_name) != c.napi_ok) {
         return translate.throw(env, "Failed to create resource name for thread-safe function.");

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -9,7 +9,7 @@ import {
 } from '.'
 
 const client = createClient({
-  cluster_id: 0,
+  cluster_id: 0n,
   replica_addresses: ['3001']
 })
 
@@ -21,7 +21,7 @@ const accountA: Account = {
   debits_pending: 0n,
   debits_posted: 0n,
   credits_pending: 0n,
-  credits_posted: 0n,  
+  credits_posted: 0n,
   user_data_128: 0n,
   user_data_64: 0n,
   user_data_32: 0,
@@ -36,7 +36,7 @@ const accountB: Account = {
   debits_pending: 0n,
   debits_posted: 0n,
   credits_pending: 0n,
-  credits_posted: 0n,  
+  credits_posted: 0n,
   user_data_128: 0n,
   user_data_64: 0n,
   user_data_32: 0,
@@ -92,7 +92,7 @@ test('can lookup accounts', async (): Promise<void> => {
   assert.strictEqual(account1.credits_posted, 0n)
   assert.strictEqual(account1.credits_pending, 0n)
   assert.strictEqual(account1.debits_posted, 0n)
-  assert.strictEqual(account1.debits_pending, 0n)  
+  assert.strictEqual(account1.debits_pending, 0n)
   assert.strictEqual(account1.user_data_128, 0n)
   assert.strictEqual(account1.user_data_64, 0n)
   assert.strictEqual(account1.user_data_32, 0)
@@ -355,7 +355,7 @@ async function main () {
     console.log('Time taken (s):', (end - start)/1000)
   } finally {
     await client.destroy()
-  }    
+  }
 }
 
 main().catch((error: AssertionError) => {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -529,7 +529,7 @@ comptime {
 
 /// A multiple of batch inserts that a mutable table can definitely accommodate before flushing.
 /// For example, if a message_size_max batch can contain at most 8181 transfers then a multiple of 4
-/// means that the transfer tree's mutable table will be sized to 8191 * 4 = 32764 transfers.
+/// means that the transfer tree's mutable table will be sized to 8190 * 4 = 32760 transfers.
 pub const lsm_batch_multiple = config.cluster.lsm_batch_multiple;
 
 comptime {

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -44,7 +44,7 @@ pub fn request(
 ) !void {
     const allocator = std.heap.page_allocator;
     const client_id = std.crypto.random.int(u128);
-    const cluster_id: u32 = 0;
+    const cluster_id: u128 = 0;
     var addresses = [_]std.net.Address{try std.net.Address.parseIp4("127.0.0.1", constants.port)};
 
     var io = try IO.init(32, 0);

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -79,7 +79,7 @@ pub const TableIndex = struct {
         data_block_count_max: u32,
         key_size: u32,
         tree_id: u16,
-        reserved: [130]u8 = [_]u8{0} ** 130,
+        reserved: [114]u8 = [_]u8{0} ** 114,
 
         comptime {
             assert(stdx.no_padding(Metadata));
@@ -223,7 +223,7 @@ pub const TableData = struct {
         value_count: u32,
         value_size: u32,
         tree_id: u16,
-        reserved: [130]u8 = [_]u8{0} ** 130,
+        reserved: [114]u8 = [_]u8{0} ** 114,
 
         comptime {
             assert(stdx.no_padding(Metadata));
@@ -364,7 +364,7 @@ pub const ManifestNode = struct {
         previous_manifest_block_checksum: u128,
         previous_manifest_block_address: u64,
         entry_count: u32,
-        reserved: [116]u8 = .{0} ** 116,
+        reserved: [100]u8 = .{0} ** 100,
 
         comptime {
             assert(stdx.no_padding(Metadata));

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -292,7 +292,7 @@ pub fn TableType(
             }
 
             const DataFinishOptions = struct {
-                cluster: u32,
+                cluster: u128,
                 address: u64,
                 snapshot_min: u64,
                 tree_id: u16,
@@ -389,7 +389,7 @@ pub fn TableType(
             }
 
             const IndexFinishOptions = struct {
-                cluster: u32,
+                cluster: u128,
                 address: u64,
                 snapshot_min: u64,
                 tree_id: u16,

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -46,7 +46,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         pool: *MessagePool,
         io: *IO,
 
-        cluster: u32,
+        cluster: u128,
         configuration: []const std.net.Address,
 
         process: switch (process_type) {
@@ -99,7 +99,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         /// Initialize the MessageBus for the given cluster, configuration and replica/client process.
         pub fn init(
             allocator: mem.Allocator,
-            cluster: u32,
+            cluster: u128,
             process: Process,
             message_pool: *MessagePool,
             on_message_callback: *const fn (message_bus: *Self, message: *Message) void,

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -58,7 +58,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         pub const ManifestChecker = ManifestCheckerType(StateMachine.Forest);
 
         pub const Options = struct {
-            cluster_id: u32,
+            cluster_id: u128,
             replica_count: u8,
             standby_count: u8,
             client_count: u8,

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -20,7 +20,7 @@ pub const MessageBus = struct {
     network: *Network,
     pool: *MessagePool,
 
-    cluster: u32,
+    cluster: u128,
     process: Process,
 
     /// The callback to be called when a message is received.
@@ -32,7 +32,7 @@ pub const MessageBus = struct {
 
     pub fn init(
         _: std.mem.Allocator,
-        cluster: u32,
+        cluster: u128,
         process: Process,
         message_pool: *MessagePool,
         on_message_callback: *const fn (message_bus: *MessageBus, message: *Message) void,

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -41,7 +41,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
         /// Tracks the latest op acked by a replica across restarts.
         replica_head_max: []ReplicaHead,
         pub fn init(allocator: mem.Allocator, options: struct {
-            cluster_id: u32,
+            cluster_id: u128,
             replica_count: u8,
             replicas: []const Replica,
             clients: []const Client,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -16,7 +16,7 @@ const StateMachine = vsr.state_machine.StateMachineType(
 
 const CliArgs = union(enum) {
     format: struct {
-        cluster: u32,
+        cluster: u128,
         replica: u8,
         replica_count: u8,
 
@@ -45,7 +45,7 @@ const CliArgs = union(enum) {
 
     client: struct {
         addresses: []const u8,
-        cluster: u32,
+        cluster: u128,
         verbose: bool = false,
         command: []const u8 = "",
     },
@@ -82,7 +82,7 @@ const CliArgs = union(enum) {
         \\        Print this help message and exit.
         \\
         \\  --cluster=<integer>
-        \\        Set the cluster ID to the provided 32-bit unsigned integer.
+        \\        Set the cluster ID to the provided 128-bit unsigned decimal integer.
         \\
         \\  --replica=<index>
         \\        Set the zero-based index that will be used for the replica process.
@@ -148,14 +148,14 @@ pub const Command = union(enum) {
 
     pub const Repl = struct {
         addresses: []net.Address,
-        cluster: u32,
+        cluster: u128,
         verbose: bool,
         statements: []const u8,
     };
 
     format: struct {
         args_allocated: std.process.ArgIterator,
-        cluster: u32,
+        cluster: u128,
         replica: u8,
         replica_count: u8,
         path: [:0]const u8,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -63,10 +63,6 @@ pub fn main() !void {
     }
 }
 
-// Pad the cluster id number and the replica index with 0s
-const filename_fmt = "cluster_{d:0>10}_replica_{d:0>3}.tigerbeetle";
-const filename_len = fmt.count(filename_fmt, .{ 0, 0 });
-
 const Command = struct {
     dir_fd: os.fd_t,
     fd: os.fd_t,

--- a/src/tigerbeetle/repl.zig
+++ b/src/tigerbeetle/repl.zig
@@ -553,7 +553,7 @@ pub fn ReplType(comptime MessageBus: type) type {
         pub fn run(
             arena: *std.heap.ArenaAllocator,
             addresses: []std.net.Address,
-            cluster_id: u32,
+            cluster_id: u128,
             statements: []const u8,
             verbose: bool,
         ) !void {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -982,13 +982,13 @@ pub const Members = [constants.members_max]u128;
 /// However, that requires unergonomic two-step process for spinning a new cluster up.  To avoid
 /// needlessly compromising the experience until reconfiguration is fully implemented, derive
 /// replica ids for the initial cluster deterministically.
-pub fn root_members(cluster: u32) Members {
+pub fn root_members(cluster: u128) Members {
     const IdSeed = extern struct {
         cluster_config_checksum: u128 align(1),
-        cluster: u32 align(1),
+        cluster: u128 align(1),
         replica: u8 align(1),
     };
-    comptime assert(@sizeOf(IdSeed) == 21);
+    comptime assert(@sizeOf(IdSeed) == 33);
 
     var result = [_]u128{0} ** constants.members_max;
     var replica: u8 = 0;
@@ -1241,7 +1241,7 @@ const ViewChangeHeadersArray = struct {
     command: ViewChangeCommand,
     array: Headers.Array,
 
-    pub fn root(cluster: u32) ViewChangeHeadersArray {
+    pub fn root(cluster: u128) ViewChangeHeadersArray {
         return ViewChangeHeadersArray.init_from_slice(.start_view, &.{
             Header.Prepare.root(cluster),
         });

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -46,7 +46,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
         id: u128,
 
         /// The identifier for the cluster that this client intends to communicate with.
-        cluster: u32,
+        cluster: u128,
 
         /// The number of replicas in the cluster.
         replica_count: u8,
@@ -105,7 +105,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
         pub fn init(
             allocator: mem.Allocator,
             id: u128,
-            cluster: u32,
+            cluster: u128,
             replica_count: u8,
             message_pool: *MessagePool,
             message_bus_options: MessageBus.Options,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -496,7 +496,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
         /// Returns the highest op number prepared, as per `header_ok()` in the untrusted headers.
         fn op_maximum_headers_untrusted(
-            cluster: u32,
+            cluster: u128,
             headers_untrusted: []const Header.Prepare,
         ) u64 {
             var op: u64 = 0;
@@ -2376,7 +2376,7 @@ fn recovery_case(
 /// * has an expected command, and
 /// * resides in the correct slot.
 fn header_ok(
-    cluster: u32,
+    cluster: u128,
     slot: Slot,
     header: *const Header.Prepare,
 ) ?*const Header.Prepare {
@@ -2472,7 +2472,7 @@ pub const BitSet = struct {
 ///
 /// `offset_logical` is relative to the beginning of the `wal_headers` zone.
 /// Returns the number of bytes written to `target`.
-pub fn format_wal_headers(cluster: u32, offset_logical: u64, target: []u8) usize {
+pub fn format_wal_headers(cluster: u128, offset_logical: u64, target: []u8) usize {
     assert(offset_logical <= constants.journal_size_headers);
     assert(offset_logical % constants.sector_size == 0);
     assert(target.len > 0);
@@ -2503,7 +2503,7 @@ test "format_wal_headers" {
 ///
 /// `offset_logical` is relative to the beginning of the `wal_prepares` zone.
 /// Returns the number of bytes written to `target`.
-pub fn format_wal_prepares(cluster: u32, offset_logical: u64, target: []u8) usize {
+pub fn format_wal_prepares(cluster: u128, offset_logical: u64, target: []u8) usize {
     assert(offset_logical <= constants.journal_size_prepares);
     assert(offset_logical % constants.sector_size == 0);
     assert(target.len > 0);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -35,7 +35,7 @@ pub const Header = extern struct {
     /// The cluster number binds intention into the header, so that a client or replica can indicate
     /// the cluster it believes it is speaking to, instead of accidentally talking to the wrong
     /// cluster (for example, staging vs production).
-    cluster: u32,
+    cluster: u128,
 
     /// The size of the Header structure (always), plus any associated body.
     size: u32,
@@ -58,11 +58,11 @@ pub const Header = extern struct {
     replica: u8,
 
     /// Reserved for future use by the header frame (i.e. to be shared by all message types).
-    reserved_frame: [12]u8,
+    reserved_frame: [16]u8,
 
     /// This data's schema is different depending on the `Header.command`.
     /// (No default value – `Header`s should not be constructed directly.)
-    reserved_command: [176]u8,
+    reserved_command: [160]u8,
 
     comptime {
         assert(@sizeOf(Header) == 256);
@@ -255,16 +255,16 @@ pub const Header = extern struct {
         checksum: u128,
         checksum_body: u128,
         reserved_nonce: u128,
-        cluster: u32,
+        cluster: u128,
         size: u32,
         epoch: u32 = 0,
         view: u32 = 0,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
-        reserved_frame: [12]u8,
+        reserved_frame: [16]u8,
 
-        reserved: [176]u8 = [_]u8{0} ** 176,
+        reserved: [160]u8 = [_]u8{0} ** 160,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .reserved);
@@ -278,14 +278,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// Current checkpoint id (possibly uncanonical).
         checkpoint_id: u128,
@@ -294,7 +294,7 @@ pub const Header = extern struct {
 
         ping_timestamp_monotonic: u64,
 
-        reserved: [144]u8 = [_]u8{0} ** 144,
+        reserved: [128]u8 = [_]u8{0} ** 128,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .ping);
@@ -314,19 +314,19 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         ping_timestamp_monotonic: u64,
         pong_timestamp_wall: u64,
 
-        reserved: [160]u8 = [_]u8{0} ** 160,
+        reserved: [144]u8 = [_]u8{0} ** 144,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .pong);
@@ -346,17 +346,17 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0, // Always 0.
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         client: u128,
-        reserved: [160]u8 = [_]u8{0} ** 160,
+        reserved: [144]u8 = [_]u8{0} ** 144,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .ping_client);
@@ -376,16 +376,16 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
-        reserved: [176]u8 = [_]u8{0} ** 176,
+        reserved: [160]u8 = [_]u8{0} ** 160,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .pong_client);
@@ -402,14 +402,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0, // Always 0.
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// Clients hash-chain their requests to verify linearizability:
         /// - A session's first request (operation=register) sets `parent=0`.
@@ -443,7 +443,7 @@ pub const Header = extern struct {
         /// A client is allowed to have at most one request inflight at a time.
         request: u32,
         operation: Operation,
-        reserved: [123]u8 = [_]u8{0} ** 123,
+        reserved: [107]u8 = [_]u8{0} ** 107,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request);
@@ -491,14 +491,16 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
+
+        // TODO client session?
 
         /// A backpointer to the previous prepare checksum for hash chain verification.
         /// This provides a cryptographic guarantee for linearizability across our distributed log
@@ -522,7 +524,7 @@ pub const Header = extern struct {
         request: u32,
         /// The state machine operation to apply.
         operation: Operation,
-        reserved: [99]u8 = [_]u8{0} ** 99,
+        reserved: [83]u8 = [_]u8{0} ** 83,
 
         fn invalid_header(self: *const Prepare) ?[]const u8 {
             assert(self.command == .prepare);
@@ -573,7 +575,7 @@ pub const Header = extern struct {
             return null;
         }
 
-        pub fn reserved(cluster: u32, slot: u64) Prepare {
+        pub fn reserved(cluster: u128, slot: u64) Prepare {
             assert(slot < constants.journal_slot_count);
 
             var header = Prepare{
@@ -595,7 +597,7 @@ pub const Header = extern struct {
             return header;
         }
 
-        pub fn root(cluster: u32) Prepare {
+        pub fn root(cluster: u128) Prepare {
             var header = Prepare{
                 .cluster = cluster,
                 .size = @sizeOf(Header),
@@ -623,14 +625,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         checkpoint_id: u128,
         /// The corresponding request message's checksum.
@@ -642,7 +644,7 @@ pub const Header = extern struct {
         timestamp: u64,
         request: u32,
         operation: Operation = .reserved,
-        reserved: [83]u8 = [_]u8{0} ** 83,
+        reserved: [67]u8 = [_]u8{0} ** 67,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .prepare_ok);
@@ -685,14 +687,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         parent: u128,
         client: u128,
@@ -707,7 +709,7 @@ pub const Header = extern struct {
         timestamp: u64,
         request: u32,
         operation: Operation = .reserved,
-        reserved: [99]u8 = [_]u8{0} ** 99,
+        reserved: [83]u8 = [_]u8{0} ** 83,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .reply);
@@ -735,14 +737,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// Current checkpoint id (possibly uncanonical).
         checkpoint_id: u128,
@@ -758,7 +760,7 @@ pub const Header = extern struct {
 
         timestamp_monotonic: u64,
 
-        reserved: [120]u8 = [_]u8{0} ** 120,
+        reserved: [104]u8 = [_]u8{0} ** 104,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .commit);
@@ -777,16 +779,16 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
-        reserved: [176]u8 = [_]u8{0} ** 176,
+        reserved: [160]u8 = [_]u8{0} ** 160,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .start_view_change);
@@ -803,14 +805,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// A bitset of "present" prepares. If a bit is set, then the corresponding header is not
         /// "blank", the replica has the prepare, and the prepare is not known to be faulty.
@@ -825,7 +827,7 @@ pub const Header = extern struct {
         commit_min: u64,
         checkpoint_op: u64,
         log_view: u32,
-        reserved: [116]u8 = [_]u8{0} ** 116,
+        reserved: [100]u8 = [_]u8{0} ** 100,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .do_view_change);
@@ -845,14 +847,14 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// Set to zero for a new view, and to a nonce from an RSV when responding to the RSV.
         nonce: u128,
@@ -861,7 +863,7 @@ pub const Header = extern struct {
         commit: u64,
         /// The replica's `op_checkpoint`.
         checkpoint_op: u64,
-        reserved: [136]u8 = [_]u8{0} ** 136,
+        reserved: [120]u8 = [_]u8{0} ** 120,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .start_view);
@@ -878,17 +880,17 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         nonce: u128,
-        reserved: [160]u8 = [_]u8{0} ** 160,
+        reserved: [144]u8 = [_]u8{0} ** 144,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_start_view);
@@ -906,20 +908,20 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// The minimum op requested (inclusive).
         op_min: u64,
         /// The maximum op requested (inclusive).
         op_max: u64,
-        reserved: [160]u8 = [_]u8{0} ** 160,
+        reserved: [144]u8 = [_]u8{0} ** 144,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_headers);
@@ -938,18 +940,18 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         prepare_checksum: u128,
         prepare_op: u64,
-        reserved: [152]u8 = [_]u8{0} ** 152,
+        reserved: [136]u8 = [_]u8{0} ** 136,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_prepare);
@@ -967,19 +969,19 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         reply_client: u128,
         reply_checksum: u128,
         reply_op: u64,
-        reserved: [136]u8 = [_]u8{0} ** 136,
+        reserved: [120]u8 = [_]u8{0} ** 120,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_reply);
@@ -998,16 +1000,16 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
-        reserved: [176]u8 = [_]u8{0} ** 176,
+        reserved: [160]u8 = [_]u8{0} ** 160,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .headers);
@@ -1023,17 +1025,17 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         client: u128,
-        reserved: [160]u8 = [_]u8{0} ** 160,
+        reserved: [144]u8 = [_]u8{0} ** 144,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .eviction);
@@ -1051,16 +1053,16 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
-        reserved: [176]u8 = [_]u8{0} ** 176,
+        reserved: [160]u8 = [_]u8{0} ** 160,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_blocks);
@@ -1076,19 +1078,19 @@ pub const Header = extern struct {
 
     pub const Block = extern struct {
         pub usingnamespace HeaderFunctions(@This());
-        pub const metadata_size = 144;
+        pub const metadata_size = 128;
 
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0, // Always 0.
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         // Schema is determined by `block_type`.
         metadata_bytes: [metadata_size]u8,
@@ -1119,18 +1121,18 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         checkpoint_id: u128,
         checkpoint_op: u64,
-        reserved: [152]u8 = [_]u8{0} ** 152,
+        reserved: [136]u8 = [_]u8{0} ** 136,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_sync_checkpoint);
@@ -1148,18 +1150,18 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         checkpoint_id: u128,
         checkpoint_op: u64,
-        reserved: [152]u8 = [_]u8{0} ** 152,
+        reserved: [136]u8 = [_]u8{0} ** 136,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .sync_checkpoint);
@@ -1178,19 +1180,19 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         checkpoint_id: u128,
         checkpoint_op: u64,
         trailer_offset: u32,
-        reserved: [148]u8 = [_]u8{0} ** 148,
+        reserved: [132]u8 = [_]u8{0} ** 132,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_sync_free_set);
@@ -1208,19 +1210,19 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         checkpoint_id: u128,
         checkpoint_op: u64,
         trailer_offset: u32 = 0,
-        reserved: [148]u8 = [_]u8{0} ** 148,
+        reserved: [132]u8 = [_]u8{0} ** 132,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_sync_client_sessions);
@@ -1238,21 +1240,21 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         trailer_checksum: u128,
         checkpoint_id: u128,
         checkpoint_op: u64,
         trailer_size: u32,
         trailer_offset: u32,
-        reserved: [128]u8 = [_]u8{0} ** 128,
+        reserved: [112]u8 = [_]u8{0} ** 112,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .sync_free_set);
@@ -1271,21 +1273,21 @@ pub const Header = extern struct {
         checksum: u128 = 0,
         checksum_body: u128 = 0,
         reserved_nonce: u128 = 0,
-        cluster: u32,
+        cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
-        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+        reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         trailer_checksum: u128,
         checkpoint_id: u128,
         checkpoint_op: u64,
         trailer_size: u32,
         trailer_offset: u32,
-        reserved: [128]u8 = [_]u8{0} ** 128,
+        reserved: [112]u8 = [_]u8{0} ** 112,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .sync_client_sessions);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -155,7 +155,7 @@ pub fn ReplicaType(
         static_allocator: StaticAllocator,
 
         /// The number of the cluster to which this replica belongs:
-        cluster: u32,
+        cluster: u128,
 
         /// The number of replicas in the cluster:
         replica_count: u8,
@@ -719,7 +719,7 @@ pub fn ReplicaType(
         }
 
         const Options = struct {
-            cluster: u32,
+            cluster: u128,
             replica_count: u8,
             standby_count: u8,
             replica_index: u8,

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -52,7 +52,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
         fn format_wal(
             self: *Self,
             allocator: std.mem.Allocator,
-            cluster: u32,
+            cluster: u128,
             storage: *Storage,
         ) !void {
             assert(!self.formatting);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -65,8 +65,8 @@ pub const SuperBlockHeader = extern struct {
     /// The version of the superblock format in use, reserved for major breaking changes.
     version: u16,
 
-    /// Protects against writing to or reading from the wrong data file.
-    cluster: u32,
+    /// Align the next fields.
+    reserved_start: u32 = 0,
 
     /// The current size of the data file.
     storage_size: u64,
@@ -78,6 +78,9 @@ pub const SuperBlockHeader = extern struct {
 
     /// A monotonically increasing counter to locate the latest superblock at startup.
     sequence: u64,
+
+    /// Protects against writing to or reading from the wrong data file.
+    cluster: u128,
 
     /// The checksum of the previous superblock to hash chain across sequence numbers.
     parent: u128,
@@ -104,7 +107,7 @@ pub const SuperBlockHeader = extern struct {
     /// The number of headers in vsr_headers_all.
     vsr_headers_count: u32,
 
-    reserved: [3580]u8 = [_]u8{0} ** 3580,
+    reserved: [3564]u8 = [_]u8{0} ** 3564,
 
     /// SV/DVC header suffix. Headers are ordered from high-to-low op.
     /// Unoccupied headers (after vsr_headers_count) are zeroed.
@@ -168,7 +171,7 @@ pub const SuperBlockHeader = extern struct {
         }
 
         pub fn root(options: struct {
-            cluster: u32,
+            cluster: u128,
             replica_id: u128,
             members: vsr.Members,
             replica_count: u8,
@@ -342,6 +345,7 @@ pub const SuperBlockHeader = extern struct {
         assert(superblock.version == SuperBlockVersion);
         assert(superblock.flags == 0);
 
+        assert(superblock.reserved_start == 0);
         assert(stdx.zeroed(&superblock.reserved));
         assert(stdx.zeroed(&superblock.vsr_state.reserved));
         assert(stdx.zeroed(&superblock.vsr_state.checkpoint.reserved));
@@ -364,6 +368,9 @@ pub const SuperBlockHeader = extern struct {
 
     /// Does not consider { checksum, copy } when comparing equality.
     pub fn equal(a: *const SuperBlockHeader, b: *const SuperBlockHeader) bool {
+        assert(a.reserved_start == 0);
+        assert(b.reserved_start == 0);
+
         assert(stdx.zeroed(&a.reserved));
         assert(stdx.zeroed(&b.reserved));
 
@@ -722,7 +729,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
         }
 
         pub const FormatOptions = struct {
-            cluster: u32,
+            cluster: u128,
             replica: u8,
             replica_count: u8,
         };
@@ -1333,7 +1340,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 log.debug(
                     "{[replica]?}: " ++
                         "{[caller]s}: installed working superblock: checksum={[checksum]x:0>32} " ++
-                        "sequence={[sequence]} cluster={[cluster]} replica_id={[replica_id]} " ++
+                        "sequence={[sequence]} " ++
+                        "cluster={[cluster]x:0>32} replica_id={[replica_id]} " ++
                         "size={[size]} checkpoint_id={[checkpoint_id]x:0>32} " ++
                         "free_set_checksum={[free_set_checksum]x:0>32} " ++
                         "client_sessions_checksum={[client_sessions_checksum]x:0>32} " ++


### PR DESCRIPTION
Rationale (via https://github.com/tigerbeetle/tigerbeetle/pull/1295#discussion_r1389061252):

> A 128-bit cluster also improves our "resolution" for interoperability with other systems that want to use UUIDs for cluster ID to allow for random generation of cluster ID without the cost of having to introduce a centralized ID coordinator. Plus it gives us a further security guarantee that clusters can't talk to other clusters unless they can literally “guess” the identifier, which is now cryptographically "tough" (granted, we might not be able to imagine now why this could be important, but it's a stronger property nevertheless—especially from an online verification point of view).