### PR TITLE
tidy: validate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   uninitialized bytes can be stored or transmitted over the network. Previously, we checked only
   if the struct had no padding, but not its fields.
 
-### Internals  
+### Internals
 
 - [#1299](https://github.com/tigerbeetle/tigerbeetle/pull/1299)
 
@@ -42,7 +42,7 @@
   repurpose and reinterpret fields so that the same header could hold different data depending on
   the context. Now, commands have their own specialized data type containing the fields that are
   only pertinent to the context, making the API much safer and intent-clear.
-  
+
 - [#1304](https://github.com/tigerbeetle/tigerbeetle/pull/1304)
 
   With larger headers (see #1295) we have enough room to make the cluster ID a 128-bit integer,
@@ -105,7 +105,8 @@
 
   Revive the TigerBeetle [VOPRHub](https://github.com/tigerbeetle-vopr)! Some previous changes left
   it on it's [Last Stand](https://open.spotify.com/track/1ibHApXtb0pgplmNDRLHrJ), but the bot is
-  back in business finding liveness bugs: [#1266](https://github.com/tigerbeetle/tigerbeetle/issues/1266)
+  back in business finding liveness bugs:
+  [#1266](https://github.com/tigerbeetle/tigerbeetle/issues/1266)
 
 ### Features
 
@@ -137,8 +138,8 @@
 
 - [#1198](https://github.com/tigerbeetle/tigerbeetle/pull/1198)
 
-  Recommend using [ULID](https://github.com/ulid/spec) for event IDs. ULIDs are approximately sorted,
-  which significantly improves common-case performance.
+  Recommend using [ULID](https://github.com/ulid/spec) for event IDs. ULIDs are approximately
+  sorted, which significantly improves common-case performance.
 
 ### Internals
 
@@ -221,4 +222,5 @@ history, but any notable change from this point on shall be captured by this doc
 For archeological inquiries, check out the state of the repository at the time of the first
 changelog:
 
-[https://github.com/tigerbeetle/tigerbeetle/](https://github.com/tigerbeetle/tigerbeetle/tree/d2d6484188ecc57680e8bde446b5d09b6f2d83ca)
+[https://github.com/tigerbeetle/tigerbeetle/](
+https://github.com/tigerbeetle/tigerbeetle/tree/d2d6484188ecc57680e8bde446b5d09b6f2d83ca)


### PR DESCRIPTION
Check that lines are not too long and don't end in whitespace using the existing tidy script. One alternative would be to use a general markdown linter, I don't know a good one off the top of my head.

As [promised](https://github.com/tigerbeetle/tigerbeetle/pull/1296#discussion_r1391170235) a couple of weeks ago! 