### PR TITLE
VSR: Pad checksum from u128 to u256

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -545,7 +545,7 @@ pub const lsm_snapshots_max = config.cluster.lsm_snapshots_max;
 ///   tree configuration. (To prevent Grid from depending on StateMachine).
 /// - This counts data blocks, but does not count the index block itself.
 pub const lsm_table_data_blocks_max = table_blocks_max: {
-    const checksum_size = @sizeOf(u128);
+    const checksum_size = @sizeOf(u256);
     const address_size = @sizeOf(u64);
     break :table_blocks_max @divFloor(
         block_size - @sizeOf(vsr.Header),

--- a/src/lsm/table_data_iterator.zig
+++ b/src/lsm/table_data_iterator.zig
@@ -25,7 +25,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
             /// Table data block addresses.
             addresses: []const u64,
             /// Table data block checksums.
-            checksums: []const u128,
+            checksums: []const schema.Checksum,
             direction: Direction,
         };
 
@@ -99,12 +99,14 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                     .descending => it.context.addresses.len - 1,
                 };
 
+                assert(it.context.checksums[index].padding == 0);
+
                 it.callback = .{ .read = callback };
                 it.context.grid.read_block(
                     .{ .from_local_or_global_storage = on_read },
                     &it.read,
                     it.context.addresses[index],
-                    it.context.checksums[index],
+                    it.context.checksums[index].value,
                     .{ .cache_read = true, .cache_write = true },
                 );
             } else {
@@ -126,7 +128,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                     if (constants.verify) {
                         const header = schema.header_from_block(block);
                         assert(header.address == it.context.addresses[0]);
-                        assert(header.checksum == it.context.checksums[0]);
+                        assert(header.checksum == it.context.checksums[0].value);
                     }
 
                     it.context.addresses = it.context.addresses[1..];
@@ -137,7 +139,7 @@ pub fn TableDataIteratorType(comptime Storage: type) type {
                     if (constants.verify) {
                         const header = schema.header_from_block(block);
                         assert(header.address == it.context.addresses[index_last]);
-                        assert(header.checksum == it.context.checksums[index_last]);
+                        assert(header.checksum == it.context.checksums[index_last].value);
                     }
 
                     it.context.addresses = it.context.addresses[0..index_last];

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -670,7 +670,7 @@ pub const Storage = struct {
             const data_block_header = schema.header_from_block(data_block);
 
             assert(data_block_header.address == address);
-            assert(data_block_header.checksum == checksum);
+            assert(data_block_header.checksum == checksum.value);
             assert(data_block_header.block_type == .data);
         }
     }

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -401,7 +401,7 @@ pub const GridBlocksMissing = struct {
         ) |address, checksum, index| {
             const enqueue = queue.enqueue_faulty_block(
                 address,
-                checksum,
+                checksum.value,
                 .{ .table_data = .{ .table = table, .index = @intCast(index) } },
             );
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6216,7 +6216,7 @@ pub fn ReplicaType(
                     @bitCast(Header.PrepareOk{
                         .command = .prepare_ok,
                         .checkpoint_id = checkpoint_id,
-                        .parent = header.parent,
+                        // .parent = header.parent,
                         .client = header.client,
                         .prepare_checksum = header.checksum,
                         .request = header.request,
@@ -9351,7 +9351,7 @@ const PipelineQueue = struct {
             ok.header.prepare_checksum,
         ) orelse return null;
         assert(prepare.message.header.command == .prepare);
-        assert(prepare.message.header.parent == ok.header.parent);
+        // assert(prepare.message.header.parent == ok.header.parent);
         assert(prepare.message.header.client == ok.header.client);
         assert(prepare.message.header.request == ok.header.request);
         assert(prepare.message.header.cluster == ok.header.cluster);


### PR DESCRIPTION
- Checksums are still `u128`.
- But in storage (message/block headers, table index blocks, etc), those checksums are padded to `u256`.
- Don't actually use the `u256` type though, since Zig doesn't support `u256` in `extern struct`s (yet).
- Instead of a custom `Checksum` type (e.g. `[32]u8` or `struct { u128, u128 }`), include explicit `checksum_padding: u128` fields for the time being. This ensures that formatting (`log.debug("header={}", .{message.header})`) and equality checks (`header.checksum == other.checksum`) both work as expected. (In particular, changing to a custom `.equal()` function would be inconvenient, especially with the intent to switch back).

In the future, the whole `u256` can be used for AEAD tags.