### PR TITLE
LSM: Cleanup of binary_search_values

### DIFF
--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -530,7 +530,7 @@ pub fn TableType(
         pub fn data_block_search(data_block: BlockPtrConst, key: Key) ?*const Value {
             const values = data_block_values_used(data_block);
 
-            const result = binary_search.binary_search_values(
+            return binary_search.binary_search_values(
                 Key,
                 Value,
                 key_from_value,
@@ -538,21 +538,6 @@ pub fn TableType(
                 key,
                 .{},
             );
-            if (result.exact) {
-                const value = &values[result.index];
-                if (constants.verify) {
-                    assert(key == key_from_value(value));
-                }
-                return value;
-            }
-
-            if (constants.verify) {
-                for (values) |*value| {
-                    assert(key != key_from_value(value));
-                }
-            }
-
-            return null;
         }
 
         pub fn verify(

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -97,7 +97,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             assert(table.value_context.count <= value_count_max);
             assert(table.value_context.sorted);
 
-            const result = binary_search.binary_search_values(
+            return binary_search.binary_search_values(
                 Key,
                 Value,
                 key_from_value,
@@ -105,13 +105,6 @@ pub fn TableMemoryType(comptime Table: type) type {
                 key,
                 .{ .mode = .upper_bound },
             );
-            if (result.exact) {
-                const value = &table.values[result.index];
-                assert(key == key_from_value(value));
-                return value;
-            }
-
-            return null;
         }
 
         pub fn make_immutable(table: *TableMemory, snapshot_min: u64) void {

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -534,7 +534,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                         var it = model.iterator();
                         while (it.next()) |entry| {
                             const model_value_key = Value.key_from_value(entry.value_ptr);
-                            const search = binary_search.binary_search_values(
+                            const value_maybe = binary_search.binary_search_values(
                                 u64,
                                 Value,
                                 Table.key_from_value,
@@ -547,7 +547,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                                 model_value_key <= scan_range.max)
                             {
                                 // Must be found:
-                                if (!search.exact) {
+                                if (value_maybe == null) {
                                     // Or our buffer has exceeded, in this case the key should
                                     // be less than the first element or greater than the last element,
                                     // depending on the scan direction.
@@ -565,9 +565,9 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                                 }
                             } else {
                                 // Must not be found:
-                                if (search.exact) {
+                                if (value_maybe) |value| {
                                     // Or it's a tombstone.
-                                    assert(Table.tombstone(&tree_values[search.index]));
+                                    assert(Table.tombstone(value));
                                 }
                             }
                         }


### PR DESCRIPTION
Switch the return type to an optional, so that we can centralize all the asserts in one place. Previously we had different asserts at different callsites for no real reason.

This is less expressive, but it turns out we were not actaully using the index in the inexact case at any callsites.

`?*const Value` and `BinarySearchResult` have the same size so there shouldn't be performance issues down the line.