### PR TITLE
vopr: account for state sync in the convergence checker

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -419,7 +419,7 @@ pub const Simulator = struct {
                     const header = replica.journal.header_with_op(op).?;
                     if (!replica.journal.has_clean(header)) return false;
                 }
-                // It's okay for a replcia to miss some prepares older than the current checkpoint.
+                // It's okay for a replica to miss some prepares older than the current checkpoint.
                 maybe(replica.journal.faulty.count > 0);
 
                 if (!replica.sync_content_done()) return false;


### PR DESCRIPTION
It's normal for a core of a cluster to be missing some prepares, as long as they are from a past checkpoint.

SEED: 3206062160591889559

closes: https://github.com/tigerbeetle/tigerbeetle/issues/1370

