### PR TITLE
VSR: Allow checkpoint of empty trailer

### DIFF
--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -24,7 +24,7 @@ pub const TableUsage = enum {
     /// * TableKey == TableValue (modulo padding, eg CompositeKey).
     /// Then we can unlock additional optimizations:
     /// * Immediately cancel out a tombstone and the corresponding insert, without waiting for the
-    ///   tombstone to sink to the bottom of the LSM true: absence of updates guarantees that
+    ///   tombstone to sink to the bottom of the LSM tree: absence of updates guarantees that
     ///   there are no otherwise visible values on lower level.
     /// * Immediately cancel out an insert and a tombstone for a "different" insert: as the values
     ///   are equal, it is correct to just resurrect an older value.

--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -305,7 +305,7 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
             trailer.size_transferred = 0;
             trailer.checksum = vsr.checksum(trailer.buffer[0..trailer.size]);
 
-            { // TODO if trailer.size > 0
+            if (trailer.size > 0) {
                 assert(trailer.grid.?.free_set.count_reservations() == 0);
                 const reservation = trailer.grid.?.free_set.reserve(trailer.block_count()).?;
                 defer trailer.grid.?.free_set.forfeit(reservation);


### PR DESCRIPTION
(The TODO was a note-to-self to check this that I didn't realize I committed.)

If the freeset shrinks down such that all blocks are freed (which admittedly isn't actually possible with our state machine) then it would encode to `0` bytes. `free_set.reserve()` asserts that the `block_count` to reserve is nonzero, so we must guard against that.