### PR TITLE
fuzz: remove needless logs 

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -16,6 +16,9 @@ comptime {
 
 pub const std_options = struct {
     pub const log_level: std.log.Level = .info;
+    pub const log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .superblock_quorums, .level = .err },
+    };
 };
 
 const Fuzzers = .{


### PR DESCRIPTION
superblock correctly warns a lot during fuzzing, but we generally don't
need to see that, as that's expected.