### PR TITLE
ci: actually use release branch for release validation

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -22,7 +22,7 @@ jobs:
       # could be done.
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version:
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build lint
     env:
@@ -16,19 +16,19 @@ jobs:
   docs_link_spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./.github/ci/docs_check.sh
 
   test_on_alpine:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./.github/ci/tests_on_alpine.sh
 
   test_on_ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           COV=1 ./.github/ci/tests_on_ubuntu.sh && \
           (cp kcov-output/test.*/cobertura.xml cov-pr.xml) || true
@@ -46,10 +46,10 @@ jobs:
   #   continue-on-error: true
   #   steps:
   #     # Check out the PR, copy the tests_on_ubuntu.sh from there, checkout main.
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - run: cp ./.github/ci/tests_on_ubuntu.sh /tmp/tests_on_ubuntu.sh
   #     - run: cp ./build.zig /tmp/build.zig
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #       with:
   #         ref: 'main'
 
@@ -83,8 +83,8 @@ jobs:
   #   needs: [test_on_ubuntu, test_on_ubuntu_main]
   #   continue-on-error: true
   #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v4
   #       with:
   #         ref: 'main'
   #         path: 'tigerbeetle-main'
@@ -132,27 +132,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/benchmark.sh --transfer-count=4000
 
   aof:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: ./.github/ci/test_aof.sh
 
   c_sample:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build c_sample -Drelease
 
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build fuzz -- smoke
 
@@ -162,7 +162,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - run: ./scripts/install_zig.sh
@@ -176,7 +176,7 @@ jobs:
   simulate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build simulator_run -Dsimulator-state-machine=accounting -Drelease -- ${{ github.sha }}
       - run: zig/zig build simulator_run -Dsimulator-state-machine=testing    -Drelease -- ${{ github.sha }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
         target: [macos-13]
     runs-on: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build test
       - run: ./scripts/install.sh
@@ -25,7 +25,7 @@ jobs:
         target: [macos-13]
     runs-on: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/benchmark.sh --transfer-count=4000
 
   c_sample:
@@ -34,6 +34,6 @@ jobs:
         target: [macos-13]
     runs-on: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build c_sample -Drelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: release # Use the 'release' branch even if triggered manually
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          rev: release # Use the 'release' branch even if triggered manually
+          ref: release # Use the 'release' branch even if triggered manually
 
       - uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           rev: release # Use the 'release' branch even if triggered by cron.
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,5 +8,5 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh && ./zig/zig build install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,12 +7,12 @@ jobs:
   benchmark:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: .\scripts\benchmark.bat --transfer-count=4000
 
   c_sample:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: .\scripts\install_zig.bat
       - run: .\zig\zig build c_sample


### PR DESCRIPTION
Commits are unrelated, the first fixes rev->ref typo, the second one updates version of the action.