### PR TITLE
vsr: allow cluster of two primaries to viewchange

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -283,7 +283,9 @@ pub const Header = extern struct {
         cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
-        view: u32 = 0, // Always 0.
+        // NB: unlike every other message, pings and pongs use on disk view, rather than in-memory
+        // view, to avoid disrupting clock synchronization while the view is being updated.
+        view: u32 = 0,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,
@@ -302,7 +304,6 @@ pub const Header = extern struct {
             assert(self.command == .ping);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-            if (self.view != 0) return "view != 0";
             if (!vsr.Checkpoint.valid(self.checkpoint_op)) return "checkpoint_op invalid";
             if (self.ping_timestamp_monotonic == 0) return "ping_timestamp_monotonic != expected";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
@@ -321,7 +322,9 @@ pub const Header = extern struct {
         cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
-        view: u32 = 0, // Always 0.
+        // NB: unlike every other message, pings and pongs use on disk view, rather than in-memory
+        // view, to avoid disrupting clock synchronization while the view is being updated.
+        view: u32 = 0,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
@@ -336,7 +339,6 @@ pub const Header = extern struct {
             assert(self.command == .pong);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
-            if (self.view != 0) return "view != 0";
             if (self.ping_timestamp_monotonic == 0) return "ping_timestamp_monotonic == 0";
             if (self.pong_timestamp_wall == 0) return "pong_timestamp_wall == 0";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1237,6 +1237,7 @@ pub fn ReplicaType(
                 .command = .pong,
                 .cluster = self.cluster,
                 .replica = self.replica,
+                .view = self.view_durable(), // Don't drop pongs while the view is being updated.
                 // Copy the ping's monotonic timestamp to our pong and add our wall clock sample:
                 .ping_timestamp_monotonic = message.header.ping_timestamp_monotonic,
                 .pong_timestamp_wall = @as(u64, @bitCast(self.clock.realtime())),
@@ -2543,11 +2544,12 @@ pub fn ReplicaType(
                 .command = .ping,
                 .cluster = self.cluster,
                 .replica = self.replica,
-                .ping_timestamp_monotonic = self.clock.monotonic(),
-                // Checkpoint information:
+                .view = self.view_durable(), // Don't drop pings while the view is being updated.
                 .checkpoint_id = self.superblock.working.checkpoint_id(),
                 .checkpoint_op = self.op_checkpoint(),
+                .ping_timestamp_monotonic = self.clock.monotonic(),
             };
+            assert(ping.view <= self.view);
 
             self.send_header_to_other_replicas_and_standbys(ping.frame_const().*);
         }
@@ -8312,7 +8314,14 @@ pub fn ReplicaType(
                 .prepare, .commit => .normal,
                 // When we are recovering_head we can't participate in a view-change anyway.
                 // But there is a chance that the primary is actually running, despite the DVC/SVC.
-                .do_view_change, .start_view_change => if (self.status == .recovering_head) Status.normal else .view_change,
+                .do_view_change,
+                .start_view_change,
+                // For pings, we don't actually know where the new view is started or not.
+                // Conservatively transition to view change: at worst, we'll send a larger DVC
+                // instead of a RSV.
+                .ping,
+                .pong,
+                => if (self.status == .recovering_head) Status.normal else .view_change,
                 // on_start_view() handles the (possible) transition to view-change manually, before
                 // transitioning to normal.
                 .start_view => return,


### PR DESCRIPTION
Most of the time, passively abdicating is enough for the rest of the
cluster to trigger a view change. But there is an edge case --- if "the
rest of the cluster" is a single replica that believes itself to be a
primary (in an older view), and that replica doesn't have locally
uncommitted prepares, it will not itself try to abdicate, and it will
not learn that a newer view has started.

A _tactical_ fix here would be for the abdicating primary to sending an
SVC message, but let's use a brute force solution and just include view
information with pings. That way, we get a very robust way to
communicate the current view across the cluster.

We actually used to include view numbers with pings, but then got rid of
them, as:

- pings also carry clock synchronization information,
- we have a logic for dropping all messages whose view is > replica.view_durable()

The new insight here is that we can just include `view_durable` with
pings and pongs!


SEED: 9762771235456011173