### PR TITLE
ci: check for unwanted extensions as a defense in depth

### DIFF
--- a/src/docs_website/.gitattribues
+++ b/src/docs_website/.gitattribues
@@ -1,1 +1,0 @@
-* text=auto eol=lf


### PR DESCRIPTION
To protect from accidentally committing unwanted files, check that
extension are in the allowed set.

Is it useful? Well, this uncovered at last one misspelled
`.gitattributes` file!