### PR TITLE
VSR: Use previous `checkpoint_id` in prepares' headers

### DIFF
--- a/docs/internals/sync.md
+++ b/docs/internals/sync.md
@@ -50,7 +50,7 @@ Checkpoints:
 6. [Request superblock checkpoint state](#6-request-superblock-checkpoint-state).
 7. Update the superblock headers with:
     - Bump `vsr_state.checkpoint.commit_min`/`vsr_state.checkpoint.commit_min_checksum` to the sync target op/op-checksum.
-    - Bump `vsr_state.checkpoint.previous_checkpoint_id` to the checkpoint id that is previous to our sync target (i.e. it isn't _our_ previous checkpoint).
+    - Bump `vsr_state.checkpoint.parent_checkpoint_id` to the checkpoint id that is previous to our sync target (i.e. it isn't _our_ previous checkpoint).
     - Bump `replica.commit_min`. (If `replica.commit_min` exceeds `replica.op`, transition to `status=recovering_head`).
     - Set `vsr_state.sync_op_min` to the minimum op which has not been repaired.
     - Set `vsr_state.sync_op_max` to the maximum op which has not been repaired.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1397,6 +1397,16 @@ pub const Checkpoint = struct {
         }
     }
 
+    pub fn border_for_checkpoint(checkpoint: u64) ?u64 {
+        assert(valid(checkpoint));
+
+        if (trigger_for_checkpoint(checkpoint)) |trigger| {
+            return trigger + constants.pipeline_prepare_queue_max;
+        } else {
+            return null;
+        }
+    }
+
     pub fn valid(op: u64) bool {
         // Divide by `lsm_batch_multiple` instead of `vsr_checkpoint_interval`:
         // although today in practice checkpoints are evenly spaced, the LSM layer doesn't assume

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -530,20 +530,13 @@ pub const Header = extern struct {
         request_checksum_padding: u128 = 0,
         /// The id of the checkpoint where:
         ///
-        ///   prepare.op > border_for_checkpoint(checkpoint_op)
-        ///   prepare.op ≤ border_for_checkpoint(checkpoint_after(checkpoint_op))
+        ///   prepare.op > checkpoint_op
+        ///   prepare.op ≤ checkpoint_after(checkpoint_op)
         ///
         /// The purpose of including the checkpoint id is to strictly bound the number of commits
         /// that it may take to discover a divergent replica. If a replica diverges, then that
         /// divergence will be discovered *at latest* when the divergent replica attempts to commit
-        /// the first op after the next checkpoint trigger + pipeline_prepare_queue_max.
-        ///
-        /// The first `pipeline_prepare_queue_max` ops immediately after a checkpoint trigger are
-        /// border prepares.
-        ///
-        /// A "border prepare" is a prepare that can be prepared in the *next* checkpoint before our
-        /// previous checkpoint is done. (These prepares' `header.checkpoint_id` will be the id of
-        /// the *previous* checkpoint, since the id of the next checkpoint may not yet be known).
+        /// the first op after the next checkpoint.
         checkpoint_id: u128,
         client: u128,
         /// The op number of the latest prepare that may or may not yet be committed. Uncommitted

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -530,13 +530,22 @@ pub const Header = extern struct {
         request_checksum_padding: u128 = 0,
         /// The id of the checkpoint where:
         ///
-        ///   prepare.op > trigger_for_checkpoint(checkpoint_op)
-        ///   prepare.op ≤ trigger_for_checkpoint(checkpoint_after(checkpoint_op))
+        ///   prepare.op >
+        ///     pipeline_prepare_queue_max + trigger_for_checkpoint(checkpoint_op)
+        ///   prepare.op ≤
+        ///     pipeline_prepare_queue_max + trigger_for_checkpoint(checkpoint_after(checkpoint_op))
         ///
         /// The purpose of including the checkpoint id is to strictly bound the number of commits
         /// that it may take to discover a divergent replica. If a replica diverges, then that
         /// divergence will be discovered *at latest* when the divergent replica attempts to commit
-        /// the first op after the next checkpoint trigger.
+        /// the first op after the next checkpoint trigger + pipeline_prepare_queue_max.
+        ///
+        /// The first `pipeline_prepare_queue_max` ops immediately after a checkpoint trigger are
+        /// border prepares.
+        ///
+        /// A "border prepare" is a prepare that can be prepared in the *next* checkpoint before our
+        /// previous checkpoint is done. (These prepares' `header.checkpoint_id` will be the id of
+        /// the *previous* checkpoint, since the id of the next checkpoint may not yet be known).
         checkpoint_id: u128,
         client: u128,
         /// The op number of the latest prepare that may or may not yet be committed. Uncommitted

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -530,10 +530,8 @@ pub const Header = extern struct {
         request_checksum_padding: u128 = 0,
         /// The id of the checkpoint where:
         ///
-        ///   prepare.op >
-        ///     pipeline_prepare_queue_max + trigger_for_checkpoint(checkpoint_op)
-        ///   prepare.op ≤
-        ///     pipeline_prepare_queue_max + trigger_for_checkpoint(checkpoint_after(checkpoint_op))
+        ///   prepare.op > border_for_checkpoint(checkpoint_op)
+        ///   prepare.op ≤ border_for_checkpoint(checkpoint_after(checkpoint_op))
         ///
         /// The purpose of including the checkpoint id is to strictly bound the number of commits
         /// that it may take to discover a divergent replica. If a replica diverges, then that

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5021,9 +5021,10 @@ pub fn ReplicaType(
 
         /// Returns checkpoint id associated with the op.
         ///
-        /// Normally, this is just the id of the op's previous checkpoint. However, ops
-        /// between a checkpoint and its trigger can't know checkpoint's id yet, and instead use
-        /// the id of the grandparent checkpoint.
+        /// Specifically, returns the checkpoint id corresponding to the checkpoint with:
+        ///
+        ///   prepare.op > checkpoint_op
+        ///   prepare.op ≤ checkpoint_after(checkpoint_op)
         ///
         /// Returns `null` for ops which are too far in the past/future to know their checkpoint
         /// ids.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1408,7 +1408,7 @@ pub fn ReplicaType(
             }
 
             if (message.header.checkpoint_id != self.superblock.working.checkpoint_id() and
-                message.header.checkpoint_id != self.superblock.working.vsr_state.checkpoint.previous_checkpoint_id)
+                message.header.checkpoint_id != self.superblock.working.vsr_state.checkpoint.parent_checkpoint_id)
             {
                 // Panic on encountering a prepare which does not match our own checkpoint id.
                 // (Or the previous checkpoint id, for border prepares.)
@@ -5042,7 +5042,7 @@ pub fn ReplicaType(
                         return null;
                     }
                     // Case 3: op is from the previous checkpoint whose id we still remember.
-                    return self.superblock.working.vsr_state.checkpoint.previous_checkpoint_id;
+                    return self.superblock.working.vsr_state.checkpoint.parent_checkpoint_id;
                 }
 
                 assert(op + constants.vsr_checkpoint_interval > self.op_checkpoint_next_border());
@@ -5214,7 +5214,7 @@ pub fn ReplicaType(
                 if (vsr.Checkpoint.border_for_checkpoint(self.op_checkpoint())) |op_border| {
                     if (self.op + 1 <= op_border) {
                         // Border prepares use the previous checkpoint id.
-                        break :checkpoint_id self.superblock.working.vsr_state.checkpoint.previous_checkpoint_id;
+                        break :checkpoint_id self.superblock.working.vsr_state.checkpoint.parent_checkpoint_id;
                     }
                 }
                 break :checkpoint_id self.superblock.working.checkpoint_id();

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -24,6 +24,9 @@ const checkpoint_3 = vsr.Checkpoint.checkpoint_after(checkpoint_2);
 const checkpoint_1_trigger = vsr.Checkpoint.trigger_for_checkpoint(checkpoint_1).?;
 const checkpoint_2_trigger = vsr.Checkpoint.trigger_for_checkpoint(checkpoint_2).?;
 const checkpoint_3_trigger = vsr.Checkpoint.trigger_for_checkpoint(checkpoint_3).?;
+const checkpoint_1_border = vsr.Checkpoint.border_for_checkpoint(checkpoint_1).?;
+const checkpoint_2_border = vsr.Checkpoint.border_for_checkpoint(checkpoint_2).?;
+const checkpoint_3_border = vsr.Checkpoint.border_for_checkpoint(checkpoint_3).?;
 const log_level = std.log.Level.err;
 
 // TODO Test client eviction once it no longer triggers a client panic.
@@ -1048,8 +1051,6 @@ test "Cluster: sync: view-change with lagging replica in recovering_head" {
 }
 
 test "Cluster: async-checkpoints: prepare beyond checkpoint trigger" {
-    const pipeline_prepare_queue_max = constants.pipeline_prepare_queue_max;
-
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
 
@@ -1065,7 +1066,7 @@ test "Cluster: async-checkpoints: prepare beyond checkpoint trigger" {
     t.replica(.R_).drop(.__, .bidirectional, .prepare_ok);
 
     // Prepare ops beyond the checkpoint.
-    try c.request(checkpoint_1_trigger - 1 + pipeline_prepare_queue_max, checkpoint_1_trigger - 1);
+    try c.request(checkpoint_1_border - 1, checkpoint_1_trigger - 1);
     try expectEqual(t.replica(.R_).op_checkpoint(), 0);
     try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger - 1);
     try expectEqual(t.replica(.R_).op_head(), checkpoint_1_trigger);
@@ -1074,10 +1075,10 @@ test "Cluster: async-checkpoints: prepare beyond checkpoint trigger" {
 
     t.replica(.R_).pass(.__, .bidirectional, .prepare_ok);
     t.run();
-    try expectEqual(c.replies(), checkpoint_1_trigger - 1 + pipeline_prepare_queue_max);
+    try expectEqual(c.replies(), checkpoint_1_border - 1);
     try expectEqual(t.replica(.R_).op_checkpoint(), checkpoint_1);
-    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger - 1 + pipeline_prepare_queue_max);
-    try expectEqual(t.replica(.R_).op_head(), checkpoint_1_trigger - 1 + pipeline_prepare_queue_max);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_border - 1);
+    try expectEqual(t.replica(.R_).op_head(), checkpoint_1_border - 1);
 }
 
 const ProcessSelector = enum {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -156,7 +156,7 @@ pub const SuperBlockHeader = extern struct {
         }) VSRState {
             return .{
                 .checkpoint = .{
-                    .previous_checkpoint_id = 0,
+                    .parent_checkpoint_id = 0,
                     .commit_min_checksum = vsr.Header.Prepare.root(options.cluster).checksum,
                     .commit_min = 0,
                     .free_set_checksum = comptime vsr.checksum(&.{}),
@@ -258,8 +258,8 @@ pub const SuperBlockHeader = extern struct {
                 }
             } else {
                 assert(old.checkpoint.commit_min_checksum != new.checkpoint.commit_min_checksum);
-                assert(old.checkpoint.previous_checkpoint_id !=
-                    new.checkpoint.previous_checkpoint_id);
+                assert(old.checkpoint.parent_checkpoint_id !=
+                    new.checkpoint.parent_checkpoint_id);
             }
             assert(old.replica_id == new.replica_id);
             assert(old.replica_count == new.replica_count);
@@ -321,7 +321,7 @@ pub const SuperBlockHeader = extern struct {
 
         /// The checkpoint_id() of the checkpoint which last updated our commit_min.
         /// Following state sync, this is set to the last checkpoint that we skipped.
-        previous_checkpoint_id: u128,
+        parent_checkpoint_id: u128,
 
         free_set_last_block_address: u64,
         client_sessions_last_block_address: u64,
@@ -708,7 +708,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .parent = 0,
                 .vsr_state = .{
                     .checkpoint = .{
-                        .previous_checkpoint_id = 0,
+                        .parent_checkpoint_id = 0,
                         .commit_min_checksum = 0,
                         .commit_min = 0,
                         .manifest_oldest_checksum = 0,
@@ -814,7 +814,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
             var vsr_state = superblock.staging.vsr_state;
             vsr_state.checkpoint = .{
-                .previous_checkpoint_id = superblock.staging.checkpoint_id(),
+                .parent_checkpoint_id = superblock.staging.checkpoint_id(),
                 .commit_min = update.commit_min,
                 .commit_min_checksum = update.commit_min_checksum,
                 .free_set_checksum = update.free_set_reference.checksum,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -99,6 +99,7 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
         .latest_vsr_state = SuperBlockHeader.VSRState{
             .checkpoint = .{
                 .parent_checkpoint_id = 0,
+                .grandparent_checkpoint_id = 0,
                 .commit_min_checksum = 0,
                 .free_set_checksum = vsr.checksum(&.{}),
                 .free_set_last_block_checksum = 0,
@@ -383,6 +384,7 @@ const Environment = struct {
         const vsr_state = VSRState{
             .checkpoint = .{
                 .parent_checkpoint_id = env.superblock.staging.checkpoint_id(),
+                .grandparent_checkpoint_id = vsr_state_old.checkpoint.parent_checkpoint_id,
                 .commit_min_checksum = vsr_state_old.checkpoint.commit_min_checksum + 1,
                 .commit_min = vsr_state_old.checkpoint.commit_min + 1,
                 .free_set_checksum = vsr.checksum(&.{}),

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -98,7 +98,7 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
         .superblock_verify = &superblock_verify,
         .latest_vsr_state = SuperBlockHeader.VSRState{
             .checkpoint = .{
-                .previous_checkpoint_id = 0,
+                .parent_checkpoint_id = 0,
                 .commit_min_checksum = 0,
                 .free_set_checksum = vsr.checksum(&.{}),
                 .free_set_last_block_checksum = 0,
@@ -382,7 +382,7 @@ const Environment = struct {
         const vsr_state_old = env.superblock.staging.vsr_state;
         const vsr_state = VSRState{
             .checkpoint = .{
-                .previous_checkpoint_id = env.superblock.staging.checkpoint_id(),
+                .parent_checkpoint_id = env.superblock.staging.checkpoint_id(),
                 .commit_min_checksum = vsr_state_old.checkpoint.commit_min_checksum + 1,
                 .commit_min = vsr_state_old.checkpoint.commit_min + 1,
                 .free_set_checksum = vsr.checksum(&.{}),


### PR DESCRIPTION
### Background

Right now, a replica will not prepare (or even queue) requests whose op would extend beyond their next checkpoint's trigger op.

This is problematic for performance (the "checkpoint latency spike"), since the replica enters the new checkpoint with nothing to commit.
And the "latency spike" is farther exacerbated by the fact that clients will back off retrying their requests.

Originally we didn't start preparing past the checkpoint to guard against overwriting WAL entries before they will definitely not be needed again. But thanks to `vsr_checkpoint_interval`, that reason does not apply.

However, prepare headers include a `checkpoint_id` ([motivation here](https://github.com/tigerbeetle/tigerbeetle/blob/30cfbfa2eca94b8cd0b1d2a8ce41c7e7720128f0/src/vsr/message_header.zig#L531-L539)). That checkpoint id isn't available until the checkpoint trigger prepare commits.

### Fix

~The first `constants.pipeline_prepare_queue_max` prepares that follow a checkpoint trigger op will now contain the _previous_ checkpoint's id, since that is available both before and after that checkpoint trigger commits.~

~These are called the "border" prepares – they may be prepared during either checkpoint. (This part is not implemented in this commit, though!)~

All prepares within a checkpoint include the `checkpoint_id` of the _previous_ checkpoint. The transition occurs at the checkpoint op.