### PR TITLE
Client: Java ID generator helper 

### DIFF
--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -94,9 +94,10 @@ A ULID ("Universally Unique Lexicographically Sortable identifier") consists of:
 - 80 bits of randomness (low-order bits)
 
 **Important**: When creating multiple objects during the same millisecond, increment the random bytes
-(instead of generating new random bytes). This ensures that a sequence of objects within a
-[batch](./client-requests.md#batching-events) has strictly increasing ids. (Batches of strictly
-increasing ids are amenable to LSM optimizations, leading to higher database throughput).
+(instead of generating new random bytes). Make sure to also store random bytes first, timestamp bytes 
+second, and both in little-endian. These details ensure that a sequence of objects have strictly 
+increasing ids according to the server. (Such ids are amenable to LSM optimizations, 
+leading to higher database throughput).
 
 - ULIDs have an insignificant risk of collision.
 - ULIDs do not require a central oracle.

--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -58,6 +58,7 @@
         </os>
       </activation>
       <properties>
+        <executable.extension>.exe</executable.extension>
         <script.extension>.bat</script.extension>
       </properties>
     </profile>
@@ -69,6 +70,7 @@
         </os>
       </activation>
       <properties>
+        <executable.extension></executable.extension>
         <script.extension>.sh</script.extension>
       </properties>
     </profile>
@@ -209,7 +211,7 @@
         <version>3.1.0</version>
         <configuration>
           <workingDirectory>${project.basedir}/../../../</workingDirectory>
-          <executable>${project.basedir}/../../../zig/zig</executable>
+          <executable>${project.basedir}/../../../zig/zig${executable.extension}</executable>
         </configuration>
         <executions>
           <execution>

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -179,12 +179,13 @@ public enum UInt128 {
     private static final SecureRandom idSecureRandom = new SecureRandom();
 
     /**
-     * Generates a Universally Unique Sortable Identifier as 16 bytes of a 128-bit value.
+     * Generates a Universally Unique Binary Sortable Identifier as 16 bytes of a 128-bit value.
      *
-     * The ID() function is thread-safe, the bytes returned are formatted in little endian, and the
-     * unsigned 128-bit value always monotonically increasing.
+     * The ID() function is thread-safe, the bytes returned are stored in little endian, and the
+     * unsigned 128-bit value increases monotonically. The algorithm is based on 
+     * <a href="https://github.com/ulid/spec">ULID</a> but is adjusted for u128-LE interpretation.
      *
-     * @throws ArithmeticException if the random monotonic value in the same millisecond overflows.
+     * @throws ArithmeticException if the random monotonic bits in the same millisecond overflows.
      * @return an array of 16 bytes representing an unsigned 128-bit value in little endian.
      */
     public static byte[] ID() {
@@ -209,7 +210,7 @@ public enum UInt128 {
             // If randomLo will overflow from increment, then increment randomHi as carry.
             // If randomHi will overflow on increment, throw error on 80-bit random overflow.
             if (randomLo == 0xFFFFFFFFFFFFFFFFL) {
-                if (randomHi == 0xffff) {
+                if (randomHi == 0xFFFF) {
                     throw new ArithmeticException("random bits overflow on monotonic increment");
                 }
                 randomHi += 1;

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -227,7 +227,7 @@ public enum UInt128 {
         buffer.putLong(randomLo);
         buffer.putShort(randomHi);
         buffer.putShort((short) timestamp); // timestamp lo
-        buffer.putInt((int) (timestamp >> 32)); // timestamp hi
+        buffer.putInt((int) (timestamp >> 16)); // timestamp hi
         return buffer.array();
     }
 }

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -182,7 +182,7 @@ public enum UInt128 {
      * Generates a Universally Unique Binary Sortable Identifier as 16 bytes of a 128-bit value.
      *
      * The ID() function is thread-safe, the bytes returned are stored in little endian, and the
-     * unsigned 128-bit value increases monotonically. The algorithm is based on 
+     * unsigned 128-bit value increases monotonically. The algorithm is based on
      * <a href="https://github.com/ulid/spec">ULID</a> but is adjusted for u128-LE interpretation.
      *
      * @throws ArithmeticException if the random monotonic bits in the same millisecond overflows.

--- a/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
@@ -171,22 +171,20 @@ public class UInt128Test {
     }
 
     @Test
-    public void testULID() throws Exception {
-        // Java's BigInteger uses bytes in big-endian, which should allow direct casting from ULID.
-
+    public void testID() throws Exception {
         {
-            // Generate ULIDs, sleeping for ~1ms after a few to test intra-millisecond monotonicity.
-            var ulidA = new BigInteger(UInt128.ULID());
+            // Generate IDs, sleeping for ~1ms after a few to test intra-millisecond monotonicity.
+            var idA = UInt128.asBigInteger(UInt128.ID());
             for (int i = 0; i < 10_000_000; i++) {
                 if (i % 10_000 == 0) {
                     Thread.sleep(1);
                 }
 
-                var ulidB = new BigInteger(UInt128.ULID());
-                assertTrue(ulidB.compareTo(ulidA) > 0);
+                var idB = UInt128.asBigInteger(UInt128.ID());
+                assertTrue(idB.compareTo(idA) > 0);
 
-                // Use the generated ULID as the new reference point for the next loop.
-                ulidA = ulidB;
+                // Use the generated ID as the new reference point for the next loop.
+                idA = idB;
             }
         }
 
@@ -203,15 +201,15 @@ public class UInt128Test {
                     latchStart.await();
 
                     // Same as serial test above, but with smaller bounds.
-                    var ulidA = new BigInteger(UInt128.ULID());
+                    var idA = UInt128.asBigInteger(UInt128.ID());
                     for (int j = 0; j < 10_000; j++) {
                         if (j % 1000 == 0) {
                             Thread.sleep(1);
                         }
 
-                        var ulidB = new BigInteger(UInt128.ULID());
-                        assertTrue(ulidB.compareTo(ulidA) > 0);
-                        ulidA = ulidB;
+                        var idB = UInt128.asBigInteger(UInt128.ID());
+                        assertTrue(idB.compareTo(idA) > 0);
+                        idA = idB;
                     }
 
                 } catch (Exception e) {


### PR DESCRIPTION
Creates a static helper function in the java client for generating thread-safe, unique, and monotonic `u128` IDs to use for Accounts and Transfers.