### PR TITLE
VSR/Sync: Remove jump_sync_target() kludge for R=2

### DIFF
--- a/docs/internals/sync.md
+++ b/docs/internals/sync.md
@@ -150,7 +150,6 @@ A checkpoint identifier is attached to the following message types:
 A _canonical_ checkpoint is a checkpoint:
 1. with an op committed atop it by the primary (discovery via `command=commit`), or
 2. that a majority quorum of replicas have reached (discovery via `command=ping`), or
-3. (when `R=2`: that a single replica has reached).
 
 The primary ignores `command=prepare`s which have a different checkpoint id attached than they expect.
 This means that if a replica's history diverges (due to nondeterminism), the diverging replica is effectively excluded from participating in consensus until it has performed superblock-sync.


### PR DESCRIPTION
Thanks to https://github.com/tigerbeetle/tigerbeetle/pull/1346, there is no risk in a R=2 cluster of the leading replica overwriting a prepare required by the lagging replica. This workaround is not needed anymore!

(I removed the `"Cluster: sync: checkpoint diverges, sync (primary diverges)"` test in a separate commit to emphasize that the test still passes, it just isn't really needed anymore since it doesn't exercise anything interesting anymore.)