### PR TITLE
Client: add ULID helper functions

### DIFF
--- a/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
@@ -104,7 +104,8 @@ public static class UInt128Extensions
 }
 
 /// <summary>
-/// Safe generation of Universally Unique and Byte-Sortable Identifiers as UInt128s.
+/// Universally Unique and Binary-Sortable Identifiers as UInt128s based on
+/// <a href="https://github.com/ulid/spec">ULID</a>
 /// </summary>
 public static class ID
 {
@@ -113,8 +114,8 @@ public static class ID
 
     /// <summary>
     /// Generates a universally unique identifier as a UInt128.
-    /// Each call generates a monotonically increasing value to last under sequential consistency.
-    /// This function is thread-safe.
+    /// IDs are guaranteed to be monotonically increasing from the last.
+    /// This function is thread-safe and monotonicity is sequentially consistent.
     /// </summary>
     public static UInt128 Create()
     {

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -47,6 +47,14 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
         try shell.exec("go run main.go", .{});
     }
+
+    // Test the `types` package helpers
+    {
+        try shell.pushd("./pkg/types");
+        defer shell.popd();
+
+        try shell.exec("go test", .{});
+    }
 }
 
 pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {

--- a/src/clients/go/pkg/types/main.go
+++ b/src/clients/go/pkg/types/main.go
@@ -92,9 +92,9 @@ func BigIntToUint128(value big.Int) Uint128 {
 		return BytesToUint128(*(*[16]byte)(bytes))
 	}
 	
-	var padded [16]byte
-	copy(padded[:], bytes)
-	return BytesToUint128(padded)
+	var zeroPadded [16]byte
+	copy(zeroPadded[:], bytes)
+	return BytesToUint128(zeroPadded)
 }
 
 // ToUint128 converts a integer to a Uint128.
@@ -107,8 +107,10 @@ var idLastTimestamp int64
 var idLastRandom [10]byte
 var idMutex sync.Mutex
 
-// Generates a Universally Unique and Sortable Identifier encoded as a Uint128. 
-func CreateID() Uint128 {
+// Generates a Universally Unique and Sortable Identifier based on https://github.com/ulid/spec.
+// Uint128 returned are guaranteed to be monotonically increasing when interpreted as little-endian.
+// `ID()` is safe to call from multiple goroutines with monotonicity being sequentially consistent. 
+func ID() Uint128 {
 	timestamp := time.Now().UnixMilli()
 
 	// Lock the mutex for global id variables.

--- a/src/clients/go/pkg/types/main.go
+++ b/src/clients/go/pkg/types/main.go
@@ -5,9 +5,13 @@ package types
 */
 import "C"
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"sync"
+	"time"
 	"unsafe"
 )
 
@@ -17,17 +21,20 @@ func (value Uint128) Bytes() [16]byte {
 	return *(*[16]byte)(unsafe.Pointer(&value))
 }
 
-func (value Uint128) String() string {
-	bytes := value.Bytes()
-
-	// Convert little-endian number to big-endian string
+func swapEndian(bytes []byte) {
 	for i, j := 0, len(bytes)-1; i < j; i, j = i+1, j-1 {
 		bytes[i], bytes[j] = bytes[j], bytes[i]
 	}
+}
 
+func (value Uint128) String() string {
+	bytes := value.Bytes()
+
+	// Convert little-endian Uint128 number to big-endian string.
+	swapEndian(bytes[:])
 	s := hex.EncodeToString(bytes[:16])
 
-	// Prettier to drop preceding zeros so you get "0" instead of "0000000000000000"
+	// Prettier to drop preceding zeros so you get "0" instead of "0000000000000000".
 	lastNonZero := 0
 	for s[lastNonZero] == '0' && lastNonZero < len(s)-1 {
 		lastNonZero++
@@ -36,8 +43,11 @@ func (value Uint128) String() string {
 }
 
 func (value Uint128) BigInt() big.Int {
-	ret := big.Int{}
+	// big.Int uses bytes in big-endian but Uint128 stores bytes in little endian, so reverse it.
 	bytes := value.Bytes()
+	swapEndian(bytes[:])
+
+	ret := big.Int{}
 	ret.SetBytes(bytes[:])
 	return ret
 }
@@ -73,12 +83,73 @@ func HexStringToUint128(value string) (Uint128, error) {
 
 // BigIntToUint128 converts a [math/big.Int] to a Uint128.
 func BigIntToUint128(value big.Int) Uint128 {
+	// big.Int bytes are big-endian so convert them to little-endian for Uint128 bytes.
 	bytes := value.Bytes()
-	return BytesToUint128(*(*[16]byte)(bytes))
+	swapEndian(bytes[:])
+	
+	// Only cast slice to bytes when theres enough.
+	if len(bytes) >= 16 {
+		return BytesToUint128(*(*[16]byte)(bytes))
+	}
+	
+	var padded [16]byte
+	copy(padded[:], bytes)
+	return BytesToUint128(padded)
 }
 
 // ToUint128 converts a integer to a Uint128.
 func ToUint128(value uint64) Uint128 {
 	values := [2]uint64{value, 0}
 	return *(*Uint128)(unsafe.Pointer(&values[0]))
+}
+
+var idLastTimestamp int64
+var idLastRandom [10]byte
+var idMutex sync.Mutex
+
+// Generates a Universally Unique and Sortable Identifier encoded as a Uint128. 
+func ID() Uint128 {
+	timestamp := time.Now().UnixMilli()
+
+	// Lock the mutex for global id variables.
+	// Then ensure lastTimestamp is monotonically increasing & lastRandom changes each millisecond 
+	idMutex.Lock()
+	if timestamp <= idLastTimestamp {
+		timestamp = idLastTimestamp
+	} else {
+		idLastTimestamp = timestamp
+		_, err := rand.Read(idLastRandom[:])
+		if err != nil {
+			idMutex.Unlock()
+			panic("crypto.rand failed to provide random bytes")
+		}
+	}
+
+	// Read out a uint80 from lastRandom as a uint64 and uint16.
+	randomLo := binary.LittleEndian.Uint64(idLastRandom[:8])
+	randomHi := binary.LittleEndian.Uint16(idLastRandom[8:])
+
+	// Increment the random bits as a uint80 together, checking for overflow.
+	// Golang defines unsigned arithmetic to wrap around on overflow by default so check for zero.
+	randomLo += 1
+	if randomLo == 0 {
+		randomHi += 1
+		if randomHi == 0 {
+			idMutex.Unlock()
+			panic("random bits overflow on monotonic increment")
+		}
+	}
+
+	// Write incremented uint80 back to lastRandom and stop mutating global id variables.
+	binary.LittleEndian.PutUint64(idLastRandom[:8], randomLo)
+	binary.LittleEndian.PutUint16(idLastRandom[8:], randomHi)
+	idMutex.Unlock()
+
+	// Create Uint128 from new timestamp and random.
+	var id [16]byte
+	binary.LittleEndian.PutUint64(id[:8], randomLo)
+	binary.LittleEndian.PutUint16(id[8:], randomHi)
+	binary.LittleEndian.PutUint16(id[10:], (uint16)(timestamp)) // timestamp lo
+	binary.LittleEndian.PutUint32(id[12:], (uint32)(timestamp >> 16)) // timestamp hi
+	return BytesToUint128(id)
 }

--- a/src/clients/go/pkg/types/main.go
+++ b/src/clients/go/pkg/types/main.go
@@ -108,7 +108,7 @@ var idLastRandom [10]byte
 var idMutex sync.Mutex
 
 // Generates a Universally Unique and Sortable Identifier encoded as a Uint128. 
-func ID() Uint128 {
+func CreateID() Uint128 {
 	timestamp := time.Now().UnixMilli()
 
 	// Lock the mutex for global id variables.
@@ -130,7 +130,7 @@ func ID() Uint128 {
 	randomHi := binary.LittleEndian.Uint16(idLastRandom[8:])
 
 	// Increment the random bits as a uint80 together, checking for overflow.
-	// Golang defines unsigned arithmetic to wrap around on overflow by default so check for zero.
+	// Go defines unsigned arithmetic to wrap around on overflow by default so check for zero.
 	randomLo += 1
 	if randomLo == 0 {
 		randomHi += 1

--- a/src/clients/go/pkg/types/main_test.go
+++ b/src/clients/go/pkg/types/main_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"math/big"
+	"sync"
 	"testing"
+	"time"
 )
 
 func Test_HexStringToUint128(t *testing.T) {
@@ -18,11 +19,11 @@ func Test_HexStringToUint128(t *testing.T) {
 	for _, test := range tests {
 		res, err := HexStringToUint128(test)
 		if err != nil {
-			t.Errorf("Expected %s to be a valid hex string, got: %s", test, err)
+			t.Fatalf("Expected %s to be a valid hex string, got: %s", test, err)
 		}
 		thereAndBack := res.String()
 		if thereAndBack != test {
-			t.Errorf("Expected %s to be %s, got %s", test, test, thereAndBack)
+			t.Fatalf("Expected %s to be %s, got %s", test, test, thereAndBack)
 		}
 	}
 }
@@ -33,13 +34,13 @@ func Test_HexStringToUint128_LittleEndian(t *testing.T) {
 
 	res, err := HexStringToUint128(test)
 	if err != nil {
-		t.Errorf("Expected %s to be a valid hex string, got: %s", test, err)
+		t.Fatalf("Expected %s to be a valid hex string, got: %s", test, err)
 	}
 
 	expected := [16]byte{86, 52, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 	if res.Bytes() != expected {
-		t.Errorf("Expected %s to produce bytes %v, got bytes %v", test, expected, res.Bytes())
+		t.Fatalf("Expected %s to produce bytes %v, got bytes %v", test, expected, res.Bytes())
 	}
 }
 
@@ -58,15 +59,56 @@ func Test_BigIntToUint128(t *testing.T) {
 		uint128, err := HexStringToUint128(test)
 
 		if err != nil {
-			t.Errorf("Expected %s to be a valid hex string, got: %s", test, err)
+			t.Fatalf("Expected %s to be a valid hex string, got: %s", test, err)
 		}
 
 		bigint := uint128.BigInt()
-		uint128_back = BigIntToUint128(bigint)
-		string_back = uint128_back.String()
+		uint128_back := BigIntToUint128(bigint)
+		string_back := uint128_back.String()
 
 		if string_back != test {
-			t.Errorf("Expected %s to be %s, got %s", test, test, string_back)
+			t.Fatalf("Expected %s to be %s, got %s", test, test, string_back)
 		}
 	}
+}
+
+func Test_ID(t *testing.T) {
+	verifier := func() {
+		idA := ID()
+		for i := 0; i < 1_000_000; i++ {
+			if i % 1_000 == 0 {
+				time.Sleep(1 * time.Millisecond)
+			}
+
+			idB := ID()
+
+			a := idA.BigInt()
+			b := idB.BigInt()
+			if b.Cmp(&a) != 1 {
+				t.Fatalf("Expected ID %v to be greater than ID %v", b, a)
+			}
+
+			idA = idB
+		}
+	}
+
+	// Verify monotonic IDs locally.
+	verifier()
+
+	// Verify monotonic IDs across multiple threads.
+	var barrier, finish sync.WaitGroup
+	concurrency := 10
+	barrier.Add(concurrency) // To sync up all goroutines before verifier() to maximize contetion.
+	finish.Add(concurrency) // To wait for all goroutines to finish running verifier().
+
+	for i := 0; i < concurrency; i++ {
+		go func(){
+			barrier.Done()
+			barrier.Wait()
+			verifier()
+			finish.Done()
+		}()
+	}
+
+	finish.Wait()
 }

--- a/src/clients/go/pkg/types/main_test.go
+++ b/src/clients/go/pkg/types/main_test.go
@@ -72,16 +72,17 @@ func Test_BigIntToUint128(t *testing.T) {
 	}
 }
 
-func Test_ID(t *testing.T) {
+func Test_CreateID(t *testing.T) {
 	verifier := func() {
-		idA := ID()
+		idA := CreateID()
 		for i := 0; i < 1_000_000; i++ {
 			if i % 1_000 == 0 {
 				time.Sleep(1 * time.Millisecond)
 			}
 
-			idB := ID()
-
+			idB := CreateID()
+			
+			// Verify idB and idA are monotonic using BigInts. 
 			a := idA.BigInt()
 			b := idB.BigInt()
 			if b.Cmp(&a) != 1 {

--- a/src/clients/go/pkg/types/main_test.go
+++ b/src/clients/go/pkg/types/main_test.go
@@ -72,15 +72,15 @@ func Test_BigIntToUint128(t *testing.T) {
 	}
 }
 
-func Test_CreateID(t *testing.T) {
+func Test_ID(t *testing.T) {
 	verifier := func() {
-		idA := CreateID()
+		idA := ID()
 		for i := 0; i < 1_000_000; i++ {
 			if i % 1_000 == 0 {
 				time.Sleep(1 * time.Millisecond)
 			}
 
-			idB := CreateID()
+			idB := ID()
 			
 			// Verify idB and idA are monotonic using BigInts. 
 			a := idA.BigInt()

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -175,7 +175,7 @@ public enum UInt128 {
     }
 
     private static long idLastTimestamp = 0L;
-    private static final byte[] idLastRandom = new byte[80];
+    private static final byte[] idLastRandom = new byte[10];
     private static final SecureRandom idSecureRandom = new SecureRandom();
 
     /**
@@ -186,7 +186,7 @@ public enum UInt128 {
      * <a href="https://github.com/ulid/spec">ULID</a> but is adjusted for u128-LE interpretation.
      *
      * @throws ArithmeticException if the random monotonic bits in the same millisecond overflows.
-     * @return an array of 16 bytes representing an unsigned 128-bit value in little endian.
+     * @return An array of 16 bytes representing an unsigned 128-bit value in little endian.
      */
     public static byte[] ID() {
         long randomLo;
@@ -207,16 +207,16 @@ public enum UInt128 {
             randomLo = random.getLong();
             randomHi = random.getShort();
 
-            // If randomLo will overflow from increment, then increment randomHi as carry.
-            // If randomHi will overflow on increment, throw error on 80-bit random overflow.
-            if (randomLo == 0xFFFFFFFFFFFFFFFFL) {
-                if (randomHi == 0xFFFF) {
+            // Increment the u80 stored in idLastRandom using a u64 increment then u16 increment.
+            // Throws an exception if the entire u80 represented with both overflows.
+            // In Java, all arithmetic wraps around on overflow by default so check for zero.
+            randomLo += 1;
+            if (randomLo == 0) {
+                randomHi += 1;
+                if (randomHi == 0) {
                     throw new ArithmeticException("random bits overflow on monotonic increment");
                 }
-                randomHi += 1;
             }
-            // Wrapping increment on randomLo. Java allows overflowing arithmetic by default.
-            randomLo += 1;
 
             // Write back the incremented random.
             random.flip();

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -188,7 +188,7 @@ public enum UInt128 {
      * @throws ArithmeticException if the random monotonic bits in the same millisecond overflows.
      * @return An array of 16 bytes representing an unsigned 128-bit value in little endian.
      */
-    public static byte[] ID() {
+    public static byte[] createID() {
         long randomLo;
         short randomHi;
         long timestamp = System.currentTimeMillis();
@@ -214,7 +214,7 @@ public enum UInt128 {
             if (randomLo == 0) {
                 randomHi += 1;
                 if (randomHi == 0) {
-                    throw new ArithmeticException("random bits overflow on monotonic increment");
+                    throw new ArithmeticException("Random bits overflow on monotonic increment");
                 }
             }
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -188,7 +188,7 @@ public enum UInt128 {
      * @throws ArithmeticException if the random monotonic bits in the same millisecond overflows.
      * @return An array of 16 bytes representing an unsigned 128-bit value in little endian.
      */
-    public static byte[] createID() {
+    public static byte[] id() {
         long randomLo;
         short randomHi;
         long timestamp = System.currentTimeMillis();

--- a/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
@@ -173,14 +173,14 @@ public class UInt128Test {
     @Test
     public void testID() throws Exception {
         {
-            // Generate IDs, sleeping for ~1ms after a few to test intra-millisecond monotonicity.
-            var idA = UInt128.asBigInteger(UInt128.ID());
-            for (int i = 0; i < 10_000_000; i++) {
+            // Generate IDs, sleeping for ~1ms occasionally to test intra-millisecond monotonicity.
+            var idA = UInt128.asBigInteger(UInt128.createID());
+            for (int i = 0; i < 1_000_000; i++) {
                 if (i % 10_000 == 0) {
                     Thread.sleep(1);
                 }
 
-                var idB = UInt128.asBigInteger(UInt128.ID());
+                var idB = UInt128.asBigInteger(UInt128.createID());
                 assertTrue(idB.compareTo(idA) > 0);
 
                 // Use the generated ID as the new reference point for the next loop.
@@ -201,13 +201,13 @@ public class UInt128Test {
                     latchStart.await();
 
                     // Same as serial test above, but with smaller bounds.
-                    var idA = UInt128.asBigInteger(UInt128.ID());
+                    var idA = UInt128.asBigInteger(UInt128.createID());
                     for (int j = 0; j < 10_000; j++) {
                         if (j % 1000 == 0) {
                             Thread.sleep(1);
                         }
 
-                        var idB = UInt128.asBigInteger(UInt128.ID());
+                        var idB = UInt128.asBigInteger(UInt128.createID());
                         assertTrue(idB.compareTo(idA) > 0);
                         idA = idB;
                     }

--- a/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
@@ -174,13 +174,13 @@ public class UInt128Test {
     public void testID() throws Exception {
         {
             // Generate IDs, sleeping for ~1ms occasionally to test intra-millisecond monotonicity.
-            var idA = UInt128.asBigInteger(UInt128.createID());
+            var idA = UInt128.asBigInteger(UInt128.id());
             for (int i = 0; i < 1_000_000; i++) {
                 if (i % 10_000 == 0) {
                     Thread.sleep(1);
                 }
 
-                var idB = UInt128.asBigInteger(UInt128.createID());
+                var idB = UInt128.asBigInteger(UInt128.id());
                 assertTrue(idB.compareTo(idA) > 0);
 
                 // Use the generated ID as the new reference point for the next loop.
@@ -201,13 +201,13 @@ public class UInt128Test {
                     latchStart.await();
 
                     // Same as serial test above, but with smaller bounds.
-                    var idA = UInt128.asBigInteger(UInt128.createID());
+                    var idA = UInt128.asBigInteger(UInt128.id());
                     for (int j = 0; j < 10_000; j++) {
                         if (j % 1000 == 0) {
                             Thread.sleep(1);
                         }
 
-                        var idB = UInt128.asBigInteger(UInt128.createID());
+                        var idB = UInt128.asBigInteger(UInt128.id());
                         assertTrue(idB.compareTo(idA) > 0);
                         idA = idB;
                     }

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -141,12 +141,13 @@ let idLastTimestamp = 0;
 let idLastBuffer = new DataView(new ArrayBuffer(16));
 
 /**
- * Generates a Universally Unique and Binary Sortable Identifier as a u128 bigint.
- * 
+ * Generates a Universally Unique and Sortable Identifier as a u128 bigint.
+ *
  * @remarks
- * IDs returned are monotonically increasing 
+ * Based on {@link https://github.com/ulid/spec}, IDs returned are guaranteed to be monotonically
+ * increasing.
  */
-export function createID(): bigint {
+export function id(): bigint {
   // Ensure timestamp monotonically increases and generate a new random on each new timestamp.
   let timestamp = Date.now()
   if (timestamp <= idLastTimestamp) {

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -8,6 +8,7 @@ import {
   AccountFilter,
   AccountBalance,
 } from './bindings'
+import { randomFillSync } from 'node:crypto'
 
 const binding: Binding = (() => {
   const { arch, platform } = process
@@ -134,4 +135,45 @@ export function createClient (args: ClientInitArgs): Client {
     getAccountHistory(filter) { return request(Operation.get_account_history, [filter]) },
     destroy() { binding.deinit(context) },
   }
+}
+
+let idLastTimestamp = 0;
+let idLastBuffer = new DataView(new ArrayBuffer(16));
+
+/**
+ * Generates a Universally Unique and Binary Sortable Identifier as a u128 bigint.
+ * 
+ * @remarks
+ * IDs returned are monotonically increasing 
+ */
+export function createID(): bigint {
+  // Ensure timestamp monotonically increases and generate a new random on each new timestamp.
+  let timestamp = Date.now()
+  if (timestamp <= idLastTimestamp) {
+    timestamp = idLastTimestamp
+  } else {
+    idLastTimestamp = timestamp
+    randomFillSync(idLastBuffer)
+  }
+
+  // Increment the u80 in idLastBuffer using carry arithmetic on u32s (as JS doesn't have fast u64).
+  const littleEndian = true
+  const randomLo32 = idLastBuffer.getUint32(0, littleEndian) + 1
+  const randomHi32 = idLastBuffer.getUint32(4, littleEndian) + (randomLo32 > 0xFFFFFFFF ? 1 : 0)
+  const randomHi16 = idLastBuffer.getUint16(8, littleEndian) + (randomHi32 > 0xFFFFFFFF ? 1 : 0)
+  if (randomHi16 > 0xFFFF) {
+    throw new Error('random bits overflow on monotonic increment')
+  }
+
+  // Store the incremented random monotonic and the timestamp into the buffer.
+  idLastBuffer.setUint32(0, randomLo32 & 0xFFFFFFFF, littleEndian)
+  idLastBuffer.setUint32(4, randomHi32 & 0xFFFFFFFF, littleEndian)
+  idLastBuffer.setUint16(8, randomHi16, littleEndian) // No need to mask since checked above.
+  idLastBuffer.setUint16(10, timestamp & 0xFFFF, littleEndian) // timestamp lo.
+  idLastBuffer.setUint32(12, (timestamp >>> 16) & 0xFFFFFFFF, littleEndian) // timestamp hi.
+
+  // Then return the buffer's contents as a little-endian u128 bigint.
+  const lo = idLastBuffer.getBigUint64(0, littleEndian)
+  const hi = idLastBuffer.getBigUint64(8, littleEndian)
+  return (hi << 64n) | lo
 }

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -9,7 +9,7 @@ import {
   AccountFilter,
   AccountFilterFlags,
   AccountFlags,
-  createID,
+  id,
 } from '.'
 
 const client = createClient({
@@ -59,16 +59,16 @@ test.skip = (name: string, fn: () => Promise<void>) => {
   console.log(name + ': SKIPPED')
 }
 
-test('createID monotonically increasing', async (): Promise<void> => {
-  let idA = createID();
+test('id() monotonically increasing', async (): Promise<void> => {
+  let idA = id();
   for (let i = 0; i < 10_000_000; i++) {
     // Ensure ID is monotonic between milliseconds if the loop executes too fast.
     if (i % 10_000 == 0) {
       await new Promise(resolve => setTimeout(resolve, 1))
     }
 
-    const idB = createID();
-    assert.ok(idB > idA, 'createID() returned an id that did not monotonically increase');
+    const idB = id();
+    assert.ok(idB > idA, 'id() returned an id that did not monotonically increase');
     idA = idB;
   }
 })

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -9,6 +9,7 @@ import {
   AccountFilter,
   AccountFilterFlags,
   AccountFlags,
+  createID,
 } from '.'
 
 const client = createClient({
@@ -57,6 +58,20 @@ function test(name: string, fn: () => Promise<void>) {
 test.skip = (name: string, fn: () => Promise<void>) => {
   console.log(name + ': SKIPPED')
 }
+
+test('createID monotonically increasing', async (): Promise<void> => {
+  let idA = createID();
+  for (let i = 0; i < 10_000_000; i++) {
+    // Ensure ID is monotonic between milliseconds if the loop executes too fast.
+    if (i % 10_000 == 0) {
+      await new Promise(resolve => setTimeout(resolve, 1))
+    }
+
+    const idB = createID();
+    assert.ok(idB > idA, 'createID() returned an id that did not monotonically increase');
+    idA = idB;
+  }
+})
 
 test('range check `code` on Account to be u16', async (): Promise<void> => {
   const account = { ...accountA, id: 0n }


### PR DESCRIPTION
Taking inspiration from the java client, add little-endian ID generation helpers (based on [ULID](https://github.com/ulid/spec)) to the language clients.

This also re-enables the unit tests for our Go `pkg/types` module which was previously dead code.