### PR TITLE
vopr: liveness false positive

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -272,7 +272,7 @@ pub fn main() !void {
 
     // Liveness: a core set of replicas is up and fully connected. The rest of replicas might be
     // crashed or partitioned permanently. The core should converge to the same state.
-    const ticks_max_convergence = 5_000_000;
+    const ticks_max_convergence = 10_000_000;
     tick = 0;
     while (tick < ticks_max_convergence) : (tick += 1) {
         simulator.tick();


### PR DESCRIPTION
With 10 replicas, it just takes longer for the cluster to fully converge. I considered using something like

    ticks_max_convergence = replica_count * 1_000_000;

to make this adaptive, but it seems better to just keep this simple

Seed: 15234016844864204286
Closes: #1524