### PR TITLE
Revert "node: fix sample instructions"

### DIFF
--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -21,8 +21,7 @@ First, create a directory for your project and `cd` into the directory.
 Then, install the TigerBeetle client:
 
 ```console
-npm install --prefix ../../
-npm install
+npm install tigerbeetle-node
 ```
 
 Now, create `main.js` and copy this into it:

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -87,10 +87,7 @@ pub const NodeDocs = Docs{
     \\console.log("Import ok!");
     ,
 
-    .install_commands =
-    \\npm install --prefix ../../
-    \\npm install
-    ,
+    .install_commands = "npm install tigerbeetle-node",
     .build_commands =
     \\npm install typescript @types/node
     \\npx tsc --allowJs --noEmit main.js

--- a/src/clients/node/samples/basic/README.md
+++ b/src/clients/node/samples/basic/README.md
@@ -18,8 +18,7 @@ First, clone this repo and `cd` into `tigerbeetle/src/clients/node/samples/basic
 Then, install the TigerBeetle client:
 
 ```console
-npm install --prefix ../../
-npm install
+npm install tigerbeetle-node
 ```
 
 ## Start the TigerBeetle server

--- a/src/clients/node/samples/two-phase-many/README.md
+++ b/src/clients/node/samples/two-phase-many/README.md
@@ -18,8 +18,7 @@ First, clone this repo and `cd` into `tigerbeetle/src/clients/node/samples/two-p
 Then, install the TigerBeetle client:
 
 ```console
-npm install --prefix ../../
-npm install
+npm install tigerbeetle-node
 ```
 
 ## Start the TigerBeetle server

--- a/src/clients/node/samples/two-phase/README.md
+++ b/src/clients/node/samples/two-phase/README.md
@@ -18,8 +18,7 @@ First, clone this repo and `cd` into `tigerbeetle/src/clients/node/samples/two-p
 Then, install the TigerBeetle client:
 
 ```console
-npm install --prefix ../../
-npm install
+npm install tigerbeetle-node
 ```
 
 ## Start the TigerBeetle server


### PR DESCRIPTION
This reverts commit a22174400a355462d7cca716b720251314883ce6.

There are two ways to look at our node docs:

- on the npm website, where we want to install the latest published version
- in the GitHub repo, where we want to use the version from the repository

Right now, our docs infra uses the same instructions for both. For the time being, bias towards npm use-case, as that's more important