### PR TITLE
Test: Simplify "forfeit" replica_test

### DIFF
--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -467,20 +467,13 @@ test "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfe
 
     b1.drop_all(.__, .bidirectional);
 
-    try c.request(checkpoint_1_trigger, checkpoint_1_trigger);
-    try expectEqual(a0.commit(), checkpoint_1_trigger);
-    try expectEqual(b1.commit(), 20);
-    try expectEqual(b2.commit(), checkpoint_1_trigger);
-
-    // Ensure that B2 does not commit op=trigger+1.
-    b2.drop(.__, .incoming, .commit);
     try c.request(checkpoint_1_trigger + 1, checkpoint_1_trigger + 1);
     try expectEqual(a0.op_checkpoint(), checkpoint_1);
     try expectEqual(b1.op_checkpoint(), 0);
     try expectEqual(b2.op_checkpoint(), checkpoint_1);
     try expectEqual(a0.commit(), checkpoint_1_trigger + 1);
     try expectEqual(b1.commit(), 20);
-    try expectEqual(b2.commit(), checkpoint_1_trigger);
+    try expectEqual(b2.commit(), checkpoint_1_trigger + 1);
     try expectEqual(a0.op_head(), checkpoint_1_trigger + 1);
     try expectEqual(b1.op_head(), 20);
     try expectEqual(b2.op_head(), checkpoint_1_trigger + 1);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -490,6 +490,8 @@ test "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfe
     b2.pass_all(.__, .bidirectional);
     b1.pass_all(.__, .bidirectional);
     a0.drop_all(.__, .bidirectional);
+    // Block state sync to prove that B1 recovers via WAL repair.
+    b1.drop(.__, .bidirectional, .sync_checkpoint);
     // TODO: Explicit coverage marks: This should hit the
     // "on_do_view_change: lagging primary; forfeiting" log line.
     t.run();


### PR DESCRIPTION
I'm not sure why I included the extra steps when originally writing this test!

I can see _what_ I was doing: past-me apparently wanted the checkpoint to be committed atop, but not by either of the replicas in the second phase of the test. But that doesn't seem to be relevant to the on-do-view-change/forfeit logic. As far as present-me can tell, the important thing is only that the checkpoint is prepared atop, but that the cluster is not so far ahead of the lagging replica as to necessitate state sync.

I verified that (both before and after this change) the `"on_do_view_change: lagging primary; forfeiting"` log line is hit.

---

(Also add a new rule to the test, to be extra sure that this test doesn't cheat by using state sync.)