### PR TITLE
VSR: Prepare beyond checkpoint

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -68,6 +68,7 @@ comptime {
     //   from the previous WAL wrap until a quorum of replicas has reached that checkpoint.
     assert(vsr_checkpoint_interval + lsm_batch_multiple + pipeline_prepare_queue_max <=
         journal_slot_count);
+    assert(vsr_checkpoint_interval >= pipeline_prepare_queue_max);
     assert(vsr_checkpoint_interval >= lsm_batch_multiple);
     assert(vsr_checkpoint_interval % lsm_batch_multiple == 0);
 }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1400,7 +1400,7 @@ pub const Checkpoint = struct {
         }
     }
 
-    pub fn border_for_checkpoint(checkpoint: u64) ?u64 {
+    pub fn prepare_max_for_checkpoint(checkpoint: u64) ?u64 {
         assert(valid(checkpoint));
 
         if (trigger_for_checkpoint(checkpoint)) |trigger| {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1822,8 +1822,8 @@ pub fn ReplicaType(
                 //
                 // - If 1 and ¬2, then the ops in the next checkpoint are uncommitted and our
                 //   current checkpoint is sufficient.
-                // - If 2 and ¬1, then the ops past the checkpoint-trigger must be uncommitted
-                //   because no replica in the DVC quorum even prepared them.
+                // - If 2 and ¬1, then the ops past the checkpoint's op-prepare-max must be
+                //   uncommitted because no replica in the DVC quorum even prepared them.
                 //   (They are present anyway because the origin of the DVC is reusing its SV
                 //   headers as a DVC since it has not completed repair.)
                 //

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1814,11 +1814,8 @@ pub fn ReplicaType(
 
             const op_checkpoint_max =
                 DVCQuorum.op_checkpoint_max(self.do_view_change_from_all_replicas);
-            // This *could* be ≤border instead of ≤trigger, but that is hard to test in
-            // "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfeit"
-            // because prepares carry commit numbers:
             if (op_checkpoint_max > self.op_checkpoint() and
-                op_head > self.op_checkpoint_next_trigger())
+                op_head > self.op_checkpoint_next_border())
             {
                 // When:
                 // 1. the cluster is at a checkpoint ahead of the local checkpoint,
@@ -7674,7 +7671,7 @@ pub fn ReplicaType(
 
             // We learned that we are lagging behind the cluster, so we know we shouldn't actually
             // be the primary. But we can't join a new view until the view's headers are within our
-            // `op_checkpoint_next_trigger`. We need to bump our `op_checkpoint` first – but that is
+            // `op_checkpoint_next_border`. We need to bump our `op_checkpoint` first – but that is
             // async. So even if we are arriving at `sync_start_from_committing` via
             // `on_start_view`, `on_start_view` leaves us as the "primary" for now.
             if (self.status == .normal and self.primary()) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -274,7 +274,7 @@ pub fn ReplicaType(
         /// * `replica.op - replica.commit_min    ≤ journal_slot_count`
         /// * `replica.op - replica.op_checkpoint ≤ journal_slot_count`
         ///   It is safe to overwrite `op_checkpoint` itself.
-        /// * `replica.op ≤ replica.op_checkpoint_next_trigger`:
+        /// * `replica.op ≤ replica.op_checkpoint_next_border`:
         ///   Don't wrap the WAL until we are sure that the overwritten entry will not be required
         ///   for recovery.
         op: u64,
@@ -533,7 +533,7 @@ pub fn ReplicaType(
             const vsr_headers = self.superblock.working.vsr_headers();
             // If we were a lagging backup that installed an SV but didn't finish fast-forwarding,
             // the vsr_headers head op may be part of the checkpoint after this one.
-            maybe(vsr_headers.slice[0].op > self.op_checkpoint_next_trigger());
+            maybe(vsr_headers.slice[0].op > self.op_checkpoint_next_border());
 
             // Given on-disk state, try to recover the head op after a restart.
             //
@@ -553,7 +553,7 @@ pub fn ReplicaType(
                 for (self.journal.headers) |*header| {
                     assert(header.command == .prepare);
                     if (header.operation != .reserved) {
-                        assert(header.op <= self.op_checkpoint_next_trigger());
+                        assert(header.op <= self.op_checkpoint_next_border());
                         assert(header.view <= self.log_view);
 
                         if (op_head == null or op_head.? < header.op) op_head = header.op;
@@ -586,7 +586,7 @@ pub fn ReplicaType(
             // 6. Checkpoint X is truncated.
             for (vsr_headers.slice) |*vsr_header| {
                 if (vsr.Headers.dvc_header_type(vsr_header) == .valid and
-                    vsr_header.op <= self.op_checkpoint_next_trigger() and
+                    vsr_header.op <= self.op_checkpoint_next_border() and
                     (op_head == null or op_head.? <= vsr_header.op))
                 {
                     op_head = vsr_header.op;
@@ -605,7 +605,7 @@ pub fn ReplicaType(
                     op_head = self.journal.op_maximum();
                 }
             }
-            assert(op_head.? <= self.op_checkpoint_next_trigger());
+            assert(op_head.? <= self.op_checkpoint_next_border());
 
             self.op = op_head.?;
             self.commit_max = @max(
@@ -1396,11 +1396,11 @@ pub fn ReplicaType(
             }
 
             // Verify that the new request will fit in the WAL.
-            if (message.header.op > self.op_checkpoint_next_trigger()) {
-                log.debug("{}: on_prepare: ignoring op={} (too far ahead, checkpoint={})", .{
+            if (message.header.op > self.op_checkpoint_next_border()) {
+                log.debug("{}: on_prepare: ignoring op={} (too far ahead, border={})", .{
                     self.replica,
                     message.header.op,
-                    self.op_checkpoint(),
+                    self.op_checkpoint_next_border(),
                 });
                 // When we are the primary, `on_request` enforces this invariant.
                 assert(self.backup());
@@ -1451,7 +1451,7 @@ pub fn ReplicaType(
                 message.header.checksum,
             });
             assert(message.header.op == self.op + 1);
-            assert(message.header.op <= self.op_checkpoint_next_trigger());
+            assert(message.header.op <= self.op_checkpoint_next_border());
             self.op = message.header.op;
             self.journal.set_header_as_dirty(message.header);
 
@@ -1814,6 +1814,9 @@ pub fn ReplicaType(
 
             const op_checkpoint_max =
                 DVCQuorum.op_checkpoint_max(self.do_view_change_from_all_replicas);
+            // This *could* be ≤border instead of ≤trigger, but that is hard to test in
+            // "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfeit"
+            // because prepares carry commit numbers:
             if (op_checkpoint_max > self.op_checkpoint() and
                 op_head > self.op_checkpoint_next_trigger())
             {
@@ -1942,7 +1945,7 @@ pub fn ReplicaType(
             for (view_headers.slice) |*header| {
                 assert(header.commit <= message.header.commit);
 
-                if (header.op <= self.op_checkpoint_next_trigger()) {
+                if (header.op <= self.op_checkpoint_next_border()) {
                     if (self.log_view < self.view or
                         (self.log_view == self.view and header.op >= self.op))
                     {
@@ -1958,9 +1961,9 @@ pub fn ReplicaType(
                 // in the WAL, precluding recovery.
                 if (self.syncing == .idle) {
                     log.warn("{}: on_start_view: start sync; lagging behind cluster " ++
-                        "(checkpoint_trigger={} quorum_head={})", .{
+                        "(checkpoint_border={} quorum_head={})", .{
                         self.replica,
-                        self.op_checkpoint_next_trigger(),
+                        self.op_checkpoint_next_border(),
                         view_headers.slice[0].op,
                     });
                     self.sync_start_from_committing();
@@ -1969,7 +1972,7 @@ pub fn ReplicaType(
             }
 
             for (view_headers.slice) |*header| {
-                if (header.op <= self.op_checkpoint_next_trigger()) {
+                if (header.op <= self.op_checkpoint_next_border()) {
                     self.replace_header(header);
                 }
             }
@@ -1978,9 +1981,9 @@ pub fn ReplicaType(
                 self.view_headers.replace(.start_view, view_headers.slice);
                 assert(self.view_headers.array.get(0).view <= self.view);
                 assert(self.view_headers.array.get(0).op == message.header.op);
-                maybe(self.view_headers.array.get(0).op > self.op_checkpoint_next_trigger());
+                maybe(self.view_headers.array.get(0).op > self.op_checkpoint_next_border());
                 assert(self.view_headers.array.get(self.view_headers.array.count() - 1).op <=
-                    self.op_checkpoint_next_trigger());
+                    self.op_checkpoint_next_border());
             }
 
             switch (self.status) {
@@ -3018,7 +3021,7 @@ pub fn ReplicaType(
             assert(message.header.operation != .reserved);
             assert(message.header.view == self.view);
             assert(message.header.op == self.op);
-            assert(message.header.op <= self.op_checkpoint_next_trigger());
+            assert(message.header.op <= self.op_checkpoint_next_border());
 
             if (self.solo() and self.pipeline.queue.prepare_queue.count > 1) {
                 // In a cluster-of-one, the prepares must always be written to the WAL sequentially
@@ -3486,7 +3489,7 @@ pub fn ReplicaType(
             assert(op <= self.op_checkpoint_next_trigger());
 
             if (op == self.op_checkpoint_next_trigger()) {
-                assert(op == self.op);
+                assert(op <= self.op);
                 assert((op + 1) % constants.lsm_batch_multiple == 0);
                 log.debug("{}: commit_op_compact_callback: checkpoint start " ++
                     "(op={} current_checkpoint={} next_checkpoint={})", .{
@@ -3515,7 +3518,7 @@ pub fn ReplicaType(
         fn commit_op_checkpoint_state_machine_callback(state_machine: *StateMachine) void {
             const self = @fieldParentPtr(Self, "state_machine", state_machine);
             assert(self.commit_stage == .checkpoint_state_machine);
-            assert(self.commit_prepare.?.header.op == self.op);
+            assert(self.commit_prepare.?.header.op <= self.op);
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op == self.op_checkpoint_next_trigger());
             self.grid.assert_only_repairing();
@@ -3539,7 +3542,8 @@ pub fn ReplicaType(
 
         fn commit_op_checkpoint_grid(self: *Self) void {
             assert(self.commit_stage == .checkpoint_grid);
-            assert(self.commit_prepare.?.header.op == self.op);
+            assert(self.commit_prepare.?.header.op <= self.op);
+            assert(self.commit_prepare.?.header.op == self.commit_min);
 
             self.grid.checkpoint(commit_op_checkpoint_grid_callback);
         }
@@ -3547,7 +3551,8 @@ pub fn ReplicaType(
         fn commit_op_checkpoint_grid_callback(grid: *Grid) void {
             const self = @fieldParentPtr(Self, "grid", grid);
             assert(self.commit_stage == .checkpoint_grid);
-            assert(self.commit_prepare.?.header.op == self.op);
+            assert(self.commit_prepare.?.header.op <= self.op);
+            assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.grid.free_set.opened);
             assert(self.grid.free_set.count_released() ==
                 self.grid.free_set_checkpoint.block_count());
@@ -3573,10 +3578,9 @@ pub fn ReplicaType(
             assert(self.grid.free_set.opened);
             assert(self.state_machine_opened);
             assert(self.commit_stage == .checkpoint_superblock);
-            assert(self.commit_prepare.?.header.op == self.op);
+            assert(self.commit_prepare.?.header.op <= self.op);
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op == self.op_checkpoint_next_trigger());
-            assert(self.op_checkpoint_next_trigger() == self.op);
             assert(self.op_checkpoint_next_trigger() <= self.commit_max);
             self.grid.assert_only_repairing();
 
@@ -3639,7 +3643,7 @@ pub fn ReplicaType(
         fn commit_op_checkpoint_superblock_callback(superblock_context: *SuperBlock.Context) void {
             const self = @fieldParentPtr(Self, "superblock_context", superblock_context);
             assert(self.commit_stage == .checkpoint_superblock);
-            assert(self.commit_prepare.?.header.op == self.op);
+            assert(self.commit_prepare.?.header.op <= self.op);
             assert(self.commit_prepare.?.header.op == self.commit_min);
 
             assert(self.op_checkpoint() == self.commit_min - constants.lsm_batch_multiple);
@@ -4037,11 +4041,11 @@ pub fn ReplicaType(
             assert(op_min <= op);
             assert(op_min <= self.op_repair_min());
 
-            // The SV includes headers corresponding to the triggers for preceding
+            // The SV includes headers corresponding to the borders for preceding
             // checkpoints (as many as we have and can help repair, which is at most 2).
             for ([_]u64{
-                self.op_checkpoint_next_trigger() -| constants.vsr_checkpoint_interval,
-                self.op_checkpoint_next_trigger() -| constants.vsr_checkpoint_interval * 2,
+                self.op_checkpoint_next_border() -| constants.vsr_checkpoint_interval,
+                self.op_checkpoint_next_border() -| constants.vsr_checkpoint_interval * 2,
             }) |op_hook| {
                 if (op > op_hook and op_hook >= op_min) {
                     op = op_hook;
@@ -4344,20 +4348,6 @@ pub fn ReplicaType(
             if (self.ignore_request_message_backup(message)) return true;
             if (self.ignore_request_message_duplicate(message)) return true;
             if (self.ignore_request_message_preparing(message)) return true;
-
-            // Don't accept more requests than will fit in the current checkpoint.
-            // (The request's op hasn't been assigned yet, but it will be `self.op + 1`
-            // when primary_pipeline_prepare() converts the request to a prepare.)
-            if (self.op + self.pipeline.queue.request_queue.count ==
-                self.op_checkpoint_next_trigger())
-            {
-                log.debug("{}: on_request: ignoring op={} (too far ahead, checkpoint={})", .{
-                    self.replica,
-                    self.op + self.pipeline.queue.request_queue.count,
-                    self.op_checkpoint(),
-                });
-                return true;
-            }
             return false;
         }
 
@@ -4679,7 +4669,7 @@ pub fn ReplicaType(
 
                     if (self.status == .recovering_head) {
                         if (message_header.view > self.view or
-                            message_header.op >= self.op_checkpoint_next_trigger() or
+                            message_header.op >= self.op_checkpoint_next_border() or
                             message_header.nonce == self.nonce)
                         {
                             // This SV is guaranteed to have originated after the replica crash,
@@ -4906,7 +4896,7 @@ pub fn ReplicaType(
             // to a newer op that is less than `commit_max` but greater than `commit_min`:
             assert(header.op > self.commit_min);
             // Never overwrite an op that still needs to be checkpointed.
-            assert(header.op <= self.op_checkpoint_next_trigger());
+            assert(header.op <= self.op_checkpoint_next_border());
 
             log.debug("{}: jump_to_newer_op: advancing: op={}..{} checksum={}..{}", .{
                 self.replica,
@@ -4969,7 +4959,7 @@ pub fn ReplicaType(
 
             // If faulty, this slot may hold either:
             // - op=op_checkpoint, or
-            // - op=op_checkpoint_next_trigger
+            // - op=op_checkpoint_next_border
             if (self.journal.faulty.bit(slot_op_checkpoint)) return false;
 
             const slot_known_range = vsr.SlotRange{
@@ -5005,16 +4995,16 @@ pub fn ReplicaType(
 
         /// Returns the next op that will trigger a checkpoint.
         ///
-        /// Receiving and storing an op higher than `op_checkpoint_next_trigger()` is forbidden;
-        /// doing so would overwrite a message (or the slot of a message) that has not yet been
-        /// committed and checkpointed.
-        ///
         /// See `op_checkpoint_next` for more detail.
         fn op_checkpoint_next_trigger(self: *const Self) u64 {
             return vsr.Checkpoint.trigger_for_checkpoint(self.op_checkpoint_next()).?;
         }
 
         /// Returns the highest op that this replica can safely prepare to its WAL.
+        ///
+        /// Receiving and storing an op higher than `op_checkpoint_next_border()` is forbidden;
+        /// doing so would overwrite a message (or the slot of a message) that has not yet been
+        /// committed and checkpointed.
         fn op_checkpoint_next_border(self: *const Self) u64 {
             return vsr.Checkpoint.border_for_checkpoint(self.op_checkpoint_next()).?;
         }
@@ -5079,7 +5069,7 @@ pub fn ReplicaType(
         fn op_repair_min(self: *const Self) u64 {
             if (self.status == .recovering) assert(self.solo());
             assert(self.op >= self.op_checkpoint());
-            assert(self.op <= self.op_checkpoint_next_trigger());
+            assert(self.op <= self.op_checkpoint_next_border());
 
             const op = op: {
                 if (self.primary_index(self.view) == self.replica) {
@@ -5091,8 +5081,9 @@ pub fn ReplicaType(
                         // newer ops which were then truncated by a view-change, causing the head op
                         // to backtrack.
                         self.op + constants.pipeline_prepare_queue_max,
-                        // ...But the pipeline messages could not have moved past the checkpoint.
-                        self.op_checkpoint_next_trigger(),
+                        // ...But the pipeline messages could not have moved past the next
+                        // checkpoint's border.
+                        self.op_checkpoint_next_border(),
                     ) -| (constants.journal_slot_count - 1);
 
                     // We know checkpoint ids for the previous checkpoint and the one before that.
@@ -5136,10 +5127,10 @@ pub fn ReplicaType(
         fn op_repair_max(self: *const Self) u64 {
             assert(self.status != .recovering_head);
             assert(self.op >= self.op_checkpoint());
-            assert(self.op <= self.op_checkpoint_next_trigger());
+            assert(self.op <= self.op_checkpoint_next_border());
             assert(self.op <= self.commit_max + constants.pipeline_prepare_queue_max);
 
-            return @min(self.commit_max, self.op_checkpoint_next_trigger());
+            return @min(self.commit_max, self.op_checkpoint_next_border());
         }
 
         /// Panics if immediate neighbors in the same view would have a broken hash chain.
@@ -5326,9 +5317,9 @@ pub fn ReplicaType(
         /// Repair. Each step happens in sequence — step n+1 executes when step n is done.
         ///
         /// 1. If we are a backup and have fallen too far behind the primary, initiate state sync.
-        /// 2. Advance the head op to `op_repair_max = min(op_checkpoint_next_trigger, commit_max)`.
+        /// 2. Advance the head op to `op_repair_max = min(op_checkpoint_next_border, commit_max)`.
         ///    To advance the head op we request+await a SV. Either:
-        ///    - the SV's "hook" headers include op_checkpoint_next_trigger (if we are ≤1 wrap
+        ///    - the SV's "hook" headers include op_checkpoint_next_border (if we are ≤1 wrap
         ///      behind), or
         ///    - the SV is too far ahead, so we will fall back from WAL repair to state sync.
         /// 3. Acquire missing or disconnected headers in reverse chronological order, backwards from
@@ -6080,7 +6071,7 @@ pub fn ReplicaType(
             assert(header.command == .prepare);
             assert(header.view <= self.view);
             assert(header.op <= self.op); // Never advance the op.
-            assert(header.op <= self.op_checkpoint_next_trigger());
+            assert(header.op <= self.op_checkpoint_next_border());
 
             // If we already committed this op, the repair must be the identical message.
             if (self.op_checkpoint() < header.op and header.op <= self.commit_min) {
@@ -6624,7 +6615,7 @@ pub fn ReplicaType(
                     assert(self.status == .normal);
                     assert(self.syncing == .idle);
                     assert(header.view == self.view);
-                    assert(header.op <= self.op_checkpoint_next_trigger());
+                    assert(header.op <= self.op_checkpoint_next_border());
                     // We must only ever send a prepare_ok to the latest primary of the active view:
                     // We must never straddle views by sending to a primary in an older view.
                     // Otherwise, we would be enabling a partitioned primary to commit.
@@ -6974,7 +6965,7 @@ pub fn ReplicaType(
             assert(self.status == .view_change or self.status == .normal or
                 self.status == .recovering_head);
 
-            assert(op <= self.op_checkpoint_next_trigger());
+            assert(op <= self.op_checkpoint_next_border());
             maybe(op >= self.commit_max);
             maybe(op >= commit_max);
 
@@ -7055,7 +7046,7 @@ pub fn ReplicaType(
             assert(self.primary_index(self.view) == self.replica);
             assert(!self.solo());
             assert(self.syncing == .idle);
-            assert(self.commit_max <= self.op_checkpoint_next_trigger());
+            assert(self.commit_max <= self.op_checkpoint_next_border());
             assert(self.do_view_change_quorum);
             assert(self.do_view_change_from_all_replicas[self.replica] != null);
             DVCQuorum.verify(self.do_view_change_from_all_replicas);
@@ -7064,7 +7055,8 @@ pub fn ReplicaType(
             assert(dvcs_all.count() >= self.quorum_view_change);
 
             for (dvcs_all.const_slice()) |message| {
-                assert(message.header.op <= self.op_checkpoint_next_border());
+                assert(message.header.op <=
+                    self.op_checkpoint_next_border() + constants.pipeline_prepare_queue_max);
             }
 
             // The `prepare_timestamp` prevents a primary's own clock from running backwards.
@@ -7090,7 +7082,7 @@ pub fn ReplicaType(
             assert(header_head.op >= self.op_checkpoint());
             assert(header_head.op >= self.commit_min);
             assert(header_head.op >= self.commit_max);
-            assert(header_head.op <= self.op_checkpoint_next_trigger());
+            assert(header_head.op <= self.op_checkpoint_next_border());
             for (dvcs_all.const_slice()) |dvc| assert(header_head.op >= dvc.header.commit_min);
 
             // When computing the new commit_max, we cannot simply rely on the fact that our own
@@ -7114,7 +7106,7 @@ pub fn ReplicaType(
                 // set_op_and_commit_max() and replace_header().
 
                 self.set_op_and_commit_max(header_head.op, commit_max, "on_do_view_change");
-                assert(self.commit_max <= self.op_checkpoint_next_trigger());
+                assert(self.commit_max <= self.op_checkpoint_next_border());
                 assert(self.commit_max <= self.op);
                 maybe(self.journal.header_with_op(self.op) == null);
 
@@ -7593,7 +7585,7 @@ pub fn ReplicaType(
                 // - the highest cluster-committed op (if available).
                 // We cannot safely go beyond that in all cases:
                 // - During a prior view-change we might have only accepted a single header from the
-                //   DVC: "header.op = op_checkpoint_next_trigger", and then not completed any
+                //   DVC: "header.op = op_checkpoint_next_border", and then not completed any
                 //   repair.
                 // - Similarly, we might have receive a catch-up SV message and only installed a
                 //   single (checkpoint trigger) hook header.

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -470,16 +470,16 @@ test "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfe
 
     b1.drop_all(.__, .bidirectional);
 
-    try c.request(checkpoint_1_trigger + 1, checkpoint_1_trigger + 1);
+    try c.request(checkpoint_1_border + 1, checkpoint_1_border + 1);
     try expectEqual(a0.op_checkpoint(), checkpoint_1);
     try expectEqual(b1.op_checkpoint(), 0);
     try expectEqual(b2.op_checkpoint(), checkpoint_1);
-    try expectEqual(a0.commit(), checkpoint_1_trigger + 1);
+    try expectEqual(a0.commit(), checkpoint_1_border + 1);
     try expectEqual(b1.commit(), 20);
-    try expectEqual(b2.commit(), checkpoint_1_trigger + 1);
-    try expectEqual(a0.op_head(), checkpoint_1_trigger + 1);
+    try expectEqual(b2.commit(), checkpoint_1_border + 1);
+    try expectEqual(a0.op_head(), checkpoint_1_border + 1);
     try expectEqual(b1.op_head(), 20);
-    try expectEqual(b2.op_head(), checkpoint_1_trigger + 1);
+    try expectEqual(b2.op_head(), checkpoint_1_border + 1);
 
     // Partition the primary, but restore B1. B1 will attempt to become the primary next,
     // but it is too far behind, so B2 becomes the new primary instead.
@@ -488,7 +488,7 @@ test "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfe
     a0.drop_all(.__, .bidirectional);
     // Block state sync to prove that B1 recovers via WAL repair.
     b1.drop(.__, .bidirectional, .sync_checkpoint);
-    // TODO: Explicit coverage marks: This should hit the
+    // TODO: Explicit coverage marks: B1 should hit the
     // "on_do_view_change: lagging primary; forfeiting" log line.
     t.run();
 
@@ -500,10 +500,10 @@ test "Cluster: repair: view-change, new-primary lagging behind checkpoint, forfe
     // Thanks to the new primary, the lagging backup is able to catch up to the latest
     // checkpoint/commit.
     try expectEqual(b1.role(), .backup);
-    try expectEqual(b1.commit(), checkpoint_1_trigger + 1);
+    try expectEqual(b1.commit(), checkpoint_1_border + 1);
     try expectEqual(b1.op_checkpoint(), checkpoint_1);
 
-    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger + 1);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_border + 1);
 }
 
 test "Cluster: repair: crash, corrupt committed pipeline op, repair it, view-change; dont nack" {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1045,7 +1045,7 @@ test "Cluster: sync: view-change with lagging replica in recovering_head" {
     // try TestReplicas.expect_sync_done(t.replica(.R_));
 }
 
-test "Cluster: async-checkpoints: prepare beyond checkpoint trigger" {
+test "Cluster: border-prepare: prepare beyond checkpoint trigger" {
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
 
@@ -1064,9 +1064,7 @@ test "Cluster: async-checkpoints: prepare beyond checkpoint trigger" {
     try c.request(checkpoint_1_border - 1, checkpoint_1_trigger - 1);
     try expectEqual(t.replica(.R_).op_checkpoint(), 0);
     try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger - 1);
-    try expectEqual(t.replica(.R_).op_head(), checkpoint_1_trigger);
-    // TODO Allow a pipeline of entries to prepare beyond the checkpoint trigger.
-    // try expectEqual(t.replica(.R_).op_head(), checkpoint_1_trigger - 1 + pipeline_prepare_queue_max);
+    try expectEqual(t.replica(.R_).op_head(), checkpoint_1_border - 1);
 
     t.replica(.R_).pass(.__, .bidirectional, .prepare_ok);
     t.run();


### PR DESCRIPTION
Prepare (or queue) requests past checkpoint boundaries.

### Background

Quoting from the [previous border-prepare PR](https://github.com/tigerbeetle/tigerbeetle/pull/1501):

> Right now, a replica will not prepare (or even queue) requests whose op would extend beyond their next checkpoint's trigger op.
> 
> This is problematic for performance (the "checkpoint latency spike"), since the replica enters the new checkpoint with nothing to commit.
> And the "latency spike" is farther exacerbated by the fact that clients will back off retrying their requests.
> 
> Originally we didn't start preparing past the checkpoint to guard against overwriting WAL entries before they will definitely not be needed again. But thanks to `vsr_checkpoint_interval`, that reason does not apply.

### Fix

The replica is now able to:
- begin preparing (at most `pipeline_prepare_queue_max`) requests, and
- queue requests (if its prepare queue is full)

...before a checkpoint begins, or while it is in progress.

### Performance

Note that because the benchmark runs with only a single client, this PR's performance improvement will not be visible.
(Even if it had multiple clients, it is unlikely to be visible because the benchmark checkpoints very infrequently).