### PR TITLE
repl: don't leak CLI arguments

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -275,6 +275,7 @@ pub fn build(b: *std.Build) !void {
         unit_tests_exe_step.dependOn(&install_unit_tests_exe.step);
 
         const run_unit_tests = b.addRunArtifact(unit_tests);
+        run_unit_tests.setEnvironmentVariable("ZIG_EXE", b.zig_exe);
         const unit_tests_step = b.step("test:unit", "Run the unit tests");
         unit_tests_step.dependOn(&run_unit_tests.step);
 

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -88,9 +88,6 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(allocator);
     defer args.deinit();
 
-    // Discard executable name.
-    _ = args.next().?;
-
     const cli_args = flags.parse(&args, CliArgs);
 
     const addresses = try vsr.parse_addresses(allocator, cli_args.addresses, constants.members_max);

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -52,7 +52,6 @@ pub fn main() !void {
     const allocator = arena.allocator();
 
     var args = try std.process.argsWithAllocator(allocator);
-    assert(args.skip());
 
     const cli_args = flags.parse(&args, CliArgs);
 

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -72,6 +72,8 @@ pub fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
 ///
 /// If `pub const help` declaration is present, it is used to implement `-h/--help` argument.
 pub fn parse(args: *std.process.ArgIterator, comptime CliArgs: type) CliArgs {
+    assert(args.skip()); // Discard executable name.
+
     return switch (@typeInfo(CliArgs)) {
         .Union => parse_commands(args, CliArgs),
         .Struct => parse_flags(args, CliArgs),

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -459,7 +459,7 @@ fn default_value(comptime field: std.builtin.Type.StructField) ?field.type {
 }
 
 // CLI parsing makes a liberal use of `fatal`, so testing it within the process is impossible. We
-// test it our of process by:
+// test it out of process by:
 //   - using Zig compiler to build this vey file as an executable in a temporary directory,
 //   - running the following main with various args and capturing stdout, stderr, and the exit code.
 //   - asserting that the captured values are correct.
@@ -505,9 +505,7 @@ pub usingnamespace if (@import("root") != @This()) struct {
         var args = try std.process.argsWithAllocator(gpa);
         defer args.deinit();
 
-        assert(args.skip());
-
-        const cli_args = parse_commands(&args, CliArgs);
+        const cli_args = parse(&args, CliArgs);
 
         const stdout = std.io.getStdOut();
         const out_stream = stdout.writer();
@@ -556,11 +554,7 @@ test "flags" {
         fn init(gpa: std.mem.Allocator) !T {
             // TODO: Avoid std.os.getenv() as it currently causes a linker error on windows.
             // See: https://github.com/ziglang/zig/issues/8456
-            const zig_exe = std.process.getEnvVarOwned(gpa, "ZIG_EXE") catch |e| switch (e) {
-                error.EnvironmentVariableNotFound => return error.SkipZigTest,
-                error.InvalidUtf8 => unreachable,
-                error.OutOfMemory => return error.OutOfMemory,
-            };
+            const zig_exe = try std.process.getEnvVarOwned(gpa, "ZIG_EXE"); // Set by build.zig
             defer gpa.free(zig_exe);
 
             var tmp_dir = std.testing.tmpDir(.{});
@@ -572,22 +566,25 @@ test "flags" {
             const flags_exe_buf = try gpa.create([std.fs.MAX_PATH_BYTES]u8);
             errdefer gpa.destroy(flags_exe_buf);
 
-            const argv = [_][]const u8{ zig_exe, "build-exe", @src().file };
-            const exec_result = try std.ChildProcess.exec(.{
-                .allocator = gpa,
-                .argv = &argv,
-                .cwd_dir = tmp_dir.dir,
-            });
-            defer gpa.free(exec_result.stdout);
-            defer gpa.free(exec_result.stderr);
+            { // Compile this file as an executable!
+                const this_file = try std.fs.cwd().realpath(@src().file, flags_exe_buf);
+                const argv = [_][]const u8{ zig_exe, "build-exe", this_file };
+                const exec_result = try std.ChildProcess.exec(.{
+                    .allocator = gpa,
+                    .argv = &argv,
+                    .cwd_dir = tmp_dir.dir,
+                });
+                defer gpa.free(exec_result.stdout);
+                defer gpa.free(exec_result.stderr);
 
-            if (exec_result.term.Exited != 0) {
-                std.debug.print("{s}{s}", .{ exec_result.stdout, exec_result.stderr });
-                return error.FailedToCompile;
+                if (exec_result.term.Exited != 0) {
+                    std.debug.print("{s}{s}", .{ exec_result.stdout, exec_result.stderr });
+                    return error.FailedToCompile;
+                }
             }
 
             const flags_exe = try tmp_dir.dir.realpath(
-                "flags" ++ if (builtin.os.tag == .windows) ".exe" else "",
+                "flags" ++ comptime builtin.target.exeFileExt(),
                 flags_exe_buf,
             );
 

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -52,7 +52,6 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(fuzz.allocator);
     defer args.deinit();
 
-    assert(args.skip()); // Discard executable name.
     const cli_args = flags.parse(&args, CliArgs);
 
     switch (cli_args.positional.fuzzer) {

--- a/src/scripts/main.zig
+++ b/src/scripts/main.zig
@@ -44,7 +44,6 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(gpa);
     defer args.deinit();
 
-    assert(args.skip()); // Discard executable name.
     const cli_args = flags.parse(&args, CliArgs);
 
     switch (cli_args) {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -147,6 +147,7 @@ pub const Command = union(enum) {
     };
 
     pub const Repl = struct {
+        args_allocated: std.process.ArgIterator,
         addresses: []net.Address,
         cluster: u128,
         verbose: bool,
@@ -169,11 +170,10 @@ pub const Command = union(enum) {
 
     pub fn deinit(command: *Command, allocator: std.mem.Allocator) void {
         switch (command.*) {
-            .start => |*start| allocator.free(start.addresses),
+            inline .start, .repl => |*cmd| allocator.free(cmd.addresses),
             else => {},
         }
         switch (command.*) {
-            .repl => {},
             inline else => |*cmd| cmd.args_allocated.deinit(),
         }
         command.* = undefined;
@@ -293,6 +293,7 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
 
             return Command{
                 .repl = .{
+                    .args_allocated = args,
                     .addresses = addresses,
                     .cluster = repl.cluster,
                     .verbose = repl.verbose,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -136,7 +136,6 @@ const CliArgs = union(enum) {
 
 pub const Command = union(enum) {
     pub const Start = struct {
-        args_allocated: std.process.ArgIterator,
         addresses: []net.Address,
         cache_accounts: u32,
         cache_transfers: u32,
@@ -147,7 +146,6 @@ pub const Command = union(enum) {
     };
 
     pub const Repl = struct {
-        args_allocated: std.process.ArgIterator,
         addresses: []net.Address,
         cluster: u128,
         verbose: bool,
@@ -155,7 +153,6 @@ pub const Command = union(enum) {
     };
 
     format: struct {
-        args_allocated: std.process.ArgIterator,
         cluster: u128,
         replica: u8,
         replica_count: u8,
@@ -163,7 +160,6 @@ pub const Command = union(enum) {
     },
     start: Start,
     version: struct {
-        args_allocated: std.process.ArgIterator,
         verbose: bool,
     },
     repl: Repl,
@@ -173,30 +169,19 @@ pub const Command = union(enum) {
             inline .start, .repl => |*cmd| allocator.free(cmd.addresses),
             else => {},
         }
-        switch (command.*) {
-            inline else => |*cmd| cmd.args_allocated.deinit(),
-        }
         command.* = undefined;
     }
 };
 
 /// Parse the command line arguments passed to the `tigerbeetle` binary.
 /// Exits the program with a non-zero exit code if an error is found.
-pub fn parse_args(allocator: std.mem.Allocator) !Command {
-    // This iterator owns the arguments and is passed to the caller as a part of `Command`.
-    var args = try std.process.argsWithAllocator(allocator);
-    errdefer args.deinit(allocator);
-
-    // Skip argv[0] which is the name of this executable
-    assert(args.skip());
-
-    const cli_args = flags.parse(&args, CliArgs);
+pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgIterator) !Command {
+    const cli_args = flags.parse(args_iterator, CliArgs);
 
     switch (cli_args) {
         .version => |version| {
             return Command{
                 .version = .{
-                    .args_allocated = args,
                     .verbose = version.verbose,
                 },
             };
@@ -221,7 +206,6 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
 
             return Command{
                 .format = .{
-                    .args_allocated = args,
                     .cluster = format.cluster, // just an ID, any value is allowed
                     .replica = format.replica,
                     .replica_count = format.replica_count,
@@ -261,7 +245,6 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
 
             return Command{
                 .start = .{
-                    .args_allocated = args,
                     .addresses = addresses,
                     .storage_size_limit = storage_size_limit,
                     .cache_accounts = parse_cache_size_to_count(
@@ -293,7 +276,6 @@ pub fn parse_args(allocator: std.mem.Allocator) !Command {
 
             return Command{
                 .repl = .{
-                    .args_allocated = args,
                     .addresses = addresses,
                     .cluster = repl.cluster,
                     .verbose = repl.verbose,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -46,10 +46,16 @@ pub fn main() !void {
     try tracer.init(allocator);
     defer tracer.deinit(allocator);
 
-    var parse_args = try cli.parse_args(allocator);
-    defer parse_args.deinit(allocator);
+    var arg_iterator = try std.process.argsWithAllocator(allocator);
+    defer arg_iterator.deinit();
 
-    switch (parse_args) {
+    // Skip argv[0] which is the name of this executable
+    assert(arg_iterator.skip());
+
+    var command = try cli.parse_args(allocator, &arg_iterator);
+    defer command.deinit(allocator);
+
+    switch (command) {
         .format => |*args| try Command.format(allocator, .{
             .cluster = args.cluster,
             .replica = args.replica,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -49,9 +49,6 @@ pub fn main() !void {
     var arg_iterator = try std.process.argsWithAllocator(allocator);
     defer arg_iterator.deinit();
 
-    // Skip argv[0] which is the name of this executable
-    assert(arg_iterator.skip());
-
     var command = try cli.parse_args(allocator, &arg_iterator);
     defer command.deinit(allocator);
 


### PR DESCRIPTION
The first commit corrects a couple of minor error with repl's arguments. The two following comments refacro related code somewhat to hopefully make memory management somewhat easier. 