### PR TITLE
node: prune down CI

### DIFF
--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -39,47 +39,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     // Container smoke tests.
     if (builtin.target.os.tag == .linux) {
         try shell.exec("npm pack --quiet", .{});
-
-        // Installing node through <https://github.com/nodesource/distributions>.
-
-        const deb_install_script =
-            \\apt-get update
-            \\apt-get install -y ca-certificates curl gnupg
-            \\mkdir -p /etc/apt/keyrings
-            \\
-            \\curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-            \\  | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-            \\
-            \\echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
-            \\    https://deb.nodesource.com/node_18.x nodistro main" \
-            \\  | tee /etc/apt/sources.list.d/nodesource.list
-            \\
-            \\apt-get update
-            \\apt-get install nodejs -y
-        ;
-
-        const rpm_install_script =
-            \\yum install \
-            \\  https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
-            \\yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
-        ;
-
-        const distributions = .{
-            "alpine", "debian",      "ubuntu",
-            "fedora", "redhat/ubi9", "amazonlinux:2.0.20230307.0",
-        };
-
-        const install_scripts = .{
-            \\apk add --update nodejs npm
-            ,
-            deb_install_script,
-            deb_install_script,
-            rpm_install_script,
-            "update-crypto-policies --set DEFAULT:SHA1\n" ++ rpm_install_script,
-            rpm_install_script,
-        };
-
-        inline for (distributions, install_scripts) |distribution, install_script| {
+        for ([_][]const u8{ "node:18", "node:18-alpine" }) |image| {
             try shell.exec(
                 \\docker run
                 \\--security-opt seccomp=unconfined
@@ -88,13 +48,12 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 \\sh
                 \\-c {script}
             , .{
-                .image = distribution,
-                .script = 
+                .image = image,
+                .script =
                 \\set -ex
                 \\mkdir test-project && cd test-project
-                ++ "\n" ++ install_script ++ "\n" ++
-                    \\npm install /host/tigerbeetle-node-*.tgz
-                    \\node -e 'require("tigerbeetle-node"); console.log("SUCCESS!")'
+                \\npm install /host/tigerbeetle-node-*.tgz
+                \\node -e 'require("tigerbeetle-node"); console.log("SUCCESS!")'
                 ,
             });
         }


### PR DESCRIPTION
For NodeJS, we used to have a hefty matrix of different distributions, to make sure our stuff works in all possible contexts. However, it looks like the main thing we are testing here is installing node itself --- we used something called `nodesource` which provides third party packages for various distros, and requires add-hoc scripts for installation. This is also something that was changed recently (they used to have a single script, which is now deprecated). And it looks like it broke again:

https://github.com/tigerbeetle/tigerbeetle/actions/runs/7359371489/job/20034038580?pr=1397#step:5:573

It feels like here we are taking onto us some else's maintainance burden. I'd say that, if official node does not provide one-liner installation for these distros, we shouldn't invent our own wheel.

Let's just check that the two official images from NodeJS work, it feels to be a better balance of coverage vs maintainance work!