### PR TITLE
build: simplify running a single test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -232,11 +232,8 @@ pub fn build(b: *std.Build) !void {
     };
 
     {
-        const test_filter = b.option(
-            []const u8,
-            "test-filter",
-            "Skip tests that do not match filter",
-        );
+        const test_filter: ?[]const u8 =
+            if (b.args != null and b.args.?.len == 1) b.args.?[0] else null;
 
         const unit_tests = b.addTest(.{
             .root_source_file = .{ .path = "src/unit_tests.zig" },

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -58,7 +58,7 @@ zig/zig build test
 To run a single test by name:
 
 ```console
-zig/zig build test:unit -Dtest-filter="name of test"
+zig/zig build test:unit -- "name of test"
 ```
 
 To run tests with code coverage (assuming `kcov` is installed on your system):


### PR DESCRIPTION
To run a single test, use:

    ./zig/zig build test -- test-name

Before, it was

    ./zig/zig build test -Dtest-filter=test-name