### PR TITLE
[Docs] Fix client libraries link descriptions

### DIFF
--- a/docs/reference/operations/create_accounts.md
+++ b/docs/reference/operations/create_accounts.md
@@ -129,10 +129,10 @@ To correctly recover from application crashes
 
 For language-specific docs see:
 
-* [Creating accounts using the .NET library](/src/clients/dotnet/README.md#creating-accounts)
-* [Creating accounts using the Java library](/src/clients/java/README.md#creating-accounts)
-* [Creating accounts using the Go library](/src/clients/go/README.md#creating-accounts)
-* [Creating accounts using the Node.js library](/src/clients/node/README.md#creating-accounts)
+* [.NET library](/src/clients/dotnet/README.md#creating-accounts)
+* [Java library](/src/clients/java/README.md#creating-accounts)
+* [Go library](/src/clients/go/README.md#creating-accounts)
+* [Node.js library](/src/clients/node/README.md#creating-accounts)
 
 ## Internals
 

--- a/docs/reference/operations/create_transfers.md
+++ b/docs/reference/operations/create_transfers.md
@@ -357,10 +357,10 @@ would exceed `credit_account.debits_posted`.
 
 For language-specific docs see:
 
-* [Creating transfers using the .NET library](/src/clients/dotnet/README.md#create-transfers)
-* [Creating transfers using the Java library](/src/clients/java/README.md#create-transfers)
-* [Creating transfers using the Go library](/src/clients/go/README.md#create-transfers)
-* [Creating transfers using the Node.js library](/src/clients/node/README.md#create-transfers)
+* [.NET library](/src/clients/dotnet/README.md#create-transfers)
+* [Java library](/src/clients/java/README.md#create-transfers)
+* [Go library](/src/clients/go/README.md#create-transfers)
+* [Node.js library](/src/clients/node/README.md#create-transfers)
 
 ## Internals
 

--- a/docs/reference/operations/get_account_history.md
+++ b/docs/reference/operations/get_account_history.md
@@ -28,7 +28,7 @@ The query filter. See [`AccountFilter`](../account_filter.md) for constraints.
 
 For language-specific docs see:
 
-* [Looking up transfers using the .NET library](/src/clients/dotnet/README.md#get-account-history)
-* [Looking up transfers using the Java library](/src/clients/java/README.md#get-account-history)
-* [Looking up transfers using the Go library](/src/clients/go/README.md#get-account-history)
-* [Looking up transfers using the Node.js library](/src/clients/node/README.md#get-account-history)
+* [.NET library](/src/clients/dotnet/README.md#get-account-history)
+* [Java library](/src/clients/java/README.md#get-account-history)
+* [Go library](/src/clients/go/README.md#get-account-history)
+* [Node.js library](/src/clients/node/README.md#get-account-history)

--- a/docs/reference/operations/get_account_transfers.md
+++ b/docs/reference/operations/get_account_transfers.md
@@ -16,7 +16,7 @@ The query filter. See [`AccountFilter`](../account_filter.md) for constraints.
 
 For language-specific docs see:
 
-* [Looking up transfers using the .NET library](/src/clients/dotnet/README.md#get-account-transfers)
-* [Looking up transfers using the Java library](/src/clients/java/README.md#get-account-transfers)
-* [Looking up transfers using the Go library](/src/clients/go/README.md#get-account-transfers)
-* [Looking up transfers using the Node.js library](/src/clients/node/README.md#get-account-transfers)
+* [.NET library](/src/clients/dotnet/README.md#get-account-transfers)
+* [Java library](/src/clients/java/README.md#get-account-transfers)
+* [Go library](/src/clients/go/README.md#get-account-transfers)
+* [Node.js library](/src/clients/node/README.md#get-account-transfers)

--- a/docs/reference/operations/lookup_accounts.md
+++ b/docs/reference/operations/lookup_accounts.md
@@ -15,10 +15,10 @@ An [`id`](../accounts.md#id) belonging to a [`Account`](../accounts.md).
 
 For language-specific docs see:
 
-* [Looking up accounts using the .NET library](/src/clients/dotnet/README.md#account-lookup)
-* [Looking up accounts using the Java library](/src/clients/java/README.md#account-lookup)
-* [Looking up accounts using the Go library](/src/clients/go/README.md#account-lookup)
-* [Looking up accounts using the Node.js library](/src/clients/node/README.md#account-lookup)
+* [.NET library](/src/clients/dotnet/README.md#account-lookup)
+* [Java library](/src/clients/java/README.md#account-lookup)
+* [Go library](/src/clients/go/README.md#account-lookup)
+* [Node.js library](/src/clients/node/README.md#account-lookup)
 
 ## Internals
 

--- a/docs/reference/operations/lookup_transfers.md
+++ b/docs/reference/operations/lookup_transfers.md
@@ -15,10 +15,10 @@ An [`id`](../transfers.md#id) belonging to a [`Transfer`](../transfers.md).
 
 For language-specific docs see:
 
-* [Looking up transfers using the .NET library](/src/clients/dotnet/README.md#transfer-lookup)
-* [Looking up transfers using the Java library](/src/clients/java/README.md#transfer-lookup)
-* [Looking up transfers using the Go library](/src/clients/go/README.md#transfer-lookup)
-* [Looking up transfers using the Node.js library](/src/clients/node/README.md#transfer-lookup)
+* [.NET library](/src/clients/dotnet/README.md#transfer-lookup)
+* [Java library](/src/clients/java/README.md#transfer-lookup)
+* [Go library](/src/clients/go/README.md#transfer-lookup)
+* [Node.js library](/src/clients/node/README.md#transfer-lookup)
 
 ## Internals
 


### PR DESCRIPTION
- Both get_account_transfers and get_account_history had the link description copied from lookup_transfers!!!

- Simplify the link description for all docs, removing the repetitive parts.