### PR TITLE
ci: bring back windows tests for .Net client

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        # os: [ubuntu-latest-large, windows-latest-large, macos-13,  macos-13-xlarge]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -28,7 +27,7 @@ jobs:
           dotnet-version:
             7.0.x
 
-      - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest-large' && 'bat' || 'sh' }}
+      - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
       - run: ./zig/zig build scripts -- ci --language=dotnet
 
   client-go:

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -71,7 +71,12 @@ pub fn init(
 
     // Pass `--addresses=0` to let the OS pick a port for us.
     var process = try shell.spawn_options(
-        .{ .stdin_behavior = .Pipe, .stderr_behavior = .Ignore },
+        .{
+            .stdin_behavior = .Pipe,
+            // TODO(Zig): ignoring stderr is broken in 0.11, fixed in 0.12:
+            //     https://github.com/ziglang/zig/pull/15565
+            .stderr_behavior = if (builtin.os.tag == .windows) .Inherit else .Ignore,
+        },
         "{tigerbeetle} start --cache-grid=512MB --addresses=0 {data_file}",
         .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
     );


### PR DESCRIPTION
We disabled them, because we were apparently running out of RAM. Since then GitHub upped specs of public runners 2X, so we should fit now.