### PR TITLE
devhub: add real benchmark 

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -20,7 +20,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     _ = gpa;
 
     var timer = try std.time.Timer.start();
-    try shell.zig("build install -Drelease", .{});
+    try shell.zig("build -Drelease -Dconfig=production install", .{});
     const build_time_ms = timer.lap() / std.time.ns_per_ms;
 
     const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;


### PR DESCRIPTION
Now that we have devhub infra, let's start tracking some actually
interesting numbers. I picked:

- resident set size
- transactions per second
- p90

As the small, representative set that tracks memory usage, throughput,
and latency. Maybe in the future we'll switch to more exhaustive
benchmark, but, for now, I'd rather have a few coarse-grained numbers,
and then ratchet up from there.

I don't really like how we have to parse out the benchmark results here,
where a single representation is used both for the humans and for the
machines. I _think_ that perhaps we should just spawn a local statsd
_server_ (in process), and use that for fine grained reports, but I am
not entirely sure.

So, let's do a simple thing to get some numbers first!

Note that no changes to devhub itself are needed --- it should just
automatically pick up new data series.

Note that no attempt is made to run the benchmark on real hardware, or
otherwise reduce variance we get from default GitHub runner. The goal
here is not yet to implement a fine-grained benchmarking, but just to
have something to catch out a 2x regression, which hopefully should be
fairly obvious even on a noisy timeline.