### PR TITLE
LSM: Add value count to TableInfo

### DIFF
--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -943,6 +943,7 @@ pub fn TestContext(
                 .snapshot_min = context.take_snapshot(),
                 .key_min = new_key_min,
                 .key_max = new_key_max,
+                .value_count = context.random.int(u32),
             };
         }
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -196,6 +196,7 @@ fn generate_events(
                     .snapshot_max = std.math.maxInt(u64),
                     .key_min = .{0} ** 16,
                     .key_max = .{0} ** 16,
+                    .value_count = 1,
                     .tree_id = 1,
                     .label = .{
                         .event = .insert,

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -464,9 +464,10 @@ pub const ManifestNode = struct {
         address: u64,
         snapshot_min: u64,
         snapshot_max: u64,
+        value_count: u32,
         tree_id: u16,
         label: Label,
-        reserved: [5]u8 = .{0} ** 5,
+        reserved: [1]u8 = .{0} ** 1,
 
         comptime {
             assert(@alignOf(TableInfo) == 16);

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -250,6 +250,7 @@ pub fn TableType(
 
             data_block_count: u32 = 0,
             value_count: u32 = 0,
+            value_count_total: u32 = 0, // Count across the entire table.
 
             pub fn init(allocator: mem.Allocator) !Builder {
                 const index_block = try allocate_block(allocator);
@@ -380,6 +381,7 @@ pub fn TableType(
                 }
 
                 builder.data_block_count += 1;
+                builder.value_count_total += builder.value_count;
                 builder.value_count = 0;
             }
 
@@ -435,6 +437,7 @@ pub fn TableType(
                     .snapshot_min = options.snapshot_min,
                     .key_min = builder.key_min,
                     .key_max = builder.key_max,
+                    .value_count = builder.value_count_total,
                 };
 
                 assert(info.snapshot_max == math.maxInt(u64));


### PR DESCRIPTION
Main use case is for paced compaction - with the value count available in TableInfo, we can more accurately spread the work since we'll now account for partially empty tables. (and lower our grid reservations per beat, too!)

The issue on the roadmap goes on to say:
> And possibly value-block count, since compression will decouple the ratio between the two

I'm not sure what our plans for compression are here - so I haven't done the value block just yet...