### PR TITLE
ci: run release validation on the release branch

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -8,13 +8,17 @@ on:
       - completed
 
   schedule:
-    - cron: 0 */6 * * * # Every six hours
+    # Schedule a validation run every six hours to make sure we catch any bugs due to changes
+    # in systems we do not control.
+    - cron: 0 */6 * * *
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          rev: release # Use the 'release' branch even if triggered by cron.
 
       - uses: actions/setup-dotnet@v3
         with:


### PR DESCRIPTION
If we run workflow from main, then the there might be a divergence between code in our sample and the current published release.