### PR TITLE
ci: fix rev/ref typo

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          rev: release # Use the 'release' branch even if triggered by cron.
+          ref: release # Use the 'release' branch even if triggered by cron.
 
       - uses: actions/setup-dotnet@v3
         with:


### PR DESCRIPTION
GitHub would [silently ignore the typo](https://github.com/tigerbeetle/tigerbeetle/actions/runs/7680274074), causing breaking changes between main and release to fail, since it would try to verify with the wrong version.