### PR TITLE
vsr: fix races in client_replies

### DIFF
--- a/src/iops.zig
+++ b/src/iops.zig
@@ -40,17 +40,30 @@ pub fn IOPS(comptime T: type, comptime size: u6) type {
             return size - self.available();
         }
 
-        pub const Iterator = struct {
-            iops: *Self,
-            bitset_iterator: Map.Iterator(.{ .kind = .unset }),
+        fn IteratorType(comptime IOPSPointer: type, comptime ItemPointer: type) type {
+            return struct {
+                iops: IOPSPointer,
+                bitset_iterator: Map.Iterator(.{ .kind = .unset }),
 
-            pub fn next(iterator: *@This()) ?*T {
-                const i = iterator.bitset_iterator.next() orelse return null;
-                return &iterator.iops.items[i];
-            }
-        };
+                pub fn next(iterator: *@This()) ?ItemPointer {
+                    const i = iterator.bitset_iterator.next() orelse return null;
+                    return &iterator.iops.items[i];
+                }
+            };
+        }
+
+        pub const Iterator = IteratorType(*Self, *T);
 
         pub fn iterate(self: *Self) Iterator {
+            return .{
+                .iops = self,
+                .bitset_iterator = self.free.iterator(.{ .kind = .unset }),
+            };
+        }
+
+        pub const IteratorConst = IteratorType(*const Self, *const T);
+
+        pub fn iterate_const(self: *const Self) IteratorConst {
             return .{
                 .iops = self,
                 .bitset_iterator = self.free.iterator(.{ .kind = .unset }),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2237,7 +2237,9 @@ pub fn ReplicaType(
                 });
 
                 if (self.client_sessions.get_slot_for_header(reply_header)) |slot| {
-                    self.client_replies.faulty.set(slot.index);
+                    if (!self.client_replies.writing_or_queued(slot)) {
+                        self.client_replies.faulty.set(slot.index);
+                    }
                 }
                 return;
             };
@@ -4490,7 +4492,9 @@ pub fn ReplicaType(
 
             const reply = reply_ orelse {
                 if (self.client_sessions.get_slot_for_header(reply_header)) |slot| {
-                    self.client_replies.faulty.set(slot.index);
+                    if (!self.client_replies.writing_or_queued(slot)) {
+                        self.client_replies.faulty.set(slot.index);
+                    }
                 } else {
                     // The read may have been a repair for an older op,
                     // or a newer op that we haven't seen yet.


### PR DESCRIPTION
- it might be the case that `writing` bitset is not set, but there's a
  write for the slot in the queue: replies can wait on read to complete.
- when a faulty read completes, it might clobber faulty bit, unset by a
  a write which was scheduled after the read.

The specific series of events here:

1. Replica receives a RequestReply and starts a reply read
2. The read completes with a failure, replica sets the faulty bit
3. Replica receives RequestReply starts a reply read
4. Replica receives Reply and starts a reply write
    - the write unsets faulty bit
    - the write doesn't start, because there's a read executing
4. The read completes, setting the faulty bit _again_
5. Replica receives RequestReply
   - It _doesn't_ start reply read, because there's an in-progress write
     that can resolve a read.
   - But the faulty bit is set, tripping up an assertion.

To prevent the clobbering:

- Introduce `writing_or_queued(slot)` to check if we _will_ write to
  this slot soon (i.e, we are writing to it right now, _or_ there's a
  write queued, but not executing because there's also a pending read).
- When a faulty read complets, check if there are any pending writes,
  and avoid setting the faulty bit.

  In other words, the state of the `faulty` bit is determined by the
  order in which IO operations start.

Some alternative approaches here:

- Embrace the races: allow clobbering of faulty bit by an old read, and
  relax the assertion. If the clobbering happens, a replica will run one
  more repair, which isn't a big deal
- Properly resolve concurrent reads and writes, run read's callback
  _before_ we enqueue clobbering write.

SEED: 2517747396662708227
Closes: https://github.com/tigerbeetle/tigerbeetle/issues/1511