### PR TITLE
vsr: increase prepare durability near checkpoint boundary

### DIFF
--- a/src/testing/cluster/sync_checker.zig
+++ b/src/testing/cluster/sync_checker.zig
@@ -139,6 +139,6 @@ fn checkpoint_index(checkpoint_op: u64) usize {
 
     return @divExact(
         checkpoint_op + 1,
-        constants.journal_slot_count - constants.lsm_batch_multiple,
+        constants.vsr_checkpoint_interval,
     ) - 1;
 }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1289,7 +1289,8 @@ const ViewChangeHeadersArray = struct {
         assert(headers.command == .start_view);
         // This function is only called by a replica that is lagging behind the primary's
         // checkpoint, so the start_view has a full suffix of headers.
-        assert(headers.array.get(0).op >= constants.journal_slot_count);
+        assert(headers.array.get(0).op >=
+            constants.vsr_checkpoint_interval + constants.lsm_batch_multiple);
         assert(headers.array.count() >= constants.view_change_headers_suffix_max);
         assert(headers.array.count() >= constants.pipeline_prepare_queue_max + 1);
 
@@ -1337,7 +1338,8 @@ const ViewChangeHeadersArray = struct {
     }
 };
 
-/// For a replica with journal_slot_count=8 and lsm_batch_multiple=2:
+/// For a replica with journal_slot_count=9, lsm_batch_multiple=2, pipeline_prepare_queue_max=1, and
+/// checkpoint_interval = journal_slot_count - (lsm_batch_multiple + pipeline_prepare_queue_max) = 6
 ///
 ///   checkpoint() call           0   1   2   3
 ///   op_checkpoint               0   5  11  17
@@ -1345,11 +1347,11 @@ const ViewChangeHeadersArray = struct {
 ///   op_checkpoint_next_trigger  7  13  19  25
 ///
 ///     commit log (ops)           │ write-ahead log (slots)
-///     0   4   8   2   6   0   4  │ 0---4---
-///   0 ─────✓·%                   │ 01234✓6%   initial log fill
-///   1 ───────────✓·%             │ 890✓2%45   first wrap of log
-///   2 ─────────────────✓·%       │ 6✓8%0123   second wrap of log
-///   3 ───────────────────────✓·% │ 4%67890✓   third wrap of log
+///     0   4   8   2   6   0   4  │  0  -  -  -  4  -  -  -  8
+///   0 ─────✓·%                   │[ 0  1  2  3  4  ✓] 6  %  R
+///   1 ───────────✓·%             │  9 10  ✓]12  %  5[ 6  7  8
+///   2 ─────────────────✓·%       │ 18  % 11[12 13 14 15 16  ✓]
+///   3 ───────────────────────✓·% │[18 19 20 21 22  ✓]24  % 17
 ///
 /// Legend:
 ///
@@ -1357,7 +1359,8 @@ const ViewChangeHeadersArray = struct {
 ///   ·/%  op in memory at checkpoint
 ///     ✓  op_checkpoint
 ///     %  op_checkpoint's trigger
-///
+///     R  slot reserved in WAL
+///    [ ] range of ops from a checkpoint
 pub const Checkpoint = struct {
     comptime {
         assert(constants.journal_slot_count > constants.lsm_batch_multiple);
@@ -1369,12 +1372,13 @@ pub const Checkpoint = struct {
 
         const result = op: {
             if (checkpoint == 0) {
-                // First wrap: op_checkpoint_next = 8-2-1 = 5
-                break :op constants.journal_slot_count - constants.lsm_batch_multiple - 1;
+                // First wrap: op_checkpoint_next = 6-1 = 5
+                // -1: vsr_checkpoint_interval is a count, result is an inclusive index.
+                break :op constants.vsr_checkpoint_interval - 1;
             } else {
-                // Second wrap: op_checkpoint_next = 5+8-2 = 11
-                // Third wrap: op_checkpoint_next = 11+8-2 = 17
-                break :op checkpoint + constants.journal_slot_count - constants.lsm_batch_multiple;
+                // Second wrap: op_checkpoint_next = 5+6 = 11
+                // Third wrap: op_checkpoint_next = 11+6 = 17
+                break :op checkpoint + constants.vsr_checkpoint_interval;
             }
         };
 
@@ -1395,7 +1399,7 @@ pub const Checkpoint = struct {
     }
 
     pub fn valid(op: u64) bool {
-        // Divide by `lsm_batch_multiple` instead of `journal_slot_count - lsm_batch_multiple`:
+        // Divide by `lsm_batch_multiple` instead of `vsr_checkpoint_interval`:
         // although today in practice checkpoints are evenly spaced, the LSM layer doesn't assume
         // that. LSM allows any bar boundary to become a checkpoint which happens, e.g., in the tree
         // fuzzer.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1913,7 +1913,7 @@ pub fn ReplicaType(
             assert(message.header.replica == self.primary_index(message.header.view));
             assert(message.header.commit >= message.header.checkpoint_op);
             assert(message.header.commit - message.header.checkpoint_op <=
-                constants.journal_slot_count);
+                constants.vsr_checkpoint_interval + constants.lsm_batch_multiple);
             assert(message.header.op >= message.header.commit);
             assert(message.header.op - message.header.commit <=
                 constants.pipeline_prepare_queue_max);
@@ -4046,10 +4046,8 @@ pub fn ReplicaType(
             // The SV includes headers corresponding to the triggers for preceding
             // checkpoints (as many as we have and can help repair, which is at most 2).
             for ([_]u64{
-                self.op_checkpoint_next_trigger() -|
-                    (constants.journal_slot_count - constants.lsm_batch_multiple),
-                self.op_checkpoint_next_trigger() -|
-                    (constants.journal_slot_count - constants.lsm_batch_multiple) * 2,
+                self.op_checkpoint_next_trigger() -| constants.vsr_checkpoint_interval,
+                self.op_checkpoint_next_trigger() -| constants.vsr_checkpoint_interval * 2,
             }) |op_hook| {
                 if (op > op_hook and op_hook >= op_min) {
                     op = op_hook;
@@ -5051,19 +5049,40 @@ pub fn ReplicaType(
             return vsr.Checkpoint.trigger_for_checkpoint(self.op_checkpoint_next()).?;
         }
 
+        /// Returns checkpoint id associated with the op.
+        ///
+        /// Normally, this is just the id of the checkpoint the op builds on top. However, ops
+        /// between a checkpoint and its trigger can't know checkpoint's id yet, and instead use
+        /// the id of the previous checkpoint.
+        ///
+        /// Returns `null` for ops which are too far in the past/future to know their checkpoint
+        /// ids.
         fn checkpoint_id_for_op(self: *const Self, op: u64) ?u128 {
+            // Case 1: for the root op, checkpoint id is zero.
             if (op == 0) return Header.Prepare.root(self.cluster).checkpoint_id;
 
             if (self.op_checkpoint() > 0) {
-                if (op < self.op_repair_min()) return null;
-
-                const op_checkpoint_next_trigger_previous =
+                const op_checkpoint_trigger =
                     vsr.Checkpoint.trigger_for_checkpoint(self.op_checkpoint()).?;
-                if (op <= op_checkpoint_next_trigger_previous) {
+                if (op <= op_checkpoint_trigger) {
+                    if (op + constants.vsr_checkpoint_interval <= op_checkpoint_trigger) {
+                        // Case 2: op is from a too distant past for us to know its checkpoint id.
+                        return null;
+                    }
+                    // Case 3: op is from the previous checkpoint whose id we still remember.
                     return self.superblock.working.vsr_state.checkpoint.previous_checkpoint_id;
                 }
+
+                assert(op + constants.vsr_checkpoint_interval > self.op_checkpoint_next_trigger());
             }
-            return self.superblock.working.checkpoint_id();
+
+            if (op <= self.op_checkpoint_next_trigger()) {
+                // Case 4: op uses the current checkpoint id.
+                return self.superblock.working.checkpoint_id();
+            }
+
+            // Case 5: op is from the too far future for us to know anything!
+            return null;
         }
 
         /// Returns the oldest op that the replica must/(is permitted to) repair.
@@ -5079,8 +5098,9 @@ pub fn ReplicaType(
         ///       nacking the latter entry.
         ///     - there is no guarantee that they will ever be available (if our head is behind),
         ///       and we don't want to stall the new view startup.
-        ///   - primaries do repair checkpointed ops — as many as are guaranteed to exist anywhere in
-        ///     the cluster, so that they can help lagging backups catch up.
+        ///   - primaries do repair checkpointed ops so that they can help lagging backups catch up,
+        ///     as long as the op is new enough to be present in the WAL of some other replica and
+        ///     is from the previous checkpoint.
         ///
         /// When called from status=recovering_head or status=recovering, the caller is responsible
         /// for ensuring that replica.op is valid.
@@ -5094,7 +5114,7 @@ pub fn ReplicaType(
                     assert(self.status == .normal or self.do_view_change_quorum or self.solo());
                     // This is the oldest op that is guaranteed to be in the WALs of any replica.
                     // (Assuming that this primary has not been superseded.)
-                    break :op @min(
+                    const op_wal_oldest = @min(
                         // Add the oldest pipeline_prepare_queue_max ops because they may have been
                         // newer ops which were then truncated by a view-change, causing the head op
                         // to backtrack.
@@ -5102,6 +5122,15 @@ pub fn ReplicaType(
                         // ...But the pipeline messages could not have moved past the checkpoint.
                         self.op_checkpoint_next_trigger(),
                     ) -| (constants.journal_slot_count - 1);
+
+                    // We know checkpoint ids for the current checkpoint and the one before that.
+                    // Don't try repairing ops with older checkpoint_ids which are impossible to
+                    // verify.
+                    const op_with_checkpoint_id_oldest =
+                        (self.op_checkpoint_next_trigger() + 1) -| constants.vsr_checkpoint_interval * 2;
+                    assert(self.checkpoint_id_for_op(op_with_checkpoint_id_oldest) != null);
+
+                    break :op @max(op_wal_oldest, op_with_checkpoint_id_oldest);
                 } else {
                     // Strictly speaking a backup only needs to repair commit_min+1… to proceed.
                     // However, if the backup crashes and recovers, it will need to replay ops
@@ -5121,6 +5150,7 @@ pub fn ReplicaType(
             assert(op <= self.commit_min + 1);
             assert(op <= self.op_checkpoint() + 1);
             assert(self.op - op < constants.journal_slot_count);
+            assert(self.checkpoint_id_for_op(op) != null);
             return op;
         }
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -866,8 +866,8 @@ test "Cluster: sync: sync, bump target, sync" {
     defer t.deinit();
 
     var c = t.clients(0, t.cluster.clients.len);
-    try c.request(20, 20);
-    try expectEqual(t.replica(.R_).commit(), 20);
+    try c.request(16, 16);
+    try expectEqual(t.replica(.R_).commit(), 16);
 
     t.replica(.R2).drop_all(.R_, .bidirectional);
     try c.request(checkpoint_2_trigger, checkpoint_2_trigger);


### PR DESCRIPTION
This fixes the following simulator failure:

$ git reset --hard 87cace1
$ ./zig/zig build simulator_run -Dsimulator-state-machine=testing -- 9854840972719737644

This is what happening:

- two replicas committed checkpoint trigger (op=59) and prepared the next op=60.
- two replicas are far behind, want to state sync, and need a canonical checkpoint.
- one replica has op=28 corrupted in the log and wants to repair it

The key issue is that preparing op=60 already pushes op=28 out from the log, but doesn't yet make the checkpoint canonical (as op=60 isn't committed). As a result:

- the two lagging replicas can't sync, because there's no canonical checkpoint.
- the repairing replica can't catch up, because corrupted op is missing from the cluster.
- the two up-to-date replicas can't commit op=60, because there isn't a prepare quorum with a fresh checkpoint.

Taking a step back, the core issue here is that we don't have enough _physical_ durability for op=28. _Logically_, it is present on three replicas, once in a WAL (where it got corrupted) and twice as data in the checkpoint. However, as these are two different representations, the cluster is not always capable of reconciling them.

It is useful to consider a different scenario of corruptions here: suppose that a single grid block is corrupted on both checkpoints, and some prepare  is corrupted in the log of a catching up replica. There are three corruptions, but as only two are correlated, the cluster should be live. However in this situation effectively any corruption in the grid "intersects" with any corruption in the WAL.

The solution here is to _extend_ durabilities of prepares, such that we only start overwriting prepares from the old checkpoint once the new one is confirmed canonical. Before, the WAL looked like this:

```
    |<-checkpoint->|<-lsm_bar->|
                               ^
                            trigger
```

We shorten the checkpoint part to make sure we can fit an extra pipeline worth of messages in:

```
    |<-checkpoint->|<-lsm_bar->|<-pipeline->|
                               ^
                            trigger
```

This gives us the following invariant:

A prepare can only be evicted from the WAL once there's a _quorum_ of checkpoints covering this prepare.