### PR TITLE
devhub: switch to a line graph and other misc enhancements

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -102,31 +102,43 @@ function plotSeries(seriesList, rootNode) {
         text: series.label,
       },
       chart: {
-        type: "bar",
+        type: "line",
         height: "400px",
         events: {
           dataPointSelection: (event, chartContext, { dataPointIndex }) => {
             window.open(
-              "https://github.com/tigerbeetle/tigerbeetle/commits/" +
+              "https://github.com/tigerbeetle/tigerbeetle/commit/" +
                 series.revision[dataPointIndex],
             );
           },
         },
+      },
+      markers: {
+        size: 4,
       },
       series: [{
         name: series.label,
         data: series.value,
       }],
       xaxis: {
-        categories: series.revision.map((sha) => sha.substring(0, 6)),
+        categories: series.timestamp.map((timestamp) =>
+          new Date(timestamp * 1000).toLocaleDateString()
+        ),
+        tooltip: {
+          enabled: false,
+        },
       },
       tooltip: {
         enabled: true,
+        shared: false,
+        intersect: true,
         x: {
           formatter: function (val, { dataPointIndex }) {
             const timestamp = new Date(series.timestamp[dataPointIndex] * 1000);
-            const formattedDate = timestamp.toISOString();
-            return `<div>${val}</div><div>${formattedDate}</div>`;
+            const formattedDate = timestamp.toLocaleString();
+            return `<div>${
+              series.revision[dataPointIndex]
+            }</div><div>${formattedDate}</div>`;
           },
         },
       },


### PR DESCRIPTION
I'm not sure if there are some ardent bar graph supporters here, but I think it's easier to see the change over time on a line graph... The y-axis range becomes relative now too.

Additionally, open tooltips to the commit rather than the range and show the date on the x-axis as it has more meaning than the commit sha (still as a category, though, to keep the points equally spaced).

Switch the date formatting to use .toLocaleString() for a nicer formatted date (/ time).

Before:
![image](https://github.com/tigerbeetle/tigerbeetle/assets/703017/c91203ea-adce-40bf-a8ba-f4f351583e56)

After:
![image](https://github.com/tigerbeetle/tigerbeetle/assets/703017/91a8fc22-6772-4e96-8a76-a8c93a4b05db)
