### PR TITLE
build: add -Drelease flag

### DIFF
--- a/.github/ci/benchmark/client.hcl
+++ b/.github/ci/benchmark/client.hcl
@@ -103,7 +103,7 @@ cd tigerbeetle
 git checkout ${var.git_ref}
 ./scripts/install_zig.sh
 
-cmd="./zig/zig build benchmark -Doptimize=ReleaseSafe -- --account-count=10000 --transfer-count=10000000 --transfer-count-per-second=1000000 --addresses=${var.addresses} --statsd --print-batch-timings"
+cmd="./zig/zig build benchmark -Drelease -- --account-count=10000 --transfer-count=10000000 --transfer-count-per-second=1000000 --addresses=${var.addresses} --statsd --print-batch-timings"
 echo "TigerBeetle Benchmark Command: ${cmd}"
 timeout -s KILL 3400 $cmd
 

--- a/.github/ci/benchmark/tigerbeetle.hcl
+++ b/.github/ci/benchmark/tigerbeetle.hcl
@@ -99,7 +99,7 @@ git clone ${var.git_url}
 cd tigerbeetle
 git checkout ${var.git_ref}
 ./scripts/install_zig.sh
-./zig/zig build install -Doptimize=ReleaseSafe
+./zig/zig build install -Drelease
 
 if ! [ -e "/tank/{{ env "NOMAD_JOB_ID" }}.tigerbeetle" ]; then
   ./tigerbeetle format --cluster=${var.cluster_id} --replica=${var.replica} --replica-count=${var.replica_count} /tank/{{ env "NOMAD_JOB_ID" }}.tigerbeetle

--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -6,11 +6,11 @@ if [ ! -d "zig" ]; then
     ./scripts/install_zig.sh
 fi
 
-# TODO: remove -Doptimize=ReleaseSafe once we no longer use a lot of stack in Groove.zig
-./zig/zig build -Doptimize=ReleaseSafe -Dconfig-aof-record=true
+# TODO: remove -Drelease once we no longer use a lot of stack in Groove.zig
+./zig/zig build -Drelease -Dconfig-aof-record=true
 mv zig-out/bin/tigerbeetle tigerbeetle-aof
 
-./zig/zig build -Doptimize=ReleaseSafe -Dconfig-aof-record=true -Dconfig-aof-recovery=true
+./zig/zig build -Drelease -Dconfig-aof-record=true -Dconfig-aof-recovery=true
 mv zig-out/bin/tigerbeetle tigerbeetle-aof-recovery
 
 rm -f aof.log

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: zig/zig build c_sample -Doptimize=ReleaseSafe
+      - run: zig/zig build c_sample -Drelease
 
   # I don't like this - having everything manually listed out here, but need to think of a better
   # way to parallelize it.
@@ -179,7 +179,7 @@ jobs:
 
       # # This both checks that the hash_log builds and acts as a regression test for
       # # https://github.com/tigerbeetle/tigerbeetle/issues/404
-      # - run: zig/zig build fuzz_lsm_forest -Dhash-log-mode=create -Doptimize=ReleaseSafe -- --seed 16319736705930193193 --events-max 10000 && zig/zig build fuzz_lsm_forest -Dhash-log-mode=check -- --seed 16319736705930193193 --events-max 10000
+      # - run: zig/zig build fuzz_lsm_forest -Dhash-log-mode=create -Drelease -- --seed 16319736705930193193 --events-max 10000 && zig/zig build fuzz_lsm_forest -Dhash-log-mode=check -- --seed 16319736705930193193 --events-max 10000
 
   # Check some build steps that would otherwise not get checked.
   # Things like "go_client", "java_client", "dotnet_client" are excluded here
@@ -203,5 +203,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: zig/zig build simulator_run -Dsimulator-state-machine=accounting -Doptimize=ReleaseSafe -- ${{ github.sha }}
-      - run: zig/zig build simulator_run -Dsimulator-state-machine=testing    -Doptimize=ReleaseSafe -- ${{ github.sha }}
+      - run: zig/zig build simulator_run -Dsimulator-state-machine=accounting -Drelease -- ${{ github.sha }}
+      - run: zig/zig build simulator_run -Dsimulator-state-machine=testing    -Drelease -- ${{ github.sha }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build c_sample -Doptimize=ReleaseSafe
+      - run: ./zig/zig build c_sample -Drelease
 
   repl_integration:
     strategy:

--- a/build.zig
+++ b/build.zig
@@ -52,7 +52,7 @@ pub fn build(b: *std.Build) !void {
         }
     } else @panic("error: unsupported target");
 
-    const mode = b.standardOptimizeOption(.{});
+    const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseSafe });
     const emit_llvm_ir = b.option(bool, "emit-llvm-ir", "Emit LLVM IR (.ll file)") orelse false;
 
     const options = b.addOptions();

--- a/docs/DEEP_DIVE.md
+++ b/docs/DEEP_DIVE.md
@@ -45,7 +45,7 @@ Let's turn up the log level some more (and your favorite album), so you can see 
 
 - Open `src/config.zig` in your editor and change `log_level` to `.debug`.
 
-- Rebuild TigerBeetle using the new debug log level by running `zig/zig build -Doptimize=ReleaseSafe && mv zig-out/bin/tigerbeetle .`
+- Rebuild TigerBeetle using the new debug log level by running `zig/zig build -Drelease && mv zig-out/bin/tigerbeetle .`
 
 - Start a single replica cluster:
 Format the data file:

--- a/scripts/benchmark.bat
+++ b/scripts/benchmark.bat
@@ -27,7 +27,7 @@ echo.
 exit /b
 
 :main
-zig\zig.exe build install -Doptimize=ReleaseSafe -Dconfig=production || exit /b
+zig\zig.exe build install -Drelease -Dconfig=production || exit /b
 
 for /l %%i in (0, 1, 0) do (
     echo Initializing replica %%i
@@ -51,5 +51,5 @@ for %%a in (%*) do (
         SET ARGS=!ARGS! %%a
     )
 )
-zig\zig.exe build benchmark -Doptimize=ReleaseSafe -Dconfig=production -- %ARGS%
+zig\zig.exe build benchmark -Drelease -Dconfig=production -- %ARGS%
 exit /b %errorlevel%

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # shellcheck disable=SC2086
-zig/zig build install -Doptimize=ReleaseSafe -Dconfig=production $ZIG_TARGET
+zig/zig build install -Drelease -Dconfig=production $ZIG_TARGET
 
 function onerror {
     if [ "$?" == "0" ]; then
@@ -70,7 +70,7 @@ done
 echo ""
 echo "Benchmarking..."
 # shellcheck disable=SC2086
-zig/zig build benchmark -Doptimize=ReleaseSafe -Dconfig=production $ZIG_TARGET -- --addresses="${PORT}" "$@"
+zig/zig build benchmark -Drelease -Dconfig=production $ZIG_TARGET -- --addresses="${PORT}" "$@"
 echo ""
 
 for I in $REPLICAS

--- a/scripts/fuzz_loop.sh
+++ b/scripts/fuzz_loop.sh
@@ -9,7 +9,7 @@ FUZZ_COMMAND=$1
 
 while true; do
   SEED=$(od -A n -t u8 -N 8 /dev/urandom | xargs)
-  (zig build "$FUZZ_COMMAND" -Doptimize=ReleaseSafe -- --seed "$SEED") || \
+  (zig build "$FUZZ_COMMAND" -Drelease -- --seed "$SEED") || \
     (zig build "$FUZZ_COMMAND" -- --seed "$SEED" 2> "fuzz_${FUZZ_COMMAND}_${SEED}") || \
     true
 done

--- a/scripts/fuzz_loop_hash_log.sh
+++ b/scripts/fuzz_loop_hash_log.sh
@@ -7,6 +7,6 @@ FUZZ_COMMAND=$1
 
 while true; do
   SEED=$(od -A n -t u8 -N 8 /dev/urandom | xargs)
-  zig build "$FUZZ_COMMAND" -Dhash-log-mode=create -Doptimize=ReleaseSafe -- --seed "$SEED" --events-max 100000;
+  zig build "$FUZZ_COMMAND" -Dhash-log-mode=create -Drelease -- --seed "$SEED" --events-max 100000;
   zig build "$FUZZ_COMMAND" -Dhash-log-mode=check -- --seed "$SEED" --events-max 100000;
 done

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -7,4 +7,4 @@ if not exist zig\ (
 )
 
 echo "Building TigerBeetle..."
-.\zig\zig.exe build install -Doptimize=ReleaseSafe
+.\zig\zig.exe build install -Drelease

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,5 +32,5 @@ if [ "$debug" = "true" ]; then
     zig/zig build install $target
 else
     echo "Building TigerBeetle..."
-    zig/zig build install -Doptimize=ReleaseSafe $target
+    zig/zig build install -Drelease $target
 fi

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -14,8 +14,8 @@
     <OS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</OS>
   </PropertyGroup>
   <Target Name="BuildZig" BeforeTargets="DispatchToInnerBuilds">
-    <Exec Command=".\zig\zig build dotnet_client -Doptimize=ReleaseSafe -Dconfig=production" WorkingDirectory="$(MSBuildProjectDirectory)\..\..\..\.." Condition="'$(OS)'=='Windows'" />
-    <Exec Command="./zig/zig build dotnet_client -Doptimize=ReleaseSafe -Dconfig=production" WorkingDirectory="$(MSBuildProjectDirectory)/../../../.." Condition="'$(OS)'!='Windows'" />
+    <Exec Command=".\zig\zig build dotnet_client -Drelease -Dconfig=production" WorkingDirectory="$(MSBuildProjectDirectory)\..\..\..\.." Condition="'$(OS)'=='Windows'" />
+    <Exec Command="./zig/zig build dotnet_client -Drelease -Dconfig=production" WorkingDirectory="$(MSBuildProjectDirectory)/../../../.." Condition="'$(OS)'!='Windows'" />
 
     <ItemGroup>
       <Content Include="runtimes\**\*.so">

--- a/src/clients/dotnet/scripts/benchmark.bat
+++ b/src/clients/dotnet/scripts/benchmark.bat
@@ -25,7 +25,7 @@ exit /b
 
 echo "Building TigerBeetle..."
 cd ..\..\..
-.\zig\zig.exe build install -Doptimize=ReleaseSafe
+.\zig\zig.exe build install -Drelease
 cd src/clients/dotnet
 
 for /l %%i in (0, 1, 0) do (

--- a/src/clients/dotnet/scripts/benchmark.sh
+++ b/src/clients/dotnet/scripts/benchmark.sh
@@ -8,7 +8,7 @@ COLOR_RED='\033[1;31m'
 COLOR_END='\033[0m'
 
 echo "Building TigerBeetle..."
-(cd ../../.. && ./zig/zig build install -Doptimize=ReleaseSafe)
+(cd ../../.. && ./zig/zig build install -Drelease)
 
 function onerror {
     if [ "$?" == "0" ]; then

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -471,7 +471,7 @@ git clone https://github.com/tigerbeetle/tigerbeetle
 cd tigerbeetle
 git submodule update --init --recursive
 ./scripts/install_zig.sh
-./zig/zig build go_client -Doptimize=ReleaseSafe -Dconfig=production
+./zig/zig build go_client -Drelease -Dconfig=production
 cd src/clients/go
 if [ "$TEST" = "true" ]; then go test; else echo "Skipping client unit tests"; fi
 ```
@@ -485,7 +485,7 @@ git clone https://github.com/tigerbeetle/tigerbeetle
 cd tigerbeetle
 git submodule update --init --recursive
 .\scripts\install_zig.bat
-.\zig\zig build go_client -Doptimize=ReleaseSafe -Dconfig=production
+.\zig\zig build go_client -Drelease -Dconfig=production
 cd src\clients\go
 if ($env:TEST -eq 'true') { go test } else { echo "Skipping client unit test" }
 ```

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -12,7 +12,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("go.mod"));
 
     // `go build`  won't compile the native library automatically, we need to do that ourselves.
-    try shell.zig("build go_client -Doptimize=ReleaseSafe -Dconfig=production", .{});
+    try shell.zig("build go_client -Drelease -Dconfig=production", .{});
 
     // Although we have compiled the TigerBeetle client library, we still need `cgo` to link it with
     // our resulting Go binary. Strictly speaking, `CC` is controlled by the users of TigerBeetle,
@@ -31,7 +31,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     };
 
     // Building the server before running the integrated tests:
-    try shell.zig("build install -Doptimize=ReleaseSafe -Dconfig=production", .{});
+    try shell.zig("build install -Drelease -Dconfig=production", .{});
     try shell.exec("go test", .{});
 
     inline for (.{ "basic", "two-phase", "two-phase-many" }) |sample| {

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -389,7 +389,7 @@ pub const GoDocs = Docs{
     // Extra steps to determine commit and repo so this works in
     // CI against forks and pull requests.
     .developer_setup_sh_commands =
-    \\./zig/zig build go_client -Doptimize=ReleaseSafe -Dconfig=production
+    \\./zig/zig build go_client -Drelease -Dconfig=production
     \\cd src/clients/go
     \\if [ "$TEST" = "true" ]; then go test; else echo "Skipping client unit tests"; fi
     ,
@@ -400,7 +400,7 @@ pub const GoDocs = Docs{
     // Extra steps to determine commit and repo so this works in
     // CI against forks and pull requests.
     .developer_setup_pwsh_commands =
-    \\.\zig\zig build go_client -Doptimize=ReleaseSafe -Dconfig=production
+    \\.\zig\zig build go_client -Drelease -Dconfig=production
     \\cd src\clients\go
     \\if ($env:TEST -eq 'true') { go test } else { echo "Skipping client unit test" }
     ,

--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -242,7 +242,7 @@
               <arguments>
                 <argument>build</argument>
                 <argument>java_client</argument>
-                <argument>-Doptimize=ReleaseSafe</argument>
+                <argument>-Drelease</argument>
                 <argument>-Dconfig=production</argument>
               </arguments>
             </configuration>

--- a/src/clients/java/scripts/benchmark.bat
+++ b/src/clients/java/scripts/benchmark.bat
@@ -25,7 +25,7 @@ exit /b
 
 echo "Building TigerBeetle..."
 cd ..\..\..
-.\zig\zig.exe build install -Doptimize=ReleaseSafe
+.\zig\zig.exe build install -Drelease
 cd src\clients\java
 
 echo "Building TigerBeetle Java Client"

--- a/src/clients/java/scripts/benchmark.sh
+++ b/src/clients/java/scripts/benchmark.sh
@@ -8,7 +8,7 @@ COLOR_RED='\033[1;31m'
 COLOR_END='\033[0m'
 
 echo "Building TigerBeetle..."
-(cd ../../.. && ./zig/zig build install -Doptimize=ReleaseSafe)
+(cd ../../.. && ./zig/zig build install -Drelease)
 
 echo "Building TigerBeetle Java Client"
 mvn -B compile --quiet

--- a/src/clients/node/scripts/prepare.js
+++ b/src/clients/node/scripts/prepare.js
@@ -30,7 +30,7 @@ fs.writeFileSync(defFile, 'EXPORTS\n    ' + allSymbolsArr.join('\n    '))
 execSync(`${zig} dlltool -m i386:x86-64 -D node.exe -d ${defFile} -l ${libFile}`)
 
 // Build the tigerbeetle node client.
-execSync(`${zig} build node_client -Doptimize=ReleaseSafe -Dconfig=production`)
+execSync(`${zig} build node_client -Drelease -Dconfig=production`)
 
 const bin_path = path.resolve(__dirname, '../dist/bin');
 const libs = get_libs(bin_path);

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -4,7 +4,7 @@
 //!
 //! To get a file with IR, use `-femit-llvm-ir` cli argument for `zig build-exe` or
 //!
-//!     $ zig build -Doptimize=ReleaseSafe -Demit-llvm-ir
+//!     $ zig build -Drelease -Demit-llvm-ir
 //!
 //! Pass the resulting .ll file to copyhound on stdin.
 //!

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -239,7 +239,7 @@ fn build_go(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     try shell.pushd("./src/clients/go");
     defer shell.popd();
 
-    try shell.zig("build go_client -Doptimize=ReleaseSafe -Dconfig=production", .{});
+    try shell.zig("build go_client -Drelease -Dconfig=production", .{});
 
     const files = try shell.exec_stdout("git ls-files", .{});
     var files_lines = std.mem.tokenize(u8, files, "\n");

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -138,8 +138,8 @@ fn build_simulator(
     mode: std.builtin.Mode,
 ) void {
     const mode_str = switch (mode) {
-        .Debug => "-Doptimize=Debug",
-        .ReleaseSafe => "-Doptimize=ReleaseSafe",
+        .Debug => "-Drelease=false",
+        .ReleaseSafe => "-Drelease",
         else => unreachable,
     };
 


### PR DESCRIPTION
Zig-as-a-language supports a variety of ways to build software, via
`standardOptimizeOption`. However, TigerBeetle as a project
intentionally doesn't support the full gamut of these options. In
particular, we always require assertions. For this reason, it makes
sense to simplify our binary config to a binary release-vs-debug build.


The first commit is the actual one-line change, the second commit adjust all call-sites 