### PR TITLE
release: don't rely on git to get the commit hash

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,7 +61,13 @@ pub fn build(b: *std.Build) !void {
     defer shell.destroy();
 
     // The "tigerbeetle version" command includes the build-time commit hash.
-    options.addOption([]const u8, "git_commit", b.option([]const u8, "git-commit", "The git commit revision of the source code.") orelse try shell.git_commit());
+    const git_commit = b.option(
+        []const u8,
+        "git-commit",
+        "The git commit revision of the source code.",
+    ) orelse try shell.git_commit();
+    options.addOption([]const u8, "git_commit", git_commit);
+
     options.addOption(
         []const u8,
         "version",

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -164,10 +164,12 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 \\build install
                 \\    -Dtarget={target}
                 \\    -Doptimize={mode}
+                \\    -Dgit-commit={commit}
                 \\    -Dversion={version}
             , .{
                 .target = target,
                 .mode = if (debug) "Debug" else "ReleaseSafe",
+                .commit = info.sha,
                 .version = info.version,
             });
 


### PR DESCRIPTION
The plan with `zig build release` all along was to just pass the hash in from the outside. Turns out, while the hash is passed, I actually forgot to thread it all the way through to build.zig!