### PR TITLE
Grid: Zero block padding, but not the entire block

### DIFF
--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -344,8 +344,6 @@ pub fn TableType(
                     assert(builder.value_count == values.len);
                     assert(block_size - header.size ==
                         (data.value_count_max - values.len) * @sizeOf(Value) + data.padding_size);
-                    // Padding is short on average, so assert unconditionally.
-                    assert(stdx.zeroed(block[header.size..]));
                 }
 
                 const key_min = key_from_value(&values[0]);
@@ -428,6 +426,11 @@ pub fn TableType(
                     .command = .block,
                     .block_type = .index,
                 };
+
+                for (index.padding(index_block)) |padding| {
+                    @memset(index_block[padding.start..padding.end], 0);
+                }
+
                 header.set_checksum_body(index_block[@sizeOf(vsr.Header)..header.size]);
                 header.set_checksum();
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2452,7 +2452,6 @@ pub fn ReplicaType(
                         write_block.*,
                         message.buffer[0..message.header.size],
                     );
-                    assert(stdx.zeroed(write_block.*[message.header.size..]));
 
                     write.* = .{ .replica = self };
                     self.grid.repair_block(grid_repair_block_callback, &write.write, write_block);


### PR DESCRIPTION
### Background

Previously when starting with a "fresh" grid block (e.g. before constructing a new block for writing), the fresh block was always zeroed.

This is nice in that it guards against buffer-bleeds. But zeroing the entire block (in `grid.zig`) is costly in terms of memory bandwidth.

### Fix

- In `grid.zig` zero the block's header (to guard against accidental reuse)...
- ...But don't zero the _entire_ block buffer.
- Before writing a block, zero its last sector's padding (since that last sector will reach the disk). (The `StorageChecker` verifies that the last sector's padding is zeroed.)