### PR TITLE
ci: allow to manually trigger a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch: # Manual triggering to re-run a release with a different run_number
   push:
     branches:
       - release
@@ -12,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          rev: release # Use the 'release' branch even if triggered manually
 
       - uses: actions/setup-dotnet@v3
         with:

--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -398,6 +398,7 @@
             <serverId>ossrh</serverId>
             <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
In case a release fails transiently, it might be useful to manually re-run it, before addressing the underlying issue.

Just clicking the re-run button doesn't work --- re-runs get same run_number, so they'll try to publish the _same_ version, which, rightfully, doesn't work.

To allow re-runnning the workflow on the same commit but with a different version, add a manual trigger.