### PR TITLE
dotnet: simplify tests

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1595,7 +1595,7 @@ internal class TBServer : IDisposable
     private const string TB_SERVER = TB_PATH + "/" + TB_EXE;
 
     private readonly Process process;
-    private readonly String dataFile;
+    private readonly string dataFile;
 
     public string Address { get; }
 
@@ -1626,16 +1626,9 @@ internal class TBServer : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (process != null && !process.HasExited)
-            {
-                process.Kill();
-                process.Dispose();
-            }
-
-            File.Delete($"./{dataFile}");
-        }
-        catch { }
+        process.Kill();
+        process.WaitForExit();
+        process.Dispose();
+        File.Delete($"./{dataFile}");
     }
 }


### PR DESCRIPTION
One issue I've fond when running tests on widows is that the data file isn't actually deleted, with an error message saying that another process still uses the data file.

Let's try:

- to always wait for the process
- and also don't swallow the error