### PR TITLE
vsr: remove storage_size_max

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -77,6 +77,7 @@ const ConfigProcess = struct {
     verify: bool,
     port: u16 = 3001,
     address: []const u8 = "127.0.0.1",
+    storage_size_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
     memory_size_max_default: u64 = 1024 * 1024 * 1024,
     cache_accounts_size_default: usize,
     cache_transfers_size_default: usize,
@@ -136,7 +137,6 @@ const ConfigCluster = struct {
     journal_slot_count: usize = 1024,
     message_size_max: usize = 1 * 1024 * 1024,
     superblock_copies: comptime_int = 4,
-    storage_size_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
     block_size: comptime_int = 1024 * 1024,
     lsm_levels: u6 = 7,
     lsm_growth_factor: u32 = 8,
@@ -237,6 +237,7 @@ pub const configs = struct {
     /// Not suitable for production, but good for testing code that would be otherwise hard to reach.
     pub const test_min = Config{
         .process = .{
+            .storage_size_max = 200 * 1024 * 1024,
             .direct_io = false,
             .direct_io_required = false,
             .cache_accounts_size_default = @sizeOf(vsr.tigerbeetle.Account) * 2048,
@@ -256,7 +257,6 @@ pub const configs = struct {
             .view_change_headers_suffix_max = 4 + 1,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,
             .message_size_max = Config.Cluster.message_size_max_min(4),
-            .storage_size_max = 200 * 1024 * 1024,
 
             .block_size = sector_size,
             .lsm_batch_multiple = 4,
@@ -270,7 +270,7 @@ pub const configs = struct {
     /// able to max out the LSM levels.
     pub const fuzz_min = config: {
         var base = test_min;
-        base.cluster.storage_size_max = 1 * 1024 * 1024 * 1024;
+        base.process.storage_size_max = 1 * 1024 * 1024 * 1024;
         break :config base;
     };
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -468,10 +468,12 @@ comptime {
 /// The maximum size of a local data file.
 /// This should not be much larger than several TiB to limit:
 /// * blast radius and recovery time when a whole replica is lost,
-/// * replicated storage overhead, since all data files are mirrored,
-/// * the size of the superblock storage zone, and
+/// * replicated storage overhead, since all data files are mirrored, and
 /// * the static memory allocation required for tracking LSM forest metadata in memory.
-pub const storage_size_max = config.cluster.storage_size_max;
+///
+/// This is a "firm" limit --- while it is a compile-time constant, it does not affect data file
+/// layout and can be safely changed for an existing cluster.
+pub const storage_size_max = config.process.storage_size_max;
 
 /// The unit of read/write access to LSM manifest and LSM table blocks in the block storage zone.
 ///

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -70,13 +70,13 @@ pub const StorageChecker = struct {
         var checkpoints = Checkpoints.init(allocator);
         errdefer checkpoints.deinit();
 
-        var free_set = try SuperBlock.FreeSet.init(allocator, vsr.superblock.grid_blocks_max);
+        var free_set = try SuperBlock.FreeSet.init(allocator, Storage.grid_blocks_max);
         errdefer free_set.deinit(allocator);
 
         var free_set_buffer = try allocator.alignedAlloc(
             u8,
             @alignOf(u64),
-            SuperBlock.FreeSet.encode_size_max(vsr.superblock.grid_blocks_max),
+            SuperBlock.FreeSet.encode_size_max(Storage.grid_blocks_max),
         );
         errdefer allocator.free(free_set);
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -194,7 +194,7 @@ test "Cluster: recovery: grid corruption (disjoint)" {
         t.replica(.R2),
     }, 0..) |replica, i| {
         var address: u64 = 1 + i; // Addresses start at 1.
-        while (address <= vsr.superblock.grid_blocks_max) : (address += 3) {
+        while (address <= Storage.grid_blocks_max) : (address += 3) {
             // Leave every third address un-corrupt.
             // Each block exists intact on exactly one replica.
             replica.corrupt(.{ .grid_block = address + 1 });

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -133,7 +133,6 @@ fn test_quorums_working(
         header.* = std.mem.zeroInit(SuperBlockHeader, .{
             .copy = @as(u8, @intCast(i)),
             .version = SuperBlockVersion,
-            .storage_size_max = superblock.data_file_size_min,
             .sequence = copies[i].sequence,
             .parent = checksums[copies[i].sequence - 1],
             .vsr_state = std.mem.zeroInit(SuperBlockHeader.VSRState, .{
@@ -162,7 +161,8 @@ fn test_quorums_working(
                     checksum = random.int(u128);
                 }
             },
-            .invalid_fork => header.storage_size_max += 1, // Ensure we have a different checksum.
+            // Ensure we have a different checksum.
+            .invalid_fork => header.vsr_state.checkpoint.free_set_size += 1,
             .invalid_parent => header.parent += 1,
             .invalid_misdirect => {
                 if (misdirect) {
@@ -280,7 +280,6 @@ pub fn fuzz_quorum_repairs(
             header.* = std.mem.zeroInit(SuperBlockHeader, .{
                 .copy = @as(u8, @intCast(i)),
                 .version = SuperBlockVersion,
-                .storage_size_max = superblock.data_file_size_min,
                 .sequence = 123,
                 .vsr_state = std.mem.zeroInit(SuperBlockHeader.VSRState, .{
                     .replica_id = members[1],


### PR DESCRIPTION
Well, not really. `constants.storage_size_max` is still a thing, but it serves only as a hard-limit for the `--storage-size-limit` CLI argument.

`constants.storage_size_max` is also used during tests as a convenient shortcut for "storage size reasonable for tests". Perhaps this could be phased away in favor of an explicit runtime parameter, so that `fuzz_min` config is not needed, but this is mostly orthogonal.