### PR TITLE
Drop support for .Net Standard 2.1

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -12,8 +12,7 @@ The TigerBeetle client for .NET.
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* Any runtime compatible with [.NET Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#select-net-standard-version).
-* Optimized for .NET >= 7.0.
+* .NET >= 7.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:
@@ -135,7 +134,7 @@ account balances have a few extension methods to make it easier
 to convert 128-bit little-endian unsigned integers between
 `BigInteger`, `byte[]`, and `Guid`.
 
-See the class [UInt128Extensions](/src/clients/dotnet/TigerBeetle/UInt128.cs) for more details.
+See the class [UInt128Extensions](/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs) for more details.
 
 ### Account Flags
 

--- a/src/clients/dotnet/TigerBeetle.Benchmarks/Benchmark.cs
+++ b/src/clients/dotnet/TigerBeetle.Benchmarks/Benchmark.cs
@@ -6,23 +6,23 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
-namespace TigerBeetle.Benchmarks
+namespace TigerBeetle.Benchmarks;
+
+public static partial class Benchmark
 {
-    public static partial class Benchmark
+    private const bool IS_ASYNC = false;
+    private const int BATCHES_COUNT = 100;
+    private const int MAX_MESSAGE_SIZE = (1024 * 1024) - 256; // config.message_size_max - @sizeOf(vsr.Header)
+    private const int TRANSFERS_PER_BATCH = (MAX_MESSAGE_SIZE / Transfer.SIZE);
+    private const int MAX_TRANSFERS = BATCHES_COUNT * TRANSFERS_PER_BATCH;
+
+    public static async Task Main()
     {
-        private const bool IS_ASYNC = false;
-        private const int BATCHES_COUNT = 100;
-        private const int MAX_MESSAGE_SIZE = (1024 * 1024) - 256; // config.message_size_max - @sizeOf(vsr.Header)
-        private const int TRANSFERS_PER_BATCH = (MAX_MESSAGE_SIZE / Transfer.SIZE);
-        private const int MAX_TRANSFERS = BATCHES_COUNT * TRANSFERS_PER_BATCH;
+        Console.WriteLine($"Benchmarking dotnet");
 
-        public static async Task Main()
-        {
-            Console.WriteLine($"Benchmarking dotnet");
+        using var client = new Client(0, new string[] { "3001" });
 
-            using var client = new Client(0, new string[] { "3001" });
-
-            var accounts = new[] {
+        var accounts = new[] {
                 new Account
                 {
                     Id = 1,
@@ -37,71 +37,70 @@ namespace TigerBeetle.Benchmarks
                 }
             };
 
-            var transfers = new Transfer[BATCHES_COUNT][];
-            for (int i = 0; i < BATCHES_COUNT; i++)
+        var transfers = new Transfer[BATCHES_COUNT][];
+        for (int i = 0; i < BATCHES_COUNT; i++)
+        {
+            transfers[i] = new Transfer[TRANSFERS_PER_BATCH];
+            for (int j = 0; j < TRANSFERS_PER_BATCH; j++)
             {
-                transfers[i] = new Transfer[TRANSFERS_PER_BATCH];
-                for (int j = 0; j < TRANSFERS_PER_BATCH; j++)
+                transfers[i][j] = new Transfer
                 {
-                    transfers[i][j] = new Transfer
-                    {
-                        Id = new UInt128((ulong)i, (ulong)j + 1),
-                        DebitAccountId = accounts[0].Id,
-                        CreditAccountId = accounts[1].Id,
-                        Amount = 1,
-                        Code = 1,
-                        Ledger = 777,
-                    };
-                }
+                    Id = new UInt128((ulong)i, (ulong)j + 1),
+                    DebitAccountId = accounts[0].Id,
+                    CreditAccountId = accounts[1].Id,
+                    Amount = 1,
+                    Code = 1,
+                    Ledger = 777,
+                };
             }
+        }
 
-            Console.WriteLine("creating accounts...");
+        Console.WriteLine("creating accounts...");
 
+        if (IS_ASYNC)
+        {
+            var results = await client.CreateAccountsAsync(accounts);
+            if (results.Length > 0) throw new Exception("Invalid account results");
+        }
+        else
+        {
+            var results = client.CreateAccounts(accounts);
+            if (results.Length > 0) throw new Exception("Invalid account results");
+        }
+
+        Console.WriteLine("starting benchmark...");
+
+        var stopWatch = new Stopwatch();
+        long totalTime = 0;
+        long maxTransfersLatency = 0;
+
+        for (int batchCount = 0; batchCount < BATCHES_COUNT; batchCount++)
+        {
+            var batch = transfers[batchCount];
+
+            stopWatch.Restart();
             if (IS_ASYNC)
             {
-                var results = await client.CreateAccountsAsync(accounts);
-                if (results.Length > 0) throw new Exception("Invalid account results");
+                var ret = await client.CreateTransfersAsync(batch);
+                if (ret.Length > 0) throw new Exception("Invalid transfer results");
             }
             else
             {
-                var results = client.CreateAccounts(accounts);
-                if (results.Length > 0) throw new Exception("Invalid account results");
+                var ret = client.CreateTransfers(batch);
+                if (ret.Length > 0) throw new Exception("Invalid transfer results");
             }
+            stopWatch.Stop();
 
-            Console.WriteLine("starting benchmark...");
-
-            var stopWatch = new Stopwatch();
-            long totalTime = 0;
-            long maxTransfersLatency = 0;
-
-            for (int batchCount = 0; batchCount < BATCHES_COUNT; batchCount++)
-            {
-                var batch = transfers[batchCount];
-
-                stopWatch.Restart();
-                if (IS_ASYNC)
-                {
-                    var ret = await client.CreateTransfersAsync(batch);
-                    if (ret.Length > 0) throw new Exception("Invalid transfer results");
-                }
-                else
-                {
-                    var ret = client.CreateTransfers(batch);
-                    if (ret.Length > 0) throw new Exception("Invalid transfer results");
-                }
-                stopWatch.Stop();
-
-                totalTime += stopWatch.ElapsedMilliseconds;
-                maxTransfersLatency = Math.Max(stopWatch.ElapsedMilliseconds, maxTransfersLatency);
-            }
-
-            Console.WriteLine("============================================");
-
-            var result = (long)((MAX_TRANSFERS * 1000) / totalTime);
-
-            Console.WriteLine($"{result} transfers per second");
-            Console.WriteLine($"create_transfers max p100 latency per {TRANSFERS_PER_BATCH} transfers = {maxTransfersLatency}ms");
-            Console.WriteLine($"total {MAX_TRANSFERS} transfers in {totalTime}ms");
+            totalTime += stopWatch.ElapsedMilliseconds;
+            maxTransfersLatency = Math.Max(stopWatch.ElapsedMilliseconds, maxTransfersLatency);
         }
+
+        Console.WriteLine("============================================");
+
+        var result = (long)((MAX_TRANSFERS * 1000) / totalTime);
+
+        Console.WriteLine($"{result} transfers per second");
+        Console.WriteLine($"create_transfers max p100 latency per {TRANSFERS_PER_BATCH} transfers = {maxTransfersLatency}ms");
+        Console.WriteLine($"total {MAX_TRANSFERS} transfers in {totalTime}ms");
     }
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/BindingTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/BindingTests.cs
@@ -4,257 +4,256 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 
-namespace TigerBeetle.Tests
+namespace TigerBeetle.Tests;
+
+[TestClass]
+public class BindingTests
 {
-    [TestClass]
-    public class BindingTests
+    [TestMethod]
+    public void Accounts()
     {
-        [TestMethod]
-        public void Accounts()
+        var account = new Account();
+        account.Id = 100;
+        Assert.AreEqual(account.Id, (UInt128)100);
+
+        account.UserData128 = 101;
+        Assert.AreEqual(account.UserData128, (UInt128)101);
+
+        account.UserData64 = 102;
+        Assert.AreEqual(account.UserData64, (ulong)102L);
+
+        account.UserData32 = 103;
+        Assert.AreEqual(account.UserData32, (uint)103);
+
+        account.Reserved = 0;
+        Assert.AreEqual(account.Reserved, (uint)0);
+
+        account.Ledger = 104;
+        Assert.AreEqual(account.Ledger, (uint)104);
+
+        account.Code = 105;
+        Assert.AreEqual(account.Code, (ushort)105);
+
+        var flags = AccountFlags.Linked | AccountFlags.DebitsMustNotExceedCredits | AccountFlags.CreditsMustNotExceedDebits;
+        account.Flags = flags;
+        Assert.AreEqual(account.Flags, flags);
+
+        account.DebitsPending = 1001;
+        Assert.AreEqual(account.DebitsPending, (UInt128)1001);
+
+        account.CreditsPending = 1002;
+        Assert.AreEqual(account.CreditsPending, (UInt128)1002);
+
+        account.DebitsPosted = 1003;
+        Assert.AreEqual(account.DebitsPosted, (UInt128)1003);
+
+        account.CreditsPosted = 1004;
+        Assert.AreEqual(account.CreditsPosted, (UInt128)1004);
+
+        account.Timestamp = 99_999;
+        Assert.AreEqual(account.Timestamp, (ulong)99_999);
+    }
+
+    [TestMethod]
+    public void AccountsDefault()
+    {
+        var account = new Account(); ;
+        Assert.AreEqual(account.Id, UInt128.Zero);
+        Assert.AreEqual(account.UserData128, UInt128.Zero);
+        Assert.AreEqual(account.UserData64, (ulong)0);
+        Assert.AreEqual(account.UserData32, (uint)0);
+        Assert.AreEqual(account.Reserved, (uint)0);
+        Assert.AreEqual(account.Ledger, (uint)0);
+        Assert.AreEqual(account.Code, (ushort)0);
+        Assert.AreEqual(account.Flags, AccountFlags.None);
+        Assert.AreEqual(account.DebitsPending, (UInt128)0);
+        Assert.AreEqual(account.CreditsPending, (UInt128)0);
+        Assert.AreEqual(account.DebitsPosted, (UInt128)0);
+        Assert.AreEqual(account.CreditsPosted, (UInt128)0);
+        Assert.AreEqual(account.Timestamp, (UInt128)0);
+    }
+
+    [TestMethod]
+    public void AccountsSerialize()
+    {
+        var expected = new byte[Account.SIZE];
+        using (var writer = new BinaryWriter(new MemoryStream(expected)))
         {
-            var account = new Account();
-            account.Id = 100;
-            Assert.AreEqual(account.Id, (UInt128)100);
-
-            account.UserData128 = 101;
-            Assert.AreEqual(account.UserData128, (UInt128)101);
-
-            account.UserData64 = 102;
-            Assert.AreEqual(account.UserData64, (ulong)102L);
-
-            account.UserData32 = 103;
-            Assert.AreEqual(account.UserData32, (uint)103);
-
-            account.Reserved = 0;
-            Assert.AreEqual(account.Reserved, (uint)0);
-
-            account.Ledger = 104;
-            Assert.AreEqual(account.Ledger, (uint)104);
-
-            account.Code = 105;
-            Assert.AreEqual(account.Code, (ushort)105);
-
-            var flags = AccountFlags.Linked | AccountFlags.DebitsMustNotExceedCredits | AccountFlags.CreditsMustNotExceedDebits;
-            account.Flags = flags;
-            Assert.AreEqual(account.Flags, flags);
-
-            account.DebitsPending = 1001;
-            Assert.AreEqual(account.DebitsPending, (UInt128)1001);
-
-            account.CreditsPending = 1002;
-            Assert.AreEqual(account.CreditsPending, (UInt128)1002);
-
-            account.DebitsPosted = 1003;
-            Assert.AreEqual(account.DebitsPosted, (UInt128)1003);
-
-            account.CreditsPosted = 1004;
-            Assert.AreEqual(account.CreditsPosted, (UInt128)1004);
-
-            account.Timestamp = 99_999;
-            Assert.AreEqual(account.Timestamp, (ulong)99_999);
+            writer.Write(10L); // Id (lsb)
+            writer.Write(11L); // Id (msb)
+            writer.Write(100L); // DebitsPending (lsb)
+            writer.Write(110L); // DebitsPending (msb)
+            writer.Write(200L); // DebitsPosted (lsb)
+            writer.Write(210L); // DebitsPosted (msb)
+            writer.Write(300L); // CreditPending (lsb)
+            writer.Write(310L); // CreditPending (msb)
+            writer.Write(400L); // CreditsPosted (lsb)
+            writer.Write(410L); // CreditsPosted (msb)
+            writer.Write(1000L); // UserData128 (lsb)
+            writer.Write(1100L); // UserData128 (msb)
+            writer.Write(2000L); // UserData64
+            writer.Write(3000); // UserData32
+            writer.Write(0); // Reserved
+            writer.Write(720); // Ledger
+            writer.Write((short)1); // Code
+            writer.Write((short)1); // Flags
+            writer.Write(999L); // Timestamp
         }
 
-        [TestMethod]
-        public void AccountsDefault()
+        var account = new Account
         {
-            var account = new Account(); ;
-            Assert.AreEqual(account.Id, UInt128.Zero);
-            Assert.AreEqual(account.UserData128, UInt128.Zero);
-            Assert.AreEqual(account.UserData64, (ulong)0);
-            Assert.AreEqual(account.UserData32, (uint)0);
-            Assert.AreEqual(account.Reserved, (uint)0);
-            Assert.AreEqual(account.Ledger, (uint)0);
-            Assert.AreEqual(account.Code, (ushort)0);
-            Assert.AreEqual(account.Flags, AccountFlags.None);
-            Assert.AreEqual(account.DebitsPending, (UInt128)0);
-            Assert.AreEqual(account.CreditsPending, (UInt128)0);
-            Assert.AreEqual(account.DebitsPosted, (UInt128)0);
-            Assert.AreEqual(account.CreditsPosted, (UInt128)0);
-            Assert.AreEqual(account.Timestamp, (UInt128)0);
+            Id = new UInt128(11L, 10L),
+            DebitsPending = new UInt128(110L, 100L),
+            DebitsPosted = new UInt128(210L, 200L),
+            CreditsPending = new UInt128(310L, 300L),
+            CreditsPosted = new UInt128(410L, 400L),
+            UserData128 = new UInt128(1100L, 1000L),
+            UserData64 = 2000L,
+            UserData32 = 3000,
+            Ledger = 720,
+            Code = 1,
+            Flags = AccountFlags.Linked,
+            Timestamp = 999,
+        };
+
+        var serialized = MemoryMarshal.AsBytes<Account>(new Account[] { account }).ToArray();
+        Assert.IsTrue(expected.SequenceEqual(serialized));
+    }
+
+    [TestMethod]
+    public void CreateAccountsResults()
+    {
+        var result = new CreateAccountsResult();
+
+        result.Index = 1;
+        Assert.AreEqual(result.Index, (uint)1);
+
+        result.Result = CreateAccountResult.Exists;
+        Assert.AreEqual(result.Result, CreateAccountResult.Exists);
+    }
+
+    [TestMethod]
+    public void Transfers()
+    {
+        var transfer = new Transfer();
+
+        transfer.Id = 100;
+        Assert.AreEqual(transfer.Id, (UInt128)100);
+
+        transfer.DebitAccountId = 101;
+        Assert.AreEqual(transfer.DebitAccountId, (UInt128)101);
+
+        transfer.CreditAccountId = 102;
+        Assert.AreEqual(transfer.CreditAccountId, (UInt128)102);
+
+        transfer.Amount = 1001;
+        Assert.AreEqual(transfer.Amount, (UInt128)1001);
+
+        transfer.PendingId = 103;
+        Assert.AreEqual(transfer.PendingId, (UInt128)103);
+
+        transfer.UserData128 = 104;
+        Assert.AreEqual(transfer.UserData128, (UInt128)104);
+
+        transfer.UserData64 = 105;
+        Assert.AreEqual(transfer.UserData64, (ulong)105);
+
+        transfer.UserData32 = 106;
+        Assert.AreEqual(transfer.UserData32, (uint)106);
+
+        transfer.Timeout = 107;
+        Assert.AreEqual(transfer.Timeout, (uint)107);
+
+        transfer.Ledger = 108;
+        Assert.AreEqual(transfer.Ledger, (uint)108);
+
+        transfer.Code = 109;
+        Assert.AreEqual(transfer.Code, (ushort)109);
+
+        var flags = TransferFlags.Linked | TransferFlags.PostPendingTransfer | TransferFlags.VoidPendingTransfer;
+        transfer.Flags = flags;
+        Assert.AreEqual(transfer.Flags, flags);
+
+        transfer.Timestamp = 99_999;
+        Assert.AreEqual(transfer.Timestamp, (ulong)99_999);
+    }
+
+    [TestMethod]
+    public void TransferDefault()
+    {
+        var transfer = new Transfer();
+        Assert.AreEqual(transfer.Id, (UInt128)0);
+        Assert.AreEqual(transfer.DebitAccountId, (UInt128)0);
+        Assert.AreEqual(transfer.CreditAccountId, (UInt128)0);
+        Assert.AreEqual(transfer.Amount, (UInt128)0);
+        Assert.AreEqual(transfer.PendingId, (UInt128)0);
+        Assert.AreEqual(transfer.UserData128, (UInt128)0);
+        Assert.AreEqual(transfer.UserData64, (ulong)0);
+        Assert.AreEqual(transfer.UserData32, (uint)0);
+        Assert.AreEqual(transfer.Timeout, (uint)0);
+        Assert.AreEqual(transfer.Ledger, (uint)0);
+        Assert.AreEqual(transfer.Code, (ushort)0);
+        Assert.AreEqual(transfer.Flags, TransferFlags.None);
+        Assert.AreEqual(transfer.Timestamp, (ulong)0);
+    }
+
+    [TestMethod]
+    public void TransfersSerialize()
+    {
+        var expected = new byte[Transfer.SIZE];
+        using (var writer = new BinaryWriter(new MemoryStream(expected)))
+        {
+            writer.Write(10L); // Id (lsb)
+            writer.Write(11L); // Id (msb)
+            writer.Write(100L); // DebitAccountId (lsb)
+            writer.Write(110L); // DebitAccountId (msb)
+            writer.Write(200L); // CreditAccountId (lsb)
+            writer.Write(210L); // CreditAccountId (msb)
+            writer.Write(300L); // Amount (lsb)
+            writer.Write(310L); // Amount (msb)
+            writer.Write(400L); // PendingId (lsb)
+            writer.Write(410L); // PendingId (msb)
+            writer.Write(1000L); // UserData128 (lsb)
+            writer.Write(1100L); // UserData128 (msb)
+            writer.Write(2000L); // UserData64
+            writer.Write(3000); // UserData32
+            writer.Write(999); // Timeout
+            writer.Write(720); // Ledger
+            writer.Write((short)1); // Code
+            writer.Write((short)1); // Flags
+            writer.Write(99_999L); // Timestamp
         }
 
-        [TestMethod]
-        public void AccountsSerialize()
+        var transfer = new Transfer
         {
-            var expected = new byte[Account.SIZE];
-            using (var writer = new BinaryWriter(new MemoryStream(expected)))
-            {
-                writer.Write(10L); // Id (lsb)
-                writer.Write(11L); // Id (msb)
-                writer.Write(100L); // DebitsPending (lsb)
-                writer.Write(110L); // DebitsPending (msb)
-                writer.Write(200L); // DebitsPosted (lsb)
-                writer.Write(210L); // DebitsPosted (msb)
-                writer.Write(300L); // CreditPending (lsb)
-                writer.Write(310L); // CreditPending (msb)
-                writer.Write(400L); // CreditsPosted (lsb)
-                writer.Write(410L); // CreditsPosted (msb)
-                writer.Write(1000L); // UserData128 (lsb)
-                writer.Write(1100L); // UserData128 (msb)
-                writer.Write(2000L); // UserData64
-                writer.Write(3000); // UserData32
-                writer.Write(0); // Reserved
-                writer.Write(720); // Ledger
-                writer.Write((short)1); // Code
-                writer.Write((short)1); // Flags
-                writer.Write(999L); // Timestamp
-            }
+            Id = new UInt128(11L, 10L),
+            DebitAccountId = new UInt128(110L, 100L),
+            CreditAccountId = new UInt128(210L, 200L),
+            Amount = new UInt128(310L, 300L),
+            PendingId = new UInt128(410L, 400L),
+            UserData128 = new UInt128(1100L, 1000L),
+            UserData64 = 2000L,
+            UserData32 = 3000,
+            Timeout = 999,
+            Ledger = 720,
+            Code = 1,
+            Flags = TransferFlags.Linked,
+            Timestamp = 99_999,
+        };
 
-            var account = new Account
-            {
-                Id = new UInt128(11L, 10L),
-                DebitsPending = new UInt128(110L, 100L),
-                DebitsPosted = new UInt128(210L, 200L),
-                CreditsPending = new UInt128(310L, 300L),
-                CreditsPosted = new UInt128(410L, 400L),
-                UserData128 = new UInt128(1100L, 1000L),
-                UserData64 = 2000L,
-                UserData32 = 3000,
-                Ledger = 720,
-                Code = 1,
-                Flags = AccountFlags.Linked,
-                Timestamp = 999,
-            };
+        var serialized = MemoryMarshal.AsBytes<Transfer>(new Transfer[] { transfer }).ToArray();
+        Assert.IsTrue(expected.SequenceEqual(serialized));
+    }
 
-            var serialized = MemoryMarshal.AsBytes<Account>(new Account[] { account }).ToArray();
-            Assert.IsTrue(expected.SequenceEqual(serialized));
-        }
+    [TestMethod]
+    public void CreateTransfersResults()
+    {
+        var result = new CreateTransfersResult();
 
-        [TestMethod]
-        public void CreateAccountsResults()
-        {
-            var result = new CreateAccountsResult();
+        result.Index = 1;
+        Assert.AreEqual(result.Index, (uint)1);
 
-            result.Index = 1;
-            Assert.AreEqual(result.Index, (uint)1);
-
-            result.Result = CreateAccountResult.Exists;
-            Assert.AreEqual(result.Result, CreateAccountResult.Exists);
-        }
-
-        [TestMethod]
-        public void Transfers()
-        {
-            var transfer = new Transfer();
-
-            transfer.Id = 100;
-            Assert.AreEqual(transfer.Id, (UInt128)100);
-
-            transfer.DebitAccountId = 101;
-            Assert.AreEqual(transfer.DebitAccountId, (UInt128)101);
-
-            transfer.CreditAccountId = 102;
-            Assert.AreEqual(transfer.CreditAccountId, (UInt128)102);
-
-            transfer.Amount = 1001;
-            Assert.AreEqual(transfer.Amount, (UInt128)1001);
-
-            transfer.PendingId = 103;
-            Assert.AreEqual(transfer.PendingId, (UInt128)103);
-
-            transfer.UserData128 = 104;
-            Assert.AreEqual(transfer.UserData128, (UInt128)104);
-
-            transfer.UserData64 = 105;
-            Assert.AreEqual(transfer.UserData64, (ulong)105);
-
-            transfer.UserData32 = 106;
-            Assert.AreEqual(transfer.UserData32, (uint)106);
-
-            transfer.Timeout = 107;
-            Assert.AreEqual(transfer.Timeout, (uint)107);
-
-            transfer.Ledger = 108;
-            Assert.AreEqual(transfer.Ledger, (uint)108);
-
-            transfer.Code = 109;
-            Assert.AreEqual(transfer.Code, (ushort)109);
-
-            var flags = TransferFlags.Linked | TransferFlags.PostPendingTransfer | TransferFlags.VoidPendingTransfer;
-            transfer.Flags = flags;
-            Assert.AreEqual(transfer.Flags, flags);
-
-            transfer.Timestamp = 99_999;
-            Assert.AreEqual(transfer.Timestamp, (ulong)99_999);
-        }
-
-        [TestMethod]
-        public void TransferDefault()
-        {
-            var transfer = new Transfer();
-            Assert.AreEqual(transfer.Id, (UInt128)0);
-            Assert.AreEqual(transfer.DebitAccountId, (UInt128)0);
-            Assert.AreEqual(transfer.CreditAccountId, (UInt128)0);
-            Assert.AreEqual(transfer.Amount, (UInt128)0);
-            Assert.AreEqual(transfer.PendingId, (UInt128)0);
-            Assert.AreEqual(transfer.UserData128, (UInt128)0);
-            Assert.AreEqual(transfer.UserData64, (ulong)0);
-            Assert.AreEqual(transfer.UserData32, (uint)0);
-            Assert.AreEqual(transfer.Timeout, (uint)0);
-            Assert.AreEqual(transfer.Ledger, (uint)0);
-            Assert.AreEqual(transfer.Code, (ushort)0);
-            Assert.AreEqual(transfer.Flags, TransferFlags.None);
-            Assert.AreEqual(transfer.Timestamp, (ulong)0);
-        }
-
-        [TestMethod]
-        public void TransfersSerialize()
-        {
-            var expected = new byte[Transfer.SIZE];
-            using (var writer = new BinaryWriter(new MemoryStream(expected)))
-            {
-                writer.Write(10L); // Id (lsb)
-                writer.Write(11L); // Id (msb)
-                writer.Write(100L); // DebitAccountId (lsb)
-                writer.Write(110L); // DebitAccountId (msb)
-                writer.Write(200L); // CreditAccountId (lsb)
-                writer.Write(210L); // CreditAccountId (msb)
-                writer.Write(300L); // Amount (lsb)
-                writer.Write(310L); // Amount (msb)
-                writer.Write(400L); // PendingId (lsb)
-                writer.Write(410L); // PendingId (msb)
-                writer.Write(1000L); // UserData128 (lsb)
-                writer.Write(1100L); // UserData128 (msb)
-                writer.Write(2000L); // UserData64
-                writer.Write(3000); // UserData32
-                writer.Write(999); // Timeout
-                writer.Write(720); // Ledger
-                writer.Write((short)1); // Code
-                writer.Write((short)1); // Flags
-                writer.Write(99_999L); // Timestamp
-            }
-
-            var transfer = new Transfer
-            {
-                Id = new UInt128(11L, 10L),
-                DebitAccountId = new UInt128(110L, 100L),
-                CreditAccountId = new UInt128(210L, 200L),
-                Amount = new UInt128(310L, 300L),
-                PendingId = new UInt128(410L, 400L),
-                UserData128 = new UInt128(1100L, 1000L),
-                UserData64 = 2000L,
-                UserData32 = 3000,
-                Timeout = 999,
-                Ledger = 720,
-                Code = 1,
-                Flags = TransferFlags.Linked,
-                Timestamp = 99_999,
-            };
-
-            var serialized = MemoryMarshal.AsBytes<Transfer>(new Transfer[] { transfer }).ToArray();
-            Assert.IsTrue(expected.SequenceEqual(serialized));
-        }
-
-        [TestMethod]
-        public void CreateTransfersResults()
-        {
-            var result = new CreateTransfersResult();
-
-            result.Index = 1;
-            Assert.AreEqual(result.Index, (uint)1);
-
-            result.Result = CreateTransferResult.Exists;
-            Assert.AreEqual(result.Result, CreateTransferResult.Exists);
-        }
+        result.Result = CreateTransferResult.Exists;
+        Assert.AreEqual(result.Result, CreateTransferResult.Exists);
     }
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/EchoTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/EchoTests.cs
@@ -6,160 +6,159 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace TigerBeetle.Tests
+namespace TigerBeetle.Tests;
+
+[TestClass]
+public class EchoTests
 {
-    [TestClass]
-    public class EchoTests
+    private const int HEADER_SIZE = 256; // @sizeOf(vsr.Header)
+    private const int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
+    private static readonly int TRANSFER_SIZE = Marshal.SizeOf(typeof(Transfer));
+    private static readonly int ITEMS_PER_BATCH = (MESSAGE_SIZE_MAX - HEADER_SIZE) / TRANSFER_SIZE;
+
+    [TestMethod]
+    public void Accounts()
     {
-        private const int HEADER_SIZE = 256; // @sizeOf(vsr.Header)
-        private const int MESSAGE_SIZE_MAX = 1024 * 1024; // config.message_size_max
-        private static readonly int TRANSFER_SIZE = Marshal.SizeOf(typeof(Transfer));
-        private static readonly int ITEMS_PER_BATCH = (MESSAGE_SIZE_MAX - HEADER_SIZE) / TRANSFER_SIZE;
+        var rnd = new Random(1);
+        using var client = new EchoClient(0, new[] { "3000" }, 32);
 
-        [TestMethod]
-        public void Accounts()
+        var batch = GetRandom<Account>(rnd);
+        var reply = client.Echo(batch);
+        Assert.IsTrue(batch.SequenceEqual(reply));
+    }
+
+    [TestMethod]
+    public async Task AccountsAsync()
+    {
+        var rnd = new Random(2);
+        using var client = new EchoClient(0, new[] { "3000" }, 32);
+
+        var batch = GetRandom<Account>(rnd);
+        var reply = await client.EchoAsync(batch);
+        Assert.IsTrue(batch.SequenceEqual(reply));
+    }
+
+    [TestMethod]
+    public void Transfers()
+    {
+        var rnd = new Random(3);
+        using var client = new EchoClient(0, new[] { "3000" }, 32);
+
+        var batch = GetRandom<Transfer>(rnd);
+        var reply = client.Echo(batch);
+        Assert.IsTrue(batch.SequenceEqual(reply));
+    }
+
+    [TestMethod]
+    public async Task TransfersAsync()
+    {
+        var rnd = new Random(4);
+        using var client = new EchoClient(0, new[] { "3000" }, 32);
+
+        var batch = GetRandom<Transfer>(rnd);
+        var reply = await client.EchoAsync(batch);
+        Assert.IsTrue(batch.SequenceEqual(reply));
+    }
+
+    [TestMethod]
+    public async Task ConcurrentAccountsAsync()
+    {
+        const int MAX_CONCURRENCY = 64;
+        var rnd = new Random(5);
+        using var client = new EchoClient(0, new[] { "3000" }, MAX_CONCURRENCY);
+
+        const int MAX_REPETITIONS = 5;
+        for (int repetition = 0; repetition < MAX_REPETITIONS; repetition++)
         {
-            var rnd = new Random(1);
-            using var client = new EchoClient(0, new[] { "3000" }, 32);
+            var list = new List<(Account[] batch, Task<Account[]> task)>();
 
-            var batch = GetRandom<Account>(rnd);
-            var reply = client.Echo(batch);
-            Assert.IsTrue(batch.SequenceEqual(reply));
-        }
-
-        [TestMethod]
-        public async Task AccountsAsync()
-        {
-            var rnd = new Random(2);
-            using var client = new EchoClient(0, new[] { "3000" }, 32);
-
-            var batch = GetRandom<Account>(rnd);
-            var reply = await client.EchoAsync(batch);
-            Assert.IsTrue(batch.SequenceEqual(reply));
-        }
-
-        [TestMethod]
-        public void Transfers()
-        {
-            var rnd = new Random(3);
-            using var client = new EchoClient(0, new[] { "3000" }, 32);
-
-            var batch = GetRandom<Transfer>(rnd);
-            var reply = client.Echo(batch);
-            Assert.IsTrue(batch.SequenceEqual(reply));
-        }
-
-        [TestMethod]
-        public async Task TransfersAsync()
-        {
-            var rnd = new Random(4);
-            using var client = new EchoClient(0, new[] { "3000" }, 32);
-
-            var batch = GetRandom<Transfer>(rnd);
-            var reply = await client.EchoAsync(batch);
-            Assert.IsTrue(batch.SequenceEqual(reply));
-        }
-
-        [TestMethod]
-        public async Task ConcurrentAccountsAsync()
-        {
-            const int MAX_CONCURRENCY = 64;
-            var rnd = new Random(5);
-            using var client = new EchoClient(0, new[] { "3000" }, MAX_CONCURRENCY);
-
-            const int MAX_REPETITIONS = 5;
-            for (int repetition = 0; repetition < MAX_REPETITIONS; repetition++)
+            for (int i = 0; i < MAX_CONCURRENCY; i++)
             {
-                var list = new List<(Account[] batch, Task<Account[]> task)>();
+                var batch = GetRandom<Account>(rnd);
+                var task = client.EchoAsync(batch);
+                list.Add((batch, task));
+            }
 
-                for (int i = 0; i < MAX_CONCURRENCY; i++)
-                {
-                    var batch = GetRandom<Account>(rnd);
-                    var task = client.EchoAsync(batch);
-                    list.Add((batch, task));
-                }
+            foreach (var (batch, task) in list)
+            {
+                var reply = await task;
+                Assert.IsTrue(batch.SequenceEqual(reply));
+            }
+        }
+    }
 
-                foreach (var (batch, task) in list)
-                {
-                    var reply = await task;
-                    Assert.IsTrue(batch.SequenceEqual(reply));
-                }
+    [TestMethod]
+    public void ConcurrentTransfers()
+    {
+        const int MAX_CONCURRENCY = 64;
+        var rnd = new Random(6);
+        using var client = new EchoClient(0, new[] { "3000" }, MAX_CONCURRENCY);
+
+        const int MAX_REPETITIONS = 5;
+        for (int repetition = 0; repetition < MAX_REPETITIONS; repetition++)
+        {
+            var barrier = new Barrier(MAX_CONCURRENCY);
+            var list = new List<ThreadContext>();
+
+            for (int i = 0; i < MAX_CONCURRENCY; i++)
+            {
+                var batch = GetRandom<Transfer>(rnd);
+                var threadContext = new ThreadContext(client, barrier, batch);
+                list.Add(threadContext);
+            }
+
+            foreach (var item in list)
+            {
+                var reply = item.Wait();
+                Assert.IsTrue(item.Batch.SequenceEqual(reply));
+            }
+        }
+    }
+
+    private class ThreadContext
+    {
+        private readonly Thread thread;
+        private readonly Transfer[] batch;
+        private Transfer[]? reply = null;
+        private Exception? exception;
+
+        public Transfer[] Batch => batch;
+
+        public ThreadContext(EchoClient client, Barrier barrier, Transfer[] batch)
+        {
+            this.batch = batch;
+            this.thread = new Thread(new ParameterizedThreadStart(Run));
+            this.thread.Start((client, barrier));
+        }
+
+        private void Run(object? state)
+        {
+            try
+            {
+                var (client, barrier) = ((EchoClient, Barrier))state!;
+                barrier.SignalAndWait();
+                reply = client.Echo(batch);
+            }
+            catch (Exception exception)
+            {
+                this.exception = exception;
             }
         }
 
-        [TestMethod]
-        public void ConcurrentTransfers()
+        public Transfer[] Wait()
         {
-            const int MAX_CONCURRENCY = 64;
-            var rnd = new Random(6);
-            using var client = new EchoClient(0, new[] { "3000" }, MAX_CONCURRENCY);
-
-            const int MAX_REPETITIONS = 5;
-            for (int repetition = 0; repetition < MAX_REPETITIONS; repetition++)
-            {
-                var barrier = new Barrier(MAX_CONCURRENCY);
-                var list = new List<ThreadContext>();
-
-                for (int i = 0; i < MAX_CONCURRENCY; i++)
-                {
-                    var batch = GetRandom<Transfer>(rnd);
-                    var threadContext = new ThreadContext(client, barrier, batch);
-                    list.Add(threadContext);
-                }
-
-                foreach (var item in list)
-                {
-                    var reply = item.Wait();
-                    Assert.IsTrue(item.Batch.SequenceEqual(reply));
-                }
-            }
+            thread.Join();
+            return reply ?? throw exception!;
         }
+    }
 
-        private class ThreadContext
-        {
-            private readonly Thread thread;
-            private readonly Transfer[] batch;
-            private Transfer[]? reply = null;
-            private Exception? exception;
+    private static T[] GetRandom<T>(Random rnd)
+        where T : unmanaged
+    {
+        var size = rnd.Next(1, ITEMS_PER_BATCH);
 
-            public Transfer[] Batch => batch;
-
-            public ThreadContext(EchoClient client, Barrier barrier, Transfer[] batch)
-            {
-                this.batch = batch;
-                this.thread = new Thread(new ParameterizedThreadStart(Run));
-                this.thread.Start((client, barrier));
-            }
-
-            private void Run(object? state)
-            {
-                try
-                {
-                    var (client, barrier) = ((EchoClient, Barrier))state!;
-                    barrier.SignalAndWait();
-                    reply = client.Echo(batch);
-                }
-                catch (Exception exception)
-                {
-                    this.exception = exception;
-                }
-            }
-
-            public Transfer[] Wait()
-            {
-                thread.Join();
-                return reply ?? throw exception!;
-            }
-        }
-
-        private static T[] GetRandom<T>(Random rnd)
-            where T : unmanaged
-        {
-            var size = rnd.Next(1, ITEMS_PER_BATCH);
-
-            var buffer = new byte[size * Marshal.SizeOf(typeof(T))];
-            rnd.NextBytes(buffer);
-            return MemoryMarshal.Cast<byte, T>(buffer).ToArray();
-        }
+        var buffer = new byte[size * Marshal.SizeOf(typeof(T))];
+        rnd.NextBytes(buffer);
+        return MemoryMarshal.Cast<byte, T>(buffer).ToArray();
     }
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/ExceptionTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/ExceptionTests.cs
@@ -9,16 +9,17 @@ namespace TigerBeetle.Tests
         [TestMethod]
         public void AssertTrue()
         {
-            AssertionException.AssertTrue(1 == 1);
-            Assert.IsTrue(true);
+            // Should not throw an exception
+            // when the condition is true.
+            AssertionException.AssertTrue(true);
         }
 
         [TestMethod]
         [ExpectedException(typeof(AssertionException))]
         public void AssertFalse()
         {
-            AssertionException.AssertTrue(1 == 0);
-            Assert.IsTrue(true);
+            // Expected AssertionException.
+            AssertionException.AssertTrue(false);
         }
 
         [TestMethod]
@@ -26,7 +27,9 @@ namespace TigerBeetle.Tests
         {
             try
             {
-                AssertionException.AssertTrue(1 == 0, "hello {0}", "world");
+                AssertionException.AssertTrue(false, "hello {0}", "world");
+
+                // Should not be reachable:
                 Assert.IsTrue(false);
             }
             catch (AssertionException exception)
@@ -38,8 +41,7 @@ namespace TigerBeetle.Tests
         [TestMethod]
         public void AssertTrueWithMessage()
         {
-            AssertionException.AssertTrue(1 == 1, "unreachable");
-            Assert.IsTrue(true);
+            AssertionException.AssertTrue(true, "unreachable");
         }
 
         [TestMethod]

--- a/src/clients/dotnet/TigerBeetle.Tests/ExceptionTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/ExceptionTests.cs
@@ -1,82 +1,81 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace TigerBeetle.Tests
+namespace TigerBeetle.Tests;
+
+[TestClass]
+public class ExceptionTests
 {
-    [TestClass]
-    public class ExceptionTests
+    [TestMethod]
+    public void AssertTrue()
     {
-        [TestMethod]
-        public void AssertTrue()
-        {
-            // Should not throw an exception
-            // when the condition is true.
-            AssertionException.AssertTrue(true);
-        }
+        // Should not throw an exception
+        // when the condition is true.
+        AssertionException.AssertTrue(true);
+    }
 
-        [TestMethod]
-        [ExpectedException(typeof(AssertionException))]
-        public void AssertFalse()
-        {
-            // Expected AssertionException.
-            AssertionException.AssertTrue(false);
-        }
+    [TestMethod]
+    [ExpectedException(typeof(AssertionException))]
+    public void AssertFalse()
+    {
+        // Expected AssertionException.
+        AssertionException.AssertTrue(false);
+    }
 
-        [TestMethod]
-        public void AssertFalseWithMessage()
+    [TestMethod]
+    public void AssertFalseWithMessage()
+    {
+        try
         {
-            try
+            AssertionException.AssertTrue(false, "hello {0}", "world");
+
+            // Should not be reachable:
+            Assert.IsTrue(false);
+        }
+        catch (AssertionException exception)
+        {
+            Assert.AreEqual("hello world", exception.Message);
+        }
+    }
+
+    [TestMethod]
+    public void AssertTrueWithMessage()
+    {
+        AssertionException.AssertTrue(true, "unreachable");
+    }
+
+    [TestMethod]
+    public void InitializationException()
+    {
+        foreach (InitializationStatus status in (InitializationStatus[])Enum.GetValues(typeof(InitializationStatus)))
+        {
+            var exception = new InitializationException(status);
+            var unknownMessage = "Unknown error status " + status;
+            if (status == InitializationStatus.Success)
             {
-                AssertionException.AssertTrue(false, "hello {0}", "world");
-
-                // Should not be reachable:
-                Assert.IsTrue(false);
+                Assert.AreEqual(unknownMessage, exception.Message);
             }
-            catch (AssertionException exception)
+            else
             {
-                Assert.AreEqual("hello world", exception.Message);
-            }
-        }
-
-        [TestMethod]
-        public void AssertTrueWithMessage()
-        {
-            AssertionException.AssertTrue(true, "unreachable");
-        }
-
-        [TestMethod]
-        public void InitializationException()
-        {
-            foreach (InitializationStatus status in (InitializationStatus[])Enum.GetValues(typeof(InitializationStatus)))
-            {
-                var exception = new InitializationException(status);
-                var unknownMessage = "Unknown error status " + status;
-                if (status == InitializationStatus.Success)
-                {
-                    Assert.AreEqual(unknownMessage, exception.Message);
-                }
-                else
-                {
-                    Assert.AreNotEqual(unknownMessage, exception.Message);
-                }
+                Assert.AreNotEqual(unknownMessage, exception.Message);
             }
         }
+    }
 
-        [TestMethod]
-        public void RequestException()
+    [TestMethod]
+    public void RequestException()
+    {
+        foreach (PacketStatus status in (PacketStatus[])Enum.GetValues(typeof(PacketStatus)))
         {
-            foreach (PacketStatus status in (PacketStatus[])Enum.GetValues(typeof(PacketStatus)))
+            var exception = new RequestException(status);
+            var unknownMessage = "Unknown error status " + status;
+            if (status == PacketStatus.Ok)
             {
-                var exception = new RequestException(status);
-                var unknownMessage = "Unknown error status " + status;
-                if (status == PacketStatus.Ok)
-                {
-                    Assert.AreEqual(unknownMessage, exception.Message);
-                }
-                else
-                {
-                    Assert.AreNotEqual(unknownMessage, exception.Message);
-                }
+                Assert.AreEqual(unknownMessage, exception.Message);
+            }
+            else
+            {
+                Assert.AreNotEqual(unknownMessage, exception.Message);
             }
         }
     }

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -8,15 +8,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
 
-namespace TigerBeetle.Tests
-{
-    [TestClass]
-    public class IntegrationTests
-    {
-        private static Client GetClient(string address, int concurrencyMax = 32) => new(0, new string[] { address }, concurrencyMax);
+namespace TigerBeetle.Tests;
 
-        private static readonly Account[] accounts = new[]
-        {
+[TestClass]
+public class IntegrationTests
+{
+    private static Client GetClient(string address, int concurrencyMax = 32) => new(0, new string[] { address }, concurrencyMax);
+
+    private static readonly Account[] accounts = new[]
+    {
             new Account
             {
                 Id = 100,
@@ -39,1407 +39,1406 @@ namespace TigerBeetle.Tests
             }
         };
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void ConstructorWithNullReplicaAddresses()
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void ConstructorWithNullReplicaAddresses()
+    {
+        string[]? addresses = null;
+        _ = new Client(0, addresses!, 1);
+    }
+
+    [TestMethod]
+    public void ConstructorWithNullReplicaAddressElement()
+    {
+        try
         {
-            string[]? addresses = null;
+            var addresses = new string?[] { "3000", null };
             _ = new Client(0, addresses!, 1);
-        }
-
-        [TestMethod]
-        public void ConstructorWithNullReplicaAddressElement()
-        {
-            try
-            {
-                var addresses = new string?[] { "3000", null };
-                _ = new Client(0, addresses!, 1);
-                Assert.IsTrue(false);
-            }
-            catch (InitializationException exception)
-            {
-                Assert.AreEqual(InitializationStatus.AddressInvalid, exception.Status);
-            }
-        }
-
-        [TestMethod]
-        public void ConstructorWithEmptyReplicaAddresses()
-        {
-            try
-            {
-                _ = new Client(0, Array.Empty<string>(), 1);
-                Assert.IsTrue(false);
-            }
-            catch (InitializationException exception)
-            {
-                Assert.AreEqual(InitializationStatus.AddressInvalid, exception.Status);
-            }
-        }
-
-        [TestMethod]
-        public void ConstructorWithEmptyReplicaAddressElement()
-        {
-            try
-            {
-                _ = new Client(0, new string[] { "" }, 1);
-                Assert.IsTrue(false);
-            }
-            catch (InitializationException exception)
-            {
-                Assert.AreEqual(InitializationStatus.AddressInvalid, exception.Status);
-            }
-        }
-
-        [TestMethod]
-        public void ConstructorWithInvalidReplicaAddresses()
-        {
-            try
-            {
-                var addresses = Enumerable.Range(3000, 3100).Select(x => x.ToString()).ToArray();
-                _ = new Client(0, addresses, 1);
-                Assert.IsTrue(false);
-            }
-            catch (InitializationException exception)
-            {
-                Assert.AreEqual(InitializationStatus.AddressLimitExceeded, exception.Status);
-            }
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public void ConstructorWithZeroConcurrencyMax()
-        {
-            _ = new Client(0, new string[] { "3000" }, 0);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public void ConstructorWithNegativeConcurrencyMax()
-        {
-            _ = new Client(0, new string[] { "3000" }, -1);
-        }
-
-        [TestMethod]
-        public void ConstructorWithInvalidConcurrencyMax()
-        {
-            try
-            {
-                _ = new Client(0, new string[] { "3000" }, 99_999);
-                Assert.IsTrue(false);
-            }
-            catch (InitializationException exception)
-            {
-                Assert.AreEqual(InitializationStatus.ConcurrencyMaxInvalid, exception.Status);
-            }
-        }
-
-        [TestMethod]
-        public void ConstructorAndFinalizer()
-        {
-            // No using here, we want to test the finalizer
-            var client = new Client(1, new string[] { "3000" }, 32);
-            Assert.IsTrue(client.ClusterID == 1);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateAccount()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var okResult = client.CreateAccount(accounts[0]);
-            Assert.IsTrue(okResult == CreateAccountResult.Ok);
-
-            var lookupAccount = client.LookupAccount(accounts[0].Id);
-            Assert.IsNotNull(lookupAccount);
-            AssertAccount(accounts[0], lookupAccount!.Value);
-
-            var existsResult = client.CreateAccount(accounts[0]);
-            Assert.IsTrue(existsResult == CreateAccountResult.Exists);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateAccountAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var okResult = await client.CreateAccountAsync(accounts[0]);
-            Assert.IsTrue(okResult == CreateAccountResult.Ok);
-
-            var lookupAccount = await client.LookupAccountAsync(accounts[0].Id);
-            Assert.IsNotNull(lookupAccount);
-            AssertAccount(accounts[0], lookupAccount!.Value);
-
-            var existsResult = await client.CreateAccountAsync(accounts[0]);
-            Assert.IsTrue(existsResult == CreateAccountResult.Exists);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateAccounts()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = client.CreateAccounts(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateAccountsAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = await client.CreateAccountsAsync(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateTransfers()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var accountResults = client.CreateAccounts(accounts);
-            Assert.IsTrue(accountResults.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-            };
-
-            var transferResults = client.CreateTransfers(new Transfer[] { transfer });
-            Assert.IsTrue(transferResults.Length == 0);
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            var lookupTransfers = client.LookupTransfers(new UInt128[] { transfer.Id });
-            Assert.IsTrue(lookupTransfers.Length == 1);
-            AssertTransfer(transfer, lookupTransfers[0]);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateTransfersAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var accountResults = await client.CreateAccountsAsync(accounts);
-            Assert.IsTrue(accountResults.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-            };
-
-            var transferResults = await client.CreateTransfersAsync(new Transfer[] { transfer });
-            Assert.IsTrue(transferResults.Length == 0);
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            var lookupTransfers = await client.LookupTransfersAsync(new UInt128[] { transfer.Id });
-            Assert.IsTrue(lookupTransfers.Length == 1);
-            AssertTransfer(transfer, lookupTransfers[0]);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateTransfer()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = client.CreateAccounts(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-            };
-
-            var successResult = client.CreateTransfer(transfer);
-            Assert.IsTrue(successResult == CreateTransferResult.Ok);
-
-            var lookupTransfer = client.LookupTransfer(transfer.Id);
-            Assert.IsTrue(lookupTransfer != null);
-            AssertTransfer(transfer, lookupTransfer!.Value);
-
-            var existsResult = client.CreateTransfer(transfer);
-            Assert.IsTrue(existsResult == CreateTransferResult.Exists);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateTransferAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = await client.CreateAccountsAsync(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-            };
-
-            var successResult = await client.CreateTransferAsync(transfer);
-            Assert.IsTrue(successResult == CreateTransferResult.Ok);
-
-            var lookupTransfer = await client.LookupTransferAsync(transfer.Id);
-            Assert.IsTrue(lookupTransfer != null);
-            AssertTransfer(transfer, lookupTransfer!.Value);
-
-            var existsResult = await client.CreateTransferAsync(transfer);
-            Assert.IsTrue(existsResult == CreateTransferResult.Exists);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreatePendingTransfers()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = client.CreateAccounts(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Timeout = uint.MaxValue,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.Pending,
-            };
-
-            var result = client.CreateTransfer(transfer);
-            Assert.IsTrue(result == CreateTransferResult.Ok);
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
-
-            var postTransfer = new Transfer
-            {
-                Id = 2,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                PendingId = transfer.Id,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.PostPendingTransfer,
-            };
-
-            var postResult = client.CreateTransfer(postTransfer);
-            Assert.IsTrue(postResult == CreateTransferResult.Ok);
-
-            lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreatePendingTransfersAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = await client.CreateAccountsAsync(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Timeout = uint.MaxValue,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.Pending,
-            };
-
-            var result = await client.CreateTransferAsync(transfer);
-            Assert.IsTrue(result == CreateTransferResult.Ok);
-
-            var lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
-
-            var postTransfer = new Transfer
-            {
-                Id = 2,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                PendingId = transfer.Id,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.PostPendingTransfer,
-            };
-
-            var postResult = await client.CreateTransferAsync(postTransfer);
-            Assert.IsTrue(postResult == CreateTransferResult.Ok);
-
-            lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreatePendingTransfersAndVoid()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = client.CreateAccounts(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Timeout = uint.MaxValue,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.Pending,
-            };
-
-            var result = client.CreateTransfer(transfer);
-            Assert.IsTrue(result == CreateTransferResult.Ok);
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
-
-            var postTransfer = new Transfer
-            {
-                Id = 2,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.VoidPendingTransfer,
-                PendingId = transfer.Id,
-            };
-
-            var postResult = client.CreateTransfer(postTransfer);
-            Assert.IsTrue(postResult == CreateTransferResult.Ok);
-
-            lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreatePendingTransfersAndVoidAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = await client.CreateAccountsAsync(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Timeout = uint.MaxValue,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.Pending,
-            };
-
-            var result = await client.CreateTransferAsync(transfer);
-            Assert.IsTrue(result == CreateTransferResult.Ok);
-
-            var lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
-
-            var postTransfer = new Transfer
-            {
-                Id = 2,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                PendingId = transfer.Id,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.VoidPendingTransfer,
-            };
-
-            var postResult = await client.CreateTransferAsync(postTransfer);
-            Assert.IsTrue(postResult == CreateTransferResult.Ok);
-
-            lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateLinkedTransfers()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = client.CreateAccounts(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer1 = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.Linked,
-            };
-
-            var transfer2 = new Transfer
-            {
-                Id = 2,
-                CreditAccountId = accounts[1].Id,
-                DebitAccountId = accounts[0].Id,
-                Amount = 49,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.None,
-            };
-
-            var transferResults = client.CreateTransfers(new[] { transfer1, transfer2 });
-            Assert.IsTrue(transferResults.All(x => x.Result == CreateTransferResult.Ok));
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            var lookupTransfers = client.LookupTransfers(new UInt128[] { transfer1.Id, transfer2.Id });
-            Assert.IsTrue(lookupTransfers.Length == 2);
-            AssertTransfer(transfer1, lookupTransfers[0]);
-            AssertTransfer(transfer2, lookupTransfers[1]);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer1.Amount);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, transfer2.Amount);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, transfer2.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer1.Amount);
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateLinkedTransfersAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var results = await client.CreateAccountsAsync(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var transfer1 = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.Linked,
-            };
-
-            var transfer2 = new Transfer
-            {
-                Id = 2,
-                CreditAccountId = accounts[1].Id,
-                DebitAccountId = accounts[0].Id,
-                Amount = 49,
-                Ledger = 1,
-                Code = 1,
-                Flags = TransferFlags.None,
-            };
-
-            var transferResults = await client.CreateTransfersAsync(new[] { transfer1, transfer2 });
-            Assert.IsTrue(transferResults.All(x => x.Result == CreateTransferResult.Ok));
-
-            var lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            var lookupTransfers = await client.LookupTransfersAsync(new UInt128[] { transfer1.Id, transfer2.Id });
-            Assert.IsTrue(lookupTransfers.Length == 2);
-            AssertTransfer(transfer1, lookupTransfers[0]);
-            AssertTransfer(transfer2, lookupTransfers[1]);
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer1.Amount);
-            Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, transfer2.Amount);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, transfer2.Amount);
-            Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer1.Amount);
-        }
-
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateAccountTooMuchData()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            const int TOO_MUCH_DATA = 10000;
-            var accounts = new Account[TOO_MUCH_DATA];
-            for (int i = 0; i < TOO_MUCH_DATA; i++)
-            {
-                accounts[i] = new Account
-                {
-                    Id = Guid.NewGuid().ToUInt128(),
-                    Code = 1,
-                    Ledger = 1
-                };
-            }
-
-            try
-            {
-                _ = client.CreateAccounts(accounts);
-                Assert.IsTrue(false);
-            }
-            catch (RequestException requestException)
-            {
-                Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
-            }
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateAccountTooMuchDataAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            const int TOO_MUCH_DATA = 10000;
-            var accounts = new Account[TOO_MUCH_DATA];
-            for (int i = 0; i < TOO_MUCH_DATA; i++)
-            {
-                accounts[i] = new Account
-                {
-                    Id = Guid.NewGuid().ToUInt128(),
-                    Code = 1,
-                    Ledger = 1
-                };
-            }
-
-            try
-            {
-                _ = await client.CreateAccountsAsync(accounts);
-                Assert.IsTrue(false);
-            }
-            catch (RequestException requestException)
-            {
-                Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
-            }
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void CreateTransferTooMuchData()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            const int TOO_MUCH_DATA = 10000;
-            var transfers = new Transfer[TOO_MUCH_DATA];
-            for (int i = 0; i < TOO_MUCH_DATA; i++)
-            {
-                transfers[i] = new Transfer
-                {
-                    Id = Guid.NewGuid().ToUInt128(),
-                    Code = 1,
-                    Ledger = 1
-                };
-            }
-
-            try
-            {
-                _ = client.CreateTransfers(transfers);
-                Assert.IsTrue(false);
-            }
-            catch (RequestException requestException)
-            {
-                Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
-            }
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task CreateTransferTooMuchDataAsync()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            const int TOO_MUCH_DATA = 10000;
-            var transfers = new Transfer[TOO_MUCH_DATA];
-            for (int i = 0; i < TOO_MUCH_DATA; i++)
-            {
-                transfers[i] = new Transfer
-                {
-                    Id = Guid.NewGuid().ToUInt128(),
-                    DebitAccountId = accounts[0].Id,
-                    CreditAccountId = accounts[1].Id,
-                    Code = 1,
-                    Ledger = 1,
-                    Amount = 100,
-                };
-            }
-
-            try
-            {
-                _ = await client.CreateTransfersAsync(transfers);
-                Assert.IsTrue(false);
-            }
-            catch (RequestException requestException)
-            {
-                Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
-            }
-        }
-
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void TestGetAccountTransfers()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            // Creating the accounts.
-            var createAccountErrors = client.CreateAccounts(accounts);
-            Assert.IsTrue(createAccountErrors.Length == 0);
-
-            // Creating a transfer.
-            var transfers = new Transfer[10];
-            for (int i = 0; i < 10; i++)
-            {
-                transfers[i] = new Transfer
-                {
-                    Id = (UInt128)(i + 1),
-
-                    // Swap the debit and credit accounts:
-                    CreditAccountId = accounts[i % 2 == 0 ? 0 : 1].Id,
-                    DebitAccountId = accounts[i % 2 == 0 ? 1 : 0].Id,
-
-                    Ledger = 1,
-                    Code = 2,
-                    Flags = TransferFlags.None,
-                    Amount = 100
-                };
-            }
-
-            var createTransferErrors = client.CreateTransfers(transfers);
-            Assert.IsTrue(createTransferErrors.Length == 0);
-
-            {
-                // Querying transfers where:
-                // `debit_account_id=$account1Id OR credit_account_id=$account1Id
-                // ORDER BY timestamp ASC`.
-                var filter = new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits
-                };
-                var account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 10);
-                ulong timestamp = 0;
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp > timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-            }
-
-            {
-                // Querying transfers where:
-                // `debit_account_id=$account2Id OR credit_account_id=$account2Id
-                // ORDER BY timestamp DESC`.
-                var filter = new GetAccountTransfers
-                {
-                    AccountId = accounts[1].Id,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits | GetAccountTransfersFlags.Reversed
-                };
-                var account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 10);
-                ulong timestamp = ulong.MaxValue;
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp < timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-            }
-
-            {
-                // Querying transfers where:
-                // `debit_account_id=$account1Id
-                // ORDER BY timestamp ASC`.                
-                var filter = new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = GetAccountTransfersFlags.Debits
-                };
-                var account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 5);
-                ulong timestamp = 0;
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp > timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-            }
-
-            {
-                // Querying transfers where:
-                // `credit_account_id=$account2Id
-                // ORDER BY timestamp DESC`.            
-                var filter = new GetAccountTransfers
-                {
-                    AccountId = accounts[1].Id,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Reversed
-                };
-                var account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 5);
-                ulong timestamp = ulong.MaxValue;
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp < timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-            }
-
-            {
-                // Querying transfers where:
-                // `debit_account_id=$account1Id OR credit_account_id=$account1Id
-                // ORDER BY timestamp ASC LIMIT 5`.       
-                var filter = new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = 0,
-                    Limit = 5,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits
-                };
-
-                // First 5 items:            
-                var account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 5);
-                ulong timestamp = 0;
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp > timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-
-                // Next 5 items from this timestamp:
-                filter.Timestamp = timestamp;
-                account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 5);
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp > timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-
-                // No more pages after that:
-                filter.Timestamp = timestamp;
-                account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 0);
-            }
-
-            {
-                // Querying transfers where:
-                // `debit_account_id=$account2Id OR credit_account_id=$account2Id
-                // ORDER BY timestamp DESC LIMIT 5`.       
-                var filter = new GetAccountTransfers
-                {
-                    AccountId = accounts[1].Id,
-                    Timestamp = 0,
-                    Limit = 5,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits | GetAccountTransfersFlags.Reversed
-                };
-
-                // First 5 items:                
-                var account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 5);
-                ulong timestamp = ulong.MaxValue;
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp < timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-
-                // Next 5 items from this timestamp:
-                filter.Timestamp = timestamp;
-                account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 5);
-                foreach (var transfer in account_transfers)
-                {
-                    Assert.IsTrue(transfer.Timestamp < timestamp);
-                    timestamp = transfer.Timestamp;
-                }
-
-                // No more pages after that:
-                filter.Timestamp = timestamp;
-                account_transfers = client.GetAccountTransfers(filter);
-                Assert.IsTrue(account_transfers.Length == 0);
-            }
-
-            {
-                // Empty filter:
-                Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers { }).Length == 0);
-
-                // Invalid account
-                Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
-                {
-                    AccountId = 0,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits,
-                }).Length == 0);
-
-                // Invalid timestamp
-                Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = ulong.MaxValue,
-                    Limit = 8190,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits,
-                }).Length == 0);
-
-                // Zero limit
-                Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = 0,
-                    Limit = 0,
-                    Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits,
-                }).Length == 0);
-
-                // Empty flags
-                Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = (GetAccountTransfersFlags)0,
-                }).Length == 0);
-
-                // Invalid flags
-                Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
-                {
-                    AccountId = accounts[0].Id,
-                    Timestamp = 0,
-                    Limit = 8190,
-                    Flags = (GetAccountTransfersFlags)0xFFFF,
-                }).Length == 0);
-            }
-        }
-
-        /// <summary>
-        /// This test asserts that a single Client can be shared by multiple concurrent tasks
-        /// </summary>
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void ConcurrencyTest() => ConcurrencyTest(isAsync: false);
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void ConcurrencyTestAsync() => ConcurrencyTest(isAsync: true);
-
-        private void ConcurrencyTest(bool isAsync)
-        {
-            const int TASKS_QTY = 32;
-            int MAX_CONCURRENCY = 32;
-
-            using var server = new TBServer();
-            using var client = GetClient(server.Address, MAX_CONCURRENCY);
-
-            var errors = client.CreateAccounts(accounts);
-            Assert.IsTrue(errors.Length == 0);
-
-            var list = new List<Task<CreateTransferResult>>();
-
-            for (int i = 0; i < TASKS_QTY; i++)
-            {
-                var transfer = new Transfer
-                {
-                    Id = (UInt128)(i + 1),
-                    CreditAccountId = accounts[0].Id,
-                    DebitAccountId = accounts[1].Id,
-                    Amount = 100,
-                    Ledger = 1,
-                    Code = 1,
-                };
-
-                /// Starts multiple tasks.
-                var task = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
-                list.Add(task);
-            }
-
-            Task.WhenAll(list).Wait();
-
-            Assert.IsTrue(list.All(x => x.Result == CreateTransferResult.Ok));
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            // Assert that all tasks ran to the conclusion
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (ulong)(100 * TASKS_QTY));
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, 0LU);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, 0LU);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (ulong)(100 * TASKS_QTY));
-        }
-
-        /// <summary>
-        /// This test asserts that a single Client can be shared by multiple concurrent tasks
-        /// Even if a limited "concurrencyMax" value results in "ConcurrencyExceededException"
-        /// </summary>
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void ConcurrencyExceededTest() => ConcurrencyExceededTest(isAsync: false);
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void ConcurrencyExceededTestAsync() => ConcurrencyExceededTest(isAsync: true);
-
-        private void ConcurrencyExceededTest(bool isAsync)
-        {
-            const int TASKS_QTY = 32;
-            int MAX_CONCURRENCY = 2;
-
-            using var server = new TBServer();
-            using var client = GetClient(server.Address, MAX_CONCURRENCY);
-
-            var errors = client.CreateAccounts(accounts);
-            Assert.IsTrue(errors.Length == 0);
-
-            var list = new List<Task<CreateTransferResult>>();
-
-            for (int i = 0; i < TASKS_QTY; i++)
-            {
-                var transfer = new Transfer
-                {
-                    Id = (UInt128)(i + 1),
-                    CreditAccountId = accounts[0].Id,
-                    DebitAccountId = accounts[1].Id,
-                    Ledger = 1,
-                    Code = 1,
-                    Amount = 100,
-                };
-
-                /// Starts multiple tasks using a client with a limited concurrencyMax:
-                var task = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
-                list.Add(task);
-            }
-
-            try
-            {
-                // Ignoring exceptions from the tasks.
-                Task.WhenAll(list).Wait();
-            }
-            catch { }
-
-            // It's expected for some tasks to failt with ConcurrencyExceededException or ObjectDisposedException:
-            var successCount = list.Count(x => !x.IsFaulted && x.Result == CreateTransferResult.Ok);
-            var failedCount = list.Count(x => x.IsFaulted &&
-                (AssertException<ConcurrencyExceededException>(x.Exception!) ||
-                AssertException<ObjectDisposedException>(x.Exception!)));
-            Assert.IsTrue(successCount > 0);
-            Assert.IsTrue(successCount + failedCount == TASKS_QTY);
-
-            // Asserting that either the task failed or succeeded.
-            Assert.IsTrue(list.All(x => x.IsFaulted || x.Result == CreateTransferResult.Ok));
-
-            var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
-            AssertAccounts(lookupAccounts);
-
-            // Assert that all tasks ran to the conclusion
-
-            Assert.AreEqual(lookupAccounts[0].CreditsPosted, (ulong)(100 * successCount));
-            Assert.AreEqual(lookupAccounts[0].DebitsPosted, 0LU);
-
-            Assert.AreEqual(lookupAccounts[1].CreditsPosted, 0LU);
-            Assert.AreEqual(lookupAccounts[1].DebitsPosted, (ulong)(100 * successCount));
-        }
-
-        /// <summary>
-        /// This test asserts that Client.Dispose() will wait for any ongoing request to complete
-        /// And new requests will fail with ObjectDisposedException.
-        /// </summary>
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void ConcurrentTasksDispose() => ConcurrentTasksDispose(isAsync: false);
-
-        [TestMethod]
-        [DoNotParallelize]
-        public void ConcurrentTasksDisposeAsync() => ConcurrentTasksDispose(isAsync: true);
-
-        private void ConcurrentTasksDispose(bool isAsync)
-        {
-            const int TASKS_QTY = 32;
-            int MAX_CONCURRENCY = 32;
-
-            using var server = new TBServer();
-            using var client = GetClient(server.Address, MAX_CONCURRENCY);
-
-            var results = client.CreateAccounts(accounts);
-            Assert.IsTrue(results.Length == 0);
-
-            var list = new List<Task<CreateTransferResult>>();
-
-            for (int i = 0; i < TASKS_QTY; i++)
-            {
-                var transfer = new Transfer
-                {
-                    Id = (UInt128)(i + 1),
-                    CreditAccountId = accounts[0].Id,
-                    DebitAccountId = accounts[1].Id,
-                    Amount = 100,
-                    Ledger = 1,
-                    Code = 1,
-                };
-
-                /// Starts multiple tasks.
-                var task = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
-                list.Add(task);
-            }
-
-            // Waiting for just one task, the others may be pending.
-            list.First().Wait();
-
-            // Disposes the client, waiting all placed requests to finish.
-            client.Dispose();
-
-            try
-            {
-                // Ignoring exceptions from the tasks.
-                Task.WhenAll(list).Wait();
-            }
-            catch { }
-
-            // Asserting that either the task failed or succeeded,
-            // at least one must be succeeded.
-            Assert.IsTrue(list.Any(x => !x.IsFaulted && x.Result == CreateTransferResult.Ok));
-            Assert.IsTrue(list.All(x => x.IsFaulted || x.Result == CreateTransferResult.Ok));
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ObjectDisposedException))]
-        [DoNotParallelize]
-        public void DisposedClient()
-        {
-            using var server = new TBServer();
-            using var client = GetClient(server.Address);
-
-            var accountResults = client.CreateAccounts(accounts);
-            Assert.IsTrue(accountResults.Length == 0);
-
-            client.Dispose();
-
-            var transfer = new Transfer
-            {
-                Id = 1,
-                CreditAccountId = accounts[0].Id,
-                DebitAccountId = accounts[1].Id,
-                Amount = 100,
-                Ledger = 1,
-                Code = 1,
-            };
-
-            _ = client.CreateTransfers(new Transfer[] { transfer });
             Assert.IsTrue(false);
         }
-
-
-        private static void AssertAccounts(Account[] lookupAccounts)
+        catch (InitializationException exception)
         {
-            Assert.IsTrue(lookupAccounts.Length == accounts.Length);
-            for (int i = 0; i < accounts.Length; i++)
-            {
-                AssertAccount(accounts[i], lookupAccounts[i]);
-            }
-        }
-
-        private static void AssertAccount(Account a, Account b)
-        {
-            Assert.AreEqual(a.Id, b.Id);
-            Assert.AreEqual(a.UserData128, b.UserData128);
-            Assert.AreEqual(a.UserData64, b.UserData64);
-            Assert.AreEqual(a.UserData32, b.UserData32);
-            Assert.AreEqual(a.Flags, b.Flags);
-            Assert.AreEqual(a.Code, b.Code);
-            Assert.AreEqual(a.Ledger, b.Ledger);
-        }
-
-        private static void AssertTransfer(Transfer a, Transfer b)
-        {
-            Assert.AreEqual(a.Id, b.Id);
-            Assert.AreEqual(a.DebitAccountId, b.DebitAccountId);
-            Assert.AreEqual(a.CreditAccountId, b.CreditAccountId);
-            Assert.AreEqual(a.Amount, b.Amount);
-            Assert.AreEqual(a.PendingId, b.PendingId);
-            Assert.AreEqual(a.UserData128, b.UserData128);
-            Assert.AreEqual(a.UserData64, b.UserData64);
-            Assert.AreEqual(a.UserData32, b.UserData32);
-            Assert.AreEqual(a.Timeout, b.Timeout);
-            Assert.AreEqual(a.Flags, b.Flags);
-            Assert.AreEqual(a.Code, b.Code);
-            Assert.AreEqual(a.Ledger, b.Ledger);
-        }
-
-        private static bool AssertException<T>(Exception exception) where T : Exception
-        {
-            while (exception is AggregateException aggregateException && aggregateException.InnerException != null)
-            {
-                exception = aggregateException.InnerException;
-            }
-
-            return exception is T;
+            Assert.AreEqual(InitializationStatus.AddressInvalid, exception.Status);
         }
     }
 
-    internal class TBServer : IDisposable
+    [TestMethod]
+    public void ConstructorWithEmptyReplicaAddresses()
     {
-        // Path relative from /TigerBeetle.Test/bin/<framework>/<release>/<platform> :
-        private const string PROJECT_ROOT = "../../../../..";
-        private const string TB_PATH = PROJECT_ROOT + "/../../../zig-out/bin";
-        private const string TB_EXE = "tigerbeetle";
-        private const string TB_FILE = "dotnet-tests.tigerbeetle";
-        private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
-        private const string FORMAT = $"format --cluster=0 --replica=0 --replica-count=1 ./" + TB_FILE;
-        private const string START = $"start --addresses=0  --cache-grid=512MB ./" + TB_FILE;
-
-        private readonly Process process;
-
-        public string Address { get; }
-
-        public TBServer()
+        try
         {
-            CleanUp();
+            _ = new Client(0, Array.Empty<string>(), 1);
+            Assert.IsTrue(false);
+        }
+        catch (InitializationException exception)
+        {
+            Assert.AreEqual(InitializationStatus.AddressInvalid, exception.Status);
+        }
+    }
 
+    [TestMethod]
+    public void ConstructorWithEmptyReplicaAddressElement()
+    {
+        try
+        {
+            _ = new Client(0, new string[] { "" }, 1);
+            Assert.IsTrue(false);
+        }
+        catch (InitializationException exception)
+        {
+            Assert.AreEqual(InitializationStatus.AddressInvalid, exception.Status);
+        }
+    }
+
+    [TestMethod]
+    public void ConstructorWithInvalidReplicaAddresses()
+    {
+        try
+        {
+            var addresses = Enumerable.Range(3000, 3100).Select(x => x.ToString()).ToArray();
+            _ = new Client(0, addresses, 1);
+            Assert.IsTrue(false);
+        }
+        catch (InitializationException exception)
+        {
+            Assert.AreEqual(InitializationStatus.AddressLimitExceeded, exception.Status);
+        }
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    public void ConstructorWithZeroConcurrencyMax()
+    {
+        _ = new Client(0, new string[] { "3000" }, 0);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    public void ConstructorWithNegativeConcurrencyMax()
+    {
+        _ = new Client(0, new string[] { "3000" }, -1);
+    }
+
+    [TestMethod]
+    public void ConstructorWithInvalidConcurrencyMax()
+    {
+        try
+        {
+            _ = new Client(0, new string[] { "3000" }, 99_999);
+            Assert.IsTrue(false);
+        }
+        catch (InitializationException exception)
+        {
+            Assert.AreEqual(InitializationStatus.ConcurrencyMaxInvalid, exception.Status);
+        }
+    }
+
+    [TestMethod]
+    public void ConstructorAndFinalizer()
+    {
+        // No using here, we want to test the finalizer
+        var client = new Client(1, new string[] { "3000" }, 32);
+        Assert.IsTrue(client.ClusterID == 1);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateAccount()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var okResult = client.CreateAccount(accounts[0]);
+        Assert.IsTrue(okResult == CreateAccountResult.Ok);
+
+        var lookupAccount = client.LookupAccount(accounts[0].Id);
+        Assert.IsNotNull(lookupAccount);
+        AssertAccount(accounts[0], lookupAccount!.Value);
+
+        var existsResult = client.CreateAccount(accounts[0]);
+        Assert.IsTrue(existsResult == CreateAccountResult.Exists);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateAccountAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var okResult = await client.CreateAccountAsync(accounts[0]);
+        Assert.IsTrue(okResult == CreateAccountResult.Ok);
+
+        var lookupAccount = await client.LookupAccountAsync(accounts[0].Id);
+        Assert.IsNotNull(lookupAccount);
+        AssertAccount(accounts[0], lookupAccount!.Value);
+
+        var existsResult = await client.CreateAccountAsync(accounts[0]);
+        Assert.IsTrue(existsResult == CreateAccountResult.Exists);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateAccounts()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateAccountsAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateTransfers()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var accountResults = client.CreateAccounts(accounts);
+        Assert.IsTrue(accountResults.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+        };
+
+        var transferResults = client.CreateTransfers(new Transfer[] { transfer });
+        Assert.IsTrue(transferResults.Length == 0);
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        var lookupTransfers = client.LookupTransfers(new UInt128[] { transfer.Id });
+        Assert.IsTrue(lookupTransfers.Length == 1);
+        AssertTransfer(transfer, lookupTransfers[0]);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateTransfersAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var accountResults = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(accountResults.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+        };
+
+        var transferResults = await client.CreateTransfersAsync(new Transfer[] { transfer });
+        Assert.IsTrue(transferResults.Length == 0);
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        var lookupTransfers = await client.LookupTransfersAsync(new UInt128[] { transfer.Id });
+        Assert.IsTrue(lookupTransfers.Length == 1);
+        AssertTransfer(transfer, lookupTransfers[0]);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateTransfer()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+        };
+
+        var successResult = client.CreateTransfer(transfer);
+        Assert.IsTrue(successResult == CreateTransferResult.Ok);
+
+        var lookupTransfer = client.LookupTransfer(transfer.Id);
+        Assert.IsTrue(lookupTransfer != null);
+        AssertTransfer(transfer, lookupTransfer!.Value);
+
+        var existsResult = client.CreateTransfer(transfer);
+        Assert.IsTrue(existsResult == CreateTransferResult.Exists);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateTransferAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+        };
+
+        var successResult = await client.CreateTransferAsync(transfer);
+        Assert.IsTrue(successResult == CreateTransferResult.Ok);
+
+        var lookupTransfer = await client.LookupTransferAsync(transfer.Id);
+        Assert.IsTrue(lookupTransfer != null);
+        AssertTransfer(transfer, lookupTransfer!.Value);
+
+        var existsResult = await client.CreateTransferAsync(transfer);
+        Assert.IsTrue(existsResult == CreateTransferResult.Exists);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreatePendingTransfers()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Timeout = uint.MaxValue,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.Pending,
+        };
+
+        var result = client.CreateTransfer(transfer);
+        Assert.IsTrue(result == CreateTransferResult.Ok);
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
+
+        var postTransfer = new Transfer
+        {
+            Id = 2,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            PendingId = transfer.Id,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.PostPendingTransfer,
+        };
+
+        var postResult = client.CreateTransfer(postTransfer);
+        Assert.IsTrue(postResult == CreateTransferResult.Ok);
+
+        lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreatePendingTransfersAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Timeout = uint.MaxValue,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.Pending,
+        };
+
+        var result = await client.CreateTransferAsync(transfer);
+        Assert.IsTrue(result == CreateTransferResult.Ok);
+
+        var lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
+
+        var postTransfer = new Transfer
+        {
+            Id = 2,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            PendingId = transfer.Id,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.PostPendingTransfer,
+        };
+
+        var postResult = await client.CreateTransferAsync(postTransfer);
+        Assert.IsTrue(postResult == CreateTransferResult.Ok);
+
+        lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreatePendingTransfersAndVoid()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Timeout = uint.MaxValue,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.Pending,
+        };
+
+        var result = client.CreateTransfer(transfer);
+        Assert.IsTrue(result == CreateTransferResult.Ok);
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
+
+        var postTransfer = new Transfer
+        {
+            Id = 2,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.VoidPendingTransfer,
+            PendingId = transfer.Id,
+        };
+
+        var postResult = client.CreateTransfer(postTransfer);
+        Assert.IsTrue(postResult == CreateTransferResult.Ok);
+
+        lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreatePendingTransfersAndVoidAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Timeout = uint.MaxValue,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.Pending,
+        };
+
+        var result = await client.CreateTransferAsync(transfer);
+        Assert.IsTrue(result == CreateTransferResult.Ok);
+
+        var lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, transfer.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
+
+        var postTransfer = new Transfer
+        {
+            Id = 2,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            PendingId = transfer.Id,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.VoidPendingTransfer,
+        };
+
+        var postResult = await client.CreateTransferAsync(postTransfer);
+        Assert.IsTrue(postResult == CreateTransferResult.Ok);
+
+        lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateLinkedTransfers()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer1 = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.Linked,
+        };
+
+        var transfer2 = new Transfer
+        {
+            Id = 2,
+            CreditAccountId = accounts[1].Id,
+            DebitAccountId = accounts[0].Id,
+            Amount = 49,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.None,
+        };
+
+        var transferResults = client.CreateTransfers(new[] { transfer1, transfer2 });
+        Assert.IsTrue(transferResults.All(x => x.Result == CreateTransferResult.Ok));
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        var lookupTransfers = client.LookupTransfers(new UInt128[] { transfer1.Id, transfer2.Id });
+        Assert.IsTrue(lookupTransfers.Length == 2);
+        AssertTransfer(transfer1, lookupTransfers[0]);
+        AssertTransfer(transfer2, lookupTransfers[1]);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer1.Amount);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, transfer2.Amount);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, transfer2.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer1.Amount);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateLinkedTransfersAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var results = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var transfer1 = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.Linked,
+        };
+
+        var transfer2 = new Transfer
+        {
+            Id = 2,
+            CreditAccountId = accounts[1].Id,
+            DebitAccountId = accounts[0].Id,
+            Amount = 49,
+            Ledger = 1,
+            Code = 1,
+            Flags = TransferFlags.None,
+        };
+
+        var transferResults = await client.CreateTransfersAsync(new[] { transfer1, transfer2 });
+        Assert.IsTrue(transferResults.All(x => x.Result == CreateTransferResult.Ok));
+
+        var lookupAccounts = await client.LookupAccountsAsync(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        var lookupTransfers = await client.LookupTransfersAsync(new UInt128[] { transfer1.Id, transfer2.Id });
+        Assert.IsTrue(lookupTransfers.Length == 2);
+        AssertTransfer(transfer1, lookupTransfers[0]);
+        AssertTransfer(transfer2, lookupTransfers[1]);
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, transfer1.Amount);
+        Assert.AreEqual(lookupAccounts[0].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, transfer2.Amount);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, transfer2.Amount);
+        Assert.AreEqual(lookupAccounts[1].DebitsPending, (UInt128)0);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, transfer1.Amount);
+    }
+
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateAccountTooMuchData()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        const int TOO_MUCH_DATA = 10000;
+        var accounts = new Account[TOO_MUCH_DATA];
+        for (int i = 0; i < TOO_MUCH_DATA; i++)
+        {
+            accounts[i] = new Account
             {
-                var format = new Process();
-                format.StartInfo.FileName = TB_SERVER;
-                format.StartInfo.Arguments = FORMAT;
-                format.StartInfo.RedirectStandardError = true;
-                format.Start();
-                var formatStderr = format.StandardError.ReadToEnd();
-                format.WaitForExit();
-                if (format.ExitCode != 0) throw new InvalidOperationException($"format failed, ExitCode={format.ExitCode} stderr:\n{formatStderr}");
+                Id = Guid.NewGuid().ToUInt128(),
+                Code = 1,
+                Ledger = 1
+            };
+        }
+
+        try
+        {
+            _ = client.CreateAccounts(accounts);
+            Assert.IsTrue(false);
+        }
+        catch (RequestException requestException)
+        {
+            Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
+        }
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateAccountTooMuchDataAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        const int TOO_MUCH_DATA = 10000;
+        var accounts = new Account[TOO_MUCH_DATA];
+        for (int i = 0; i < TOO_MUCH_DATA; i++)
+        {
+            accounts[i] = new Account
+            {
+                Id = Guid.NewGuid().ToUInt128(),
+                Code = 1,
+                Ledger = 1
+            };
+        }
+
+        try
+        {
+            _ = await client.CreateAccountsAsync(accounts);
+            Assert.IsTrue(false);
+        }
+        catch (RequestException requestException)
+        {
+            Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
+        }
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void CreateTransferTooMuchData()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        const int TOO_MUCH_DATA = 10000;
+        var transfers = new Transfer[TOO_MUCH_DATA];
+        for (int i = 0; i < TOO_MUCH_DATA; i++)
+        {
+            transfers[i] = new Transfer
+            {
+                Id = Guid.NewGuid().ToUInt128(),
+                Code = 1,
+                Ledger = 1
+            };
+        }
+
+        try
+        {
+            _ = client.CreateTransfers(transfers);
+            Assert.IsTrue(false);
+        }
+        catch (RequestException requestException)
+        {
+            Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
+        }
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public async Task CreateTransferTooMuchDataAsync()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        const int TOO_MUCH_DATA = 10000;
+        var transfers = new Transfer[TOO_MUCH_DATA];
+        for (int i = 0; i < TOO_MUCH_DATA; i++)
+        {
+            transfers[i] = new Transfer
+            {
+                Id = Guid.NewGuid().ToUInt128(),
+                DebitAccountId = accounts[0].Id,
+                CreditAccountId = accounts[1].Id,
+                Code = 1,
+                Ledger = 1,
+                Amount = 100,
+            };
+        }
+
+        try
+        {
+            _ = await client.CreateTransfersAsync(transfers);
+            Assert.IsTrue(false);
+        }
+        catch (RequestException requestException)
+        {
+            Assert.AreEqual(PacketStatus.TooMuchData, requestException.Status);
+        }
+    }
+
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void TestGetAccountTransfers()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        // Creating the accounts.
+        var createAccountErrors = client.CreateAccounts(accounts);
+        Assert.IsTrue(createAccountErrors.Length == 0);
+
+        // Creating a transfer.
+        var transfers = new Transfer[10];
+        for (int i = 0; i < 10; i++)
+        {
+            transfers[i] = new Transfer
+            {
+                Id = (UInt128)(i + 1),
+
+                // Swap the debit and credit accounts:
+                CreditAccountId = accounts[i % 2 == 0 ? 0 : 1].Id,
+                DebitAccountId = accounts[i % 2 == 0 ? 1 : 0].Id,
+
+                Ledger = 1,
+                Code = 2,
+                Flags = TransferFlags.None,
+                Amount = 100
+            };
+        }
+
+        var createTransferErrors = client.CreateTransfers(transfers);
+        Assert.IsTrue(createTransferErrors.Length == 0);
+
+        {
+            // Querying transfers where:
+            // `debit_account_id=$account1Id OR credit_account_id=$account1Id
+            // ORDER BY timestamp ASC`.
+            var filter = new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits
+            };
+            var account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 10);
+            ulong timestamp = 0;
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp > timestamp);
+                timestamp = transfer.Timestamp;
+            }
+        }
+
+        {
+            // Querying transfers where:
+            // `debit_account_id=$account2Id OR credit_account_id=$account2Id
+            // ORDER BY timestamp DESC`.
+            var filter = new GetAccountTransfers
+            {
+                AccountId = accounts[1].Id,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits | GetAccountTransfersFlags.Reversed
+            };
+            var account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 10);
+            ulong timestamp = ulong.MaxValue;
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp < timestamp);
+                timestamp = transfer.Timestamp;
+            }
+        }
+
+        {
+            // Querying transfers where:
+            // `debit_account_id=$account1Id
+            // ORDER BY timestamp ASC`.                
+            var filter = new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = GetAccountTransfersFlags.Debits
+            };
+            var account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 5);
+            ulong timestamp = 0;
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp > timestamp);
+                timestamp = transfer.Timestamp;
+            }
+        }
+
+        {
+            // Querying transfers where:
+            // `credit_account_id=$account2Id
+            // ORDER BY timestamp DESC`.            
+            var filter = new GetAccountTransfers
+            {
+                AccountId = accounts[1].Id,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Reversed
+            };
+            var account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 5);
+            ulong timestamp = ulong.MaxValue;
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp < timestamp);
+                timestamp = transfer.Timestamp;
+            }
+        }
+
+        {
+            // Querying transfers where:
+            // `debit_account_id=$account1Id OR credit_account_id=$account1Id
+            // ORDER BY timestamp ASC LIMIT 5`.       
+            var filter = new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = 0,
+                Limit = 5,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits
+            };
+
+            // First 5 items:            
+            var account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 5);
+            ulong timestamp = 0;
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp > timestamp);
+                timestamp = transfer.Timestamp;
             }
 
-            process = new Process();
-            process.StartInfo.FileName = TB_SERVER;
-            process.StartInfo.Arguments = START;
-            process.StartInfo.RedirectStandardError = true;
-            process.Start();
-            if (process.WaitForExit(100)) throw new InvalidOperationException("Tigerbeetle server failed to start");
-
-            var readPortEvent = new AutoResetEvent(false);
-            var addressLogged = "";
-            var stderrLogged = new StringBuilder();
-            process.ErrorDataReceived += (sender, e) =>
+            // Next 5 items from this timestamp:
+            filter.Timestamp = timestamp;
+            account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 5);
+            foreach (var transfer in account_transfers)
             {
-                var line = e.Data;
-                if (line == null) return;
-                stderrLogged.Append(line);
-                const string listening = "listening on ";
-                var found = line.IndexOf(listening);
-                if (found != -1)
-                {
-                    if (addressLogged != "") throw new InvalidOperationException("have already read the port");
-                    addressLogged = line.Substring(found + listening.Length).Trim();
-                    readPortEvent.Set();
-                }
-            };
-            process.BeginErrorReadLine();
-            readPortEvent.WaitOne(60_000);
+                Assert.IsTrue(transfer.Timestamp > timestamp);
+                timestamp = transfer.Timestamp;
+            }
 
-            if (addressLogged == "")
+            // No more pages after that:
+            filter.Timestamp = timestamp;
+            account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 0);
+        }
+
+        {
+            // Querying transfers where:
+            // `debit_account_id=$account2Id OR credit_account_id=$account2Id
+            // ORDER BY timestamp DESC LIMIT 5`.       
+            var filter = new GetAccountTransfers
+            {
+                AccountId = accounts[1].Id,
+                Timestamp = 0,
+                Limit = 5,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits | GetAccountTransfersFlags.Reversed
+            };
+
+            // First 5 items:                
+            var account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 5);
+            ulong timestamp = ulong.MaxValue;
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp < timestamp);
+                timestamp = transfer.Timestamp;
+            }
+
+            // Next 5 items from this timestamp:
+            filter.Timestamp = timestamp;
+            account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 5);
+            foreach (var transfer in account_transfers)
+            {
+                Assert.IsTrue(transfer.Timestamp < timestamp);
+                timestamp = transfer.Timestamp;
+            }
+
+            // No more pages after that:
+            filter.Timestamp = timestamp;
+            account_transfers = client.GetAccountTransfers(filter);
+            Assert.IsTrue(account_transfers.Length == 0);
+        }
+
+        {
+            // Empty filter:
+            Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers { }).Length == 0);
+
+            // Invalid account
+            Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
+            {
+                AccountId = 0,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits,
+            }).Length == 0);
+
+            // Invalid timestamp
+            Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = ulong.MaxValue,
+                Limit = 8190,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits,
+            }).Length == 0);
+
+            // Zero limit
+            Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = 0,
+                Limit = 0,
+                Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits,
+            }).Length == 0);
+
+            // Empty flags
+            Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = (GetAccountTransfersFlags)0,
+            }).Length == 0);
+
+            // Invalid flags
+            Assert.IsTrue(client.GetAccountTransfers(new GetAccountTransfers
+            {
+                AccountId = accounts[0].Id,
+                Timestamp = 0,
+                Limit = 8190,
+                Flags = (GetAccountTransfersFlags)0xFFFF,
+            }).Length == 0);
+        }
+    }
+
+    /// <summary>
+    /// This test asserts that a single Client can be shared by multiple concurrent tasks
+    /// </summary>
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ConcurrencyTest() => ConcurrencyTest(isAsync: false);
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ConcurrencyTestAsync() => ConcurrencyTest(isAsync: true);
+
+    private void ConcurrencyTest(bool isAsync)
+    {
+        const int TASKS_QTY = 32;
+        int MAX_CONCURRENCY = 32;
+
+        using var server = new TBServer();
+        using var client = GetClient(server.Address, MAX_CONCURRENCY);
+
+        var errors = client.CreateAccounts(accounts);
+        Assert.IsTrue(errors.Length == 0);
+
+        var list = new List<Task<CreateTransferResult>>();
+
+        for (int i = 0; i < TASKS_QTY; i++)
+        {
+            var transfer = new Transfer
+            {
+                Id = (UInt128)(i + 1),
+                CreditAccountId = accounts[0].Id,
+                DebitAccountId = accounts[1].Id,
+                Amount = 100,
+                Ledger = 1,
+                Code = 1,
+            };
+
+            /// Starts multiple tasks.
+            var task = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
+            list.Add(task);
+        }
+
+        Task.WhenAll(list).Wait();
+
+        Assert.IsTrue(list.All(x => x.Result == CreateTransferResult.Ok));
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        // Assert that all tasks ran to the conclusion
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (ulong)(100 * TASKS_QTY));
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, 0LU);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, 0LU);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (ulong)(100 * TASKS_QTY));
+    }
+
+    /// <summary>
+    /// This test asserts that a single Client can be shared by multiple concurrent tasks
+    /// Even if a limited "concurrencyMax" value results in "ConcurrencyExceededException"
+    /// </summary>
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ConcurrencyExceededTest() => ConcurrencyExceededTest(isAsync: false);
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ConcurrencyExceededTestAsync() => ConcurrencyExceededTest(isAsync: true);
+
+    private void ConcurrencyExceededTest(bool isAsync)
+    {
+        const int TASKS_QTY = 32;
+        int MAX_CONCURRENCY = 2;
+
+        using var server = new TBServer();
+        using var client = GetClient(server.Address, MAX_CONCURRENCY);
+
+        var errors = client.CreateAccounts(accounts);
+        Assert.IsTrue(errors.Length == 0);
+
+        var list = new List<Task<CreateTransferResult>>();
+
+        for (int i = 0; i < TASKS_QTY; i++)
+        {
+            var transfer = new Transfer
+            {
+                Id = (UInt128)(i + 1),
+                CreditAccountId = accounts[0].Id,
+                DebitAccountId = accounts[1].Id,
+                Ledger = 1,
+                Code = 1,
+                Amount = 100,
+            };
+
+            /// Starts multiple tasks using a client with a limited concurrencyMax:
+            var task = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
+            list.Add(task);
+        }
+
+        try
+        {
+            // Ignoring exceptions from the tasks.
+            Task.WhenAll(list).Wait();
+        }
+        catch { }
+
+        // It's expected for some tasks to failt with ConcurrencyExceededException or ObjectDisposedException:
+        var successCount = list.Count(x => !x.IsFaulted && x.Result == CreateTransferResult.Ok);
+        var failedCount = list.Count(x => x.IsFaulted &&
+            (AssertException<ConcurrencyExceededException>(x.Exception!) ||
+            AssertException<ObjectDisposedException>(x.Exception!)));
+        Assert.IsTrue(successCount > 0);
+        Assert.IsTrue(successCount + failedCount == TASKS_QTY);
+
+        // Asserting that either the task failed or succeeded.
+        Assert.IsTrue(list.All(x => x.IsFaulted || x.Result == CreateTransferResult.Ok));
+
+        var lookupAccounts = client.LookupAccounts(new[] { accounts[0].Id, accounts[1].Id });
+        AssertAccounts(lookupAccounts);
+
+        // Assert that all tasks ran to the conclusion
+
+        Assert.AreEqual(lookupAccounts[0].CreditsPosted, (ulong)(100 * successCount));
+        Assert.AreEqual(lookupAccounts[0].DebitsPosted, 0LU);
+
+        Assert.AreEqual(lookupAccounts[1].CreditsPosted, 0LU);
+        Assert.AreEqual(lookupAccounts[1].DebitsPosted, (ulong)(100 * successCount));
+    }
+
+    /// <summary>
+    /// This test asserts that Client.Dispose() will wait for any ongoing request to complete
+    /// And new requests will fail with ObjectDisposedException.
+    /// </summary>
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ConcurrentTasksDispose() => ConcurrentTasksDispose(isAsync: false);
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ConcurrentTasksDisposeAsync() => ConcurrentTasksDispose(isAsync: true);
+
+    private void ConcurrentTasksDispose(bool isAsync)
+    {
+        const int TASKS_QTY = 32;
+        int MAX_CONCURRENCY = 32;
+
+        using var server = new TBServer();
+        using var client = GetClient(server.Address, MAX_CONCURRENCY);
+
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+
+        var list = new List<Task<CreateTransferResult>>();
+
+        for (int i = 0; i < TASKS_QTY; i++)
+        {
+            var transfer = new Transfer
+            {
+                Id = (UInt128)(i + 1),
+                CreditAccountId = accounts[0].Id,
+                DebitAccountId = accounts[1].Id,
+                Amount = 100,
+                Ledger = 1,
+                Code = 1,
+            };
+
+            /// Starts multiple tasks.
+            var task = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
+            list.Add(task);
+        }
+
+        // Waiting for just one task, the others may be pending.
+        list.First().Wait();
+
+        // Disposes the client, waiting all placed requests to finish.
+        client.Dispose();
+
+        try
+        {
+            // Ignoring exceptions from the tasks.
+            Task.WhenAll(list).Wait();
+        }
+        catch { }
+
+        // Asserting that either the task failed or succeeded,
+        // at least one must be succeeded.
+        Assert.IsTrue(list.Any(x => !x.IsFaulted && x.Result == CreateTransferResult.Ok));
+        Assert.IsTrue(list.All(x => x.IsFaulted || x.Result == CreateTransferResult.Ok));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ObjectDisposedException))]
+    [DoNotParallelize]
+    public void DisposedClient()
+    {
+        using var server = new TBServer();
+        using var client = GetClient(server.Address);
+
+        var accountResults = client.CreateAccounts(accounts);
+        Assert.IsTrue(accountResults.Length == 0);
+
+        client.Dispose();
+
+        var transfer = new Transfer
+        {
+            Id = 1,
+            CreditAccountId = accounts[0].Id,
+            DebitAccountId = accounts[1].Id,
+            Amount = 100,
+            Ledger = 1,
+            Code = 1,
+        };
+
+        _ = client.CreateTransfers(new Transfer[] { transfer });
+        Assert.IsTrue(false);
+    }
+
+
+    private static void AssertAccounts(Account[] lookupAccounts)
+    {
+        Assert.IsTrue(lookupAccounts.Length == accounts.Length);
+        for (int i = 0; i < accounts.Length; i++)
+        {
+            AssertAccount(accounts[i], lookupAccounts[i]);
+        }
+    }
+
+    private static void AssertAccount(Account a, Account b)
+    {
+        Assert.AreEqual(a.Id, b.Id);
+        Assert.AreEqual(a.UserData128, b.UserData128);
+        Assert.AreEqual(a.UserData64, b.UserData64);
+        Assert.AreEqual(a.UserData32, b.UserData32);
+        Assert.AreEqual(a.Flags, b.Flags);
+        Assert.AreEqual(a.Code, b.Code);
+        Assert.AreEqual(a.Ledger, b.Ledger);
+    }
+
+    private static void AssertTransfer(Transfer a, Transfer b)
+    {
+        Assert.AreEqual(a.Id, b.Id);
+        Assert.AreEqual(a.DebitAccountId, b.DebitAccountId);
+        Assert.AreEqual(a.CreditAccountId, b.CreditAccountId);
+        Assert.AreEqual(a.Amount, b.Amount);
+        Assert.AreEqual(a.PendingId, b.PendingId);
+        Assert.AreEqual(a.UserData128, b.UserData128);
+        Assert.AreEqual(a.UserData64, b.UserData64);
+        Assert.AreEqual(a.UserData32, b.UserData32);
+        Assert.AreEqual(a.Timeout, b.Timeout);
+        Assert.AreEqual(a.Flags, b.Flags);
+        Assert.AreEqual(a.Code, b.Code);
+        Assert.AreEqual(a.Ledger, b.Ledger);
+    }
+
+    private static bool AssertException<T>(Exception exception) where T : Exception
+    {
+        while (exception is AggregateException aggregateException && aggregateException.InnerException != null)
+        {
+            exception = aggregateException.InnerException;
+        }
+
+        return exception is T;
+    }
+}
+
+internal class TBServer : IDisposable
+{
+    // Path relative from /TigerBeetle.Test/bin/<framework>/<release>/<platform> :
+    private const string PROJECT_ROOT = "../../../../..";
+    private const string TB_PATH = PROJECT_ROOT + "/../../../zig-out/bin";
+    private const string TB_EXE = "tigerbeetle";
+    private const string TB_FILE = "dotnet-tests.tigerbeetle";
+    private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
+    private const string FORMAT = $"format --cluster=0 --replica=0 --replica-count=1 ./" + TB_FILE;
+    private const string START = $"start --addresses=0  --cache-grid=512MB ./" + TB_FILE;
+
+    private readonly Process process;
+
+    public string Address { get; }
+
+    public TBServer()
+    {
+        CleanUp();
+
+        {
+            var format = new Process();
+            format.StartInfo.FileName = TB_SERVER;
+            format.StartInfo.Arguments = FORMAT;
+            format.StartInfo.RedirectStandardError = true;
+            format.Start();
+            var formatStderr = format.StandardError.ReadToEnd();
+            format.WaitForExit();
+            if (format.ExitCode != 0) throw new InvalidOperationException($"format failed, ExitCode={format.ExitCode} stderr:\n{formatStderr}");
+        }
+
+        process = new Process();
+        process.StartInfo.FileName = TB_SERVER;
+        process.StartInfo.Arguments = START;
+        process.StartInfo.RedirectStandardError = true;
+        process.Start();
+        if (process.WaitForExit(100)) throw new InvalidOperationException("Tigerbeetle server failed to start");
+
+        var readPortEvent = new AutoResetEvent(false);
+        var addressLogged = "";
+        var stderrLogged = new StringBuilder();
+        process.ErrorDataReceived += (sender, e) =>
+        {
+            var line = e.Data;
+            if (line == null) return;
+            stderrLogged.Append(line);
+            const string listening = "listening on ";
+            var found = line.IndexOf(listening);
+            if (found != -1)
+            {
+                if (addressLogged != "") throw new InvalidOperationException("have already read the port");
+                addressLogged = line.Substring(found + listening.Length).Trim();
+                readPortEvent.Set();
+            }
+        };
+        process.BeginErrorReadLine();
+        readPortEvent.WaitOne(60_000);
+
+        if (addressLogged == "")
+        {
+            process.Kill();
+            process.WaitForExit();
+            throw new InvalidOperationException($"failed to read the port, ExitCode={process.ExitCode} stderr:\n{stderrLogged.ToString()}");
+        }
+
+        process.CancelErrorRead();
+        Address = addressLogged;
+    }
+
+    public void Dispose()
+    {
+        CleanUp();
+    }
+
+    private void CleanUp()
+    {
+        try
+        {
+            if (process != null && !process.HasExited)
             {
                 process.Kill();
-                process.WaitForExit();
-                throw new InvalidOperationException($"failed to read the port, ExitCode={process.ExitCode} stderr:\n{stderrLogged.ToString()}");
+                process.Dispose();
             }
 
-            process.CancelErrorRead();
-            Address = addressLogged;
+            File.Delete($"./{TB_FILE}");
         }
-
-        public void Dispose()
-        {
-            CleanUp();
-        }
-
-        private void CleanUp()
-        {
-            try
-            {
-                if (process != null && !process.HasExited)
-                {
-                    process.Kill();
-                    process.Dispose();
-                }
-
-                File.Delete($"./{TB_FILE}");
-            }
-            catch { }
-        }
+        catch { }
     }
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/RequestTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/RequestTests.cs
@@ -3,120 +3,120 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-namespace TigerBeetle.Tests
+namespace TigerBeetle.Tests;
+
+[TestClass]
+public class RequestTests
 {
-    [TestClass]
-    public class RequestTests
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void EmptyBatch()
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void EmptyBatch()
+        using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
+        var request = new AsyncRequest<Account, UInt128>(nativeClient, TBOperation.LookupAccounts);
+
+        request.Submit(Array.Empty<UInt128>());
+        Assert.IsTrue(false);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void NullBatch()
+    {
+        using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
+        var request = new AsyncRequest<Account, UInt128>(nativeClient, TBOperation.LookupAccounts);
+
+        request.Submit((UInt128[])null!);
+        Assert.IsTrue(false);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(AssertionException))]
+    public async Task UnexpectedOperation()
+    {
+        using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
+
+        var callback = new CallbackSimulator<Account, UInt128>(
+            nativeClient,
+            TBOperation.LookupAccounts,
+            (byte)99,
+            null,
+            PacketStatus.Ok,
+            delay: 100,
+            isAsync: true
+        );
+        var task = callback.Run();
+        Assert.IsFalse(task.IsCompleted);
+
+        _ = await task;
+        Assert.IsTrue(false);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(AssertionException))]
+    public async Task InvalidSizeOperation()
+    {
+        using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
+
+        var buffer = new byte[Account.SIZE + 1];
+        var callback = new CallbackSimulator<Account, UInt128>(
+            nativeClient,
+            TBOperation.LookupAccounts,
+            (byte)TBOperation.LookupAccounts,
+            buffer,
+            PacketStatus.Ok,
+            delay: 100,
+            isAsync: true
+        );
+
+        var task = callback.Run();
+        Assert.IsFalse(task.IsCompleted);
+
+        _ = await task;
+        Assert.IsTrue(false);
+    }
+
+    [TestMethod]
+    public async Task RequestException()
+    {
+        using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
+
+        foreach (var isAsync in new bool[] { true, false })
         {
-            using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
-            var request = new AsyncRequest<Account, UInt128>(nativeClient, TBOperation.LookupAccounts);
-
-            request.Submit(Array.Empty<UInt128>());
-            Assert.IsTrue(false);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void NullBatch()
-        {
-            using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
-            var request = new AsyncRequest<Account, UInt128>(nativeClient, TBOperation.LookupAccounts);
-
-            request.Submit((UInt128[])null!);
-            Assert.IsTrue(false);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(AssertionException))]
-        public async Task UnexpectedOperation()
-        {
-            using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
-
-            var callback = new CallbackSimulator<Account, UInt128>(
-                nativeClient,
-                TBOperation.LookupAccounts,
-                (byte)99,
-                null,
-                PacketStatus.Ok,
-                delay: 100,
-                isAsync: true
-            );
-            var task = callback.Run();
-            Assert.IsFalse(task.IsCompleted);
-
-            _ = await task;
-            Assert.IsTrue(false);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(AssertionException))]
-        public async Task InvalidSizeOperation()
-        {
-            using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
-
-            var buffer = new byte[Account.SIZE + 1];
-            var callback = new CallbackSimulator<Account, UInt128>(
-                nativeClient,
+            var buffer = new byte[Account.SIZE];
+            var callback = new CallbackSimulator<Account, UInt128>(nativeClient,
                 TBOperation.LookupAccounts,
                 (byte)TBOperation.LookupAccounts,
                 buffer,
-                PacketStatus.Ok,
+                PacketStatus.TooMuchData,
                 delay: 100,
-                isAsync: true
+                isAsync
             );
 
             var task = callback.Run();
             Assert.IsFalse(task.IsCompleted);
 
-            _ = await task;
-            Assert.IsTrue(false);
-        }
-
-        [TestMethod]
-        public async Task RequestException()
-        {
-            using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
-
-            foreach (var isAsync in new bool[] { true, false })
+            try
             {
-                var buffer = new byte[Account.SIZE];
-                var callback = new CallbackSimulator<Account, UInt128>(nativeClient,
-                    TBOperation.LookupAccounts,
-                    (byte)TBOperation.LookupAccounts,
-                    buffer,
-                    PacketStatus.TooMuchData,
-                    delay: 100,
-                    isAsync
-                );
-
-                var task = callback.Run();
-                Assert.IsFalse(task.IsCompleted);
-
-                try
-                {
-                    _ = await task;
-                    Assert.IsTrue(false);
-                }
-                catch (RequestException exception)
-                {
-                    Assert.AreEqual(PacketStatus.TooMuchData, exception.Status);
-                }
+                _ = await task;
+                Assert.IsTrue(false);
+            }
+            catch (RequestException exception)
+            {
+                Assert.AreEqual(PacketStatus.TooMuchData, exception.Status);
             }
         }
+    }
 
-        [TestMethod]
-        public async Task Success()
+    [TestMethod]
+    public async Task Success()
+    {
+        using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
+
+        foreach (var isAsync in new bool[] { true, false })
         {
-            using var nativeClient = NativeClient.InitEcho(0, new string[] { "3000" }, 1);
-
-            foreach (var isAsync in new bool[] { true, false })
+            var buffer = MemoryMarshal.Cast<Account, byte>(new Account[]
             {
-                var buffer = MemoryMarshal.Cast<Account, byte>(new Account[]
-                {
                     new Account
                     {
                         Id = 1,
@@ -127,83 +127,82 @@ namespace TigerBeetle.Tests
                         Ledger = 6,
                         Flags = AccountFlags.Linked,
                     }
-                }).ToArray();
+            }).ToArray();
 
-                var callback = new CallbackSimulator<Account, UInt128>(nativeClient,
-                    TBOperation.LookupAccounts,
-                    (byte)TBOperation.LookupAccounts,
-                    buffer,
-                    PacketStatus.Ok,
-                    delay: 100,
-                    isAsync
-                );
+            var callback = new CallbackSimulator<Account, UInt128>(nativeClient,
+                TBOperation.LookupAccounts,
+                (byte)TBOperation.LookupAccounts,
+                buffer,
+                PacketStatus.Ok,
+                delay: 100,
+                isAsync
+            );
 
-                var task = callback.Run();
-                Assert.IsFalse(task.IsCompleted);
+            var task = callback.Run();
+            Assert.IsFalse(task.IsCompleted);
 
-                var accounts = await task;
-                Assert.IsTrue(accounts.Length == 1);
-                Assert.IsTrue(accounts[0].Id == 1);
-                Assert.IsTrue(accounts[0].UserData128 == 2);
-                Assert.IsTrue(accounts[0].UserData64 == 3);
-                Assert.IsTrue(accounts[0].UserData32 == 4);
-                Assert.IsTrue(accounts[0].Code == 5);
-                Assert.IsTrue(accounts[0].Ledger == 6);
-                Assert.IsTrue(accounts[0].Flags == AccountFlags.Linked);
+            var accounts = await task;
+            Assert.IsTrue(accounts.Length == 1);
+            Assert.IsTrue(accounts[0].Id == 1);
+            Assert.IsTrue(accounts[0].UserData128 == 2);
+            Assert.IsTrue(accounts[0].UserData64 == 3);
+            Assert.IsTrue(accounts[0].UserData32 == 4);
+            Assert.IsTrue(accounts[0].Code == 5);
+            Assert.IsTrue(accounts[0].Ledger == 6);
+            Assert.IsTrue(accounts[0].Flags == AccountFlags.Linked);
+        }
+    }
+
+    private class CallbackSimulator<TResult, TBody>
+        where TResult : unmanaged
+        where TBody : unmanaged
+    {
+        private readonly Request<TResult, TBody> request;
+        private readonly Packet packet;
+        private readonly byte receivedOperation;
+        private readonly Memory<byte> buffer;
+        private readonly PacketStatus status;
+        private readonly int delay;
+
+        public CallbackSimulator(NativeClient nativeClient, TBOperation operation, byte receivedOperation, Memory<byte> buffer, PacketStatus status, int delay, bool isAsync)
+        {
+            unsafe
+            {
+                this.request = isAsync ? new AsyncRequest<TResult, TBody>(nativeClient, operation) : new BlockingRequest<TResult, TBody>(nativeClient, operation);
+                this.packet = nativeClient.AcquirePacket();
+                this.receivedOperation = receivedOperation;
+                this.buffer = buffer;
+                this.status = status;
+                this.delay = delay;
             }
         }
 
-        private class CallbackSimulator<TResult, TBody>
-            where TResult : unmanaged
-            where TBody : unmanaged
+        public Task<TResult[]> Run()
         {
-            private readonly Request<TResult, TBody> request;
-            private readonly Packet packet;
-            private readonly byte receivedOperation;
-            private readonly Memory<byte> buffer;
-            private readonly PacketStatus status;
-            private readonly int delay;
-
-            public CallbackSimulator(NativeClient nativeClient, TBOperation operation, byte receivedOperation, Memory<byte> buffer, PacketStatus status, int delay, bool isAsync)
+            Task.Run(() =>
             {
                 unsafe
                 {
-                    this.request = isAsync ? new AsyncRequest<TResult, TBody>(nativeClient, operation) : new BlockingRequest<TResult, TBody>(nativeClient, operation);
-                    this.packet = nativeClient.AcquirePacket();
-                    this.receivedOperation = receivedOperation;
-                    this.buffer = buffer;
-                    this.status = status;
-                    this.delay = delay;
+                    Task.Delay(delay).Wait();
+                    packet.Pointer->operation = receivedOperation;
+                    packet.Pointer->status = status;
+                    request.Complete(packet, buffer.Span);
                 }
-            }
+            });
 
-            public Task<TResult[]> Run()
+            if (request is AsyncRequest<TResult, TBody> asyncRequest)
             {
-                Task.Run(() =>
-                {
-                    unsafe
-                    {
-                        Task.Delay(delay).Wait();
-                        packet.Pointer->operation = receivedOperation;
-                        packet.Pointer->status = status;
-                        request.Complete(packet, buffer.Span);
-                    }
-                });
-
-                if (request is AsyncRequest<TResult, TBody> asyncRequest)
-                {
-                    return asyncRequest.Wait();
-                }
-                else if (request is BlockingRequest<TResult, TBody> blockingRequest)
-                {
-                    return Task.Run(() => blockingRequest.Wait());
-                }
-                else
-                {
-                    throw new NotImplementedException();
-                }
+                return asyncRequest.Wait();
+            }
+            else if (request is BlockingRequest<TResult, TBody> blockingRequest)
+            {
+                return Task.Run(() => blockingRequest.Wait());
+            }
+            else
+            {
+                throw new NotImplementedException();
             }
         }
-
     }
+
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
+++ b/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>

--- a/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
@@ -60,6 +60,7 @@ namespace TigerBeetle.Tests
         [ExpectedException(typeof(ArgumentException))]
         public void InvalidArrayConvertion()
         {
+            // Expected ArgumentException.
             byte[] array = new byte[17];
             _ = array.ToUInt128();
         }
@@ -68,25 +69,37 @@ namespace TigerBeetle.Tests
         [TestMethod]
         public void BigIntegerConvertion()
         {
-            BigInteger bigInteger = BigInteger.Parse("123456789012345678901234567890123456789");
-            UInt128 value = bigInteger.ToUInt128();
+            var checkConvertion = (BigInteger bigInteger) =>
+            {
+                UInt128 uint128 = bigInteger.ToUInt128();
 
-            Assert.AreEqual(value, bigInteger.ToUInt128());
-            Assert.AreEqual(bigInteger, value.ToBigInteger());
-            Assert.IsTrue(value.Equals(bigInteger.ToUInt128()));
+                Assert.AreEqual(uint128, bigInteger.ToUInt128());
+                Assert.AreEqual(bigInteger, uint128.ToBigInteger());
+                Assert.IsTrue(uint128.Equals(bigInteger.ToUInt128()));
+            };
+
+            checkConvertion(BigInteger.Parse("0"));
+            checkConvertion(BigInteger.Parse("1"));
+            checkConvertion(BigInteger.Parse("123456789012345678901234567890123456789"));
+            checkConvertion(new BigInteger(uint.MaxValue));
+            checkConvertion(new BigInteger(ulong.MaxValue));
         }
 
+
+
         [TestMethod]
-        public void DecimalToString()
+        [ExpectedException(typeof(OverflowException))]
+        public void BigIntegerNegative()
         {
-            UInt128 value = (UInt128)1234567890;
-            Assert.AreEqual(value.ToString(), "1234567890");
+            // Expected OverflowException.
+            _ = BigInteger.MinusOne.ToUInt128();
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void BigIntegerExceedU128()
         {
+            // Expected ArgumentOutOfRangeException.
             BigInteger bigInteger = BigInteger.Parse("9999999999999999999999999999999999999999");
             _ = bigInteger.ToUInt128();
         }
@@ -101,52 +114,5 @@ namespace TigerBeetle.Tests
             Assert.IsTrue(expected.SequenceEqual(new Guid(expected).ToUInt128().ToArray()));
             Assert.IsTrue(expected.SequenceEqual(new UInt128(0, 0x123456).ToArray()));
         }
-
-#if !NET7_0_OR_GREATER
-
-        [TestMethod]
-        public void HashCode()
-        {
-            UInt128 a = 100;
-            UInt128 b = 101;
-
-            Assert.AreNotEqual(a.GetHashCode(), b.GetHashCode());
-        }
-
-        [TestMethod]
-        public void Equals()
-        {
-            // Same type:
-            Assert.IsTrue(UInt128.Zero.Equals(UInt128.Zero));
-            Assert.IsTrue(((UInt128)1).Equals((UInt128)1));
-            Assert.IsTrue(new UInt128(0UL, ulong.MaxValue).Equals(new UInt128(0UL, ulong.MaxValue)));
-
-            // Implicit conversion:
-            Assert.IsTrue(UInt128.Zero.Equals(0));
-            Assert.IsTrue(((UInt128)1).Equals(1));
-            Assert.IsTrue(new UInt128(0UL, ulong.MaxValue).Equals(ulong.MaxValue));
-
-            // Explicit conversion:
-            Assert.IsTrue(UInt128.Zero.Equals((int)0));
-            Assert.IsTrue(((UInt128)1).Equals((int)1));
-            Assert.IsTrue(new UInt128(0UL, long.MaxValue).Equals(long.MaxValue));
-
-        }
-
-        [TestMethod]
-        public void Operators()
-        {
-            var a = new UInt128(100, 200);
-            var b = new UInt128(100, 200);
-
-            Assert.AreEqual(a, b);
-            Assert.IsTrue(a.Equals(b));
-            Assert.IsTrue(b.Equals(a));
-            Assert.IsTrue(a == b);
-            Assert.IsTrue(b == a);
-            Assert.IsFalse(a != b);
-            Assert.IsTrue(a != UInt128.Zero);
-        }
-#endif
     }
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
@@ -4,115 +4,114 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 
-namespace TigerBeetle.Tests
+namespace TigerBeetle.Tests;
+
+[TestClass]
+public class UInt128Tests
 {
-    [TestClass]
-    public class UInt128Tests
+    [TestMethod]
+    public void GuidConvertion()
     {
-        [TestMethod]
-        public void GuidConvertion()
+        Guid guid = Guid.Parse("A945C62A-4CC7-425B-B44A-893577632902");
+        UInt128 value = guid.ToUInt128();
+
+        Assert.AreEqual(value, guid.ToUInt128());
+        Assert.AreEqual(guid, value.ToGuid());
+    }
+
+    [TestMethod]
+    public void GuidMaxConvertion()
+    {
+        Guid guid = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        UInt128 value = guid.ToUInt128();
+
+        Assert.AreEqual(value, guid.ToUInt128());
+        Assert.AreEqual(guid, value.ToGuid());
+    }
+
+    [TestMethod]
+    public void ArrayConvertion()
+    {
+        byte[] array = new byte[16] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10 };
+        UInt128 value = array.ToUInt128();
+
+        Assert.IsTrue(value.ToArray().SequenceEqual(array));
+        Assert.IsTrue(array.SequenceEqual(value.ToArray()));
+        Assert.IsTrue(value.Equals(array.ToUInt128()));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void NullArrayConvertion()
+    {
+        byte[] array = null!;
+        _ = array.ToUInt128();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void EmptyArrayConvertion()
+    {
+        byte[] array = new byte[0];
+        _ = array.ToUInt128();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void InvalidArrayConvertion()
+    {
+        // Expected ArgumentException.
+        byte[] array = new byte[17];
+        _ = array.ToUInt128();
+    }
+
+
+    [TestMethod]
+    public void BigIntegerConvertion()
+    {
+        var checkConvertion = (BigInteger bigInteger) =>
         {
-            Guid guid = Guid.Parse("A945C62A-4CC7-425B-B44A-893577632902");
-            UInt128 value = guid.ToUInt128();
+            UInt128 uint128 = bigInteger.ToUInt128();
 
-            Assert.AreEqual(value, guid.ToUInt128());
-            Assert.AreEqual(guid, value.ToGuid());
-        }
+            Assert.AreEqual(uint128, bigInteger.ToUInt128());
+            Assert.AreEqual(bigInteger, uint128.ToBigInteger());
+            Assert.IsTrue(uint128.Equals(bigInteger.ToUInt128()));
+        };
 
-        [TestMethod]
-        public void GuidMaxConvertion()
-        {
-            Guid guid = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
-            UInt128 value = guid.ToUInt128();
-
-            Assert.AreEqual(value, guid.ToUInt128());
-            Assert.AreEqual(guid, value.ToGuid());
-        }
-
-        [TestMethod]
-        public void ArrayConvertion()
-        {
-            byte[] array = new byte[16] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10 };
-            UInt128 value = array.ToUInt128();
-
-            Assert.IsTrue(value.ToArray().SequenceEqual(array));
-            Assert.IsTrue(array.SequenceEqual(value.ToArray()));
-            Assert.IsTrue(value.Equals(array.ToUInt128()));
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void NullArrayConvertion()
-        {
-            byte[] array = null!;
-            _ = array.ToUInt128();
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void EmptyArrayConvertion()
-        {
-            byte[] array = new byte[0];
-            _ = array.ToUInt128();
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void InvalidArrayConvertion()
-        {
-            // Expected ArgumentException.
-            byte[] array = new byte[17];
-            _ = array.ToUInt128();
-        }
-
-
-        [TestMethod]
-        public void BigIntegerConvertion()
-        {
-            var checkConvertion = (BigInteger bigInteger) =>
-            {
-                UInt128 uint128 = bigInteger.ToUInt128();
-
-                Assert.AreEqual(uint128, bigInteger.ToUInt128());
-                Assert.AreEqual(bigInteger, uint128.ToBigInteger());
-                Assert.IsTrue(uint128.Equals(bigInteger.ToUInt128()));
-            };
-
-            checkConvertion(BigInteger.Parse("0"));
-            checkConvertion(BigInteger.Parse("1"));
-            checkConvertion(BigInteger.Parse("123456789012345678901234567890123456789"));
-            checkConvertion(new BigInteger(uint.MaxValue));
-            checkConvertion(new BigInteger(ulong.MaxValue));
-        }
+        checkConvertion(BigInteger.Parse("0"));
+        checkConvertion(BigInteger.Parse("1"));
+        checkConvertion(BigInteger.Parse("123456789012345678901234567890123456789"));
+        checkConvertion(new BigInteger(uint.MaxValue));
+        checkConvertion(new BigInteger(ulong.MaxValue));
+    }
 
 
 
-        [TestMethod]
-        [ExpectedException(typeof(OverflowException))]
-        public void BigIntegerNegative()
-        {
-            // Expected OverflowException.
-            _ = BigInteger.MinusOne.ToUInt128();
-        }
+    [TestMethod]
+    [ExpectedException(typeof(OverflowException))]
+    public void BigIntegerNegative()
+    {
+        // Expected OverflowException.
+        _ = BigInteger.MinusOne.ToUInt128();
+    }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public void BigIntegerExceedU128()
-        {
-            // Expected ArgumentOutOfRangeException.
-            BigInteger bigInteger = BigInteger.Parse("9999999999999999999999999999999999999999");
-            _ = bigInteger.ToUInt128();
-        }
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    public void BigIntegerExceedU128()
+    {
+        // Expected ArgumentOutOfRangeException.
+        BigInteger bigInteger = BigInteger.Parse("9999999999999999999999999999999999999999");
+        _ = bigInteger.ToUInt128();
+    }
 
-        [TestMethod]
-        public void LittleEndian()
-        {
-            var expected = new byte[16] { 86, 52, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    [TestMethod]
+    public void LittleEndian()
+    {
+        var expected = new byte[16] { 86, 52, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-            Assert.IsTrue(expected.SequenceEqual(expected.ToUInt128().ToArray()));
-            Assert.IsTrue(expected.SequenceEqual(BigInteger.Parse("123456", NumberStyles.HexNumber).ToUInt128().ToArray()));
-            Assert.IsTrue(expected.SequenceEqual(new Guid(expected).ToUInt128().ToArray()));
-            Assert.IsTrue(expected.SequenceEqual(new UInt128(0, 0x123456).ToArray()));
-        }
+        Assert.IsTrue(expected.SequenceEqual(expected.ToUInt128().ToArray()));
+        Assert.IsTrue(expected.SequenceEqual(BigInteger.Parse("123456", NumberStyles.HexNumber).ToUInt128().ToArray()));
+        Assert.IsTrue(expected.SequenceEqual(new Guid(expected).ToUInt128().ToArray()));
+        Assert.IsTrue(expected.SequenceEqual(new UInt128(0, 0x123456).ToArray()));
     }
 }

--- a/src/clients/dotnet/TigerBeetle/AssertionException.cs
+++ b/src/clients/dotnet/TigerBeetle/AssertionException.cs
@@ -1,33 +1,32 @@
 using System;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+/// <summary>
+/// The exception that is thrown when an assertion used for correctness checks is triggered.
+/// Correctness check assertions differ from other assertions offered by the .Net ecosystem
+/// i.e. Tracer.Assert and Debug.Assert, because they are not meant to be disabled or re-routed.
+/// It's recommended that the application handle AssertionException as unrecoverable fatal errors.
+/// </remarks>
+public sealed class AssertionException : Exception
 {
-    /// <summary>
-    /// The exception that is thrown when an assertion used for correctness checks is triggered.
-    /// Correctness check assertions differ from other assertions offered by the .Net ecosystem
-    /// i.e. Tracer.Assert and Debug.Assert, because they are not meant to be disabled or re-routed.
-    /// It's recommended that the application handle AssertionException as unrecoverable fatal errors.
-    /// </remarks>
-    public sealed class AssertionException : Exception
+    internal AssertionException() { }
+
+    internal AssertionException(string format, params object[] args) : base(string.Format(format, args)) { }
+
+    internal static void AssertTrue(bool condition, string format, params object[] args)
     {
-        internal AssertionException() { }
-
-        internal AssertionException(string format, params object[] args) : base(string.Format(format, args)) { }
-
-        internal static void AssertTrue(bool condition, string format, params object[] args)
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw new AssertionException(format, args);
-            }
+            throw new AssertionException(format, args);
         }
+    }
 
-        internal static void AssertTrue(bool condition)
+    internal static void AssertTrue(bool condition)
+    {
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw new AssertionException();
-            }
+            throw new AssertionException();
         }
     }
 }

--- a/src/clients/dotnet/TigerBeetle/AssertionException.cs
+++ b/src/clients/dotnet/TigerBeetle/AssertionException.cs
@@ -7,7 +7,7 @@ namespace TigerBeetle;
 /// Correctness check assertions differ from other assertions offered by the .Net ecosystem
 /// i.e. Tracer.Assert and Debug.Assert, because they are not meant to be disabled or re-routed.
 /// It's recommended that the application handle AssertionException as unrecoverable fatal errors.
-/// </remarks>
+/// </summary>
 public sealed class AssertionException : Exception
 {
     internal AssertionException() { }

--- a/src/clients/dotnet/TigerBeetle/AssertionException.cs
+++ b/src/clients/dotnet/TigerBeetle/AssertionException.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace TigerBeetle
 {
+    /// <summary>
+    /// The exception that is thrown when an assertion used for correctness checks is triggered.
+    /// Correctness check assertions differ from other assertions offered by the .Net ecosystem
+    /// i.e. Tracer.Assert and Debug.Assert, because they are not meant to be disabled or re-routed.
+    /// It's recommended that the application handle AssertionException as unrecoverable fatal errors.
+    /// </remarks>
     public sealed class AssertionException : Exception
     {
         internal AssertionException() { }

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -6,891 +6,870 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+[Flags]
+public enum AccountFlags : ushort
 {
-    [Flags]
-    public enum AccountFlags : ushort
-    {
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts#flagslinked
-        /// </summary>
-        Linked = 1 << 0,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts#flagslinked
+    /// </summary>
+    Linked = 1 << 0,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts#flagsdebits_must_not_exceed_credits
-        /// </summary>
-        DebitsMustNotExceedCredits = 1 << 1,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts#flagsdebits_must_not_exceed_credits
+    /// </summary>
+    DebitsMustNotExceedCredits = 1 << 1,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts#flagscredits_must_not_exceed_debits
-        /// </summary>
-        CreditsMustNotExceedDebits = 1 << 2,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts#flagscredits_must_not_exceed_debits
+    /// </summary>
+    CreditsMustNotExceedDebits = 1 << 2,
 
-    }
+}
 
-    [Flags]
-    public enum TransferFlags : ushort
-    {
-        None = 0,
+[Flags]
+public enum TransferFlags : ushort
+{
+    None = 0,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers#flagslinked
-        /// </summary>
-        Linked = 1 << 0,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers#flagslinked
+    /// </summary>
+    Linked = 1 << 0,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers#flagspending
-        /// </summary>
-        Pending = 1 << 1,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers#flagspending
+    /// </summary>
+    Pending = 1 << 1,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers#flagspost_pending_transfer
-        /// </summary>
-        PostPendingTransfer = 1 << 2,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers#flagspost_pending_transfer
+    /// </summary>
+    PostPendingTransfer = 1 << 2,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers#flagsvoid_pending_transfer
-        /// </summary>
-        VoidPendingTransfer = 1 << 3,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers#flagsvoid_pending_transfer
+    /// </summary>
+    VoidPendingTransfer = 1 << 3,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers#flagsbalancing_debit
-        /// </summary>
-        BalancingDebit = 1 << 4,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers#flagsbalancing_debit
+    /// </summary>
+    BalancingDebit = 1 << 4,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers#flagsbalancing_credit
-        /// </summary>
-        BalancingCredit = 1 << 5,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers#flagsbalancing_credit
+    /// </summary>
+    BalancingCredit = 1 << 5,
 
-    }
+}
 
-    [Flags]
-    public enum GetAccountTransfersFlags : uint
-    {
-        None = 0,
+[Flags]
+public enum GetAccountTransfersFlags : uint
+{
+    None = 0,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flagsdebits
-        /// </summary>
-        Debits = 1 << 0,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flagsdebits
+    /// </summary>
+    Debits = 1 << 0,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flagscredits
-        /// </summary>
-        Credits = 1 << 1,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flagscredits
+    /// </summary>
+    Credits = 1 << 1,
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flagsreversed
-        /// </summary>
-        Reversed = 1 << 2,
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flagsreversed
+    /// </summary>
+    Reversed = 1 << 2,
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-    public struct Account
-    {
-        public const int SIZE = 128;
+[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+public struct Account
+{
+    public const int SIZE = 128;
 
-        private UInt128 id;
+    private UInt128 id;
 
-        private UInt128 debitsPending;
+    private UInt128 debitsPending;
 
-        private UInt128 debitsPosted;
+    private UInt128 debitsPosted;
 
-        private UInt128 creditsPending;
+    private UInt128 creditsPending;
 
-        private UInt128 creditsPosted;
+    private UInt128 creditsPosted;
 
-        private UInt128 userData128;
+    private UInt128 userData128;
 
-        private ulong userData64;
+    private ulong userData64;
 
-        private uint userData32;
+    private uint userData32;
 
-        private uint reserved;
+    private uint reserved;
 
-        private uint ledger;
+    private uint ledger;
 
-        private ushort code;
+    private ushort code;
 
-        private AccountFlags flags;
+    private AccountFlags flags;
 
-        private ulong timestamp;
+    private ulong timestamp;
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#id
-        /// </summary>
-        public UInt128 Id { get => id; set => id = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#id
+    /// </summary>
+    public UInt128 Id { get => id; set => id = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#debits_pending
-        /// </summary>
-        public UInt128 DebitsPending { get => debitsPending; internal set => debitsPending = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#debits_pending
+    /// </summary>
+    public UInt128 DebitsPending { get => debitsPending; internal set => debitsPending = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#debits_posted
-        /// </summary>
-        public UInt128 DebitsPosted { get => debitsPosted; internal set => debitsPosted = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#debits_posted
+    /// </summary>
+    public UInt128 DebitsPosted { get => debitsPosted; internal set => debitsPosted = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#credits_pending
-        /// </summary>
-        public UInt128 CreditsPending { get => creditsPending; internal set => creditsPending = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#credits_pending
+    /// </summary>
+    public UInt128 CreditsPending { get => creditsPending; internal set => creditsPending = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#credits_posted
-        /// </summary>
-        public UInt128 CreditsPosted { get => creditsPosted; internal set => creditsPosted = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#credits_posted
+    /// </summary>
+    public UInt128 CreditsPosted { get => creditsPosted; internal set => creditsPosted = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#user_data_128
-        /// </summary>
-        public UInt128 UserData128 { get => userData128; set => userData128 = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#user_data_128
+    /// </summary>
+    public UInt128 UserData128 { get => userData128; set => userData128 = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#user_data_64
-        /// </summary>
-        public ulong UserData64 { get => userData64; set => userData64 = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#user_data_64
+    /// </summary>
+    public ulong UserData64 { get => userData64; set => userData64 = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#user_data_32
-        /// </summary>
-        public uint UserData32 { get => userData32; set => userData32 = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#user_data_32
+    /// </summary>
+    public uint UserData32 { get => userData32; set => userData32 = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#reserved
-        /// </summary>
-        internal uint Reserved { get => reserved; set => reserved = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#reserved
+    /// </summary>
+    internal uint Reserved { get => reserved; set => reserved = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#ledger
-        /// </summary>
-        public uint Ledger { get => ledger; set => ledger = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#ledger
+    /// </summary>
+    public uint Ledger { get => ledger; set => ledger = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#code
-        /// </summary>
-        public ushort Code { get => code; set => code = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#code
+    /// </summary>
+    public ushort Code { get => code; set => code = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#flags
-        /// </summary>
-        public AccountFlags Flags { get => flags; set => flags = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#flags
+    /// </summary>
+    public AccountFlags Flags { get => flags; set => flags = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/accounts/#timestamp
-        /// </summary>
-        public ulong Timestamp { get => timestamp; internal set => timestamp = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/accounts/#timestamp
+    /// </summary>
+    public ulong Timestamp { get => timestamp; internal set => timestamp = value; }
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-    public struct Transfer
-    {
-        public const int SIZE = 128;
+[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+public struct Transfer
+{
+    public const int SIZE = 128;
 
-        private UInt128 id;
+    private UInt128 id;
 
-        private UInt128 debitAccountId;
+    private UInt128 debitAccountId;
 
-        private UInt128 creditAccountId;
+    private UInt128 creditAccountId;
 
-        private UInt128 amount;
+    private UInt128 amount;
 
-        private UInt128 pendingId;
+    private UInt128 pendingId;
 
-        private UInt128 userData128;
+    private UInt128 userData128;
 
-        private ulong userData64;
+    private ulong userData64;
 
-        private uint userData32;
+    private uint userData32;
 
-        private uint timeout;
+    private uint timeout;
 
-        private uint ledger;
+    private uint ledger;
 
-        private ushort code;
+    private ushort code;
 
-        private TransferFlags flags;
+    private TransferFlags flags;
 
-        private ulong timestamp;
+    private ulong timestamp;
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#id
-        /// </summary>
-        public UInt128 Id { get => id; set => id = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#id
+    /// </summary>
+    public UInt128 Id { get => id; set => id = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#debit_account_id
-        /// </summary>
-        public UInt128 DebitAccountId { get => debitAccountId; set => debitAccountId = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#debit_account_id
+    /// </summary>
+    public UInt128 DebitAccountId { get => debitAccountId; set => debitAccountId = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#credit_account_id
-        /// </summary>
-        public UInt128 CreditAccountId { get => creditAccountId; set => creditAccountId = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#credit_account_id
+    /// </summary>
+    public UInt128 CreditAccountId { get => creditAccountId; set => creditAccountId = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#amount
-        /// </summary>
-        public UInt128 Amount { get => amount; set => amount = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#amount
+    /// </summary>
+    public UInt128 Amount { get => amount; set => amount = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#pending_id
-        /// </summary>
-        public UInt128 PendingId { get => pendingId; set => pendingId = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#pending_id
+    /// </summary>
+    public UInt128 PendingId { get => pendingId; set => pendingId = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#user_data_128
-        /// </summary>
-        public UInt128 UserData128 { get => userData128; set => userData128 = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#user_data_128
+    /// </summary>
+    public UInt128 UserData128 { get => userData128; set => userData128 = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#user_data_64
-        /// </summary>
-        public ulong UserData64 { get => userData64; set => userData64 = value; }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#user_data_64
+    /// </summary>
+    public ulong UserData64 { get => userData64; set => userData64 = value; }
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#user_data_32
+    /// </summary>
+    public uint UserData32 { get => userData32; set => userData32 = value; }
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#timeout
+    /// </summary>
+    public uint Timeout { get => timeout; set => timeout = value; }
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#ledger
+    /// </summary>
+    public uint Ledger { get => ledger; set => ledger = value; }
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#code
+    /// </summary>
+    public ushort Code { get => code; set => code = value; }
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#flags
+    /// </summary>
+    public TransferFlags Flags { get => flags; set => flags = value; }
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/transfers/#timestamp
+    /// </summary>
+    public ulong Timestamp { get => timestamp; internal set => timestamp = value; }
+
+}
+
+public enum CreateAccountResult : uint
+{
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#ok
+    /// </summary>
+    Ok = 0,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#linked_event_failed
+    /// </summary>
+    LinkedEventFailed = 1,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#linked_event_chain_open
+    /// </summary>
+    LinkedEventChainOpen = 2,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#timestamp_must_be_zero
+    /// </summary>
+    TimestampMustBeZero = 3,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#reserved_field
+    /// </summary>
+    ReservedField = 4,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#reserved_flag
+    /// </summary>
+    ReservedFlag = 5,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#id_must_not_be_zero
+    /// </summary>
+    IdMustNotBeZero = 6,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#id_must_not_be_int_max
+    /// </summary>
+    IdMustNotBeIntMax = 7,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#flags_are_mutually_exclusive
+    /// </summary>
+    FlagsAreMutuallyExclusive = 8,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#debits_pending_must_be_zero
+    /// </summary>
+    DebitsPendingMustBeZero = 9,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#debits_posted_must_be_zero
+    /// </summary>
+    DebitsPostedMustBeZero = 10,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#credits_pending_must_be_zero
+    /// </summary>
+    CreditsPendingMustBeZero = 11,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#credits_posted_must_be_zero
+    /// </summary>
+    CreditsPostedMustBeZero = 12,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#ledger_must_not_be_zero
+    /// </summary>
+    LedgerMustNotBeZero = 13,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#code_must_not_be_zero
+    /// </summary>
+    CodeMustNotBeZero = 14,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_flags
+    /// </summary>
+    ExistsWithDifferentFlags = 15,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_user_data_128
+    /// </summary>
+    ExistsWithDifferentUserData128 = 16,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_user_data_64
+    /// </summary>
+    ExistsWithDifferentUserData64 = 17,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_user_data_32
+    /// </summary>
+    ExistsWithDifferentUserData32 = 18,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_ledger
+    /// </summary>
+    ExistsWithDifferentLedger = 19,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_code
+    /// </summary>
+    ExistsWithDifferentCode = 20,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists
+    /// </summary>
+    Exists = 21,
+
+}
+
+public enum CreateTransferResult : uint
+{
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#ok
+    /// </summary>
+    Ok = 0,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#linked_event_failed
+    /// </summary>
+    LinkedEventFailed = 1,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#linked_event_chain_open
+    /// </summary>
+    LinkedEventChainOpen = 2,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#timestamp_must_be_zero
+    /// </summary>
+    TimestampMustBeZero = 3,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#reserved_flag
+    /// </summary>
+    ReservedFlag = 4,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#id_must_not_be_zero
+    /// </summary>
+    IdMustNotBeZero = 5,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#id_must_not_be_int_max
+    /// </summary>
+    IdMustNotBeIntMax = 6,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#flags_are_mutually_exclusive
+    /// </summary>
+    FlagsAreMutuallyExclusive = 7,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#debit_account_id_must_not_be_zero
+    /// </summary>
+    DebitAccountIdMustNotBeZero = 8,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#debit_account_id_must_not_be_int_max
+    /// </summary>
+    DebitAccountIdMustNotBeIntMax = 9,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#credit_account_id_must_not_be_zero
+    /// </summary>
+    CreditAccountIdMustNotBeZero = 10,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#credit_account_id_must_not_be_int_max
+    /// </summary>
+    CreditAccountIdMustNotBeIntMax = 11,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#accounts_must_be_different
+    /// </summary>
+    AccountsMustBeDifferent = 12,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_be_zero
+    /// </summary>
+    PendingIdMustBeZero = 13,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_not_be_zero
+    /// </summary>
+    PendingIdMustNotBeZero = 14,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_not_be_int_max
+    /// </summary>
+    PendingIdMustNotBeIntMax = 15,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_be_different
+    /// </summary>
+    PendingIdMustBeDifferent = 16,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#timeout_reserved_for_pending_transfer
+    /// </summary>
+    TimeoutReservedForPendingTransfer = 17,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#amount_must_not_be_zero
+    /// </summary>
+    AmountMustNotBeZero = 18,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#ledger_must_not_be_zero
+    /// </summary>
+    LedgerMustNotBeZero = 19,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#code_must_not_be_zero
+    /// </summary>
+    CodeMustNotBeZero = 20,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#debit_account_not_found
+    /// </summary>
+    DebitAccountNotFound = 21,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#credit_account_not_found
+    /// </summary>
+    CreditAccountNotFound = 22,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#accounts_must_have_the_same_ledger
+    /// </summary>
+    AccountsMustHaveTheSameLedger = 23,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#transfer_must_have_the_same_ledger_as_accounts
+    /// </summary>
+    TransferMustHaveTheSameLedgerAsAccounts = 24,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_not_found
+    /// </summary>
+    PendingTransferNotFound = 25,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_not_pending
+    /// </summary>
+    PendingTransferNotPending = 26,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_debit_account_id
+    /// </summary>
+    PendingTransferHasDifferentDebitAccountId = 27,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_credit_account_id
+    /// </summary>
+    PendingTransferHasDifferentCreditAccountId = 28,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_ledger
+    /// </summary>
+    PendingTransferHasDifferentLedger = 29,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_code
+    /// </summary>
+    PendingTransferHasDifferentCode = 30,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exceeds_pending_transfer_amount
+    /// </summary>
+    ExceedsPendingTransferAmount = 31,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_amount
+    /// </summary>
+    PendingTransferHasDifferentAmount = 32,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_already_posted
+    /// </summary>
+    PendingTransferAlreadyPosted = 33,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_already_voided
+    /// </summary>
+    PendingTransferAlreadyVoided = 34,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_expired
+    /// </summary>
+    PendingTransferExpired = 35,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_flags
+    /// </summary>
+    ExistsWithDifferentFlags = 36,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_debit_account_id
+    /// </summary>
+    ExistsWithDifferentDebitAccountId = 37,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_credit_account_id
+    /// </summary>
+    ExistsWithDifferentCreditAccountId = 38,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_amount
+    /// </summary>
+    ExistsWithDifferentAmount = 39,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_pending_id
+    /// </summary>
+    ExistsWithDifferentPendingId = 40,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_user_data_128
+    /// </summary>
+    ExistsWithDifferentUserData128 = 41,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_user_data_64
+    /// </summary>
+    ExistsWithDifferentUserData64 = 42,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_user_data_32
+    /// </summary>
+    ExistsWithDifferentUserData32 = 43,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_timeout
+    /// </summary>
+    ExistsWithDifferentTimeout = 44,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_code
+    /// </summary>
+    ExistsWithDifferentCode = 45,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists
+    /// </summary>
+    Exists = 46,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_debits_pending
+    /// </summary>
+    OverflowsDebitsPending = 47,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_credits_pending
+    /// </summary>
+    OverflowsCreditsPending = 48,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_debits_posted
+    /// </summary>
+    OverflowsDebitsPosted = 49,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_credits_posted
+    /// </summary>
+    OverflowsCreditsPosted = 50,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_debits
+    /// </summary>
+    OverflowsDebits = 51,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_credits
+    /// </summary>
+    OverflowsCredits = 52,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_timeout
+    /// </summary>
+    OverflowsTimeout = 53,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exceeds_credits
+    /// </summary>
+    ExceedsCredits = 54,
+
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exceeds_debits
+    /// </summary>
+    ExceedsDebits = 55,
+
+}
+
+[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+public struct CreateAccountsResult
+{
+    public const int SIZE = 8;
+
+    private uint index;
+
+    private CreateAccountResult result;
+
+    public uint Index { get => index; set => index = value; }
+
+    public CreateAccountResult Result { get => result; set => result = value; }
+
+}
+
+[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+public struct CreateTransfersResult
+{
+    public const int SIZE = 8;
+
+    private uint index;
+
+    private CreateTransferResult result;
+
+    public uint Index { get => index; set => index = value; }
+
+    public CreateTransferResult Result { get => result; set => result = value; }
+
+}
+
+[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+public struct GetAccountTransfers
+{
+    public const int SIZE = 32;
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#user_data_32
-        /// </summary>
-        public uint UserData32 { get => userData32; set => userData32 = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#timeout
-        /// </summary>
-        public uint Timeout { get => timeout; set => timeout = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#ledger
-        /// </summary>
-        public uint Ledger { get => ledger; set => ledger = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#code
-        /// </summary>
-        public ushort Code { get => code; set => code = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#flags
-        /// </summary>
-        public TransferFlags Flags { get => flags; set => flags = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/transfers/#timestamp
-        /// </summary>
-        public ulong Timestamp { get => timestamp; internal set => timestamp = value; }
-
-    }
-
-    public enum CreateAccountResult : uint
-    {
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#ok
-        /// </summary>
-        Ok = 0,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#linked_event_failed
-        /// </summary>
-        LinkedEventFailed = 1,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#linked_event_chain_open
-        /// </summary>
-        LinkedEventChainOpen = 2,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#timestamp_must_be_zero
-        /// </summary>
-        TimestampMustBeZero = 3,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#reserved_field
-        /// </summary>
-        ReservedField = 4,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#reserved_flag
-        /// </summary>
-        ReservedFlag = 5,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#id_must_not_be_zero
-        /// </summary>
-        IdMustNotBeZero = 6,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#id_must_not_be_int_max
-        /// </summary>
-        IdMustNotBeIntMax = 7,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#flags_are_mutually_exclusive
-        /// </summary>
-        FlagsAreMutuallyExclusive = 8,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#debits_pending_must_be_zero
-        /// </summary>
-        DebitsPendingMustBeZero = 9,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#debits_posted_must_be_zero
-        /// </summary>
-        DebitsPostedMustBeZero = 10,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#credits_pending_must_be_zero
-        /// </summary>
-        CreditsPendingMustBeZero = 11,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#credits_posted_must_be_zero
-        /// </summary>
-        CreditsPostedMustBeZero = 12,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#ledger_must_not_be_zero
-        /// </summary>
-        LedgerMustNotBeZero = 13,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#code_must_not_be_zero
-        /// </summary>
-        CodeMustNotBeZero = 14,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_flags
-        /// </summary>
-        ExistsWithDifferentFlags = 15,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_user_data_128
-        /// </summary>
-        ExistsWithDifferentUserData128 = 16,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_user_data_64
-        /// </summary>
-        ExistsWithDifferentUserData64 = 17,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_user_data_32
-        /// </summary>
-        ExistsWithDifferentUserData32 = 18,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_ledger
-        /// </summary>
-        ExistsWithDifferentLedger = 19,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists_with_different_code
-        /// </summary>
-        ExistsWithDifferentCode = 20,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_accounts#exists
-        /// </summary>
-        Exists = 21,
-
-    }
-
-    public enum CreateTransferResult : uint
-    {
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#ok
-        /// </summary>
-        Ok = 0,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#linked_event_failed
-        /// </summary>
-        LinkedEventFailed = 1,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#linked_event_chain_open
-        /// </summary>
-        LinkedEventChainOpen = 2,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#timestamp_must_be_zero
-        /// </summary>
-        TimestampMustBeZero = 3,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#reserved_flag
-        /// </summary>
-        ReservedFlag = 4,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#id_must_not_be_zero
-        /// </summary>
-        IdMustNotBeZero = 5,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#id_must_not_be_int_max
-        /// </summary>
-        IdMustNotBeIntMax = 6,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#flags_are_mutually_exclusive
-        /// </summary>
-        FlagsAreMutuallyExclusive = 7,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#debit_account_id_must_not_be_zero
-        /// </summary>
-        DebitAccountIdMustNotBeZero = 8,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#debit_account_id_must_not_be_int_max
-        /// </summary>
-        DebitAccountIdMustNotBeIntMax = 9,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#credit_account_id_must_not_be_zero
-        /// </summary>
-        CreditAccountIdMustNotBeZero = 10,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#credit_account_id_must_not_be_int_max
-        /// </summary>
-        CreditAccountIdMustNotBeIntMax = 11,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#accounts_must_be_different
-        /// </summary>
-        AccountsMustBeDifferent = 12,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_be_zero
-        /// </summary>
-        PendingIdMustBeZero = 13,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_not_be_zero
-        /// </summary>
-        PendingIdMustNotBeZero = 14,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_not_be_int_max
-        /// </summary>
-        PendingIdMustNotBeIntMax = 15,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_id_must_be_different
-        /// </summary>
-        PendingIdMustBeDifferent = 16,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#timeout_reserved_for_pending_transfer
-        /// </summary>
-        TimeoutReservedForPendingTransfer = 17,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#amount_must_not_be_zero
-        /// </summary>
-        AmountMustNotBeZero = 18,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#ledger_must_not_be_zero
-        /// </summary>
-        LedgerMustNotBeZero = 19,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#code_must_not_be_zero
-        /// </summary>
-        CodeMustNotBeZero = 20,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#debit_account_not_found
-        /// </summary>
-        DebitAccountNotFound = 21,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#credit_account_not_found
-        /// </summary>
-        CreditAccountNotFound = 22,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#accounts_must_have_the_same_ledger
-        /// </summary>
-        AccountsMustHaveTheSameLedger = 23,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#transfer_must_have_the_same_ledger_as_accounts
-        /// </summary>
-        TransferMustHaveTheSameLedgerAsAccounts = 24,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_not_found
-        /// </summary>
-        PendingTransferNotFound = 25,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_not_pending
-        /// </summary>
-        PendingTransferNotPending = 26,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_debit_account_id
-        /// </summary>
-        PendingTransferHasDifferentDebitAccountId = 27,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_credit_account_id
-        /// </summary>
-        PendingTransferHasDifferentCreditAccountId = 28,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_ledger
-        /// </summary>
-        PendingTransferHasDifferentLedger = 29,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_code
-        /// </summary>
-        PendingTransferHasDifferentCode = 30,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exceeds_pending_transfer_amount
-        /// </summary>
-        ExceedsPendingTransferAmount = 31,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_has_different_amount
-        /// </summary>
-        PendingTransferHasDifferentAmount = 32,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_already_posted
-        /// </summary>
-        PendingTransferAlreadyPosted = 33,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_already_voided
-        /// </summary>
-        PendingTransferAlreadyVoided = 34,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#pending_transfer_expired
-        /// </summary>
-        PendingTransferExpired = 35,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_flags
-        /// </summary>
-        ExistsWithDifferentFlags = 36,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_debit_account_id
-        /// </summary>
-        ExistsWithDifferentDebitAccountId = 37,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_credit_account_id
-        /// </summary>
-        ExistsWithDifferentCreditAccountId = 38,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_amount
-        /// </summary>
-        ExistsWithDifferentAmount = 39,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_pending_id
-        /// </summary>
-        ExistsWithDifferentPendingId = 40,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_user_data_128
-        /// </summary>
-        ExistsWithDifferentUserData128 = 41,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_user_data_64
-        /// </summary>
-        ExistsWithDifferentUserData64 = 42,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_user_data_32
-        /// </summary>
-        ExistsWithDifferentUserData32 = 43,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_timeout
-        /// </summary>
-        ExistsWithDifferentTimeout = 44,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists_with_different_code
-        /// </summary>
-        ExistsWithDifferentCode = 45,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exists
-        /// </summary>
-        Exists = 46,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_debits_pending
-        /// </summary>
-        OverflowsDebitsPending = 47,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_credits_pending
-        /// </summary>
-        OverflowsCreditsPending = 48,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_debits_posted
-        /// </summary>
-        OverflowsDebitsPosted = 49,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_credits_posted
-        /// </summary>
-        OverflowsCreditsPosted = 50,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_debits
-        /// </summary>
-        OverflowsDebits = 51,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_credits
-        /// </summary>
-        OverflowsCredits = 52,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#overflows_timeout
-        /// </summary>
-        OverflowsTimeout = 53,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exceeds_credits
-        /// </summary>
-        ExceedsCredits = 54,
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/create_transfers#exceeds_debits
-        /// </summary>
-        ExceedsDebits = 55,
-
-    }
-
-    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-    public struct CreateAccountsResult
-    {
-        public const int SIZE = 8;
-
-        private uint index;
-
-        private CreateAccountResult result;
-
-        public uint Index { get => index; set => index = value; }
-
-        public CreateAccountResult Result { get => result; set => result = value; }
-
-    }
-
-    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-    public struct CreateTransfersResult
-    {
-        public const int SIZE = 8;
-
-        private uint index;
+    private UInt128 accountId;
 
-        private CreateTransferResult result;
-
-        public uint Index { get => index; set => index = value; }
-
-        public CreateTransferResult Result { get => result; set => result = value; }
-
-    }
+    private ulong timestamp;
 
-    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-    public struct GetAccountTransfers
-    {
-        public const int SIZE = 32;
+    private uint limit;
 
-        private UInt128 accountId;
+    private GetAccountTransfersFlags flags;
 
-        private ulong timestamp;
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#account_id
+    /// </summary>
+    public UInt128 AccountId { get => accountId; set => accountId = value; }
 
-        private uint limit;
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#timestamp
+    /// </summary>
+    public ulong Timestamp { get => timestamp; set => timestamp = value; }
 
-        private GetAccountTransfersFlags flags;
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#limit
+    /// </summary>
+    public uint Limit { get => limit; set => limit = value; }
 
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#account_id
-        /// </summary>
-        public UInt128 AccountId { get => accountId; set => accountId = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#timestamp
-        /// </summary>
-        public ulong Timestamp { get => timestamp; set => timestamp = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#limit
-        /// </summary>
-        public uint Limit { get => limit; set => limit = value; }
-
-        /// <summary>
-        /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flags
-        /// </summary>
-        public GetAccountTransfersFlags Flags { get => flags; set => flags = value; }
-
-    }
-
-    public enum InitializationStatus : uint
-    {
-        Success = 0,
-
-        Unexpected = 1,
-
-        OutOfMemory = 2,
-
-        AddressInvalid = 3,
-
-        AddressLimitExceeded = 4,
-
-        ConcurrencyMaxInvalid = 5,
-
-        SystemResources = 6,
-
-        NetworkSubsystem = 7,
-
-    }
-
-    public enum PacketStatus : byte
-    {
-        Ok = 0,
-
-        TooMuchData = 1,
-
-        InvalidOperation = 2,
-
-        InvalidDataSize = 3,
-
-    }
-
-    internal enum PacketAcquireStatus : uint
-    {
-        Ok = 0,
-
-        ConcurrencyMaxExceeded = 1,
-
-        Shutdown = 2,
-
-    }
-
-    internal enum TBOperation : byte
-    {
-        CreateAccounts = 128,
-
-        CreateTransfers = 129,
-
-        LookupAccounts = 130,
-
-        LookupTransfers = 131,
-
-        GetAccountTransfers = 132,
-
-    }
-
-    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-    internal unsafe struct TBPacket
-    {
-        public const int SIZE = 32;
-
-        public TBPacket* next;
-
-        public IntPtr userData;
-
-        public byte operation;
-
-        public PacketStatus status;
-
-        public uint dataSize;
-
-        public IntPtr data;
-
-    }
-
-    internal static class TBClient
-    {
-        private const string LIB_NAME = "tb_client";
-
-        // Uses either the new function pointer by value, or the old managed delegate in .Net standard
-        // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
-
-#if NETSTANDARD
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public unsafe delegate void OnCompletionFn(IntPtr ctx, IntPtr client, TBPacket* packet, byte* result, uint result_len);
-#endif
-
-        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern InitializationStatus tb_client_init(
-            IntPtr* out_client,
-            UInt128Extensions.UnsafeU128 cluster_id,
-            byte* address_ptr,
-            uint address_len,
-            uint num_packets,
-            IntPtr on_completion_ctx,
-
-#if NETSTANDARD
-            [MarshalAs(UnmanagedType.FunctionPtr)]
-            OnCompletionFn on_completion_fn
-#else
-            delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
-#endif
-        );
-
-        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern InitializationStatus tb_client_init_echo(
-            IntPtr* out_client,
-            UInt128Extensions.UnsafeU128 cluster_id,
-            byte* address_ptr,
-            uint address_len,
-            uint num_packets,
-            IntPtr on_completion_ctx,
-
-#if NETSTANDARD
-            [MarshalAs(UnmanagedType.FunctionPtr)]
-            OnCompletionFn on_completion_fn
-#else
-            delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
-#endif
-        );
-
-        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern PacketAcquireStatus tb_client_acquire_packet(
-            IntPtr client,
-            TBPacket** out_packet
-        );
-
-        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern void tb_client_release_packet(
-            IntPtr client,
-            TBPacket* packet
-        );
-
-        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern void tb_client_submit(
-            IntPtr client,
-            TBPacket* packet
-        );
-
-        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern void tb_client_deinit(
-            IntPtr client
-        );
-    }
+    /// <summary>
+    /// https://docs.tigerbeetle.com/reference/operations/get_account_transfers#flags
+    /// </summary>
+    public GetAccountTransfersFlags Flags { get => flags; set => flags = value; }
+
+}
+
+public enum InitializationStatus : uint
+{
+    Success = 0,
+
+    Unexpected = 1,
+
+    OutOfMemory = 2,
+
+    AddressInvalid = 3,
+
+    AddressLimitExceeded = 4,
+
+    ConcurrencyMaxInvalid = 5,
+
+    SystemResources = 6,
+
+    NetworkSubsystem = 7,
+
+}
+
+public enum PacketStatus : byte
+{
+    Ok = 0,
+
+    TooMuchData = 1,
+
+    InvalidOperation = 2,
+
+    InvalidDataSize = 3,
+
+}
+
+internal enum PacketAcquireStatus : uint
+{
+    Ok = 0,
+
+    ConcurrencyMaxExceeded = 1,
+
+    Shutdown = 2,
+
+}
+
+internal enum TBOperation : byte
+{
+    CreateAccounts = 128,
+
+    CreateTransfers = 129,
+
+    LookupAccounts = 130,
+
+    LookupTransfers = 131,
+
+    GetAccountTransfers = 132,
+
+}
+
+[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+internal unsafe struct TBPacket
+{
+    public const int SIZE = 32;
+
+    public TBPacket* next;
+
+    public IntPtr userData;
+
+    public byte operation;
+
+    public PacketStatus status;
+
+    public uint dataSize;
+
+    public IntPtr data;
+
+}
+
+internal static class TBClient
+{
+    private const string LIB_NAME = "tb_client";
+
+    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern InitializationStatus tb_client_init(
+        IntPtr* out_client,
+        UInt128Extensions.UnsafeU128 cluster_id,
+        byte* address_ptr,
+        uint address_len,
+        uint num_packets,
+        IntPtr on_completion_ctx,
+        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+    );
+
+    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern InitializationStatus tb_client_init_echo(
+        IntPtr* out_client,
+        UInt128Extensions.UnsafeU128 cluster_id,
+        byte* address_ptr,
+        uint address_len,
+        uint num_packets,
+        IntPtr on_completion_ctx,
+        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+    );
+
+    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern PacketAcquireStatus tb_client_acquire_packet(
+        IntPtr client,
+        TBPacket** out_packet
+    );
+
+    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern void tb_client_release_packet(
+        IntPtr client,
+        TBPacket* packet
+    );
+
+    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern void tb_client_submit(
+        IntPtr client,
+        TBPacket* packet
+    );
+
+    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern void tb_client_deinit(
+        IntPtr client
+    );
 }
 

--- a/src/clients/dotnet/TigerBeetle/Client.cs
+++ b/src/clients/dotnet/TigerBeetle/Client.cs
@@ -5,141 +5,140 @@ using System.Threading.Tasks;
 
 [assembly: InternalsVisibleTo("TigerBeetle.Tests")]
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+public sealed class Client : IDisposable
 {
-    public sealed class Client : IDisposable
+    private const int DEFAULT_CONCURRENCY_MAX = 256; // arbitrary
+
+    private readonly UInt128 clusterID;
+    private readonly NativeClient nativeClient;
+
+    public Client(UInt128 clusterID, string[] addresses, int concurrencyMax = DEFAULT_CONCURRENCY_MAX)
     {
-        private const int DEFAULT_CONCURRENCY_MAX = 256; // arbitrary
+        this.nativeClient = NativeClient.Init(clusterID, addresses, concurrencyMax);
+        this.clusterID = clusterID;
+    }
 
-        private readonly UInt128 clusterID;
-        private readonly NativeClient nativeClient;
-
-        public Client(UInt128 clusterID, string[] addresses, int concurrencyMax = DEFAULT_CONCURRENCY_MAX)
+    ~Client()
+    {
+        // NativeClient can be null if the constructor threw an exception.
+        if (nativeClient != null)
         {
-            this.nativeClient = NativeClient.Init(clusterID, addresses, concurrencyMax);
-            this.clusterID = clusterID;
+            Dispose(disposing: false);
         }
+    }
 
-        ~Client()
-        {
-            // NativeClient can be null if the constructor threw an exception.
-            if (nativeClient != null)
-            {
-                Dispose(disposing: false);
-            }
-        }
+    public UInt128 ClusterID => clusterID;
 
-        public UInt128 ClusterID => clusterID;
+    public CreateAccountResult CreateAccount(Account account)
+    {
+        var ret = nativeClient.CallRequest<CreateAccountsResult, Account>(TBOperation.CreateAccounts, new[] { account });
+        return ret.Length == 0 ? CreateAccountResult.Ok : ret[0].Result;
+    }
 
-        public CreateAccountResult CreateAccount(Account account)
-        {
-            var ret = nativeClient.CallRequest<CreateAccountsResult, Account>(TBOperation.CreateAccounts, new[] { account });
-            return ret.Length == 0 ? CreateAccountResult.Ok : ret[0].Result;
-        }
+    public CreateAccountsResult[] CreateAccounts(Account[] batch)
+    {
+        return nativeClient.CallRequest<CreateAccountsResult, Account>(TBOperation.CreateAccounts, batch);
+    }
 
-        public CreateAccountsResult[] CreateAccounts(Account[] batch)
-        {
-            return nativeClient.CallRequest<CreateAccountsResult, Account>(TBOperation.CreateAccounts, batch);
-        }
+    public Task<CreateAccountResult> CreateAccountAsync(Account account)
+    {
+        return nativeClient.CallRequestAsync<CreateAccountsResult, Account>(TBOperation.CreateAccounts, new[] { account })
+        .ContinueWith(x => x.Result.Length == 0 ? CreateAccountResult.Ok : x.Result[0].Result);
+    }
 
-        public Task<CreateAccountResult> CreateAccountAsync(Account account)
-        {
-            return nativeClient.CallRequestAsync<CreateAccountsResult, Account>(TBOperation.CreateAccounts, new[] { account })
-            .ContinueWith(x => x.Result.Length == 0 ? CreateAccountResult.Ok : x.Result[0].Result);
-        }
+    public Task<CreateAccountsResult[]> CreateAccountsAsync(Account[] batch)
+    {
+        return nativeClient.CallRequestAsync<CreateAccountsResult, Account>(TBOperation.CreateAccounts, batch);
+    }
 
-        public Task<CreateAccountsResult[]> CreateAccountsAsync(Account[] batch)
-        {
-            return nativeClient.CallRequestAsync<CreateAccountsResult, Account>(TBOperation.CreateAccounts, batch);
-        }
+    public CreateTransferResult CreateTransfer(Transfer transfer)
+    {
+        var ret = nativeClient.CallRequest<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, new[] { transfer });
+        return ret.Length == 0 ? CreateTransferResult.Ok : ret[0].Result;
+    }
 
-        public CreateTransferResult CreateTransfer(Transfer transfer)
-        {
-            var ret = nativeClient.CallRequest<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, new[] { transfer });
-            return ret.Length == 0 ? CreateTransferResult.Ok : ret[0].Result;
-        }
+    public CreateTransfersResult[] CreateTransfers(Transfer[] batch)
+    {
+        return nativeClient.CallRequest<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, batch);
+    }
 
-        public CreateTransfersResult[] CreateTransfers(Transfer[] batch)
-        {
-            return nativeClient.CallRequest<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, batch);
-        }
+    public Task<CreateTransferResult> CreateTransferAsync(Transfer transfer)
+    {
+        return nativeClient.CallRequestAsync<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, new[] { transfer })
+        .ContinueWith(x => x.Result.Length == 0 ? CreateTransferResult.Ok : x.Result[0].Result);
+    }
 
-        public Task<CreateTransferResult> CreateTransferAsync(Transfer transfer)
-        {
-            return nativeClient.CallRequestAsync<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, new[] { transfer })
-            .ContinueWith(x => x.Result.Length == 0 ? CreateTransferResult.Ok : x.Result[0].Result);
-        }
+    public Task<CreateTransfersResult[]> CreateTransfersAsync(Transfer[] batch)
+    {
+        return nativeClient.CallRequestAsync<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, batch);
+    }
 
-        public Task<CreateTransfersResult[]> CreateTransfersAsync(Transfer[] batch)
-        {
-            return nativeClient.CallRequestAsync<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, batch);
-        }
+    public Account? LookupAccount(UInt128 id)
+    {
+        var ret = nativeClient.CallRequest<Account, UInt128>(TBOperation.LookupAccounts, new[] { id });
+        return ret.Length == 0 ? null : ret[0];
+    }
 
-        public Account? LookupAccount(UInt128 id)
-        {
-            var ret = nativeClient.CallRequest<Account, UInt128>(TBOperation.LookupAccounts, new[] { id });
-            return ret.Length == 0 ? null : ret[0];
-        }
+    public Account[] LookupAccounts(UInt128[] ids)
+    {
+        return nativeClient.CallRequest<Account, UInt128>(TBOperation.LookupAccounts, ids);
+    }
 
-        public Account[] LookupAccounts(UInt128[] ids)
-        {
-            return nativeClient.CallRequest<Account, UInt128>(TBOperation.LookupAccounts, ids);
-        }
+    public Task<Account?> LookupAccountAsync(UInt128 id)
+    {
+        return nativeClient.CallRequestAsync<Account, UInt128>(TBOperation.LookupAccounts, new[] { id })
+        .ContinueWith(x => x.Result.Length == 0 ? (Account?)null : x.Result[0]);
+    }
 
-        public Task<Account?> LookupAccountAsync(UInt128 id)
-        {
-            return nativeClient.CallRequestAsync<Account, UInt128>(TBOperation.LookupAccounts, new[] { id })
-            .ContinueWith(x => x.Result.Length == 0 ? (Account?)null : x.Result[0]);
-        }
+    public Task<Account[]> LookupAccountsAsync(UInt128[] ids)
+    {
+        return nativeClient.CallRequestAsync<Account, UInt128>(TBOperation.LookupAccounts, ids);
+    }
 
-        public Task<Account[]> LookupAccountsAsync(UInt128[] ids)
-        {
-            return nativeClient.CallRequestAsync<Account, UInt128>(TBOperation.LookupAccounts, ids);
-        }
+    public Transfer? LookupTransfer(UInt128 id)
+    {
+        var ret = nativeClient.CallRequest<Transfer, UInt128>(TBOperation.LookupTransfers, new[] { id });
+        return ret.Length == 0 ? null : ret[0];
+    }
 
-        public Transfer? LookupTransfer(UInt128 id)
-        {
-            var ret = nativeClient.CallRequest<Transfer, UInt128>(TBOperation.LookupTransfers, new[] { id });
-            return ret.Length == 0 ? null : ret[0];
-        }
+    public Transfer[] LookupTransfers(UInt128[] ids)
+    {
+        return nativeClient.CallRequest<Transfer, UInt128>(TBOperation.LookupTransfers, ids);
+    }
 
-        public Transfer[] LookupTransfers(UInt128[] ids)
-        {
-            return nativeClient.CallRequest<Transfer, UInt128>(TBOperation.LookupTransfers, ids);
-        }
+    public Task<Transfer?> LookupTransferAsync(UInt128 id)
+    {
+        return nativeClient.CallRequestAsync<Transfer, UInt128>(TBOperation.LookupTransfers, new[] { id })
+        .ContinueWith(x => x.Result.Length == 0 ? (Transfer?)null : x.Result[0]);
+    }
 
-        public Task<Transfer?> LookupTransferAsync(UInt128 id)
-        {
-            return nativeClient.CallRequestAsync<Transfer, UInt128>(TBOperation.LookupTransfers, new[] { id })
-            .ContinueWith(x => x.Result.Length == 0 ? (Transfer?)null : x.Result[0]);
-        }
+    public Task<Transfer[]> LookupTransfersAsync(UInt128[] ids)
+    {
+        return nativeClient.CallRequestAsync<Transfer, UInt128>(TBOperation.LookupTransfers, ids);
+    }
 
-        public Task<Transfer[]> LookupTransfersAsync(UInt128[] ids)
-        {
-            return nativeClient.CallRequestAsync<Transfer, UInt128>(TBOperation.LookupTransfers, ids);
-        }
+    public Transfer[] GetAccountTransfers(GetAccountTransfers filter)
+    {
+        return nativeClient.CallRequest<Transfer, GetAccountTransfers>(TBOperation.GetAccountTransfers, new[] { filter });
+    }
 
-        public Transfer[] GetAccountTransfers(GetAccountTransfers filter)
-        {
-            return nativeClient.CallRequest<Transfer, GetAccountTransfers>(TBOperation.GetAccountTransfers, new[] { filter });
-        }
-
-        public Task<Transfer[]> GetAccountTransfersAsync(GetAccountTransfers filter)
-        {
-            return nativeClient.CallRequestAsync<Transfer, GetAccountTransfers>(TBOperation.GetAccountTransfers, new[] { filter });
-        }
+    public Task<Transfer[]> GetAccountTransfersAsync(GetAccountTransfers filter)
+    {
+        return nativeClient.CallRequestAsync<Transfer, GetAccountTransfers>(TBOperation.GetAccountTransfers, new[] { filter });
+    }
 
 
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-            Dispose(disposing: true);
-        }
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        Dispose(disposing: true);
+    }
 
-        private void Dispose(bool disposing)
-        {
-            _ = disposing;
-            nativeClient.Dispose();
-        }
+    private void Dispose(bool disposing)
+    {
+        _ = disposing;
+        nativeClient.Dispose();
     }
 }

--- a/src/clients/dotnet/TigerBeetle/ConcurrencyExceededException.cs
+++ b/src/clients/dotnet/TigerBeetle/ConcurrencyExceededException.cs
@@ -1,19 +1,18 @@
 using System;
 
-namespace TigerBeetle
-{
-    public sealed class ConcurrencyExceededException : Exception
-    {
-        internal ConcurrencyExceededException()
-        {
-        }
+namespace TigerBeetle;
 
-        public override string Message
+public sealed class ConcurrencyExceededException : Exception
+{
+    internal ConcurrencyExceededException()
+    {
+    }
+
+    public override string Message
+    {
+        get
         {
-            get
-            {
-                return "The maximum configured concurrency for the client has been exceeded.";
-            }
+            return "The maximum configured concurrency for the client has been exceeded.";
         }
     }
 }

--- a/src/clients/dotnet/TigerBeetle/EchoClient.cs
+++ b/src/clients/dotnet/TigerBeetle/EchoClient.cs
@@ -2,47 +2,46 @@ using System;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+internal sealed class EchoClient : IDisposable
 {
-    internal sealed class EchoClient : IDisposable
+    private readonly NativeClient nativeClient;
+
+    public EchoClient(UInt128 clusterID, string[] addresses, int concurrencyMax)
     {
-        private readonly NativeClient nativeClient;
+        this.nativeClient = NativeClient.InitEcho(clusterID, addresses, concurrencyMax);
+    }
 
-        public EchoClient(UInt128 clusterID, string[] addresses, int concurrencyMax)
-        {
-            this.nativeClient = NativeClient.InitEcho(clusterID, addresses, concurrencyMax);
-        }
+    public Account[] Echo(Account[] batch)
+    {
+        return nativeClient.CallRequest<Account, Account>(TBOperation.CreateAccounts, batch);
+    }
 
-        public Account[] Echo(Account[] batch)
-        {
-            return nativeClient.CallRequest<Account, Account>(TBOperation.CreateAccounts, batch);
-        }
+    public Task<Account[]> EchoAsync(Account[] batch)
+    {
+        return nativeClient.CallRequestAsync<Account, Account>(TBOperation.CreateAccounts, batch);
+    }
 
-        public Task<Account[]> EchoAsync(Account[] batch)
-        {
-            return nativeClient.CallRequestAsync<Account, Account>(TBOperation.CreateAccounts, batch);
-        }
+    public Transfer[] Echo(Transfer[] batch)
+    {
+        return nativeClient.CallRequest<Transfer, Transfer>(TBOperation.CreateTransfers, batch);
+    }
 
-        public Transfer[] Echo(Transfer[] batch)
-        {
-            return nativeClient.CallRequest<Transfer, Transfer>(TBOperation.CreateTransfers, batch);
-        }
+    public Task<Transfer[]> EchoAsync(Transfer[] batch)
+    {
+        return nativeClient.CallRequestAsync<Transfer, Transfer>(TBOperation.CreateTransfers, batch);
+    }
 
-        public Task<Transfer[]> EchoAsync(Transfer[] batch)
-        {
-            return nativeClient.CallRequestAsync<Transfer, Transfer>(TBOperation.CreateTransfers, batch);
-        }
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        Dispose(disposing: true);
+    }
 
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-            Dispose(disposing: true);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            _ = disposing;
-            nativeClient.Dispose();
-        }
+    private void Dispose(bool disposing)
+    {
+        _ = disposing;
+        nativeClient.Dispose();
     }
 }

--- a/src/clients/dotnet/TigerBeetle/InitializationException.cs
+++ b/src/clients/dotnet/TigerBeetle/InitializationException.cs
@@ -1,31 +1,30 @@
 using System;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+public sealed class InitializationException : Exception
 {
-    public sealed class InitializationException : Exception
+    public InitializationStatus Status { get; }
+
+    internal InitializationException(InitializationStatus status)
     {
-        public InitializationStatus Status { get; }
+        Status = status;
+    }
 
-        internal InitializationException(InitializationStatus status)
+    public override string Message
+    {
+        get
         {
-            Status = status;
-        }
-
-        public override string Message
-        {
-            get
+            switch (Status)
             {
-                switch (Status)
-                {
-                    case InitializationStatus.Unexpected: return "Unexpected internal error";
-                    case InitializationStatus.OutOfMemory: return "Internal client ran out of memory";
-                    case InitializationStatus.AddressInvalid: return "Replica addresses format is invalid";
-                    case InitializationStatus.AddressLimitExceeded: return "Replica addresses limit exceeded";
-                    case InitializationStatus.ConcurrencyMaxInvalid: return "Invalid concurrencyMax";
-                    case InitializationStatus.SystemResources: return "Internal client ran out of system resources";
-                    case InitializationStatus.NetworkSubsystem: return "Internal client had unexpected networking issues";
-                    default: return "Unknown error status " + Status;
-                }
+                case InitializationStatus.Unexpected: return "Unexpected internal error";
+                case InitializationStatus.OutOfMemory: return "Internal client ran out of memory";
+                case InitializationStatus.AddressInvalid: return "Replica addresses format is invalid";
+                case InitializationStatus.AddressLimitExceeded: return "Replica addresses limit exceeded";
+                case InitializationStatus.ConcurrencyMaxInvalid: return "Invalid concurrencyMax";
+                case InitializationStatus.SystemResources: return "Internal client ran out of system resources";
+                case InitializationStatus.NetworkSubsystem: return "Internal client had unexpected networking issues";
+                default: return "Unknown error status " + Status;
             }
         }
     }

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -6,165 +6,164 @@ using System.Threading.Tasks;
 using static TigerBeetle.AssertionException;
 using static TigerBeetle.TBClient;
 
-namespace TigerBeetle
-{
-    internal sealed class NativeClient : IDisposable
-    {
-        private volatile IntPtr client;
+namespace TigerBeetle;
 
-        private unsafe delegate InitializationStatus InitFunction(
-                    IntPtr* out_client,
-                    UInt128Extensions.UnsafeU128 cluster_id,
-                    byte* address_ptr,
-                    uint address_len,
-                    uint num_packets,
-                    IntPtr on_completion_ctx,
-                    delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+internal sealed class NativeClient : IDisposable
+{
+    private volatile IntPtr client;
+
+    private unsafe delegate InitializationStatus InitFunction(
+                IntPtr* out_client,
+                UInt128Extensions.UnsafeU128 cluster_id,
+                byte* address_ptr,
+                uint address_len,
+                uint num_packets,
+                IntPtr on_completion_ctx,
+                delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+            );
+
+
+    private NativeClient(IntPtr client)
+    {
+        this.client = client;
+    }
+
+    private static byte[] GetBytes(string[] addresses)
+    {
+        if (addresses == null) throw new ArgumentNullException(nameof(addresses));
+        return Encoding.UTF8.GetBytes(string.Join(',', addresses) + "\0");
+    }
+
+    public static NativeClient Init(UInt128 clusterID, string[] addresses, int concurrencyMax)
+    {
+        unsafe
+        {
+            return CallInit(tb_client_init, clusterID, addresses, concurrencyMax);
+        }
+    }
+
+    public static NativeClient InitEcho(UInt128 clusterID, string[] addresses, int concurrencyMax)
+    {
+        unsafe
+        {
+            return CallInit(tb_client_init_echo, clusterID, addresses, concurrencyMax);
+        }
+    }
+
+    private static NativeClient CallInit(InitFunction initFunction, UInt128Extensions.UnsafeU128 clusterID, string[] addresses, int concurrencyMax)
+    {
+        if (concurrencyMax <= 0) throw new ArgumentOutOfRangeException(nameof(concurrencyMax), "Concurrency must be positive");
+
+        var addresses_byte = GetBytes(addresses);
+        unsafe
+        {
+            fixed (byte* addressPtr = addresses_byte)
+            {
+                IntPtr handle;
+
+                var status = initFunction(
+                    &handle,
+                    clusterID,
+                    addressPtr,
+                    (uint)addresses_byte.Length - 1,
+                    (uint)concurrencyMax,
+                    IntPtr.Zero,
+                    &OnCompletionCallback
                 );
 
-
-        private NativeClient(IntPtr client)
-        {
-            this.client = client;
-        }
-
-        private static byte[] GetBytes(string[] addresses)
-        {
-            if (addresses == null) throw new ArgumentNullException(nameof(addresses));
-            return Encoding.UTF8.GetBytes(string.Join(',', addresses) + "\0");
-        }
-
-        public static NativeClient Init(UInt128 clusterID, string[] addresses, int concurrencyMax)
-        {
-            unsafe
-            {
-                return CallInit(tb_client_init, clusterID, addresses, concurrencyMax);
+                if (status != InitializationStatus.Success) throw new InitializationException(status);
+                return new NativeClient(handle);
             }
         }
+    }
 
-        public static NativeClient InitEcho(UInt128 clusterID, string[] addresses, int concurrencyMax)
+    public TResult[] CallRequest<TResult, TBody>(TBOperation operation, TBody[] batch)
+        where TResult : unmanaged
+        where TBody : unmanaged
+    {
+        var blockingRequest = new BlockingRequest<TResult, TBody>(this, operation);
+        blockingRequest.Submit(batch);
+        return blockingRequest.Wait();
+    }
+
+    public async Task<TResult[]> CallRequestAsync<TResult, TBody>(TBOperation operation, TBody[] batch)
+        where TResult : unmanaged
+        where TBody : unmanaged
+    {
+        var asyncRequest = new AsyncRequest<TResult, TBody>(this, operation);
+        asyncRequest.Submit(batch);
+        return await asyncRequest.Wait().ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    public void ReleasePacket(Packet packet)
+    {
+        unsafe
         {
-            unsafe
+            // It is unexpected for the client to be disposed here
+            // Since we wait for all acquired packets to be submitted and returned before disposing.
+            AssertTrue(client != IntPtr.Zero, "Client is closed");
+            AssertTrue(packet.Pointer != null, "Null packet pointer");
+            tb_client_release_packet(client, packet.Pointer);
+        }
+    }
+
+    public void Submit(Packet packet)
+    {
+        unsafe
+        {
+            // It is unexpected for the client to be disposed here
+            // Since we wait for all acquired packets to be submitted and returned before disposing.
+            AssertTrue(client != IntPtr.Zero, "Client is closed");
+            tb_client_submit(client, packet.Pointer);
+        }
+    }
+
+    public Packet AcquirePacket()
+    {
+        unsafe
+        {
+            if (client == IntPtr.Zero) throw new ObjectDisposedException("Client is closed");
+
+            TBPacket* packet;
+            var status = tb_client_acquire_packet(client, &packet);
+            switch (status)
             {
-                return CallInit(tb_client_init_echo, clusterID, addresses, concurrencyMax);
+                case PacketAcquireStatus.Ok:
+                    AssertTrue(packet != null);
+                    return new Packet(packet);
+                case PacketAcquireStatus.ConcurrencyMaxExceeded:
+                    throw new ConcurrencyExceededException();
+                case PacketAcquireStatus.Shutdown:
+                    throw new ObjectDisposedException("Client is closing");
+                default:
+                    throw new NotImplementedException();
             }
         }
+    }
 
-        private static NativeClient CallInit(InitFunction initFunction, UInt128Extensions.UnsafeU128 clusterID, string[] addresses, int concurrencyMax)
+    public void Dispose()
+    {
+        if (client != IntPtr.Zero)
         {
-            if (concurrencyMax <= 0) throw new ArgumentOutOfRangeException(nameof(concurrencyMax), "Concurrency must be positive");
-
-            var addresses_byte = GetBytes(addresses);
-            unsafe
+            lock (this)
             {
-                fixed (byte* addressPtr = addresses_byte)
+                if (client != IntPtr.Zero)
                 {
-                    IntPtr handle;
-
-                    var status = initFunction(
-                        &handle,
-                        clusterID,
-                        addressPtr,
-                        (uint)addresses_byte.Length - 1,
-                        (uint)concurrencyMax,
-                        IntPtr.Zero,
-                        &OnCompletionCallback
-                    );
-
-                    if (status != InitializationStatus.Success) throw new InitializationException(status);
-                    return new NativeClient(handle);
+                    tb_client_deinit(client);
+                    this.client = IntPtr.Zero;
                 }
             }
         }
+    }
 
-        public TResult[] CallRequest<TResult, TBody>(TBOperation operation, TBody[] batch)
-            where TResult : unmanaged
-            where TBody : unmanaged
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private unsafe static void OnCompletionCallback(IntPtr ctx, IntPtr client, TBPacket* packet, byte* result, uint result_len)
+    {
+        var request = IRequest.FromUserData(packet->userData);
+        if (request != null)
         {
-            var blockingRequest = new BlockingRequest<TResult, TBody>(this, operation);
-            blockingRequest.Submit(batch);
-            return blockingRequest.Wait();
-        }
-
-        public async Task<TResult[]> CallRequestAsync<TResult, TBody>(TBOperation operation, TBody[] batch)
-            where TResult : unmanaged
-            where TBody : unmanaged
-        {
-            var asyncRequest = new AsyncRequest<TResult, TBody>(this, operation);
-            asyncRequest.Submit(batch);
-            return await asyncRequest.Wait().ConfigureAwait(continueOnCapturedContext: false);
-        }
-
-        public void ReleasePacket(Packet packet)
-        {
-            unsafe
-            {
-                // It is unexpected for the client to be disposed here
-                // Since we wait for all acquired packets to be submitted and returned before disposing.
-                AssertTrue(client != IntPtr.Zero, "Client is closed");
-                AssertTrue(packet.Pointer != null, "Null packet pointer");
-                tb_client_release_packet(client, packet.Pointer);
-            }
-        }
-
-        public void Submit(Packet packet)
-        {
-            unsafe
-            {
-                // It is unexpected for the client to be disposed here
-                // Since we wait for all acquired packets to be submitted and returned before disposing.
-                AssertTrue(client != IntPtr.Zero, "Client is closed");
-                tb_client_submit(client, packet.Pointer);
-            }
-        }
-
-        public Packet AcquirePacket()
-        {
-            unsafe
-            {
-                if (client == IntPtr.Zero) throw new ObjectDisposedException("Client is closed");
-
-                TBPacket* packet;
-                var status = tb_client_acquire_packet(client, &packet);
-                switch (status)
-                {
-                    case PacketAcquireStatus.Ok:
-                        AssertTrue(packet != null);
-                        return new Packet(packet);
-                    case PacketAcquireStatus.ConcurrencyMaxExceeded:
-                        throw new ConcurrencyExceededException();
-                    case PacketAcquireStatus.Shutdown:
-                        throw new ObjectDisposedException("Client is closing");
-                    default:
-                        throw new NotImplementedException();
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            if (client != IntPtr.Zero)
-            {
-                lock (this)
-                {
-                    if (client != IntPtr.Zero)
-                    {
-                        tb_client_deinit(client);
-                        this.client = IntPtr.Zero;
-                    }
-                }
-            }
-        }
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-        private unsafe static void OnCompletionCallback(IntPtr ctx, IntPtr client, TBPacket* packet, byte* result, uint result_len)
-        {
-            var request = IRequest.FromUserData(packet->userData);
-            if (request != null)
-            {
-                var span = result_len > 0 ? new ReadOnlySpan<byte>(result, (int)result_len) : ReadOnlySpan<byte>.Empty;
-                request.Complete(new Packet(packet), span);
-            }
+            var span = result_len > 0 ? new ReadOnlySpan<byte>(result, (int)result_len) : ReadOnlySpan<byte>.Empty;
+            request.Complete(new Packet(packet), span);
         }
     }
 }

--- a/src/clients/dotnet/TigerBeetle/Request.cs
+++ b/src/clients/dotnet/TigerBeetle/Request.cs
@@ -4,219 +4,218 @@ using System.Threading;
 using System.Threading.Tasks;
 using static TigerBeetle.AssertionException;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+internal struct Packet
 {
-    internal struct Packet
-    {
-        public readonly unsafe TBPacket* Pointer;
+    public readonly unsafe TBPacket* Pointer;
 
-        public unsafe Packet(TBPacket* pointer)
+    public unsafe Packet(TBPacket* pointer)
+    {
+        Pointer = pointer;
+    }
+}
+
+internal interface IRequest
+{
+    public static IRequest? FromUserData(IntPtr userData)
+    {
+        var handle = GCHandle.FromIntPtr(userData);
+        return handle.IsAllocated ? handle.Target as IRequest : null;
+    }
+
+    void Complete(Packet packet, ReadOnlySpan<byte> result);
+}
+
+internal abstract class Request<TResult, TBody> : IRequest
+    where TResult : unmanaged
+    where TBody : unmanaged
+{
+    private static readonly unsafe int RESULT_SIZE = sizeof(TResult);
+    private static readonly unsafe int BODY_SIZE = sizeof(TBody);
+
+    private readonly NativeClient nativeClient;
+    private readonly TBOperation operation;
+    private readonly GCHandle requestGCHandle;
+    private GCHandle bodyGCHandle;
+
+    public Request(NativeClient nativeClient, TBOperation operation)
+    {
+        requestGCHandle = GCHandle.Alloc(this, GCHandleType.Normal);
+
+        this.nativeClient = nativeClient;
+        this.operation = operation;
+    }
+
+    private IntPtr Pin(TBody[] body, out uint size)
+    {
+        AssertTrue(body.Length > 0, "Message body cannot be empty");
+        AssertTrue(!bodyGCHandle.IsAllocated, "Request body GCHandle is already allocated");
+        bodyGCHandle = GCHandle.Alloc(body, GCHandleType.Pinned);
+
+        size = (uint)(body.Length * BODY_SIZE);
+        return bodyGCHandle.AddrOfPinnedObject();
+    }
+
+    public void Submit(TBody[] batch)
+    {
+        if (batch == null) throw new ArgumentNullException(nameof(batch));
+        if (batch.Length == 0) throw new ArgumentException("Batch cannot be empty", nameof(batch));
+
+        AssertTrue(requestGCHandle.IsAllocated, "Request GCHandle not allocated");
+
+        unsafe
         {
-            Pointer = pointer;
+            var packet = this.nativeClient.AcquirePacket();
+
+            var ptr = packet.Pointer;
+            ptr->next = null;
+            ptr->userData = (IntPtr)requestGCHandle;
+            ptr->operation = (byte)operation;
+            ptr->data = Pin(batch, out uint size);
+            ptr->dataSize = size;
+            ptr->status = PacketStatus.Ok;
+
+            this.nativeClient.Submit(packet);
         }
     }
 
-    internal interface IRequest
+    public void Complete(Packet packet, ReadOnlySpan<byte> result)
     {
-        public static IRequest? FromUserData(IntPtr userData)
+        unsafe
         {
-            var handle = GCHandle.FromIntPtr(userData);
-            return handle.IsAllocated ? handle.Target as IRequest : null;
-        }
+            TResult[]? array = null;
+            Exception? exception = null;
 
-        void Complete(Packet packet, ReadOnlySpan<byte> result);
-    }
-
-    internal abstract class Request<TResult, TBody> : IRequest
-        where TResult : unmanaged
-        where TBody : unmanaged
-    {
-        private static readonly unsafe int RESULT_SIZE = sizeof(TResult);
-        private static readonly unsafe int BODY_SIZE = sizeof(TBody);
-
-        private readonly NativeClient nativeClient;
-        private readonly TBOperation operation;
-        private readonly GCHandle requestGCHandle;
-        private GCHandle bodyGCHandle;
-
-        public Request(NativeClient nativeClient, TBOperation operation)
-        {
-            requestGCHandle = GCHandle.Alloc(this, GCHandleType.Normal);
-
-            this.nativeClient = nativeClient;
-            this.operation = operation;
-        }
-
-        private IntPtr Pin(TBody[] body, out uint size)
-        {
-            AssertTrue(body.Length > 0, "Message body cannot be empty");
-            AssertTrue(!bodyGCHandle.IsAllocated, "Request body GCHandle is already allocated");
-            bodyGCHandle = GCHandle.Alloc(body, GCHandleType.Pinned);
-
-            size = (uint)(body.Length * BODY_SIZE);
-            return bodyGCHandle.AddrOfPinnedObject();
-        }
-
-        public void Submit(TBody[] batch)
-        {
-            if (batch == null) throw new ArgumentNullException(nameof(batch));
-            if (batch.Length == 0) throw new ArgumentException("Batch cannot be empty", nameof(batch));
-
-            AssertTrue(requestGCHandle.IsAllocated, "Request GCHandle not allocated");
-
-            unsafe
+            try
             {
-                var packet = this.nativeClient.AcquirePacket();
-
-                var ptr = packet.Pointer;
-                ptr->next = null;
-                ptr->userData = (IntPtr)requestGCHandle;
-                ptr->operation = (byte)operation;
-                ptr->data = Pin(batch, out uint size);
-                ptr->dataSize = size;
-                ptr->status = PacketStatus.Ok;
-
-                this.nativeClient.Submit(packet);
-            }
-        }
-
-        public void Complete(Packet packet, ReadOnlySpan<byte> result)
-        {
-            unsafe
-            {
-                TResult[]? array = null;
-                Exception? exception = null;
+                AssertTrue(packet.Pointer != null, "Null callback packet pointer");
 
                 try
                 {
-                    AssertTrue(packet.Pointer != null, "Null callback packet pointer");
+                    AssertTrue((byte)operation == packet.Pointer->operation, "Unexpected callback operation: expected={0}, actual={1}", (byte)operation, packet.Pointer->operation);
 
-                    try
+                    if (packet.Pointer->status == PacketStatus.Ok && result.Length > 0)
                     {
-                        AssertTrue((byte)operation == packet.Pointer->operation, "Unexpected callback operation: expected={0}, actual={1}", (byte)operation, packet.Pointer->operation);
+                        AssertTrue(result.Length % RESULT_SIZE == 0,
+                            "Invalid received data: result.Length={0}, SizeOf({1})={2}",
+                            result.Length,
+                            typeof(TResult).Name,
+                            RESULT_SIZE
+                        );
 
-                        if (packet.Pointer->status == PacketStatus.Ok && result.Length > 0)
-                        {
-                            AssertTrue(result.Length % RESULT_SIZE == 0,
-                                "Invalid received data: result.Length={0}, SizeOf({1})={2}",
-                                result.Length,
-                                typeof(TResult).Name,
-                                RESULT_SIZE
-                            );
+                        array = new TResult[result.Length / RESULT_SIZE];
 
-                            array = new TResult[result.Length / RESULT_SIZE];
-
-                            var span = MemoryMarshal.Cast<byte, TResult>(result);
-                            span.CopyTo(array);
-                        }
-                        else
-                        {
-                            array = Array.Empty<TResult>();
-                        }
-                    }
-                    finally
-                    {
-                        nativeClient.ReleasePacket(packet);
-                    }
-
-                    if (requestGCHandle.IsAllocated) requestGCHandle.Free();
-                    if (bodyGCHandle.IsAllocated) bodyGCHandle.Free();
-                }
-                catch (Exception any)
-                {
-                    exception = any;
-                }
-
-                if (exception != null)
-                {
-                    SetException(exception);
-                }
-                else
-                {
-                    if (packet.Pointer->status == PacketStatus.Ok)
-                    {
-                        SetResult(array!);
+                        var span = MemoryMarshal.Cast<byte, TResult>(result);
+                        span.CopyTo(array);
                     }
                     else
                     {
-                        SetException(new RequestException(packet.Pointer->status));
+                        array = Array.Empty<TResult>();
                     }
                 }
-            }
-        }
-
-        protected abstract void SetResult(TResult[] result);
-
-        protected abstract void SetException(Exception exception);
-    }
-
-    internal sealed class AsyncRequest<TResult, TBody> : Request<TResult, TBody>, IRequest
-        where TResult : unmanaged
-        where TBody : unmanaged
-    {
-        private readonly TaskCompletionSource<TResult[]> completionSource;
-
-        public AsyncRequest(NativeClient nativeClient, TBOperation operation) : base(nativeClient, operation)
-        {
-            // Hints the TPL to execute the continuation on its own thread pool thread, instead of the unamaged's callback thread:
-            this.completionSource = new TaskCompletionSource<TResult[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-        }
-
-        public Task<TResult[]> Wait() => completionSource.Task;
-
-        protected override void SetResult(TResult[] result) => completionSource.SetResult(result);
-
-        protected override void SetException(Exception exception) => completionSource.SetException(exception);
-
-    }
-
-    internal sealed class BlockingRequest<TResult, TBody> : Request<TResult, TBody>, IRequest
-        where TResult : unmanaged
-        where TBody : unmanaged
-    {
-        private volatile TResult[]? result = null;
-        private volatile Exception? exception = null;
-
-        private bool Completed => result != null || exception != null;
-
-        public BlockingRequest(NativeClient nativeClient, TBOperation operation) : base(nativeClient, operation)
-        {
-        }
-
-        public TResult[] Wait()
-        {
-            if (!Completed)
-            {
-                lock (this)
+                finally
                 {
-                    if (!Completed)
-                    {
-                        _ = Monitor.Wait(this);
-                    }
+                    nativeClient.ReleasePacket(packet);
+                }
+
+                if (requestGCHandle.IsAllocated) requestGCHandle.Free();
+                if (bodyGCHandle.IsAllocated) bodyGCHandle.Free();
+            }
+            catch (Exception any)
+            {
+                exception = any;
+            }
+
+            if (exception != null)
+            {
+                SetException(exception);
+            }
+            else
+            {
+                if (packet.Pointer->status == PacketStatus.Ok)
+                {
+                    SetResult(array!);
+                }
+                else
+                {
+                    SetException(new RequestException(packet.Pointer->status));
                 }
             }
-
-            return result ?? throw exception!;
         }
+    }
 
-        protected override void SetResult(TResult[] result)
+    protected abstract void SetResult(TResult[] result);
+
+    protected abstract void SetException(Exception exception);
+}
+
+internal sealed class AsyncRequest<TResult, TBody> : Request<TResult, TBody>, IRequest
+    where TResult : unmanaged
+    where TBody : unmanaged
+{
+    private readonly TaskCompletionSource<TResult[]> completionSource;
+
+    public AsyncRequest(NativeClient nativeClient, TBOperation operation) : base(nativeClient, operation)
+    {
+        // Hints the TPL to execute the continuation on its own thread pool thread, instead of the unamaged's callback thread:
+        this.completionSource = new TaskCompletionSource<TResult[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public Task<TResult[]> Wait() => completionSource.Task;
+
+    protected override void SetResult(TResult[] result) => completionSource.SetResult(result);
+
+    protected override void SetException(Exception exception) => completionSource.SetException(exception);
+
+}
+
+internal sealed class BlockingRequest<TResult, TBody> : Request<TResult, TBody>, IRequest
+    where TResult : unmanaged
+    where TBody : unmanaged
+{
+    private volatile TResult[]? result = null;
+    private volatile Exception? exception = null;
+
+    private bool Completed => result != null || exception != null;
+
+    public BlockingRequest(NativeClient nativeClient, TBOperation operation) : base(nativeClient, operation)
+    {
+    }
+
+    public TResult[] Wait()
+    {
+        if (!Completed)
         {
             lock (this)
             {
-                this.result = result;
-                this.exception = null;
-                Monitor.Pulse(this);
+                if (!Completed)
+                {
+                    _ = Monitor.Wait(this);
+                }
             }
         }
 
-        protected override void SetException(Exception exception)
+        return result ?? throw exception!;
+    }
+
+    protected override void SetResult(TResult[] result)
+    {
+        lock (this)
         {
-            lock (this)
-            {
-                this.exception = exception;
-                this.result = null;
-                Monitor.Pulse(this);
-            }
+            this.result = result;
+            this.exception = null;
+            Monitor.Pulse(this);
+        }
+    }
+
+    protected override void SetException(Exception exception)
+    {
+        lock (this)
+        {
+            this.exception = exception;
+            this.result = null;
+            Monitor.Pulse(this);
         }
     }
 }

--- a/src/clients/dotnet/TigerBeetle/RequestException.cs
+++ b/src/clients/dotnet/TigerBeetle/RequestException.cs
@@ -1,27 +1,26 @@
 using System;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+public sealed class RequestException : Exception
 {
-    public sealed class RequestException : Exception
+    public PacketStatus Status { get; }
+
+    internal RequestException(PacketStatus status)
     {
-        public PacketStatus Status { get; }
+        Status = status;
+    }
 
-        internal RequestException(PacketStatus status)
+    public override string Message
+    {
+        get
         {
-            Status = status;
-        }
-
-        public override string Message
-        {
-            get
+            switch (Status)
             {
-                switch (Status)
-                {
-                    case PacketStatus.TooMuchData: return "Too much data provided on this batch.";
-                    case PacketStatus.InvalidOperation: return "Invalid operation. Check if this client is compatible with the server's version.";
-                    case PacketStatus.InvalidDataSize: return "Invalid data size. Check if this client is compatible with the server's version.";
-                    default: return "Unknown error status " + Status;
-                }
+                case PacketStatus.TooMuchData: return "Too much data provided on this batch.";
+                case PacketStatus.InvalidOperation: return "Invalid operation. Check if this client is compatible with the server's version.";
+                case PacketStatus.InvalidDataSize: return "Invalid data size. Check if this client is compatible with the server's version.";
+                default: return "Unknown error status " + Status;
             }
         }
     }

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="TigerBeetle.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
     <LangVersion>10</LangVersion>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -9,6 +9,9 @@
     <AssemblyName>TigerBeetle</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RollForward>LatestMajor</RollForward>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn> <!-- Disables the warning CS1591: Missing XML comment for publicly visible type or member -->
   </PropertyGroup>
   <PropertyGroup>
     <OS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</OS>

--- a/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
@@ -1,10 +1,6 @@
 using System;
 using System.Numerics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Buffers.Binary;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace TigerBeetle
 {
@@ -105,51 +101,4 @@ namespace TigerBeetle
             }
         }
     }
-
-    // DotNet 7.0 already introduces UInt128.
-    // We keep the bare minimum implementation for compatibility reasons.
-#if !NET7_0_OR_GREATER
-    [StructLayout(LayoutKind.Sequential, Size = UInt128Extensions.SIZE)]
-    public struct UInt128 : IEquatable<UInt128>
-    {
-        public const int SIZE = UInt128Extensions.SIZE;
-
-        public static readonly UInt128 Zero = new();
-
-        private readonly ulong _0;
-        private readonly ulong _1;
-        public UInt128(ulong mostSignificantBytes, ulong leastSignificantBytes = 0L)
-        {
-            _0 = leastSignificantBytes;
-            _1 = mostSignificantBytes;
-        }
-
-        public override bool Equals([NotNullWhen(true)] object? obj)
-        {
-            return obj switch
-            {
-                UInt128 other => Equals(other),
-                _ => false,
-            };
-        }
-
-        public bool Equals(UInt128 other) => _0 == other._0 && _1 == other._1;
-
-        public override int GetHashCode() => HashCode.Combine(_0, _1);
-
-        public override string ToString() => this.ToBigInteger().ToString();
-
-        public static bool operator ==(UInt128 left, UInt128 right) => left.Equals(right);
-
-        public static bool operator !=(UInt128 left, UInt128 right) => !left.Equals(right);
-
-        public static implicit operator UInt128(ushort value) => new UInt128(0, value);
-
-        public static implicit operator UInt128(uint value) => new UInt128(0, value);
-
-        public static implicit operator UInt128(ulong value) => new UInt128(0, value);
-
-        public static implicit operator UInt128(nuint value) => new UInt128(0, value);
-    }
-#endif
 }

--- a/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
@@ -2,103 +2,102 @@ using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
-namespace TigerBeetle
+namespace TigerBeetle;
+
+/// <summary>
+/// Conversion functions between UInt128 and commonly used types such as Guid, BigInteger and byte[].
+/// </summary>
+public static class UInt128Extensions
 {
     /// <summary>
-    /// Conversion functions between UInt128 and commonly used types such as Guid, BigInteger and byte[].
+    /// Unsafe representation of a tb_uint128_t used only internally
+    /// for P/Invove in methods marked with the [DllImport] attribute.
+    /// It's necessary only because P/Invoke's marshaller does not support System.UInt128.
     /// </summary>
-    public static class UInt128Extensions
+    [StructLayout(LayoutKind.Explicit, Size = SIZE)]
+    internal unsafe struct UnsafeU128
     {
+        [FieldOffset(0)]
+        fixed byte raw[SIZE];
+
         /// <summary>
-        /// Unsafe representation of a tb_uint128_t used only internally
-        /// for P/Invove in methods marked with the [DllImport] attribute.
-        /// It's necessary only because P/Invoke's marshaller does not support System.UInt128.
+        /// Reinterprets memory, casting the managed UInt128 directly to the unsafe representation.
         /// </summary>
-        [StructLayout(LayoutKind.Explicit, Size = SIZE)]
-        internal unsafe struct UnsafeU128
-        {
-            [FieldOffset(0)]
-            fixed byte raw[SIZE];
+        public static implicit operator UnsafeU128(UInt128 value) => *(UnsafeU128*)&value;
+    }
 
-            /// <summary>
-            /// Reinterprets memory, casting the managed UInt128 directly to the unsafe representation.
-            /// </summary>
-            public static implicit operator UnsafeU128(UInt128 value) => *(UnsafeU128*)&value;
+    internal const int SIZE = 16;
+
+    public static Guid ToGuid(this UInt128 value)
+    {
+        unsafe
+        {
+            return new Guid(new ReadOnlySpan<byte>(&value, SIZE));
         }
+    }
 
-        internal const int SIZE = 16;
-
-        public static Guid ToGuid(this UInt128 value)
+    public static UInt128 ToUInt128(this Guid value)
+    {
+        unsafe
         {
-            unsafe
+            UInt128 ret = UInt128.Zero;
+
+            // Passing a fixed 16-byte span, there's no possibility
+            // of returning false.
+            _ = value.TryWriteBytes(new Span<byte>(&ret, SIZE));
+
+            return ret;
+        }
+    }
+
+    public static byte[] ToArray(this UInt128 value)
+    {
+        unsafe
+        {
+            var span = new ReadOnlySpan<byte>(&value, SIZE);
+            return span.ToArray();
+        }
+    }
+
+    public static UInt128 ToUInt128(this ReadOnlySpan<byte> memory)
+    {
+        if (memory.Length != SIZE) throw new ArgumentException(nameof(memory));
+
+        unsafe
+        {
+            fixed (void* ptr = memory)
             {
-                return new Guid(new ReadOnlySpan<byte>(&value, SIZE));
+                return *(UInt128*)ptr;
             }
         }
+    }
 
-        public static UInt128 ToUInt128(this Guid value)
+    public static UInt128 ToUInt128(this byte[] array)
+    {
+        if (array == null) throw new ArgumentNullException(nameof(array));
+        if (array.Length != SIZE) throw new ArgumentException(nameof(array));
+        return new ReadOnlySpan<byte>(array, 0, SIZE).ToUInt128();
+    }
+
+    public static BigInteger ToBigInteger(this UInt128 value)
+    {
+        unsafe
         {
-            unsafe
-            {
-                UInt128 ret = UInt128.Zero;
-
-                // Passing a fixed 16-byte span, there's no possibility
-                // of returning false.
-                _ = value.TryWriteBytes(new Span<byte>(&ret, SIZE));
-
-                return ret;
-            }
+            return new BigInteger(new ReadOnlySpan<byte>(&value, SIZE), isUnsigned: true, isBigEndian: false);
         }
+    }
 
-        public static byte[] ToArray(this UInt128 value)
+    public static UInt128 ToUInt128(this BigInteger value)
+    {
+        unsafe
         {
-            unsafe
+            UInt128 ret = UInt128.Zero;
+            if (!value.TryWriteBytes(new Span<byte>(&ret, SIZE), out int _, isUnsigned: true, isBigEndian: false))
             {
-                var span = new ReadOnlySpan<byte>(&value, SIZE);
-                return span.ToArray();
+                throw new ArgumentOutOfRangeException();
             }
-        }
 
-        public static UInt128 ToUInt128(this ReadOnlySpan<byte> memory)
-        {
-            if (memory.Length != SIZE) throw new ArgumentException(nameof(memory));
-
-            unsafe
-            {
-                fixed (void* ptr = memory)
-                {
-                    return *(UInt128*)ptr;
-                }
-            }
-        }
-
-        public static UInt128 ToUInt128(this byte[] array)
-        {
-            if (array == null) throw new ArgumentNullException(nameof(array));
-            if (array.Length != SIZE) throw new ArgumentException(nameof(array));
-            return new ReadOnlySpan<byte>(array, 0, SIZE).ToUInt128();
-        }
-
-        public static BigInteger ToBigInteger(this UInt128 value)
-        {
-            unsafe
-            {
-                return new BigInteger(new ReadOnlySpan<byte>(&value, SIZE), isUnsigned: true, isBigEndian: false);
-            }
-        }
-
-        public static UInt128 ToUInt128(this BigInteger value)
-        {
-            unsafe
-            {
-                UInt128 ret = UInt128.Zero;
-                if (!value.TryWriteBytes(new Span<byte>(&ret, SIZE), out int _, isUnsigned: true, isBigEndian: false))
-                {
-                    throw new ArgumentOutOfRangeException();
-                }
-
-                return ret;
-            }
+            return ret;
         }
     }
 }

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -49,8 +49,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         try shell.exec("dotnet pack --configuration Release", .{});
 
         const image_tags = .{
-            "7.0",        "6.0",        "3.1",
-            "7.0-alpine", "6.0-alpine", "3.1-alpine",
+            "7.0",        "8.0",
+            "7.0-alpine", "8.0-alpine",
         };
 
         inline for (image_tags) |image_tag| {

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -151,8 +151,7 @@ pub const DotnetDocs = Docs{
     ,
 
     .prerequisites =
-    \\* Any runtime compatible with [.NET Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#select-net-standard-version).
-    \\* Optimized for .NET >= 7.0.
+    \\* .NET >= 7.0.
     \\
     \\And if you do not already have NuGet.org as a package
     \\source, make sure to add it:
@@ -246,7 +245,7 @@ pub const DotnetDocs = Docs{
     \\to convert 128-bit little-endian unsigned integers between
     \\`BigInteger`, `byte[]`, and `Guid`.
     \\
-    \\See the class [UInt128Extensions](/src/clients/dotnet/TigerBeetle/UInt128.cs) for more details.
+    \\See the class [UInt128Extensions](/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs) for more details.
     ,
 
     .account_flags_documentation =

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -179,12 +179,12 @@ fn emit_enum(
     if (is_packed_struct) {
         assert(type_info.layout == .Packed);
         // Packed structs represented as Enum needs a Flags attribute:
-        try buffer.writer().print("    [Flags]\n", .{});
+        try buffer.writer().print("[Flags]\n", .{});
     }
 
     try buffer.writer().print(
-        \\    {s} enum {s} : {s}
-        \\    {{
+        \\{s} enum {s} : {s}
+        \\{{
         \\
     , .{
         @tagName(mapping.visibility),
@@ -195,7 +195,7 @@ fn emit_enum(
     if (is_packed_struct) {
         // Packed structs represented as Enum needs a ZERO value:
         try buffer.writer().print(
-            \\        None = 0,
+            \\    None = 0,
             \\
             \\
         , .{});
@@ -206,21 +206,20 @@ fn emit_enum(
 
         try emit_docs(buffer, mapping, field.name);
         if (is_packed_struct) {
-            try buffer.writer().print("        {s} = 1 << {},\n\n", .{
+            try buffer.writer().print("    {s} = 1 << {},\n\n", .{
                 to_case(field.name, .pascal),
                 i,
             });
         } else {
-            try buffer.writer().print("        {s} = {},\n\n", .{
+            try buffer.writer().print("    {s} = {},\n\n", .{
                 to_case(field.name, .pascal),
-
                 @intFromEnum(@field(Type, field.name)),
             });
         }
     }
 
     try buffer.writer().print(
-        \\    }}
+        \\}}
         \\
         \\
     , .{});
@@ -233,10 +232,10 @@ fn emit_struct(
     comptime size: usize,
 ) !void {
     try buffer.writer().print(
-        \\    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-        \\    {s} {s}struct {s}
-        \\    {{
-        \\        public const int SIZE = {};
+        \\[StructLayout(LayoutKind.Sequential, Size = SIZE)]
+        \\{s} {s}struct {s}
+        \\{{
+        \\    public const int SIZE = {};
         \\
         \\
     , .{
@@ -253,32 +252,32 @@ fn emit_struct(
         switch (@typeInfo(field.type)) {
             .Array => |array| {
                 try buffer.writer().print(
-                    \\        [StructLayout(LayoutKind.Sequential, Size = SIZE)]
-                    \\        private unsafe struct {s}Data
+                    \\    [StructLayout(LayoutKind.Sequential, Size = SIZE)]
+                    \\    private unsafe struct {s}Data
+                    \\    {{
+                    \\        public const int SIZE = {};
+                    \\
+                    \\        private fixed byte raw[SIZE];
+                    \\
+                    \\        public byte[] GetData()
                     \\        {{
-                    \\            public const int SIZE = {};
-                    \\
-                    \\            private fixed byte raw[SIZE];
-                    \\
-                    \\            public byte[] GetData()
+                    \\            fixed (void* ptr = raw)
                     \\            {{
-                    \\                fixed (void* ptr = raw)
-                    \\                {{
-                    \\                    return new ReadOnlySpan<byte>(ptr, SIZE).ToArray();
-                    \\                }}
-                    \\            }}
-                    \\
-                    \\            public void SetData(byte[] value)
-                    \\            {{
-                    \\                if (value == null) throw new ArgumentNullException(nameof(value));
-                    \\                if (value.Length != SIZE) throw new ArgumentException("Expected a byte[" + SIZE + "] array", nameof(value));
-                    \\
-                    \\                fixed (void* ptr = raw)
-                    \\                {{
-                    \\                    value.CopyTo(new Span<byte>(ptr, SIZE));
-                    \\                }}
+                    \\                return new ReadOnlySpan<byte>(ptr, SIZE).ToArray();
                     \\            }}
                     \\        }}
+                    \\
+                    \\        public void SetData(byte[] value)
+                    \\        {{
+                    \\            if (value == null) throw new ArgumentNullException(nameof(value));
+                    \\            if (value.Length != SIZE) throw new ArgumentException("Expected a byte[" + SIZE + "] array", nameof(value));
+                    \\
+                    \\            fixed (void* ptr = raw)
+                    \\            {{
+                    \\                value.CopyTo(new Span<byte>(ptr, SIZE));
+                    \\            }}
+                    \\        }}
+                    \\     }}
                     \\
                     \\
                 , .{
@@ -294,7 +293,7 @@ fn emit_struct(
     inline for (type_info.fields) |field| {
         switch (@typeInfo(field.type)) {
             .Array => try buffer.writer().print(
-                \\        {s} {s}Data {s};
+                \\    {s} {s}Data {s};
                 \\
                 \\
             ,
@@ -305,7 +304,7 @@ fn emit_struct(
                 },
             ),
             else => try buffer.writer().print(
-                \\        {s} {s} {s};
+                \\    {s} {s} {s};
                 \\
                 \\
             ,
@@ -329,7 +328,7 @@ fn emit_struct(
 
             switch (@typeInfo(field.type)) {
                 .Array => try buffer.writer().print(
-                    \\        {s} byte[] {s} {{ get => {s}.GetData(); {s}set => {s}.SetData(value); }}
+                    \\    {s} byte[] {s} {{ get => {s}.GetData(); {s}set => {s}.SetData(value); }}
                     \\
                     \\
                 , .{
@@ -340,7 +339,7 @@ fn emit_struct(
                     to_case(field.name, .camel),
                 }),
                 else => try buffer.writer().print(
-                    \\        {s} {s} {s} {{ get => {s}; {s}set => {s} = value; }}
+                    \\    {s} {s} {s} {{ get => {s}; {s}set => {s} = value; }}
                     \\
                     \\
                 , .{
@@ -356,7 +355,7 @@ fn emit_struct(
     }
 
     try buffer.writer().print(
-        \\    }}
+        \\}}
         \\
         \\
     , .{});
@@ -365,9 +364,9 @@ fn emit_struct(
 fn emit_docs(buffer: anytype, comptime mapping: TypeMapping, comptime field: ?[]const u8) !void {
     if (mapping.docs_link) |docs_link| {
         try buffer.writer().print(
-            \\        /// <summary>
-            \\        /// https://docs.tigerbeetle.com/{s}{s}
-            \\        /// </summary>
+            \\    /// <summary>
+            \\    /// https://docs.tigerbeetle.com/{s}{s}
+            \\    /// </summary>
             \\
         , .{
             docs_link,
@@ -388,8 +387,8 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\using System;
         \\using System.Runtime.InteropServices;
         \\
-        \\namespace TigerBeetle
-        \\{{
+        \\namespace TigerBeetle;
+        \\
         \\
     , .{});
 
@@ -430,75 +429,54 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
     // TODO: use `std.meta.declaractions` and generate with pub + export functions.
     // Zig 0.9.1 has `decl.data.Fn.arg_names` but it's currently/incorrectly a zero-sized slice.
     try buffer.writer().print(
-        \\    internal static class TBClient
-        \\    {{
-        \\        private const string LIB_NAME = "tb_client";
+        \\internal static class TBClient
+        \\{{
+        \\    private const string LIB_NAME = "tb_client";
         \\
-        \\        // Uses either the new function pointer by value, or the old managed delegate in .Net standard
-        \\        // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
+        \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        \\    public static unsafe extern InitializationStatus tb_client_init(
+        \\        IntPtr* out_client,
+        \\        UInt128Extensions.UnsafeU128 cluster_id,
+        \\        byte* address_ptr,
+        \\        uint address_len,
+        \\        uint num_packets,
+        \\        IntPtr on_completion_ctx,
+        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+        \\    );
         \\
-        \\#if NETSTANDARD
-        \\        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        \\        public unsafe delegate void OnCompletionFn(IntPtr ctx, IntPtr client, TBPacket* packet, byte* result, uint result_len);
-        \\#endif
+        \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        \\    public static unsafe extern InitializationStatus tb_client_init_echo(
+        \\        IntPtr* out_client,
+        \\        UInt128Extensions.UnsafeU128 cluster_id,
+        \\        byte* address_ptr,
+        \\        uint address_len,
+        \\        uint num_packets,
+        \\        IntPtr on_completion_ctx,
+        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+        \\    );
         \\
-        \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        \\        public static unsafe extern InitializationStatus tb_client_init(
-        \\            IntPtr* out_client,
-        \\            UInt128Extensions.UnsafeU128 cluster_id,
-        \\            byte* address_ptr,
-        \\            uint address_len,
-        \\            uint num_packets,
-        \\            IntPtr on_completion_ctx,
+        \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        \\    public static unsafe extern PacketAcquireStatus tb_client_acquire_packet(
+        \\        IntPtr client,
+        \\        TBPacket** out_packet
+        \\    );
         \\
-        \\#if NETSTANDARD
-        \\            [MarshalAs(UnmanagedType.FunctionPtr)]
-        \\            OnCompletionFn on_completion_fn
-        \\#else
-        \\            delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
-        \\#endif
-        \\        );
+        \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        \\    public static unsafe extern void tb_client_release_packet(
+        \\        IntPtr client,
+        \\        TBPacket* packet
+        \\    );
         \\
-        \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        \\        public static unsafe extern InitializationStatus tb_client_init_echo(
-        \\            IntPtr* out_client,
-        \\            UInt128Extensions.UnsafeU128 cluster_id,
-        \\            byte* address_ptr,
-        \\            uint address_len,
-        \\            uint num_packets,
-        \\            IntPtr on_completion_ctx,
+        \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        \\    public static unsafe extern void tb_client_submit(
+        \\        IntPtr client,
+        \\        TBPacket* packet
+        \\    );
         \\
-        \\#if NETSTANDARD
-        \\            [MarshalAs(UnmanagedType.FunctionPtr)]
-        \\            OnCompletionFn on_completion_fn
-        \\#else
-        \\            delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
-        \\#endif
-        \\        );
-        \\
-        \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        \\        public static unsafe extern PacketAcquireStatus tb_client_acquire_packet(
-        \\            IntPtr client,
-        \\            TBPacket** out_packet
-        \\        );
-        \\
-        \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        \\        public static unsafe extern void tb_client_release_packet(
-        \\            IntPtr client,
-        \\            TBPacket* packet
-        \\        );
-        \\
-        \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        \\        public static unsafe extern void tb_client_submit(
-        \\            IntPtr client,
-        \\            TBPacket* packet
-        \\        );
-        \\
-        \\        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
-        \\        public static unsafe extern void tb_client_deinit(
-        \\            IntPtr client
-        \\        );
-        \\    }}
+        \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        \\    public static unsafe extern void tb_client_deinit(
+        \\        IntPtr client
+        \\    );
         \\}}
         \\
         \\

--- a/src/clients/dotnet/samples/basic/README.md
+++ b/src/clients/dotnet/samples/basic/README.md
@@ -9,8 +9,7 @@ Code for this sample is in [./Program.cs](./Program.cs).
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* Any runtime compatible with [.NET Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#select-net-standard-version).
-* Optimized for .NET >= 7.0.
+* .NET >= 7.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:

--- a/src/clients/dotnet/samples/two-phase-many/README.md
+++ b/src/clients/dotnet/samples/two-phase-many/README.md
@@ -9,8 +9,7 @@ Code for this sample is in [./Program.cs](./Program.cs).
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* Any runtime compatible with [.NET Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#select-net-standard-version).
-* Optimized for .NET >= 7.0.
+* .NET >= 7.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:

--- a/src/clients/dotnet/samples/two-phase/README.md
+++ b/src/clients/dotnet/samples/two-phase/README.md
@@ -9,8 +9,7 @@ Code for this sample is in [./Program.cs](./Program.cs).
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* Any runtime compatible with [.NET Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#select-net-standard-version).
-* Optimized for .NET >= 7.0.
+* .NET >= 7.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:


### PR DESCRIPTION
In practice, drops the support for .Net Core 3.1 (already in [EOL](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)) and .Net <= 6 (in [EOL](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) in Dec 2024). The minimum supported version now is .Net 7.0; Recommended version is .Net 8.0 LTS.

- Simplifies the code, removing the custom `UInt128` type, and version-specific conditionals (i.e `#if NETSTANDARD` and `#if !NET7_0_OR_GREATER`).

- Removes the burden of publishing dual-version artifacts on Nuget.

- Speeds up the CI by not having to run the same tests for each supported version.

- Bonus: Introduces ~top-level~ file-scoped namespaces, saving one level of indentation.