### PR TITLE
Fix java context handle

### DIFF
--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1088,7 +1088,7 @@ public class IntegrationTest {
      * threads trying to submit a request after the client was closed will fail with
      * IllegalStateException.
      */
-    // @Test
+    @Test
     public void testCloseWithConcurrentTasks() throws Throwable {
 
         try (var server = new Server()) {


### PR DESCRIPTION
## The problem
The `contextHandle` can be in use by `submit` while the `deinit` function is called.
We synchronize `acquire_packet` to prevent new packets from being acquired during shutdown, but we didn't guard the `contextHandle` itself, causing the JVM to crash when `acquire_packet` was called with a disposed context.

## Solution
Guard the contextHandle and a reference counter behind atomics. It's cheaper than a lock.

Undo the temp fix introduced by https://github.com/tigerbeetle/tigerbeetle/pull/1375
