### PR TITLE
build: reduce Linux binary size from 12 to 2 megs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -127,6 +127,9 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = mode,
     });
+    if (mode == .ReleaseSafe) {
+        tigerbeetle.strip = true;
+    }
     if (emit_llvm_ir) {
         _ = tigerbeetle.getEmittedLlvmIr();
     }


### PR DESCRIPTION
Zig includes debug info by default, and it needs to be stripped explicitly.