### PR TITLE
LSM: Fix segmented array fuzz not having any `insert()`s

### DIFF
--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -1027,7 +1027,10 @@ fn TestContext(
                 }
             }
 
-            try context.remove_all();
+            // Rarely, the code above won't generate an insert at all.
+            if (context.inserts > 0) {
+                try context.remove_all();
+            }
 
             if (element_order == .unsorted) {
                 // Insert at the beginning of the array until the array is full.


### PR DESCRIPTION
It's possible (but unlikely) for the fuzz code above `context.remove_all` to not generate any insert ops, which will cause `remove_all` to fail.

Ensure there's always at least one insert before calling `remove_all`.

Failing fuzz:
```bash
zig build -Doptimize=Debug fuzz_lsm_segmented_array -- --seed 11767020692845232958
```