### PR TITLE
Improve integration tests

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -705,7 +705,8 @@ public class IntegrationTests
         Assert.AreEqual(lookupAccounts[1].DebitsPosted, (UInt128)0);
 
         // Waiting for the transfer to expire:
-        await Task.Delay(1000);
+        // Do not use Task.Delay here as it seems to be less precise.
+        Thread.Sleep(1000);
 
         var postTransfer = new Transfer
         {


### PR DESCRIPTION
While investigating this [Rafik issue](https://github.com/interledger/rafiki/actions/runs/7653128123/job/20854361776?pr=2364), I noticed that our Node.js CI passes even if tests fail.

- Ensure that the Node.js test runner returns a non-zero exit code when tests fail.
- Add Node, Java, and Dotnet tests for `pending_transfer_expired`.
