### PR TITLE
[Dotnet] Remove the csproj property UseCurrentRuntimeIdentifier

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
+++ b/src/clients/dotnet/TigerBeetle.Benchmarks/TigerBeetle.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <SelfContained>false</SelfContained>    
     <RollForward>LatestMajor</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
+++ b/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <RollForward>LatestMajor</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
-    <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>TigerBeetle</AssemblyName>

--- a/src/clients/dotnet/samples/basic/Basic.csproj
+++ b/src/clients/dotnet/samples/basic/Basic.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/src/clients/dotnet/samples/two-phase-many/TwoPhaseMany.csproj
+++ b/src/clients/dotnet/samples/two-phase-many/TwoPhaseMany.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/src/clients/dotnet/samples/two-phase/TwoPhase.csproj
+++ b/src/clients/dotnet/samples/two-phase/TwoPhase.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/src/clients/dotnet/samples/walkthrough/Walkthrough.csproj
+++ b/src/clients/dotnet/samples/walkthrough/Walkthrough.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 


### PR DESCRIPTION
Not necessary since we are not building for multiple runtimes anymore (like we used to do with .Net 7.0 and Standard 2.1).

Also removes the warning:

> For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a self contained app by default. To continue building self-contained apps, set the SelfContained property to true or use the --self-contained argument."