### PR TITLE
vsr: consider state sync done only when all replies hit the disk

### DIFF
--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -129,6 +129,18 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             // Don't unref `write_queue`'s Writes — they are a subset of `writes`.
         }
 
+        /// Returns true if the reply at the given slot is  durably persisted to disk. The
+        /// difference with `faulty` bit set is that `faulty` is cleared at the start of a write
+        /// when the reply is still in RAM. In contrast, `reply_durable` checks that the
+        /// corresponding reply hit the disk.
+        pub fn reply_durable(
+            client_replies: *const ClientReplies,
+            slot: Slot,
+        ) bool {
+            return !client_replies.faulty.isSet(slot.index) and
+                !client_replies.writing.isSet(slot.index);
+        }
+
         pub fn read_reply_sync(
             client_replies: *ClientReplies,
             slot: Slot,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8046,7 +8046,9 @@ pub fn ReplicaType(
                     if (entry.header.op >= self.superblock.working.vsr_state.sync_op_min and
                         entry.header.op <= self.superblock.working.vsr_state.sync_op_max)
                     {
-                        if (self.client_replies.faulty.isSet(entry_slot)) return false;
+                        if (!self.client_replies.reply_durable(.{ .index = entry_slot })) {
+                            return false;
+                        }
                     }
                 }
                 return self.sync_tables == null and self.grid_repair_tables.executing() == 0;


### PR DESCRIPTION
Before `sync_content_done` could return true while some repaired replies are still in flight. This is a durability issue: if replica completes the sync, but then crashes _before_ the reply is fully written, it won't attempt to fix it subsequently.

And, naturally, this will be caught by the VOPR, which notices that data files are different at a checkpoint between replicas.

SEED: 11435969822295410219
Closes: #1494