### PR TITLE
Allow the node pool size to be set on the command line

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -555,6 +555,19 @@ pub const lsm_table_data_blocks_max = table_blocks_max: {
     );
 };
 
+/// The default size in bytes of the NodePool used for the LSM forest's manifests.
+pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
+    // TODO Tune this better.
+    const lsm_forest_node_count: u32 = 4096;
+    break :lsm_manifest_memory lsm_forest_node_count * lsm_manifest_node_size;
+};
+
+/// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
+pub const lsm_manifest_memory_size_max = lsm_manifest_memory_max: {
+    const u32_max = std.math.maxInt(u32);
+    break: lsm_manifest_memory_max u32_max - (u32_max % lsm_manifest_node_size);
+};
+
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.
 pub const tick_ms = config.process.tick_ms;

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -565,7 +565,7 @@ pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
 /// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_max = lsm_manifest_memory_max: {
     const u32_max = std.math.maxInt(u32);
-    break: lsm_manifest_memory_max u32_max - (u32_max % lsm_manifest_node_size);
+    break :lsm_manifest_memory_max u32_max - (u32_max % lsm_manifest_node_size);
 };
 
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -563,10 +563,8 @@ pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
 };
 
 /// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
-pub const lsm_manifest_memory_size_max = lsm_manifest_memory_max: {
-    const u32_max = std.math.maxInt(u32);
-    break :lsm_manifest_memory_max u32_max - (u32_max % lsm_manifest_node_size);
-};
+pub const lsm_manifest_memory_size_max =
+    @divFloor(std.math.maxInt(u32), lsm_manifest_node_size) * lsm_manifest_node_size;
 
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -564,7 +564,21 @@ pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
 
 /// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_max =
-    @divFloor(std.math.maxInt(u32), lsm_manifest_node_size) * lsm_manifest_node_size;
+    @divFloor(std.math.maxInt(u32), lsm_manifest_memory_size_multiplier) *
+    lsm_manifest_memory_size_multiplier;
+
+/// The minimum size in bytes of the NodePool used for the LSM forest's manifests.
+pub const lsm_manifest_memory_size_min = lsm_manifest_memory_size_multiplier;
+
+/// The lsm memory size must be a multiple of this value.
+///
+/// While technically this could be equal to lsm_manifest_node_size, we set it
+/// to 1MB so it is a more obvious increment for users.
+pub const lsm_manifest_memory_size_multiplier = lsm_manifest_memory_multiplier: {
+    const lsm_manifest_memory_multiplier = 64 * lsm_manifest_node_size;
+    assert(lsm_manifest_memory_multiplier == 1024 * 1024);
+    break :lsm_manifest_memory_multiplier lsm_manifest_memory_multiplier;
+};
 
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -33,9 +33,8 @@ const CliArgs = union(enum) {
         cache_transfers_posted: flags.ByteSize =
             .{ .bytes = constants.cache_transfers_posted_size_default },
         cache_grid: flags.ByteSize = .{ .bytes = constants.grid_cache_size_default },
-        lsm_manifest_memory: flags.ByteSize = .{
-            .bytes = constants.lsm_manifest_memory_size_default
-        },
+        lsm_manifest_memory: flags.ByteSize =
+            .{ .bytes = constants.lsm_manifest_memory_size_default },
 
         positional: struct {
             path: [:0]const u8,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -291,7 +291,7 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
             }
 
             const lsm_forest_node_count_u64 =
-                lsm_manifest_memory / constants.lsm_manifest_node_size;
+                @divExact(lsm_manifest_memory, constants.lsm_manifest_node_size);
             assert(lsm_forest_node_count_u64 <= std.math.maxInt(u32));
             const lsm_forest_node_count: u32 = @intCast(lsm_forest_node_count_u64);
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -112,7 +112,7 @@ const CliArgs = union(enum) {
         \\  --memory-lsm-manifest=<size><KB|MB|GB>
         \\        Sets the amount of memory allocated for LSM-tree manifests. When the
         \\        number or size of LSM-trees would become too large for their manifests to fit
-        \\        into memory, such requests are rejected.
+        \\        into memory the server will terminate.
         \\        Defaults to 64MB.
         \\
         \\  --verbose

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -291,10 +291,8 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
                 );
             }
 
-            const lsm_forest_node_count_u64 =
-                @divExact(lsm_manifest_memory, constants.lsm_manifest_node_size);
-            assert(lsm_forest_node_count_u64 <= std.math.maxInt(u32));
-            const lsm_forest_node_count: u32 = @intCast(lsm_forest_node_count_u64);
+            const lsm_forest_node_count: u32 =
+                @intCast(@divExact(lsm_manifest_memory, constants.lsm_manifest_node_size));
 
             return Command{
                 .start = .{

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -270,7 +270,8 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
 
             const lsm_manifest_memory = start.memory_lsm_manifest.bytes;
             const lsm_manifest_memory_max = constants.lsm_manifest_memory_size_max;
-            const lsm_manifest_memory_min = constants.lsm_manifest_node_size;
+            const lsm_manifest_memory_min = constants.lsm_manifest_memory_size_min;
+            const lsm_manifest_memory_multiplier = constants.lsm_manifest_memory_size_multiplier;
             if (lsm_manifest_memory > lsm_manifest_memory_max) {
                 flags.fatal("--memory-lsm-manifest: size {} exceeds maximum: {}", .{
                     lsm_manifest_memory,
@@ -283,10 +284,10 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
                     lsm_manifest_memory_min,
                 });
             }
-            if (lsm_manifest_memory % constants.lsm_manifest_node_size != 0) {
+            if (lsm_manifest_memory % lsm_manifest_memory_multiplier != 0) {
                 flags.fatal(
-                    "--memory-lsm-manifest: size {} must be a multiple of node size ({})",
-                    .{ lsm_manifest_memory, constants.lsm_manifest_node_size },
+                    "--memory-lsm-manifest: size {} must be a multiple of size ({})",
+                    .{ lsm_manifest_memory, lsm_manifest_memory_multiplier },
                 );
             }
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -33,7 +33,7 @@ const CliArgs = union(enum) {
         cache_transfers_posted: flags.ByteSize =
             .{ .bytes = constants.cache_transfers_posted_size_default },
         cache_grid: flags.ByteSize = .{ .bytes = constants.grid_cache_size_default },
-        lsm_manifest_memory: flags.ByteSize =
+        memory_lsm_manifest: flags.ByteSize =
             .{ .bytes = constants.lsm_manifest_memory_size_default },
 
         positional: struct {
@@ -109,7 +109,7 @@ const CliArgs = union(enum) {
         \\        (Total RAM) - 3GB (TigerBeetle) - 1GB (System), eg 12GB for a 16GB machine.
         \\        Defaults to 1GB.
         \\
-        \\  --lsm-manifest-memory=<size><KB|MB|GB>
+        \\  --memory-lsm-manifest=<size><KB|MB|GB>
         \\        Sets the amount of memory allocated for LSM-tree manifests. When the
         \\        number or size of LSM-trees would become too large for their manifests to fit
         \\        into memory, such requests are rejected.
@@ -268,24 +268,24 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
                 );
             }
 
-            const lsm_manifest_memory = start.lsm_manifest_memory.bytes;
+            const lsm_manifest_memory = start.memory_lsm_manifest.bytes;
             const lsm_manifest_memory_max = constants.lsm_manifest_memory_size_max;
             const lsm_manifest_memory_min = constants.lsm_manifest_node_size;
             if (lsm_manifest_memory > lsm_manifest_memory_max) {
-                flags.fatal("--lsm-memory: size {} exceeds maximum: {}", .{
+                flags.fatal("--memory-lsm-manifest: size {} exceeds maximum: {}", .{
                     lsm_manifest_memory,
                     lsm_manifest_memory_max,
                 });
             }
             if (lsm_manifest_memory < lsm_manifest_memory_min) {
-                flags.fatal("--lsm-memory: size {} is below minimum: {}", .{
+                flags.fatal("--memory-lsm-manifest: size {} is below minimum: {}", .{
                     lsm_manifest_memory,
                     lsm_manifest_memory_min,
                 });
             }
             if (lsm_manifest_memory % constants.lsm_manifest_node_size != 0) {
                 flags.fatal(
-                    "--lsm-memory: size {} must be a multiple of node size ({})",
+                    "--memory-lsm-manifest: size {} must be a multiple of node size ({})",
                     .{ lsm_manifest_memory, constants.lsm_manifest_node_size },
                 );
             }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -181,8 +181,7 @@ const Command = struct {
             .nonce = nonce,
             .time = .{},
             .state_machine_options = .{
-                // TODO Tune lsm_forest_node_count better.
-                .lsm_forest_node_count = 4096,
+                .lsm_forest_node_count = args.lsm_forest_node_count,
                 .cache_entries_accounts = args.cache_accounts,
                 .cache_entries_transfers = args.cache_transfers,
                 .cache_entries_posted = args.cache_transfers_posted,
@@ -209,11 +208,15 @@ const Command = struct {
                 node_maybe = node.next;
             }
         }
-        log_main.info("{}: Allocated {}MB in {} regions during replica init (Grid Cache: {}MB)", .{
+        log_main.info("{}: Allocated {}MB in {} regions during replica init", .{
             replica.replica,
             @divFloor(allocation_size, 1024 * 1024),
             allocation_count,
+        });
+        log_main.info("{}: Grid cache: {}MB, LSM-tree manifests: {}MB", .{
+            replica.replica,
             @divFloor(grid_cache_size, 1024 * 1024),
+            @divFloor(args.lsm_forest_node_count * constants.lsm_manifest_node_size, 1024 * 1024),
         });
 
         log_main.info("{}: cluster={}: listening on {}", .{


### PR DESCRIPTION
This partially addresses the [roadmap](https://github.com/tigerbeetle/tigerbeetle/issues/259) item

> LSM: Runtime-configurable NodePool size, with a sane default. (Currently it is constant and too small.)

It adds a CLI flag, `--lsm-manifest-memory`, that says how many bytes to allocate for the node pool. It does not address the matter of fixing the default size of the node pool. If this PR is merged I will update the roadmap to split these items in two and indicate one is not complete.

I'm open to other names for this flag. I chose this one since it seems relatively understandable, though it requires understanding the concept of a "manifest". This argument is similar in function to `--grid-cache` though, and the name of the flag doesn't follow the same format, e.g. it could be called `--lsm-manifest`.

I am unsure about the help text

> "When the number or size of LSM-trees would become too large for their 
    manifests to fit into memory, such requests are rejected."

In particular: "number or size" - is this true? Additionally, from comments I think it is not the case that such requests are _currently_ rejected, but that is the intent.

The value of this flag must be a large multiple of 16KB (the default is 64MB), which is perhaps not the easiest for users to reason about without help, and the error text currently displays this 16KB multiplier in bytes, which reads poorly.

The minimum value of this flag is equal to one node, which in practice would seemingly be a poor choice. The maximum value of this flag is the largest multiple of the node size which won't cause overflows elsewhere (slightly less than `maxInt(u32)`).

To match the grid cache, I have added this value to the initialization log sequence, splitting the current line about allocations into two, as one line was looking long to me on my console at 107 characters.