### PR TITLE
vsr: liveness, nack prepares from before log view 

### DIFF
--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -43,6 +43,8 @@ pub const Network = struct {
         }
     };
 
+    const PacketSimulator = PacketSimulatorType(Packet);
+
     pub const Path = struct {
         source: Process,
         target: Process,
@@ -59,7 +61,7 @@ pub const Network = struct {
     allocator: std.mem.Allocator,
 
     options: NetworkOptions,
-    packet_simulator: PacketSimulatorType(Packet),
+    packet_simulator: PacketSimulator,
 
     // TODO(Zig) If this stored a ?*MessageBus, then a process's bus could be set to `null` while
     // the replica is crashed, and replaced when it is destroyed. But Zig complains:
@@ -195,6 +197,13 @@ pub const Network = struct {
 
     pub fn link_filter(network: *Network, path: Path) *LinkFilter {
         return network.packet_simulator.link_filter(.{
+            .source = network.process_to_address(path.source),
+            .target = network.process_to_address(path.target),
+        });
+    }
+
+    pub fn link_drop_packet_fn(network: *Network, path: Path) *?PacketSimulator.LinkDropPacketFn {
+        return network.packet_simulator.link_drop_packet_fn(.{
             .source = network.process_to_address(path.source),
             .target = network.process_to_address(path.target),
         });

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -857,6 +857,63 @@ test "Cluster: view-change: primary with dirty log" {
     // try expectEqual(b2.status(), .normal);
 }
 
+test "Cluster: view-change: nack older view" {
+    // a0 prepares (but does not commit) three ops (`x`, `x + 1`, `x + 2`) at view `v`.
+    // b1 prepares (but does not commit) the same ops at view `v + 1`.
+    // b2 receives only `x + 2` op prepared at b1.
+    // b1 gets permanently partitioned from the cluster, and a0 and b2 form a core.
+    //
+    // a0 and b2 and should be able to truncate all the prepared, but uncommitted ops.
+    const t = try TestContext.init(.{ .replica_count = 3 });
+    defer t.deinit();
+
+    var c = t.clients(0, t.cluster.clients.len);
+    try c.request(checkpoint_1_trigger, checkpoint_1_trigger);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger);
+
+    var a0 = t.replica(.A0);
+    var b1 = t.replica(.B1);
+    var b2 = t.replica(.B2);
+
+    try expectEqual(a0.role(), .primary);
+    t.replica(.R_).drop_all(.R_, .bidirectional);
+    try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger);
+    try expectEqual(a0.op_head(), checkpoint_1_trigger + 3);
+
+    b1.pass(.R_, .bidirectional, .start_view_change);
+    b1.pass(.R_, .incoming, .do_view_change);
+    b1.pass(.R_, .outgoing, .start_view);
+    a0.drop_all(.R_, .bidirectional);
+    b2.pass(.R_, .incoming, .prepare);
+    b2.filter(.R_, .incoming, struct {
+        fn drop_message(message: *Message) bool {
+            switch (message.into_any()) {
+                .prepare => |prepare| {
+                    return (prepare.header.op < checkpoint_1_trigger + 3);
+                },
+                else => return false,
+            }
+        }
+    }.drop_message);
+
+    t.run();
+    try expectEqual(b1.role(), .primary);
+    try expectEqual(b1.status(), .normal);
+
+    try expectEqual(t.replica(.R_).op_head(), checkpoint_1_trigger + 3);
+    try expectEqual(t.replica(.R_).commit_max(), checkpoint_1_trigger);
+
+    a0.pass_all(.R_, .bidirectional);
+    b2.pass_all(.R_, .bidirectional);
+    b2.filter(.R_, .incoming, null);
+    b1.drop_all(.R_, .bidirectional);
+
+    try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger + 3);
+    try expectEqual(b2.commit_max(), checkpoint_1_trigger + 3);
+    try expectEqual(a0.commit_max(), checkpoint_1_trigger + 3);
+    try expectEqual(b1.commit_max(), checkpoint_1_trigger);
+}
+
 test "Cluster: sync: partition, lag, sync (transition from idle)" {
     for ([_]u64{
         // Normal case: the cluster has committed atop the checkpoint trigger.


### PR DESCRIPTION
A DVC with a log-view `v` includes _some_ of the
potentially committed messages for views `≥v`.

However, it will include all potentially committed
messages from views `<v`:

log-view=v means that a replica accepted an SV
message for that view (or the replica was a
primary for that view). In any case, the starting
headers for that view were durably persisted by
the replica.

So all those headers must be a part of DVC the
replica subsequently sends.

This means that if

- we are deciding whether we should truncate op=x
- we _don't_ know the canonical header for op=x
- and we have an uncanonical DVC with a header for op=x with view<log_view_canonical

That DVC is a nack for `op=x`. We don't know which
header would be canonical, but it definitely isn't
the one from the DVC.

Seed: 15677965580699030051
Closes: https://github.com/tigerbeetle/tigerbeetle/issues/1510