### PR TITLE
Test: "ack committed prepare": Remove extra t.run() workaround

### DIFF
--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -697,6 +697,10 @@ test "Cluster: repair: ack committed prepare" {
     try expectEqual(b1.op_head(), 21);
     try expectEqual(b2.op_head(), 20);
 
+    try expectEqual(p.status(), .normal);
+    try expectEqual(b1.status(), .normal);
+    try expectEqual(b2.status(), .normal);
+
     // Change views. B1/B2 participate. Don't allow B2 to repair op=21.
     t.replica(.R_).pass(.R_, .bidirectional, .start_view_change);
     t.replica(.R_).pass(.R_, .bidirectional, .do_view_change);
@@ -707,6 +711,10 @@ test "Cluster: repair: ack committed prepare" {
     try expectEqual(b1.commit(), 20);
     try expectEqual(b2.commit(), 20);
 
+    try expectEqual(p.status(), .normal);
+    try expectEqual(b1.status(), .normal);
+    try expectEqual(b2.status(), .normal);
+
     // But other than that, heal A0/B1, but partition B2 completely.
     // (Prevent another view change.)
     p.pass_all(.__, .bidirectional);
@@ -716,8 +724,14 @@ test "Cluster: repair: ack committed prepare" {
     t.replica(.R_).drop(.R_, .bidirectional, .do_view_change);
     t.run();
 
+    try expectEqual(p.status(), .normal);
+    try expectEqual(b1.status(), .normal);
+    try expectEqual(b2.status(), .normal);
+
     // A0 acks op=21 even though it already committed it.
+    try expectEqual(p.commit(), 21);
     try expectEqual(b1.commit(), 21);
+    try expectEqual(b2.commit(), 20);
 }
 
 test "Cluster: repair: primary checkpoint, backup crash before checkpoint, primary prepare" {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -702,8 +702,8 @@ test "Cluster: repair: ack committed prepare" {
     t.replica(.R_).pass(.R_, .bidirectional, .do_view_change);
     p.drop(.__, .bidirectional, .prepare);
     p.drop(.__, .bidirectional, .do_view_change);
+    p.drop(.__, .bidirectional, .start_view_change);
     t.run();
-    t.run(); // TODO: Workaround after async prefetch callback.
     try expectEqual(b1.commit(), 20);
     try expectEqual(b2.commit(), 20);
 


### PR DESCRIPTION
As part of the [Scan API](https://github.com/tigerbeetle/tigerbeetle/pull/1054) code review, we found that `Groove.prefetch()` would invoke its callback synchronously if all of the objects could be prefetched from cache. That was fixed as part of the same PR.

But fixing it caused an unrelated test to fail: `replica_test.zig`'s `"Cluster: repair: ack committed prepare"`.

During the `Change views. B1/B2 participate. Don't allow B2 to repair op=21.` step, even though only B1/B2 participated in the view change, A0 was still allowed to send SVC messages. Deferring `prefetch()`'s callback to next tick made commits take slightly longer. This permutation meant that B1/B2 would finish their view change (as before), but then A0 would prod them into kicking off another view change. So after the `t.run()`, B1/B2 were in status=view_change instead of status=normal.

---

(Also add some additional assertions that were useful while troubleshooting.)