### PR TITLE
java: don't use checked exceptions for our own programming errors 

### DIFF
--- a/src/clients/java/samples/basic/src/main/java/Main.java
+++ b/src/clients/java/samples/basic/src/main/java/Main.java
@@ -7,7 +7,7 @@ import com.tigerbeetle.*;
 
 public final class Main {
 	public static void main(String[] args)
-			throws RequestException, ConcurrencyExceededException {
+			throws ConcurrencyExceededException {
 		String replicaAddress = System.getenv("TB_ADDRESS");
 
 		byte[] clusterID = UInt128.asBytes(0);

--- a/src/clients/java/samples/two-phase-many/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase-many/src/main/java/Main.java
@@ -7,7 +7,7 @@ import com.tigerbeetle.*;
 
 public final class Main {
 	public static void main(String[] args)
-			throws RequestException, ConcurrencyExceededException {
+			throws ConcurrencyExceededException {
 		String replicaAddress = System.getenv("TB_ADDRESS");
 
 		byte[] clusterID = UInt128.asBytes(0);

--- a/src/clients/java/samples/two-phase/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase/src/main/java/Main.java
@@ -8,7 +8,7 @@ import com.tigerbeetle.*;
 
 public final class Main {
 	public static void main(String[] args)
-			throws RequestException, ConcurrencyExceededException {
+			throws ConcurrencyExceededException {
 		String replicaAddress = System.getenv("TB_ADDRESS");
 
 		byte[] clusterID = UInt128.asBytes(0);

--- a/src/clients/java/src/main/java/com/tigerbeetle/BlockingRequest.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/BlockingRequest.java
@@ -85,7 +85,7 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
         return result != null || exception != null;
     }
 
-    public TResponse waitForResult() throws RequestException {
+    public TResponse waitForResult() {
 
         waitForCompletionUninterruptibly();
         return getResult();
@@ -143,7 +143,7 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
         }
     }
 
-    TResponse getResult() throws RequestException {
+    TResponse getResult() {
 
         assertTrue(result != null || exception != null, "Unexpected request result: result=null");
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/Client.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Client.java
@@ -104,7 +104,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalStateException if this client is closed.
      */
     public CreateAccountResultBatch createAccounts(final AccountBatch batch)
-            throws ConcurrencyExceededException, RequestException {
+            throws ConcurrencyExceededException {
         final var request = BlockingRequest.createAccounts(this.nativeClient, batch);
         request.beginRequest();
         return request.waitForResult();
@@ -142,8 +142,7 @@ public final class Client implements AutoCloseable {
      *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
-    public AccountBatch lookupAccounts(final IdBatch batch)
-            throws ConcurrencyExceededException, RequestException {
+    public AccountBatch lookupAccounts(final IdBatch batch) throws ConcurrencyExceededException {
         final var request = BlockingRequest.lookupAccounts(this.nativeClient, batch);
         request.beginRequest();
         return request.waitForResult();
@@ -183,7 +182,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalStateException if this client is closed.
      */
     public CreateTransferResultBatch createTransfers(final TransferBatch batch)
-            throws ConcurrencyExceededException, RequestException {
+            throws ConcurrencyExceededException {
         final var request = BlockingRequest.createTransfers(this.nativeClient, batch);
         request.beginRequest();
         return request.waitForResult();
@@ -221,8 +220,7 @@ public final class Client implements AutoCloseable {
      *         {@link #Client(byte[], String[], int) concurrencyMax} parameter.
      * @throws IllegalStateException if this client is closed.
      */
-    public TransferBatch lookupTransfers(final IdBatch batch)
-            throws ConcurrencyExceededException, RequestException {
+    public TransferBatch lookupTransfers(final IdBatch batch) throws ConcurrencyExceededException {
         final var request = BlockingRequest.lookupTransfers(this.nativeClient, batch);
         request.beginRequest();
         return request.waitForResult();
@@ -260,7 +258,7 @@ public final class Client implements AutoCloseable {
      * @throws IllegalStateException if this client is closed.
      */
     public TransferBatch getAccountTransfers(final AccountTransfers filter)
-            throws ConcurrencyExceededException, RequestException {
+            throws ConcurrencyExceededException {
         final var request = BlockingRequest.getAccountTransfers(this.nativeClient, filter);
         request.beginRequest();
         return request.waitForResult();

--- a/src/clients/java/src/main/java/com/tigerbeetle/EchoClient.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/EchoClient.java
@@ -11,15 +11,13 @@ public final class EchoClient implements AutoCloseable {
         this.nativeClient = NativeClient.initEcho(clusterID, replicaAddresses, concurrencyMax);
     }
 
-    public AccountBatch echo(final AccountBatch batch)
-            throws ConcurrencyExceededException, RequestException {
+    public AccountBatch echo(final AccountBatch batch) throws ConcurrencyExceededException {
         final var request = BlockingRequest.echo(this.nativeClient, batch);
         request.beginRequest();
         return request.waitForResult();
     }
 
-    public TransferBatch echo(final TransferBatch batch)
-            throws ConcurrencyExceededException, RequestException {
+    public TransferBatch echo(final TransferBatch batch) throws ConcurrencyExceededException {
         final var request = BlockingRequest.echo(this.nativeClient, batch);
         request.beginRequest();
         return request.waitForResult();

--- a/src/clients/java/src/main/java/com/tigerbeetle/RequestException.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/RequestException.java
@@ -1,6 +1,12 @@
 package com.tigerbeetle;
 
-public final class RequestException extends Exception {
+/**
+ * RequestException is thrown when the internal invariants of the underlying native library are
+ * violated, which is expected to never happen. If tis exception is thrown, then either there is a
+ * programming error in the tigerbeetle-java library itself, or there is a version mismatch between
+ * the java code and the underlying native library.
+ */
+public final class RequestException extends RuntimeException {
 
     private final byte status;
 
@@ -22,9 +28,9 @@ public final class RequestException extends Exception {
         if (status == PacketStatus.TooMuchData.value)
             return "Too much data provided on this batch.";
         else if (status == PacketStatus.InvalidOperation.value)
-            return "Invalid operation. Check if this client is compatible with the server's version.";
+            return "Invalid operation.";
         else if (status == PacketStatus.InvalidDataSize.value)
-            return "Invalid data size. Check if this client is compatible with the server's version.";
+            return "Invalid data size.";
         else
             return "Unknown error status " + status;
     }

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -93,7 +93,7 @@ public class BlockingRequestTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testEndRequestWithInvalidOperation() throws RequestException {
+    public void testEndRequestWithInvalidOperation() {
 
         var client = getDummyClient();
         var batch = new TransferBatch(1);
@@ -113,7 +113,7 @@ public class BlockingRequestTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testEndRequestWithUnknownOperation() throws RequestException {
+    public void testEndRequestWithUnknownOperation() {
 
         var client = getDummyClient();
         var batch = new TransferBatch(1);
@@ -135,7 +135,7 @@ public class BlockingRequestTest {
     }
 
     @Test
-    public void testEndRequestWithNullBuffer() throws RequestException {
+    public void testEndRequestWithNullBuffer() {
 
         var client = getDummyClient();
         var batch = new TransferBatch(1);
@@ -154,7 +154,7 @@ public class BlockingRequestTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testEndRequestWithInvalidBufferSize() throws RequestException {
+    public void testEndRequestWithInvalidBufferSize() {
 
         var client = getDummyClient();
         var batch = new TransferBatch(1);
@@ -175,7 +175,7 @@ public class BlockingRequestTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testGetResultBeforeEndRequest() throws RequestException {
+    public void testGetResultBeforeEndRequest() {
 
         var client = getDummyClient();
         var batch = new TransferBatch(1);
@@ -216,8 +216,7 @@ public class BlockingRequestTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testEndRequestWithAmountOfResultsGreaterThanAmountOfRequests()
-            throws RequestException {
+    public void testEndRequestWithAmountOfResultsGreaterThanAmountOfRequests() {
         var client = getDummyClient();
 
         // A batch with only 1 item
@@ -237,7 +236,7 @@ public class BlockingRequestTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testEndRequestTwice() throws RequestException {
+    public void testEndRequestTwice() {
         var client = getDummyClient();
 
         // A batch with only 1 item
@@ -268,7 +267,7 @@ public class BlockingRequestTest {
     }
 
     @Test
-    public void testCreateAccountEndRequest() throws RequestException {
+    public void testCreateAccountEndRequest() {
         var client = getDummyClient();
         var batch = new AccountBatch(2);
         batch.add();
@@ -301,7 +300,7 @@ public class BlockingRequestTest {
     }
 
     @Test
-    public void testCreateTransferEndRequest() throws RequestException {
+    public void testCreateTransferEndRequest() {
         var client = getDummyClient();
         var batch = new TransferBatch(2);
         batch.add();
@@ -334,7 +333,7 @@ public class BlockingRequestTest {
     }
 
     @Test
-    public void testLookupAccountEndRequest() throws RequestException {
+    public void testLookupAccountEndRequest() {
         var client = getDummyClient();
         var batch = new IdBatch(2);
         batch.add();
@@ -365,7 +364,7 @@ public class BlockingRequestTest {
     }
 
     @Test
-    public void testLookupTransferEndRequest() throws RequestException {
+    public void testLookupTransferEndRequest() {
         var client = getDummyClient();
         var batch = new IdBatch(2);
         batch.add();
@@ -396,7 +395,7 @@ public class BlockingRequestTest {
     }
 
     @Test
-    public void testSuccessCompletion() throws RequestException {
+    public void testSuccessCompletion() {
 
         var client = getDummyClient();
         var batch = new IdBatch(2);


### PR DESCRIPTION
RequestException is thrown when the underlying C library detects that
the request is invalid --- the op or the size of message body is wrong.

However, the public API of of our Java client ensures that these are
always correct: it is impossible to trigger these errors unless:

* there's a bug in our C or Java code
* there's a version mismatch between our Java and C code (which is
  unlikely, as they come from the same jar)

So, there's absolutely no reason to tax the caller with declaring and
handling this exception.