### PR TITLE
vsr: lift BlockReference up

### DIFF
--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -38,6 +38,7 @@ const tree = @import("tree.zig");
 const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 const schema = @import("schema.zig");
 const TableInfo = schema.ManifestNode.TableInfo;
+const BlockReference = vsr.BlockReference;
 
 const block_builder_schema = schema.ManifestNode{
     .entry_count = schema.ManifestNode.entry_count_max,
@@ -69,11 +70,6 @@ pub fn ManifestLogType(comptime Storage: type) type {
         pub const TableExtent = struct {
             block: u64, // Manifest block address.
             entry: u32, // Index within the manifest block Label/TableInfo arrays.
-        };
-
-        const BlockReference = struct {
-            checksum: u128,
-            address: u64,
         };
 
         superblock: *SuperBlock,

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -27,6 +27,8 @@ const vsr = @import("../vsr.zig");
 
 const stdx = @import("../stdx.zig");
 
+const BlockReference = vsr.BlockReference;
+
 const address_size = @sizeOf(u64);
 const checksum_size = @sizeOf(u256);
 
@@ -381,7 +383,7 @@ pub const FreeSetNode = struct {
         _ = metadata(free_set_block);
     }
 
-    pub fn previous(free_set_block: BlockPtrConst) ?struct { checksum: u128, address: u64 } {
+    pub fn previous(free_set_block: BlockPtrConst) ?BlockReference {
         const header_metadata = metadata(free_set_block);
 
         if (header_metadata.previous_free_set_block_address == 0) {
@@ -511,7 +513,7 @@ pub const ManifestNode = struct {
 
     /// Note that the returned block reference is no longer be part of the manifest if
     /// `manifest_block` is the oldest block in the superblock's CheckpointState.
-    pub fn previous(manifest_block: BlockPtrConst) ?struct { checksum: u128, address: u64 } {
+    pub fn previous(manifest_block: BlockPtrConst) ?BlockReference {
         _ = from(manifest_block); // Validation only.
 
         const header_metadata = metadata(manifest_block);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -148,6 +148,19 @@ pub const Zone = enum {
     }
 };
 
+/// Reference to a single block in the grid.
+///
+/// Blocks are always referred to by a pair of an address and a checksum to protect from misdirected
+/// reads and writes: checksum inside the block itself doesn't help if the disk accidentally reads a
+/// wrong block.
+///
+/// Block addresses start from one, such that zeroed-out memory can not be confused with a valid
+/// address.
+pub const BlockReference = struct {
+    checksum: u128,
+    address: u64,
+};
+
 /// Viewstamped Replication protocol commands:
 pub const Command = enum(u8) {
     reserved = 0,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -39,6 +39,7 @@ const constants = @import("../constants.zig");
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
 const log = std.log.scoped(.superblock);
+const BlockReference = vsr.BlockReference;
 
 pub const SuperBlockFreeSet = @import("superblock_free_set.zig").FreeSet;
 pub const SuperBlockClientSessions = @import("superblock_client_sessions.zig").ClientSessions;


### PR DESCRIPTION
We use an isomorphic struct in a couple of places, so makes sense to
lift it up to the VSR layer, rather then redeclare everywhere.

We could also consider changing things like ManifestLogReferences from

```
  pub const ManifestReferences = struct {
      oldest_checksum: u128,
      oldest_address: u64,
      newest_checksum: u128,
      newest_address: u64,
      block_count: u32,
  }
```

to something akin to

```
  pub const ManifestReferences = struct {
      oldest: BlockReference,
      newest: BlockReference,
      block_count: u32,
  }
```

but I think it won't be a big win, flat is simpler. Similarly, I think
it's better if `grid.read_block` and such accept two flat parameters, as
that simpler, and also avoids the need to re-pack SoAs which we use a
lot.