### PR TITLE
Allow git commit hash to be passed at build time.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) !void {
     defer shell.destroy();
 
     // The "tigerbeetle version" command includes the build-time commit hash.
-    options.addOption([]const u8, "git_commit", try shell.git_commit());
+    options.addOption([]const u8, "git_commit", b.option([]const u8, "git-commit", "The git commit revision of the source code.") orelse try shell.git_commit());
     options.addOption(
         []const u8,
         "version",


### PR DESCRIPTION
When building with nix, usually we don't fetch the git repository if it can be avoided (and instead use the source archive generated by GitHub). This PR allows the git commit revision to be passed at build time rather than be determined by running `git`, which makes the build play nicer with nix.