### PR TITLE
cli: use port=0 to make testing with tigerbeetle easier

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1036,7 +1036,7 @@ public class IntegrationTests
         {
             // Querying transfers where:
             // `debit_account_id=$account1Id
-            // ORDER BY timestamp ASC`.                
+            // ORDER BY timestamp ASC`.
             var filter = new GetAccountTransfers
             {
                 AccountId = accounts[0].Id,
@@ -1057,7 +1057,7 @@ public class IntegrationTests
         {
             // Querying transfers where:
             // `credit_account_id=$account2Id
-            // ORDER BY timestamp DESC`.            
+            // ORDER BY timestamp DESC`.
             var filter = new GetAccountTransfers
             {
                 AccountId = accounts[1].Id,
@@ -1078,7 +1078,7 @@ public class IntegrationTests
         {
             // Querying transfers where:
             // `debit_account_id=$account1Id OR credit_account_id=$account1Id
-            // ORDER BY timestamp ASC LIMIT 5`.       
+            // ORDER BY timestamp ASC LIMIT 5`.
             var filter = new GetAccountTransfers
             {
                 AccountId = accounts[0].Id,
@@ -1087,7 +1087,7 @@ public class IntegrationTests
                 Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits
             };
 
-            // First 5 items:            
+            // First 5 items:
             var account_transfers = client.GetAccountTransfers(filter);
             Assert.IsTrue(account_transfers.Length == 5);
             ulong timestamp = 0;
@@ -1116,7 +1116,7 @@ public class IntegrationTests
         {
             // Querying transfers where:
             // `debit_account_id=$account2Id OR credit_account_id=$account2Id
-            // ORDER BY timestamp DESC LIMIT 5`.       
+            // ORDER BY timestamp DESC LIMIT 5`.
             var filter = new GetAccountTransfers
             {
                 AccountId = accounts[1].Id,
@@ -1125,7 +1125,7 @@ public class IntegrationTests
                 Flags = GetAccountTransfersFlags.Credits | GetAccountTransfersFlags.Debits | GetAccountTransfersFlags.Reversed
             };
 
-            // First 5 items:                
+            // First 5 items:
             var account_transfers = client.GetAccountTransfers(filter);
             Assert.IsTrue(account_transfers.Length == 5);
             ulong timestamp = ulong.MaxValue;
@@ -1479,7 +1479,7 @@ internal class TBServer : IDisposable
     private const string TB_FILE = "dotnet-tests.tigerbeetle";
     private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
     private const string FORMAT = $"format --cluster=0 --replica=0 --replica-count=1 ./" + TB_FILE;
-    private const string START = $"start --addresses=0  --cache-grid=512MB ./" + TB_FILE;
+    private const string START = $"start --addresses=0 --cache-grid=512MB ./" + TB_FILE;
 
     private readonly Process process;
 
@@ -1503,39 +1503,11 @@ internal class TBServer : IDisposable
         process = new Process();
         process.StartInfo.FileName = TB_SERVER;
         process.StartInfo.Arguments = START;
-        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.RedirectStandardInput = true;
+        process.StartInfo.RedirectStandardOutput = true;
         process.Start();
-        if (process.WaitForExit(100)) throw new InvalidOperationException("Tigerbeetle server failed to start");
 
-        var readPortEvent = new AutoResetEvent(false);
-        var addressLogged = "";
-        var stderrLogged = new StringBuilder();
-        process.ErrorDataReceived += (sender, e) =>
-        {
-            var line = e.Data;
-            if (line == null) return;
-            stderrLogged.Append(line);
-            const string listening = "listening on ";
-            var found = line.IndexOf(listening);
-            if (found != -1)
-            {
-                if (addressLogged != "") throw new InvalidOperationException("have already read the port");
-                addressLogged = line.Substring(found + listening.Length).Trim();
-                readPortEvent.Set();
-            }
-        };
-        process.BeginErrorReadLine();
-        readPortEvent.WaitOne(60_000);
-
-        if (addressLogged == "")
-        {
-            process.Kill();
-            process.WaitForExit();
-            throw new InvalidOperationException($"failed to read the port, ExitCode={process.ExitCode} stderr:\n{stderrLogged.ToString()}");
-        }
-
-        process.CancelErrorRead();
-        Address = addressLogged;
+        Address = process.StandardOutput.ReadLine().Trim();
     }
 
     public void Dispose()

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -531,6 +531,18 @@ pub fn exec_raw(
 /// sadly, child will still be leaked if the parent process is killed itself, because POSIX doesn't
 /// have nice APIs for structured concurrency).
 pub fn spawn(shell: Shell, comptime cmd: []const u8, cmd_args: anytype) !std.ChildProcess {
+    return try shell.spawn_options(.{}, cmd, cmd_args);
+}
+
+pub fn spawn_options(
+    shell: Shell,
+    options: struct {
+        stdin_behavior: std.ChildProcess.StdIo = .Ignore,
+        stderr_behavior: std.ChildProcess.StdIo = .Pipe,
+    },
+    comptime cmd: []const u8,
+    cmd_args: anytype,
+) !std.ChildProcess {
     var argv = Argv.init(shell.gpa);
     defer argv.deinit();
 
@@ -542,9 +554,9 @@ pub fn spawn(shell: Shell, comptime cmd: []const u8, cmd_args: anytype) !std.Chi
 
     var child = std.ChildProcess.init(argv.slice(), shell.gpa);
     child.cwd = cwd_path;
-    child.stdin_behavior = .Ignore;
+    child.stdin_behavior = options.stdin_behavior;
     child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    child.stderr_behavior = options.stderr_behavior;
 
     try child.spawn();
 

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -19,17 +19,7 @@ port_str: stdx.BoundedArray(u8, 8),
 
 tmp_dir: std.testing.TmpDir,
 
-// Lifetimes are tricky here! The order is:
-// - `kill` the process,
-// - `join` the thread,
-// - `destroy` the reader
-// - `wait` the process
-//
-// That is, we need to kill the process first so that the thread is unblocked, but we
-// need to wait for it last, so that stderr file descriptor is still good while we use it!
 process: std.ChildProcess,
-stderr_reader: *StderrReader,
-stderr_reader_thread: std.Thread,
 
 pub fn init(
     gpa: std.mem.Allocator,
@@ -80,7 +70,8 @@ pub fn init(
     );
 
     // Pass `--addresses=0` to let the OS pick a port for us.
-    var process = try shell.spawn(
+    var process = try shell.spawn_options(
+        .{ .stdin_behavior = .Pipe, .stderr_behavior = .Ignore },
         "{tigerbeetle} start --cache-grid=512MB --addresses=0 {data_file}",
         .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
     );
@@ -88,109 +79,26 @@ pub fn init(
         _ = process.kill() catch unreachable;
     }
 
-    var stderr_reader = try StderrReader.create(gpa, process.stderr.?);
-    errdefer stderr_reader.destroy(gpa);
-
-    stderr_reader.echo = options.echo;
-
-    // Parse stderr to learn the assigned port. After that, spawn a dedicated thread to read the
-    // rest of stderr to avoid blocking stderr. No need to read stdout as we don't print there.
-    var limit: u32 = 0;
-    const port = while (limit < 32) : (limit += 1) {
-        const line = try stderr_reader.read_line();
-        if (parse_port(line)) |port| break port;
-    } else {
-        log.err("failed to read port number from tigerbeetle process", .{});
-        return error.NoPort;
+    const port = port: {
+        errdefer log.err("failed to read port number from tigerbeetle process", .{});
+        var port_buf: [std.fmt.count("{}\n", .{std.math.maxInt(u16)})]u8 = undefined;
+        const port_bun_len = try process.stdout.?.readAll(&port_buf);
+        break :port try std.fmt.parseInt(u16, port_buf[0 .. port_bun_len - 1], 10);
     };
 
     var port_str: stdx.BoundedArray(u8, 8) = .{};
     std.fmt.formatInt(port, 10, .lower, .{}, port_str.writer()) catch unreachable;
 
-    const stderr_reader_thread = try std.Thread.spawn(.{}, StderrReader.read_all, .{stderr_reader});
-    errdefer stderr_reader_thread.join();
-
     return TmpTigerBeetle{
         .port = port,
         .port_str = port_str,
         .tmp_dir = tmp_dir,
-        .stderr_reader = stderr_reader,
-        .stderr_reader_thread = stderr_reader_thread,
         .process = process,
     };
 }
 
 pub fn deinit(tb: *TmpTigerBeetle, gpa: std.mem.Allocator) void {
-    // Signal to the `stderr_reader_thread` that it can exit
-    // TODO(Zig) https://github.com/ziglang/zig/issues/16820
-    if (builtin.os.tag == .windows) {
-        const exit_code = 1;
-        std.os.windows.TerminateProcess(tb.process.id, exit_code) catch {};
-    } else {
-        std.os.kill(tb.process.id, std.os.SIG.TERM) catch {};
-    }
-
-    tb.stderr_reader_thread.join();
-    tb.stderr_reader.destroy(gpa);
-    _ = tb.process.wait() catch unreachable;
+    _ = gpa;
+    _ = tb.process.kill() catch unreachable;
     tb.tmp_dir.cleanup();
-}
-
-const StderrReader = struct {
-    fd: std.fs.File, // owned by the caller
-    echo: bool = false,
-    buf: [4096]u8 = undefined,
-
-    fn create(gpa: std.mem.Allocator, fd: std.fs.File) !*StderrReader {
-        var reader = try gpa.create(StderrReader);
-        errdefer gpa.destroy(reader);
-
-        reader.* = .{ .fd = fd };
-        return reader;
-    }
-
-    fn destroy(reader: *StderrReader, gpa: std.mem.Allocator) void {
-        gpa.destroy(reader);
-    }
-
-    fn read_line(reader: *StderrReader) ![]const u8 {
-        const line = try reader.fd.reader().readUntilDelimiter(&reader.buf, '\n');
-        if (reader.echo) {
-            std.debug.print("{s}\n", .{line});
-        }
-        return line;
-    }
-
-    fn read_all(reader: *StderrReader) void {
-        while (true) {
-            _ = reader.read_line() catch return;
-        }
-    }
-};
-
-fn parse_port(stderr_log: []const u8) ?u16 {
-    assert(std.mem.indexOf(u8, stderr_log, "\n") == null);
-
-    var result = stderr_log;
-    result = (stdx.cut(result, "listening on ") orelse return null).suffix;
-    result = (stdx.cut(result, ":") orelse return null).suffix;
-    const port = std.fmt.parseInt(u16, result, 10) catch return null;
-    return port;
-}
-
-test parse_port {
-    try std.testing.expectEqual(
-        parse_port("info(main): 0: cluster=1: listening on 127.0.0.1:39047"),
-        39047,
-    );
-}
-
-pub fn main() !void {
-    var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    const gpa = gpa_allocator.allocator();
-
-    var tb = try TmpTigerBeetle.init(gpa, .{});
-    defer tb.deinit(gpa);
-
-    std.debug.print("\n{}\n", .{tb.port});
 }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -137,6 +137,10 @@ const CliArgs = union(enum) {
 pub const Command = union(enum) {
     pub const Start = struct {
         addresses: []net.Address,
+        // true when the value of `--addresses` is exactly `0`. Used to enable "magic zero" mode for
+        // testing. We check the raw string rather then the parsed address to prevent triggering
+        // this logic by accident.
+        addresses_zero: bool,
         cache_accounts: u32,
         cache_transfers: u32,
         cache_transfers_posted: u32,
@@ -246,6 +250,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             return Command{
                 .start = .{
                     .addresses = addresses,
+                    .addresses_zero = std.mem.eql(u8, start.addresses, "0"),
                     .storage_size_limit = storage_size_limit,
                     .cache_accounts = parse_cache_size_to_count(
                         tigerbeetle.Account,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -230,15 +230,14 @@ const Command = struct {
                 "if it's unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.", .{replica.replica});
         }
 
-        // It is possible to start tigerbetele passing `0` as an address:
-        //     $ tigerbeetle start --addresses=0 0_0.tigrebeetle
+        // It is possible to start tigerbeetle passing `0` as an address:
+        //     $ tigerbeetle start --addresses=0 0_0.tigerbeetle
         // This enables a couple of special behaviors, useful in tests:
         // - The operating system picks a free port, avoiding "address already in use" errors.
         // - The port, and only the port, is printed to the stdout, so that the parent process
         //   can learn it.
         // - tigerbeetle process exits when its stdin gets closed.
-        const port_zero = std.net.Address.parseIp(constants.address, 0) catch unreachable;
-        if (args.addresses[replica.replica].eql(port_zero)) {
+        if (args.addresses_zero) {
             const port_actual = replica.message_bus.process.accept_address.getPort();
             const stdout = std.io.getStdOut();
             try stdout.writer().print("{}\n", .{port_actual});

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -230,6 +230,34 @@ const Command = struct {
                 "if it's unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.", .{replica.replica});
         }
 
+        // It is possible to start tigerbetele passing `0` as an address:
+        //     $ tigerbeetle start --addresses=0 0_0.tigrebeetle
+        // This enables a couple of special behaviors, useful in tests:
+        // - The operating system picks a free port, avoiding "address already in use" errors.
+        // - The port, and only the port, is printed to the stdout, so that the parent process
+        //   can learn it.
+        // - tigerbeetle process exits when its stdin gets closed.
+        const port_zero = std.net.Address.parseIp(constants.address, 0) catch unreachable;
+        if (args.addresses[replica.replica].eql(port_zero)) {
+            const port_actual = replica.message_bus.process.accept_address.getPort();
+            const stdout = std.io.getStdOut();
+            try stdout.writer().print("{}\n", .{port_actual});
+            stdout.close();
+
+            // While it is possible to integrate stdin with our io_uring loop, using a dedicated
+            // thread is simpler, and gives us _un_graceful shutdown, which is exactly what we want
+            // to keep behavior close to the normal case.
+            const watchdog = try std.Thread.spawn(.{}, struct {
+                fn thread_main() void {
+                    var buf: [1]u8 = .{0};
+                    _ = std.io.getStdIn().read(&buf) catch {};
+                    log_main.info("stdin closed, exiting", .{});
+                    std.process.exit(0);
+                }
+            }.thread_main, .{});
+            watchdog.detach();
+        }
+
         while (true) {
             replica.tick();
             try command.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);


### PR DESCRIPTION
It is possible to start tigerbetele passing `0` as an address:
    $ tigerbeetle start --addresses=0 0_0.tigrebeetle
This enables a couple of special behaviors, useful in tests:
- The operating system picks a free port, avoiding "address already in use" errors.
- The port, and only the port, is printed to the stdout, so that the parent process
  can learn it.
- tigerbeetle process exits when its stdin gets closed.

Practically, this allows us to remove a bunch of tricky asynchronous programming from all our integration tests:

- To get the port, just read a line of stdout. No need to worry about process deadlocking due to filling the stderr pipe
- To ensure that the process dies properly, pipe its stdin. Even if driver process is killed, the child will die, a pattern from https://matklad.github.io/2023/10/11/unix-structured-concurrency.html


We've discussed this couple of times already, but what I've realized today is that we can just do this when the port is zero. This is a (fair) bit of magical behavior, of course, but I think this is justified --- if you specify `--addresses=0`, you already need something extra to get the actual port anyway, and here we fully formalize this pattern. 

The backstory here is that, for `tigerbeetle benchmark`, I need to spawn a temporary tigrebeetle once again. I don't want to port the existing logic:

https://github.com/tigerbeetle/tigerbeetle/blob/30cfbfa2eca94b8cd0b1d2a8ce41c7e7720128f0/scripts/benchmark.sh#L12-L17

But I also don't want to depend on `tmp_tigerbeetle.zig` or `shell.zig` --- those things are for "test" and "scripts", and `tigrebeetle benchmark` is real production code. So I'd rather stick to raw `std.ChildProcess`, but doing the "let's stream stderr until this special line" dance again is also something I'd love to avoid. 