### PR TITLE
vsr: liveness when SV strands checkpoint boundary in an idle cluster

### DIFF
--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -498,8 +498,10 @@ test "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfe
     // Thanks to the new primary, the lagging backup is able to catch up to the latest
     // checkpoint/commit.
     try expectEqual(b1.role(), .backup);
-    try expectEqual(b1.commit(), checkpoint_1_trigger);
+    try expectEqual(b1.commit(), checkpoint_1_trigger + 1);
     try expectEqual(b1.op_checkpoint(), checkpoint_1);
+
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger + 1);
 }
 
 // TODO: Re-enable when the op_checkpoint hack is removed from ignore_request_message().


### PR DESCRIPTION
An SV might include messages from the current and the next checkpoint.

Installing headers from the next checkpoint would be unsafe, so replica effectively accepts only _part_ of an SV message if it hasn't checkpointed yet.

What makes this tricky is that "skipped" headers are from the previous view.

So, if a a replica sees such a header/prepare after it checkpoints, it will _still_ ignore it: this header is from the previous view, so it could have been truncated.

For prepares from older views, a replica needs primary to positively tell it that, yes, that prepare is part of the canonical history.

To fix this, detect if our view headers are ahead of our op during repair, and request a start view in that case.

SEED: 15556801325249033142