### PR TITLE
workbench: initial

### DIFF
--- a/.github/workflows/pipeline-main.yml
+++ b/.github/workflows/pipeline-main.yml
@@ -26,3 +26,21 @@ jobs:
       TIGERBEETLE_DOCS_DEPLOY_KEY: ${{secrets.TIGERBEETLE_DOCS_DEPLOY_KEY}}
       TIGERBEETLE_GO_DEPLOY_KEY: ${{ secrets.TIGERBEETLE_GO_DEPLOY_KEY }}
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+
+  workbench:
+    runs-on: ubuntu-latest
+    environment: workbench
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/install_zig.sh
+      - run: ./zig/zig build scripts -- ci-benchmark --sha=${{ github.sha }}
+        env:
+          WORKBENCHDB_PAT: ${{ secrets.WORKBENCHDB_PAT }}
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./src/workbench
+      - uses: actions/deploy-pages@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.TIGERBEETLE_NODE_PUBLISH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
   alert_failure:
     runs-on: ubuntu-latest
     needs: [release]

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -348,7 +348,7 @@ test('can get account transfers', async (): Promise<void> => {
     debits_pending: 0n,
     debits_posted: 0n,
     credits_pending: 0n,
-    credits_posted: 0n,  
+    credits_posted: 0n,
     user_data_128: 0n,
     user_data_64: 0n,
     user_data_32: 0,
@@ -380,7 +380,7 @@ test('can get account transfers', async (): Promise<void> => {
       timestamp: 0n,
     });
   }
-  
+
   const transfers_created_result = await client.createTransfers(transfers_created)
   assert.strictEqual(transfers_created_result.length, 0)
 
@@ -412,7 +412,7 @@ test('can get account transfers', async (): Promise<void> => {
   for (var transfer of transfers) {
     assert.ok(transfer.timestamp < timestamp);
     timestamp = transfer.timestamp;
-  }  
+  }
 
   // Query only the credit transfers for accountC, descending:
   filter = {
@@ -427,7 +427,7 @@ test('can get account transfers', async (): Promise<void> => {
   for (var transfer of transfers) {
     assert.ok(transfer.timestamp < timestamp);
     timestamp = transfer.timestamp;
-  }    
+  }
 
   // Query the first 5 transfers for accountC:
   filter = {
@@ -442,7 +442,7 @@ test('can get account transfers', async (): Promise<void> => {
   for (var transfer of transfers) {
     assert.ok(timestamp < transfer.timestamp);
     timestamp = transfer.timestamp;
-  } 
+  }
 
   // Query the next 5 transfers for accountC, with pagination:
   filter = {
@@ -456,7 +456,7 @@ test('can get account transfers', async (): Promise<void> => {
   for (var transfer of transfers) {
     assert.ok(timestamp < transfer.timestamp);
     timestamp = transfer.timestamp;
-  } 
+  }
 
   // Query again, no more transfers should be found:
   filter = {
@@ -491,8 +491,8 @@ test('can get account transfers', async (): Promise<void> => {
     timestamp: 0n,
     limit: 0,
     flags: GetAccountTransfersFlags.credits | GetAccountTransfersFlags.debits,
-  })).length, 0) 
-  
+  })).length, 0)
+
   // Empty flags:
   assert.strictEqual((await client.getAccountTransfers({
     account_id: accountC.id,
@@ -507,7 +507,7 @@ test('can get account transfers', async (): Promise<void> => {
     timestamp: 0n,
     limit: 8190,
     flags: 0xFFFF,
-  })).length, 0)     
+  })).length, 0)
 
 })
 

--- a/src/scripts/main.zig
+++ b/src/scripts/main.zig
@@ -19,10 +19,12 @@ const Shell = @import("../shell.zig");
 
 const ci = @import("./ci.zig");
 const release = @import("./release.zig");
+const workbench = @import("./workbench.zig");
 
 const CliArgs = union(enum) {
     ci: ci.CliArgs,
     release: release.CliArgs,
+    workbench: workbench.CliArgs,
 };
 
 pub fn main() !void {
@@ -48,5 +50,6 @@ pub fn main() !void {
     switch (cli_args) {
         .ci => |args_ci| try ci.main(shell, gpa, args_ci),
         .release => |args_release| try release.main(shell, gpa, args_release),
+        .workbench => |args_workbench| try workbench.main(shell, gpa, args_workbench),
     }
 }

--- a/src/scripts/workbench.zig
+++ b/src/scripts/workbench.zig
@@ -1,0 +1,75 @@
+/// Runs a set of macro-benchmarks whose result is displayed at <https://tigerbeetle.github.io>.
+///
+/// Specifically:
+///
+/// - This script is run by the CI infrastructure on every merge to main.
+/// - It runs a set of "benchmarks", where a "benchmark" can be anything (eg, measuring the size of
+///   the binary).
+/// - The results of all measurements are serialized as a single JSON object, `Run`.
+/// - The key part: this JSON is then stored in a "distributed database" for our visualization
+///   front-end to pick up. This "database" is just a newline-delimited JSON file in a git repo
+const std = @import("std");
+
+const Shell = @import("../shell.zig");
+
+pub const CliArgs = struct {
+    sha: []const u8,
+};
+
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+    _ = gpa;
+
+    var timer = try std.time.Timer.start();
+    try shell.zig("build install -Drelease", .{});
+    const build_time_ms = timer.lap() / std.time.ns_per_ms;
+
+    const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;
+
+    const run = Run{
+        .timestamp = std.time.timestamp(),
+        .revision = cli_args.sha,
+        .measurements = &[_]Measurement{
+            .{ .label = "build time", .value = build_time_ms, .unit = "ms" },
+            .{ .label = "executable size", .value = executable_size_bytes, .unit = "bytes" },
+        },
+    };
+
+    const token = try shell.env_get("WORKBENCHDB_PAT");
+    try shell.exec(
+        \\git clone --depth 1
+        \\  https://oauth2:{token}@github.com/tigerbeetle/workbenchdb.git
+        \\  workbenchdb
+    , .{
+        .token = token,
+    });
+
+    try shell.pushd("./workbenchdb");
+    defer shell.popd();
+
+    {
+        const file = try shell.cwd.openFile("./workbench/data.json", .{
+            .mode = .write_only,
+        });
+        defer file.close();
+
+        try file.seekFromEnd(0);
+        try std.json.stringify(run, .{}, file.writer());
+        try file.writeAll("\n");
+    }
+
+    try shell.exec("git add ./workbench/data.json", .{});
+    try shell.exec("git commit -m 📈", .{});
+    try shell.exec("git push", .{});
+}
+
+const Measurement = struct {
+    label: []const u8,
+    value: u64,
+    unit: []const u8,
+};
+
+const Run = struct {
+    timestamp: i64,
+    revision: []const u8,
+    measurements: []const Measurement,
+};

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -272,6 +272,7 @@ test "tidy extensions" {
         .{".editorconfig"}, .{".gitattributes"}, .{".gitignore"},             .{".nojekyll"},
         .{"CNAME"},         .{"Dockerfile"},     .{"exclude-pmd.properties"}, .{"favicon.ico"},
         .{"favicon.png"},   .{"LICENSE"},        .{"logo.svg"},               .{"module-info.test"},
+        .{"index.html"},
     });
 
     const allocator = std.testing.allocator;

--- a/src/workbench/index.html
+++ b/src/workbench/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TigerBeetle Dev Workbench</title>
+  <script src="./workbench.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/apexcharts/3.45.2/apexcharts.min.js"
+    integrity="sha512-vIqZt7ReO939RQssENNbZ+Iu3j0CSsgk41nP3AYabLiIFajyebORlk7rKPjGddmO1FQkbuOb2EVK6rJkiHsmag=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+
+<body>
+  <h1>TigerBeetle Dev Workbench</h1>
+
+  <section>
+    <h2>Release</h2>
+
+    Release Manager for:
+    <ul>
+      <li>last week: <span id="release-previous">N/A</span> </li>
+      <li><strong>this week: <span id="release-current">N/A</span></strong></li>
+      <li>next week: <span id="release-next">N/A</span></li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Release Metrics</h2>
+    <div id="charts" style="display: flex; flex-direction: column;">
+    </div>
+  </section>
+</body>
+
+</html>

--- a/src/workbench/workbench.js
+++ b/src/workbench/workbench.js
@@ -1,0 +1,206 @@
+// Code powering "developer dashboard" aka workbench, at <https://tigerbeetle.github.io>.
+//
+// At the moment, it isn't clear what's the right style for this kind of non-Zig developer facing
+// code, so the following is somewhat arbitrary:
+//
+// - camelCase naming
+// - `deno fmt` for style
+// - no TypeScript, no build step
+
+async function main() {
+  const runs = await fetchData();
+  const series = runsToSeries(runs);
+  plotSeries(series, document.querySelector("#charts"));
+
+  const releaseManager = getReleaseManager();
+  for (const week of ["previous", "current", "next"]) {
+    document.querySelector(`#release-${week}`).textContent =
+      releaseManager[week];
+  }
+}
+
+window.onload = main;
+
+function assert(condition) {
+  if (!condition) {
+    alert("Assertion failed");
+    throw "Assertion failed";
+  }
+}
+
+function getReleaseManager() {
+  const week = getWeek(new Date());
+  const candidates = [
+    "batiati",
+    "cb22",
+    "kprotty",
+    "matklad",
+    "sentientwaffle",
+  ];
+  candidates.sort();
+
+  return {
+    previous: candidates[week % candidates.length],
+    current: candidates[(week + 1) % candidates.length],
+    next: candidates[(week + 2) % candidates.length],
+  };
+}
+
+const dataUrl =
+  "https://raw.githubusercontent.com/tigerbeetle/workbenchdb/main/workbench/data.json";
+
+async function fetchData() {
+  const data = await (await fetch(dataUrl)).text();
+  return data.split("\n")
+    .filter((it) => it.length > 0)
+    .map((it) => JSON.parse(it));
+}
+
+// The input data is array of runs, where a single run contains many measurements (eg, file size,
+// build time).
+//
+// This function "transposes" the data, such that measurements with identical labels are merged to
+// form a single array which is what we want to plot.
+//
+// This doesn't depend on particular plotting library though.
+function runsToSeries(runs) {
+  const result = new Map();
+  for (const run of runs) {
+    for (const measurement of run.measurements) {
+      if (!result.has(measurement.label)) {
+        result.set(measurement.label, {
+          label: measurement.label,
+          unit: undefined,
+          value: [],
+          revision: [],
+          timestamp: [],
+        });
+      }
+
+      const series = result.get(measurement.label);
+      assert(series.label == measurement.label);
+
+      if (series.unit) {
+        assert(series.unit == measurement.unit);
+      } else {
+        series.unit = measurement.unit;
+      }
+
+      series.value.push(measurement.value);
+      series.revision.push(run.revision);
+      series.timestamp.push(run.timestamp);
+    }
+  }
+  return result.values();
+}
+
+// Plot time series using <https://apexcharts.com>.
+function plotSeries(seriesList, rootNode) {
+  for (const series of seriesList) {
+    let options = {
+      title: {
+        text: series.label,
+      },
+      chart: {
+        type: "bar",
+        height: "400px",
+      },
+      series: [{
+        name: series.label,
+        data: series.timestamp.map((t, i) => [t * 1000, series.value[i]]),
+      }],
+      xaxis: {
+        type: "datetime",
+      },
+    };
+
+    if (series.unit === "bytes") {
+      options.yaxis = {
+        labels: {
+          formatter: formatBytes,
+        },
+      };
+    }
+
+    if (series.unit === "ms") {
+      options.yaxis = {
+        labels: {
+          formatter: formatDuration,
+        },
+      };
+    }
+
+    const div = document.createElement("div");
+    rootNode.append(div);
+    const chart = new ApexCharts(div, options);
+    chart.render();
+  }
+}
+
+function formatBytes(bytes) {
+  if (bytes === 0) return "0 Bytes";
+
+  const k = 1024;
+  const sizes = [
+    "Bytes",
+    "KiB",
+    "MiB",
+    "GiB",
+    "TiB",
+    "PiB",
+    "EiB",
+    "ZiB",
+    "YiB",
+  ];
+
+  let i = 0;
+  while (i != sizes.length - 1 && Math.pow(k, i + 1) < bytes) {
+    i += 1;
+  }
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+}
+
+function formatDuration(durationInMilliseconds) {
+  const milliseconds = durationInMilliseconds % 1000;
+  const seconds = Math.floor((durationInMilliseconds / 1000) % 60);
+  const minutes = Math.floor((durationInMilliseconds / (1000 * 60)) % 60);
+  const hours = Math.floor((durationInMilliseconds / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(durationInMilliseconds / (1000 * 60 * 60 * 24));
+  const parts = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  if (seconds > 0 || parts.length === 0) {
+    parts.push(`${seconds}s`);
+  }
+  if (milliseconds > 0) {
+    parts.push(`${milliseconds}ms`);
+  }
+
+  return parts.join(" ");
+}
+
+// Returns the ISO week of the date.
+//
+// Source: https://weeknumber.com/how-to/javascript
+function getWeek(date) {
+  date = new Date(date.getTime());
+  date.setHours(0, 0, 0, 0);
+  // Thursday in current week decides the year.
+  date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
+  // January 4 is always in week 1.
+  const week1 = new Date(date.getFullYear(), 0, 4);
+  // Adjust to Thursday in week 1 and count number of weeks from date to week1.
+  return 1 + Math.round(
+    ((date.getTime() - week1.getTime()) / 86400000 -
+      3 + (week1.getDay() + 6) % 7) / 7,
+  );
+}


### PR DESCRIPTION
## What & Why

Add a workbench --- a simple HTML page, maintained as a part of
TigerBeetle monorepo, whose purpose is to serve any kind of developer
related information in a low-effort way. Basically, this is GUI for all
our automation.

Currently, workbench displays two pieces of information:

1. Release rotation (subsuming the python script)
2. Results of macro benchmarks across commits (binary size & build time)

To enable 2, this also adds some continuous benchmarking (CB)
infrastructure.

 ## How: Benchmark

CB is triggered by an GH action on the main branch. This action
intentionally isn't a CI gate (yet?). The idea is that we want to track
long-term trends in numbers, and find obvious regressions within a week.

CB is orechstrated by the `scripts/workbench.zig` script. There's no
specific rules what goes there, but, for starters, track just two
numbers:

- the size of a release binary,
- the time to build the software.

These probably aren't the most impactful things to track, but the idea
here is to establish a process of tracking. Adding _more_ things should
be relatively trivial, once the base infrastructure is in place.

Benchmark results across many runs are stored as a JSON file in the
<https://github.com/tigerbeetle/workbenchdb> repository, using `git` as
a distributed database of sorts.

Specifically:

- `workbench/data.json` is the file (the directory to allow "log
  rotation" once a year)
- it is a newline delimited JSON --- each line is a JSON object
- each objects records a "run" --- a set of measurements at a particular
  commit and a timestamp
- a measurement has a label, a value, and a unit (bytes, ms, etc)
- aggregating measurements with the same label across runs gives a time
  series
- the set of measurements can change over time --- different runs might
  have different sets of measurements
- unit is convenient both for humans and for the front-end to display
  results without hard-coding a list of measurements.
- as a TODO, it would perhaps be nice to track hosts cpu, memory and an
  OS in the run.

It is assumed that a single workbench is run at a time, so no provision
for merge conflicts is made.

  ## How: Workbench

A GitHub pages without any build step --- just some static files in
`src/workbench` directory. If this grows big, we'll probably want to
switch to TypeScript at least, but maybe it needn't grow big.

To display benchmark results, the data is `fetch`ed from
`raw.githubusercontent` and displayed using <https://apexcharts.com/>. No
affiliation with this particular library, it's just something I saw on
<https://deno.com/benchmarks> and I quite like that page.