### PR TITLE
lsm: remove redundant stash

### DIFF
--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -110,6 +110,7 @@ pub fn TableMemoryType(comptime Table: type) type {
         pub fn make_immutable(table: *TableMemory, snapshot_min: u64) void {
             assert(table.mutability == .mutable);
             assert(table.value_context.count <= value_count_max);
+            defer assert(table.value_context.sorted);
 
             // Sort all the values. In future, this will be done incrementally, and use
             // k_way_merge, but for now the performance regression was too bad.

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -319,6 +319,10 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         /// ascertain the existence of the key are not in the Grid cache, it bails out.
         /// The returned `.positive` Value pointer is only valid synchronously.
         pub fn lookup_from_levels_cache(tree: *Tree, snapshot: u64, key: Key) LookupMemoryResult {
+            if (tree.table_immutable.get(key)) |value| {
+                return .{ .positive = value };
+            }
+
             var iterator = tree.manifest.lookup(snapshot, key, 0);
             while (iterator.next()) |table| {
                 const index_block = tree.grid.read_block_from_cache(


### PR DESCRIPTION
At the moment, CacheMap handles lookups for both mutable and immutable
tables. However, immutable table is already sorted, so we can just look
into it directly, getting rid of the second stash.

This cuts self-reported memory usage with --cache-grid=512MB:
from 5043MB to 3085MB

And the RSS goes down:
from 3271MB to 2875MB