### PR TITLE
vsr: more logging around advancing commit_max

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3769,7 +3769,14 @@ pub fn ReplicaType(
 
             self.commit_min += 1;
             assert(self.commit_min == prepare.header.op);
-            if (self.commit_min > self.commit_max) self.commit_max = self.commit_min;
+            if (self.commit_min > self.commit_max) {
+                log.debug("{}: commit_op: advancing commit_max={}..{}", .{
+                    self.replica,
+                    self.commit_max,
+                    self.commit_min,
+                });
+                self.commit_max = self.commit_min;
+            }
 
             if (self.event_callback) |hook| hook(self, .committed);
 


### PR DESCRIPTION
This line is pretty crucial --- this is _the_ moment when we say "yep, this prepare here is committed and a part of the official history", if we are a primary.

Looking at this more generally, I wonder if perhaps we should restructure the control flow here a bit, so that `commit_max` is advanced _before_ we start committing, so that we don't mix up control plane (deciding what's committed) and data plane (actually committing stuff).

But just logging this seems like a good start.