### PR TITLE
Removes the account debits/credits posted/pending indexes

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -75,35 +75,31 @@ pub fn StateMachineType(
             pub const tree_ids = struct {
                 pub const accounts = .{
                     .id = 1,
-                    .debits_pending = 2,
-                    .debits_posted = 3,
-                    .credits_pending = 4,
-                    .credits_posted = 5,
-                    .user_data_128 = 6,
-                    .user_data_64 = 7,
-                    .user_data_32 = 8,
-                    .ledger = 9,
-                    .code = 10,
-                    .timestamp = 11,
+                    .user_data_128 = 2,
+                    .user_data_64 = 3,
+                    .user_data_32 = 4,
+                    .ledger = 5,
+                    .code = 6,
+                    .timestamp = 7,
                 };
 
                 pub const transfers = .{
-                    .id = 12,
-                    .debit_account_id = 13,
-                    .credit_account_id = 14,
-                    .amount = 15,
-                    .pending_id = 16,
-                    .user_data_128 = 17,
-                    .user_data_64 = 18,
-                    .user_data_32 = 19,
-                    .timeout = 20,
-                    .ledger = 21,
-                    .code = 22,
-                    .timestamp = 23,
+                    .id = 8,
+                    .debit_account_id = 9,
+                    .credit_account_id = 10,
+                    .amount = 11,
+                    .pending_id = 12,
+                    .user_data_128 = 13,
+                    .user_data_64 = 14,
+                    .user_data_32 = 15,
+                    .timeout = 16,
+                    .ledger = 17,
+                    .code = 18,
+                    .timestamp = 19,
                 };
 
                 pub const posted = .{
-                    .timestamp = 24,
+                    .timestamp = 20,
                 };
             };
         };
@@ -167,39 +163,26 @@ pub fn StateMachineType(
                 .ids = constants.tree_ids.accounts,
                 .value_count_max = .{
                     .id = config.lsm_batch_multiple * constants.batch_max.create_accounts,
-                    // Transfers mutate the secondary indices for debits/credits pending/posted.
-                    //
-                    // * Each mutation results in a remove and an insert: the ×2 multiplier.
-                    // * Each transfer modifies two accounts. However, this does not
-                    //   necessitate an additional ×2 multiplier — the credits of the debit
-                    //   account and the debits of the credit account are not modified.
-                    .debits_pending = config.lsm_batch_multiple * @as(usize, @max(
-                        constants.batch_max.create_accounts,
-                        2 * constants.batch_max.create_transfers,
-                    )),
-                    .debits_posted = config.lsm_batch_multiple * @as(usize, @max(
-                        constants.batch_max.create_accounts,
-                        2 * constants.batch_max.create_transfers,
-                    )),
-                    .credits_pending = config.lsm_batch_multiple * @as(usize, @max(
-                        constants.batch_max.create_accounts,
-                        2 * constants.batch_max.create_transfers,
-                    )),
-                    .credits_posted = config.lsm_batch_multiple * @as(usize, @max(
-                        constants.batch_max.create_accounts,
-                        2 * constants.batch_max.create_transfers,
-                    )),
                     .user_data_128 = config.lsm_batch_multiple * constants.batch_max.create_accounts,
                     .user_data_64 = config.lsm_batch_multiple * constants.batch_max.create_accounts,
                     .user_data_32 = config.lsm_batch_multiple * constants.batch_max.create_accounts,
                     .ledger = config.lsm_batch_multiple * constants.batch_max.create_accounts,
                     .code = config.lsm_batch_multiple * constants.batch_max.create_accounts,
+                    // Transfers mutate the account balance for debits/credits pending/posted.
+                    // Each transfer modifies two accounts.
                     .timestamp = config.lsm_batch_multiple * @as(usize, @max(
                         constants.batch_max.create_accounts,
                         2 * constants.batch_max.create_transfers,
                     )),
                 },
-                .ignored = &[_][]const u8{ "flags", "reserved" },
+                .ignored = &[_][]const u8{
+                    "debits_posted",
+                    "debits_pending",
+                    "credits_posted",
+                    "credits_pending",
+                    "flags",
+                    "reserved",
+                },
                 .derived = .{},
             },
         );
@@ -1336,10 +1319,6 @@ pub fn StateMachineType(
                         .user_data_32 = .{},
                         .ledger = .{},
                         .code = .{},
-                        .debits_pending = .{},
-                        .debits_posted = .{},
-                        .credits_pending = .{},
-                        .credits_posted = .{},
                     },
                 },
                 .transfers = .{


### PR DESCRIPTION
Removes the account debits/credits posted/pending indexes, as they're too expensive for little practical benefits: If the user ever needs to query accounts by the balance, it is more likely that they will need to filter by the *net* debit/credit balance and not by the accumulated balance as we index it today.

If it becomes a use-case, we can add them in the future as derived indexes.

On My Machine™, it reduced ~300MiB of memory and increased +15% in TPS.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr><td>
<code>1258 batches in 46.94 s
load offered = 1000000 tx/s
load accepted = 213039 tx/s
batch latency p1 = 0 ms
batch latency p10 = 8 ms
batch latency p20 = 8 ms
batch latency p30 = 8 ms
batch latency p40 = 10 ms
batch latency p50 = 16 ms
batch latency p60 = 19 ms
batch latency p70 = 24 ms
batch latency p80 = 32 ms
batch latency p90 = 39 ms
batch latency p95 = 49 ms
batch latency p99 = 666 ms
batch latency p100 = 852 ms
</code> </td>
<td>
<code>1265 batches in 38.66 s
load offered = 1000000 tx/s
load accepted = 258678 tx/s
batch latency p1 = 0 ms
batch latency p10 = 5 ms
batch latency p20 = 7 ms
batch latency p30 = 8 ms
batch latency p40 = 8 ms
batch latency p50 = 13 ms
batch latency p60 = 18 ms
batch latency p70 = 21 ms
batch latency p80 = 28 ms
batch latency p90 = 37 ms
batch latency p95 = 44 ms
batch latency p99 = 515 ms
batch latency p100 = 775 ms
</code> </td> </tr>
</table>

Let's do that after #1503 so we can compare both.