### PR TITLE
Benchmark: Forward replica process stderr

### DIFF
--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -116,7 +116,7 @@ fn start(allocator: std.mem.Allocator, options: struct {
     child.request_resource_usage_statistics = true;
     child.stdin_behavior = .Pipe;
     child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Ignore;
+    child.stderr_behavior = .Inherit;
     try child.spawn();
     errdefer {
         _ = child.kill() catch {};


### PR DESCRIPTION
Forward the replica child process' stderr to the parent process.

(Sometimes I like to add timers to specific parts of the code before running the full benchmark – this way those results are easily available.)

Also if there were any non-fatal issues with the replica, this would help to surface them.