### PR TITLE
docs: add installation page

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # FAQ

--- a/docs/deploy/_category_.json
+++ b/docs/deploy/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Deploy",
-    "position": 4
+    "position": 5
 }

--- a/docs/design/_category_.json
+++ b/docs/design/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Design",
-    "position": 3
+    "position": 4
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 2
+---
+
+# Installation
+
+TigerBeetle is a single, small, statically linked binary, download it here:
+
+|               | Linux                            | Windows                          | MacOS                             |
+| :------------ | :------------------------------- | :------------------------------- | :-------------------------------- |
+| x86_64        |[tigerbeetle-x86_64-linux.zip]    |[tigerbeetle-x86_64-windows.zip]  | [tigerbeetle-universal-macos.zip] |
+| aarch64       |[tigerbeetle-aarch64-linux.zip]   |             N/A                  | [tigerbeetle-universal-macos.zip] |
+
+[tigerbeetle-aarch64-linux.zip]: https://github.com/tigerbeetle/tigerbeetle/releases/latest/download/tigerbeetle-aarch64-linux.zip
+[tigerbeetle-universal-macos.zip]: https://github.com/tigerbeetle/tigerbeetle/releases/latest/download/tigerbeetle-universal-macos.zip
+[tigerbeetle-x86_64-linux.zip]: https://github.com/tigerbeetle/tigerbeetle/releases/latest/download/tigerbeetle-x86_64-linux.zip
+[tigerbeetle-x86_64-windows.zip]: https://github.com/tigerbeetle/tigerbeetle/releases/latest/download/tigerbeetle-x86_64-windows.zip
+
+While not required (TigerBeetle is designed to be easy to deploy as a single binary), a Docker
+container is also available:
+
+<https://github.com/tigerbeetle/tigerbeetle/pkgs/container/tigerbeetle>
+
+
+Client libraries for .Net, Go, Java, and NodeJS are available in the respective registries:
+
+|               |                                                                           |
+| :------------ | :------------------------------------------------------------------------ |
+| .Net          |<https://www.nuget.org/packages/tigerbeetle>                               |
+| Go            |<https://github.com/tigerbeetle/tigerbeetle-go>                            |
+| Java          |<https://central.sonatype.com/artifact/com.tigerbeetle/tigerbeetle-java>   |
+| NodeJS        |<https://www.npmjs.com/package/tigerbeetle-node>                           |
+
+**Note:** TigerBeetle is not yet production-ready. In particular, the protocol and data file formats
+may change and might not be compatible across different releases. Please make sure that the version
+of the client library used matches the version of `tigerbeetle` binary.

--- a/docs/internals/_category_.json
+++ b/docs/internals/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Internals",
-    "position": 9
+    "position": 10
 }

--- a/docs/quick-start/_category_.json
+++ b/docs/quick-start/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Quick Start",
-    "position": 2
+    "position": 3
 }

--- a/docs/recipes/_category_.json
+++ b/docs/recipes/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Recipes",
-    "position": 5
+    "position": 6
 }

--- a/docs/reference/_category_.json
+++ b/docs/reference/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Reference",
-    "position": 7
+    "position": 8
 }

--- a/src/docs_website/scripts/build.sh
+++ b/src/docs_website/scripts/build.sh
@@ -25,13 +25,15 @@ for client in $clients; do
 
     cp ../../src/clients/$client/README.md pages/clients/$client.md
 done
-echo '{ "label": "Client Libraries", "position": 6 }' >> pages/clients/_category_.json
+echo '{ "label": "Client Libraries", "position": 7 }' >> pages/clients/_category_.json
 
 # Everything else will be rewritten as a link into GitHub.
 find pages -type f | xargs -I {} sed -i "s@/src/clients/@$repo/blob/main/src/clients/@g" {}
 
 for page in $(ls pages/*.md); do
-    if ! [[ "$page" == "pages/intro.md" ]] && ! [[ "$page" == "pages/FAQ.md" ]]; then
+    if ! [[ "$page" == "pages/intro.md" ]] && \
+       ! [[ "$page" == "pages/FAQ.md" ]] && \
+       ! [[ "$page" == "pages/installation.md" ]]; then
         rm "$page"
     fi
 done

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -113,6 +113,23 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         log.warn("skip release verification for platforms other than Linux", .{});
     }
 
+    // Note: when updating the list of artifacts, don't forget to check for any external links.
+    //
+    // At minimum, `installation.md` requires an update.
+    const artifacts = [_][]const u8{
+        "tigerbeetle-aarch64-linux-debug.zip",
+        "tigerbeetle-aarch64-linux.zip",
+        "tigerbeetle-universal-macos-debug.zip",
+        "tigerbeetle-universal-macos.zip",
+        "tigerbeetle-x86_64-linux-debug.zip",
+        "tigerbeetle-x86_64-linux.zip",
+        "tigerbeetle-x86_64-windows-debug.zip",
+        "tigerbeetle-x86_64-windows.zip",
+    };
+    for (artifacts) |artifact| {
+        assert(shell.file_exists(artifact));
+    }
+
     try shell.exec("unzip tigerbeetle-x86_64-linux.zip", .{});
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -390,7 +390,7 @@ fn publish(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
         });
 
         try shell.exec(
-            \\gh release create --draft --prerelease
+            \\gh release create --draft
             \\  --notes {notes}
             \\  {tag}
         , .{
@@ -428,7 +428,7 @@ fn publish(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
 
     if (languages.contains(.zig)) {
         try shell.exec(
-            \\gh release edit --draft=false
+            \\gh release edit --draft=false --latest=true
             \\  {tag}
         , .{ .tag = info.version });
     }


### PR DESCRIPTION
- The official way to install TigerBeetle is to download a release binary.
- Don't tether us to GitHub releases, provide a table with downloads and treat URLs as opaque
- Don't advertise `-debug` artifacts, we want to keep the release page lean.
- Don't mark releases as `--prerelease` --- this is required for `/latest` links to work.

Future work: don't `.zip` our executable, it should be small enough as is.