### PR TITLE
lsm: resurrect secondary indexes gravestone optimization

### DIFF
--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -23,10 +23,10 @@ pub const TableUsage = enum {
     /// * Only remove keys which are present.
     /// * TableKey == TableValue (modulo padding, eg CompositeKey).
     /// Then we can unlock additional optimizations:
-    /// * Immediately cancel out tombstone  and the corresponding insert, without waiting for the
-    ///   tombstone to sink to the bottom of the LSM true: absence of upserts guarantees that
+    /// * Immediately cancel out a tombstone and the corresponding insert, without waiting for the
+    ///   tombstone to sink to the bottom of the LSM true: absence of updates guarantees that
     ///   there are no otherwise visible values on lower level.
-    /// * Immediately cancel out insert and a tombstone for a "different" insert: as the values
+    /// * Immediately cancel out an insert and a tombstone for a "different" insert: as the values
     ///   are equal, it is correct to just resurrect an older value.
     secondary_index,
 };

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -21,8 +21,13 @@ pub const TableUsage = enum {
     /// If your usage fits this pattern:
     /// * Only put keys which are not present.
     /// * Only remove keys which are present.
-    /// * TableKey == TableValue (modulo padding, eg CompositeKey)
-    /// Then we can unlock additional optimizations.
+    /// * TableKey == TableValue (modulo padding, eg CompositeKey).
+    /// Then we can unlock additional optimizations:
+    /// * Immediately cancel out tombstone  and the corresponding insert, without waiting for the
+    ///   tombstone to sink to the bottom of the LSM true: absence of upserts guarantees that
+    ///   there are no otherwise visible values on lower level.
+    /// * Immediately cancel out insert and a tombstone for a "different" insert: as the values
+    ///   are equal, it is correct to just resurrect an older value.
     secondary_index,
 };
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -191,7 +191,6 @@ const naughty_list = [_][]const u8{
     "io/test.zig",
     "io/windows.zig",
     "lsm/binary_search.zig",
-    "lsm/compaction.zig",
     "lsm/binary_search_benchmark.zig",
     "lsm/forest_fuzz.zig",
     "lsm/groove.zig",


### PR DESCRIPTION
For secondary indexes, we don't need to compact tombstones all the way
to the last layer, and can immediately cancel out an insert and a
tombstone. What's more, both `put then remove` and `remove than put` are
cancelable, the first case just resurrects a previously inserted value.