### PR TITLE
Don't exit repl on 'help'

### DIFF
--- a/src/tigerbeetle/repl.zig
+++ b/src/tigerbeetle/repl.zig
@@ -448,7 +448,6 @@ pub fn ReplType(comptime MessageBus: type) type {
                 },
                 .help => {
                     try repl.display_help();
-                    std.os.exit(0);
                 },
 
                 .create_accounts,


### PR DESCRIPTION
One of the first things I did with tigerbeetle, per the docs, was run the repl, and the first thing I did in the repl was type 'help', which immediately exited the repl.

I thought this behavior was surprising (e.g. the python repl doesn't exit on help), and I couldn't find an obvious reason for it in the code or the commit log.

This change just removes the call to `exit`, so the repl continues to run after displaying the help message.