### PR TITLE
ci: retry downloads of .Net docker images

### DIFF
--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -54,6 +54,15 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         };
 
         inline for (image_tags) |image_tag| {
+            const image = "mcr.microsoft.com/dotnet/sdk:" ++ image_tag;
+
+            for (0..5) |attempt| {
+                if (attempt > 0) std.time.sleep(60 * std.time.ns_per_min);
+                if (shell.exec("docker image pull {image}", .{ .image = image })) {
+                    break;
+                } else |_| {}
+            }
+
             try shell.exec(
                 \\docker run
                 \\--security-opt seccomp=unconfined
@@ -62,7 +71,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 \\sh
                 \\-c {script}
             , .{
-                .image = "mcr.microsoft.com/dotnet/sdk:" ++ image_tag,
+                .image = image,
                 .script =
                 \\set -ex
                 \\mkdir test-project && cd test-project


### PR DESCRIPTION
Downloading these images fails fairly frequently on GitHub actions, let's retry for a bit.