### PR TITLE
release: tag correct commit

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -374,11 +374,13 @@ fn publish(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
 
         try shell.exec(
             \\gh release create --draft
+            \\  --target {sha}
             \\  --notes {notes}
             \\  {tag}
         , .{
-            .tag = info.version,
+            .sha = info.sha,
             .notes = notes,
+            .tag = info.version,
         });
 
         // Here and elsewhere for publishing we explicitly spell out the files we are uploading


### PR DESCRIPTION
By default, `gh release create` tags whatever commit is the tip of the `main` branch. This is not what we want, we want to release a specific commit, even if the main branched moved ahead in the meantime.