### PR TITLE
ci: drop dead code from yml

### DIFF
--- a/.github/workflows/pipeline-main.yml
+++ b/.github/workflows/pipeline-main.yml
@@ -10,22 +10,6 @@ jobs:
     uses: ./.github/workflows/pipeline-core.yml
   other:
     uses: ./.github/workflows/pipeline-other.yml
-  release:
-    needs:
-      - clients
-      - core
-      - other
-    uses: ./.github/workflows/release.yml
-    secrets:
-      TIGERBEETLE_NODE_PUBLISH_KEY: ${{secrets.TIGERBEETLE_NODE_PUBLISH_KEY}}
-      NUGET_KEY: ${{secrets.NUGET_KEY}}
-      MAVEN_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_SECRET_KEY }}
-      MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-      MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-      MAVEN_GPG_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
-      TIGERBEETLE_DOCS_DEPLOY_KEY: ${{secrets.TIGERBEETLE_DOCS_DEPLOY_KEY}}
-      TIGERBEETLE_GO_DEPLOY_KEY: ${{ secrets.TIGERBEETLE_GO_DEPLOY_KEY }}
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
   workbench:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Triggers for release.yml are specified in the workflow itself:

```
name: Release

on:
  workflow_dispatch: # Manual triggering to re-run a release with a different run_number
  push:
    branches:
      - release
```

given that it misses `workflow_call`, I am actually surprise that we don't get any kind of error for the `pipeline-main.yml`...