### PR TITLE
ci: ensure all scripts are compiling

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -29,7 +29,7 @@ jobs:
             7.0.x
 
       - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest-large' && 'bat' || 'sh' }}
-      - run: ./zig/zig build ci -- --language=dotnet
+      - run: ./zig/zig build scripts -- ci --language=dotnet
       # - run: ./zig/zig build client_docs -- --language=dotnet
       # - if: matrix.os == 'ubuntu-latest-large'
         # run: ./.github/ci/fail_on_diff.sh
@@ -51,7 +51,7 @@ jobs:
           go-version: '1.18'
 
       - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest-large' && 'bat' || 'sh' }}
-      - run: ./zig/zig build ci -- --language=go
+      - run: ./zig/zig build scripts -- ci --language=go
       # - run: ./zig/zig build client_docs -- --language=go
       # - if: matrix.os == 'ubuntu-latest-large'
         # run: ./.github/ci/fail_on_diff.sh
@@ -85,7 +85,7 @@ jobs:
          run: '"$env:GITHUB_WORKSPACE/apache-maven-3.9.3/bin" | Out-File -FilePath $env:GITHUB_PATH -Append'
 
       - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest-large' && 'bat' || 'sh' }}
-      - run: ./zig/zig build ci -- --language=java
+      - run: ./zig/zig build scripts -- ci --language=java
       # - run: ./zig/zig build client_docs -- --language=java
       # - if: matrix.os == 'ubuntu-latest-large'
         # run: ./.github/ci/fail_on_diff.sh
@@ -113,7 +113,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest-large' && 'bat' || 'sh' }}
-      - run: ./zig/zig build ci -- --language=node
+      - run: ./zig/zig build scripts -- ci --language=node
       # - run: ./zig/zig build client_docs -- --language=node
       # - if: matrix.os == 'ubuntu-latest-large'
         # run: ./.github/ci/fail_on_diff.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       # We need llvm-lipo utility from LLVM to build a universal mac binary.
       - run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build release -- --build --publish --version=0.14.${{ github.run_number }} --sha=${{ github.sha }}
+      - run: ./zig/zig build scripts -- release --build --publish --version=0.14.${{ github.run_number }} --sha=${{ github.sha }}
         env:
           NUGET_KEY: ${{ secrets.NUGET_KEY }}
           TIGERBEETLE_GO_PAT: ${{ secrets.TIGERBEETLE_GO_PAT }}

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run: ./scripts/install_zig.sh
 
-      - run: ./zig/zig build ci -- --validate-release
+      - run: ./zig/zig build scripts -- ci --validate-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.zig
+++ b/build.zig
@@ -413,17 +413,6 @@ pub fn build(b: *std.Build) !void {
             mode,
             target,
         );
-
-        const ci_exe = b.addExecutable(.{
-            .name = "ci",
-            .root_source_file = .{ .path = "src/scripts/ci.zig" },
-            .target = target,
-            .main_pkg_path = .{ .path = "src" },
-        });
-        const ci_run = b.addRunArtifact(ci_exe);
-        if (b.args) |args| ci_run.addArgs(args);
-        const ci_step = b.step("ci", "Run CI checks");
-        ci_step.dependOn(&ci_run.step);
     }
 
     {
@@ -679,16 +668,16 @@ pub fn build(b: *std.Build) !void {
         step.dependOn(&run_cmd.step);
     }
 
-    const release_exe = b.addExecutable(.{
-        .name = "release",
-        .root_source_file = .{ .path = "src/scripts/release.zig" },
+    const scripts_exe = b.addExecutable(.{
+        .name = "scripts",
+        .root_source_file = .{ .path = "src/scripts/main.zig" },
         .target = target,
         .main_pkg_path = .{ .path = "src" },
     });
-    const release_exe_run = b.addRunArtifact(release_exe);
-    if (b.args) |args| release_exe_run.addArgs(args);
-    const release_step = b.step("release", "build and publish release artifacts");
-    release_step.dependOn(&release_exe_run.step);
+    const scripts_run = b.addRunArtifact(scripts_exe);
+    if (b.args) |args| scripts_run.addArgs(args);
+    const scripts_step = b.step("scripts", "Run automation scripts");
+    scripts_step.dependOn(&scripts_run.step);
 }
 
 fn link_tracer_backend(

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -91,7 +91,7 @@ pub fn main() !void {
     // Discard executable name.
     _ = args.next().?;
 
-    const cli_args = flags.parse_flags(&args, CliArgs);
+    const cli_args = flags.parse(&args, CliArgs);
 
     const addresses = try vsr.parse_addresses(allocator, cli_args.addresses, constants.members_max);
     defer allocator.free(addresses);

--- a/src/clients/docs_generate.zig
+++ b/src/clients/docs_generate.zig
@@ -831,7 +831,7 @@ pub fn main() !void {
 
     assert(args.skip());
 
-    const cli_args = flags.parse_flags(&args, CliArgs);
+    const cli_args = flags.parse(&args, CliArgs);
 
     if (cli_args.validate != null and cli_args.no_validate) {
         flags.fatal("--validate: conflicts with --no-validate", .{});

--- a/src/clients/repl_integration.zig
+++ b/src/clients/repl_integration.zig
@@ -246,7 +246,7 @@ pub fn main() !void {
 
     assert(args.skip());
 
-    const cli_args = flags.parse_flags(&args, CliArgs);
+    const cli_args = flags.parse(&args, CliArgs);
 
     var t = try TmpDir.init(&arena);
     defer if (!cli_args.keep_tmp) {

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -54,7 +54,7 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(allocator);
     assert(args.skip());
 
-    const cli_args = flags.parse_commands(&args, CliArgs);
+    const cli_args = flags.parse(&args, CliArgs);
 
     var line_buffer = try allocator.alloc(u8, 1024 * 1024);
     var func_buf = try allocator.alloc(u8, 4096);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -22,31 +22,12 @@ const LanguageCI = .{
     .node = @import("../clients/node/ci.zig"),
 };
 
-const CliArgs = struct {
+pub const CliArgs = struct {
     language: ?Language = null,
     validate_release: bool = false,
 };
 
-pub fn main() !void {
-    var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    defer switch (gpa_allocator.deinit()) {
-        .ok => {},
-        .leak => fatal("memory leak", .{}),
-    };
-
-    const gpa = gpa_allocator.allocator();
-    var arena_allocator = std.heap.ArenaAllocator.init(gpa);
-    defer arena_allocator.deinit();
-
-    const shell = try Shell.create(gpa);
-    defer shell.destroy();
-
-    var args = try std.process.argsWithAllocator(gpa);
-    defer args.deinit();
-
-    assert(args.skip());
-    const cli_args = flags.parse_flags(&args, CliArgs);
-
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     if (cli_args.validate_release) {
         try validate_release(shell, gpa, cli_args.language);
     } else {

--- a/src/scripts/main.zig
+++ b/src/scripts/main.zig
@@ -1,0 +1,52 @@
+//! Grab bag of automation scripts around TigerBeetle.
+//!
+//! Design rationale:
+//! - Bash is not cross platform, suffers from high accidental complexity, and is a second language.
+//!   We strive to centralize on Zig for all of the things.
+//! - While build.zig is great for _building_ software using a graph of tasks with dependency
+//!   tracking, higher-level orchestration is easier if you just write direct imperative code.
+//! - To minimize the number of things that need compiling and improve link times, all scripts are
+//!   subcommands of a single binary.
+//!
+//!   This is a special case of the following rule-of-thumb: length of `build.zig` should be O(1).
+const std = @import("std");
+const assert = std.debug.assert;
+
+const stdx = @import("../stdx.zig");
+const flags = @import("../flags.zig");
+const fatal = flags.fatal;
+const Shell = @import("../shell.zig");
+
+const ci = @import("./ci.zig");
+const release = @import("./release.zig");
+
+const CliArgs = union(enum) {
+    ci: ci.CliArgs,
+    release: release.CliArgs,
+};
+
+pub fn main() !void {
+    var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+    defer switch (gpa_allocator.deinit()) {
+        .ok => {},
+        .leak => fatal("memory leak", .{}),
+    };
+
+    const gpa = gpa_allocator.allocator();
+    var arena_allocator = std.heap.ArenaAllocator.init(gpa);
+    defer arena_allocator.deinit();
+
+    const shell = try Shell.create(gpa);
+    defer shell.destroy();
+
+    var args = try std.process.argsWithAllocator(gpa);
+    defer args.deinit();
+
+    assert(args.skip()); // Discard executable name.
+    const cli_args = flags.parse(&args, CliArgs);
+
+    switch (cli_args) {
+        .ci => |args_ci| try ci.main(shell, gpa, args_ci),
+        .release => |args_release| try release.main(shell, gpa, args_release),
+    }
+}

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -26,7 +26,7 @@ const Shell = @import("../shell.zig");
 
 const Language = enum { dotnet, go, java, node, zig, docker };
 const LanguageSet = std.enums.EnumSet(Language);
-const CliArgs = struct {
+pub const CliArgs = struct {
     version: []const u8,
     sha: []const u8,
     language: ?Language = null,
@@ -39,27 +39,8 @@ const VersionInfo = struct {
     sha: []const u8,
 };
 
-pub fn main() !void {
-    var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    defer switch (gpa_allocator.deinit()) {
-        .ok => {},
-        .leak => fatal("memory leak", .{}),
-    };
-
-    const gpa = gpa_allocator.allocator();
-    var arena_allocator = std.heap.ArenaAllocator.init(gpa);
-    defer arena_allocator.deinit();
-
-    const shell = try Shell.create(gpa);
-    defer shell.destroy();
-
-    var args = try std.process.argsWithAllocator(gpa);
-    defer args.deinit();
-
-    // Discard executable name.
-    _ = args.next().?;
-
-    const cli_args = flags.parse_flags(&args, CliArgs);
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+    _ = gpa;
 
     const languages = if (cli_args.language) |language|
         LanguageSet.initOne(language)

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -190,7 +190,7 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
     // Skip argv[0] which is the name of this executable
     assert(args.skip());
 
-    const cli_args = flags.parse_commands(&args, CliArgs);
+    const cli_args = flags.parse(&args, CliArgs);
 
     switch (cli_args) {
         .version => |version| {


### PR DESCRIPTION
Unify all script binaries (ci&release) under the same umbrella `zig build scripts --`. That way:

- they are always compiled and can't bitrot,
- we only pay linking cost once,
- build.zig shrinks in size.

Also unify `flags.parse_command` & `flags.parse_flags` into a single `flags.parse`. Not sure why I didn't do that from the start, seems obviously better to have just one entry point?