### PR TITLE
LSM: Fix tree fuzz using outdated pointers

### DIFF
--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -296,6 +296,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         /// This function is intended to never be called by regular code. It only
         /// exists for fuzzing, due to the performance overhead it carries. Real
         /// code must rely on the Groove cache for lookups.
+        /// The returned Value pointer is only valid synchronously.
         pub fn lookup_from_memory(tree: *Tree, key: Key) ?*const Value {
             assert(constants.verify);
 
@@ -312,6 +313,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         /// could contain the key synchronously from the Grid cache. It then attempts to ascertain
         /// the existence of the key in the data block. If any of the blocks needed to
         /// ascertain the existence of the key are not in the Grid cache, it bails out.
+        /// The returned `.positive` Value pointer is only valid synchronously.
         pub fn lookup_from_levels_cache(tree: *Tree, snapshot: u64, key: Key) LookupMemoryResult {
             var iterator = tree.manifest.lookup(snapshot, key, 0);
             while (iterator.next()) |table| {
@@ -369,6 +371,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         }
 
         /// Call this function only after checking `lookup_from_memory()`.
+        /// The returned Value pointer is only valid synchronously.
         pub fn lookup_from_levels_storage(tree: *Tree, parameters: struct {
             callback: *const fn (*LookupContext, ?*const Value) void,
             context: *LookupContext,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -371,7 +371,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         }
 
         /// Call this function only after checking `lookup_from_memory()`.
-        /// The returned Value pointer is only valid synchronously.
+        /// The callback's Value pointer is only valid synchronously within the callback.
         pub fn lookup_from_levels_storage(tree: *Tree, parameters: struct {
             callback: *const fn (*LookupContext, ?*const Value) void,
             context: *LookupContext,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -129,7 +129,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         node_pool: NodePool,
         tree: Tree,
         lookup_context: Tree.LookupContext,
-        lookup_value: ?*const Value,
+        lookup_value: ?Value,
 
         pub fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
             var env: Environment = undefined;
@@ -301,7 +301,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.superblock_checkpoint, .fuzzing);
         }
 
-        pub fn get(env: *Environment, key: u64) ?*const Value {
+        pub fn get(env: *Environment, key: u64) ?Value {
             env.change_state(.fuzzing, .tree_lookup);
             env.lookup_value = null;
 
@@ -324,7 +324,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Value) void {
             const env = @fieldParentPtr(Environment, "lookup_context", lookup_context);
             assert(env.lookup_value == null);
-            env.lookup_value = value;
+            env.lookup_value = if (value) |val| val.* else null;
             env.change_state(.tree_lookup, .fuzzing);
         }
 
@@ -384,7 +384,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                                     assert(std.mem.eql(
                                         u8,
                                         std.mem.asBytes(&model_value.?),
-                                        std.mem.asBytes(tree_value.?),
+                                        std.mem.asBytes(&tree_value.?),
                                     ));
                                 },
                                 .secondary_index => {
@@ -392,7 +392,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                                     assert(std.mem.eql(
                                         u8,
                                         std.mem.asBytes(&Value.key_from_value(&model_value.?)),
-                                        std.mem.asBytes(&Value.key_from_value(tree_value.?)),
+                                        std.mem.asBytes(&Value.key_from_value(&tree_value.?)),
                                     ));
                                 },
                             }


### PR DESCRIPTION
Our tree fuzzer had a `lookup_value: ?*const Value` which stored the result from the `lookup_from_levels_storage` callback. However, this result is returned after a `tick_until_state_change()` which can result in the value changing between the callback and it being read.

This `*const Value` ultimately points into a data block, so it's subject to the same restrictions. The other call site of `lookup_from_levels_storage` is in the Groove, which does correctly take a copy for the object cache.

This started manifesting from 32f438a35018f456de93a77c56562382deeea9b5 - likely because the increased checksum size caused things to spill over.

Failing fuzz:
```bash
zig build -Doptimize=ReleaseSafe fuzz_lsm_tree -- --seed 8745333161403778570
```