### PR TITLE
Update slack invite in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here are a few key pages you might be interested in:
 ## Community
 
 * [Projects using TigerBeetle developed by community members.](./docs/COMMUNITY_PROJECTS.md)
-* [Join the TigerBeetle chat on Slack.](https://join.slack.com/t/tigerbeetle/shared_invite/zt-1gf3qnvkz-GwkosudMCM3KGbGiSu87RQ)
+* [Join the TigerBeetle chat on Slack.](https://slack.tigerbeetle.com/invite)
 * [Follow us on Twitter](https://twitter.com/TigerBeetleDB), [YouTube](https://www.youtube.com/@tigerbeetledb), and [Twitch](https://www.twitch.tv/tigerbeetle).
 * [Subscribe to our monthly newsletter for the backstory on recent database changes.](https://mailchi.mp/8e9fa0f36056/subscribe-to-tigerbeetle)
 * [Check out past and upcoming talks.](/docs/TALKS.md)


### PR DESCRIPTION
The invite in the readme is expired. This one is a permanent invite URL, the same as on the website.