### PR TITLE
Revisiting the code!

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1022,7 +1022,7 @@ const FailStep = struct {
     message: []const u8,
 
     fn add(b: *std.Build, message: []const u8) *FailStep {
-        var result = b.allocator.create(FailStep) catch unreachable;
+        const result = b.allocator.create(FailStep) catch unreachable;
         result.* = .{
             .step = std.Build.Step.init(.{
                 .id = .custom,
@@ -1047,7 +1047,7 @@ const ShellcheckStep = struct {
     gpa: std.mem.Allocator,
 
     fn add(b: *std.Build) *ShellcheckStep {
-        var result = b.allocator.create(ShellcheckStep) catch unreachable;
+        const result = b.allocator.create(ShellcheckStep) catch unreachable;
         result.* = .{
             .step = std.Build.Step.init(.{
                 .id = .custom,
@@ -1098,7 +1098,7 @@ const GitCloneStep = struct {
     };
 
     fn add(b: *std.Build, options: Options) *GitCloneStep {
-        var result = b.allocator.create(GitCloneStep) catch unreachable;
+        const result = b.allocator.create(GitCloneStep) catch unreachable;
         result.* = .{
             .step = std.Build.Step.init(.{
                 .id = .custom,
@@ -1130,13 +1130,13 @@ fn set_windows_dll(allocator: std.mem.Allocator, java_home: []const u8) void {
         pub extern "kernel32" fn SetDllDirectoryA(path: [*:0]const u8) callconv(.C) std.os.windows.BOOL;
     }.SetDllDirectoryA;
 
-    var java_bin_path = std.fs.path.joinZ(
+    const java_bin_path = std.fs.path.joinZ(
         allocator,
         &.{ java_home, "\\bin" },
     ) catch unreachable;
     _ = set_dll_directory(java_bin_path);
 
-    var java_bin_server_path = std.fs.path.joinZ(
+    const java_bin_server_path = std.fs.path.joinZ(
         allocator,
         &.{ java_home, "\\bin\\server" },
     ) catch unreachable;

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -198,7 +198,7 @@ pub const AOF = struct {
 
                 try it.file.seekTo(it.offset);
 
-                var buf = std.mem.asBytes(target);
+                const buf = std.mem.asBytes(target);
                 const bytes_read = try it.file.readAll(buf);
 
                 if (bytes_read < target.calculate_disk_size()) {
@@ -293,7 +293,7 @@ pub const AOFReplayClient = struct {
     inflight_message: ?*Message.Request = null,
 
     pub fn init(allocator: std.mem.Allocator, raw_addresses: []const u8) !Self {
-        var addresses = try vsr.parse_addresses(allocator, raw_addresses, constants.replicas_max);
+        const addresses = try vsr.parse_addresses(allocator, raw_addresses, constants.replicas_max);
 
         var io = try allocator.create(IO);
         errdefer allocator.destroy(io);
@@ -518,14 +518,14 @@ pub fn aof_merge(
     // Next, start from our root checksum, walk down the hash chain until there's nothing left. We
     // currently take the root checksum as the first entry in the first AOF.
     while (entries_by_parent.count() > 0) {
-        var message = message_pool.get_message(.prepare);
+        const message = message_pool.get_message(.prepare);
         defer message_pool.unref(message);
 
         assert(current_parent != null);
         const entry = entries_by_parent.getPtr(current_parent.?) orelse unreachable;
 
         try entry.aof.file.seekTo(entry.index);
-        var buf = std.mem.asBytes(target)[0..entry.size];
+        const buf = std.mem.asBytes(target)[0..entry.size];
         const bytes_read = try entry.aof.file.readAll(buf);
 
         // None of these conditions should happen, but double check them to prevent any TOCTOUs
@@ -595,7 +595,7 @@ test "aof write / read" {
     const demo_message = message_pool.get_message(.prepare);
     defer message_pool.unref(demo_message);
 
-    var target = try allocator.create(AOFEntry);
+    const target = try allocator.create(AOFEntry);
     defer allocator.destroy(target);
 
     const demo_payload = "hello world";
@@ -727,7 +727,7 @@ pub fn main() !void {
         count += 1;
     }
 
-    var target = try allocator.create(AOFEntry);
+    const target = try allocator.create(AOFEntry);
     defer allocator.destroy(target);
 
     if (action != null and std.mem.eql(u8, action.?, "recover") and count == 4) {

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -314,7 +314,7 @@ pub const AOFReplayClient = struct {
             allocator,
             std.crypto.random.int(u128),
             0,
-            @as(u8, @intCast(addresses.len)),
+            @intCast(addresses.len),
             message_pool,
             .{
                 .configuration = addresses,
@@ -387,7 +387,7 @@ pub const AOFReplayClient = struct {
         _ = operation;
         _ = result;
 
-        const self = @as(*AOFReplayClient, @ptrFromInt(@as(u64, @intCast(user_data))));
+        const self: *AOFReplayClient = @ptrFromInt(@as(usize, @intCast(user_data)));
         assert(self.inflight_message != null);
         self.inflight_message = null;
     }
@@ -613,8 +613,8 @@ test "aof write / read" {
         .timestamp = 0,
         .checkpoint_id = 0,
         .command = .prepare,
-        .operation = @as(vsr.Operation, @enumFromInt(4)),
-        .size = @as(u32, @intCast(@sizeOf(Header) + demo_payload.len)),
+        .operation = @enumFromInt(4),
+        .size = @intCast(@sizeOf(Header) + demo_payload.len),
     };
 
     stdx.copy_disjoint(.exact, u8, demo_message.body(), demo_payload);

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -116,7 +116,7 @@ pub fn main() !void {
         allocator,
         client_id,
         cluster_id,
-        @as(u8, @intCast(addresses.len)),
+        @intCast(addresses.len),
         &message_pool,
         .{
             .configuration = addresses,
@@ -512,7 +512,7 @@ const Benchmark = struct {
         operation: StateMachine.Operation,
         result: []const u8,
     ) void {
-        const b: *Benchmark = @ptrFromInt(@as(u64, @intCast(user_data)));
+        const b: *Benchmark = @ptrFromInt(@as(usize, @intCast(user_data)));
         const callback = b.callback.?;
         b.callback = null;
 

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -46,7 +46,7 @@ const TestingContext = blk: {
 };
 
 pub fn context_to_client(implementation: *ContextImplementation) tb_client_t {
-    return @as(tb_client_t, @ptrCast(implementation));
+    return @ptrCast(implementation);
 }
 
 fn client_to_context(tb_client: tb_client_t) *ContextImplementation {

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -172,7 +172,7 @@ pub fn ContextType(
                 allocator,
                 context.client_id,
                 cluster_id,
-                @as(u8, @intCast(context.addresses.len)),
+                @intCast(context.addresses.len),
                 &context.message_pool,
                 .{
                     .configuration = context.addresses,
@@ -268,10 +268,10 @@ pub fn ContextType(
 
             // Submit the message for processing:
             self.client.batch_submit(
-                @as(u128, @bitCast(UserData{
+                @bitCast(UserData{
                     .self = self,
                     .packet = packet,
-                })),
+                }),
                 Context.on_result,
                 batch,
             );
@@ -282,7 +282,7 @@ pub fn ContextType(
             op: Client.StateMachine.Operation,
             results: []const u8,
         ) void {
-            const user_data = @as(UserData, @bitCast(raw_user_data));
+            const user_data: UserData = @bitCast(raw_user_data);
             const self = user_data.self;
             const packet = user_data.packet;
 
@@ -313,7 +313,7 @@ pub fn ContextType(
 
             // The packet completed normally.
             packet.status = .ok;
-            (self.completion_fn)(completion_ctx, tb_client, packet, bytes.ptr, @as(u32, @intCast(bytes.len)));
+            (self.completion_fn)(completion_ctx, tb_client, packet, bytes.ptr, @intCast(bytes.len));
         }
 
         inline fn get_context(implementation: *ContextImplementation) *Context {

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -49,7 +49,7 @@ fn RequestContextType(comptime request_size_max: comptime_int) type {
                     // Copy the message's body to the context buffer:
                     assert(result_len <= request_size_max);
                     var writable: [request_size_max]u8 = undefined;
-                    const readable = @as([*]const u8, @ptrCast(result_ptr.?));
+                    const readable: [*]const u8 = @ptrCast(result_ptr.?);
                     stdx.copy_disjoint(.inexact, u8, &writable, readable[0..result_len]);
                     break :blk writable;
                 } else null,
@@ -111,7 +111,7 @@ test "c_client echo" {
         &tb_client,
         cluster_id,
         address,
-        @as(u32, @intCast(address.len)),
+        @intCast(address.len),
         concurrency_max,
         tb_context,
         RequestContext.on_complete,
@@ -197,7 +197,7 @@ test "c_client tb_status" {
                 &tb_client,
                 cluster_id,
                 addresses.ptr,
-                @as(u32, @intCast(addresses.len)),
+                @intCast(addresses.len),
                 concurrency_max,
                 tb_context,
                 RequestContextType(0).on_complete,
@@ -248,7 +248,7 @@ test "c_client tb_packet_status" {
         &tb_client,
         cluster_id,
         address,
-        @as(u32, @intCast(address.len)),
+        @intCast(address.len),
         concurrency_max,
         tb_context,
         RequestContext.on_complete,

--- a/src/clients/java/src/jni_tests.zig
+++ b/src/clients/java/src/jni_tests.zig
@@ -18,7 +18,7 @@ test "JNI: check jvm" {
     var vm_len: jni.JSize = 0;
     const get_created_java_vm_result = JavaVM.get_created_java_vm(
         &vm_buf,
-        @as(jni.JSize, @intCast(vm_buf.len)),
+        @intCast(vm_buf.len),
         &vm_len,
     );
 
@@ -630,7 +630,7 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
 
     const element: u8 = 42;
     var native_buffer = [_]u8{element} ** 256;
-    const buffer = env.new_direct_byte_buffer(&native_buffer, @as(jni.JSize, @intCast(native_buffer.len)));
+    const buffer = env.new_direct_byte_buffer(&native_buffer, @intCast(native_buffer.len));
     try testing.expect(buffer != null);
     defer env.delete_local_ref(buffer);
 
@@ -642,7 +642,7 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         const non_virtual_method_id = env.get_method_id(direct_buffer_class, "get", "()B");
         try testing.expect(non_virtual_method_id != null);
 
-        const expected = @as(jni.JByte, @bitCast(element));
+        const expected: jni.JByte = @bitCast(element);
 
         const read = env.call_byte_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -663,10 +663,10 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         try testing.expect(non_virtual_method_id != null);
 
         const Packed = packed struct { a: u8, b: u8 };
-        const expected = @as(jni.JShort, @bitCast(Packed{
+        const expected: jni.JShort = @bitCast(Packed{
             .a = element,
             .b = element,
-        }));
+        });
 
         const read = env.call_short_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -687,10 +687,10 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         try testing.expect(non_virtual_method_id != null);
 
         const Packed = packed struct { a: u8, b: u8 };
-        const expected = @as(jni.JChar, @bitCast(Packed{
+        const expected: jni.JChar = @bitCast(Packed{
             .a = element,
             .b = element,
-        }));
+        });
 
         const read = env.call_char_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -711,12 +711,12 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         try testing.expect(non_virtual_method_id != null);
 
         const Packed = packed struct { a: u8, b: u8, c: u8, d: u8 };
-        const expected = @as(jni.JInt, @bitCast(Packed{
+        const expected: jni.JInt = @bitCast(Packed{
             .a = element,
             .b = element,
             .c = element,
             .d = element,
-        }));
+        });
 
         const read = env.call_int_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -737,7 +737,7 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         try testing.expect(non_virtual_method_id != null);
 
         const Packed = packed struct { a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, g: u8, h: u8 };
-        const expected = @as(jni.JLong, @bitCast(Packed{
+        const expected: jni.JLong = @bitCast(Packed{
             .a = element,
             .b = element,
             .c = element,
@@ -746,7 +746,7 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
             .f = element,
             .g = element,
             .h = element,
-        }));
+        });
 
         const read = env.call_long_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -767,12 +767,12 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         try testing.expect(non_virtual_method_id != null);
 
         const Packed = packed struct { a: u8, b: u8, c: u8, d: u8 };
-        const expected = @as(jni.JFloat, @bitCast(Packed{
+        const expected: jni.JFloat = @bitCast(Packed{
             .a = element,
             .b = element,
             .c = element,
             .d = element,
-        }));
+        });
 
         const read = env.call_float_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -793,7 +793,7 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
         try testing.expect(non_virtual_method_id != null);
 
         const Packed = packed struct { a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, g: u8, h: u8 };
-        const expected = @as(jni.JDouble, @bitCast(Packed{
+        const expected: jni.JDouble = @bitCast(Packed{
             .a = element,
             .b = element,
             .c = element,
@@ -802,7 +802,7 @@ test "JNI: Call<Type>Method,CallNonVirtual<Type>Method" {
             .f = element,
             .g = element,
             .h = element,
-        }));
+        });
 
         const read = env.call_double_method(buffer, method_id, null);
         try testing.expect(env.exception_check() == .jni_false);
@@ -1178,7 +1178,7 @@ test "JNI: strings" {
     const content: []const u16 = std.unicode.utf8ToUtf16LeStringLiteral("Hello utf16")[0..];
     const string = env.new_string(
         content.ptr,
-        @as(jni.JSize, @intCast(content.len)),
+        @intCast(content.len),
     );
     try testing.expect(string != null);
     defer env.delete_local_ref(string);
@@ -1221,7 +1221,7 @@ test "JNI: GetStringRegion" {
     const content: []const u16 = std.unicode.utf8ToUtf16LeStringLiteral("ABCDEFGHIJKLMNOPQRSTUVXYZ")[0..];
     const string = env.new_string(
         content.ptr,
-        @as(jni.JSize, @intCast(content.len)),
+        @intCast(content.len),
     );
     try testing.expect(string != null);
     defer env.delete_local_ref(string);
@@ -1255,7 +1255,7 @@ test "JNI: GetStringCritical" {
     const env: *JNIEnv = get_testing_env();
 
     const content: []const u16 = std.unicode.utf8ToUtf16LeStringLiteral("ABCDEFGHIJKLMNOPQRSTUVXYZ")[0..];
-    const str = env.new_string(content.ptr, @as(jni.JSize, @intCast(content.len)));
+    const str = env.new_string(content.ptr, @intCast(content.len));
     try testing.expect(str != null);
     defer env.delete_local_ref(str);
 
@@ -1350,8 +1350,8 @@ test "JNI: primitive arrays" {
                             0 => jni.JBoolean.jni_false,
                             else => jni.JBoolean.jni_true,
                         },
-                        jni.JFloat, jni.JDouble => @as(PrimitiveType, @floatFromInt(value)),
-                        else => @as(PrimitiveType, @intCast(value)),
+                        jni.JFloat, jni.JDouble => @floatFromInt(value),
+                        else => @intCast(value),
                     };
                 }
 

--- a/src/clients/node/src/node.zig
+++ b/src/clients/node/src/node.zig
@@ -386,7 +386,10 @@ fn decode_array(comptime Event: type, env: c.napi_env, array: c.napi_value, even
                         // Arrays are only used for padding/reserved fields,
                         // instead of requiring the user to explicitly set an empty buffer,
                         // we just hide those fields and preserve their default value.
-                        .Array => @as(*const field.type, @ptrCast(field.default_value.?)).*,
+                        .Array => @as(
+                            *const field.type,
+                            @ptrCast(@alignCast(field.default_value.?)),
+                        ).*,
                         else => unreachable,
                     };
 

--- a/src/clients/node/src/translate.zig
+++ b/src/clients/node/src/translate.zig
@@ -161,7 +161,7 @@ pub fn u128_from_value(env: c.napi_env, value: c.napi_value, comptime name: [:0]
     // we would need to convert, but big endian is not supported by tigerbeetle.
     var result: u128 = 0;
     var sign_bit: c_int = undefined;
-    const words = @as(*[2]u64, @ptrCast(&result));
+    const words: *[2]u64 = @ptrCast(&result);
     var word_count: usize = 2;
     switch (c.napi_get_value_bigint_words(env, value, &sign_bit, &word_count, words)) {
         c.napi_ok => {},

--- a/src/demos/demo.zig
+++ b/src/demos/demo.zig
@@ -57,7 +57,7 @@ pub fn request(
         allocator,
         client_id,
         cluster_id,
-        @as(u8, @intCast(addresses.len)),
+        @intCast(addresses.len),
         &message_pool,
         .{
             .configuration = &addresses,

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -309,7 +309,7 @@ test "ewah encode→decode cycle" {
         for ([_]usize{ 1, 2, 4, 5, 8, 16, 17, 32 }) |chunk_count| {
             var decoded: [4096]Word = undefined;
 
-            var fuzz_options = .{
+            const fuzz_options = .{
                 .encode_chunk_words_count = @divFloor(decoded.len, chunk_count),
                 .decode_chunk_words_count = @divFloor(decoded.len, chunk_count),
             };

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -61,7 +61,7 @@ pub fn ewah(comptime Word: type) type {
         }
 
         inline fn marker_word(mark: Marker) Word {
-            return @as(Word, @bitCast(mark));
+            return @bitCast(mark);
         }
 
         pub const Decoder = struct {
@@ -225,8 +225,8 @@ pub fn ewah(comptime Word: type) type {
                     };
                     source_index += uniform_word_count;
                     // For consistent encoding, set the run/uniform bit to 0 when there is no run.
-                    const uniform_bit =
-                        if (uniform_word_count == 0) 0 else @as(u1, @intCast(word & 1));
+                    const uniform_bit: u1 =
+                        if (uniform_word_count == 0) 0 else @intCast(word & 1);
 
                     const literal_word_count = count: {
                         // Count sequential literals that immediately follow the run.
@@ -242,8 +242,8 @@ pub fn ewah(comptime Word: type) type {
 
                     target_words[target_index] = marker_word(.{
                         .uniform_bit = uniform_bit,
-                        .uniform_word_count = @as(MarkerUniformCount, @intCast(uniform_word_count)),
-                        .literal_word_count = @as(MarkerLiteralCount, @intCast(literal_word_count)),
+                        .uniform_word_count = @intCast(uniform_word_count),
+                        .literal_word_count = @intCast(literal_word_count),
                     });
                     target_index += 1;
 
@@ -334,7 +334,7 @@ test "ewah Word=u8" {
         try test_decode(u8, &.{
             codec.marker_word(.{
                 .uniform_bit = 0,
-                .uniform_word_count = @as(codec.MarkerUniformCount, @intCast(uniform_word_count)),
+                .uniform_word_count = @intCast(uniform_word_count),
                 .literal_word_count = 3,
             }),
             12,

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -118,7 +118,7 @@ pub const IO = struct {
             self.io_inflight -= new_events;
 
             for (events[0..new_events]) |event| {
-                const completion = @as(*Completion, @ptrFromInt(event.udata));
+                const completion: *Completion = @ptrFromInt(event.udata);
                 completion.next = null;
                 self.completed.push(completion);
             }
@@ -455,7 +455,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
                 .offset = offset,
             },
             struct {
@@ -465,10 +465,10 @@ pub const IO = struct {
                             op.fd,
                             op.buf,
                             op.len,
-                            @as(isize, @bitCast(op.offset)),
+                            @bitCast(op.offset),
                         );
                         return switch (os.errno(rc)) {
-                            .SUCCESS => @as(usize, @intCast(rc)),
+                            .SUCCESS => @intCast(rc),
                             .INTR => continue,
                             .AGAIN => error.WouldBlock,
                             .BADF => error.NotOpenForReading,
@@ -514,7 +514,7 @@ pub const IO = struct {
             .{
                 .socket = socket,
                 .buf = buffer.ptr,
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
             },
             struct {
                 fn do_operation(op: anytype) RecvError!usize {
@@ -547,7 +547,7 @@ pub const IO = struct {
             .{
                 .socket = socket,
                 .buf = buffer.ptr,
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
             },
             struct {
                 fn do_operation(op: anytype) SendError!usize {
@@ -630,7 +630,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
                 .offset = offset,
             },
             struct {
@@ -786,7 +786,7 @@ pub const IO = struct {
             .fst_flags = F_ALLOCATECONTIG | F_ALLOCATEALL,
             .fst_posmode = F_PEOFPOSMODE,
             .fst_offset = 0,
-            .fst_length = @as(os.off_t, @intCast(size)),
+            .fst_length = @intCast(size),
             .fst_bytesalloc = 0,
         };
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -455,7 +455,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @intCast(buffer_limit(buffer.len)),
+                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
             },
             struct {
@@ -514,7 +514,7 @@ pub const IO = struct {
             .{
                 .socket = socket,
                 .buf = buffer.ptr,
-                .len = @intCast(buffer_limit(buffer.len)),
+                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
             },
             struct {
                 fn do_operation(op: anytype) RecvError!usize {
@@ -547,7 +547,7 @@ pub const IO = struct {
             .{
                 .socket = socket,
                 .buf = buffer.ptr,
-                .len = @intCast(buffer_limit(buffer.len)),
+                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
             },
             struct {
                 fn do_operation(op: anytype) SendError!usize {
@@ -630,7 +630,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @intCast(buffer_limit(buffer.len)),
+                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
             },
             struct {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -177,7 +177,7 @@ pub const IO = struct {
                     if (-cqe.res == @intFromEnum(os.E.TIME)) etime.* = true;
                     continue;
                 }
-                const completion = @as(*Completion, @ptrFromInt(cqe.user_data));
+                const completion: *Completion = @ptrFromInt(cqe.user_data);
                 completion.result = cqe.res;
                 // We do not run the completion here (instead appending to a linked list) to avoid:
                 // * recursion through `flush_submissions()` and `flush_completions()`,
@@ -328,7 +328,7 @@ pub const IO = struct {
                             };
                             break :blk err;
                         } else {
-                            break :blk @as(os.socket_t, @intCast(completion.result));
+                            break :blk @intCast(completion.result);
                         }
                     };
                     call_callback(completion, &result, callback_tracer_slot);
@@ -410,7 +410,7 @@ pub const IO = struct {
                             };
                             break :blk err;
                         } else {
-                            break :blk @as(usize, @intCast(completion.result));
+                            break :blk @intCast(completion.result);
                         }
                     };
                     call_callback(completion, &result, callback_tracer_slot);
@@ -438,7 +438,7 @@ pub const IO = struct {
                             };
                             break :blk err;
                         } else {
-                            break :blk @as(usize, @intCast(completion.result));
+                            break :blk @intCast(completion.result);
                         }
                     };
                     call_callback(completion, &result, callback_tracer_slot);
@@ -473,7 +473,7 @@ pub const IO = struct {
                             };
                             break :blk err;
                         } else {
-                            break :blk @as(usize, @intCast(completion.result));
+                            break :blk @intCast(completion.result);
                         }
                     };
                     call_callback(completion, &result, callback_tracer_slot);
@@ -517,7 +517,7 @@ pub const IO = struct {
                             };
                             break :blk err;
                         } else {
-                            break :blk @as(usize, @intCast(completion.result));
+                            break :blk @intCast(completion.result);
                         }
                     };
                     call_callback(completion, &result, callback_tracer_slot);
@@ -1136,7 +1136,7 @@ pub const IO = struct {
             const res = os.linux.openat(dir_fd, path, os.O.CLOEXEC | os.O.RDONLY | os.O.DIRECT, 0);
             switch (os.linux.getErrno(res)) {
                 .SUCCESS => {
-                    os.close(@as(os.fd_t, @intCast(res)));
+                    os.close(@intCast(res));
                     return true;
                 },
                 .INTR => continue,
@@ -1151,7 +1151,7 @@ pub const IO = struct {
     fn fs_allocate(fd: os.fd_t, size: u64) !void {
         const mode: i32 = 0;
         const offset: i64 = 0;
-        const length = @as(i64, @intCast(size));
+        const length: i64 = @intCast(size);
 
         while (true) {
             const rc = os.linux.fallocate(fd, mode, offset, length);

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1006,7 +1006,7 @@ pub const IO = struct {
         if (@hasDecl(os.O, "LARGEFILE")) flags |= os.O.LARGEFILE;
 
         var direct_io_supported = false;
-        var dir_on_tmpfs = try fs_is_tmpfs(dir_fd);
+        const dir_on_tmpfs = try fs_is_tmpfs(dir_fd);
 
         if (dir_on_tmpfs) {
             log.warn("tmpfs is not durable, and your data will be lost on reboot", .{});

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -473,7 +473,7 @@ test "tick to wait" {
                     else => |err| return os.windows.unexpectedWSAError(err),
                 }
             } else {
-                return @as(usize, @intCast(rc));
+                return @intCast(rc);
             }
         }
     }.run_test();

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -773,7 +773,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @intCast(buffer_limit(buffer.len)),
+                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
             },
             struct {
@@ -817,7 +817,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @intCast(buffer_limit(buffer.len)),
+                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
             },
             struct {

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -973,7 +973,7 @@ pub const IO = struct {
         }
 
         // O_EXCL
-        var shared_mode: os.windows.DWORD = 0;
+        const shared_mode: os.windows.DWORD = 0;
 
         // O_RDWR
         var access_mask: os.windows.DWORD = 0;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -257,7 +257,7 @@ pub const IO = struct {
         // Setup the completion with the callback wrapper above
         completion.* = .{
             .next = null,
-            .context = @as(?*anyopaque, @ptrCast(context)),
+            .context = @ptrCast(context),
             .callback = Callback.onComplete,
             .operation = @unionInit(Completion.Operation, @tagName(op_tag), op_data),
         };
@@ -469,9 +469,9 @@ pub const IO = struct {
                         switch (os.windows.ws2_32.WSAIoctl(
                             op.socket,
                             os.windows.ws2_32.SIO_GET_EXTENSION_FUNCTION_POINTER,
-                            @as(*const anyopaque, @ptrCast(&guid)),
+                            @ptrCast(&guid),
                             @sizeOf(os.windows.GUID),
-                            @as(*anyopaque, @ptrCast(&connect_ex)),
+                            @ptrCast(&connect_ex),
                             @sizeOf(LPFN_CONNECTEX),
                             &num_bytes,
                             null,
@@ -556,7 +556,7 @@ pub const IO = struct {
         const transfer = Completion.Transfer{
             .socket = socket,
             .buf = os.windows.ws2_32.WSABUF{
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
                 .buf = @constCast(buffer.ptr),
             },
             .overlapped = undefined,
@@ -595,7 +595,7 @@ pub const IO = struct {
                         // Start the send operation.
                         break :blk switch (os.windows.ws2_32.WSASend(
                             op.socket,
-                            @as([*]os.windows.ws2_32.WSABUF, @ptrCast(&op.buf)),
+                            @ptrCast(&op.buf),
                             1, // one buffer
                             &transferred,
                             0, // no flags
@@ -656,7 +656,7 @@ pub const IO = struct {
         const transfer = Completion.Transfer{
             .socket = socket,
             .buf = os.windows.ws2_32.WSABUF{
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
                 .buf = buffer.ptr,
             },
             .overlapped = undefined,
@@ -695,7 +695,7 @@ pub const IO = struct {
                         // Start the recv operation.
                         break :blk switch (os.windows.ws2_32.WSARecv(
                             op.socket,
-                            @as([*]os.windows.ws2_32.WSABUF, @ptrCast(&op.buf)),
+                            @ptrCast(&op.buf),
                             1, // one buffer
                             &transferred,
                             &flags,
@@ -773,7 +773,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
                 .offset = offset,
             },
             struct {
@@ -817,7 +817,7 @@ pub const IO = struct {
             .{
                 .fd = fd,
                 .buf = buffer.ptr,
-                .len = @as(u32, @intCast(buffer_limit(buffer.len))),
+                .len = @intCast(buffer_limit(buffer.len)),
                 .offset = offset,
             },
             struct {
@@ -925,8 +925,8 @@ pub const IO = struct {
 
         const socket = try os.windows.WSASocketW(
             @as(i32, @bitCast(family)),
-            @as(i32, @bitCast(sock_type)),
-            @as(i32, @bitCast(protocol)),
+            @bitCast(sock_type),
+            @bitCast(protocol),
             null,
             0,
             flags,
@@ -942,7 +942,7 @@ pub const IO = struct {
         mode |= os.windows.FILE_SKIP_COMPLETION_PORT_ON_SUCCESS;
         mode |= os.windows.FILE_SKIP_SET_EVENT_ON_HANDLE;
 
-        const handle = @as(os.windows.HANDLE, @ptrCast(socket));
+        const handle: os.windows.HANDLE = @ptrCast(socket);
         try os.windows.SetFileCompletionNotificationModes(handle, mode);
 
         return socket;
@@ -1138,7 +1138,7 @@ pub const IO = struct {
         // Move the file pointer to the start + size
         const seeked = os.windows.kernel32.SetFilePointerEx(
             handle,
-            @as(i64, @intCast(size)),
+            @intCast(size),
             null, // no reference to new file pointer
             os.windows.FILE_BEGIN,
         );
@@ -1188,7 +1188,7 @@ fn getsockoptError(socket: os.socket_t) IO.ConnectError!void {
     if (err_code == 0)
         return;
 
-    const ws_err = @as(os.windows.ws2_32.WinsockError, @enumFromInt(@as(u16, @intCast(err_code))));
+    const ws_err: os.windows.ws2_32.WinsockError = @enumFromInt(@as(u16, @intCast(err_code)));
     return switch (ws_err) {
         .WSAEACCES => error.PermissionDenied,
         .WSAEADDRINUSE => error.AddressInUse,

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -142,7 +142,7 @@ pub fn binary_search_values_upsert_index(
             key <= key_from_value(&values[offset]));
     }
 
-    return @as(u32, @intCast(offset));
+    return @intCast(offset);
 }
 
 pub inline fn binary_search_keys_upsert_index(
@@ -365,16 +365,16 @@ const test_binary_search = struct {
         const keys = try gpa.alloc(u32, keys_count);
         defer gpa.free(keys);
 
-        for (keys, 0..) |*key, i| key.* = @as(u32, @intCast(7 * i + 3));
+        for (keys, 0..) |*key, i| key.* = @intCast(7 * i + 3);
 
         var target_key: u32 = 0;
         while (target_key < keys_count + 13) : (target_key += 1) {
             var expect: BinarySearchResult = .{ .index = 0, .exact = false };
             for (keys, 0..) |key, i| {
                 switch (std.math.order(key, target_key)) {
-                    .lt => expect.index = @as(u32, @intCast(i)) + 1,
+                    .lt => expect.index = @intCast(i + 1),
                     .eq => {
-                        expect.index = @as(u32, @intCast(i));
+                        expect.index = @intCast(i);
                         expect.exact = true;
                         if (mode == .lower_bound) break;
                     },
@@ -451,9 +451,9 @@ const test_binary_search = struct {
         var expect: BinarySearchResult = .{ .index = 0, .exact = false };
         for (keys, 0..) |key, i| {
             switch (std.math.order(key, target_key)) {
-                .lt => expect.index = @as(u32, @intCast(i)) + 1,
+                .lt => expect.index = @intCast(i + 1),
                 .eq => {
-                    expect.index = @as(u32, @intCast(i));
+                    expect.index = @intCast(i);
                     expect.exact = true;
                     if (mode == .lower_bound) break;
                 },

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -692,7 +692,7 @@ pub fn CompactionType(
 
             const values_in = compaction.values_in[@intFromEnum(input_level)];
             const values_out = compaction.table_builder.data_block_values();
-            var values_out_index = compaction.table_builder.value_count;
+            const values_out_index = compaction.table_builder.value_count;
 
             assert(values_in.len > 0);
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -208,7 +208,7 @@ pub fn GrooveType(
         const derive_func_info = @typeInfo(@TypeOf(derive_func)).Fn;
 
         // Make sure it has only one argument.
-        if (derive_func_info.args.len != 1) {
+        if (derive_func_info.params.len != 1) {
             @compileError("expected derive fn to take in *const " ++ @typeName(Object));
         }
 
@@ -224,12 +224,14 @@ pub fn GrooveType(
             @compileError("expected derive fn to return valid tree index type");
         };
 
-        // Create an IndexTree for the DerivedType:
-        const tree_name = @typeName(Object) ++ "." ++ field.name;
         const DerivedType = @typeInfo(derive_return_type).Optional.child;
-        const IndexTree = IndexTreeType(Storage, DerivedType, tree_name);
+        const IndexTree = IndexTreeType(
+            Storage,
+            DerivedType,
+            @field(groove_options.value_count_max, field.name),
+        );
 
-        index_fields = index_fields ++ &.{
+        index_fields = index_fields ++ [_]std.builtin.Type.StructField{
             .{
                 .name = field.name,
                 .type = IndexTree,
@@ -330,7 +332,7 @@ pub fn GrooveType(
             }
 
             const derived_fn = @TypeOf(@field(groove_options.derived, field_name));
-            return @typeInfo(derived_fn).Fn.return_type.?.Optional.child;
+            return std.meta.Child(@typeInfo(derived_fn).Fn.return_type.?);
         }
 
         fn HelperType(comptime field_name: []const u8) type {

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -269,14 +269,14 @@ fn TestContext(comptime k_max: u32) type {
                 for (stream_keys, 0..) |key, j| {
                     streams[i][j] = .{
                         .key = key,
-                        .version = @as(u32, @intCast(i)),
+                        .version = @intCast(i),
                     };
                 }
             }
             defer for (streams[0..streams_keys.len]) |s| testing.allocator.free(s);
 
             var context: Self = .{ .streams = streams };
-            var kway = KWay.init(&context, @as(u32, @intCast(streams_keys.len)), direction);
+            var kway = KWay.init(&context, @intCast(streams_keys.len), direction);
 
             while (try kway.pop()) |value| {
                 try actual.append(value);
@@ -320,7 +320,7 @@ fn TestContext(comptime k_max: u32) type {
                     for (stream) |key| {
                         expect_buffer[expect_buffer_len] = .{
                             .key = key,
-                            .version = @as(u32, @intCast(version)),
+                            .version = @intCast(version),
                         };
                         expect_buffer_len += 1;
                     }

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -434,7 +434,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
         pub fn assert_level_table_counts(manifest: *const Manifest) void {
             for (&manifest.levels, 0..) |*manifest_level, index| {
-                const level = @as(u8, @intCast(index));
+                const level: u8 = @intCast(index);
                 const table_count_visible_max = table_count_max_for_level(growth_factor, level);
                 assert(manifest_level.table_count_visible <= table_count_visible_max);
             }
@@ -442,7 +442,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
         pub fn assert_no_invisible_tables(manifest: *const Manifest, snapshots: []const u64) void {
             for (manifest.levels, 0..) |_, level| {
-                manifest.assert_no_invisible_tables_at_level(@as(u8, @intCast(level)), snapshots);
+                manifest.assert_no_invisible_tables_at_level(@intCast(level), snapshots);
             }
         }
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -1002,7 +1002,7 @@ pub fn TestContext(
         }
 
         fn delete_tables(context: *Self) !void {
-            const reference_len = @as(u32, @intCast(context.reference.items.len));
+            const reference_len: u32 = @intCast(context.reference.items.len);
             if (reference_len == 0) return;
 
             const count_max = @min(reference_len, 13);
@@ -1165,7 +1165,7 @@ pub fn TestContext(
             }
 
             if (reference.len > 0) {
-                const reference_len = @as(u32, @intCast(reference.len));
+                const reference_len: u32 = @intCast(reference.len);
                 const start = context.random.uintLessThanBiased(u32, reference_len);
                 const end = context.random.uintLessThanBiased(u32, reference_len - start) + start;
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -714,7 +714,7 @@ pub fn ManifestLevelType(
                 // This const cast is safe as we know that the memory pointed to is in fact
                 // mutable. That is, the table is not in the .text or .rodata section.
                 if (range.tables.count() < max_overlapping_tables) {
-                    var table_info_reference = TableInfoReference{
+                    const table_info_reference = TableInfoReference{
                         .table_info = @constCast(table),
                         .generation = level.generation,
                     };
@@ -911,7 +911,7 @@ pub fn TestContext(
 
             assert(new_key_min > key);
 
-            var i = binary_search.binary_search_values_upsert_index(
+            const i = binary_search.binary_search_values_upsert_index(
                 Key,
                 TableInfo,
                 key_min_from_table,
@@ -1019,7 +1019,7 @@ pub fn TestContext(
                     table.key_min,
                     .ascending,
                 ).?;
-                var absolute_index = context.level.keys.absolute_index_for_cursor(cursor_start);
+                const absolute_index = context.level.keys.absolute_index_for_cursor(cursor_start);
 
                 var it = context.level.tables.iterator_from_index(absolute_index, .ascending);
                 while (it.next()) |level_table| {

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -187,7 +187,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             }
             errdefer for (blocks.buffer) |b| allocator.free(b);
 
-            var writes = try allocator.alloc(Write, half_bar_buffer_blocks_max);
+            const writes = try allocator.alloc(Write, half_bar_buffer_blocks_max);
             errdefer allocator.free(writes);
             @memset(writes, undefined);
 
@@ -379,7 +379,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                             assert(manifest_log.tables_removed.remove(table.address));
                         }
                     } else {
-                        var extent =
+                        const extent =
                             manifest_log.table_extents.getOrPutAssumeCapacity(table.address);
                         if (!extent.found_existing) {
                             extent.value_ptr.* = .{ .block = block_address, .entry = entry };
@@ -517,7 +517,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 .insert,
                 .update,
                 => {
-                    var extent = manifest_log.table_extents.getOrPutAssumeCapacity(table.address);
+                    const extent = manifest_log.table_extents.getOrPutAssumeCapacity(table.address);
                     if (extent.found_existing) {
                         maybe(table.label.event == .insert); // (Compaction.)
                     } else {
@@ -1118,7 +1118,7 @@ const Pace = struct {
                 .compact_extra_blocks = constants.lsm_manifest_compact_extra_blocks,
             });
 
-            inline for (std.meta.fields(Pace)) |pace_field| {
+            for (std.meta.fields(Pace)) |pace_field| {
                 @compileLog(std.fmt.comptimePrint("ManifestLog.Pace.{s} = {d}", .{
                     pace_field.name,
                     @field(pace, pace_field.name),

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -42,11 +42,11 @@ pub fn ScanBuilderType(
         merge_slots: *MergeSlots,
 
         pub fn init(allocator: Allocator) !ScanBuilder {
-            var scan_slots = try allocator.create(ScanSlots);
+            const scan_slots = try allocator.create(ScanSlots);
             errdefer allocator.destroy(scan_slots);
             scan_slots.* = .{};
 
-            var merge_slots = try allocator.create(MergeSlots);
+            const merge_slots = try allocator.create(MergeSlots);
             errdefer allocator.destroy(merge_slots);
             merge_slots.* = .{};
 

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -180,7 +180,7 @@ fn SegmentedArrayType(
                 }
             }
             for (array.nodes[0..array.node_count], 0..) |_, node_index| {
-                const c = array.count(@as(u32, @intCast(node_index)));
+                const c = array.count(@intCast(node_index));
                 // Every node is at most full.
                 assert(c <= node_capacity);
                 // Every node is at least half-full, except the last.
@@ -192,7 +192,7 @@ fn SegmentedArrayType(
                 // If Key is not null then the elements must be sorted by key_from_value (but not necessarily unique).
                 var key_prior_or_null: ?K = null;
                 for (array.nodes[0..array.node_count], 0..) |_, node_index| {
-                    for (array.node_elements(@as(u32, @intCast(node_index)))) |*value| {
+                    for (array.node_elements(@intCast(node_index))) |*value| {
                         const key = key_from_value(value);
                         if (key_prior_or_null) |key_prior| {
                             assert(key_prior <= key);
@@ -309,7 +309,7 @@ fn SegmentedArrayType(
                 );
                 stdx.copy_disjoint(.inexact, T, a_pointer[cursor.relative_index..], elements);
 
-                array.increment_indexes_after(a, @as(u32, @intCast(elements.len)));
+                array.increment_indexes_after(a, @intCast(elements.len));
                 return;
             }
 
@@ -386,7 +386,7 @@ fn SegmentedArrayType(
             );
 
             array.indexes[b] = array.indexes[a] + a_half;
-            array.increment_indexes_after(b, @as(u32, @intCast(elements.len)));
+            array.increment_indexes_after(b, @intCast(elements.len));
         }
 
         /// Behaves like mem.copyBackwards, but as if `a` and `b` were a single contiguous slice.
@@ -436,7 +436,7 @@ fn SegmentedArrayType(
                 assert(std.meta.alignment(@TypeOf(node_pointer)) >= @alignOf(T));
                 assert(@sizeOf(@TypeOf(node_pointer.*)) >= @sizeOf([node_capacity]T));
             }
-            array.nodes[node] = @as(*[node_capacity]T, @ptrCast(node_pointer));
+            array.nodes[node] = @ptrCast(@alignCast(node_pointer));
             assert(array.indexes[node] == array.indexes[node + 1]);
         }
 
@@ -911,7 +911,7 @@ fn SegmentedArrayType(
                 //
                 // (If there are two adjacent nodes starting with keys A and C, and we search B,
                 // we want to pick the A node.)
-                const node = @as(u32, @intCast(offset));
+                const node: u32 = @intCast(offset);
                 assert(node < array.node_count);
 
                 const relative_index = binary_search_values_upsert_index(
@@ -1057,7 +1057,7 @@ fn FuzzContextType(
         }
 
         fn insert(context: *Self) !void {
-            const reference_len = @as(u32, @intCast(context.reference.items.len));
+            const reference_len: u32 = @intCast(context.reference.items.len);
             const count_free = element_count_max - reference_len;
 
             if (count_free == 0) return;
@@ -1092,7 +1092,7 @@ fn FuzzContextType(
         }
 
         fn remove(context: *Self) !void {
-            const reference_len = @as(u32, @intCast(context.reference.items.len));
+            const reference_len: u32 = @intCast(context.reference.items.len);
             if (reference_len == 0) return;
 
             const count_max = @min(reference_len, TestArray.node_capacity * 3);
@@ -1201,7 +1201,7 @@ fn FuzzContextType(
                     try testing.expect(std.meta.eql(
                         i,
                         context.array.absolute_index_for_cursor(
-                            context.array.cursor_for_absolute_index(@as(u32, @intCast(i))),
+                            context.array.cursor_for_absolute_index(@intCast(i)),
                         ),
                     ));
                 }

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -776,7 +776,7 @@ fn BitIterator(comptime Bits: type) type {
         inline fn next(it: *Self) ?BitIndex {
             if (it.bits == 0) return null;
             // This @intCast() is safe since we never pass 0 to @ctz().
-            const index = @as(BitIndex, @intCast(@ctz(it.bits)));
+            const index: BitIndex = @intCast(@ctz(it.bits));
             // Zero the lowest set bit.
             it.bits &= it.bits - 1;
             return index;
@@ -826,7 +826,7 @@ fn search_tags_test(comptime Key: type, comptime Value: type, comptime layout: L
             var count: usize = 0;
             for (tags, 0..) |t, i| {
                 if (t == tag) {
-                    const bit = @as(math.Log2Int(SAC.Ways), @intCast(i));
+                    const bit: math.Log2Int(SAC.Ways) = @intCast(i);
                     bits |= (@as(SAC.Ways, 1) << bit);
                     count += 1;
                 }

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -55,7 +55,7 @@ pub fn TableMemoryType(comptime Table: type) type {
         }
 
         pub fn reset(table: *TableMemory) void {
-            var mutability: Mutability = switch (table.mutability) {
+            const mutability: Mutability = switch (table.mutability) {
                 .immutable => .{ .immutable = .{} },
                 .mutable => .mutable,
             };

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -493,7 +493,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 assert(bus.replicas[replica] == null);
                 bus.replicas[replica] = connection;
 
-                var attempts = &bus.replicas_connect_attempts[replica];
+                const attempts = &bus.replicas_connect_attempts[replica];
                 const ms = vsr.exponential_backoff_with_jitter(
                     bus.prng.random(),
                     constants.connection_delay_min_ms,

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -193,7 +193,7 @@ pub const Parser = struct {
     ) !void {
         inline for (@typeInfo(ObjectSyntaxTree).Union.fields) |object_syntax_tree_field| {
             if (std.mem.eql(u8, @tagName(out.*), object_syntax_tree_field.name)) {
-                var active_value = @field(out, object_syntax_tree_field.name);
+                const active_value = @field(out, object_syntax_tree_field.name);
                 const ActiveValue = @TypeOf(active_value);
 
                 inline for (@typeInfo(ActiveValue).Struct.fields) |active_value_field| {
@@ -597,7 +597,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                     // Release allocation after every execution.
                     var execution_arena = std.heap.ArenaAllocator.init(allocator);
                     defer execution_arena.deinit();
-                    var statement = Parser.parse_statement(
+                    const statement = Parser.parse_statement(
                         &execution_arena,
                         statement_string,
                         repl.printer,
@@ -876,7 +876,7 @@ const null_printer = Printer{
 };
 
 test "repl.zig: Parser single transfer successfully" {
-    var tests = [_]struct {
+    const tests = [_]struct {
         in: []const u8 = "",
         want: tb.Transfer,
     }{
@@ -959,7 +959,7 @@ test "repl.zig: Parser single transfer successfully" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
 
-        var statement = try Parser.parse_statement(
+        const statement = try Parser.parse_statement(
             &arena,
             t.in,
             null_printer,
@@ -971,7 +971,7 @@ test "repl.zig: Parser single transfer successfully" {
 }
 
 test "repl.zig: Parser multiple transfers successfully" {
-    var tests = [_]struct {
+    const tests = [_]struct {
         in: []const u8 = "",
         want: [2]tb.Transfer,
     }{
@@ -1016,7 +1016,7 @@ test "repl.zig: Parser multiple transfers successfully" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
 
-        var statement = try Parser.parse_statement(
+        const statement = try Parser.parse_statement(
             &arena,
             t.in,
             null_printer,
@@ -1028,7 +1028,7 @@ test "repl.zig: Parser multiple transfers successfully" {
 }
 
 test "repl.zig: Parser single account successfully" {
-    var tests = [_]struct {
+    const tests = [_]struct {
         in: []const u8,
         want: tb.Account,
     }{
@@ -1100,7 +1100,7 @@ test "repl.zig: Parser single account successfully" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
 
-        var statement = try Parser.parse_statement(
+        const statement = try Parser.parse_statement(
             &arena,
             t.in,
             null_printer,
@@ -1112,7 +1112,7 @@ test "repl.zig: Parser single account successfully" {
 }
 
 test "repl.zig: Parser multiple accounts successfully" {
-    var tests = [_]struct {
+    const tests = [_]struct {
         in: []const u8,
         want: [2]tb.Account,
     }{
@@ -1155,7 +1155,7 @@ test "repl.zig: Parser multiple accounts successfully" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
 
-        var statement = try Parser.parse_statement(
+        const statement = try Parser.parse_statement(
             &arena,
             t.in,
             null_printer,
@@ -1167,7 +1167,7 @@ test "repl.zig: Parser multiple accounts successfully" {
 }
 
 test "repl.zig: Parser odd but correct formatting" {
-    var tests = [_]struct {
+    const tests = [_]struct {
         in: []const u8 = "",
         want: tb.Transfer,
     }{
@@ -1282,7 +1282,7 @@ test "repl.zig: Parser odd but correct formatting" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
 
-        var statement = try Parser.parse_statement(
+        const statement = try Parser.parse_statement(
             &arena,
             t.in,
             null_printer,
@@ -1294,7 +1294,7 @@ test "repl.zig: Parser odd but correct formatting" {
 }
 
 test "repl.zig: Handle parsing errors" {
-    var tests = [_]struct {
+    const tests = [_]struct {
         in: []const u8 = "",
         err: anyerror,
     }{
@@ -1348,7 +1348,7 @@ test "repl.zig: Handle parsing errors" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
 
-        var result = Parser.parse_statement(
+        const result = Parser.parse_statement(
             &arena,
             t.in,
             null_printer,

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -582,7 +582,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                 allocator,
                 client_id,
                 cluster_id,
-                @as(u8, @intCast(addresses.len)),
+                @intCast(addresses.len),
                 &message_pool,
                 .{
                     .configuration = addresses,
@@ -698,7 +698,7 @@ pub fn ReplType(comptime MessageBus: type) type {
             repl.request_done = false;
             try repl.debug("Sending command: {}.\n", .{operation});
             repl.client.batch_submit(
-                @as(u128, @intCast(@intFromPtr(repl))),
+                @intCast(@intFromPtr(repl)),
                 client_request_callback,
                 batch,
             );
@@ -752,7 +752,7 @@ pub fn ReplType(comptime MessageBus: type) type {
             operation: StateMachine.Operation,
             result: []const u8,
         ) !void {
-            const repl = @as(*Repl, @ptrFromInt(@as(usize, @intCast(user_data))));
+            const repl: *Repl = @ptrFromInt(@as(usize, @intCast(user_data)));
             assert(repl.request_done == false);
             try repl.debug("Operation completed: {}.\n", .{operation});
 
@@ -843,7 +843,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                 operation,
                 result,
             ) catch |err| {
-                const repl = @as(*Repl, @ptrFromInt(@as(u64, @intCast(user_data))));
+                const repl: *Repl = @ptrFromInt(@as(usize, @intCast(user_data)));
                 repl.fail("Error in callback: {any}", .{err}) catch return;
             };
         }

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -66,7 +66,7 @@ pub fn create(gpa: std.mem.Allocator) !*Shell {
 
     const ci = env.get("CI") != null;
 
-    var result = try gpa.create(Shell);
+    const result = try gpa.create(Shell);
     errdefer gpa.destroy(result);
 
     result.* = Shell{

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -462,7 +462,7 @@ pub const Simulator = struct {
         while (it.next()) |replica_index| {
             const fault = false;
             if (simulator.cluster.replica_health[replica_index] == .down) {
-                simulator.restart_replica(@as(u8, @intCast(replica_index)), fault);
+                simulator.restart_replica(@intCast(replica_index), fault);
             }
         }
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -872,7 +872,7 @@ pub fn StateMachineType(
                             var chain_index = chain_start_index;
                             while (chain_index < index) : (chain_index += 1) {
                                 results[count] = .{
-                                    .index = @as(u32, @intCast(chain_index)),
+                                    .index = @intCast(chain_index),
                                     .result = .linked_event_failed,
                                 };
                                 count += 1;
@@ -881,7 +881,7 @@ pub fn StateMachineType(
                             assert(result == .linked_event_failed or result == .linked_event_chain_open);
                         }
                     }
-                    results[count] = .{ .index = @as(u32, @intCast(index)), .result = result };
+                    results[count] = .{ .index = @intCast(index), .result = result };
                     count += 1;
                 }
                 if (chain != null and (!event.flags.linked or result == .linked_event_chain_open)) {
@@ -1313,8 +1313,8 @@ pub fn StateMachineType(
         }
 
         pub fn forest_options(options: Options) Forest.GroovesOptions {
-            const batch_accounts_max = @as(u32, @intCast(constants.batch_max.create_accounts));
-            const batch_transfers_max = @as(u32, @intCast(constants.batch_max.create_transfers));
+            const batch_accounts_max: u32 = @intCast(constants.batch_max.create_accounts);
+            const batch_transfers_max: u32 = @intCast(constants.batch_max.create_transfers);
             assert(batch_accounts_max == constants.batch_max.lookup_accounts);
             assert(batch_transfers_max == constants.batch_max.lookup_transfers);
 
@@ -1657,7 +1657,7 @@ fn check(test_table: []const u8) !void {
                     try accounts.put(a.id, event);
                 } else {
                     const result = CreateAccountsResult{
-                        .index = @as(u32, @intCast(@divExact(request.items.len, @sizeOf(Account)) - 1)),
+                        .index = @intCast(@divExact(request.items.len, @sizeOf(Account)) - 1),
                         .result = a.result,
                     };
                     try reply.appendSlice(std.mem.asBytes(&result));
@@ -1673,7 +1673,7 @@ fn check(test_table: []const u8) !void {
                     try transfers.put(t.id, event);
                 } else {
                     const result = CreateTransfersResult{
-                        .index = @as(u32, @intCast(@divExact(request.items.len, @sizeOf(Transfer)) - 1)),
+                        .index = @intCast(@divExact(request.items.len, @sizeOf(Transfer)) - 1),
                         .result = t.result,
                     };
                     try reply.appendSlice(std.mem.asBytes(&result));

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -235,7 +235,6 @@ pub fn StateMachineType(
                 .ids = constants.tree_ids.posted,
                 .value_count_max = .{
                     .timestamp = config.lsm_batch_multiple * constants.batch_max.create_transfers,
-                    .fulfillment = config.lsm_batch_multiple * constants.batch_max.create_transfers,
                 },
                 .ignored = &[_][]const u8{ "fulfillment", "padding" },
                 .derived = .{},
@@ -300,6 +299,8 @@ pub fn StateMachineType(
                 comptime field: Field,
                 completion: *FieldType(field),
             ) *StateMachine {
+                comptime assert(field != .null);
+
                 const context = @fieldParentPtr(PrefetchContext, @tagName(field), completion);
                 return @fieldParentPtr(StateMachine, "prefetch_context", context);
             }
@@ -819,7 +820,7 @@ pub fn StateMachineType(
             input: []align(16) const u8,
             output: *align(16) [constants.message_body_size_max]u8,
         ) usize {
-            comptime assert(operation != .lookup_accounts and operation != .lookup_transfers);
+            comptime assert(operation == .create_accounts or operation == .create_transfers);
 
             const events = mem.bytesAsSlice(Event(operation), input);
             var results = mem.bytesAsSlice(Result(operation), output);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -635,7 +635,7 @@ pub fn StateMachineType(
             const transfers_groove: *TransfersGroove = &self.forest.grooves.transfers;
             const scan_builder: *TransfersGroove.ScanBuilder = &transfers_groove.scan_builder;
 
-            var scan = scan: {
+            const scan = scan: {
                 const timestamp_range: TimestampRange = .{
                     .min = if (filter.timestamp_min == 0)
                         TimestampRange.timestamp_min
@@ -1628,7 +1628,7 @@ fn check(test_table: []const u8) !void {
             .setup => |b| {
                 assert(operation == null);
 
-                var account = context.state_machine.forest.grooves.accounts.get(b.account).?;
+                const account = context.state_machine.forest.grooves.accounts.get(b.account).?;
                 var account_new = account.*;
 
                 account_new.debits_pending = b.debits_pending;
@@ -1732,7 +1732,7 @@ fn check(test_table: []const u8) !void {
                     request.items,
                     reply_actual_buffer[0..TestContext.message_body_size_max],
                 );
-                var reply_actual = reply_actual_buffer[0..reply_actual_size];
+                const reply_actual = reply_actual_buffer[0..reply_actual_size];
 
                 if (commit_operation == .lookup_accounts) {
                     for (std.mem.bytesAsSlice(Account, reply_actual)) |*a| a.timestamp = 0;

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -131,7 +131,7 @@ pub const AccountingAuditor = struct {
 
         var pending_transfers = std.AutoHashMapUnmanaged(u128, PendingTransfer){};
         errdefer pending_transfers.deinit(allocator);
-        try pending_transfers.ensureTotalCapacity(allocator, @as(u32, @intCast(options.transfers_pending_max)));
+        try pending_transfers.ensureTotalCapacity(allocator, @intCast(options.transfers_pending_max));
 
         var pending_expiries = PendingExpiryQueue.init(allocator, {});
         errdefer pending_expiries.deinit();
@@ -139,7 +139,7 @@ pub const AccountingAuditor = struct {
 
         var in_flight = InFlightQueue{};
         errdefer in_flight.deinit(allocator);
-        try in_flight.ensureTotalCapacity(allocator, @as(u32, @intCast(options.in_flight_max)));
+        try in_flight.ensureTotalCapacity(allocator, @intCast(options.in_flight_max));
 
         var creates_sent = try allocator.alloc(usize, options.client_count);
         errdefer allocator.free(creates_sent);

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -141,11 +141,11 @@ pub const AccountingAuditor = struct {
         errdefer in_flight.deinit(allocator);
         try in_flight.ensureTotalCapacity(allocator, @intCast(options.in_flight_max));
 
-        var creates_sent = try allocator.alloc(usize, options.client_count);
+        const creates_sent = try allocator.alloc(usize, options.client_count);
         errdefer allocator.free(creates_sent);
         @memset(creates_sent, 0);
 
-        var creates_delivered = try allocator.alloc(usize, options.client_count);
+        const creates_delivered = try allocator.alloc(usize, options.client_count);
         errdefer allocator.free(creates_delivered);
         @memset(creates_delivered, 0);
 

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -880,7 +880,7 @@ fn sample_distribution(
     const SampleSpace = std.meta.FieldEnum(@TypeOf(distribution));
     const Indexer = std.enums.EnumIndexer(SampleSpace);
 
-    var sum = sum: {
+    const sum = sum: {
         var sum: usize = 0;
         comptime var i: usize = 0;
         inline while (i < Indexer.count) : (i += 1) {

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -156,7 +156,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             for (storages, 0..) |*storage, replica_index| {
                 errdefer for (storages[0..replica_index]) |*s| s.deinit(allocator);
                 var storage_options = options.storage;
-                storage_options.replica_index = @as(u8, @intCast(replica_index));
+                storage_options.replica_index = @intCast(replica_index);
                 storage_options.fault_atlas = storage_fault_atlas;
                 storage_options.grid_checker = grid_checker;
                 storage.* = try Storage.init(allocator, options.storage_size_limit, storage_options);
@@ -243,6 +243,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     allocator,
                     .{
                         .cluster = options.cluster_id,
+                        // TODO(zig) It should be possible to remove the `@as(u8,...)`.
                         .replica = @as(u8, @intCast(replica_index)),
                         .replica_count = options.replica_count,
                     },
@@ -283,7 +284,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 // Nonces are incremented on restart, so spread them out across 128 bit space
                 // to avoid collisions.
                 const nonce = 1 + @as(u128, replica_index) << 64;
-                try cluster.open_replica(@as(u8, @intCast(replica_index)), nonce, .{
+                try cluster.open_replica(@intCast(replica_index), nonce, .{
                     .resolution = constants.tick_ms * std.time.ns_per_ms,
                     .offset_type = .linear,
                     .offset_coefficient_A = 0,

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -361,7 +361,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             const nonce = cluster.replicas[replica_index].nonce + 1;
             // Pass the old replica's Time through to the new replica. It will continue to tick while
             // the replica is crashed, to ensure the clocks don't desynchronize too far to recover.
-            const time = cluster.replicas[replica_index].time;
+            // Intentionally `var` to force the compiler to make a copy and not do a pass-by-reference.
+            var time: Time = undefined;
+            time = cluster.replicas[replica_index].time;
             try cluster.open_replica(replica_index, nonce, time);
             cluster.network.process_enable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .up;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -135,7 +135,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             );
             errdefer network.deinit();
 
-            var storage_fault_atlas = try allocator.create(StorageFaultAtlas);
+            const storage_fault_atlas = try allocator.create(StorageFaultAtlas);
             errdefer allocator.destroy(storage_fault_atlas);
 
             storage_fault_atlas.* = StorageFaultAtlas.init(
@@ -358,10 +358,10 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         pub fn restart_replica(cluster: *Self, replica_index: u8) !void {
             assert(cluster.replica_health[replica_index] == .down);
 
-            var nonce = cluster.replicas[replica_index].nonce + 1;
+            const nonce = cluster.replicas[replica_index].nonce + 1;
             // Pass the old replica's Time through to the new replica. It will continue to tick while
             // the replica is crashed, to ensure the clocks don't desynchronize too far to recover.
-            var time = cluster.replicas[replica_index].time;
+            const time = cluster.replicas[replica_index].time;
             try cluster.open_replica(replica_index, nonce, time);
             cluster.network.process_enable(.{ .replica = replica_index });
             cluster.replica_health[replica_index] = .up;

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -148,8 +148,8 @@ pub const Network = struct {
             while (it_target.next()) |replica_target| {
                 if (replica_target != replica_source) {
                     network.link_filter(.{
-                        .source = .{ .replica = @as(u8, @intCast(replica_source)) },
-                        .target = .{ .replica = @as(u8, @intCast(replica_target)) },
+                        .source = .{ .replica = @intCast(replica_source) },
+                        .target = .{ .replica = @intCast(replica_target) },
                     }).* = LinkFilter.initFull();
                 }
             }
@@ -243,7 +243,7 @@ pub const Network = struct {
                     .replica => assert(i < network.options.node_count),
                     .client => assert(i >= network.options.node_count),
                 }
-                return @as(u8, @intCast(i));
+                return @intCast(i);
             }
         }
         log.err("no such process: {} (have {any})", .{ process, network.processes.items });
@@ -298,7 +298,7 @@ pub const Network = struct {
 
     fn raw_process_to_process(raw: u128) Process {
         switch (raw) {
-            0...(constants.members_max - 1) => return .{ .replica = @as(u8, @intCast(raw)) },
+            0...(constants.members_max - 1) => return .{ .replica = @intCast(raw) },
             else => {
                 assert(raw >= constants.members_max);
                 return .{ .client = raw };

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -58,7 +58,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 .replicas = commit_replicas,
             });
 
-            var replica_head_max = try allocator.alloc(ReplicaHead, options.replicas.len);
+            const replica_head_max = try allocator.alloc(ReplicaHead, options.replicas.len);
             errdefer allocator.free(replica_head_max);
             for (replica_head_max) |*head| head.* = .{ .view = 0, .op = 0 };
 

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -63,7 +63,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             for (replica_head_max) |*head| head.* = .{ .view = 0, .op = 0 };
 
             return Self{
-                .node_count = @as(u8, @intCast(options.replicas.len)),
+                .node_count = @intCast(options.replicas.len),
                 .replica_count = options.replica_count,
                 .commits = commits,
                 .replicas = options.replicas,

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -72,14 +72,14 @@ pub const StorageChecker = struct {
         var client_sessions = try vsr.ClientSessions.init(allocator);
         errdefer client_sessions.deinit(allocator);
 
-        var free_set_buffer = try allocator.alignedAlloc(
+        const free_set_buffer = try allocator.alignedAlloc(
             u8,
             @alignOf(u64),
             vsr.FreeSet.encode_size_max(Storage.grid_blocks_max),
         );
         errdefer allocator.free(free_set_buffer);
 
-        var client_sessions_buffer =
+        const client_sessions_buffer =
             try allocator.alignedAlloc(u8, @sizeOf(u256), vsr.ClientSessions.encode_size);
         errdefer allocator.free(client_sessions_buffer);
 

--- a/src/testing/id.zig
+++ b/src/testing/id.zig
@@ -49,17 +49,17 @@ pub const IdPermutation = union(enum) {
 
     pub fn decode(self: *const IdPermutation, id: u128) usize {
         return switch (self.*) {
-            .identity => @as(usize, @intCast(id)),
-            .inversion => @as(usize, @intCast(std.math.maxInt(u128) - id)),
+            .identity => @intCast(id),
+            .inversion => @intCast(std.math.maxInt(u128) - id),
             .zigzag => {
                 if (id % 2 == 0) {
-                    return @as(usize, @intCast(id));
+                    return @intCast(id);
                 } else {
                     // -1 to stay odd.
-                    return @as(usize, @intCast(std.math.maxInt(u128) - id -% 1));
+                    return @intCast(std.math.maxInt(u128) - id -% 1);
                 }
             },
-            .random => @as(usize, @truncate(id >> 32)),
+            .random => @truncate(id >> 32),
         };
     }
 

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -148,7 +148,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
 
             const auto_partition_nodes = try allocator.alloc(u8, @as(usize, options.node_count));
             errdefer allocator.free(auto_partition_nodes);
-            for (auto_partition_nodes, 0..) |*node, i| node.* = @as(u8, @intCast(i));
+            for (auto_partition_nodes, 0..) |*node, i| node.* = @intCast(i);
 
             return Self{
                 .options = options,

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -399,7 +399,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             path: Path,
         ) void {
             const queue = &self.links[self.path_index(path)].queue;
-            var queue_length = queue.count();
+            const queue_length = queue.count();
             if (queue_length + 1 > self.options.path_maximum_capacity) {
                 const index = self.prng.random().uintLessThanBiased(u64, queue_length);
                 const link_packet = queue.removeIndex(index);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -179,7 +179,7 @@ pub const Storage = struct {
         assert(options.read_latency_mean >= options.read_latency_min);
         assert(options.fault_atlas == null or options.replica_index != null);
 
-        var prng = std.rand.DefaultPrng.init(options.seed);
+        const prng = std.rand.DefaultPrng.init(options.seed);
         const sector_count = @divExact(size, constants.sector_size);
         const memory = try allocator.alignedAlloc(u8, constants.sector_size, size);
         errdefer allocator.free(memory);

--- a/src/testing/table.zig
+++ b/src/testing/table.zig
@@ -93,7 +93,7 @@ fn parse_data(comptime Data: type, tokens: *std.mem.TokenIterator(u8, .any)) Dat
 }
 
 fn eat(tokens: *std.mem.TokenIterator(u8, .any), token: []const u8) bool {
-    var index_before = tokens.index;
+    const index_before = tokens.index;
     if (std.mem.eql(u8, tokens.next().?, token)) return true;
     tokens.index = index_before;
     return false;

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -408,7 +408,6 @@ const naughty_list = [_][]const u8{
     "state_machine/auditor.zig",
     "state_machine/workload.zig",
     "testing/aof.zig",
-    "testing/cluster.zig",
     "testing/cluster/network.zig",
     "testing/cluster/state_checker.zig",
     "testing/hash_log.zig",

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -329,7 +329,7 @@ fn parse_cache_size_to_count(
         value_count_max_multiple,
     ) * value_count_max_multiple;
 
-    const result = @as(u32, @intCast(count_rounded)); // TODO: better error message on overflow
+    const result: u32 = @intCast(count_rounded); // TODO: better error message on overflow
     assert(@as(u64, result) * @sizeOf(T) <= size.bytes);
 
     return result;

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -176,7 +176,7 @@ const Command = struct {
 
         var replica: Replica = undefined;
         replica.open(allocator, .{
-            .node_count = @as(u8, @intCast(args.addresses.len)),
+            .node_count = @intCast(args.addresses.len),
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .aof = &aof,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -145,7 +145,7 @@ const Command = struct {
 
         var aof: AOFType = undefined;
         if (constants.aof_record) {
-            var aof_path = try std.fmt.allocPrint(allocator, "{s}.aof", .{args.path});
+            const aof_path = try std.fmt.allocPrint(allocator, "{s}.aof", .{args.path});
             defer allocator.free(aof_path);
 
             aof = try AOF.from_absolute_path(aof_path);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -365,7 +365,7 @@ fn create_report(allocator: mem.Allocator, bug: Bug, seed: u64) Report {
     var message = Report{
         .checksum = undefined,
         .bug = bug_type,
-        .seed = @as([8]u8, @bitCast(@byteSwap(seed))),
+        .seed = @bitCast(@byteSwap(seed)),
         .commit = commit_byte_array,
     };
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -662,7 +662,7 @@ pub fn exponential_backoff_with_jitter(
 
     // Do not use `@truncate(u6, attempt)` since that only discards the high bits:
     // We want a saturating exponent here instead.
-    const exponent = @as(u6, @intCast(@min(std.math.maxInt(u6), attempt)));
+    const exponent: u6 = @intCast(@min(std.math.maxInt(u6), attempt));
 
     // A "1" shifted left gives any power of two:
     // 1<<0 = 1, 1<<1 = 2, 1<<2 = 4, 1<<3 = 8
@@ -678,7 +678,7 @@ pub fn exponential_backoff_with_jitter(
     const backoff = @min(range, min_non_zero * power);
     const jitter = random.uintAtMostBiased(u64, backoff);
 
-    const result = @as(u64, @intCast(min + jitter));
+    const result: u64 = @intCast(min + jitter);
     assert(result >= min);
     assert(result <= max);
 
@@ -1028,7 +1028,7 @@ pub fn valid_members(members: *const Members) bool {
 
 fn member_count(members: *const Members) u8 {
     for (members, 0..) |member, index| {
-        if (member == 0) return @as(u8, @intCast(index));
+        if (member == 0) return @intCast(index);
     }
     return constants.members_max;
 }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -884,7 +884,7 @@ test "parse_addresses: fuzz" {
     var input_max: [len_max]u8 = .{0} ** len_max;
     for (0..test_count) |_| {
         const len = random.uintAtMost(usize, len_max);
-        var input = input_max[0..len];
+        const input = input_max[0..len];
         for (input) |*c| {
             c.* = alphabet[random.uintAtMost(usize, alphabet.len)];
         }

--- a/src/vsr/checksum.zig
+++ b/src/vsr/checksum.zig
@@ -120,7 +120,7 @@ test "checksum simple fuzzing" {
     var msg_buf = try testing.allocator.alloc(u8, msg_max);
     defer testing.allocator.free(msg_buf);
 
-    var cipher_buf = try testing.allocator.alloc(u8, msg_max);
+    const cipher_buf = try testing.allocator.alloc(u8, msg_max);
     defer testing.allocator.free(cipher_buf);
 
     var i: usize = 0;

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -82,7 +82,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             /// (spread across all requests).
             const batch_logical_max = blk: {
                 var max: usize = 1;
-                inline for (std.enums.values(StateMachine.Operation)) |operation| {
+                for (std.enums.values(StateMachine.Operation)) |operation| {
                     if (@intFromEnum(operation) < constants.vsr_operations_reserved) continue;
                     if (!StateMachine.batch_logical_allowed.get(operation)) continue;
                     max = @max(max, @sizeOf(StateMachine.Result(operation)));

--- a/src/vsr/client_sessions.zig
+++ b/src/vsr/client_sessions.zig
@@ -54,7 +54,7 @@ pub const ClientSessions = struct {
         try entries_by_client.ensureTotalCapacity(allocator, @intCast(constants.clients_max));
         assert(entries_by_client.capacity() >= constants.clients_max);
 
-        var entries = try allocator.alloc(Entry, constants.clients_max);
+        const entries = try allocator.alloc(Entry, constants.clients_max);
         errdefer allocator.free(entries);
         @memset(entries, std.mem.zeroes(Entry));
 

--- a/src/vsr/client_sessions.zig
+++ b/src/vsr/client_sessions.zig
@@ -51,7 +51,7 @@ pub const ClientSessions = struct {
         var entries_by_client: EntriesByClient = .{};
         errdefer entries_by_client.deinit(allocator);
 
-        try entries_by_client.ensureTotalCapacity(allocator, @as(u32, @intCast(constants.clients_max)));
+        try entries_by_client.ensureTotalCapacity(allocator, @intCast(constants.clients_max));
         assert(entries_by_client.capacity() >= constants.clients_max);
 
         var entries = try allocator.alloc(Entry, constants.clients_max);

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -382,7 +382,7 @@ pub fn ClockType(comptime Time: type) type {
                 fmt.fmtDurationSigned(new_interval.upper_bound - new_interval.lower_bound),
             });
 
-            const elapsed = @as(i64, @intCast(self.epoch.elapsed(self)));
+            const elapsed: i64 = @intCast(self.epoch.elapsed(self));
             const system = self.realtime();
             const lower = self.epoch.realtime + elapsed + new_interval.lower_bound;
             const upper = self.epoch.realtime + elapsed + new_interval.upper_bound;
@@ -424,13 +424,13 @@ pub fn ClockType(comptime Time: type) type {
             for (self.window.sources, 0..) |sampled, source| {
                 if (sampled) |sample| {
                     self.marzullo_tuples[count] = Marzullo.Tuple{
-                        .source = @as(u8, @intCast(source)),
+                        .source = @intCast(source),
                         .offset = sample.clock_offset - @as(i64, @intCast(sample.one_way_delay + tolerance)),
                         .bound = .lower,
                     };
                     count += 1;
                     self.marzullo_tuples[count] = Marzullo.Tuple{
-                        .source = @as(u8, @intCast(source)),
+                        .source = @intCast(source),
                         .offset = sample.clock_offset + @as(i64, @intCast(sample.one_way_delay + tolerance)),
                         .bound = .upper,
                     };
@@ -489,7 +489,7 @@ const ClockUnitTestContainer = struct {
             if (@mod(self.clock.time.ticks, self.learn_interval) == 0) {
                 const on_pong_time = self.clock.monotonic();
                 const m0 = on_pong_time - self.rtt;
-                const t1 = @as(i64, @intCast(on_pong_time - self.owd));
+                const t1: i64 = @intCast(on_pong_time - self.owd);
 
                 self.clock.learn(1, m0, t1, on_pong_time);
                 self.clock.learn(2, m0, t1, on_pong_time);
@@ -521,38 +521,38 @@ const ClockUnitTestContainer = struct {
                 };
                 ret[1] = .{
                     .tick = threshold + 100,
-                    .expected_offset = @as(i64, @intCast(self.owd)),
+                    .expected_offset = @intCast(self.owd),
                 };
                 ret[2] = .{
                     .tick = threshold + 200,
-                    .expected_offset = @as(i64, @intCast(self.owd)),
+                    .expected_offset = @intCast(self.owd),
                 };
             },
             .periodic => {
                 ret[0] = .{
-                    .tick = @as(u64, @intCast(@divTrunc(self.clock.time.offset_coefficient_B, 4))),
-                    .expected_offset = @as(i64, @intCast(self.owd)),
+                    .tick = @intCast(@divTrunc(self.clock.time.offset_coefficient_B, 4)),
+                    .expected_offset = @intCast(self.owd),
                 };
                 ret[1] = .{
-                    .tick = @as(u64, @intCast(@divTrunc(self.clock.time.offset_coefficient_B, 2))),
+                    .tick = @intCast(@divTrunc(self.clock.time.offset_coefficient_B, 2)),
                     .expected_offset = 0,
                 };
                 ret[2] = .{
-                    .tick = @as(u64, @intCast(@divTrunc(self.clock.time.offset_coefficient_B * 3, 4))),
+                    .tick = @intCast(@divTrunc(self.clock.time.offset_coefficient_B * 3, 4)),
                     .expected_offset = -@as(i64, @intCast(self.owd)),
                 };
             },
             .step => {
                 ret[0] = .{
-                    .tick = @as(u64, @intCast(self.clock.time.offset_coefficient_B - 10)),
+                    .tick = @intCast(self.clock.time.offset_coefficient_B - 10),
                     .expected_offset = 0,
                 };
                 ret[1] = .{
-                    .tick = @as(u64, @intCast(self.clock.time.offset_coefficient_B + 10)),
+                    .tick = @intCast(self.clock.time.offset_coefficient_B + 10),
                     .expected_offset = -@as(i64, @intCast(self.owd)),
                 };
                 ret[2] = .{
-                    .tick = @as(u64, @intCast(self.clock.time.offset_coefficient_B + 10)),
+                    .tick = @intCast(self.clock.time.offset_coefficient_B + 10),
                     .expected_offset = -@as(i64, @intCast(self.owd)),
                 };
             },
@@ -738,7 +738,7 @@ const ClockSimulator = struct {
                             ClockSimulator.handle_packet,
                             .{
                                 .source = clock.replica,
-                                .target = @as(u8, @intCast(target)),
+                                .target = @intCast(target),
                             },
                         );
                     }
@@ -791,7 +791,7 @@ test "clock: fuzz test" {
         .offset_coefficient_A = 0,
         .offset_coefficient_B = 0,
     };
-    var seed = @as(u64, @intCast(system_time.realtime()));
+    var seed: u64 = @intCast(system_time.realtime());
     var min_sync_error: u64 = 1_000_000_000;
     var max_sync_error: u64 = 0;
     var max_clock_offset: u64 = 0;
@@ -827,7 +827,7 @@ test "clock: fuzz test" {
 
         for (simulator.clocks, 0..) |*clock, index| {
             var offset = clock.time.offset(simulator.ticks);
-            var abs_offset = if (offset >= 0) @as(u64, @intCast(offset)) else @as(u64, @intCast(-offset));
+            var abs_offset: u64 = if (offset >= 0) @intCast(offset) else @intCast(-offset);
             max_clock_offset = if (abs_offset > max_clock_offset) abs_offset else max_clock_offset;
             min_clock_offset = if (abs_offset < min_clock_offset) abs_offset else min_clock_offset;
 
@@ -842,7 +842,7 @@ test "clock: fuzz test" {
                     continue;
                 };
                 var err: i64 = synced_time - other_clock_sync_time;
-                var abs_err: u64 = if (err >= 0) @as(u64, @intCast(err)) else @as(u64, @intCast(-err));
+                var abs_err: u64 = if (err >= 0) @intCast(err) else @intCast(-err);
                 max_sync_error = if (abs_err > max_sync_error) abs_err else max_sync_error;
                 min_sync_error = if (abs_err < min_sync_error) abs_err else min_sync_error;
             }

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -115,7 +115,7 @@ pub fn ClockType(comptime Time: type) type {
             errdefer allocator.free(window.sources);
 
             // There are two Marzullo tuple bounds (lower and upper) per source clock offset sample:
-            var marzullo_tuples = try allocator.alloc(Marzullo.Tuple, replica_count * 2);
+            const marzullo_tuples = try allocator.alloc(Marzullo.Tuple, replica_count * 2);
             errdefer allocator.free(marzullo_tuples);
 
             var self = Self{
@@ -514,7 +514,7 @@ const ClockUnitTestContainer = struct {
                 // Beyond this, the offset > OWD and the Marzullo interval will be from replica 1 and
                 // replica 2. The `clock.realtime_synchronized` will be clamped to the lower bound.
                 // Therefore the `clock.realtime_synchronized` will be offset by the OWD.
-                var threshold = self.owd / @as(u64, @intCast(self.clock.time.offset_coefficient_A));
+                const threshold = self.owd / @as(u64, @intCast(self.clock.time.offset_coefficient_A));
                 ret[0] = .{
                     .tick = threshold,
                     .expected_offset = self.clock.time.offset(threshold - self.learn_interval),
@@ -580,7 +580,7 @@ test "ideal clocks get clamped to cluster time" {
         std.time.ns_per_ms, // loses 1ms per tick
         0,
     );
-    var linear_clock_assertion_points = ideal_constant_drift_clock.ticks_to_perform_assertions();
+    const linear_clock_assertion_points = ideal_constant_drift_clock.ticks_to_perform_assertions();
     for (linear_clock_assertion_points) |point| {
         ideal_constant_drift_clock.run_till_tick(point.tick);
         try testing.expectEqual(
@@ -597,7 +597,7 @@ test "ideal clocks get clamped to cluster time" {
         std.time.ns_per_s, // loses up to 1s
         200, // period of 200 ticks
     );
-    var ideal_periodic_drift_clock_assertion_points =
+    const ideal_periodic_drift_clock_assertion_points =
         ideal_periodic_drift_clock.ticks_to_perform_assertions();
     for (ideal_periodic_drift_clock_assertion_points) |point| {
         ideal_periodic_drift_clock.run_till_tick(point.tick);
@@ -615,7 +615,7 @@ test "ideal clocks get clamped to cluster time" {
         -5 * std.time.ns_per_day, // jumps 5 days ahead.
         49, // after 49 ticks
     );
-    var ideal_jumping_clock_assertion_points = ideal_jumping_clock.ticks_to_perform_assertions();
+    const ideal_jumping_clock_assertion_points = ideal_jumping_clock.ticks_to_perform_assertions();
     for (ideal_jumping_clock_assertion_points) |point| {
         ideal_jumping_clock.run_till_tick(point.tick);
         try testing.expectEqual(
@@ -791,7 +791,7 @@ test "clock: fuzz test" {
         .offset_coefficient_A = 0,
         .offset_coefficient_B = 0,
     };
-    var seed: u64 = @intCast(system_time.realtime());
+    const seed: u64 = @intCast(system_time.realtime());
     var min_sync_error: u64 = 1_000_000_000;
     var max_sync_error: u64 = 0;
     var max_clock_offset: u64 = 0;
@@ -826,23 +826,23 @@ test "clock: fuzz test" {
         simulator.tick();
 
         for (simulator.clocks, 0..) |*clock, index| {
-            var offset = clock.time.offset(simulator.ticks);
-            var abs_offset: u64 = if (offset >= 0) @intCast(offset) else @intCast(-offset);
+            const offset = clock.time.offset(simulator.ticks);
+            const abs_offset: u64 = if (offset >= 0) @intCast(offset) else @intCast(-offset);
             max_clock_offset = if (abs_offset > max_clock_offset) abs_offset else max_clock_offset;
             min_clock_offset = if (abs_offset < min_clock_offset) abs_offset else min_clock_offset;
 
-            var synced_time = clock.realtime_synchronized() orelse {
+            const synced_time = clock.realtime_synchronized() orelse {
                 clock_ticks_without_synchronization[index] += 1;
                 continue;
             };
 
             for (simulator.clocks, 0..) |*other_clock, other_clock_index| {
                 if (index == other_clock_index) continue;
-                var other_clock_sync_time = other_clock.realtime_synchronized() orelse {
+                const other_clock_sync_time = other_clock.realtime_synchronized() orelse {
                     continue;
                 };
-                var err: i64 = synced_time - other_clock_sync_time;
-                var abs_err: u64 = if (err >= 0) @intCast(err) else @intCast(-err);
+                const err: i64 = synced_time - other_clock_sync_time;
+                const abs_err: u64 = if (err >= 0) @intCast(err) else @intCast(-err);
                 max_sync_error = if (abs_err > max_sync_error) abs_err else max_sync_error;
                 min_sync_error = if (abs_err < min_sync_error) abs_err else min_sync_error;
             }

--- a/src/vsr/free_set.zig
+++ b/src/vsr/free_set.zig
@@ -242,7 +242,7 @@ pub const FreeSet = struct {
         assert(set.reservation_state == .reserving);
         assert(reserve_count > 0);
 
-        var shard_start = find_bit(
+        const shard_start = find_bit(
             set.index,
             @divFloor(set.reservation_blocks, shard_bits),
             set.index.bit_length,
@@ -1000,7 +1000,7 @@ test "FreeSet encode/decode manual" {
     try std.testing.expectEqualSlices(usize, &decoded_expect, bit_set_masks(decoded_actual.blocks));
 
     // Test encode.
-    var encoded_actual = try std.testing.allocator.alignedAlloc(
+    const encoded_actual = try std.testing.allocator.alignedAlloc(
         u8,
         @alignOf(usize),
         FreeSet.encode_size_max(decoded_actual.blocks.bit_length),
@@ -1095,10 +1095,10 @@ test "FreeSet.acquire part-way through a shard" {
     var set = try FreeSet.open_empty(std.testing.allocator, FreeSet.shard_bits * 3);
     defer set.deinit(std.testing.allocator);
 
-    var reservation_a = set.reserve(1).?;
+    const reservation_a = set.reserve(1).?;
     defer set.forfeit(reservation_a);
 
-    var reservation_b = set.reserve(2 * FreeSet.shard_bits).?;
+    const reservation_b = set.reserve(2 * FreeSet.shard_bits).?;
     defer set.forfeit(reservation_b);
 
     // Acquire all of reservation B.

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -209,10 +209,10 @@ pub fn GridType(comptime Storage: type) type {
             missing_blocks_max: usize,
             missing_tables_max: usize,
         }) !Grid {
-            const shard_count_limit = @as(usize, @intCast(@divFloor(
+            const shard_count_limit: usize = @intCast(@divFloor(
                 options.superblock.storage_size_limit - vsr.superblock.data_file_size_min,
                 constants.block_size * FreeSet.shard_bits,
-            )));
+            ));
             const block_count_limit = shard_count_limit * FreeSet.shard_bits;
 
             var free_set = try FreeSet.init(allocator, block_count_limit);

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -287,7 +287,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             // TODO Fix this assertion:
             // assert(write_ahead_log_zone_size <= storage.size);
 
-            var headers = try allocator.alignedAlloc(
+            const headers = try allocator.alignedAlloc(
                 Header.Prepare,
                 constants.sector_size,
                 slot_count,
@@ -295,7 +295,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             errdefer allocator.free(headers);
             for (headers) |*header| header.* = undefined;
 
-            var headers_redundant = try allocator.alignedAlloc(
+            const headers_redundant = try allocator.alignedAlloc(
                 Header.Prepare,
                 constants.sector_size,
                 slot_count,
@@ -309,11 +309,11 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             var faulty = try BitSet.init_full(allocator, slot_count);
             errdefer faulty.deinit(allocator);
 
-            var prepare_checksums = try allocator.alloc(u128, slot_count);
+            const prepare_checksums = try allocator.alloc(u128, slot_count);
             errdefer allocator.free(prepare_checksums);
             @memset(prepare_checksums, 0);
 
-            var prepare_inhabited = try allocator.alloc(bool, slot_count);
+            const prepare_inhabited = try allocator.alloc(bool, slot_count);
             errdefer allocator.free(prepare_inhabited);
             @memset(prepare_inhabited, false);
 
@@ -630,7 +630,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 op -= 1;
 
                 // Get the entry at @mod(op) location, but only if entry.op == op, else null:
-                var A = journal.header_with_op(op);
+                const A = journal.header_with_op(op);
                 if (A) |a| {
                     if (B) |b| {
                         // If A was reordered then A may have a newer op than B (but an older view).
@@ -2513,7 +2513,7 @@ pub fn format_wal_prepares(cluster: u128, offset_logical: u64, target: []u8) usi
     const sectors_per_message = @divExact(constants.message_size_max, constants.sector_size);
     const sector_max = @divExact(constants.journal_size_prepares, constants.sector_size);
 
-    var sectors = std.mem.bytesAsSlice([constants.sector_size]u8, target);
+    const sectors = std.mem.bytesAsSlice([constants.sector_size]u8, target);
     for (sectors, 0..) |*sector_data, i| {
         const sector = @divExact(offset_logical, constants.sector_size) + i;
         if (sector == sector_max) {
@@ -2528,7 +2528,7 @@ pub fn format_wal_prepares(cluster: u128, offset_logical: u64, target: []u8) usi
             @memset(sector_data, 0);
             if (sector % sectors_per_message == 0) {
                 // The header goes in the first sector of the message.
-                var sector_header =
+                const sector_header =
                     std.mem.bytesAsValue(Header.Prepare, sector_data[0..@sizeOf(Header)]);
                 if (message_slot == 0) {
                     sector_header.* = Header.Prepare.root(cluster);

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1156,7 +1156,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(journal.dirty.count <= journal.faulty.count);
             assert(read.destination_replica == null);
 
-            const slot = Slot{ .index = @as(u64, @intCast(read.op)) };
+            const slot = Slot{ .index = @intCast(read.op) };
             assert(slot.index < slot_count);
             assert(!journal.dirty.bit(slot));
             assert(journal.faulty.bit(slot));

--- a/src/vsr/marzullo.zig
+++ b/src/vsr/marzullo.zig
@@ -41,7 +41,7 @@ pub const Marzullo = struct {
     /// Returns the smallest interval consistent with the largest number of sources.
     pub fn smallest_interval(tuples: []Tuple) Interval {
         // There are two bounds (lower and upper) per source clock offset sample.
-        const sources = @as(u8, @intCast(@divExact(tuples.len, 2)));
+        const sources: u8 = @intCast(@divExact(tuples.len, 2));
 
         if (sources == 0) {
             return Interval{
@@ -102,7 +102,7 @@ pub const Marzullo = struct {
         // The number of false sources (ones which do not overlap the optimal interval) is the
         // number of sources minus the value of `best`:
         assert(best <= sources);
-        interval.sources_true = @as(u8, @intCast(best));
+        interval.sources_true = @intCast(best);
         interval.sources_false = @as(u8, @intCast(sources - @as(u8, @intCast(best))));
         assert(interval.sources_true + interval.sources_false == sources);
 
@@ -139,7 +139,7 @@ fn test_smallest_interval(bounds: []const i64, smallest_interval: Marzullo.Inter
     var tuples = try allocator.alloc(Marzullo.Tuple, bounds.len);
     for (bounds, 0..) |bound, i| {
         tuples[i] = .{
-            .source = @as(u8, @intCast(@divTrunc(i, 2))),
+            .source = @intCast(@divTrunc(i, 2)),
             .offset = bound,
             .bound = if (i % 2 == 0) .lower else .upper,
         };

--- a/src/vsr/marzullo.zig
+++ b/src/vsr/marzullo.zig
@@ -145,7 +145,7 @@ fn test_smallest_interval(bounds: []const i64, smallest_interval: Marzullo.Inter
         };
     }
 
-    var interval = Marzullo.smallest_interval(tuples);
+    const interval = Marzullo.smallest_interval(tuples);
     try std.testing.expectEqual(smallest_interval, interval);
 }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9213,6 +9213,8 @@ const PipelineQueue = struct {
         // ordered and consecutive.
         const head_op = pipeline.prepare_queue.head_ptr().?.message.header.op;
         const tail_op = pipeline.prepare_queue.tail_ptr().?.message.header.op;
+        assert(tail_op == head_op + pipeline.prepare_queue.count - 1);
+
         if (op < head_op) return null;
         if (op > tail_op) return null;
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -488,8 +488,8 @@ pub fn ReplicaType(
             self.superblock.working.vsr_state.assert_internally_consistent();
 
             const replica_id = self.superblock.working.vsr_state.replica_id;
-            const replica = for (self.superblock.working.vsr_state.members, 0..) |member, index| {
-                if (member == replica_id) break @as(u8, @intCast(index));
+            const replica: u8 = for (self.superblock.working.vsr_state.members, 0..) |member, index| {
+                if (member == replica_id) break @intCast(index);
             } else unreachable;
             const replica_count = self.superblock.working.vsr_state.replica_count;
             if (replica >= options.node_count or replica_count > options.node_count) {
@@ -1236,7 +1236,7 @@ pub fn ReplicaType(
                 .view = self.view_durable(), // Don't drop pongs while the view is being updated.
                 // Copy the ping's monotonic timestamp to our pong and add our wall clock sample:
                 .ping_timestamp_monotonic = message.header.ping_timestamp_monotonic,
-                .pong_timestamp_wall = @as(u64, @bitCast(self.clock.realtime())),
+                .pong_timestamp_wall = @bitCast(self.clock.realtime()),
             }));
         }
 
@@ -1251,7 +1251,7 @@ pub fn ReplicaType(
             if (message.header.replica >= self.replica_count) return;
 
             const m0 = message.header.ping_timestamp_monotonic;
-            const t1 = @as(i64, @bitCast(message.header.pong_timestamp_wall));
+            const t1: i64 = @bitCast(message.header.pong_timestamp_wall);
             const m2 = self.clock.monotonic();
 
             self.clock.learn(message.header.replica, m0, t1, m2);
@@ -2163,7 +2163,7 @@ pub fn ReplicaType(
                 return;
             }
 
-            response.header.size = @as(u32, @intCast(@sizeOf(Header) * (1 + count)));
+            response.header.size = @intCast(@sizeOf(Header) * (1 + count));
             response.header.set_checksum_body(response.body());
             response.header.set_checksum();
 
@@ -2577,7 +2577,7 @@ pub fn ReplicaType(
                 assert(replica < self.replica_count);
 
                 if (replica != self.replica) {
-                    waiting[waiting_len] = @as(u8, @intCast(replica));
+                    waiting[waiting_len] = @intCast(replica);
                     waiting_len += 1;
                 }
             } else {
@@ -4854,7 +4854,7 @@ pub fn ReplicaType(
 
         /// Returns the index into the configuration of the primary for a given view.
         pub fn primary_index(self: *const Self, view: u32) u8 {
-            return @as(u8, @intCast(@mod(view, self.replica_count)));
+            return @intCast(@mod(view, self.replica_count));
         }
 
         /// Returns whether the replica is the primary for the current view.

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -145,7 +145,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
             assert(!self.formatting);
 
             // Direct I/O requires the buffer to be sector-aligned.
-            var message_buffer =
+            const message_buffer =
                 try allocator.alignedAlloc(u8, constants.sector_size, constants.message_size_max);
             defer allocator.free(message_buffer);
             @memset(message_buffer, 0);
@@ -175,7 +175,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
 
             if (padding_size > 0) {
                 // Direct I/O requires the buffer to be sector-aligned.
-                var padding_buffer = try allocator.alignedAlloc(
+                const padding_buffer = try allocator.alignedAlloc(
                     u8,
                     constants.sector_size,
                     vsr.Zone.size(.grid_padding).?,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1249,21 +1249,21 @@ const TestContext = struct {
             .S3 => array.append_assume_capacity(.{ .replica = replica_count + 3 }),
             .S4 => array.append_assume_capacity(.{ .replica = replica_count + 4 }),
             .S5 => array.append_assume_capacity(.{ .replica = replica_count + 5 }),
-            .A0 => array.append_assume_capacity(.{ .replica = @as(u8, @intCast((view + 0) % replica_count)) }),
-            .B1 => array.append_assume_capacity(.{ .replica = @as(u8, @intCast((view + 1) % replica_count)) }),
-            .B2 => array.append_assume_capacity(.{ .replica = @as(u8, @intCast((view + 2) % replica_count)) }),
-            .B3 => array.append_assume_capacity(.{ .replica = @as(u8, @intCast((view + 3) % replica_count)) }),
-            .B4 => array.append_assume_capacity(.{ .replica = @as(u8, @intCast((view + 4) % replica_count)) }),
-            .B5 => array.append_assume_capacity(.{ .replica = @as(u8, @intCast((view + 5) % replica_count)) }),
+            .A0 => array.append_assume_capacity(.{ .replica = @intCast((view + 0) % replica_count) }),
+            .B1 => array.append_assume_capacity(.{ .replica = @intCast((view + 1) % replica_count) }),
+            .B2 => array.append_assume_capacity(.{ .replica = @intCast((view + 2) % replica_count) }),
+            .B3 => array.append_assume_capacity(.{ .replica = @intCast((view + 3) % replica_count) }),
+            .B4 => array.append_assume_capacity(.{ .replica = @intCast((view + 4) % replica_count) }),
+            .B5 => array.append_assume_capacity(.{ .replica = @intCast((view + 5) % replica_count) }),
             .__, .R_, .S_, .C_ => {
                 if (selector == .__ or selector == .R_) {
                     for (t.cluster.replicas[0..replica_count], 0..) |_, i| {
-                        array.append_assume_capacity(.{ .replica = @as(u8, @intCast(i)) });
+                        array.append_assume_capacity(.{ .replica = @intCast(i) });
                     }
                 }
                 if (selector == .__ or selector == .S_) {
                     for (t.cluster.replicas[replica_count..], 0..) |_, i| {
-                        array.append_assume_capacity(.{ .replica = @as(u8, @intCast(replica_count + i)) });
+                        array.append_assume_capacity(.{ .replica = @intCast(replica_count + i) });
                     }
                 }
                 if (selector == .__ or selector == .C_) {

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -251,12 +251,12 @@ pub fn QuorumsType(comptime options: Options) type {
                 // for certain which copy this was supposed to be.
                 // We make the assumption that this was not a double-fault (corrupt + misdirect) —
                 // that is, the copy is in the correct slot, and its copy index is simply corrupt.
-                quorum.slots[slot] = @as(u8, @intCast(slot));
+                quorum.slots[slot] = @intCast(slot);
                 quorum.copies.set(slot);
             } else if (quorum.copies.isSet(copy.copy)) {
                 // Ignore the duplicate copy.
             } else {
-                quorum.slots[slot] = @as(u8, @intCast(copy.copy));
+                quorum.slots[slot] = @intCast(copy.copy);
                 quorum.copies.set(copy.copy);
             }
 
@@ -350,10 +350,10 @@ pub fn QuorumsType(comptime options: Options) type {
                 var b: ?u8 = null;
                 var c: ?u8 = null;
                 for (iterator.slots, 0..) |slot, i| {
-                    if (slot == null and !copies_any.isSet(i)) a = @as(u8, @intCast(i));
-                    if (slot == null and copies_any.isSet(i)) b = @as(u8, @intCast(i));
+                    if (slot == null and !copies_any.isSet(i)) a = @intCast(i);
+                    if (slot == null and copies_any.isSet(i)) b = @intCast(i);
                     if (slot) |slot_copy| {
-                        if (slot_copy != i and copies_duplicate.isSet(slot_copy)) c = @as(u8, @intCast(i));
+                        if (slot_copy != i and copies_duplicate.isSet(slot_copy)) c = @intCast(i);
                     }
                 }
 


### PR DESCRIPTION
A collection of unrelated changes that were in my stash for a while, and I decided to submit them as a single PR.
To simplify the review process, each change has its own commit:

- Removed (almost) all uses of unnecessary `@as(...)` where:
a) The compiler can infer the type, such as return values, variables/fields assignment, and function parameters.
b) Expressions such as `const a = @as(T, ...);` could be refactored to `const a: T = ...;`

- Changed the immutable variables declared with `var` to `const`.
With a little help from the Zig compiler 0.12-dev;

- Upgraded the code for derived indexes to use Zig 0.11.0.
This code was never referenced, so it wasn't migrated during the last upgrade.

-  Added some misc `assert`s.