### PR TITLE
tests: remove fake empty test

### DIFF
--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -1,4 +1,4 @@
-test {
+comptime {
     _ = @import("aof.zig");
     _ = @import("copyhound.zig");
     _ = @import("ewah.zig");


### PR DESCRIPTION
Both `comptime {` and `test {` achieve the result of including tests from other files, but `test` is _itself_ considered an empty test that always passes.

By using `comptime`, we guarantee that the test runner correctly reporrs "zero tests run" if no tests were in fact selected

Before:

```
λ ./zig/zig build --summary all test:unit -- no-such-test
Build Summary: 6/6 steps succeeded; 1/1 tests passed
test:unit success
└─ run test 1 passed 864us MaxRSS:2M

λ ./zig/zig build --summary all test:unit
Build Summary: 6/6 steps succeeded; 177/177 tests passed
test:unit success
└─ run test 177 passed 36s MaxRSS:1G

```

After:

```
λ ./zig/zig build --summary all test:unit -- no-such-test
Build Summary: 6/6 steps succeeded
test:unit success
└─ run test success 746us MaxRSS:1M

λ ./zig/zig build --summary all test:unit
Build Summary: 6/6 steps succeeded; 176/176 tests passed
test:unit success
└─ run test 176 passed 35s MaxRSS:1G
```