### PR TITLE
vsr: state invariant positively for readability

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9135,9 +9135,10 @@ const DVCQuorum = struct {
                 } else {
                     return .complete_invalid;
                 }
-            } else {
-                // This op is eligible to be the view's head.
             }
+
+            // This op is eligible to be the view's head.
+            assert(header_canonical != null and copies > 0);
         } else op_head_max;
         assert(op_head >= op_head_min);
         assert(op_head <= op_head_max);


### PR DESCRIPTION
Micro-changed, but stating invariant positively and putting it to the syntactically-obvious tail position makes the loop invariant clear, and explains (part of) why `else op_head_max;` is correct. (the other part is that `op_head_max` is computed using view-change quorum, so it **must** include the latest op that could have been committed)