### PR TITLE
style: main on top

### DIFF
--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -268,6 +268,13 @@ Beyond these rules:
 * Callbacks go last in the list of parameters. This mirrors control flow: callbacks are also
   _invoked_ last.
 
+* More generally, _order_ matters for readability even if it doesn't affect semantics. On the
+  initial scan, a file is read top-down, so put important things near the top. The `main` function
+  goes first.
+
+  At the same time, not everything has a single right order. When in doubt, consider sorting
+  alphabetically, taking advantage of big-endian naming.
+
 * Don't overload names with multiple meanings that are context-dependent. For example, TigerBeetle
   has a feature called *pending transfers* where a pending transfer can be subsequently *posted* or
   *voided*. At first, we called them *two-phase commit transfers*, but this overloaded the

--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -268,8 +268,8 @@ Beyond these rules:
 * Callbacks go last in the list of parameters. This mirrors control flow: callbacks are also
   _invoked_ last.
 
-* More generally, _order_ matters for readability even if it doesn't affect semantics. On the
-  initial scan, a file is read top-down, so put important things near the top. The `main` function
+* _Order_ matters for readability (even if it doesn't affect semantics). On the
+  first read, a file is read top-down, so put important things near the top. The `main` function
   goes first.
 
   At the same time, not everything has a single right order. When in doubt, consider sorting


### PR DESCRIPTION
We are horribly inconsistent here!

1. main first: tigerbeetle, simulator, scripts, half of the fuzzers
2. main last: aof.zig, docs_generate.zig, (go,dotnet,node)_bindings, half of the fuzzers

Zig is not C, it deliberately allows declarations to be in any order, and I'd say writing and reading code top down

https://www.teamten.com/lawrence/programming/write-code-top-down.html

is much more human friendly. 