### PR TITLE
Reapply "vsr: liveness, nack prepares from before log view"

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8954,6 +8954,7 @@ const DVCQuorum = struct {
         const dvcs_all_ = DVCQuorum.dvcs_all(dvc_quorum);
         if (dvcs_all_.count() < options.quorum_view_change) return .awaiting_quorum;
 
+        const log_view_canonical = DVCQuorum.log_view_max(dvc_quorum);
         const dvcs_canonical_ = DVCQuorum.dvcs_canonical(dvc_quorum);
         assert(dvcs_canonical_.count() > 0);
         assert(dvcs_canonical_.count() <= dvcs_all_.count());
@@ -8995,6 +8996,7 @@ const DVCQuorum = struct {
 
                 const header = &headers.slice[header_index];
                 assert(header.op == op);
+                assert(header.view <= log_view_canonical);
 
                 const header_nacks = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.nack_bitset };
                 const header_present = std.bit_set.IntegerBitSet(128){ .mask = dvc.header.present_bitset };
@@ -9009,11 +9011,17 @@ const DVCQuorum = struct {
                 if (header_nacks.isSet(header_index)) {
                     // The op is nacked explicitly.
                     nacks += 1;
-                } else if (vsr.Headers.dvc_header_type(header) == .valid and
-                    header_canonical != null and header_canonical.?.checksum != header.checksum)
-                {
-                    // The op is nacked implicitly, because the replica has a different header.
-                    nacks += 1;
+                } else if (vsr.Headers.dvc_header_type(header) == .valid) {
+                    if (header_canonical != null and header_canonical.?.checksum != header.checksum) {
+                        // The op is nacked implicitly, because the replica has a different header.
+                        nacks += 1;
+                    }
+                    if (header_canonical == null and header.view < log_view_canonical) {
+                        assert(dvc.header.log_view < log_view_canonical);
+                        // The op is nacked implicitly, because the header has already been
+                        // truncated in the latest log_view.
+                        nacks += 1;
+                    }
                 }
             }
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -857,6 +857,63 @@ test "Cluster: view-change: primary with dirty log" {
     // try expectEqual(b2.status(), .normal);
 }
 
+test "Cluster: view-change: nack older view" {
+    // a0 prepares (but does not commit) three ops (`x`, `x + 1`, `x + 2`) at view `v`.
+    // b1 prepares (but does not commit) the same ops at view `v + 1`.
+    // b2 receives only `x + 2` op prepared at b1.
+    // b1 gets permanently partitioned from the cluster, and a0 and b2 form a core.
+    //
+    // a0 and b2 and should be able to truncate all the prepared, but uncommitted ops.
+    const t = try TestContext.init(.{ .replica_count = 3 });
+    defer t.deinit();
+
+    var c = t.clients(0, t.cluster.clients.len);
+    try c.request(checkpoint_1_trigger, checkpoint_1_trigger);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger);
+
+    var a0 = t.replica(.A0);
+    var b1 = t.replica(.B1);
+    var b2 = t.replica(.B2);
+
+    try expectEqual(a0.role(), .primary);
+    t.replica(.R_).drop_all(.R_, .bidirectional);
+    try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger);
+    try expectEqual(a0.op_head(), checkpoint_1_trigger + 3);
+
+    b1.pass(.R_, .bidirectional, .start_view_change);
+    b1.pass(.R_, .incoming, .do_view_change);
+    b1.pass(.R_, .outgoing, .start_view);
+    a0.drop_all(.R_, .bidirectional);
+    b2.pass(.R_, .incoming, .prepare);
+    b2.filter(.R_, .incoming, struct {
+        fn drop_message(message: *Message) bool {
+            switch (message.into_any()) {
+                .prepare => |prepare| {
+                    return (prepare.header.op < checkpoint_1_trigger + 3);
+                },
+                else => return false,
+            }
+        }
+    }.drop_message);
+
+    t.run();
+    try expectEqual(b1.role(), .primary);
+    try expectEqual(b1.status(), .normal);
+
+    try expectEqual(t.replica(.R_).op_head(), checkpoint_1_trigger + 3);
+    try expectEqual(t.replica(.R_).commit_max(), checkpoint_1_trigger);
+
+    a0.pass_all(.R_, .bidirectional);
+    b2.pass_all(.R_, .bidirectional);
+    b2.filter(.R_, .incoming, null);
+    b1.drop_all(.R_, .bidirectional);
+
+    try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger + 3);
+    try expectEqual(b2.commit_max(), checkpoint_1_trigger + 3);
+    try expectEqual(a0.commit_max(), checkpoint_1_trigger + 3);
+    try expectEqual(b1.commit_max(), checkpoint_1_trigger);
+}
+
 test "Cluster: sync: partition, lag, sync (transition from idle)" {
     for ([_]u64{
         // Normal case: the cluster has committed atop the checkpoint trigger.


### PR DESCRIPTION
This reverts commit 8de25235f1203d4f4518a3062abc36ca4e70500c.