### PR TITLE
[Experimental] Add support to INCLUDE indexes

### DIFF
--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -599,7 +599,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                 // In this way, enough object deletions may lead to compactions where the both input
                 // tables entirely cancel each other out, and no output table is written at all.
                 // See `TableUsage` for more detail.
-                .secondary_index => {},
+                .secondary_index, .include_index => {},
             }
 
             const snapshot_from_commit = vsr.Snapshot.readable_at_commit;

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -29,6 +29,9 @@ pub const TableUsage = enum {
     /// * Immediately cancel out an insert and a tombstone for a "different" insert: as the values
     ///   are equal, it is correct to just resurrect an older value.
     secondary_index,
+    /// The same behavior as `secondary_index`, except TableValue can include user-defined fields.
+    /// See the `include` field in the `groove_options`.
+    include_index,
 };
 
 const address_size = @sizeOf(u64);

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -53,7 +53,8 @@ pub const AccountFlags = packed struct(u16) {
     linked: bool = false,
     debits_must_not_exceed_credits: bool = false,
     credits_must_not_exceed_debits: bool = false,
-    padding: u13 = 0,
+    history: bool = false,
+    padding: u12 = 0,
 
     comptime {
         assert(@sizeOf(AccountFlags) == @sizeOf(u16));

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -225,7 +225,9 @@ const Benchmark = struct {
                 .reserved = 0,
                 .ledger = 2,
                 .code = 1,
-                .flags = .{},
+                .flags = .{
+                    .history = true,
+                },
                 .debits_pending = 0,
                 .debits_posted = 0,
                 .credits_pending = 0,


### PR DESCRIPTION
## EXPERIMENTAL - It's not supposed to be merged

**Background:**

While prototyping the support for **historical account balances**, the idea of having _INCLUDED VALUES_ into the index was quite appealing:

- They're orthogonal with existing indexes. We can still use indexes to find the Groove Object, whether or not they have an included part. With the additional capacity of indexes having extra values that can save further lookups.

- They add less size to the Tree since they piggyback on the existing indexes (in comparison with creating a new Tree containing the key + fields)

- It's such an elegant solution to storing the history of account balances as included values for the existing indexes `Transfer.debit_account_id` and `Transfer.credit_account_id`.
  With the big advantage of sharing the same logic for searching all transfers or all balances for a given account).

- It's a nice primitive that can be useful for future use cases.

## So what went wrong?

Once we define that an index has an INCLUDE part, it changes the `Tree.Value` in compile-time.

It means that we can't have the account history as an **opt-in feature**.
If we store it as included values in the `debit_account_id` and `credit_account_id`, we're always paying for it!

The alternative would be, instead of using the existing indexes, creating two new indexes + include that are only inserted if the history is enabled for the account.

It would work fine, but we also would lose half of the benefits listed above!!!


So, let's this **PR archived for reference** while we try other approaches.
Benchmark shows the cost of having the history always enabled:

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr><td>
<code>1252 batches in 40.29 s
load offered = 1000000 tx/s
load accepted = 248204 tx/s
batch latency p1 = 0 ms
batch latency p10 = 6 ms
batch latency p20 = 8 ms
batch latency p30 = 8 ms
batch latency p40 = 9 ms
batch latency p50 = 15 ms
batch latency p60 = 20 ms
batch latency p70 = 24 ms
batch latency p80 = 32 ms
batch latency p90 = 38 ms
batch latency p95 = 48 ms
batch latency p99 = 501 ms
batch latency p100 = 597 ms
</code>
 </td>
<td>
<code>1255 batches in 64.96 s
load offered = 1000000 tx/s
load accepted = 153929 tx/s
batch latency p1 = 0 ms
batch latency p10 = 8 ms
batch latency p20 = 9 ms
batch latency p30 = 11 ms
batch latency p40 = 13 ms
batch latency p50 = 16 ms
batch latency p60 = 20 ms
batch latency p70 = 24 ms
batch latency p80 = 29 ms
batch latency p90 = 36 ms
batch latency p95 = 57 ms
batch latency p99 = 1123 ms
batch latency p100 = 1623 ms
</code>
 </td> </tr>
</table>




