### PR TITLE
cli: rename client to repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ First let's create two accounts. (Don't worry about the details, you
 can read about them later.)
 
 ```console
-./tigerbeetle client --cluster=0 --addresses=3000
+./tigerbeetle repl --cluster=0 --addresses=3000
 ```
 ```console
 TigerBeetle Client

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,7 +17,7 @@ First, get TigerBeetle running:
 * Or [run a single-node cluster with Docker](./quick-start/with-docker.md)
 * Or [run a three-node cluster with docker-compose](./quick-start/with-docker-compose.md)
 
-Then, try creating accounts and transfers [using the TigerBeetle CLI client](./quick-start/cli-client.md).
+Then, try creating accounts and transfers [using the TigerBeetle CLI](./quick-start/cli-repl.md).
 
 ## Designing for TigerBeetle
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -7,4 +7,4 @@ First, get TigerBeetle running:
 * Or [run a single-node cluster with Docker](./with-docker.md)
 * Or [run a three-node cluster with docker-compose](./with-docker-compose.md)
 
-Then, try creating accounts and transfers [using the TigerBeetle CLI](./cli-client.md).
+Then, try creating accounts and transfers [using the TigerBeetle CLI](./cli-repl.md).

--- a/docs/quick-start/cli-repl.md
+++ b/docs/quick-start/cli-repl.md
@@ -2,7 +2,7 @@
 sidebar_position: 4
 ---
 
-# Creating accounts and transfers with the CLI client
+# Creating accounts and transfers with the CLI repl
 
 Once you've got some TigerBeetle replicas running, let's connect to the
 replicas and do some accounting!
@@ -11,7 +11,7 @@ First let's create two accounts. (Don't worry about the details, you
 can read about them later.)
 
 ```console
-./tigerbeetle client --cluster=0 --addresses=3000
+./tigerbeetle repl --cluster=0 --addresses=3000
 ```
 ```
 TigerBeetle Client

--- a/docs/quick-start/single-binary-three.md
+++ b/docs/quick-start/single-binary-three.md
@@ -51,4 +51,4 @@ provided.
 
 Now you can connect to the running server with any client. For a quick
 start, try creating accounts and transfers [using the TigerBeetle CLI
-client](./cli-client.md).
+client](./cli-repl.md).

--- a/docs/quick-start/single-binary.md
+++ b/docs/quick-start/single-binary.md
@@ -46,4 +46,4 @@ info(main): 0: cluster=0: listening on 127.0.0.1:3000
 
 Now you can connect to the running server with any client. For a quick
 start, try creating accounts and transfers [using the TigerBeetle CLI
-client](./cli-client.md).
+client](./cli-repl.md).

--- a/docs/quick-start/with-docker-compose.md
+++ b/docs/quick-start/with-docker-compose.md
@@ -88,7 +88,7 @@ tigerbeetle_1    | info(clock): 1: system time is 78ns ahead
 
 Now you can connect to the running server with any client. For a quick
 start, try creating accounts and transfers [using the TigerBeetle CLI
-client](./cli-client.md).
+client](./cli-repl.md).
 
 ## `error: SystemResources` on macOS
 

--- a/docs/quick-start/with-docker.md
+++ b/docs/quick-start/with-docker.md
@@ -30,7 +30,7 @@ info(main): 0: cluster=0: listening on 0.0.0.0:3000
 
 Now you can connect to the running server with any client. For a quick
 start, try creating accounts and transfers [using the TigerBeetle CLI
-client](./cli-client.md).
+client](./cli-repl.md).
 
 ## `error: SystemResources` on macOS
 

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -57,7 +57,7 @@ test "repl integration" {
 
         fn repl_command(context: *Context, command: []const u8) ![]const u8 {
             return try context.shell.exec_stdout(
-                \\{tigerbeetle} client --cluster=0 --addresses={addresses} --command={command}
+                \\{tigerbeetle} repl --cluster=0 --addresses={addresses} --command={command}
             , .{
                 .tigerbeetle = context.tigerbeetle_exe,
                 .addresses = context.tmp_beetle.port_str.slice(),

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -43,7 +43,7 @@ const CliArgs = union(enum) {
         verbose: bool = false,
     },
 
-    client: struct {
+    repl: struct {
         addresses: []const u8,
         cluster: u128,
         verbose: bool = false,
@@ -62,7 +62,7 @@ const CliArgs = union(enum) {
         \\
         \\  tigerbeetle version [--version]
         \\
-        \\  tigerbeetle client --cluster=<integer> --addresses=<addresses>
+        \\  tigerbeetle repl --cluster=<integer> --addresses=<addresses>
         \\
         \\Commands:
         \\
@@ -74,7 +74,7 @@ const CliArgs = union(enum) {
         \\
         \\  version  Print the TigerBeetle build version and the compile-time config values.
         \\
-        \\  client   Enter the TigerBeetle client REPL.
+        \\  repl     Enter the TigerBeetle client REPL.
         \\
         \\Options:
         \\
@@ -126,7 +126,7 @@ const CliArgs = union(enum) {
         \\
         \\  tigerbeetle version --verbose
         \\
-        \\  tigerbeetle client --addresses=3003,3002,3001 --cluster=0
+        \\  tigerbeetle repl --addresses=3003,3002,3001 --cluster=0
         \\
     , .{
         .default_address = constants.address,
@@ -288,7 +288,7 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
                 },
             };
         },
-        .client => |repl| {
+        .repl => |repl| {
             const addresses = parse_addresses(allocator, repl.addresses);
 
             return Command{


### PR DESCRIPTION
That is

   tigerbeetle client --addressses=...

now becomes

   tigerbeetle repl --addressses=...

This is to reduce ambiguity between client.zig and repl.zig, both internally, and for the end user (there are "TigreBeetle client libraries").