### PR TITLE
[Experimental] Track all snapshot usage

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -52,6 +52,7 @@ const schema = @import("schema.zig");
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
 const LevelTableValueBlockIteratorType =
     @import("level_data_iterator.zig").LevelTableValueBlockIteratorType;
+const Snapshot = schema.Snapshot;
 
 pub fn CompactionType(
     comptime Table: type,
@@ -357,9 +358,12 @@ pub fn CompactionType(
                     .{ compaction.tree_config.name, context.level_b },
                 );
 
-                const snapshot_max = snapshot_max_for_table_input(context.op_min);
+                const snapshot_max = Snapshot{
+                    //FIXME
+                    .timestamp = snapshot_max_for_table_input(context.op_min),
+                };
                 const table_a = context.table_info_a.disk.table_info;
-                assert(table_a.snapshot_max >= snapshot_max);
+                assert(table_a.snapshot_max.timestamp >= snapshot_max.timestamp);
 
                 compaction.manifest_entries.append_assume_capacity(.{
                     .operation = .move_to_level_b,
@@ -379,7 +383,10 @@ pub fn CompactionType(
                 compaction.iterator_b.start(.{
                     .grid = context.grid,
                     .level = context.level_b,
-                    .snapshot = context.op_min,
+                    .snapshot = Snapshot{
+                        // FIXME
+                        .timestamp = context.op_min,
+                    },
                     .tables = .{ .compaction = compaction.context.range_b.tables.const_slice() },
                     .index_block = compaction.index_block_b,
                     .direction = .ascending,
@@ -819,7 +826,10 @@ pub fn CompactionType(
                 table_builder.data_block_finish(.{
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
-                    .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
+                    .snapshot_min = Snapshot{
+                        // FIXME
+                        .timestamp = snapshot_min_for_table_output(compaction.context.op_min),
+                    },
                     .tree_id = compaction.tree_config.id,
                 });
                 WriteBlock(.data).write_block(compaction);
@@ -833,7 +843,10 @@ pub fn CompactionType(
                 const table = table_builder.index_block_finish(.{
                     .cluster = compaction.context.grid.superblock.working.cluster,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
-                    .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
+                    .snapshot_min = Snapshot{
+                        // FIXME
+                        .timestamp = snapshot_min_for_table_output(compaction.context.op_min),
+                    },
                     .tree_id = compaction.tree_config.id,
                 });
                 // Make this table visible at the end of this half-bar.
@@ -946,7 +959,10 @@ pub fn CompactionType(
             // - manifest updates are not visible until after the blocks are all on disk.
             const manifest = &compaction.context.tree.manifest;
             const level_b = compaction.context.level_b;
-            const snapshot_max = snapshot_max_for_table_input(compaction.context.op_min);
+            const snapshot_max = Snapshot{
+                //FIXME
+                .timestamp = snapshot_max_for_table_input(compaction.context.op_min),
+            };
 
             if (compaction.move_table) {
                 // If no compaction is required, don't update snapshot_max.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -605,8 +605,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 assert(std.meta.eql(table_latest.table.key_max, forest_table_item.key_max));
                 assert(table_latest.table.checksum == forest_table_item.checksum);
                 assert(table_latest.table.address == forest_table_item.address);
-                assert(table_latest.table.snapshot_min == forest_table_item.snapshot_min);
-                assert(table_latest.table.snapshot_max == forest_table_item.snapshot_max);
+                assert(table_latest.table.snapshot_min.timestamp == forest_table_item.snapshot_min.timestamp);
+                assert(table_latest.table.snapshot_max.timestamp == forest_table_item.snapshot_max.timestamp);
                 assert(table_latest.table.tree_id == forest_table_item.tree_id);
 
                 const table_removed = tables_latest.remove(forest_table_item.checksum);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -12,6 +12,7 @@ const log = std.log.scoped(.lsm_forest_fuzz);
 const tracer = @import("../tracer.zig");
 const lsm = @import("tree.zig");
 const tb = @import("../tigerbeetle.zig");
+const Snapshot = @import("schema.zig").Snapshot;
 
 const Transfer = @import("../tigerbeetle.zig").Transfer;
 const Account = @import("../tigerbeetle.zig").Account;
@@ -406,7 +407,7 @@ const Environment = struct {
             const scan_range = scan_builder.scan_range(
                 index,
                 scan_buffer,
-                lsm.snapshot_latest,
+                Snapshot.latest,
                 .{ .field = min, .timestamp = 0 },
                 .{ .field = max, .timestamp = std.math.maxInt(u63) },
                 params.direction,

--- a/src/lsm/forest_table_iterator.zig
+++ b/src/lsm/forest_table_iterator.zig
@@ -26,6 +26,7 @@ const assert = std.debug.assert;
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const TableInfo = @import("./schema.zig").ManifestNode.TableInfo;
+const Snapshot = @import("schema.zig").Snapshot;
 
 pub fn ForestTableIteratorType(comptime Forest: type) type {
     // struct { (Tree.name) → TreeTableIteratorType(Tree) }
@@ -155,7 +156,10 @@ fn TreeTableIteratorType(comptime Tree: type) type {
                                 .{
                                     // +1 to skip past the previous table.
                                     // (The tables are ordered by (key_max,snapshot_min).)
-                                    .snapshot_min = position.previous.snapshot_min + 1,
+                                    .snapshot_min = Snapshot{
+                                        //FIXME
+                                        .timestamp = position.previous.snapshot_min.timestamp + 1,
+                                    },
                                     .key_max = position.previous.key_max,
                                 },
                             )),
@@ -174,7 +178,7 @@ fn TreeTableIteratorType(comptime Tree: type) type {
 
             if (iterator.position) |position| {
                 switch (std.math.order(position.previous.key_max, table.key_max)) {
-                    .eq => assert(position.previous.snapshot_min < table.snapshot_min),
+                    .eq => assert(position.previous.snapshot_min.timestamp < table.snapshot_min.timestamp),
                     .lt => {},
                     .gt => unreachable,
                 }

--- a/src/lsm/level_data_iterator.zig
+++ b/src/lsm/level_data_iterator.zig
@@ -14,6 +14,7 @@ const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
 const Direction = @import("../direction.zig").Direction;
 const TableDataIteratorType = @import("table_data_iterator.zig").TableDataIteratorType;
+const Snapshot = schema.Snapshot;
 
 // Iterates over the data blocks in a level B table. References to the level B
 // tables to be iterated over are passed via the `tables` field in the context,
@@ -37,7 +38,7 @@ pub fn LevelTableValueBlockIteratorType(comptime Table: type, comptime Storage: 
         pub const Context = struct {
             grid: *Grid,
             level: u8,
-            snapshot: u64,
+            snapshot: Snapshot,
             index_block: BlockPtr,
             // `tables` contains TableInfo references from ManifestLevel.
             tables: union(enum) {

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -477,8 +477,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(manifest_log.grid_reservation != null);
             assert(table.label.level < constants.lsm_levels);
             assert(table.address > 0);
-            assert(table.snapshot_min > 0);
-            assert(table.snapshot_max > table.snapshot_min);
+            assert(table.snapshot_min.timestamp > 0);
+            assert(table.snapshot_max.timestamp > table.snapshot_min.timestamp);
 
             if (manifest_log.entry_count == 0) {
                 assert(manifest_log.blocks.count == manifest_log.blocks_closed);
@@ -892,7 +892,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             header.* = .{
                 .cluster = manifest_log.superblock.working.cluster,
                 .address = block_address,
-                .snapshot = 0, // TODO(snapshots): Set this properly; it is useful for debugging.
+                .snapshot = .{ .timestamp = 0 }, // TODO(snapshots): Set this properly; it is useful for debugging.
                 .size = undefined,
                 .command = .block,
                 .metadata_bytes = undefined, // Set by close_block().

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -189,8 +189,8 @@ fn generate_events(
                 const table = TableInfo{
                     .checksum = 0,
                     .address = table_address,
-                    .snapshot_min = 1,
-                    .snapshot_max = std.math.maxInt(u64),
+                    .snapshot_min = .{ .timestamp = 1 },
+                    .snapshot_max = .{ .timestamp = std.math.maxInt(u64) },
                     .key_min = .{0} ** 16,
                     .key_max = .{0} ** 16,
                     .value_count = 1,
@@ -222,9 +222,9 @@ fn generate_events(
 
                 var table = tables.items[random.uintLessThan(usize, tables.items.len)];
                 // Only update a table snapshot_max once (like real compaction).
-                if (table.snapshot_max == 2) continue;
+                if (table.snapshot_max.timestamp == 2) continue;
                 table.label.event = .update;
-                table.snapshot_max = 2;
+                table.snapshot_max = .{ .timestamp = 2 };
                 try events.append(.{ .append = table });
             }
         }
@@ -233,7 +233,7 @@ fn generate_events(
         // mimic how compaction is followed by remove_invisible_tables().
         var i: usize = 0;
         while (i < tables.items.len) {
-            if (tables.items[i].snapshot_max == 2) {
+            if (tables.items[i].snapshot_max.timestamp == 2) {
                 var table = tables.swapRemove(i);
                 table.label.event = .remove;
                 try events.append(.{ .append = table });

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -12,6 +12,7 @@ const ScanMergeIntersectionType = @import("scan_merge.zig").ScanMergeIntersectio
 const ScanMergeDifferenceType = @import("scan_merge.zig").ScanMergeDifferenceType;
 const ScanBuffer = @import("scan_buffer.zig").ScanBuffer;
 const ScanState = @import("scan_state.zig").ScanState;
+const Snapshot = @import("schema.zig").Snapshot;
 
 const Direction = @import("../direction.zig").Direction;
 const TimestampRange = @import("timestamp_range.zig").TimestampRange;
@@ -109,7 +110,7 @@ pub fn ScanBuilderType(
             self: *ScanBuilder,
             comptime index: std.meta.FieldEnum(Groove.IndexTrees),
             buffer: *const ScanBuffer,
-            snapshot: u64,
+            snapshot: Snapshot,
             value: CompositeKeyPrefix(index),
             timestamp_range: TimestampRange,
             direction: Direction,
@@ -137,7 +138,7 @@ pub fn ScanBuilderType(
             self: *ScanBuilder,
             comptime index: std.meta.FieldEnum(Groove.IndexTrees),
             buffer: *const ScanBuffer,
-            snapshot: u64,
+            snapshot: Snapshot,
             min: CompositeKeyType(index),
             max: CompositeKeyType(index),
             direction: Direction,
@@ -414,7 +415,7 @@ pub fn ScanType(
             }
         }
 
-        pub fn snapshot(scan: *const Scan) u64 {
+        pub fn snapshot(scan: *const Scan) Snapshot {
             return switch (scan.dispatcher) {
                 inline else => |*scan_impl| scan_impl.snapshot,
             };

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -5,10 +5,10 @@ const Allocator = std.mem.Allocator;
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
-const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const GridType = @import("../vsr/grid.zig").GridType;
 const ScanType = @import("scan_builder.zig").ScanType;
+const Snapshot = @import("schema.zig").Snapshot;
 
 /// Implements the lookup logic for loading objects from scans.
 pub fn ScanLookupType(
@@ -164,7 +164,7 @@ pub fn ScanLookupType(
                     objects.table_immutable.get(timestamp)) |object|
                 {
                     // TODO(batiati) Handle this properly when we implement snapshot queries.
-                    assert(self.scan.snapshot() == snapshot_latest);
+                    assert(self.scan.snapshot().timestamp == Snapshot.latest.timestamp);
 
                     // Object present in table mutable/immutable,
                     // continue the loop to fetch the next one.

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -8,6 +8,7 @@ const ScanState = @import("scan_state.zig").ScanState;
 const Direction = @import("../direction.zig").Direction;
 const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
 const ScanType = @import("scan_builder.zig").ScanType;
+const Snapshot = @import("schema.zig").Snapshot;
 
 /// Union ∪ operation over an array of non-specialized `Scan` instances.
 /// At a high level, this is an ordered iterator over the set-union of the timestamps of
@@ -60,7 +61,7 @@ pub fn ScanMergeUnionType(
         );
 
         direction: Direction,
-        snapshot: u64,
+        snapshot: Snapshot,
         scan_context: Scan.Context = .{ .callback = &scan_read_callback },
 
         state: union(ScanState) {
@@ -105,7 +106,7 @@ pub fn ScanMergeUnionType(
                 assert(scan.timestamp_direction().? == direction_first);
 
                 // All inner scans must have the same snapshot.
-                assert(scan.snapshot() == snapshot_first);
+                assert(scan.snapshot().timestamp == snapshot_first.timestamp);
             };
 
             var self = ScanMergeUnion{

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -9,11 +9,11 @@ const binary_search = @import("binary_search.zig");
 
 const stdx = @import("../stdx.zig");
 const div_ceil = stdx.div_ceil;
-const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const allocate_block = @import("../vsr/grid.zig").allocate_block;
 const TreeTableInfoType = @import("manifest.zig").TreeTableInfoType;
 const schema = @import("schema.zig");
+const Snapshot = schema.Snapshot;
 
 pub const TableUsage = enum {
     /// General purpose table.
@@ -299,7 +299,7 @@ pub fn TableType(
             const DataFinishOptions = struct {
                 cluster: u128,
                 address: u64,
-                snapshot_min: u64,
+                snapshot_min: Snapshot,
                 tree_id: u16,
             };
 
@@ -396,7 +396,7 @@ pub fn TableType(
             const IndexFinishOptions = struct {
                 cluster: u128,
                 address: u64,
-                snapshot_min: u64,
+                snapshot_min: Snapshot,
                 tree_id: u16,
             };
 
@@ -443,7 +443,7 @@ pub fn TableType(
                     .value_count = builder.value_count_total,
                 };
 
-                assert(info.snapshot_max == math.maxInt(u64));
+                assert(info.snapshot_max.timestamp == math.maxInt(u64));
 
                 // Reset the builder to its initial state, leaving the buffers untouched.
                 builder.* = .{

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -5,6 +5,9 @@ const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");
 const binary_search = @import("binary_search.zig");
+const schema = @import("schema.zig");
+
+const Snapshot = schema.Snapshot;
 
 pub fn TableMemoryType(comptime Table: type) type {
     const Key = Table.Key;
@@ -25,7 +28,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             immutable: struct {
                 /// An empty table has nothing to flush
                 flushed: bool = true,
-                snapshot_min: u64 = 0,
+                snapshot_min: Snapshot = .{ .timestamp = 0 },
             },
         };
 
@@ -107,7 +110,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             );
         }
 
-        pub fn make_immutable(table: *TableMemory, snapshot_min: u64) void {
+        pub fn make_immutable(table: *TableMemory, snapshot_min: Snapshot) void {
             assert(table.mutability == .mutable);
             assert(table.value_context.count <= value_count_max);
 
@@ -202,7 +205,7 @@ test "table_memory: unit" {
     assert(table_memory.value_context.sorted);
 
     table_memory.put(&.{ .key = 0, .value = 0, .tombstone = false });
-    table_memory.make_immutable(0);
+    table_memory.make_immutable(Snapshot{ .timestamp = 0 });
 
     assert(table_memory.count() == 4 and table_memory.value_context.count == 4);
     assert(table_memory.key_min() == 0);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -31,6 +31,7 @@ const SuperBlock = vsr.SuperBlockType(Storage);
 const ScanBuffer = @import("scan_buffer.zig").ScanBuffer;
 const ScanTreeType = @import("scan_tree.zig").ScanTreeType;
 const FreeSetEncoded = vsr.FreeSetEncodedType(Storage);
+const Snapshot = @import("schema.zig").Snapshot;
 
 const Value = packed struct(u128) {
     id: u64,
@@ -79,7 +80,6 @@ const FuzzOp = union(enum) {
 const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
 const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Value));
 const value_count_max = constants.lsm_batch_multiple * commit_entries_max;
-const snapshot_latest = @import("tree.zig").snapshot_latest;
 const table_count_max = @import("tree.zig").table_count_max;
 
 const cluster = 32;
@@ -347,7 +347,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 env.tree.lookup_from_levels_storage(.{
                     .callback = get_callback,
                     .context = &env.lookup_context,
-                    .snapshot = snapshot_latest,
+                    .snapshot = Snapshot.latest,
                     .key = key,
                     .level_min = 0,
                 });
@@ -371,7 +371,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.scan_tree = ScanTree.init(
                 &env.tree,
                 &env.scan_buffer,
-                snapshot_latest,
+                Snapshot.latest,
                 key_min,
                 key_max,
                 direction,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -9,12 +9,13 @@ const tracer = @import("tracer.zig");
 const stdx = @import("./stdx.zig");
 const global_constants = @import("constants.zig");
 const tb = @import("tigerbeetle.zig");
-const snapshot_latest = @import("lsm/tree.zig").snapshot_latest;
 const ScopeCloseMode = @import("lsm/tree.zig").ScopeCloseMode;
 const WorkloadType = @import("state_machine/workload.zig").WorkloadType;
 
 const Direction = @import("direction.zig").Direction;
 const TimestampRange = @import("lsm/timestamp_range.zig").TimestampRange;
+
+const Snapshot = @import("lsm/schema.zig").Snapshot;
 
 const Account = tb.Account;
 const AccountFlags = tb.AccountFlags;
@@ -857,7 +858,7 @@ pub fn StateMachineType(
                 scan_conditions.append_assume_capacity(scan_builder.scan_prefix(
                     .debit_account_id,
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                    snapshot_latest,
+                    Snapshot.latest,
                     filter.account_id,
                     timestamp_range,
                     direction,
@@ -869,7 +870,7 @@ pub fn StateMachineType(
                 scan_conditions.append_assume_capacity(scan_builder.scan_prefix(
                     .credit_account_id,
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                    snapshot_latest,
+                    Snapshot.latest,
                     filter.account_id,
                     timestamp_range,
                     direction,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1418,13 +1418,3 @@ pub const Checkpoint = struct {
         return op == 0 or (op + 1) % constants.lsm_batch_multiple == 0;
     }
 };
-
-pub const Snapshot = struct {
-    /// A table with TableInfo.snapshot_min=S was written during some commit with op<S.
-    /// A block with snapshot_min=S is definitely readable at op=S.
-    pub fn readable_at_commit(op: u64) u64 {
-        // TODO: This is going to become more complicated when snapshot numbers match the op
-        // acquiring the snapshot.
-        return op + 1;
-    }
-};

--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -397,7 +397,7 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
                 .cluster = trailer.grid.?.superblock.working.cluster,
                 .metadata_bytes = @bitCast(metadata),
                 .address = trailer.block_addresses[trailer.block_index],
-                .snapshot = 0, // TODO(snapshots): Set this properly; it is useful for debugging.
+                .snapshot = .{ .timestamp = 0 }, // TODO(snapshots): Set this properly; it is useful for debugging.
                 .size = @sizeOf(vsr.Header) + chunk_size,
                 .command = .block,
                 .block_type = trailer.trailer_type.block_type(),

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -8,6 +8,7 @@ const vsr = @import("../vsr.zig");
 const Command = vsr.Command;
 const Operation = vsr.Operation;
 const schema = @import("../lsm/schema.zig");
+const Snapshot = schema.Snapshot;
 
 const checksum_body_empty = vsr.checksum(&.{});
 
@@ -1173,7 +1174,7 @@ pub const Header = extern struct {
 
         // Fields shared by all block types:
         address: u64,
-        snapshot: u64,
+        snapshot: Snapshot,
         block_type: schema.BlockType,
         reserved_block: [15]u8 = [_]u8{0} ** 15,
 


### PR DESCRIPTION
This PR tracks all usage of `snapshot` and highlights with `FIXME` points where the op number is used as a snapshot.

The goal is to define the best strategy to handle those points with the timestamp instead.
It's not intended to change the snapshot datatype from `u64` to a struct; It was only for type-checking the transition between op numbers and snapshots.

