### PR TITLE
vsr: panic if crypto.random.int returns zero

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -115,8 +115,8 @@ pub fn ContextType(
             errdefer allocator.destroy(context);
 
             context.allocator = allocator;
-            context.client_id = std.crypto.random.int(u128) +| 1;
-            assert(context.client_id != 0);
+            context.client_id = std.crypto.random.int(u128);
+            assert(context.client_id != 0); // Broken CSPRNG is the likeliest explanation for zero.
 
             log.debug("{}: init: initializing", .{context.client_id});
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -170,8 +170,8 @@ const Command = struct {
             });
         }
 
-        const nonce = std.crypto.random.int(u128) +| 1;
-        assert(nonce != 0);
+        const nonce = std.crypto.random.int(u128);
+        assert(nonce != 0); // Broken CSPRNG is the likeliest explanation for zero.
 
         var replica: Replica = undefined;
         replica.open(allocator, .{


### PR DESCRIPTION
While getting zero here by accident is possible, it is by far likelier that the CSPRNG is broken and panicking would be prudent.

Context: https://github.com/tigerbeetle/tigerbeetle/pull/1295#discussion_r1391495628

There's a kernel of truth to every joke!