### PR TITLE
Clients: Fix TooManyOutstanding

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -300,7 +300,7 @@ pub fn ContextType(
             assert(self.client.messages_available <= constants.client_request_queue_max);
 
             // Signal to resume sending requests that was waiting for available messages.
-            if (self.client.messages_available == 1) self.thread.signal.notify();
+            self.thread.signal.notify();
 
             const tb_client = api.context_to_client(&self.implementation);
             const bytes = result catch |err| {

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -20,7 +20,7 @@ const (
 	TIGERBEETLE_CLUSTER_ID      uint64 = 0
 	TIGERBEETLE_REPLICA_ID      uint32 = 0
 	TIGERBEETLE_REPLICA_COUNT   uint32 = 1
-	TIGERBEETLE_CONCURRENCY_MAX uint   = 4096
+	TIGERBEETLE_CONCURRENCY_MAX uint   = 8192
 )
 
 func HexStringToUint128(value string) types.Uint128 {


### PR DESCRIPTION
- Fixes a bug in the C client that wasn't handling `error.TooManyOutstanding` correctly when the client runs out of `Demux`ers but still has enough messages.

- Bumps the `concurrency_max` to 8192 for Java, C# and Go tests.