### PR TITLE
VSR: Assert request header fields

### DIFF
--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -587,6 +587,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                     });
                     return;
                 }
+                assert(reply.header.parent == inflight.message.header.checksum);
             } else {
                 log.debug("{}: on_reply: ignoring (no inflight request)", .{self.id});
                 return;

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -587,7 +587,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                     });
                     return;
                 }
-                assert(reply.header.parent == inflight.message.header.checksum);
+                assert(reply.header.request_checksum == inflight.message.header.checksum);
             } else {
                 log.debug("{}: on_reply: ignoring (no inflight request)", .{self.id});
                 return;
@@ -619,7 +619,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 reply.header.operation.tag_name(StateMachine),
             });
 
-            assert(reply.header.parent == self.parent);
+            assert(reply.header.request_checksum == self.parent);
             assert(reply.header.client == self.id);
             assert(reply.header.request == inflight_request);
             assert(reply.header.cluster == self.cluster);
@@ -1043,7 +1043,7 @@ test "Client Batching" {
                 .view = message.header.view,
                 .command = .reply,
                 .replica = message.header.replica,
-                .parent = message.header.checksum,
+                .request_checksum = message.header.checksum,
                 .client = message.header.client,
                 .context = undefined, // computed below.
                 .op = bus.commit,

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -739,8 +739,8 @@ pub const Header = extern struct {
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
         /// The checksum of the corresponding Request.
-        parent: u128,
-        parent_padding: u128 = 0,
+        request_checksum: u128,
+        request_checksum_padding: u128 = 0,
         /// The checksum of the prepare message to which this message refers.
         /// This allows for cryptographic guarantees beyond request, op, and commit numbers, which
         /// have low entropy and may otherwise collide in the event of any correctness bugs.
@@ -760,7 +760,7 @@ pub const Header = extern struct {
             assert(self.command == .reply);
             // Initialization within `client.zig` asserts that client `id` is greater than zero:
             if (self.client == 0) return "client == 0";
-            if (self.parent_padding != 0) return "parent_padding != 0";
+            if (self.request_checksum_padding != 0) return "request_checksum_padding != 0";
             if (self.context_padding != 0) return "context_padding != 0";
             if (self.op != self.commit) return "op != commit";
             if (self.timestamp == 0) return "timestamp == 0";

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -738,6 +738,7 @@ pub const Header = extern struct {
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
 
+        /// The checksum of the corresponding Request.
         parent: u128,
         parent_padding: u128 = 0,
         /// The checksum of the prepare message to which this message refers.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4578,6 +4578,7 @@ pub fn ReplicaType(
                         assert(pipeline_message_header.client == message.header.client);
 
                         if (pipeline_message.header.checksum == message.header.checksum) {
+                            assert(pipeline_message_header.request == message.header.request);
                             log.debug("{}: on_request: ignoring (already queued)", .{self.replica});
                             return true;
                         }
@@ -4587,6 +4588,7 @@ pub fn ReplicaType(
 
                         if (pipeline_message_header.request_checksum == message.header.checksum) {
                             assert(pipeline_message_header.op > self.commit_max);
+                            assert(pipeline_message_header.request == message.header.request);
                             log.debug("{}: on_request: ignoring (already preparing)", .{self.replica});
                             return true;
                         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3791,7 +3791,7 @@ pub fn ReplicaType(
             reply.header.* = .{
                 .command = .reply,
                 .operation = prepare.header.operation,
-                .parent = prepare.header.request_checksum,
+                .request_checksum = prepare.header.request_checksum,
                 .client = prepare.header.client,
                 .request = prepare.header.request,
                 .cluster = prepare.header.cluster,
@@ -4386,7 +4386,7 @@ pub fn ReplicaType(
                     log.debug("{}: on_request: ignoring older request", .{self.replica});
                     return true;
                 } else if (entry.header.request == message.header.request) {
-                    if (message.header.checksum == entry.header.parent) {
+                    if (message.header.checksum == entry.header.request_checksum) {
                         assert(entry.header.operation == message.header.operation);
 
                         log.debug("{}: on_request: replying to duplicate request", .{self.replica});
@@ -4450,7 +4450,7 @@ pub fn ReplicaType(
             assert(message.header.view <= self.view); // See ignore_request_message_backup().
             assert(message.header.session == 0 or message.header.operation != .register);
             assert(message.header.request == 0 or message.header.operation != .register);
-            assert(message.header.checksum == entry.header.parent);
+            assert(message.header.checksum == entry.header.request_checksum);
             assert(message.header.request == entry.header.request);
 
             if (entry.header.size == @sizeOf(Header)) {


### PR DESCRIPTION
A request's index number and message checksum are both also included in the corresponding reply message.

Verify that they match!