### PR TITLE
fuzz: use correct config

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -63,10 +63,14 @@ pub fn main() !void {
             assert(cli_args.events_max == null);
             try smoke();
         },
-        inline else => |fuzzer| try @field(Fuzzers, @tagName(fuzzer)).main(.{
-            .seed = seed,
-            .events_max = cli_args.events_max,
-        }),
+        inline else => |fuzzer| {
+            var timer = try std.time.Timer.start();
+            try @field(Fuzzers, @tagName(fuzzer)).main(.{
+                .seed = seed,
+                .events_max = cli_args.events_max,
+            });
+            log.info("done in {}", .{std.fmt.fmtDuration(timer.lap())});
+        },
     }
 }
 
@@ -103,5 +107,5 @@ fn smoke() !void {
         }
     }
 
-    log.info("done {}", .{std.fmt.fmtDuration(timer_all.lap())});
+    log.info("done in {}", .{std.fmt.fmtDuration(timer_all.lap())});
 }

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -2,13 +2,17 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const flags = @import("./flags.zig");
+const constants = @import("./constants.zig");
 const fuzz = @import("./testing/fuzz.zig");
 const fatal = flags.fatal;
 
 const log = std.log.scoped(.fuzz);
 
 // NB: this changes values in `constants.zig`!
-pub const tigerbeetle_config = @import("config.zig").configs.test_min;
+pub const tigerbeetle_config = @import("config.zig").configs.fuzz_min;
+comptime {
+    assert(constants.storage_size_limit_max == tigerbeetle_config.process.storage_size_limit_max);
+}
 
 pub const std_options = struct {
     pub const log_level: std.log.Level = .info;
@@ -77,28 +81,28 @@ pub fn main() !void {
 fn smoke() !void {
     var timer_all = try std.time.Timer.start();
     inline for (comptime std.enums.values(FuzzersEnum)) |fuzzer| {
-        const fuzz_args = switch (fuzzer) {
+        const events_max = switch (fuzzer) {
             .smoke => continue,
             // TODO: At one point, these were too slow to run, but surely there is _some_ way
             // to run them fast enough?
-            .lsm_forest,
             .lsm_cache_map,
             .lsm_manifest_log,
             .vsr_free_set,
             => continue,
 
-            .lsm_tree => .{ .seed = 123, .events_max = 400 },
-            .vsr_superblock => .{ .seed = 123, .events_max = 3 },
+            .lsm_forest => 10000,
+            .lsm_tree => 400,
+            .vsr_superblock => 3,
 
             inline .ewah,
             .lsm_segmented_array,
             .vsr_journal_format,
             .vsr_superblock_quorums,
-            => .{ .seed = 123, .events_max = null },
+            => null,
         };
 
         var timer_single = try std.time.Timer.start();
-        try @field(Fuzzers, @tagName(fuzzer)).main(fuzz_args);
+        try @field(Fuzzers, @tagName(fuzzer)).main(.{ .seed = 123, .events_max = events_max });
         const fuzz_duration = timer_single.lap();
         if (fuzz_duration > 60 * std.time.ns_per_s) {
             log.err("fuzzer too slow for the smoke mode: " ++ @tagName(fuzzer) ++ " {}", .{

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -216,6 +216,7 @@ const Environment = struct {
     /// than one block to exercise the block linked list logic from CheckpointTrailer.
     fn fragmentate_free_set(env: *Environment) void {
         assert(env.grid.free_set.count_acquired() == 0);
+        assert(free_set_fragments_max * free_set_fragment_size <= env.grid.free_set.count_free());
 
         var reservations: [free_set_fragments_max]Reservation = undefined;
         for (&reservations) |*reservation| {


### PR DESCRIPTION
We should be using fuzz_min rather than test_min here! Luckily, this was
caught by the forest fuzzer, which simply fails with too small storage
size.

With the correct config, we can now re-enable that fuzzer.