### PR TITLE
vopr: log replica's checkpoint

### DIFF
--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -34,7 +34,10 @@ Documentation for (roughly) code in the `src/testing` directory.
     - `h`: `recovering_head`
     - `s`: `sync`
 5. View: e.g. `74V` indicates `replica.view=74`.
-6. Commit: e.g. `150/160C` indicates `replica.commit_min=150` and `replica.commit_max=160`.
+6. Checkpoint and Commit: e.g. `83/_90/_98C` indicates that:
+   - the highest checkpointed op at the replica is `83` (`replica.op_checkpoint()=83`),
+   - on top of that checkpoint, the replica applied ops up to and including `90` (`replica.commit_min=90`),
+   - replica knows that ops at least up to `98` are committed in the cluster (`replica.commit_max=98`).
 7. Journal op: e.g. `87:150Jo` indicates that the minimum op in the journal is `87` and the maximum is `150`.
 8. Journal faulty/dirty: `0/1Jd` indicates that the journal has 0 faulty headers and 1 dirty headers.
 9. WAL prepare ops: e.g. `85:149Wo` indicates that the op of the oldest prepare in the WAL is `85` and the op of the newest prepare in the WAL is `149`.
@@ -50,25 +53,23 @@ Documentation for (roughly) code in the `src/testing` directory.
 (The first line labels the columns, but is not part of the actual VOPR output).
 
 ```
- 1 2 3 4--------------- 5- 6-------  7-------  8-----  9-------   10-----   11-----  12-   13-   14---  15---
+ 1 2 3 4------------- 5---  6----------  7-------  8-----  9------- 10-----     11-----  12-   13-   14---  15---
 
-11   |            .     1V 126/126C  64:127Jo  0/_1J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?
- 0   \ .                1V 126/126C  64:127Jo  0/_2J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
- 6   |       .          1V 126/126C  64:127Jo  0/_2J!  62:125Wo   <0:__0>   44857Gf  0G!   0G?
- 7   |        .         1V 126/126C  64:127Jo  0/_2J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?
- 9   |          .       1V 126/126C  64:127Jo  0/_2J!  62:125Wo   <0:__0>   44857Gf  0G!   0G?
- 1   /  .               1V 127/127C  64:127Jo  0/_0J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?   1/4Pp  0/3Rq
- 2   \   .              1V 127/127C  64:127Jo  0/_0J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?
- 9   |          .       1V 127/127C  64:127Jo  0/_2J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
- 7   |        .         1V 127/127C  64:127Jo  0/_2J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?
- 6   |       .          1V 127/127C  64:127Jo  0/_2J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
-11   |            .     1V 127/127C  64:127Jo  0/_0J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?
-10 ^ |           h      1V   0/_11C  15:_15Jo 31/31J!   0:_15Wo   <0:__0>   45056Gf  0G!   0G?
- 0   \ .                1V 127/127C  64:127Jo  0/_1J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
- 4   \     .            1V 127/127C  64:127Jo  0/_1J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
- 5   \      .           1V 127/127C  64:127Jo  0/_0J!  64:127Wo   <0:__0>   44857Gf  0G!   0G?
- 3   \    .             1V 127/127C  64:127Jo  0/_1J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
- 8   |         .        1V 127/127C  64:127Jo  0/_1J!  63:126Wo   <0:__0>   44857Gf  0G!   0G?
-10 < ~           h      1V   0/_11C  15:_15Jo 31/31J!   0:_15Wo   <0:__0>   45056Gf  0G!   0G?
-10 > |           h      1V 119/119C  15:_15Jo 31/31J!   0:_15Wo   <0:123>   44877Gf  0G!   0G?
+11   |            .   354V  83/_97/_97C  66:_97Jo  0/_0J!  66:_97Wo <__0:__0>   48894Gf  0G!   0G?
+ 7   |        .       354V  83/_97/_97C  66:_97Jo  0/_0J!  66:_97Wo <__0:__0>   48894Gf  0G!   0G?
+ 6   |       .        354V  83/_97/_97C  66:_97Jo  0/_0J!  66:_97Wo <__0:__0>   48894Gf  0G!   0G?
+ 9   |          .     354V  83/_97/_97C  66:_97Jo  0/_0J!  66:_97Wo <__0:__0>   48894Gf  0G!   0G?
+ 2   \   .            354V  83/_97/_97C  66:_97Jo  0/_0J!  66:_97Wo <__0:__0>   48894Gf  0G!   0G?
+ 0   / .              366V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?   1/4Pp  0/3Rq
+ 3   \    .           366V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+ 6   |       .        366V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+ 7   |        .       366V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+ 5 ^ \      v         192V  27/_27/_49C  20:_51Jo  0/_0J!  20:_51Wo <__0:__0>    nullGf  0G!   0G?
+ 5 < ~      v         367V  27/_27/_49C  20:_51Jo  0/_0J!  20:_51Wo <__0:__0>   49108Gf  0G!   0G?
+ 1   /  .             367V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?   1/4Pp  0/3Rq
+ 2   \   .            367V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+ 4   \     .          367V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+ 9   |          .     367V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+11   |            .   367V  83/_98/_98C  67:_98Jo  0/_0J!  67:_98Wo <__0:__0>   48894Gf  0G!   0G?
+ 5 > \      h         367V  83/_83/_83C  20:_51Jo  0/_0J!  20:_51Wo <__0:_87>    nullGf  0G!   0G?
 ```

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -642,7 +642,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
                 info = std.fmt.bufPrint(&info_buffer, "" ++
                     "{[view]:>4}V " ++
-                    "{[commit_min]:>3}/{[commit_max]:_>3}C " ++
+                    "{[op_checkpoint]:>3}/{[commit_min]:_>3}/{[commit_max]:_>3}C " ++
                     "{[journal_op_min]:>3}:{[journal_op_max]:_>3}Jo " ++
                     "{[journal_faulty]:>2}/{[journal_dirty]:_>2}J! " ++
                     "{[wal_op_min]:>3}:{[wal_op_max]:_>3}Wo " ++
@@ -651,6 +651,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     "{[grid_blocks_global]:>2}G! " ++
                     "{[grid_blocks_repair]:>3}G?", .{
                     .view = replica.view,
+                    .op_checkpoint = replica.op_checkpoint(),
                     .commit_min = replica.commit_min,
                     .commit_max = replica.commit_max,
                     .journal_op_min = journal_op_min,


### PR DESCRIPTION
While it is possible to infer checkpoint from commit_min and static cluster's config, that requires an uncomfortable amount of mental arithmetic.

```
no liveness, final cluster state (core=11):
 0   / .       9V  95/_99/_99C  68:_99Jo  0/_0J!  68:_99Wo <__0:__0>   44959Gf  0G!   0G?   0/4Pp  0/3Rq
 1   \  .      9V  47/_51/_99C  23:_75Jo  0/_8J!  23:_54Wo <__0:__0>   45008Gf  0G!   0G?  
 2   /   .     8V  95/_99/_99C  68:_99Jo  0/_0J!  68:_99Wo <__0:__0>   44959Gf  0G!   0G?   0/4Pp  0/3Rq
```