### PR TITLE
Bump concurrency_max

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -118,14 +118,9 @@ pub fn ContextType(
 
             log.debug("{}: init: initializing", .{context.client_id});
 
-            // To take advantage of batching, the concurrency is limited to the max number of events
-            // that can be filled in a single batch.
-            const concurrency_limit = @max(
-                Client.StateMachine.constants.batch_max.create_accounts,
-                Client.StateMachine.constants.batch_max.create_transfers,
-            );
-
-            if (concurrency_max == 0 or concurrency_max > concurrency_limit) {
+            // Arbitrary limit: To take advantage of batching, the `concurrency_max` should be set
+            // high enough to allow concurrent requests to completely fill the message body.
+            if (concurrency_max == 0 or concurrency_max > 8192) {
                 return error.ConcurrencyMaxInvalid;
             }
 

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -118,7 +118,14 @@ pub fn ContextType(
 
             log.debug("{}: init: initializing", .{context.client_id});
 
-            if (concurrency_max == 0 or concurrency_max > 4096) {
+            // To take advantage of batching, the concurrency is limited to the max number of events
+            // that can be filled in a single batch.
+            const concurrency_limit = @max(
+                Client.StateMachine.constants.batch_max.create_accounts,
+                Client.StateMachine.constants.batch_max.create_transfers,
+            );
+
+            if (concurrency_max == 0 or concurrency_max > concurrency_limit) {
                 return error.ConcurrencyMaxInvalid;
             }
 

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -214,7 +214,7 @@ test "c_client tb_status" {
     try assert_status(128, "127.0.0.1:3000", c.TB_STATUS_SUCCESS);
     try assert_status(512, "3000,3001,3002", c.TB_STATUS_SUCCESS);
     try assert_status(1024, "127.0.0.1,127.0.0.2,172.0.0.3", c.TB_STATUS_SUCCESS);
-    try assert_status(4096, "127.0.0.1:3000,127.0.0.1:3002,127.0.0.1:3003", c.TB_STATUS_SUCCESS);
+    try assert_status(8192, "127.0.0.1:3000,127.0.0.1:3002,127.0.0.1:3003", c.TB_STATUS_SUCCESS);
 
     // Invalid or empty address should return "TB_STATUS_ADDRESS_INVALID":
     try assert_status(1, "invalid", c.TB_STATUS_ADDRESS_INVALID);
@@ -229,7 +229,7 @@ test "c_client tb_status" {
 
     // ConcurrencyMax Zero or greater than 4096 should return "TB_STATUS_CONCURRENCY_MAX_INVALID":
     try assert_status(0, "3000", c.TB_STATUS_CONCURRENCY_MAX_INVALID);
-    try assert_status(4097, "3000", c.TB_STATUS_CONCURRENCY_MAX_INVALID);
+    try assert_status(8193, "3000", c.TB_STATUS_CONCURRENCY_MAX_INVALID);
     try assert_status(std.math.maxInt(u32), "3000", c.TB_STATUS_CONCURRENCY_MAX_INVALID);
 
     // All other status are not testable.

--- a/src/clients/dotnet/TigerBeetle/Client.cs
+++ b/src/clients/dotnet/TigerBeetle/Client.cs
@@ -9,7 +9,7 @@ namespace TigerBeetle
 {
     public sealed class Client : IDisposable
     {
-        private const int DEFAULT_CONCURRENCY_MAX = 32;
+        private const int DEFAULT_CONCURRENCY_MAX = 256; // arbitrary
 
         private readonly UInt128 clusterID;
         private readonly NativeClient nativeClient;

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -100,7 +100,7 @@ defer client.Close()
 ```
 
 The third argument to `NewClient` is a `uint` max concurrency
-setting. `256` is a good default and can increase to `8190`
+setting. `256` is a good default and can increase to `8192`
 as you need increased throughput.
 
 The following are valid addresses:

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -91,7 +91,7 @@ tbAddress := os.Getenv("TB_ADDRESS")
 if len(tbAddress) == 0 {
   tbAddress = "3000"
 }
-client, err := NewClient(ToUint128(0), []string{tbAddress}, 32)
+client, err := NewClient(ToUint128(0), []string{tbAddress}, 256)
 if err != nil {
 	log.Printf("Error creating client: %s", err)
 	return
@@ -100,7 +100,7 @@ defer client.Close()
 ```
 
 The third argument to `NewClient` is a `uint` max concurrency
-setting. `32` is a good default and can increase to `4096`
+setting. `256` is a good default and can increase to `8190`
 as you need increased throughput.
 
 The following are valid addresses:

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -163,7 +163,7 @@ pub const GoDocs = Docs{
 
     .client_object_documentation =
     \\The third argument to `NewClient` is a `uint` max concurrency
-    \\setting. `256` is a good default and can increase to `8190`
+    \\setting. `256` is a good default and can increase to `8192`
     \\as you need increased throughput.
     ,
 

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -153,7 +153,7 @@ pub const GoDocs = Docs{
     \\if len(tbAddress) == 0 {
     \\  tbAddress = "3000"
     \\}
-    \\client, err := NewClient(ToUint128(0), []string{tbAddress}, 32)
+    \\client, err := NewClient(ToUint128(0), []string{tbAddress}, 256)
     \\if err != nil {
     \\	log.Printf("Error creating client: %s", err)
     \\	return
@@ -163,7 +163,7 @@ pub const GoDocs = Docs{
 
     .client_object_documentation =
     \\The third argument to `NewClient` is a `uint` max concurrency
-    \\setting. `32` is a good default and can increase to `4096`
+    \\setting. `256` is a good default and can increase to `8190`
     \\as you need increased throughput.
     ,
 

--- a/src/clients/go/samples/basic/main.go
+++ b/src/clients/go/samples/basic/main.go
@@ -24,7 +24,7 @@ func main() {
 		port = "3000"
 	}
 
-	client, err := NewClient(ToUint128(0), []string{port}, 32)
+	client, err := NewClient(ToUint128(0), []string{port}, 256)
 	if err != nil {
 		log.Fatalf("Error creating client: %s", err)
 	}

--- a/src/clients/go/samples/two-phase-many/main.go
+++ b/src/clients/go/samples/two-phase-many/main.go
@@ -57,7 +57,7 @@ func main() {
 		port = "3000"
 	}
 
-	client, err := NewClient(ToUint128(0), []string{port}, 32)
+	client, err := NewClient(ToUint128(0), []string{port}, 256)
 	if err != nil {
 		log.Fatalf("Error creating client: %s", err)
 	}

--- a/src/clients/go/samples/two-phase/main.go
+++ b/src/clients/go/samples/two-phase/main.go
@@ -24,7 +24,7 @@ func main() {
 		port = "3000"
 	}
 
-	client, err := NewClient(ToUint128(0), []string{port}, 32)
+	client, err := NewClient(ToUint128(0), []string{port}, 256)
 	if err != nil {
 		log.Fatalf("Error creating client: %s", err)
 	}

--- a/src/clients/java/src/main/java/com/tigerbeetle/Client.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Client.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletableFuture;
 
 public final class Client implements AutoCloseable {
 
-    private static final int DEFAULT_MAX_CONCURRENCY = 32;
+    private static final int DEFAULT_MAX_CONCURRENCY = 256; // arbitrary
 
     private final byte[] clusterID;
     private final NativeClient nativeClient;

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -96,7 +96,7 @@ export interface Client {
 }
 
 export function createClient (args: ClientInitArgs): Client {
-  const concurrency_max_default = 32 // arbitrary
+  const concurrency_max_default = 256 // arbitrary
   const context = binding.init({
     cluster_id: args.cluster_id,
     concurrency: args.concurrency_max || concurrency_max_default,


### PR DESCRIPTION
To fully take advantage of [client batching](https://github.com/tigerbeetle/tigerbeetle/pull/1257), the `concurrency_max` parameter needs to be set high enough for concurrent threads/tasks to be able to fill a batch completely.

This PR:

- Bumps the hard limit from `4096` (arbitrary) to `8190` (calculated from the max number of elements in a batch).
- Bumps the default runtime limit from `32` to `256` (still arbitrary).
