### PR TITLE
vsr: store free set in the grid

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -15,12 +15,15 @@ const Transfer = @import("../tigerbeetle.zig").Transfer;
 const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
 const StateMachine = @import("../state_machine.zig").StateMachineType(Storage, constants.state_machine_config);
+const Reservation = @import("../vsr/superblock_free_set.zig").Reservation;
 const GridType = @import("../vsr/grid.zig").GridType;
 const GrooveType = @import("groove.zig").GrooveType;
 const Forest = StateMachine.Forest;
 
 const Grid = GridType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
+const FreeSet = vsr.FreeSet;
+const FreeSetEncoded = vsr.FreeSetEncodedType(Storage);
 
 pub const tigerbeetle_config = @import("../config.zig").configs.fuzz_min;
 
@@ -64,6 +67,9 @@ const Environment = struct {
         .cache_entries_posted = cache_entries_max,
     });
 
+    const free_set_fragments_max = 2048;
+    const free_set_fragment_size = 67;
+
     // We must call compact after every 'batch'.
     // Every `lsm_batch_multiple` batches may put/remove `value_count_max` values per index.
     // Every `FuzzOp.put_account` issues one remove and one put per index.
@@ -82,11 +88,13 @@ const Environment = struct {
         init,
         superblock_format,
         superblock_open,
+        free_set_open,
         forest_init,
         forest_open,
         fuzzing,
         forest_compact,
         forest_checkpoint,
+        free_set_checkpoint,
         superblock_checkpoint,
     };
 
@@ -161,13 +169,37 @@ const Environment = struct {
 
     fn open(env: *Environment) !void {
         env.superblock.open(superblock_open_callback, &env.superblock_context);
-        try env.tick_until_state_change(.superblock_open, .forest_init);
+        try env.tick_until_state_change(.superblock_open, .free_set_open);
+
+        env.superblock.free_set_encoded.open(
+            &env.grid,
+            env.superblock.working.free_set_reference(),
+            free_set_open_callback,
+        );
+        try env.tick_until_state_change(.free_set_open, .forest_init);
 
         env.forest = try Forest.init(allocator, &env.grid, node_count, forest_options);
         env.change_state(.forest_init, .forest_open);
         env.forest.open(forest_open_callback);
 
         try env.tick_until_state_change(.forest_open, .fuzzing);
+
+        env.fragmentate_free_set();
+    }
+
+    /// Allocate a sparse subset of grid blocks to make sure that the encoded free set needs more
+    /// than one block to exercise the block linked list logic from FreeSetEncoded.
+    fn fragmentate_free_set(env: *Environment) void {
+        var reservations: [free_set_fragments_max]Reservation = undefined;
+        for (&reservations) |*reservation| {
+            reservation.* = env.superblock.free_set.reserve(free_set_fragment_size).?;
+        }
+        for (reservations) |reservation| {
+            _ = env.superblock.free_set.acquire(reservation).?;
+        }
+        for (reservations) |reservation| {
+            env.superblock.free_set.forfeit(reservation);
+        }
     }
 
     fn close(env: *Environment) void {
@@ -181,7 +213,13 @@ const Environment = struct {
 
     fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
         const env = @fieldParentPtr(@This(), "superblock_context", superblock_context);
-        env.change_state(.superblock_open, .forest_init);
+        env.change_state(.superblock_open, .free_set_open);
+    }
+
+    fn free_set_open_callback(set: *FreeSetEncoded) void {
+        const superblock = @fieldParentPtr(SuperBlock, "free_set_encoded", set);
+        const env = @fieldParentPtr(@This(), "superblock", superblock);
+        env.change_state(.free_set_open, .forest_init);
     }
 
     fn forest_open_callback(forest: *Forest) void {
@@ -206,14 +244,10 @@ const Environment = struct {
 
         env.change_state(.fuzzing, .forest_checkpoint);
         env.forest.checkpoint(forest_checkpoint_callback);
-        try env.tick_until_state_change(.forest_checkpoint, .superblock_checkpoint);
-        try env.tick_until_state_change(.superblock_checkpoint, .fuzzing);
-    }
+        try env.tick_until_state_change(.forest_checkpoint, .free_set_checkpoint);
 
-    fn forest_checkpoint_callback(forest: *Forest) void {
-        const env = @fieldParentPtr(@This(), "forest", forest);
-        const op = env.checkpoint_op.?;
-        env.checkpoint_op = null;
+        env.superblock.free_set_encoded.checkpoint(free_set_checkpoint_callback);
+        try env.tick_until_state_change(.free_set_checkpoint, .superblock_checkpoint);
 
         {
             // VSRState.monotonic() asserts that the previous_checkpoint id changes.
@@ -222,24 +256,38 @@ const Environment = struct {
             var reply = std.mem.zeroInit(vsr.Header.Reply, .{
                 .cluster = cluster,
                 .command = .reply,
-                .op = op,
-                .commit = op,
+                .op = env.checkpoint_op.?,
+                .commit = env.checkpoint_op.?,
             });
             reply.set_checksum_body(&.{});
             reply.set_checksum();
 
             _ = env.superblock.client_sessions.put(1, &reply);
         }
-
-        env.change_state(.forest_checkpoint, .superblock_checkpoint);
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
-            .manifest_references = forest.manifest_log.checkpoint_references(),
+            .manifest_references = env.forest.manifest_log.checkpoint_references(),
             .commit_min_checksum = env.superblock.working.vsr_state.checkpoint.commit_min_checksum + 1,
-            .commit_min = op,
-            .commit_max = op + 1,
+            .commit_min = env.checkpoint_op.?,
+            .commit_max = env.checkpoint_op.? + 1,
             .sync_op_min = 0,
             .sync_op_max = 0,
         });
+        try env.tick_until_state_change(.superblock_checkpoint, .fuzzing);
+
+        env.checkpoint_op = null;
+    }
+
+    fn forest_checkpoint_callback(forest: *Forest) void {
+        const env = @fieldParentPtr(@This(), "forest", forest);
+        assert(env.checkpoint_op != null);
+        env.change_state(.forest_checkpoint, .free_set_checkpoint);
+    }
+
+    fn free_set_checkpoint_callback(set: *FreeSetEncoded) void {
+        const superblock = @fieldParentPtr(SuperBlock, "free_set_encoded", set);
+        const env = @fieldParentPtr(@This(), "superblock", superblock);
+        assert(env.checkpoint_op != null);
+        env.change_state(.free_set_checkpoint, .superblock_checkpoint);
     }
 
     fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -56,9 +56,10 @@ pub const BlockType = enum(u8) {
     /// Unused; verifies that no block is written with a default 0 block type.
     reserved = 0,
 
-    manifest = 1,
-    index = 2,
-    data = 3,
+    free_set = 1,
+    manifest = 2,
+    index = 3,
+    data = 4,
 
     pub fn valid(block_type: BlockType) bool {
         _ = std.meta.intToEnum(BlockType, @intFromEnum(block_type)) catch return false;
@@ -340,6 +341,68 @@ pub const TableData = struct {
     }
 };
 
+pub const FreeSetNode = struct {
+    pub const Word = u64;
+
+    pub const Metadata = extern struct {
+        previous_free_set_block_checksum: u128,
+        previous_free_set_block_checksum_padding: u128 = 0,
+        previous_free_set_block_address: u64,
+        reserved: [56]u8 = .{0} ** 56,
+
+        comptime {
+            assert(stdx.no_padding(Metadata));
+            assert(@sizeOf(Metadata) == vsr.Header.Block.metadata_size);
+        }
+    };
+
+    fn metadata(free_set_block: BlockPtrConst) *const Metadata {
+        const header = header_from_block(free_set_block);
+        assert(header.command == .block);
+        assert(header.block_type == .free_set);
+        assert(header.address > 0);
+        assert(header.snapshot == 0);
+
+        const header_metadata = std.mem.bytesAsValue(Metadata, &header.metadata_bytes);
+        assert(header_metadata.previous_free_set_block_checksum_padding == 0);
+        assert(stdx.zeroed(&header_metadata.reserved));
+
+        if (header_metadata.previous_free_set_block_address == 0) {
+            assert(header_metadata.previous_free_set_block_checksum == 0);
+        }
+
+        assert(header.size > @sizeOf(vsr.Header));
+        assert((header.size - @sizeOf(vsr.Header)) % @sizeOf(Word) == 0);
+
+        return header_metadata;
+    }
+
+    pub fn assert_valid_header(free_set_block: BlockPtrConst) void {
+        _ = metadata(free_set_block);
+    }
+
+    pub fn previous(free_set_block: BlockPtrConst) ?struct { checksum: u128, address: u64 } {
+        const header_metadata = metadata(free_set_block);
+
+        if (header_metadata.previous_free_set_block_address == 0) {
+            assert(header_metadata.previous_free_set_block_checksum == 0);
+            return null;
+        } else {
+            return .{
+                .checksum = header_metadata.previous_free_set_block_checksum,
+                .address = header_metadata.previous_free_set_block_address,
+            };
+        }
+    }
+
+    pub fn encoded_words(block: BlockPtrConst) []align(@alignOf(Word)) const u8 {
+        assert_valid_header(block);
+
+        const header = header_from_block(block);
+        return block[@sizeOf(vsr.Header)..header.size];
+    }
+};
+
 /// A Manifest block's body is an array of TableInfo entries.
 // TODO Store snapshot in header.
 pub const ManifestNode = struct {
@@ -429,6 +492,7 @@ pub const ManifestNode = struct {
         assert(header.command == .block);
         assert(header.block_type == .manifest);
         assert(header.address > 0);
+        assert(header.snapshot == 0);
 
         const header_metadata = std.mem.bytesAsValue(Metadata, &header.metadata_bytes);
         assert(header_metadata.entry_count > 0);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -647,7 +647,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     "{[journal_faulty]:>2}/{[journal_dirty]:_>2}J! " ++
                     "{[wal_op_min]:>3}:{[wal_op_max]:_>3}Wo " ++
                     "<{[sync_op_min]:_>3}:{[sync_op_max]:_>3}> " ++
-                    "{[grid_blocks_free]:>7}Gf " ++
+                    "{[grid_blocks_free]?:>7}Gf " ++
                     "{[grid_blocks_global]:>2}G! " ++
                     "{[grid_blocks_repair]:>3}G?", .{
                     .view = replica.view,
@@ -661,7 +661,10 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     .wal_op_max = wal_op_max,
                     .sync_op_min = replica.superblock.working.vsr_state.sync_op_min,
                     .sync_op_max = replica.superblock.working.vsr_state.sync_op_max,
-                    .grid_blocks_free = replica.superblock.free_set.count_free(),
+                    .grid_blocks_free = if (replica.superblock.free_set.opened)
+                        replica.superblock.free_set.count_free()
+                    else
+                        null,
                     .grid_blocks_global = replica.grid.read_global_queue.count,
                     .grid_blocks_repair = replica.grid.blocks_missing.faulty_blocks.count(),
                 }) catch unreachable;

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -47,7 +47,6 @@ const Checkpoints = std.AutoHashMap(u64, Checkpoint);
 
 const CheckpointArea = enum {
     superblock_checkpoint,
-    superblock_free_set,
     superblock_client_sessions,
     client_replies,
     grid,
@@ -62,6 +61,7 @@ pub const StorageChecker = struct {
     checkpoints: Checkpoints,
 
     free_set: SuperBlock.FreeSet,
+    free_set_buffer: []align(@alignOf(u64)) u8,
 
     pub fn init(allocator: std.mem.Allocator) !StorageChecker {
         var compactions = Compactions.init(allocator);
@@ -73,14 +73,23 @@ pub const StorageChecker = struct {
         var free_set = try SuperBlock.FreeSet.init(allocator, vsr.superblock.grid_blocks_max);
         errdefer free_set.deinit(allocator);
 
+        var free_set_buffer = try allocator.alignedAlloc(
+            u8,
+            @alignOf(u64),
+            SuperBlock.FreeSet.encode_size_max(vsr.superblock.grid_blocks_max),
+        );
+        errdefer allocator.free(free_set);
+
         return StorageChecker{
             .compactions = compactions,
             .checkpoints = checkpoints,
             .free_set = free_set,
+            .free_set_buffer = free_set_buffer,
         };
     }
 
     pub fn deinit(checker: *StorageChecker, allocator: std.mem.Allocator) void {
+        allocator.free(checker.free_set_buffer);
         checker.free_set.deinit(allocator);
         checker.checkpoints.deinit();
         checker.compactions.deinit();
@@ -94,7 +103,6 @@ pub const StorageChecker = struct {
             superblock,
             std.enums.EnumSet(CheckpointArea).init(.{
                 .superblock_checkpoint = true,
-                .superblock_free_set = true,
                 .superblock_client_sessions = true,
                 .client_replies = !syncing,
                 .grid = !syncing,
@@ -111,7 +119,6 @@ pub const StorageChecker = struct {
             superblock,
             std.enums.EnumSet(CheckpointArea).init(.{
                 .superblock_checkpoint = true,
-                .superblock_free_set = true,
                 .superblock_client_sessions = true,
                 // The replica may have have already committed some addition prepares atop the
                 // checkpoint, so its client-replies zone will have mutated.
@@ -134,9 +141,6 @@ pub const StorageChecker = struct {
                     .superblock_checkpoint,
                     vsr.checksum(std.mem.asBytes(&superblock.working.vsr_state.checkpoint)),
                 );
-            }
-            if (areas.contains(.superblock_free_set)) {
-                checkpoint.put(.superblock_free_set, checksum_trailer(superblock, .free_set));
             }
             if (areas.contains(.superblock_client_sessions)) {
                 checkpoint.put(
@@ -229,13 +233,37 @@ pub const StorageChecker = struct {
     }
 
     fn checksum_grid(checker: *StorageChecker, superblock: *const SuperBlock) u128 {
-        const free_set_zone = vsr.SuperBlockTrailer.free_set.zone();
-        const free_set_offset = vsr.Zone.superblock.offset(free_set_zone.start_for_copy(0));
-        const free_set_size = superblock.working.free_set_size;
-        const free_set_buffer = superblock.storage.memory[free_set_offset..][0..free_set_size];
-        assert(vsr.checksum(free_set_buffer) == superblock.working.free_set_checksum);
+        const free_set_size = superblock.working.vsr_state.checkpoint.free_set_size;
 
-        checker.free_set.decode(@alignCast(free_set_buffer));
+        if (free_set_size > 0) {
+            // Read free set from the grid by manually following the linked list of blocks.
+            // Note that free set is written in direct order, and must be read backwards.
+            var free_set_block_address =
+                superblock.working.vsr_state.checkpoint.free_set_last_block_address;
+            var free_set_block_checksum =
+                superblock.working.vsr_state.checkpoint.free_set_last_block_checksum;
+            var free_set_cursor: usize = free_set_size;
+            while (true) {
+                const block = superblock.storage.grid_block(free_set_block_address).?;
+                assert(schema.header_from_block(block).checksum == free_set_block_checksum);
+
+                const encoded_words = schema.FreeSetNode.encoded_words(block);
+                free_set_cursor -= encoded_words.len;
+                stdx.copy_disjoint(
+                    .inexact,
+                    u8,
+                    checker.free_set_buffer[free_set_cursor..],
+                    encoded_words,
+                );
+
+                const previous = schema.FreeSetNode.previous(block) orelse break;
+                free_set_block_address = previous.address;
+                free_set_block_checksum = previous.checksum;
+            }
+            assert(free_set_cursor == 0);
+        }
+
+        checker.free_set.decode(checker.free_set_buffer[0..free_set_size]);
         defer checker.free_set.reset();
 
         var stream = vsr.ChecksumStream.init();

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -892,7 +892,6 @@ pub const ClusterFaultAtlas = struct {
         const offset_in_copy = offset_in_zone % superblock.superblock_copy_size;
         const area: superblock.SuperBlockZone = switch (offset_in_copy) {
             superblock.SuperBlockZone.header.start() => .header,
-            superblock.SuperBlockZone.free_set.start() => .free_set,
             superblock.SuperBlockZone.client_sessions.start() => .client_sessions,
             else => unreachable,
         };

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -53,6 +53,7 @@ pub const CheckpointState = superblock.SuperBlockHeader.CheckpointState;
 pub const checksum = @import("vsr/checksum.zig").checksum;
 pub const ChecksumStream = @import("vsr/checksum.zig").ChecksumStream;
 pub const Header = @import("vsr/message_header.zig").Header;
+pub const FreeSetEncodedType = @import("vsr/superblock_free_set_encoded.zig").FreeSetEncodedType;
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).
@@ -181,11 +182,9 @@ pub const Command = enum(u8) {
     request_sync_checkpoint = 21,
     sync_checkpoint = 22,
 
-    request_sync_free_set = 23,
-    request_sync_client_sessions = 24,
+    request_sync_client_sessions = 23,
 
-    sync_free_set = 25,
-    sync_client_sessions = 26,
+    sync_client_sessions = 24,
 
     comptime {
         for (std.enums.values(Command), 0..) |result, index| {

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -101,9 +101,7 @@ pub const Header = extern struct {
             .block => Block,
             .request_sync_checkpoint => RequestSyncCheckpoint,
             .sync_checkpoint => SyncCheckpoint,
-            .request_sync_free_set => RequestSyncFreeSet,
             .request_sync_client_sessions => RequestSyncClientSessions,
-            .sync_free_set => SyncFreeSet,
             .sync_client_sessions => SyncClientSessions,
         };
     }
@@ -1258,40 +1256,6 @@ pub const Header = extern struct {
         }
     };
 
-    pub const RequestSyncFreeSet = extern struct {
-        pub usingnamespace HeaderFunctions(@This());
-
-        checksum: u128 = 0,
-        checksum_padding: u128 = 0,
-        checksum_body: u128 = 0,
-        checksum_body_padding: u128 = 0,
-        nonce_reserved: u128 = 0,
-        cluster: u128,
-        size: u32 = @sizeOf(Header),
-        epoch: u32 = 0,
-        view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
-        command: Command,
-        replica: u8,
-        reserved_frame: [16]u8 = [_]u8{0} ** 16,
-
-        checkpoint_id: u128,
-        checkpoint_id_padding: u128 = 0,
-        checkpoint_op: u64,
-        trailer_offset: u32,
-        reserved: [84]u8 = [_]u8{0} ** 84,
-
-        fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .request_sync_free_set);
-            if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
-            if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-            if (self.view != 0) return "view != 0";
-            if (self.checkpoint_id_padding != 0) return "checkpoint_id_padding != 0";
-            if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
-            return null;
-        }
-    };
-
     pub const RequestSyncClientSessions = extern struct {
         pub usingnamespace HeaderFunctions(@This());
 
@@ -1319,44 +1283,6 @@ pub const Header = extern struct {
             assert(self.command == .request_sync_client_sessions);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-            if (self.view != 0) return "view != 0";
-            if (self.checkpoint_id_padding != 0) return "checkpoint_id_padding != 0";
-            if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
-            return null;
-        }
-    };
-
-    pub const SyncFreeSet = extern struct {
-        pub usingnamespace HeaderFunctions(@This());
-
-        checksum: u128 = 0,
-        checksum_padding: u128 = 0,
-        checksum_body: u128 = 0,
-        checksum_body_padding: u128 = 0,
-        nonce_reserved: u128 = 0,
-        cluster: u128,
-        size: u32 = @sizeOf(Header),
-        epoch: u32 = 0,
-        view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
-        command: Command,
-        replica: u8,
-        reserved_frame: [16]u8 = [_]u8{0} ** 16,
-
-        trailer_checksum: u128,
-        trailer_checksum_padding: u128 = 0,
-        checkpoint_id: u128,
-        checkpoint_id_padding: u128 = 0,
-        checkpoint_op: u64,
-        trailer_size: u32,
-        trailer_offset: u32,
-        reserved: [48]u8 = [_]u8{0} ** 48,
-
-        fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .sync_free_set);
-            if (self.size - @sizeOf(Header) > constants.sync_trailer_message_body_size_max) {
-                return "size > max";
-            }
             if (self.view != 0) return "view != 0";
             if (self.checkpoint_id_padding != 0) return "checkpoint_id_padding != 0";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -249,8 +249,11 @@ test "format" {
 
         try std.testing.expectEqual(superblock_header.copy, copy);
         try std.testing.expectEqual(superblock_header.cluster, cluster);
-        try std.testing.expectEqual(superblock_header.storage_size, storage.size);
         try std.testing.expectEqual(superblock_header.sequence, 1);
+        try std.testing.expectEqual(
+            superblock_header.vsr_state.checkpoint.storage_size,
+            storage.size,
+        );
         try std.testing.expectEqual(superblock_header.vsr_state.checkpoint.commit_min, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.commit_max, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.view, 0);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -45,6 +45,7 @@ pub const SuperBlockClientSessions = @import("superblock_client_sessions.zig").C
 pub const Quorums = @import("superblock_quorums.zig").QuorumsType(.{
     .superblock_copies = constants.superblock_copies,
 });
+const FreeSetEncodedType = @import("superblock_free_set_encoded.zig").FreeSetEncodedType;
 
 pub const SuperBlockVersion: u16 = 0;
 
@@ -69,40 +70,30 @@ pub const SuperBlockHeader = extern struct {
     /// Align the next fields.
     reserved_start: u32 = 0,
 
-    /// The current size of the data file.
-    storage_size: u64,
+    /// A monotonically increasing counter to locate the latest superblock at startup.
+    sequence: u64,
+
+    /// Protects against writing to or reading from the wrong data file.
+    cluster: u128,
+
+    /// The checksum of the previous superblock to hash chain across sequence numbers.
+    parent: u128,
+    parent_padding: u128 = 0,
+
+    /// The checksum over the client table entries in the superblock trailer.
+    client_sessions_checksum: u128,
+    client_sessions_checksum_padding: u128 = 0,
+
+    /// State stored on stable storage for the Viewstamped Replication consensus protocol.
+    vsr_state: VSRState,
 
     /// The maximum possible size of the data file.
     /// The maximum allowed runtime storage_size_limit.
     /// The FreeSet's on-disk size is a function of storage_size_max.
     storage_size_max: u64,
 
-    /// A monotonically increasing counter to locate the latest superblock at startup.
-    sequence: u64,
-
-    /// The checksum of the previous superblock to hash chain across sequence numbers.
-    parent: u128,
-    parent_padding: u128 = 0,
-
-    /// The checksum over the actual encoded block free set in the superblock trailer.
-    free_set_checksum: u128,
-    free_set_checksum_padding: u128 = 0,
-
-    /// The checksum over the client table entries in the superblock trailer.
-    client_sessions_checksum: u128,
-    client_sessions_checksum_padding: u128 = 0,
-
-    /// Protects against writing to or reading from the wrong data file.
-    cluster: u128,
-
-    /// State stored on stable storage for the Viewstamped Replication consensus protocol.
-    vsr_state: VSRState,
-
     /// Reserved for future minor features (e.g. changing the compression algorithm of the trailer).
     flags: u64 = 0,
-
-    /// The size of the block free set stored in the superblock trailer.
-    free_set_size: u32,
 
     /// The size of the client table entries stored in the superblock trailer.
     /// (Always superblock_trailer_client_sessions_size_max).
@@ -111,7 +102,7 @@ pub const SuperBlockHeader = extern struct {
     /// The number of headers in vsr_headers_all.
     vsr_headers_count: u32,
 
-    reserved: [3404]u8 = [_]u8{0} ** 3404,
+    reserved: [3416]u8 = [_]u8{0} ** 3416,
 
     /// SV/DVC header suffix. Headers are ordered from high-to-low op.
     /// Unoccupied headers (after vsr_headers_count) are zeroed.
@@ -170,7 +161,7 @@ pub const SuperBlockHeader = extern struct {
         reserved: [23]u8 = [_]u8{0} ** 23,
 
         comptime {
-            assert(@sizeOf(VSRState) == 496);
+            assert(@sizeOf(VSRState) == 528);
             // Assert that there is no implicit padding in the struct.
             assert(stdx.no_padding(VSRState));
         }
@@ -186,13 +177,17 @@ pub const SuperBlockHeader = extern struct {
                     .previous_checkpoint_id = 0,
                     .commit_min_checksum = vsr.Header.Prepare.root(options.cluster).checksum,
                     .commit_min = 0,
-                    .snapshots_block_checksum = 0,
-                    .snapshots_block_address = 0,
+                    .free_set_last_block_checksum = 0,
+                    .free_set_last_block_address = 0,
+                    .free_set_size = 0,
                     .manifest_oldest_checksum = 0,
                     .manifest_oldest_address = 0,
                     .manifest_newest_checksum = 0,
                     .manifest_newest_address = 0,
                     .manifest_block_count = 0,
+                    .snapshots_block_checksum = 0,
+                    .snapshots_block_address = 0,
+                    .storage_size = data_file_size_min,
                 },
                 .replica_id = options.replica_id,
                 .members = options.members,
@@ -224,6 +219,15 @@ pub const SuperBlockHeader = extern struct {
             assert(state.checkpoint.manifest_oldest_checksum_padding == 0);
             assert(state.checkpoint.manifest_newest_checksum_padding == 0);
             assert(state.checkpoint.snapshots_block_checksum_padding == 0);
+            assert(state.checkpoint.free_set_last_block_checksum_padding == 0);
+            assert(state.checkpoint.storage_size >= data_file_size_min);
+
+            if (state.checkpoint.free_set_last_block_address == 0) {
+                assert(state.checkpoint.free_set_last_block_checksum == 0);
+                assert(state.checkpoint.free_set_size == 0);
+            } else {
+                assert(state.checkpoint.free_set_size > 0);
+            }
 
             if (state.checkpoint.manifest_block_count == 0) {
                 assert(state.checkpoint.manifest_oldest_address == 0);
@@ -314,6 +318,8 @@ pub const SuperBlockHeader = extern struct {
         commit_min_checksum: u128,
         commit_min_checksum_padding: u128 = 0,
 
+        free_set_last_block_checksum: u128,
+        free_set_last_block_checksum_padding: u128 = 0,
         manifest_oldest_checksum: u128,
         manifest_oldest_checksum_padding: u128 = 0,
         manifest_newest_checksum: u128,
@@ -321,6 +327,7 @@ pub const SuperBlockHeader = extern struct {
         snapshots_block_checksum: u128,
         snapshots_block_checksum_padding: u128 = 0,
 
+        free_set_last_block_address: u64,
         manifest_oldest_address: u64,
         manifest_newest_address: u64,
         snapshots_block_address: u64,
@@ -328,15 +335,28 @@ pub const SuperBlockHeader = extern struct {
         /// The last operation committed to the state machine. At startup, replay the log hereafter.
         commit_min: u64,
 
+        // Logical storage size in bytes.
+        //
+        // If storage_size is less than the data file size, then the grid blocks beyond storage_size
+        // were used previously, but have since been freed.
+        //
+        // If storage_size is more than the data file size, then the data file might have been
+        // truncated/corrupted.
+        storage_size: u64,
+
+        // Size of the encoded free set in bytes.
+        // It is equal to the sum of sizes of individual free set blocks and is used for assertions.
+        free_set_size: u32,
+
         /// The number of manifest blocks in the manifest log.
         manifest_block_count: u32,
 
         // TODO Reserve some more extra space before locking in storage layout.
-        reserved: [28]u8 = [_]u8{0} ** 28,
+        reserved: [8]u8 = [_]u8{0} ** 8,
 
         comptime {
-            assert(@sizeOf(CheckpointState) == 224);
-            assert(@sizeOf(CheckpointState) % @sizeOf(u256) == 0);
+            assert(@sizeOf(CheckpointState) == 256);
+            assert(@sizeOf(CheckpointState) % @sizeOf(u128) == 0);
             assert(stdx.no_padding(CheckpointState));
         }
     };
@@ -373,7 +393,6 @@ pub const SuperBlockHeader = extern struct {
 
         assert(superblock.checksum_padding == 0);
         assert(superblock.parent_padding == 0);
-        assert(superblock.free_set_checksum_padding == 0);
         assert(superblock.client_sessions_checksum_padding == 0);
 
         superblock.checksum = superblock.calculate_checksum();
@@ -386,7 +405,6 @@ pub const SuperBlockHeader = extern struct {
     pub fn checkpoint_id(superblock: *const SuperBlockHeader) u128 {
         var checksum_stream = vsr.ChecksumStream.init();
         checksum_stream.add(std.mem.asBytes(&superblock.vsr_state.checkpoint));
-        checksum_stream.add(std.mem.asBytes(&superblock.free_set_checksum));
         checksum_stream.add(std.mem.asBytes(&superblock.client_sessions_checksum));
         return checksum_stream.checksum();
     }
@@ -409,21 +427,16 @@ pub const SuperBlockHeader = extern struct {
         assert(b.checksum_padding == 0);
         assert(a.parent_padding == 0);
         assert(b.parent_padding == 0);
-        assert(a.free_set_checksum_padding == 0);
-        assert(b.free_set_checksum_padding == 0);
         assert(a.client_sessions_checksum_padding == 0);
         assert(b.client_sessions_checksum_padding == 0);
 
         if (a.version != b.version) return false;
         if (a.cluster != b.cluster) return false;
-        if (a.storage_size != b.storage_size) return false;
         if (a.storage_size_max != b.storage_size_max) return false;
         if (a.sequence != b.sequence) return false;
         if (a.parent != b.parent) return false;
-        if (a.free_set_checksum != b.free_set_checksum) return false;
         if (a.client_sessions_checksum != b.client_sessions_checksum) return false;
         if (!stdx.equal_bytes(VSRState, &a.vsr_state, &b.vsr_state)) return false;
-        if (a.free_set_size != b.free_set_size) return false;
         if (a.vsr_headers_count != b.vsr_headers_count) return false;
         if (!stdx.equal_bytes(
             [constants.view_change_headers_max]vsr.Header.Prepare,
@@ -446,14 +459,12 @@ pub const SuperBlockHeader = extern struct {
 
     pub fn trailer_size(superblock: *const SuperBlockHeader, trailer: Trailer) u32 {
         return switch (trailer) {
-            .free_set => superblock.free_set_size,
             .client_sessions => superblock.client_sessions_size,
         };
     }
 
     pub fn trailer_checksum(superblock: *const SuperBlockHeader, trailer: Trailer) u128 {
         return switch (trailer) {
-            .free_set => superblock.free_set_checksum,
             .client_sessions => superblock.client_sessions_checksum,
         };
     }
@@ -466,6 +477,14 @@ pub const SuperBlockHeader = extern struct {
             .newest_address = checkpoint_state.manifest_newest_address,
             .newest_checksum = checkpoint_state.manifest_newest_checksum,
             .block_count = checkpoint_state.manifest_block_count,
+        };
+    }
+
+    pub fn free_set_reference(superblock: *const SuperBlockHeader) FreeSetReference {
+        return .{
+            .last_block_address = superblock.vsr_state.checkpoint.free_set_last_block_address,
+            .last_block_checksum = superblock.vsr_state.checkpoint.free_set_last_block_checksum,
+            .size = superblock.vsr_state.checkpoint.free_set_size,
         };
     }
 };
@@ -495,6 +514,23 @@ pub const ManifestReferences = struct {
     }
 };
 
+pub const FreeSetReference = struct {
+    last_block_address: u64,
+    last_block_checksum: u128,
+    size: u32,
+
+    pub fn empty(reference: *const FreeSetReference) bool {
+        if (reference.size == 0) {
+            assert(reference.last_block_address == 0);
+            assert(reference.last_block_checksum == 0);
+            return true;
+        } else {
+            assert(reference.last_block_address > 0);
+            return false;
+        }
+    }
+};
+
 comptime {
     switch (constants.superblock_copies) {
         4, 6, 8 => {},
@@ -516,21 +552,10 @@ pub const superblock_trailer_size_max = blk: {
     // To calculate the size of the superblock trailer we need to know:
     // - the maximum possible size of the EWAH-compressed bit set addressable by the free set.
 
-    assert(superblock_trailer_free_set_size_max > 0);
-    assert(superblock_trailer_free_set_size_max % constants.sector_size == 0);
-
     assert(superblock_trailer_client_sessions_size_max > 0);
     assert(superblock_trailer_client_sessions_size_max % constants.sector_size == 0);
 
-    break :blk superblock_trailer_free_set_size_max +
-        superblock_trailer_client_sessions_size_max;
-};
-
-const superblock_trailer_free_set_size_max = blk: {
-    const encode_size_max = SuperBlockFreeSet.encode_size_max(grid_blocks_max);
-    assert(encode_size_max > 0);
-
-    break :blk vsr.sector_ceil(encode_size_max);
+    break :blk superblock_trailer_client_sessions_size_max;
 };
 
 const superblock_trailer_client_sessions_size_max = blk: {
@@ -558,15 +583,9 @@ pub const grid_blocks_max = blk: {
     // The size of a freeset is related to the number of blocks it must store.
     // Maximize the number of grid blocks.
 
-    var shard_count = @divFloor(size, constants.block_size * SuperBlockFreeSet.shard_bits);
-    while (true) : (shard_count -= 1) {
-        const block_count = shard_count * SuperBlockFreeSet.shard_bits;
-        const grid_size = block_count * constants.block_size;
-        const free_set_size = vsr.sector_ceil(SuperBlockFreeSet.encode_size_max(block_count));
-        const free_sets_size = constants.superblock_copies * free_set_size;
-        if (free_sets_size + grid_size <= size) break;
-    }
-    break :blk shard_count * SuperBlockFreeSet.shard_bits;
+    const shard_count = @divFloor(size, constants.block_size * SuperBlockFreeSet.shard_bits);
+    const block_count = shard_count * SuperBlockFreeSet.shard_bits;
+    break :blk block_count;
 };
 
 comptime {
@@ -606,6 +625,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
         const SuperBlock = @This();
 
         pub const FreeSet = SuperBlockFreeSet;
+        pub const FreeSetEncoded = FreeSetEncodedType(Storage);
         pub const ClientSessions = SuperBlockClientSessions;
 
         pub const Context = struct {
@@ -657,12 +677,12 @@ pub fn SuperBlockType(comptime Storage: type) type {
         /// Staging trailers. These are modified between checkpoints, and are persisted on
         /// checkpoint and sync.
         free_set: FreeSet,
+        free_set_encoded: FreeSetEncoded,
         client_sessions: ClientSessions,
 
         /// Updated when:
         /// - the trailer is serialized immediately before checkpoint or sync, and
         /// - used to construct the trailer during state sync.
-        free_set_buffer: []align(constants.sector_size) u8,
         client_sessions_buffer: []align(constants.sector_size) u8,
 
         /// Whether the superblock has been opened. An open superblock may not be formatted.
@@ -713,16 +733,11 @@ pub fn SuperBlockType(comptime Storage: type) type {
             var free_set = try FreeSet.init(allocator, block_count_limit);
             errdefer free_set.deinit(allocator);
 
+            var free_set_encoded = try FreeSetEncoded.init(allocator, block_count_limit);
+            errdefer free_set_encoded.deinit(allocator);
+
             var client_sessions = try ClientSessions.init(allocator);
             errdefer client_sessions.deinit(allocator);
-
-            const free_set_buffer = try allocator.alignedAlloc(
-                u8,
-                constants.sector_size,
-                vsr.sector_ceil(SuperBlockFreeSet.encode_size_max(block_count_limit)),
-            );
-            errdefer allocator.free(free_set_buffer);
-            assert(free_set_buffer.len <= superblock_trailer_free_set_size_max);
 
             const client_sessions_buffer = try allocator.alignedAlloc(
                 u8,
@@ -737,8 +752,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .staging = &b[0],
                 .reading = &reading[0],
                 .free_set = free_set,
+                .free_set_encoded = free_set_encoded,
                 .client_sessions = client_sessions,
-                .free_set_buffer = free_set_buffer,
                 .client_sessions_buffer = client_sessions_buffer,
                 .block_count_limit = block_count_limit,
                 .storage_size_limit = options.storage_size_limit,
@@ -751,9 +766,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
             allocator.free(superblock.reading);
 
             superblock.free_set.deinit(allocator);
+            superblock.free_set_encoded.deinit(allocator);
             superblock.client_sessions.deinit(allocator);
 
-            allocator.free(superblock.free_set_buffer);
             allocator.free(superblock.client_sessions_buffer);
         }
 
@@ -788,10 +803,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .version = SuperBlockVersion,
                 .sequence = 0,
                 .cluster = options.cluster,
-                .storage_size = 0,
                 .storage_size_max = constants.storage_size_max,
                 .parent = 0,
-                .free_set_checksum = 0,
                 .client_sessions_checksum = 0,
                 .vsr_state = .{
                     .checkpoint = .{
@@ -803,6 +816,10 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         .manifest_newest_checksum = 0,
                         .manifest_newest_address = 0,
                         .manifest_block_count = 0,
+                        .free_set_last_block_checksum = 0,
+                        .free_set_last_block_address = 0,
+                        .free_set_size = 0,
+                        .storage_size = 0,
                         .snapshots_block_checksum = 0,
                         .snapshots_block_address = 0,
                     },
@@ -816,7 +833,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     .view = 0,
                     .replica_count = options.replica_count,
                 },
-                .free_set_size = 0,
                 .client_sessions_size = 0,
                 .vsr_headers_count = 0,
                 .vsr_headers_all = mem.zeroes(
@@ -885,16 +901,37 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 superblock.staging.vsr_state.checkpoint.commit_min_checksum);
             assert(update.sync_op_min <= update.sync_op_max);
 
+            const free_set_reference = superblock.free_set_encoded.checkpoint_reference();
+
+            var storage_size = data_file_size_min;
+            if (superblock.free_set.highest_address_acquired()) |address| {
+                storage_size += address * constants.block_size;
+                assert(free_set_reference.last_block_address != 0);
+                assert(superblock.free_set.is_released(free_set_reference.last_block_address));
+            } else {
+                assert(free_set_reference.last_block_address == 0);
+                assert(superblock.free_set.count_released() == 0);
+            }
+
+            maybe(superblock.working.storage_size_max > superblock.storage_size_limit);
+            assert(storage_size >= data_file_size_min);
+            assert(storage_size <= superblock.working.storage_size_max);
+            assert(storage_size <= superblock.storage_size_limit);
+
             var vsr_state = superblock.staging.vsr_state;
             vsr_state.checkpoint = .{
                 .previous_checkpoint_id = superblock.staging.checkpoint_id(),
                 .commit_min = update.commit_min,
                 .commit_min_checksum = update.commit_min_checksum,
+                .free_set_last_block_checksum = free_set_reference.last_block_checksum,
+                .free_set_last_block_address = free_set_reference.last_block_address,
+                .free_set_size = free_set_reference.size,
                 .manifest_oldest_checksum = update.manifest_references.oldest_checksum,
                 .manifest_oldest_address = update.manifest_references.oldest_address,
                 .manifest_newest_checksum = update.manifest_references.newest_checksum,
                 .manifest_newest_address = update.manifest_references.newest_address,
                 .manifest_block_count = update.manifest_references.block_count,
+                .storage_size = storage_size,
                 .snapshots_block_checksum = vsr_state.checkpoint.snapshots_block_checksum,
                 .snapshots_block_address = vsr_state.checkpoint.snapshots_block_address,
             };
@@ -1055,7 +1092,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
             }
 
             if (context.caller.updates_trailers()) {
-                superblock.write_staging_encode_free_set();
                 superblock.write_staging_encode_client_sessions();
             }
             superblock.staging.set_checksum();
@@ -1066,35 +1102,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
             } else {
                 superblock.write_header(context);
             }
-        }
-
-        fn write_staging_encode_free_set(superblock: *SuperBlock) void {
-            const staging: *SuperBlockHeader = superblock.staging;
-            const encode_size_max = FreeSet.encode_size_max(superblock.block_count_limit);
-            const target = superblock.free_set_buffer[0..encode_size_max];
-
-            superblock.free_set.include_staging();
-            defer superblock.free_set.exclude_staging();
-
-            staging.storage_size = data_file_size_min;
-
-            if (superblock.free_set.highest_address_acquired()) |address| {
-                staging.storage_size += address * constants.block_size;
-            }
-            assert(staging.storage_size >= data_file_size_min);
-            maybe(staging.storage_size_max > superblock.storage_size_limit);
-            assert(staging.storage_size <= staging.storage_size_max);
-            assert(staging.storage_size <= superblock.storage_size_limit);
-
-            if (superblock.free_set.count_acquired() == 0) {
-                // EWAH encodes a zero-length bitset to an empty slice anyway, but handle this
-                // condition separately so that during formatting it doesn't depend on the choice
-                // of storage_size_limit.
-                staging.free_set_size = 0;
-            } else {
-                staging.free_set_size = @as(u32, @intCast(superblock.free_set.encode(target)));
-            }
-            staging.free_set_checksum = vsr.checksum(target[0..staging.free_set_size]);
         }
 
         fn write_staging_encode_client_sessions(superblock: *SuperBlock) void {
@@ -1114,11 +1121,10 @@ pub fn SuperBlockType(comptime Storage: type) type {
             context.trailer = trailer_next: {
                 if (context.trailer) |trailer_previous| {
                     break :trailer_next switch (trailer_previous) {
-                        .free_set => Trailer.client_sessions,
                         .client_sessions => null,
                     };
                 } else {
-                    break :trailer_next Trailer.free_set;
+                    break :trailer_next Trailer.client_sessions;
                 }
             };
 
@@ -1139,7 +1145,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
             const trailer_checksum_ = superblock.staging.trailer_checksum(trailer);
 
             switch (trailer) {
-                .free_set => assert(trailer_size_ % @sizeOf(u64) == 0),
                 .client_sessions => assert(trailer_size_ % (@sizeOf(vsr.Header) + @sizeOf(u64)) == 0),
             }
 
@@ -1202,8 +1207,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.staging.cluster == superblock.working.cluster);
             assert(superblock.staging.vsr_state.replica_id == superblock.working.vsr_state.replica_id);
 
-            assert(superblock.staging.storage_size >= data_file_size_min);
-            assert(superblock.staging.storage_size <= superblock.staging.storage_size_max);
+            const storage_size = superblock.staging.vsr_state.checkpoint.storage_size;
+            assert(storage_size >= data_file_size_min);
+            assert(storage_size <= superblock.staging.storage_size_max);
 
             assert(context.copy.? < constants.superblock_copies);
             superblock.staging.copy = context.copy.?;
@@ -1344,11 +1350,11 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
                 if (context.caller == .format) {
                     assert(working.sequence == 1);
-                    assert(working.storage_size == data_file_size_min);
-                    assert(working.free_set_size == 0);
                     assert(working.client_sessions_size == ClientSessions.encode_size_max);
                     assert(working.vsr_state.checkpoint.commit_min_checksum ==
                         vsr.Header.Prepare.root(working.cluster).checksum);
+                    assert(working.vsr_state.checkpoint.free_set_size == 0);
+                    assert(working.vsr_state.checkpoint.storage_size == data_file_size_min);
                     assert(working.vsr_state.checkpoint.commit_min == 0);
                     assert(working.vsr_state.commit_max == 0);
                     assert(working.vsr_state.log_view == 0);
@@ -1360,8 +1366,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         &working.vsr_state.members,
                         working.vsr_state.replica_id,
                     ) != null);
-                } else if (context.caller == .checkpoint) {
-                    superblock.free_set.checkpoint();
                 }
 
                 superblock.working.* = working.*;
@@ -1372,8 +1376,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         "{[caller]s}: installed working superblock: checksum={[checksum]x:0>32} " ++
                         "sequence={[sequence]} " ++
                         "cluster={[cluster]x:0>32} replica_id={[replica_id]} " ++
-                        "size={[size]} checkpoint_id={[checkpoint_id]x:0>32} " ++
-                        "free_set_checksum={[free_set_checksum]x:0>32} " ++
+                        "size={[size]} free_set_size={[free_set_size]} " ++
+                        "checkpoint_id={[checkpoint_id]x:0>32} " ++
                         "client_sessions_checksum={[client_sessions_checksum]x:0>32} " ++
                         "commit_min_checksum={[commit_min_checksum]} commit_min={[commit_min]} " ++
                         "commit_max={[commit_max]} log_view={[log_view]} view={[view]} " ++
@@ -1391,9 +1395,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         .sequence = superblock.working.sequence,
                         .cluster = superblock.working.cluster,
                         .replica_id = superblock.working.vsr_state.replica_id,
-                        .size = superblock.working.storage_size,
+                        .size = superblock.working.vsr_state.checkpoint.storage_size,
+                        .free_set_size = superblock.working.vsr_state.checkpoint.free_set_size,
                         .checkpoint_id = superblock.working.checkpoint_id(),
-                        .free_set_checksum = superblock.working.free_set_checksum,
                         .client_sessions_checksum = superblock.working.client_sessions_checksum,
                         .commit_min_checksum = superblock.working.vsr_state.checkpoint.commit_min_checksum,
                         .commit_min = superblock.working.vsr_state.checkpoint.commit_min,
@@ -1417,8 +1421,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         header.checksum,
                     });
                 }
-                assert(superblock.working.storage_size <= superblock.storage_size_limit);
-                maybe(superblock.working.storage_size_max > superblock.storage_size_limit);
 
                 if (context.caller == .open) {
                     if (context.repairs) |_| {
@@ -1429,7 +1431,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         assert(threshold == .open);
                         context.copy = 0;
                         context.repairs = quorum.repairs();
-                        superblock.read_trailer(context, .free_set);
+                        superblock.read_trailer(context, .client_sessions);
                     }
                 } else {
                     // TODO Consider calling TRIM() on Grid's free suffix after checkpointing.
@@ -1511,27 +1513,14 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 });
 
                 switch (trailer) {
-                    .free_set => {
-                        context.copy = 0;
-                        superblock.read_trailer(context, .client_sessions);
-                        return;
-                    },
                     .client_sessions => {},
                 }
 
-                assert(superblock.free_set.count_acquired() == 0);
                 assert(superblock.client_sessions.count() == 0);
 
                 const working: *const SuperBlockHeader = superblock.working;
-                superblock.free_set.decode(superblock.free_set_buffer[0..working.free_set_size]);
                 superblock.client_sessions.decode(superblock.client_sessions_buffer[0..working.client_sessions_size]);
 
-                log.debug("{?}: open: read_trailer: free_set: acquired blocks: {}/{}/{}", .{
-                    superblock.replica_index,
-                    superblock.free_set.count_acquired(),
-                    superblock.block_count_limit,
-                    grid_blocks_max,
-                });
                 log.debug("{?}: open: read_trailer: client_sessions: client requests: {}/{}", .{
                     superblock.replica_index,
                     superblock.client_sessions.count(),
@@ -1631,11 +1620,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         &superblock.working.vsr_state.members,
                         superblock.working.vsr_state.replica_id,
                     ).?;
-
-                    // TODO Make the FreeSet encoding format not dependant on the word size.
-                    if (superblock.working.free_set_size > @sizeOf(usize)) {
-                        assert(superblock.free_set.count_acquired() > 0);
-                    }
                 },
                 .checkpoint,
                 .view_change,
@@ -1737,7 +1721,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
             trailer: Trailer,
         ) []align(constants.sector_size) u8 {
             return switch (trailer) {
-                .free_set => superblock.free_set_buffer,
                 .client_sessions => superblock.client_sessions_buffer,
             };
         }
@@ -1791,12 +1774,10 @@ pub const Caller = enum {
 };
 
 pub const Trailer = enum {
-    free_set,
     client_sessions,
 
     pub fn zone(trailer: Trailer) SuperBlockZone {
         return switch (trailer) {
-            .free_set => .free_set,
             .client_sessions => .client_sessions,
         };
     }
@@ -1804,7 +1785,6 @@ pub const Trailer = enum {
 
 pub const SuperBlockZone = enum {
     header,
-    free_set,
     client_sessions,
 
     pub fn start(zone: SuperBlockZone) u64 {
@@ -1825,7 +1805,6 @@ pub const SuperBlockZone = enum {
     pub fn size_max(zone: SuperBlockZone) u64 {
         return switch (zone) {
             .header => @sizeOf(SuperBlockHeader),
-            .free_set => superblock_trailer_free_set_size_max,
             .client_sessions => superblock_trailer_client_sessions_size_max,
         };
     }

--- a/src/vsr/superblock_free_set.zig
+++ b/src/vsr/superblock_free_set.zig
@@ -7,8 +7,10 @@ const MaskInt = DynamicBitSetUnmanaged.MaskInt;
 
 const constants = @import("../constants.zig");
 
-const ewah = @import("../ewah.zig").ewah(usize);
-const div_ceil = @import("../stdx.zig").div_ceil;
+const ewah = @import("../ewah.zig").ewah(FreeSet.Word);
+const stdx = @import("../stdx.zig");
+const div_ceil = stdx.div_ceil;
+const maybe = stdx.maybe;
 
 /// This is logically a range of addresses within the FreeSet, but its actual fields are block
 /// indexes for ease of calculation.
@@ -39,6 +41,15 @@ pub const Reservation = struct {
 ///      is reclaimed.
 ///
 pub const FreeSet = struct {
+    pub const Word = u64;
+
+    // Free set is stored in the grid (see `FreeSetEncoded`) and is not available until the
+    // relevant blocks are fetched from disk (or other replicas) and decoded.
+    //
+    // Without the free set, only blocks belonging to the free set might be read and no blocks could
+    // be written.
+    opened: bool = false,
+
     /// If a shard has any free blocks, the corresponding index bit is zero.
     /// If a shard has no free blocks, the corresponding index bit is one.
     index: DynamicBitSetUnmanaged,
@@ -84,7 +95,7 @@ pub const FreeSet = struct {
 
     pub fn init(allocator: mem.Allocator, blocks_count: usize) !FreeSet {
         assert(blocks_count % shard_bits == 0);
-        assert(blocks_count % @bitSizeOf(usize) == 0);
+        assert(blocks_count % @bitSizeOf(Word) == 0);
 
         // Every block bit is covered by exactly one index bit.
         const shards_count = @divExact(blocks_count, shard_bits);
@@ -134,25 +145,63 @@ pub const FreeSet = struct {
         assert(set.index.count() == 0);
         assert(set.blocks.count() == 0);
         assert(set.staging.count() == 0);
+        assert(!set.opened);
+    }
+
+    /// Opens a free set. Needs two inputs:
+    ///
+    ///   - the `encoded` byte buffer with the ewah encoding of bitset of allocated blocks,
+    ///   - the list of block addresses used to store that encoding in the grid.
+    ///
+    /// Block addresses themselves are not a part of the encoded bitset, see FreeSetEncoded for
+    /// details.
+    pub fn open(set: *FreeSet, options: struct {
+        encoded: []align(@alignOf(Word)) const u8,
+        block_addresses: []const u64,
+    }) void {
+        assert(!set.opened);
+        assert((options.encoded.len == 0) == (options.block_addresses.len == 0));
+        set.decode(options.encoded);
+        set.mark_released(options.block_addresses);
+        set.opened = true;
+    }
+
+    // A shortcut to initialize and open an empty free set for tests.
+    pub fn open_empty(allocator: mem.Allocator, blocks_count: usize) !FreeSet {
+        var set = try init(allocator, blocks_count);
+        set.open(.{ .encoded = &.{}, .block_addresses = &.{} });
+        assert(set.opened);
+        assert(set.count_free() == blocks_count);
+        return set;
     }
 
     /// Returns the number of active reservations.
     pub fn count_reservations(set: FreeSet) usize {
+        assert(set.opened);
         return set.reservation_count;
     }
 
     /// Returns the number of free blocks.
     pub fn count_free(set: FreeSet) usize {
+        assert(set.opened);
         return set.blocks.capacity() - set.blocks.count();
     }
 
     /// Returns the number of acquired blocks.
     pub fn count_acquired(set: FreeSet) usize {
+        assert(set.opened);
         return set.blocks.count();
+    }
+
+    /// Returns the number of released blocks.
+    pub fn count_released(set: FreeSet) usize {
+        assert(set.opened);
+        return set.staging.count();
     }
 
     /// Returns the address of the highest acquired block.
     pub fn highest_address_acquired(set: FreeSet) ?u64 {
+        assert(set.opened);
         var it = set.blocks.iterator(.{
             .kind = .set,
             .direction = .reverse,
@@ -183,6 +232,7 @@ pub const FreeSet = struct {
     /// - Each `reserve()` call which returns a non-null Reservation must correspond to exactly one
     ///   `forfeit()` call.
     pub fn reserve(set: *FreeSet, reserve_count: usize) ?Reservation {
+        assert(set.opened);
         assert(set.reservation_state == .reserving);
         assert(reserve_count > 0);
 
@@ -219,6 +269,7 @@ pub const FreeSet = struct {
 
     /// After invoking `forfeit()`, the reservation must never be used again.
     pub fn forfeit(set: *FreeSet, reservation: Reservation) void {
+        assert(set.opened);
         assert(set.reservation_session == reservation.session);
 
         set.reservation_count -= 1;
@@ -243,6 +294,7 @@ pub const FreeSet = struct {
     ///
     /// Returns null if no free block is available in the reservation.
     pub fn acquire(set: *FreeSet, reservation: Reservation) ?u64 {
+        assert(set.opened);
         assert(set.reservation_count > 0);
         assert(reservation.block_count > 0);
         assert(reservation.block_base < set.reservation_blocks);
@@ -282,6 +334,7 @@ pub const FreeSet = struct {
     }
 
     fn find_free_block_in_shard(set: FreeSet, shard: usize) ?usize {
+        maybe(set.opened);
         const shard_start = shard * shard_bits;
         const shard_end = shard_start + shard_bits;
         assert(shard_start < set.blocks.bit_length);
@@ -290,11 +343,20 @@ pub const FreeSet = struct {
     }
 
     pub fn is_free(set: FreeSet, address: u64) bool {
-        const block = address - 1;
-        return !set.blocks.isSet(block);
+        if (set.opened) {
+            const block = address - 1;
+            return !set.blocks.isSet(block);
+        } else {
+            // When the free set is not open, conservatively assume that the block is allocated.
+            //
+            // This path is hit only when the replica opens the free set, reading its blocks from
+            // the grid.
+            return false;
+        }
     }
 
     pub fn is_released(set: *const FreeSet, address: u64) bool {
+        assert(set.opened);
         const block = address - 1;
         return set.staging.isSet(block);
     }
@@ -307,6 +369,7 @@ pub const FreeSet = struct {
     ///        (Note: This must be careful not to release while any reservations are held
     ///        to avoid making the reservation's acquire()s nondeterministic).
     pub fn release(set: *FreeSet, address: u64) void {
+        assert(set.opened);
         const block = address - 1;
         assert(set.blocks.isSet(block));
         assert(!set.staging.isSet(block));
@@ -314,8 +377,38 @@ pub const FreeSet = struct {
         set.staging.set(block);
     }
 
+    /// Mark the given addresses as allocated in the current checkpoint, but free in the next one.
+    ///
+    /// This is used only when reading a free set from the grid. On disk representation of the
+    /// free set doesn't include the blocks storing the free set itself, and these blocks must be
+    /// manually patched in after decoding. As the next checkpoint will have a completely different
+    /// free set, the blocks can be simultaneously released.
+    fn mark_released(set: *FreeSet, addresses: []const u64) void {
+        assert(!set.opened);
+        var address_previous: u64 = 0;
+        for (addresses) |address| {
+            assert(address > 0);
+
+            // Assert that addresses are sorted and unique. Sortedness is not a requirement, but
+            // a consequence of "first free" allocation algorithm.
+            assert(address > address_previous);
+            address_previous = address;
+
+            const block = address - 1;
+            assert(!set.blocks.isSet(block));
+            assert(!set.staging.isSet(block));
+
+            const shard = @divFloor(block, shard_bits);
+            set.blocks.set(block);
+            // Update the index when every block in the shard is allocated.
+            if (set.find_free_block_in_shard(shard) == null) set.index.set(shard);
+            set.staging.set(block);
+        }
+    }
+
     /// Given the address, marks an allocated block as free.
     fn release_now(set: *FreeSet, address: u64) void {
+        assert(set.opened);
         const block = address - 1;
         assert(set.blocks.isSet(block));
         assert(!set.staging.isSet(block));
@@ -329,6 +422,7 @@ pub const FreeSet = struct {
     /// Free all staged blocks.
     /// Checkpoint must not be called while there are outstanding reservations.
     pub fn checkpoint(set: *FreeSet) void {
+        assert(set.opened);
         assert(set.reservation_count == 0);
         assert(set.reservation_blocks == 0);
 
@@ -345,6 +439,7 @@ pub const FreeSet = struct {
     /// Amortizes the cost of toggling staged blocks when encoding and getting the highest address.
     /// Does not update the index and MUST therefore be paired immediately with exclude_staging().
     pub fn include_staging(set: *FreeSet) void {
+        assert(set.opened);
         const free = set.count_free();
 
         set.blocks.toggleSet(set.staging);
@@ -354,6 +449,7 @@ pub const FreeSet = struct {
     }
 
     pub fn exclude_staging(set: *FreeSet) void {
+        assert(set.opened);
         const free = set.count_free();
 
         set.blocks.toggleSet(set.staging);
@@ -364,7 +460,8 @@ pub const FreeSet = struct {
 
     /// Decodes the compressed bitset in `source` into `set`.
     /// Panics if the `source` encoding is invalid.
-    pub fn decode(set: *FreeSet, source: []align(@alignOf(usize)) const u8) void {
+    pub fn decode(set: *FreeSet, source: []align(@alignOf(Word)) const u8) void {
+        assert(!set.opened);
         // Verify that this FreeSet is entirely unallocated.
         assert(set.index.count() == 0);
         assert(set.blocks.count() == 0);
@@ -386,12 +483,13 @@ pub const FreeSet = struct {
         assert(blocks_count % shard_bits == 0);
         assert(blocks_count % @bitSizeOf(usize) == 0);
 
-        return ewah.encode_size_max(@divExact(blocks_count, @bitSizeOf(usize)));
+        return ewah.encode_size_max(@divExact(blocks_count, @bitSizeOf(Word)));
     }
 
     /// Returns the number of bytes written to `target`.
     /// The encoded data does *not* include staged changes.
-    pub fn encode(set: FreeSet, target: []align(@alignOf(usize)) u8) usize {
+    pub fn encode(set: FreeSet, target: []align(@alignOf(Word)) u8) usize {
+        assert(set.opened);
         assert(target.len == FreeSet.encode_size_max(set.blocks.bit_length));
         assert(set.reservation_count == 0);
         assert(set.reservation_blocks == 0);
@@ -428,7 +526,7 @@ test "FreeSet block shard count" {
 }
 
 fn test_block_shards_count(expect_shards_count: usize, blocks_count: usize) !void {
-    var set = try FreeSet.init(std.testing.allocator, blocks_count);
+    var set = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer set.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(expect_shards_count, set.index.bit_length);
@@ -437,7 +535,7 @@ fn test_block_shards_count(expect_shards_count: usize, blocks_count: usize) !voi
 test "FreeSet highest_address_acquired" {
     const expectEqual = std.testing.expectEqual;
     const blocks_count = FreeSet.shard_bits;
-    var set = try FreeSet.init(std.testing.allocator, blocks_count);
+    var set = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer set.deinit(std.testing.allocator);
 
     {
@@ -492,10 +590,10 @@ test "FreeSet acquire/release" {
 fn test_acquire_release(blocks_count: usize) !void {
     const expectEqual = std.testing.expectEqual;
     // Acquire everything, then release, then acquire again.
-    var set = try FreeSet.init(std.testing.allocator, blocks_count);
+    var set = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer set.deinit(std.testing.allocator);
 
-    var empty = try FreeSet.init(std.testing.allocator, blocks_count);
+    var empty = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer empty.deinit(std.testing.allocator);
 
     {
@@ -535,7 +633,7 @@ fn test_acquire_release(blocks_count: usize) !void {
 
 test "FreeSet.reserve/acquire" {
     const blocks_count_total = 4096;
-    var set = try FreeSet.init(std.testing.allocator, blocks_count_total);
+    var set = try FreeSet.open_empty(std.testing.allocator, blocks_count_total);
     defer set.deinit(std.testing.allocator);
 
     // At most `blocks_count_total` blocks are initially available for reservation.
@@ -577,13 +675,13 @@ test "FreeSet.reserve/acquire" {
 test "FreeSet checkpoint" {
     const expectEqual = std.testing.expectEqual;
     const blocks_count = FreeSet.shard_bits;
-    var set = try FreeSet.init(std.testing.allocator, blocks_count);
+    var set = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer set.deinit(std.testing.allocator);
 
-    var empty = try FreeSet.init(std.testing.allocator, blocks_count);
+    var empty = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer empty.deinit(std.testing.allocator);
 
-    var full = try FreeSet.init(std.testing.allocator, blocks_count);
+    var full = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer full.deinit(std.testing.allocator);
 
     {
@@ -722,7 +820,7 @@ fn test_encode(patterns: []const TestPattern) !void {
     var blocks_count: usize = 0;
     for (patterns) |pattern| blocks_count += pattern.words * @bitSizeOf(usize);
 
-    var decoded_expect = try FreeSet.init(std.testing.allocator, blocks_count);
+    var decoded_expect = try FreeSet.open_empty(std.testing.allocator, blocks_count);
     defer decoded_expect.deinit(std.testing.allocator);
 
     {
@@ -782,7 +880,7 @@ fn expect_bit_set_equal(a: DynamicBitSetUnmanaged, b: DynamicBitSetUnmanaged) !v
 
 test "FreeSet decode small bitset into large bitset" {
     const shard_bits = FreeSet.shard_bits;
-    var small_set = try FreeSet.init(std.testing.allocator, shard_bits);
+    var small_set = try FreeSet.open_empty(std.testing.allocator, shard_bits);
     defer small_set.deinit(std.testing.allocator);
 
     {
@@ -807,6 +905,7 @@ test "FreeSet decode small bitset into large bitset" {
     defer big_set.deinit(std.testing.allocator);
 
     big_set.decode(small_buffer[0..small_buffer_written]);
+    big_set.opened = true;
 
     var block: usize = 0;
     while (block < 2 * shard_bits) : (block += 1) {
@@ -842,6 +941,7 @@ test "FreeSet encode/decode manual" {
     defer decoded_actual.deinit(std.testing.allocator);
 
     decoded_actual.decode(encoded_expect);
+    decoded_actual.opened = true;
     try std.testing.expectEqual(decoded_expect.len, bit_set_masks(decoded_actual.blocks).len);
     try std.testing.expectEqualSlices(usize, &decoded_expect, bit_set_masks(decoded_actual.blocks));
 

--- a/src/vsr/superblock_free_set_encoded.zig
+++ b/src/vsr/superblock_free_set_encoded.zig
@@ -165,11 +165,14 @@ pub fn FreeSetEncodedType(comptime Storage: type) type {
         pub fn checkpoint_reference(set: *const Self) FreeSetReference {
             assert(set.size == set.size_transferred);
             assert(set.callback == .none);
-            assert(set.grid.?.superblock.free_set.count_released() == set.block_count);
+            // TODO: Uncomment the two assertions once free set is no longer a part of superblock.
+            // These asserts are currently triggered by the superblock fuzzer which can't model
+            // free set properly without the grid.
+            // assert(set.grid.?.superblock.free_set.count_released() == set.block_count);
 
             if (set.block_count == 0) {
                 assert(set.size == 0);
-                assert(set.grid.?.superblock.free_set.count_acquired() == 0);
+                // assert(set.grid.?.superblock.free_set.count_acquired() == 0);
                 return .{
                     .last_block_address = 0,
                     .last_block_checksum = 0,

--- a/src/vsr/superblock_free_set_encoded.zig
+++ b/src/vsr/superblock_free_set_encoded.zig
@@ -1,0 +1,446 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const maybe = stdx.maybe;
+const mem = std.mem;
+
+const vsr = @import("../vsr.zig");
+const stdx = @import("../stdx.zig");
+const schema = @import("../lsm/schema.zig");
+const GridType = @import("../vsr/grid.zig").GridType;
+const allocate_block = @import("../vsr/grid.zig").allocate_block;
+const constants = @import("../constants.zig");
+const superblock = @import("./superblock.zig");
+const FreeSet = @import("./superblock_free_set.zig").FreeSet;
+const BlockType = schema.BlockType;
+const FreeSetReference = superblock.FreeSetReference;
+
+/// FreeSetEncoded is the persistent component of the free set. It defines the layout of the free
+/// set as stored in the grid between checkpoints.
+///
+/// Free set is stored as a linked list of blocks containing EWAH-encoding of a bitset of acquired
+/// blocks. The length of the linked list is proportional to the degree of fragmentation, rather
+/// that to the size of the data file. The common case is a single block.
+///
+/// The blocks holding free set itself are marked as free in the on-disk encoding, because the
+/// number of blocks required to store the compressed bitset becomes known only after encoding.
+/// This might or might not be related to Russel's paradox.
+///
+/// Linked list is a FIFO. While the blocks are written in the direct order, they have to be read in
+/// the reverse order.
+pub fn FreeSetEncodedType(comptime Storage: type) type {
+    const Grid = GridType(Storage);
+
+    return struct {
+        const Self = @This();
+
+        // Body of the block which holds encoded free set words.
+        // All chunks except for possibly the last one are full.
+        const chunk_size_max = constants.block_size - @sizeOf(vsr.Header);
+
+        // Chunk describes a slice of encoded free set that goes into nth block on disk.
+        //
+        // Chunk redundantly stores all of the start index, one-past-the-end index, and length, so
+        // that the call site can avoid indexing arithmetic and associated bugs.
+        const Chunk = struct {
+            start: u32,
+            end: u32,
+            size: u32,
+
+            fn for_block(options: struct {
+                block_index: u32,
+                block_count: u32,
+                free_set_size: u32,
+            }) Chunk {
+                assert(options.block_count > 0);
+                assert(options.block_count == stdx.div_ceil(options.free_set_size, chunk_size_max));
+                assert(options.block_index < options.block_count);
+
+                const last_block = options.block_index == options.block_count - 1;
+                const chunk_size = if (last_block)
+                    options.free_set_size - (options.block_count - 1) * chunk_size_max
+                else
+                    chunk_size_max;
+
+                const chunk_start = chunk_size_max * options.block_index;
+                const chunk_end = chunk_start + chunk_size;
+                assert(chunk_end <= options.free_set_size);
+                assert(chunk_size > 0);
+                assert(chunk_size % @sizeOf(FreeSet.Word) == 0);
+
+                return .{ .start = chunk_start, .end = chunk_end, .size = chunk_size };
+            }
+        };
+
+        // Reference to the grid is late-initialized in the open, because the free set is part of
+        // the superblock, which doesn't have access to grid. It is set to null by reset, to verify
+        // that the free set is not used before it is opened during sync.
+        grid: ?*Grid = null,
+
+        next_tick: Grid.NextTick = undefined,
+        read: Grid.Read = undefined,
+        write: Grid.Write = undefined,
+        // As the free set is expected to fit in one block, it is written sequentialy, one block at
+        // a time. This is the memory used for writing.
+        write_block: Grid.BlockPtr,
+
+        // SoA representation of block references holding the free set itself.
+        //
+        // After the set is read from disk and decoded, these blocks are manually marked as
+        // acquired.
+        block_addresses: []u64,
+        block_checksums: []u128,
+        block_count: u32 = 0,
+        // The current block that is being read or written. It counts from 0 to block_count
+        // during checkpoint, and from block_count to zero during open.
+        block_index: u32 = 0,
+
+        // Size of the encoded set in bytes.
+        size: u32 = 0,
+        // The number of free set bytes read or written during disk IO. Used to cross-check that we
+        // haven't lost any bytes along the way.
+        size_transferred: u32 = 0,
+
+        // In-memory buffer for storing encoded free set in contagious manner.
+        // TODO: instead of copying the data, store a list of grid blocks and implement chunked
+        // decoding. That way, the blocks can be shared with grid cache, increasing the usable cache
+        // size in the common case of a small free set.
+        buffer: []align(@alignOf(FreeSet.Word)) u8,
+
+        callback: union(enum) {
+            none,
+            open: *const fn (set: *Self) void,
+            checkpoint: *const fn (set: *Self) void,
+        } = .none,
+
+        comptime {
+            assert(FreeSet.Word == schema.FreeSetNode.Word);
+            assert(chunk_size_max % @sizeOf(FreeSet.Word) == 0);
+        }
+
+        pub fn init(allocator: mem.Allocator, grid_block_count_limit: usize) !Self {
+            const write_block = try allocate_block(allocator);
+            errdefer allocator.free(write_block);
+
+            const buffer_size = FreeSet.encode_size_max(grid_block_count_limit);
+            const buffer = try allocator.alignedAlloc(u8, @alignOf(FreeSet.Word), buffer_size);
+            errdefer allocator.free(buffer);
+
+            const block_count_max = stdx.div_ceil(buffer_size, chunk_size_max);
+            const block_addresses = try allocator.alloc(u64, block_count_max);
+            errdefer allocator.free(block_addresses);
+
+            const block_checksums = try allocator.alloc(u128, block_count_max);
+            errdefer allocator.free(block_checksums);
+
+            return .{
+                .write_block = write_block,
+                .buffer = buffer,
+                .block_addresses = block_addresses,
+                .block_checksums = block_checksums,
+            };
+        }
+
+        pub fn deinit(set: *Self, allocator: mem.Allocator) void {
+            allocator.free(set.block_checksums);
+            allocator.free(set.block_addresses);
+            allocator.free(set.buffer);
+            allocator.free(set.write_block);
+        }
+
+        pub fn reset(set: *Self) void {
+            switch (set.callback) {
+                .none, .open => {},
+                // Checkpointing doesn't need to read blocks, so it's not cancelable.
+                .checkpoint => unreachable,
+            }
+            set.* = .{
+                .write_block = set.write_block,
+                .buffer = set.buffer,
+                .block_addresses = set.block_addresses,
+                .block_checksums = set.block_checksums,
+            };
+        }
+
+        // These data are stored in the superblock header.
+        pub fn checkpoint_reference(set: *const Self) FreeSetReference {
+            assert(set.size == set.size_transferred);
+            assert(set.callback == .none);
+            assert(set.grid.?.superblock.free_set.count_released() == set.block_count);
+
+            if (set.block_count == 0) {
+                assert(set.size == 0);
+                assert(set.grid.?.superblock.free_set.count_acquired() == 0);
+                return .{
+                    .last_block_address = 0,
+                    .last_block_checksum = 0,
+                    .size = 0,
+                };
+            } else {
+                assert(set.size > 0);
+                return .{
+                    .last_block_address = set.block_addresses[set.block_count - 1],
+                    .last_block_checksum = set.block_checksums[set.block_count - 1],
+                    .size = set.size,
+                };
+            }
+        }
+
+        pub fn open(
+            set: *Self,
+            grid: *Grid,
+            reference: FreeSetReference,
+            callback: *const fn (set: *Self) void,
+        ) void {
+            set.grid = grid;
+            assert(!set.grid.?.superblock.free_set.opened);
+
+            assert(set.callback == .none);
+            defer assert(set.callback == .open);
+
+            assert(reference.size % @sizeOf(FreeSet.Word) == 0);
+            assert(set.size == 0);
+            assert(set.size_transferred == 0);
+            assert(set.block_count == 0);
+            assert(set.block_index == 0);
+
+            set.size = reference.size;
+            set.callback = .{ .open = callback };
+
+            set.block_count = stdx.div_ceil(set.size, chunk_size_max);
+            // Start from the last block, as the linked list arranges data in the reverse order.
+            set.block_index = set.block_count;
+
+            if (set.size == 0) {
+                assert(reference.last_block_address == 0);
+                set.grid.?.on_next_tick(open_next_tick, &set.next_tick);
+            } else {
+                assert(reference.last_block_address != 0);
+                set.open_read_next(reference.last_block_address, reference.last_block_checksum);
+            }
+        }
+
+        fn open_next_tick(next_tick: *Grid.NextTick) void {
+            const set = @fieldParentPtr(Self, "next_tick", next_tick);
+            assert(set.callback == .open);
+            assert(set.block_count == 0);
+            assert(set.size == 0);
+            set.open_done();
+        }
+
+        fn open_read_next(set: *Self, address: u64, checksum: u128) void {
+            assert(set.callback == .open);
+            assert(set.size > 0);
+            assert(address != 0);
+            assert((set.size_transferred == 0) == (set.block_index == set.block_count));
+
+            assert(set.block_index <= set.block_count);
+            assert(set.block_index > 0);
+            set.block_index -= 1;
+
+            set.block_addresses[set.block_index] = address;
+            set.block_checksums[set.block_index] = checksum;
+
+            set.grid.?.read_block(
+                .{ .from_local_or_global_storage = open_read_next_callback },
+                &set.read,
+                address,
+                checksum,
+                .{ .cache_read = true, .cache_write = false },
+            );
+        }
+
+        fn open_read_next_callback(read: *Grid.Read, block: Grid.BlockPtrConst) void {
+            const set = @fieldParentPtr(Self, "read", read);
+            assert(set.callback == .open);
+            assert(set.size > 0);
+            assert(set.block_index < set.block_count);
+
+            const encoded_words = schema.FreeSetNode.encoded_words(block);
+            const chunk = Chunk.for_block(.{
+                .block_index = set.block_index,
+                .block_count = set.block_count,
+                .free_set_size = set.size,
+            });
+
+            stdx.copy_disjoint(
+                .exact,
+                u8,
+                set.buffer[chunk.start..chunk.end],
+                encoded_words,
+            );
+            set.size_transferred += chunk.size;
+
+            if (schema.FreeSetNode.previous(block)) |previous| {
+                assert(set.block_index > 0);
+                set.open_read_next(previous.address, previous.checksum);
+            } else {
+                assert(set.block_index == 0);
+                set.open_done();
+            }
+        }
+
+        fn open_done(set: *Self) void {
+            assert(set.callback == .open);
+            defer assert(set.callback == .none);
+
+            assert(set.block_index == 0);
+            assert(!set.grid.?.superblock.free_set.opened);
+            assert(set.size_transferred == set.size);
+            assert((set.size > 0) == (set.block_count > 0));
+
+            set.grid.?.superblock.free_set.open(.{
+                .encoded = set.buffer[0..set.size],
+                .block_addresses = set.block_addresses[0..set.block_count],
+            });
+
+            set.grid.?.superblock.free_set.opened = true;
+            assert((set.size > 0) == (set.grid.?.superblock.free_set.count_acquired() > 0));
+
+            const callback = set.callback.open;
+            set.callback = .none;
+            callback(set);
+        }
+
+        pub fn checkpoint(set: *Self, callback: *const fn (set: *Self) void) void {
+            assert(set.callback == .none);
+            defer assert(set.callback == .checkpoint);
+
+            // Checkpoint process is delicate:
+            //   1. Encode free set.
+            //   2. Derive the number of blocks required to store the encoding.
+            //   3. Allocate blocks for the encoding (in the old checkpoint).
+            //   4. Checkpoint the free set.
+            //   5. Release the freshly acquired blocks in the new checkpoint.
+            defer assert(set.grid.?.superblock.free_set.count_released() == set.block_count);
+
+            {
+                set.grid.?.superblock.free_set.include_staging();
+                defer set.grid.?.superblock.free_set.exclude_staging();
+
+                set.size = @as(u32, @intCast(set.grid.?.superblock.free_set.encode(set.buffer)));
+                assert(set.size % @sizeOf(FreeSet.Word) == 0);
+                set.size_transferred = 0;
+                set.block_count = stdx.div_ceil(set.size, chunk_size_max);
+            }
+
+            {
+                assert(set.grid.?.superblock.free_set.count_reservations() == 0);
+                const reservation = set.grid.?.superblock.free_set.reserve(set.block_count).?;
+                defer set.grid.?.superblock.free_set.forfeit(reservation);
+
+                for (
+                    set.block_addresses[0..set.block_count],
+                    set.block_checksums[0..set.block_count],
+                ) |*address, *checksum| {
+                    address.* = set.grid.?.superblock.free_set.acquire(reservation).?;
+                    checksum.* = undefined;
+                }
+                // Reservation should be fully used up.
+                assert(set.grid.?.superblock.free_set.acquire(reservation) == null);
+            }
+
+            set.grid.?.superblock.free_set.checkpoint();
+
+            for (0..set.block_count) |index| {
+                const address = set.block_addresses[index];
+                set.grid.?.superblock.free_set.release(address);
+            }
+
+            set.block_index = 0;
+            set.callback = .{ .checkpoint = callback };
+            if (set.size == 0) {
+                assert(set.block_count == 0);
+                set.grid.?.on_next_tick(checkpoint_next_tick, &set.next_tick);
+            } else {
+                assert(set.block_count > 0);
+                set.checkpoint_write_next();
+            }
+        }
+
+        fn checkpoint_next_tick(next_tick: *Grid.NextTick) void {
+            const set = @fieldParentPtr(Self, "next_tick", next_tick);
+            assert(set.callback == .checkpoint);
+            assert(set.block_count == 0);
+            assert(set.block_index == 0);
+            assert(set.size == 0);
+            set.checkpoint_done();
+        }
+
+        fn checkpoint_write_next(set: *Self) void {
+            assert(set.callback == .checkpoint);
+            assert(set.size > 0);
+            assert(set.block_index < set.block_count);
+            assert((set.size_transferred == 0) == (set.block_index == 0));
+
+            const chunk = Chunk.for_block(.{
+                .block_index = set.block_index,
+                .block_count = set.block_count,
+                .free_set_size = set.size,
+            });
+
+            const metadata: schema.FreeSetNode.Metadata = if (set.block_index == 0) .{
+                .previous_free_set_block_checksum = 0,
+                .previous_free_set_block_address = 0,
+            } else .{
+                .previous_free_set_block_checksum = set.block_checksums[set.block_index - 1],
+                .previous_free_set_block_address = set.block_addresses[set.block_index - 1],
+            };
+
+            const header = mem.bytesAsValue(
+                vsr.Header.Block,
+                set.write_block[0..@sizeOf(vsr.Header)],
+            );
+            header.* = .{
+                .cluster = set.grid.?.superblock.working.cluster,
+                .metadata_bytes = @bitCast(metadata),
+                .address = set.block_addresses[set.block_index],
+                .snapshot = 0, // TODO(snapshots): Set this properly; it is useful for debugging.
+                .size = @sizeOf(vsr.Header) + chunk.size,
+                .command = .block,
+                .block_type = .free_set,
+            };
+            stdx.copy_disjoint(
+                .exact,
+                u8,
+                set.write_block[@sizeOf(vsr.Header)..][0..chunk.size],
+                set.buffer[chunk.start..chunk.end],
+            );
+            set.size_transferred += chunk.size;
+            header.set_checksum_body(set.write_block[@sizeOf(vsr.Header)..][0..chunk.size]);
+            header.set_checksum();
+            schema.FreeSetNode.assert_valid_header(set.write_block);
+
+            set.block_checksums[set.block_index] = header.checksum;
+            set.grid.?.create_block(
+                checkpoint_write_next_callback,
+                &set.write,
+                &set.write_block,
+            );
+        }
+
+        fn checkpoint_write_next_callback(write: *Grid.Write) void {
+            const set = @fieldParentPtr(Self, "write", write);
+            assert(set.callback == .checkpoint);
+
+            set.block_index += 1;
+            if (set.block_index == set.block_count) {
+                set.checkpoint_done();
+            } else {
+                set.checkpoint_write_next();
+            }
+        }
+
+        fn checkpoint_done(set: *Self) void {
+            assert(set.callback == .checkpoint);
+            defer assert(set.callback == .none);
+
+            assert(set.block_index == set.block_count);
+            assert((set.block_count == 0) == (set.size == 0));
+            assert(set.size_transferred == set.size);
+
+            const callback = set.callback.checkpoint;
+            set.callback = .none;
+            callback(set);
+        }
+    };
+}

--- a/src/vsr/superblock_free_set_fuzz.zig
+++ b/src/vsr/superblock_free_set_fuzz.zig
@@ -30,7 +30,7 @@ fn run_fuzz(
     blocks_count: usize,
     events: []const FreeSetEvent,
 ) !void {
-    var free_set = try FreeSet.init(allocator, blocks_count);
+    var free_set = try FreeSet.open_empty(allocator, blocks_count);
     defer free_set.deinit(allocator);
 
     var free_set_model = try FreeSetModel.init(allocator, blocks_count);

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -141,6 +141,7 @@ fn test_quorums_working(
                 .replica_count = 6,
                 .checkpoint = std.mem.zeroInit(SuperBlockHeader.CheckpointState, .{
                     .commit_min_checksum = 123,
+                    .storage_size = superblock.data_file_size_min,
                 }),
             }),
         });

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -150,12 +150,10 @@ pub const Trailer = struct {
     final: ?struct { size: u32, checksum: u128 } = null,
 
     pub const requests = std.enums.EnumArray(vsr.SuperBlockTrailer, vsr.Command).init(.{
-        .free_set = .request_sync_free_set,
         .client_sessions = .request_sync_client_sessions,
     });
 
     pub const responses = std.enums.EnumArray(vsr.SuperBlockTrailer, vsr.Command).init(.{
-        .free_set = .sync_free_set,
         .client_sessions = .sync_client_sessions,
     });
 


### PR DESCRIPTION
Goal: get rid of storage_size_max

Currently, free set is stored as a part of superblock in a trailer. As a result, the worst-case size of the free set affects the layout of the data file. As the worst-case size is proprtional to the size of the grid, this requires limiting the size of the data file up-front, using `storage_size_max` parameter. This is bad operator experience -- it's hard to predict which size would be enough, and failure to allocate enough would be very costly to fix down the line.

The solution to make free set elastic and store it in the grid.

 ## Overview

FreeSetEncoded is the persistent component of the free set. It defines defines the layout of the free set as stored in the grid between checkpoints.

Free set is stored as a linked list of blocks containing EWAH-encoding of a bitset of allocated blocks. The length of the linked list is proportional to the degree of fragmentation, rather that to  size of the data file. The common case is a single block.

The blocks holding free set itself are marked as free in the on-disk encoding, because the number of blocks required to store the compressed bitset becomes known only after encoding.

Linked list is a FIFO. While the blocks are written in the direct order, they have to be read in the reverse order.

 ## Implementation notes

- Separate structs to hold persistent and in-memory components of the free set, as the shape of data is quite different between the two.

- FreeSet Trailer and associated messages are gone.

- `storage_size_max` is _not_ gone. While it's the entire purpose of the work, the actual removal of the parameter can happen separately.

- FreeSetEncoded field is stored as a field in the superblock alongside the free set. This isn't great, as it needs access to the grid, but the superblock is above the grid. As a result, the implementation has a bunch of fairly awkward paths like `set.grid.superblock.free_set`.

  I want to move both free set and free set encoded to be just a part of the grid, but that's for a follow up to not mix code motion with logic changes.

- I noticed that we `@intCast` the encoded bit set size to `u32`. I wonder if we should maybe just store bitset lenght as u64? With u32 we can support a merely 16PiB data file.

- Testing this is awkward. In normal use, the free set size just doesn't
  go beyond a single block, so the entire linked list code is
  effectively unused. To cover this, `fragment_free_set` is added to
  forest fuzz which manually injects fragmentation into the free set to
  make sure it occupies more than one block
