### PR TITLE
VSR: CheckpointTrailer in grid blocks

### DIFF
--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -89,6 +89,7 @@ pub fn ewah(comptime Word: type) type {
 
                 var source_index: usize = 0;
                 var target_index: usize = decoder.target_index;
+                defer decoder.target_index = target_index;
 
                 if (decoder.source_literal_words > 0) {
                     const literal_word_count_chunk =
@@ -132,7 +133,6 @@ pub fn ewah(comptime Word: type) type {
                 assert(source_index <= source_words.len);
                 assert(target_index <= target_words.len);
 
-                defer decoder.target_index = target_index;
                 return target_index - decoder.target_index;
             }
 

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -7,6 +7,8 @@ const div_ceil = stdx.div_ceil;
 const disjoint_slices = stdx.disjoint_slices;
 const maybe = stdx.maybe;
 
+const constants = @import("constants.zig");
+
 /// Encode or decode a bitset using Daniel Lemire's EWAH codec.
 /// ("Histogram-Aware Sorting for Enhanced Word-Aligned Compression in Bitmap Indexes")
 ///
@@ -138,6 +140,7 @@ pub fn ewah(comptime Word: type) type {
         /// Decodes the compressed bitset in `source` into `target_words`.
         /// Returns the number of *words* written to `target_words`.
         pub fn decode(source: []align(@alignOf(Word)) const u8, target_words: []Word) usize {
+            assert(constants.verify);
             assert(source.len % @sizeOf(Word) == 0);
             assert(disjoint_slices(u8, Word, source, target_words));
 
@@ -256,6 +259,7 @@ pub fn ewah(comptime Word: type) type {
         // (This is a helper for testing only.)
         // Returns the number of bytes written to `target`.
         pub fn encode(source_words: []const Word, target: []align(@alignOf(Word)) u8) usize {
+            assert(constants.verify);
             assert(target.len == encode_size_max(source_words.len));
             assert(disjoint_slices(Word, u8, source_words, target));
 

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -105,7 +105,7 @@ pub fn ewah(comptime Word: type) type {
                     decoder_.source_literal_words -= literal_word_count_chunk;
                 }
 
-                while (source_index < source_words.len and target_index < target_words.len) {
+                while (source_index < source_words.len) {
                     assert(decoder_.source_literal_words == 0);
 
                     const marker: *const Marker = @ptrCast(&source_words[source_index]);

--- a/src/ewah_benchmark.zig
+++ b/src/ewah_benchmark.zig
@@ -54,7 +54,7 @@ pub fn main() !void {
             var j: usize = 0;
             var size: usize = undefined;
             while (j < repeats) : (j += 1) {
-                size = ewah.encode(bitsets[i], bitsets_encoded[i]);
+                size = ewah.encode_all(bitsets[i], bitsets_encoded[i]);
             }
             bitset_lengths[i] = size;
         }
@@ -67,7 +67,7 @@ pub fn main() !void {
             const bitset_encoded = bitsets_encoded[i][0..bitset_lengths[i]];
             var j: usize = 0;
             while (j < repeats) : (j += 1) {
-                _ = ewah.decode(bitset_encoded, bitsets_decoded[i]);
+                _ = ewah.decode_all(bitset_encoded, bitsets_decoded[i]);
             }
         }
         const decode_time = decode_timer.read() / samples / repeats;

--- a/src/ewah_fuzz.zig
+++ b/src/ewah_fuzz.zig
@@ -129,7 +129,7 @@ fn ContextType(comptime Word: type) type {
         ) !usize {
             assert(decoded_expect.len > 0);
 
-            var encoder = Codec.encoder(decoded_expect);
+            var encoder = Codec.encode_chunks(decoded_expect);
             var encoded_size: usize = 0;
             while (!encoder.done()) {
                 const chunk_words_count = @min(
@@ -140,10 +140,10 @@ fn ContextType(comptime Word: type) type {
                 const chunk =
                     context.encoded_actual[encoded_size..][0 .. chunk_words_count * @sizeOf(Word)];
 
-                encoded_size += encoder.encode(@alignCast(chunk));
+                encoded_size += encoder.encode_chunk(@alignCast(chunk));
             }
 
-            var decoder = Codec.decoder(context.decoded_actual[0..], encoded_size);
+            var decoder = Codec.decode_chunks(context.decoded_actual[0..], encoded_size);
             var decoded_actual_size: usize = 0;
             var decoder_input_offset: usize = 0;
             while (decoder_input_offset < encoded_size) {
@@ -154,7 +154,7 @@ fn ContextType(comptime Word: type) type {
 
                 const chunk = context.encoded_actual[decoder_input_offset..][0..chunk_size];
 
-                decoded_actual_size += decoder.decode(@alignCast(chunk));
+                decoded_actual_size += decoder.decode_chunk(@alignCast(chunk));
                 decoder_input_offset += chunk_size;
             }
             assert(decoder.done());

--- a/src/ewah_fuzz.zig
+++ b/src/ewah_fuzz.zig
@@ -143,7 +143,7 @@ fn ContextType(comptime Word: type) type {
                 encoded_size += encoder.encode(@alignCast(chunk));
             }
 
-            var decoder = Codec.decoder(context.decoded_actual[0..]);
+            var decoder = Codec.decoder(context.decoded_actual[0..], encoded_size);
             var decoded_actual_size: usize = 0;
             var decoder_input_offset: usize = 0;
             while (decoder_input_offset < encoded_size) {
@@ -157,6 +157,7 @@ fn ContextType(comptime Word: type) type {
                 decoded_actual_size += decoder.decode(@alignCast(chunk));
                 decoder_input_offset += chunk_size;
             }
+            assert(decoder.done());
 
             try std.testing.expectEqual(decoded_expect.len, decoded_actual_size);
             try std.testing.expectEqualSlices(

--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -137,10 +137,10 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
         }
 
         pub fn deinit(trailer: *Self, allocator: mem.Allocator) void {
-            for (trailer.blocks) |block| allocator.free(block);
             allocator.free(trailer.block_checksums);
             allocator.free(trailer.block_addresses);
             allocator.free(trailer.block_bodies);
+            for (trailer.blocks) |block| allocator.free(block);
             allocator.free(trailer.blocks);
         }
 

--- a/src/vsr/client_sessions.zig
+++ b/src/vsr/client_sessions.zig
@@ -91,6 +91,9 @@ pub const ClientSessions = struct {
         size_max = std.mem.alignForward(usize, size_max, 8);
         size_max += @sizeOf(u64) * constants.clients_max;
 
+        // For encoding/decoding simplicity, the ClientSessions always fits in a single block.
+        assert(size_max <= constants.block_size - @sizeOf(vsr.Header));
+
         break :blk size_max;
     };
 

--- a/src/vsr/free_set.zig
+++ b/src/vsr/free_set.zig
@@ -508,10 +508,10 @@ pub const FreeSet = struct {
             source_size += source_chunk.len;
         }
 
-        var decoder = ewah.decoder(bit_set_masks(set.blocks), source_size);
+        var decoder = ewah.decode_chunks(bit_set_masks(set.blocks), source_size);
         var words_decoded: usize = 0;
         for (source_chunks) |source_chunk| {
-            words_decoded += decoder.decode(source_chunk);
+            words_decoded += decoder.decode_chunk(source_chunk);
         }
         assert(words_decoded * @bitSizeOf(MaskInt) <= set.blocks.bit_length);
         assert(decoder.done());
@@ -530,12 +530,12 @@ pub const FreeSet = struct {
     }
 
     /// The encoded data does *not* include staged changes.
-    pub fn encoder(set: *const FreeSet) ewah.Encoder {
+    pub fn encode_chunks(set: *const FreeSet) ewah.Encoder {
         assert(set.opened);
         assert(set.reservation_count == 0);
         assert(set.reservation_blocks == 0);
 
-        return ewah.encoder(bit_set_masks(set.blocks));
+        return ewah.encode_chunks(bit_set_masks(set.blocks));
     }
 
     /// (This is a helper for testing only.)
@@ -548,7 +548,7 @@ pub const FreeSet = struct {
         assert(set.reservation_count == 0);
         assert(set.reservation_blocks == 0);
 
-        return ewah.encode(bit_set_masks(set.blocks), target);
+        return ewah.encode_all(bit_set_masks(set.blocks), target);
     }
 
     /// Returns `blocks_count` rounded down to the nearest multiple of shard and word bit count.

--- a/src/vsr/free_set.zig
+++ b/src/vsr/free_set.zig
@@ -503,12 +503,18 @@ pub const FreeSet = struct {
         assert(set.reservation_count == 0);
         assert(set.reservation_blocks == 0);
 
-        var decoder = ewah.decoder(bit_set_masks(set.blocks));
+        var source_size: usize = 0;
+        for (source_chunks) |source_chunk| {
+            source_size += source_chunk.len;
+        }
+
+        var decoder = ewah.decoder(bit_set_masks(set.blocks), source_size);
         var words_decoded: usize = 0;
         for (source_chunks) |source_chunk| {
             words_decoded += decoder.decode(source_chunk);
         }
         assert(words_decoded * @bitSizeOf(MaskInt) <= set.blocks.bit_length);
+        assert(decoder.done());
 
         for (0..set.index.bit_length) |shard| {
             if (set.find_free_block_in_shard(shard) == null) set.index.set(shard);

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -300,7 +300,7 @@ pub fn GridType(comptime Storage: type) type {
                 defer assert(grid.free_set.opened);
 
                 grid.free_set.open(.{
-                    .encoded = free_set_checkpoint.chunks(free_set_checkpoint.size),
+                    .encoded = free_set_checkpoint.decode_chunks(),
                     .block_addresses = free_set_checkpoint.block_addresses[0..free_set_checkpoint.block_count()],
                 });
                 assert((grid.free_set.count_acquired() > 0) == (free_set_checkpoint.size > 0));
@@ -341,9 +341,7 @@ pub fn GridType(comptime Storage: type) type {
                 var free_set_encoder = grid.free_set.encode_chunks();
                 defer assert(free_set_encoder.done());
 
-                const free_set_chunks = grid.free_set_checkpoint.chunks(
-                    FreeSet.encode_size_max(grid.free_set.blocks.bit_length),
-                );
+                const free_set_chunks = grid.free_set_checkpoint.encode_chunks();
 
                 grid.free_set_checkpoint.size = 0;
                 for (free_set_chunks) |chunk| {

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -351,8 +351,7 @@ pub fn GridType(comptime Storage: type) type {
                         @as(u32, @intCast(free_set_encoder.encode_chunk(chunk)));
 
                     if (free_set_encoder.done()) break;
-                }
-                assert(free_set_encoder.done());
+                } else unreachable;
                 assert(grid.free_set_checkpoint.size % @sizeOf(FreeSet.Word) == 0);
             }
 

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -338,7 +338,7 @@ pub fn GridType(comptime Storage: type) type {
                 grid.free_set.include_staging();
                 defer grid.free_set.exclude_staging();
 
-                var free_set_encoder = grid.free_set.encoder();
+                var free_set_encoder = grid.free_set.encode_chunks();
                 defer assert(free_set_encoder.done());
 
                 const free_set_chunks = grid.free_set_checkpoint.chunks(
@@ -348,7 +348,7 @@ pub fn GridType(comptime Storage: type) type {
                 grid.free_set_checkpoint.size = 0;
                 for (free_set_chunks) |chunk| {
                     grid.free_set_checkpoint.size +=
-                        @as(u32, @intCast(free_set_encoder.encode(chunk)));
+                        @as(u32, @intCast(free_set_encoder.encode_chunk(chunk)));
 
                     if (free_set_encoder.done()) break;
                 }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -728,15 +728,18 @@ pub fn ReplicaType(
                 }
             }
 
-            const trailer_buffer = self.client_sessions_checkpoint.buffer;
             const trailer_size = self.client_sessions_checkpoint.size;
+            const trailer_chunks = self.client_sessions_checkpoint.chunks(trailer_size);
 
             if (self.superblock.working.client_sessions_reference().empty()) {
+                assert(trailer_chunks.len == 0);
                 assert(trailer_size == 0);
             } else {
+                assert(trailer_chunks.len == 1);
                 assert(trailer_size == ClientSessions.encode_size);
+                assert(trailer_size == trailer_chunks[0].len);
 
-                self.client_sessions.decode(trailer_buffer[0..trailer_size]);
+                self.client_sessions.decode(trailer_chunks[0]);
             }
 
             self.state_machine.open(state_machine_open_callback);
@@ -3162,8 +3165,14 @@ pub fn ReplicaType(
                     self.client_replies.checkpoint(commit_op_checkpoint_client_replies_callback);
                 },
                 .checkpoint_client_sessions => {
-                    self.client_sessions_checkpoint.size =
-                        self.client_sessions.encode(self.client_sessions_checkpoint.buffer);
+                    // For encoding/decoding simplicity, require that the entire ClientSessions fits
+                    // in a single block.
+                    const chunks = self.client_sessions_checkpoint.chunks(ClientSessions.encode_size);
+                    assert(chunks.len == 1);
+
+                    self.client_sessions_checkpoint.size = self.client_sessions.encode(chunks[0]);
+                    assert(self.client_sessions_checkpoint.size == ClientSessions.encode_size);
+
                     self.client_sessions_checkpoint.checkpoint(commit_op_checkpoint_client_sessions_callback);
                 },
                 .checkpoint_grid => self.commit_op_checkpoint_grid(),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -729,7 +729,7 @@ pub fn ReplicaType(
             }
 
             const trailer_size = self.client_sessions_checkpoint.size;
-            const trailer_chunks = self.client_sessions_checkpoint.chunks(trailer_size);
+            const trailer_chunks = self.client_sessions_checkpoint.decode_chunks();
 
             if (self.superblock.working.client_sessions_reference().empty()) {
                 assert(trailer_chunks.len == 0);
@@ -3167,7 +3167,7 @@ pub fn ReplicaType(
                 .checkpoint_client_sessions => {
                     // For encoding/decoding simplicity, require that the entire ClientSessions fits
                     // in a single block.
-                    const chunks = self.client_sessions_checkpoint.chunks(ClientSessions.encode_size);
+                    const chunks = self.client_sessions_checkpoint.encode_chunks();
                     assert(chunks.len == 1);
 
                     self.client_sessions_checkpoint.size = self.client_sessions.encode(chunks[0]);


### PR DESCRIPTION
Instead of encoding/decoding the trailer into/from a `buffer`, encode/decode it directly to/from grid blocks.

Benefits:
- One less copy (of all trailer data) during every checkpoint.
- Once we have a grid pool, blocks can be acquired lazily, and when not used (which is most of the time, since the free set is _usually_ very small) they contribute to the grid cache.

To keep implementation simple (avoiding modifications to `ClientSessions.{encode,decode}`), one assumption this makes is that the `ClientSessions` trailer fits in a single grid block. (The ClientSessions trailer is fixed-size.) This was already true for all of our configurations.