### PR TITLE
Docs: Add 3️⃣-node single binary quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,8 @@ accounted for!
 
 For further reading:
 
-* [Running a 3-node cluster locally with docker-compose](https://docs.tigerbeetle.com/quick-start/with-docker-compose)
-* [Run a single-node cluster with Docker](https://docs.tigerbeetle.com/quick-start/with-docker)
 * [Run a single-node cluster](https://docs.tigerbeetle.com/quick-start/single-binary)
+* [Run a three-node cluster](https://docs.tigerbeetle.com/quick-start/single-binary-three)
 
 ## Next Steps
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -13,6 +13,7 @@ for mission critical safety and performance.
 First, get TigerBeetle running:
 
 * [Run a single-node cluster with a single binary](./quick-start/single-binary.md)
+* Or [run a three-node cluster with a single binary](./quick-start/single-binary-three.md)
 * Or [run a single-node cluster with Docker](./quick-start/with-docker.md)
 * Or [run a three-node cluster with docker-compose](./quick-start/with-docker-compose.md)
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -3,6 +3,7 @@
 First, get TigerBeetle running:
 
 * [Run a single-node cluster with a single binary](./single-binary.md)
+* Or [run a three-node cluster with a single binary](./single-binary-three.md)
 * Or [run a single-node cluster with Docker](./with-docker.md)
 * Or [run a three-node cluster with docker-compose](./with-docker-compose.md)
 

--- a/docs/quick-start/single-binary-three.md
+++ b/docs/quick-start/single-binary-three.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 2
+---
+
+# Three-node cluster with a single binary
+
+First, download a prebuilt copy of TigerBeetle.
+
+On macOS/Linux:
+
+```console
+git clone https://github.com/tigerbeetle/tigerbeetle; ./tigerbeetle/bootstrap.sh
+```
+
+On Windows:
+
+```console
+git clone https://github.com/tigerbeetle/tigerbeetle; .\tigerbeetle\bootstrap.ps1
+```
+
+Want to build from source locally? Add `-build` as an argument to the bootstrap script.
+
+## Running TigerBeetle
+
+Now create the TigerBeetle data file for each replica
+
+```console
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=3 0_0.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=1 --replica-count=3 0_1.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=2 --replica-count=3 0_2.tigerbeetle
+```
+
+And start each server in a new terminal window:
+
+```console
+./tigerbeetle start --addresses=3000,3001,3002 0_0.tigerbeetle
+```
+
+```console
+./tigerbeetle start --addresses=3000,3001,3002 0_1.tigerbeetle
+```
+
+```console
+./tigerbeetle start --addresses=3000,3001,3002 0_2.tigerbeetle
+```
+
+TigerBeetle uses the `--replica` that's stored in the data file as an index into the `--addresses`
+provided.
+
+### Connect with the CLI
+
+Now you can connect to the running server with any client. For a quick
+start, try creating accounts and transfers [using the TigerBeetle CLI
+client](./cli-client.md).

--- a/docs/quick-start/with-docker-compose.md
+++ b/docs/quick-start/with-docker-compose.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
-# 3-node cluster with Docker Compose
+# Three-node cluster with Docker Compose
 
 First, provision the data file for each node:
 

--- a/docs/quick-start/with-docker.md
+++ b/docs/quick-start/with-docker.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Single-node cluster with Docker


### PR DESCRIPTION
I feel we should move the Docker sections out of the quickstart entirely, but I'm not sure where a good place to put them would be.

They're not really for production deployment, so `Deploy` doesn't fit. `Recipes` is more client level stuff. We could add something, but not sure if that's great either. Open to suggestions :smile:.