### PR TITLE
Update docs/DEEP_DIVE.md for zig changes

### DIFF
--- a/docs/DEEP_DIVE.md
+++ b/docs/DEEP_DIVE.md
@@ -99,7 +99,7 @@ Again, the second transfer is rejected because it was never created.
 ```bash
 zig/zig run src/demos/demo_05_post_pending_transfers.zig --deps vsr --mod vsr::src/vsr.zig
 # At this point, Account[1] has reached its credit limit (no more debit transfers allowed).
-zig/zig run src/demos/demo_02_lookup_accountsf.zig --deps vsr --mod vsr::src/vsr.zig
+zig/zig run src/demos/demo_02_lookup_accounts.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 Let's also pretend someone else tried to void the pending transfer concurrently:

--- a/docs/DEEP_DIVE.md
+++ b/docs/DEEP_DIVE.md
@@ -43,9 +43,7 @@ Take a look at the source code of these demos before you run them. Check out our
 
 Let's turn up the log level some more (and your favorite album), so you can see everything the server does as you run these demos:
 
-- Open `src/config.zig` in your editor and change `log_level` to `.debug`.
-
-- Rebuild TigerBeetle using the new debug log level by running `zig/zig build -Drelease && mv zig-out/bin/tigerbeetle .`
+- Rebuild TigerBeetle with the debug log level by running `zig/zig build -Drelease -Dconfig-log-level=debug`
 
 - Start a single replica cluster:
 Format the data file:
@@ -58,14 +56,14 @@ Start the replica from the data file:
 Let's create some accounts and check their balances and limits:
 
 ```bash
-zig/zig run src/demos/demo_01_create_accounts.zig --pkg-begin vsr src/vsr.zig
-zig/zig run src/demos/demo_02_lookup_accounts.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_01_create_accounts.zig --deps vsr --mod vsr::src/vsr.zig
+zig/zig run src/demos/demo_02_lookup_accounts.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 What happens if we create those accounts again?
 
 ```bash
-zig/zig run src/demos/demo_01_create_accounts.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_01_create_accounts.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 ### Demo 3: Simple journal entries
@@ -73,10 +71,10 @@ zig/zig run src/demos/demo_01_create_accounts.zig --pkg-begin vsr src/vsr.zig
 Let's create some simple double-entry accounting journal entries:
 
 ```bash
-zig/zig run src/demos/demo_03_create_transfers.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_03_create_transfers.zig --deps vsr --mod vsr::src/vsr.zig
 # Now let's look at both accounts and the transfers for those accounts:
-zig/zig run src/demos/demo_02_lookup_accounts.zig --pkg-begin vsr src/vsr.zig
-zig/zig run src/demos/demo_07_lookup_transfers.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_02_lookup_accounts.zig --deps vsr --mod vsr::src/vsr.zig
+zig/zig run src/demos/demo_07_lookup_transfers.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 ### Demo 4, 5, 6: Two-phase transfer journal entries
@@ -88,8 +86,8 @@ Let's try full two-phase transfers (create and then post):
 You will see the second transfer is rejected with an error for tripping the debit reserved limit.
 
 ```bash
-zig/zig run src/demos/demo_04_create_pending_transfers.zig --pkg-begin vsr src/vsr.zig
-zig/zig run src/demos/demo_02_lookup_accounts.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_04_create_pending_transfers.zig --deps vsr --mod vsr::src/vsr.zig
+zig/zig run src/demos/demo_02_lookup_accounts.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 You will see these two-phase transfers only update the reserved inflight limits.
@@ -99,15 +97,15 @@ Let's post (and accept):
 Again, the second transfer is rejected because it was never created.
 
 ```bash
-zig/zig run src/demos/demo_05_post_pending_transfers.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_05_post_pending_transfers.zig --deps vsr --mod vsr::src/vsr.zig
 # At this point, Account[1] has reached its credit limit (no more debit transfers allowed).
-zig/zig run src/demos/demo_02_lookup_accounts.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_02_lookup_accountsf.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 Let's also pretend someone else tried to void the pending transfer concurrently:
 
 ```bash
-zig/zig run src/demos/demo_06_void_pending_transfers.zig --pkg-begin vsr src/vsr.zig
+zig/zig run src/demos/demo_06_void_pending_transfers.zig --deps vsr --mod vsr::src/vsr.zig
 ```
 
 **From here, feel free to tweak these demos and see what happens. You can explore all our accounting invariants (and the DSL we created for these) in `src/state_machine.zig` by grepping the source for `fn create_account` or `fn create_transfer`.**


### PR DESCRIPTION
I discovered this useful doc and tried to run through it. It needs some updates.

- Setting the `log_level` variable on `config.zig` does not work as described. It can be set on the command line while building.

- The `--pkg-begin` flag no longer exists.

---

Also, the results I got running this tutorial contradicted what the text says should happen. I'll file a separate issue about it since I don't understand enough to just fix it. (https://github.com/tigerbeetle/tigerbeetle/issues/1432)