### PR TITLE
VSR: Add checkpoint_id to Header.Prepare 

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -611,7 +611,8 @@ test "aof write / read" {
         .context = 0,
         .cluster = 0,
         .timestamp = 0,
-        .command = vsr.Command.prepare,
+        .checkpoint_id = 0,
+        .command = .prepare,
         .operation = @as(vsr.Operation, @enumFromInt(4)),
         .size = @as(u32, @intCast(@sizeOf(Header) + demo_payload.len)),
     };

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -297,6 +297,23 @@ pub fn no_padding(comptime T: type) bool {
                         if (!no_padding(field.type)) return false;
                     }
 
+                    // Check offsets of u128 and pseudo-u256 fields.
+                    for (info.fields) |field| {
+                        if (field.type == u128) {
+                            const offset = @offsetOf(T, field.name);
+                            if (offset % @sizeOf(u128) != 0) return false;
+
+                            if (@hasField(T, field.name ++ "_padding")) {
+                                if (offset % @sizeOf(u256) != 0) return false;
+                                if (offset + @sizeOf(u128) !=
+                                    @offsetOf(T, field.name ++ "_padding"))
+                                {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+
                     var offset = 0;
                     for (info.fields) |field| {
                         const field_offset = @offsetOf(T, field.name);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1065,6 +1065,7 @@ pub const Headers = struct {
             .cluster = 0,
             .view = 0,
             .context = 0,
+            .checkpoint_id = 0,
             .parent = 0,
             .client = 0,
             .commit = 0,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6232,7 +6232,7 @@ pub fn ReplicaType(
                     @bitCast(Header.PrepareOk{
                         .command = .prepare_ok,
                         .checkpoint_id = checkpoint_id,
-                        // .parent = header.parent,
+                        .parent = header.parent,
                         .client = header.client,
                         .prepare_checksum = header.checksum,
                         .request = header.request,
@@ -9369,7 +9369,7 @@ const PipelineQueue = struct {
             ok.header.prepare_checksum,
         ) orelse return null;
         assert(prepare.message.header.command == .prepare);
-        // assert(prepare.message.header.parent == ok.header.parent);
+        assert(prepare.message.header.parent == ok.header.parent);
         assert(prepare.message.header.client == ok.header.client);
         assert(prepare.message.header.request == ok.header.request);
         assert(prepare.message.header.cluster == ok.header.cluster);
@@ -9380,6 +9380,7 @@ const PipelineQueue = struct {
         assert(prepare.message.header.commit == ok.header.commit);
         assert(prepare.message.header.timestamp == ok.header.timestamp);
         assert(prepare.message.header.operation == ok.header.operation);
+        // TODO compare checkpoint id with prepare's
 
         return prepare;
     }

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -113,6 +113,7 @@ pub const SuperBlockHeader = extern struct {
         assert(@sizeOf(SuperBlockHeader) % constants.sector_size == 0);
         assert(@divExact(@sizeOf(SuperBlockHeader), constants.sector_size) >= 2);
         assert(@offsetOf(SuperBlockHeader, "parent") % @sizeOf(u256) == 0);
+        assert(@offsetOf(SuperBlockHeader, "vsr_state") % @sizeOf(u256) == 0);
         assert(@offsetOf(SuperBlockHeader, "vsr_headers_all") == constants.sector_size);
         // Assert that there is no implicit padding in the struct.
         assert(stdx.no_padding(SuperBlockHeader));
@@ -306,18 +307,10 @@ pub const SuperBlockHeader = extern struct {
     /// This struct is sent in a `sync_checkpoint` message from a healthy replica to a syncing
     /// replica.
     pub const CheckpointState = extern struct {
-        /// The checkpoint_id() of the checkpoint which last updated our commit_min.
-        /// Following state sync, this is set to the last checkpoint that we skipped.
-        previous_checkpoint_id: u128,
-
         /// The vsr.Header.checksum of commit_min's message.
         commit_min_checksum: u128,
         commit_min_checksum_padding: u128 = 0,
 
-        /// Checksum covering the entire encoded free set. Strictly speaking it is redundant:
-        /// free_set_last_block_checksum indirectly covers the same data. It is still useful
-        /// to protect from encoding-decoding bugs as a defense in depth.
-        free_set_checksum: u128,
         free_set_last_block_checksum: u128,
         free_set_last_block_checksum_padding: u128 = 0,
         manifest_oldest_checksum: u128,
@@ -326,6 +319,15 @@ pub const SuperBlockHeader = extern struct {
         manifest_newest_checksum_padding: u128 = 0,
         snapshots_block_checksum: u128,
         snapshots_block_checksum_padding: u128 = 0,
+
+        /// Checksum covering the entire encoded free set. Strictly speaking it is redundant:
+        /// free_set_last_block_checksum indirectly covers the same data. It is still useful
+        /// to protect from encoding-decoding bugs as a defense in depth.
+        free_set_checksum: u128,
+
+        /// The checkpoint_id() of the checkpoint which last updated our commit_min.
+        /// Following state sync, this is set to the last checkpoint that we skipped.
+        previous_checkpoint_id: u128,
 
         free_set_last_block_address: u64,
         manifest_oldest_address: u64,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -211,7 +211,6 @@ pub const SuperBlockHeader = extern struct {
             assert(state.checkpoint.snapshots_block_checksum == 0);
             assert(state.checkpoint.snapshots_block_address == 0);
 
-            assert(state.checkpoint.previous_checkpoint_id_padding == 0);
             assert(state.checkpoint.commit_min_checksum_padding == 0);
             assert(state.checkpoint.manifest_oldest_checksum_padding == 0);
             assert(state.checkpoint.manifest_newest_checksum_padding == 0);
@@ -310,7 +309,6 @@ pub const SuperBlockHeader = extern struct {
         /// The checkpoint_id() of the checkpoint which last updated our commit_min.
         /// Following state sync, this is set to the last checkpoint that we skipped.
         previous_checkpoint_id: u128,
-        previous_checkpoint_id_padding: u128 = 0,
 
         /// The vsr.Header.checksum of commit_min's message.
         commit_min_checksum: u128,
@@ -354,7 +352,7 @@ pub const SuperBlockHeader = extern struct {
         manifest_block_count: u32,
 
         // TODO Reserve some more extra space before locking in storage layout.
-        reserved: [8]u8 = [_]u8{0} ** 8,
+        reserved: [24]u8 = [_]u8{0} ** 24,
 
         comptime {
             assert(@sizeOf(CheckpointState) == 272);


### PR DESCRIPTION
## Context

`Header.PrepareOk` includes a `checkpoint_id`, but `Header.Prepare` does not.
Replicas ignore `PrepareOk`s from checkpoint ids that do not match their own.
This _mostly_ works, but not 100%.

As mentioned in the ["Next Steps" of the first state sync PR](https://github.com/tigerbeetle/tigerbeetle/pull/834):

> - 256-byte message headers: Make room for the checkpoint identifier in prepare messages. This will let us guarantee that a replica's history never diverges from the canonical history by more than one checkpoint.

Without `checkpoint_id` in prepares, it is technically possible (albeit very unlikely!) for a replica to diverge from the canonical history by more than one checkpoint.
(If a replica partitioned from receiving `command=commit` or `command=ping` messages, but is able to receive `command=prepare` messages, then it will keep preparing + committing messages without ever learning whether it has diverged. So it can diverge by an arbitrary number of checkpoints from the canonical history.)

## Solution

- Add `checkpoint_id` to `Header.Prepare`.
- Replicas ignore `Prepare`s from checkpoint ids that do not match their own.
- `on_prepare_ok` can now assert that the checkpoint id matches the respective `Prepare`'s.

`on_repair()` doesn't need to test the `prepare.checkpoint_id` – it can assert it.
(`on_repair` requires an intact hash chain to the head, and the head's checkpoint id _was_ tested (via `on_prepare`).)

## Also included:

- `checkpoint_id` u256 → u128: `checkpoint_id` doesn't refer to any (future) AEAD tag (i.e. message checksum), so it can just be a `u128` hash (even when 256-bit encryption is in use). This also means that `Header.Prepare` now has enough reserved bytes for the checkpoint id.
- Rearrange `CheckpointState` fields for future u256 alignment: Right now we store "message" "checksums" as two `u128`s (the latter is an always-0 padding). In the future, those will be combined into a single `u256`. Shift the actual `u128`s later in the struct so that all of the "u256"s are 32-byte aligned.
