### PR TITLE
devhub: rename workbench to devhub 

### DIFF
--- a/.github/workflows/pipeline-main.yml
+++ b/.github/workflows/pipeline-main.yml
@@ -11,9 +11,9 @@ jobs:
   other:
     uses: ./.github/workflows/pipeline-other.yml
 
-  workbench:
+  devhub:
     runs-on: ubuntu-latest
-    environment: workbench
+    environment: devhub
     permissions:
       pages: write
       id-token: write
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build scripts -- workbench --sha=${{ github.sha }}
+      - run: ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
         env:
-          WORKBENCHDB_PAT: ${{ secrets.WORKBENCHDB_PAT }}
+          DEVHUBDB_PAT: ${{ secrets.DEVHUBDB_PAT }}
       - uses: actions/upload-pages-artifact@v1
         with:
-          path: ./src/workbench
+          path: ./src/devhub
       - uses: actions/deploy-pages@v1

--- a/docs/internals/releases.md
+++ b/docs/internals/releases.md
@@ -52,8 +52,8 @@ pull requests were merged in a week).
 
 ## Release Process
 
-Releases are triggered manually, on Monday. Default release rotation is on the workbench:
-<https://tigerbeetle.github.io/tigerbeetle/>. 
+Releases are triggered manually, on Monday. Default release rotation is on the devhub:
+<https://tigerbeetle.github.io/tigerbeetle/>.
 
 The middle name is the default release manager for the _current_ week. After the release, please
 ping the next person to pass the baton.

--- a/scripts/.cspell.json
+++ b/scripts/.cspell.json
@@ -28,6 +28,7 @@
 	"Dcpu",
 	"deallocation",
 	"deduped",
+	"devhub",
 	"dfsp",
 	"Dominik",
 	"Doptimize",

--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -1,4 +1,4 @@
-// Code powering "developer dashboard" aka workbench, at <https://tigerbeetle.github.io>.
+// Code powering "developer dashboard" aka devhub, at <https://tigerbeetle.github.io/tigerbeetle>.
 //
 // At the moment, it isn't clear what's the right style for this kind of non-Zig developer facing
 // code, so the following is somewhat arbitrary:
@@ -47,7 +47,7 @@ function getReleaseManager() {
 }
 
 const dataUrl =
-  "https://raw.githubusercontent.com/tigerbeetle/workbenchdb/main/workbench/data.json";
+  "https://raw.githubusercontent.com/tigerbeetle/devhubdb/main/devhub/data.json";
 
 async function fetchData() {
   const data = await (await fetch(dataUrl)).text();

--- a/src/devhub/index.html
+++ b/src/devhub/index.html
@@ -4,15 +4,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TigerBeetle Dev Workbench</title>
-  <script src="./workbench.js"></script>
+  <title>TigerBeetle DevHub</title>
+  <script src="./devhub.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/apexcharts/3.45.2/apexcharts.min.js"
     integrity="sha512-vIqZt7ReO939RQssENNbZ+Iu3j0CSsgk41nP3AYabLiIFajyebORlk7rKPjGddmO1FQkbuOb2EVK6rJkiHsmag=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 
 <body>
-  <h1>TigerBeetle Dev Workbench</h1>
+  <h1>TigerBeetle DevHub</h1>
 
   <section>
     <h2>Release</h2>

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -34,20 +34,20 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
         },
     };
 
-    const token = try shell.env_get("WORKBENCHDB_PAT");
+    const token = try shell.env_get("DEVHUBDB_PAT");
     try shell.exec(
         \\git clone --depth 1
-        \\  https://oauth2:{token}@github.com/tigerbeetle/workbenchdb.git
-        \\  workbenchdb
+        \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb.git
+        \\  devhubdb
     , .{
         .token = token,
     });
 
-    try shell.pushd("./workbenchdb");
+    try shell.pushd("./devhubdb");
     defer shell.popd();
 
     {
-        const file = try shell.cwd.openFile("./workbench/data.json", .{
+        const file = try shell.cwd.openFile("./devhub/data.json", .{
             .mode = .write_only,
         });
         defer file.close();
@@ -57,7 +57,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
         try file.writeAll("\n");
     }
 
-    try shell.exec("git add ./workbench/data.json", .{});
+    try shell.exec("git add ./devhub/data.json", .{});
     try shell.git_env_setup();
     try shell.exec("git commit -m 📈", .{});
     try shell.exec("git push", .{});

--- a/src/scripts/main.zig
+++ b/src/scripts/main.zig
@@ -19,12 +19,12 @@ const Shell = @import("../shell.zig");
 
 const ci = @import("./ci.zig");
 const release = @import("./release.zig");
-const workbench = @import("./workbench.zig");
+const devhub = @import("./devhub.zig");
 
 const CliArgs = union(enum) {
     ci: ci.CliArgs,
     release: release.CliArgs,
-    workbench: workbench.CliArgs,
+    devhub: devhub.CliArgs,
 };
 
 pub fn main() !void {
@@ -49,6 +49,6 @@ pub fn main() !void {
     switch (cli_args) {
         .ci => |args_ci| try ci.main(shell, gpa, args_ci),
         .release => |args_release| try release.main(shell, gpa, args_release),
-        .workbench => |args_workbench| try workbench.main(shell, gpa, args_workbench),
+        .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
     }
 }

--- a/src/workbench/workbench.js
+++ b/src/workbench/workbench.js
@@ -104,13 +104,31 @@ function plotSeries(seriesList, rootNode) {
       chart: {
         type: "bar",
         height: "400px",
+        events: {
+          dataPointSelection: (event, chartContext, { dataPointIndex }) => {
+            window.open(
+              "https://github.com/tigerbeetle/tigerbeetle/commits/" +
+                series.revision[dataPointIndex],
+            );
+          },
+        },
       },
       series: [{
         name: series.label,
-        data: series.timestamp.map((t, i) => [t * 1000, series.value[i]]),
+        data: series.value,
       }],
       xaxis: {
-        type: "datetime",
+        categories: series.revision.map((sha) => sha.substring(0, 6)),
+      },
+      tooltip: {
+        enabled: true,
+        x: {
+          formatter: function (val, { dataPointIndex }) {
+            const timestamp = new Date(series.timestamp[dataPointIndex] * 1000);
+            const formattedDate = timestamp.toISOString();
+            return `<div>${val}</div><div>${formattedDate}</div>`;
+          },
+        },
       },
     };
 


### PR DESCRIPTION
The name here is going to be all over our infrastructure in the future
(or at least it is a possibility), so it's better to use something
short, unique, and memorable. "devhub" sounds like a proper name, and is
significantly better than "workbench".

After this is merged:

- rename workbenchdb repository
- rename folder in that repository
- rename/recreate github actions environment
- create new pat for devhubdb
- revoke the old pat