### PR TITLE
java: fix memory leak in tests

### DIFF
--- a/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
@@ -3,7 +3,7 @@ package com.tigerbeetle;
 import static com.tigerbeetle.AssertionError.assertTrue;
 import java.util.concurrent.atomic.AtomicLong;
 
-final class NativeClient {
+final class NativeClient implements AutoCloseable {
     static {
         JNILoader.loadFromJar();
     }
@@ -62,6 +62,7 @@ final class NativeClient {
         }
     }
 
+    @Override
     public void close() {
         if (contextHandle.getAcquire() != 0L) {
             synchronized (this) {

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -20,51 +20,50 @@ public class AsyncRequestTest {
 
     @Test
     public void testCreateAccountsRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new AccountBatch(1);
-        batch.add();
-
-        var request = AsyncRequest.createAccounts(client, batch);
-        assert request != null;
+            var request = AsyncRequest.createAccounts(client, batch);
+            assert request != null;
+        }
     }
 
     @Test
     public void testCreateTransfersRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
-
-        var request = AsyncRequest.createTransfers(client, batch);
-        assert request != null;
+            var request = AsyncRequest.createTransfers(client, batch);
+            assert request != null;
+        }
     }
 
     @Test
     public void testLookupAccountsRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
-
-        var request = AsyncRequest.lookupAccounts(client, batch);
-        assert request != null;
+            var request = AsyncRequest.lookupAccounts(client, batch);
+            assert request != null;
+        }
     }
 
     @Test
     public void testLookupTransfersRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
-
-        var request = AsyncRequest.lookupTransfers(client, batch);
-        assert request != null;
+            var request = AsyncRequest.lookupTransfers(client, batch);
+            assert request != null;
+        }
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorWithClientNull() {
-
         var batch = new AccountBatch(1);
         batch.add();
 
@@ -74,406 +73,292 @@ public class AsyncRequestTest {
 
     @Test(expected = NullPointerException.class)
     public void testConstructorWithBatchNull() {
-
-        var client = getDummyClient();
-        AsyncRequest.createAccounts(client, null);
-        assert false;
+        try (var client = getDummyClient()) {
+            AsyncRequest.createAccounts(client, null);
+            assert false;
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroCapacityBatch() {
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(0);
 
-        var client = getDummyClient();
-        var batch = new AccountBatch(0);
-
-        AsyncRequest.createAccounts(client, batch);
-        assert false;
+            AsyncRequest.createAccounts(client, batch);
+            assert false;
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroItemsBatch() {
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(1);
 
-        var client = getDummyClient();
-        var batch = new AccountBatch(1);
-
-        AsyncRequest.createAccounts(client, batch);
-        assert false;
+            AsyncRequest.createAccounts(client, batch);
+            assert false;
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidOperation() throws Throwable {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
 
+            var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
+            var callback = new CallbackSimulator<CreateTransferResultBatch>(
+                    AsyncRequest.createTransfers(client, batch),
+                    Request.Operations.LOOKUP_ACCOUNTS.value, dummyBuffer, PacketStatus.Ok.value,
+                    250);
 
-        var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
-        var callback = new CallbackSimulator<CreateTransferResultBatch>(
-                AsyncRequest.createTransfers(client, batch),
-                Request.Operations.LOOKUP_ACCOUNTS.value, dummyBuffer, PacketStatus.Ok.value, 250);
+            CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
-
-        try {
-            future.get();
-            assert false;
-        } catch (ExecutionException e) {
-            assertNotNull(e.getCause());
-            throw e.getCause();
+            try {
+                future.get();
+                assert false;
+            } catch (ExecutionException e) {
+                assertNotNull(e.getCause());
+                throw e.getCause();
+            }
         }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithUnknownOperation() throws Throwable {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            final byte UNKNOWN = 99;
 
-        final byte UNKNOWN = 99;
+            var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
+            var callback =
+                    new CallbackSimulator<CreateTransferResultBatch>(
+                            new AsyncRequest<CreateTransferResultBatch>(client,
+                                    Operations.CREATE_TRANSFERS, batch),
+                            UNKNOWN, dummyBuffer, PacketStatus.Ok.value, 250);
 
-        var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
-        var callback =
-                new CallbackSimulator<CreateTransferResultBatch>(
-                        new AsyncRequest<CreateTransferResultBatch>(client,
-                                Operations.CREATE_TRANSFERS, batch),
-                        UNKNOWN, dummyBuffer, PacketStatus.Ok.value, 250);
+            CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
-
-        try {
-            future.get();
-            assert false;
-        } catch (ExecutionException e) {
-            assertNotNull(e.getCause());
-            throw e.getCause();
+            try {
+                future.get();
+                assert false;
+            } catch (ExecutionException e) {
+                assertNotNull(e.getCause());
+                throw e.getCause();
+            }
         }
     }
 
     @Test
     public void testEndRequestWithNullBuffer() throws Throwable {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var callback = new CallbackSimulator<CreateTransferResultBatch>(
+                    AsyncRequest.createTransfers(client, batch),
+                    Request.Operations.CREATE_TRANSFERS.value, null, PacketStatus.Ok.value, 250);
 
-        var callback = new CallbackSimulator<CreateTransferResultBatch>(
-                AsyncRequest.createTransfers(client, batch),
-                Request.Operations.CREATE_TRANSFERS.value, null, PacketStatus.Ok.value, 250);
+            CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
-
-        var result = future.get();
-        assertEquals(0, result.getLength());
+            var result = future.get();
+            assertEquals(0, result.getLength());
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidBufferSize() throws Throwable {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
 
+            var invalidBuffer =
+                    ByteBuffer.allocate((CreateTransferResultBatch.Struct.SIZE * 2) - 1);
+            var callback = new CallbackSimulator<CreateTransferResultBatch>(
+                    AsyncRequest.createTransfers(client, batch),
+                    Request.Operations.CREATE_TRANSFERS.value, invalidBuffer, PacketStatus.Ok.value,
+                    250);
 
-        var invalidBuffer = ByteBuffer.allocate((CreateTransferResultBatch.Struct.SIZE * 2) - 1);
-        var callback = new CallbackSimulator<CreateTransferResultBatch>(
-                AsyncRequest.createTransfers(client, batch),
-                Request.Operations.CREATE_TRANSFERS.value, invalidBuffer, PacketStatus.Ok.value,
-                250);
+            CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
-
-        try {
-            future.get();
-            assert false;
-        } catch (ExecutionException e) {
-            assertNotNull(e.getCause());
-            throw e.getCause();
+            try {
+                future.get();
+                assert false;
+            } catch (ExecutionException e) {
+                assertNotNull(e.getCause());
+                throw e.getCause();
+            }
         }
     }
 
     @Test
     public void testEndRequestWithRequestException() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
+            var callback = new CallbackSimulator<CreateTransferResultBatch>(
+                    AsyncRequest.createTransfers(client, batch),
+                    Request.Operations.CREATE_TRANSFERS.value, dummyBuffer,
+                    PacketStatus.TooMuchData.value, 250);
 
-        var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
-        var callback = new CallbackSimulator<CreateTransferResultBatch>(
-                AsyncRequest.createTransfers(client, batch),
-                Request.Operations.CREATE_TRANSFERS.value, dummyBuffer,
-                PacketStatus.TooMuchData.value, 250);
+            CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
+            try {
+                future.join();
+                assert false;
+            } catch (CompletionException e) {
 
-        try {
-            future.join();
-            assert false;
-        } catch (CompletionException e) {
+                assertTrue(e.getCause() instanceof RequestException);
 
-            assertTrue(e.getCause() instanceof RequestException);
-
-            var requestException = (RequestException) e.getCause();
-            assertEquals(PacketStatus.TooMuchData.value, requestException.getStatus());
+                var requestException = (RequestException) e.getCause();
+                assertEquals(PacketStatus.TooMuchData.value, requestException.getStatus());
+            }
         }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithAmountOfResultsGreaterThanAmountOfRequests() throws Throwable {
-        var client = getDummyClient();
+        try (var client = getDummyClient()) {
 
-        // A batch with only 1 item
-        var batch = new AccountBatch(1);
-        batch.add();
+            // A batch with only 1 item
+            var batch = new AccountBatch(1);
+            batch.add();
 
-        // A reply with 2 items, while the batch had only 1 item
-        var incorrectReply = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
-                .order(ByteOrder.LITTLE_ENDIAN);
+            // A reply with 2 items, while the batch had only 1 item
+            var incorrectReply = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
 
-        var callback = new CallbackSimulator<CreateAccountResultBatch>(
-                AsyncRequest.createAccounts(client, batch),
-                Request.Operations.CREATE_ACCOUNTS.value, incorrectReply, PacketStatus.Ok.value,
-                250);
+            var callback = new CallbackSimulator<CreateAccountResultBatch>(
+                    AsyncRequest.createAccounts(client, batch),
+                    Request.Operations.CREATE_ACCOUNTS.value, incorrectReply, PacketStatus.Ok.value,
+                    250);
 
-        CompletableFuture<CreateAccountResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
+            CompletableFuture<CreateAccountResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        try {
-            future.get();
-            assert false;
-        } catch (ExecutionException e) {
-            assertNotNull(e.getCause());
-            throw e.getCause();
+            try {
+                future.get();
+                assert false;
+            } catch (ExecutionException e) {
+                assertNotNull(e.getCause());
+                throw e.getCause();
+            }
         }
     }
 
     @Test
     public void testCreateAccountEndRequest() throws ExecutionException, InterruptedException {
-        var client = getDummyClient();
-        var batch = new AccountBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(2);
+            batch.add();
+            batch.add();
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
-                .order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putInt(0);
-        dummyReplyBuffer.putInt(CreateAccountResult.IdMustNotBeZero.ordinal());
-        dummyReplyBuffer.putInt(1);
-        dummyReplyBuffer.putInt(CreateAccountResult.Exists.ordinal());
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putInt(0);
+            dummyReplyBuffer.putInt(CreateAccountResult.IdMustNotBeZero.ordinal());
+            dummyReplyBuffer.putInt(1);
+            dummyReplyBuffer.putInt(CreateAccountResult.Exists.ordinal());
 
-        var callback = new CallbackSimulator<CreateAccountResultBatch>(
-                AsyncRequest.createAccounts(client, batch),
-                Request.Operations.CREATE_ACCOUNTS.value, dummyReplyBuffer, PacketStatus.Ok.value,
-                250);
+            var callback = new CallbackSimulator<CreateAccountResultBatch>(
+                    AsyncRequest.createAccounts(client, batch),
+                    Request.Operations.CREATE_ACCOUNTS.value, dummyReplyBuffer,
+                    PacketStatus.Ok.value, 250);
 
-        CompletableFuture<CreateAccountResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
+            CompletableFuture<CreateAccountResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        var result = future.get();
-        assertEquals(2, result.getLength());
+            var result = future.get();
+            assertEquals(2, result.getLength());
 
-        assertTrue(result.next());
-        assertEquals(0, result.getIndex());
-        assertEquals(CreateAccountResult.IdMustNotBeZero, result.getResult());
+            assertTrue(result.next());
+            assertEquals(0, result.getIndex());
+            assertEquals(CreateAccountResult.IdMustNotBeZero, result.getResult());
 
-        assertTrue(result.next());
-        assertEquals(1, result.getIndex());
-        assertEquals(CreateAccountResult.Exists, result.getResult());
+            assertTrue(result.next());
+            assertEquals(1, result.getIndex());
+            assertEquals(CreateAccountResult.Exists, result.getResult());
+        }
     }
 
     @Test
     public void testCreateTransferEndRequest() throws InterruptedException, ExecutionException {
-        var client = getDummyClient();
-        var batch = new TransferBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(2);
+            batch.add();
+            batch.add();
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE * 2)
-                .order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putInt(0);
-        dummyReplyBuffer.putInt(CreateTransferResult.IdMustNotBeZero.ordinal());
-        dummyReplyBuffer.putInt(1);
-        dummyReplyBuffer.putInt(CreateTransferResult.Exists.ordinal());
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putInt(0);
+            dummyReplyBuffer.putInt(CreateTransferResult.IdMustNotBeZero.ordinal());
+            dummyReplyBuffer.putInt(1);
+            dummyReplyBuffer.putInt(CreateTransferResult.Exists.ordinal());
 
-        var callback = new CallbackSimulator<CreateTransferResultBatch>(
-                AsyncRequest.createTransfers(client, batch),
-                Request.Operations.CREATE_TRANSFERS.value, dummyReplyBuffer, PacketStatus.Ok.value,
-                250);
+            var callback = new CallbackSimulator<CreateTransferResultBatch>(
+                    AsyncRequest.createTransfers(client, batch),
+                    Request.Operations.CREATE_TRANSFERS.value, dummyReplyBuffer,
+                    PacketStatus.Ok.value, 250);
 
-        CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
+            CompletableFuture<CreateTransferResultBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        var result = future.get();
-        assertEquals(2, result.getLength());
+            var result = future.get();
+            assertEquals(2, result.getLength());
 
-        assertTrue(result.next());
-        assertEquals(0, result.getIndex());
-        assertEquals(CreateTransferResult.IdMustNotBeZero, result.getResult());
+            assertTrue(result.next());
+            assertEquals(0, result.getIndex());
+            assertEquals(CreateTransferResult.IdMustNotBeZero, result.getResult());
 
-        assertTrue(result.next());
-        assertEquals(1, result.getIndex());
-        assertEquals(CreateTransferResult.Exists, result.getResult());
+            assertTrue(result.next());
+            assertEquals(1, result.getIndex());
+            assertEquals(CreateTransferResult.Exists, result.getResult());
+        }
     }
 
     @Test
     public void testLookupAccountEndRequest() throws InterruptedException, ExecutionException {
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(AccountBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(AccountBatch.Struct.SIZE).putLong(200).putLong(2000);
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(AccountBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(AccountBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        var callback =
-                new CallbackSimulator<AccountBatch>(AsyncRequest.lookupAccounts(client, batch),
-                        Request.Operations.LOOKUP_ACCOUNTS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 250);
+            var callback =
+                    new CallbackSimulator<AccountBatch>(AsyncRequest.lookupAccounts(client, batch),
+                            Request.Operations.LOOKUP_ACCOUNTS.value, dummyReplyBuffer,
+                            PacketStatus.Ok.value, 250);
 
-        CompletableFuture<AccountBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
+            CompletableFuture<AccountBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
 
-        var result = future.get();
-        assertEquals(2, result.getLength());
-
-        assertTrue(result.next());
-        assertEquals(100L, result.getId(UInt128.LeastSignificant));
-        assertEquals(1000L, result.getId(UInt128.MostSignificant));
-
-        assertTrue(result.next());
-        assertEquals(200L, result.getId(UInt128.LeastSignificant));
-        assertEquals(2000L, result.getId(UInt128.MostSignificant));
-    }
-
-    @Test
-    public void testLookupTransferEndRequest() throws InterruptedException, ExecutionException {
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
-
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
-
-        var callback =
-                new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 250);
-
-        CompletableFuture<TransferBatch> future = callback.request.getFuture();
-        callback.start();
-        assertFalse(future.isDone());
-
-        var result = future.get();
-        assertEquals(2, result.getLength());
-
-        assertTrue(result.next());
-        assertEquals(100L, result.getId(UInt128.LeastSignificant));
-        assertEquals(1000L, result.getId(UInt128.MostSignificant));
-
-        assertTrue(result.next());
-        assertEquals(200L, result.getId(UInt128.LeastSignificant));
-        assertEquals(2000L, result.getId(UInt128.MostSignificant));
-    }
-
-    @Test
-    public void testSuccessFuture() throws InterruptedException, ExecutionException {
-
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
-
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
-
-        var callback =
-                new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 5000);
-
-        Future<TransferBatch> future = callback.request.getFuture();
-        callback.start();
-
-        try {
-            // Our goal is just to test the future timeout.
-            // The timeout is much smaller than the delay,
-            // to avoid flaky results due to thread scheduling.
-            future.get(5, TimeUnit.MILLISECONDS);
-            assert false;
-
-        } catch (TimeoutException timeout) {
-            assert true;
-        }
-
-        // Wait for completion
-        var result = future.get();
-        assertEquals(2, result.getLength());
-
-        assertTrue(result.next());
-        assertEquals(100L, result.getId(UInt128.LeastSignificant));
-        assertEquals(1000L, result.getId(UInt128.MostSignificant));
-
-        assertTrue(result.next());
-        assertEquals(200L, result.getId(UInt128.LeastSignificant));
-        assertEquals(2000L, result.getId(UInt128.MostSignificant));
-    }
-
-    @Test
-    public void testSuccessFutureWithTimeout() throws InterruptedException, ExecutionException {
-
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
-
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
-
-        var callback =
-                new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 5);
-
-        Future<TransferBatch> future = callback.request.getFuture();
-        callback.start();
-
-        try {
-
-            // Our goal is just to test the future completion.
-            // The timeout is much bigger than the delay,
-            // to avoid flaky results due to thread scheduling.
-            var result = future.get(5000, TimeUnit.MILLISECONDS);
+            var result = future.get();
             assertEquals(2, result.getLength());
 
             assertTrue(result.next());
@@ -483,64 +368,184 @@ public class AsyncRequestTest {
             assertTrue(result.next());
             assertEquals(200L, result.getId(UInt128.LeastSignificant));
             assertEquals(2000L, result.getId(UInt128.MostSignificant));
+        }
+    }
 
-        } catch (TimeoutException timeout) {
-            assert false;
+    @Test
+    public void testLookupTransferEndRequest() throws InterruptedException, ExecutionException {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
+
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
+
+            var callback = new CallbackSimulator<TransferBatch>(
+                    AsyncRequest.lookupTransfers(client, batch),
+                    Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
+                    PacketStatus.Ok.value, 250);
+
+            CompletableFuture<TransferBatch> future = callback.request.getFuture();
+            callback.start();
+            assertFalse(future.isDone());
+
+            var result = future.get();
+            assertEquals(2, result.getLength());
+
+            assertTrue(result.next());
+            assertEquals(100L, result.getId(UInt128.LeastSignificant));
+            assertEquals(1000L, result.getId(UInt128.MostSignificant));
+
+            assertTrue(result.next());
+            assertEquals(200L, result.getId(UInt128.LeastSignificant));
+            assertEquals(2000L, result.getId(UInt128.MostSignificant));
+        }
+    }
+
+    @Test
+    public void testSuccessFuture() throws InterruptedException, ExecutionException {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
+
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
+
+            var callback = new CallbackSimulator<TransferBatch>(
+                    AsyncRequest.lookupTransfers(client, batch),
+                    Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
+                    PacketStatus.Ok.value, 5000);
+
+            Future<TransferBatch> future = callback.request.getFuture();
+            callback.start();
+
+            try {
+                // Our goal is just to test the future timeout.
+                // The timeout is much smaller than the delay,
+                // to avoid flaky results due to thread scheduling.
+                future.get(5, TimeUnit.MILLISECONDS);
+                assert false;
+
+            } catch (TimeoutException timeout) {
+                assert true;
+            }
+
+            // Wait for completion
+            var result = future.get();
+            assertEquals(2, result.getLength());
+
+            assertTrue(result.next());
+            assertEquals(100L, result.getId(UInt128.LeastSignificant));
+            assertEquals(1000L, result.getId(UInt128.MostSignificant));
+
+            assertTrue(result.next());
+            assertEquals(200L, result.getId(UInt128.LeastSignificant));
+            assertEquals(2000L, result.getId(UInt128.MostSignificant));
+        }
+    }
+
+    @Test
+    public void testSuccessFutureWithTimeout() throws InterruptedException, ExecutionException {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
+
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
+
+            var callback = new CallbackSimulator<TransferBatch>(
+                    AsyncRequest.lookupTransfers(client, batch),
+                    Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
+                    PacketStatus.Ok.value, 5);
+
+            Future<TransferBatch> future = callback.request.getFuture();
+            callback.start();
+
+            try {
+
+                // Our goal is just to test the future completion.
+                // The timeout is much bigger than the delay,
+                // to avoid flaky results due to thread scheduling.
+                var result = future.get(5000, TimeUnit.MILLISECONDS);
+                assertEquals(2, result.getLength());
+
+                assertTrue(result.next());
+                assertEquals(100L, result.getId(UInt128.LeastSignificant));
+                assertEquals(1000L, result.getId(UInt128.MostSignificant));
+
+                assertTrue(result.next());
+                assertEquals(200L, result.getId(UInt128.LeastSignificant));
+                assertEquals(2000L, result.getId(UInt128.MostSignificant));
+
+            } catch (TimeoutException timeout) {
+                assert false;
+            }
         }
     }
 
     @Test
     public void testFailedFuture() throws InterruptedException {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
+            var callback = new CallbackSimulator<TransferBatch>(
+                    AsyncRequest.lookupTransfers(client, batch),
+                    Request.Operations.LOOKUP_TRANSFERS.value, null, PacketStatus.TooMuchData.value,
+                    250);
 
-        var callback =
-                new CallbackSimulator<TransferBatch>(AsyncRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, null,
-                        PacketStatus.TooMuchData.value, 250);
+            Future<TransferBatch> future = callback.request.getFuture();
+            callback.start();
 
-        Future<TransferBatch> future = callback.request.getFuture();
-        callback.start();
+            try {
+                future.get();
+                assert false;
+            } catch (ExecutionException exception) {
 
-        try {
-            future.get();
-            assert false;
-        } catch (ExecutionException exception) {
+                assertTrue(exception.getCause() instanceof RequestException);
 
-            assertTrue(exception.getCause() instanceof RequestException);
-
-            var requestException = (RequestException) exception.getCause();
-            assertEquals(PacketStatus.TooMuchData.value, requestException.getStatus());
+                var requestException = (RequestException) exception.getCause();
+                assertEquals(PacketStatus.TooMuchData.value, requestException.getStatus());
+            }
         }
-
     }
 
     @Test
     public void testFailedFutureWithTimeout() throws InterruptedException, TimeoutException {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
+            var callback =
+                    new CallbackSimulator<AccountBatch>(AsyncRequest.lookupAccounts(client, batch),
+                            Request.Operations.LOOKUP_ACCOUNTS.value, null,
+                            PacketStatus.InvalidDataSize.value, 100);
 
-        var callback =
-                new CallbackSimulator<AccountBatch>(AsyncRequest.lookupAccounts(client, batch),
-                        Request.Operations.LOOKUP_ACCOUNTS.value, null,
-                        PacketStatus.InvalidDataSize.value, 100);
+            Future<AccountBatch> future = callback.request.getFuture();
+            callback.start();
 
-        Future<AccountBatch> future = callback.request.getFuture();
-        callback.start();
+            try {
+                future.get(1000, TimeUnit.MILLISECONDS);
+                assert false;
+            } catch (ExecutionException exception) {
 
-        try {
-            future.get(1000, TimeUnit.MILLISECONDS);
-            assert false;
-        } catch (ExecutionException exception) {
+                assertTrue(exception.getCause() instanceof RequestException);
 
-            assertTrue(exception.getCause() instanceof RequestException);
-
-            var requestException = (RequestException) exception.getCause();
-            assertEquals(PacketStatus.InvalidDataSize.value, requestException.getStatus());
+                var requestException = (RequestException) exception.getCause();
+                assertEquals(PacketStatus.InvalidDataSize.value, requestException.getStatus());
+            }
         }
     }
 
@@ -580,4 +585,3 @@ public class AsyncRequestTest {
         }
     }
 }
-

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -12,51 +12,50 @@ public class BlockingRequestTest {
 
     @Test
     public void testCreateAccountsRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new AccountBatch(1);
-        batch.add();
-
-        var request = BlockingRequest.createAccounts(client, batch);
-        assert request != null;
+            var request = BlockingRequest.createAccounts(client, batch);
+            assert request != null;
+        }
     }
 
     @Test
     public void testCreateTransfersRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
-
-        var request = BlockingRequest.createTransfers(client, batch);
-        assert request != null;
+            var request = BlockingRequest.createTransfers(client, batch);
+            assert request != null;
+        }
     }
 
     @Test
     public void testLookupAccountsRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
-
-        var request = BlockingRequest.lookupAccounts(client, batch);
-        assert request != null;
+            var request = BlockingRequest.lookupAccounts(client, batch);
+            assert request != null;
+        }
     }
 
     @Test
     public void testLookupTransfersRequestConstructor() {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
-
-        var request = BlockingRequest.lookupTransfers(client, batch);
-        assert request != null;
+            var request = BlockingRequest.lookupTransfers(client, batch);
+            assert request != null;
+        }
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorWithClientNull() {
-
         var batch = new AccountBatch(1);
         batch.add();
 
@@ -66,391 +65,398 @@ public class BlockingRequestTest {
 
     @Test(expected = NullPointerException.class)
     public void testConstructorWithBatchNull() {
-
-        var client = getDummyClient();
-        BlockingRequest.createAccounts(client, null);
-        assert false;
+        try (var client = getDummyClient()) {
+            BlockingRequest.createAccounts(client, null);
+            assert false;
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroCapacityBatch() {
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(0);
 
-        var client = getDummyClient();
-        var batch = new AccountBatch(0);
-
-        BlockingRequest.createAccounts(client, batch);
-        assert false;
+            BlockingRequest.createAccounts(client, batch);
+            assert false;
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroItemsBatch() {
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(1);
 
-        var client = getDummyClient();
-        var batch = new AccountBatch(1);
-
-        BlockingRequest.createAccounts(client, batch);
-        assert false;
+            BlockingRequest.createAccounts(client, batch);
+            assert false;
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidOperation() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var request = BlockingRequest.createTransfers(client, batch);
 
-        var request = BlockingRequest.createTransfers(client, batch);
+            assertFalse(request.isDone());
 
-        assertFalse(request.isDone());
+            // Invalid operation, should be CREATE_TRANSFERS
+            request.endRequest(Request.Operations.LOOKUP_ACCOUNTS.value, PacketStatus.Ok.value);
 
-        // Invalid operation, should be CREATE_TRANSFERS
-        request.endRequest(Request.Operations.LOOKUP_ACCOUNTS.value, PacketStatus.Ok.value);
+            assertTrue(request.isDone());
 
-        assertTrue(request.isDone());
-
-        request.waitForResult();
-        assert false;
+            request.waitForResult();
+            assert false;
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithUnknownOperation() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            final byte UNKNOWN = 99;
+            var request = new BlockingRequest<CreateTransferResultBatch>(client,
+                    Operations.CREATE_TRANSFERS, batch);
 
-        final byte UNKNOWN = 99;
-        var request = new BlockingRequest<CreateTransferResultBatch>(client,
-                Operations.CREATE_TRANSFERS, batch);
+            assertFalse(request.isDone());
 
-        assertFalse(request.isDone());
+            // Unknown operation
+            request.endRequest(UNKNOWN, PacketStatus.Ok.value);
 
-        // Unknown operation
-        request.endRequest(UNKNOWN, PacketStatus.Ok.value);
+            assertTrue(request.isDone());
 
-        assertTrue(request.isDone());
-
-        request.waitForResult();
-        assert false;
+            request.waitForResult();
+            assert false;
+        }
     }
 
     @Test
     public void testEndRequestWithNullBuffer() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var request = BlockingRequest.createTransfers(client, batch);
 
-        var request = BlockingRequest.createTransfers(client, batch);
+            assertFalse(request.isDone());
 
-        assertFalse(request.isDone());
+            request.endRequest(Request.Operations.CREATE_TRANSFERS.value, PacketStatus.Ok.value);
 
-        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, PacketStatus.Ok.value);
+            assertTrue(request.isDone());
 
-        assertTrue(request.isDone());
-
-        var result = request.waitForResult();
-        assertEquals(0, result.getLength());
+            var result = request.waitForResult();
+            assertEquals(0, result.getLength());
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithInvalidBufferSize() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var request = BlockingRequest.createTransfers(client, batch);
+            var invalidBuffer =
+                    ByteBuffer.allocate((CreateTransferResultBatch.Struct.SIZE * 2) - 1);
 
-        var request = BlockingRequest.createTransfers(client, batch);
-        var invalidBuffer = ByteBuffer.allocate((CreateTransferResultBatch.Struct.SIZE * 2) - 1);
+            assertFalse(request.isDone());
 
-        assertFalse(request.isDone());
+            request.setReplyBuffer(invalidBuffer.array());
+            request.endRequest(Request.Operations.CREATE_TRANSFERS.value, PacketStatus.Ok.value);
 
-        request.setReplyBuffer(invalidBuffer.array());
-        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, PacketStatus.Ok.value);
+            assertTrue(request.isDone());
 
-        assertTrue(request.isDone());
-
-        request.waitForResult();
-        assert false;
+            request.waitForResult();
+            assert false;
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testGetResultBeforeEndRequest() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var request = BlockingRequest.createTransfers(client, batch);
 
-        var request = BlockingRequest.createTransfers(client, batch);
+            assertFalse(request.isDone());
 
-        assertFalse(request.isDone());
-
-        request.getResult();
-        assert false;
+            request.getResult();
+            assert false;
+        }
     }
 
     @Test
     public void testEndRequestWithRequestException() {
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new TransferBatch(1);
-        batch.add();
+            var request = BlockingRequest.createTransfers(client, batch);
 
-        var request = BlockingRequest.createTransfers(client, batch);
+            assertFalse(request.isDone());
 
-        assertFalse(request.isDone());
+            var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
+            request.setReplyBuffer(dummyBuffer.array());
+            request.endRequest(Request.Operations.CREATE_TRANSFERS.value,
+                    PacketStatus.TooMuchData.value);
 
-        var dummyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE);
-        request.setReplyBuffer(dummyBuffer.array());
-        request.endRequest(Request.Operations.CREATE_TRANSFERS.value,
-                PacketStatus.TooMuchData.value);
+            assertTrue(request.isDone());
 
-        assertTrue(request.isDone());
-
-        try {
-            request.waitForResult();
-            assert false;
-        } catch (RequestException e) {
-            assertEquals(PacketStatus.TooMuchData.value, e.getStatus());
+            try {
+                request.waitForResult();
+                assert false;
+            } catch (RequestException e) {
+                assertEquals(PacketStatus.TooMuchData.value, e.getStatus());
+            }
         }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestWithAmountOfResultsGreaterThanAmountOfRequests() {
-        var client = getDummyClient();
+        try (var client = getDummyClient()) {
 
-        // A batch with only 1 item
-        var batch = new AccountBatch(1);
-        batch.add();
+            // A batch with only 1 item
+            var batch = new AccountBatch(1);
+            batch.add();
 
-        // A reply with 2 items, while the batch had only 1 item
-        var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
-                .order(ByteOrder.LITTLE_ENDIAN);
+            // A reply with 2 items, while the batch had only 1 item
+            var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
 
-        var request = BlockingRequest.createAccounts(client, batch);
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+            var request = BlockingRequest.createAccounts(client, batch);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
-        request.waitForResult();
+            assertTrue(request.isDone());
+            request.waitForResult();
+        }
     }
 
     @Test(expected = AssertionError.class)
     public void testEndRequestTwice() {
-        var client = getDummyClient();
+        try (var client = getDummyClient()) {
 
-        // A batch with only 1 item
-        var batch = new AccountBatch(1);
-        batch.add();
+            // A batch with only 1 item
+            var batch = new AccountBatch(1);
+            batch.add();
 
-        // A reply with 2 items, while the batch had only 1 item
-        var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE)
-                .order(ByteOrder.LITTLE_ENDIAN);
+            // A reply with 2 items, while the batch had only 1 item
+            var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE)
+                    .order(ByteOrder.LITTLE_ENDIAN);
 
-        var request = BlockingRequest.createAccounts(client, batch);
-        assertFalse(request.isDone());
+            var request = BlockingRequest.createAccounts(client, batch);
+            assertFalse(request.isDone());
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
-        var result = request.waitForResult();
-        assertEquals(1, result.getLength());
+            assertTrue(request.isDone());
+            var result = request.waitForResult();
+            assertEquals(1, result.getLength());
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
+            assertTrue(request.isDone());
 
-        request.waitForResult();
-        assert false;
+            request.waitForResult();
+            assert false;
+        }
     }
 
     @Test
     public void testCreateAccountEndRequest() {
-        var client = getDummyClient();
-        var batch = new AccountBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new AccountBatch(2);
+            batch.add();
+            batch.add();
 
-        var request = BlockingRequest.createAccounts(client, batch);
+            var request = BlockingRequest.createAccounts(client, batch);
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
-                .order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putInt(0);
-        dummyReplyBuffer.putInt(CreateAccountResult.IdMustNotBeZero.ordinal());
-        dummyReplyBuffer.putInt(1);
-        dummyReplyBuffer.putInt(CreateAccountResult.Exists.ordinal());
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(CreateAccountResultBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putInt(0);
+            dummyReplyBuffer.putInt(CreateAccountResult.IdMustNotBeZero.ordinal());
+            dummyReplyBuffer.putInt(1);
+            dummyReplyBuffer.putInt(CreateAccountResult.Exists.ordinal());
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
-        var result = request.waitForResult();
-        assertEquals(2, result.getLength());
+            assertTrue(request.isDone());
+            var result = request.waitForResult();
+            assertEquals(2, result.getLength());
 
-        assertTrue(result.next());
-        assertEquals(0, result.getIndex());
-        assertEquals(CreateAccountResult.IdMustNotBeZero, result.getResult());
+            assertTrue(result.next());
+            assertEquals(0, result.getIndex());
+            assertEquals(CreateAccountResult.IdMustNotBeZero, result.getResult());
 
-        assertTrue(result.next());
-        assertEquals(1, result.getIndex());
-        assertEquals(CreateAccountResult.Exists, result.getResult());
+            assertTrue(result.next());
+            assertEquals(1, result.getIndex());
+            assertEquals(CreateAccountResult.Exists, result.getResult());
+        }
     }
 
     @Test
     public void testCreateTransferEndRequest() {
-        var client = getDummyClient();
-        var batch = new TransferBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new TransferBatch(2);
+            batch.add();
+            batch.add();
 
-        var request = BlockingRequest.createTransfers(client, batch);
+            var request = BlockingRequest.createTransfers(client, batch);
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE * 2)
-                .order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putInt(0);
-        dummyReplyBuffer.putInt(CreateTransferResult.IdMustNotBeZero.ordinal());
-        dummyReplyBuffer.putInt(1);
-        dummyReplyBuffer.putInt(CreateTransferResult.Exists.ordinal());
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(CreateTransferResultBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putInt(0);
+            dummyReplyBuffer.putInt(CreateTransferResult.IdMustNotBeZero.ordinal());
+            dummyReplyBuffer.putInt(1);
+            dummyReplyBuffer.putInt(CreateTransferResult.Exists.ordinal());
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_TRANSFERS.value, PacketStatus.Ok.value);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.CREATE_TRANSFERS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
-        var result = request.waitForResult();
-        assertEquals(2, result.getLength());
+            assertTrue(request.isDone());
+            var result = request.waitForResult();
+            assertEquals(2, result.getLength());
 
-        assertTrue(result.next());
-        assertEquals(0, result.getIndex());
-        assertEquals(CreateTransferResult.IdMustNotBeZero, result.getResult());
+            assertTrue(result.next());
+            assertEquals(0, result.getIndex());
+            assertEquals(CreateTransferResult.IdMustNotBeZero, result.getResult());
 
-        assertTrue(result.next());
-        assertEquals(1, result.getIndex());
-        assertEquals(CreateTransferResult.Exists, result.getResult());
+            assertTrue(result.next());
+            assertEquals(1, result.getIndex());
+            assertEquals(CreateTransferResult.Exists, result.getResult());
+        }
     }
 
     @Test
     public void testLookupAccountEndRequest() {
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
 
-        var request = BlockingRequest.lookupAccounts(client, batch);
+            var request = BlockingRequest.lookupAccounts(client, batch);
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(AccountBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(AccountBatch.Struct.SIZE).putLong(200).putLong(2000);
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(AccountBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(AccountBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.LOOKUP_ACCOUNTS.value, PacketStatus.Ok.value);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.LOOKUP_ACCOUNTS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
-        var result = request.waitForResult();
-        assertEquals(2, result.getLength());
+            assertTrue(request.isDone());
+            var result = request.waitForResult();
+            assertEquals(2, result.getLength());
 
-        assertTrue(result.next());
-        assertEquals(100L, result.getId(UInt128.LeastSignificant));
-        assertEquals(1000L, result.getId(UInt128.MostSignificant));
+            assertTrue(result.next());
+            assertEquals(100L, result.getId(UInt128.LeastSignificant));
+            assertEquals(1000L, result.getId(UInt128.MostSignificant));
 
-        assertTrue(result.next());
-        assertEquals(200L, result.getId(UInt128.LeastSignificant));
-        assertEquals(2000L, result.getId(UInt128.MostSignificant));
+            assertTrue(result.next());
+            assertEquals(200L, result.getId(UInt128.LeastSignificant));
+            assertEquals(2000L, result.getId(UInt128.MostSignificant));
+        }
     }
 
     @Test
     public void testLookupTransferEndRequest() {
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
 
-        var request = BlockingRequest.lookupTransfers(client, batch);
+            var request = BlockingRequest.lookupTransfers(client, batch);
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.LOOKUP_TRANSFERS.value, PacketStatus.Ok.value);
+            request.setReplyBuffer(dummyReplyBuffer.position(0).array());
+            request.endRequest(Request.Operations.LOOKUP_TRANSFERS.value, PacketStatus.Ok.value);
 
-        assertTrue(request.isDone());
-        var result = request.waitForResult();
-        assertEquals(2, result.getLength());
+            assertTrue(request.isDone());
+            var result = request.waitForResult();
+            assertEquals(2, result.getLength());
 
-        assertTrue(result.next());
-        assertEquals(100L, result.getId(UInt128.LeastSignificant));
-        assertEquals(1000L, result.getId(UInt128.MostSignificant));
+            assertTrue(result.next());
+            assertEquals(100L, result.getId(UInt128.LeastSignificant));
+            assertEquals(1000L, result.getId(UInt128.MostSignificant));
 
-        assertTrue(result.next());
-        assertEquals(200L, result.getId(UInt128.LeastSignificant));
-        assertEquals(2000L, result.getId(UInt128.MostSignificant));
+            assertTrue(result.next());
+            assertEquals(200L, result.getId(UInt128.LeastSignificant));
+            assertEquals(2000L, result.getId(UInt128.MostSignificant));
+        }
     }
 
     @Test
     public void testSuccessCompletion() {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(2);
+            batch.add();
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(2);
-        batch.add();
-        batch.add();
+            // A dummy ByteBuffer simulating some simple reply
+            var dummyReplyBuffer = ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2)
+                    .order(ByteOrder.LITTLE_ENDIAN);
 
-        // A dummy ByteBuffer simulating some simple reply
-        var dummyReplyBuffer =
-                ByteBuffer.allocate(TransferBatch.Struct.SIZE * 2).order(ByteOrder.LITTLE_ENDIAN);
+            dummyReplyBuffer.putLong(100).putLong(1000);
+            dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
 
-        dummyReplyBuffer.putLong(100).putLong(1000);
-        dummyReplyBuffer.position(TransferBatch.Struct.SIZE).putLong(200).putLong(2000);
+            var callback = new CallbackSimulator<TransferBatch>(
+                    BlockingRequest.lookupTransfers(client, batch),
+                    Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
+                    PacketStatus.Ok.value, 500);
 
-        var callback =
-                new CallbackSimulator<TransferBatch>(BlockingRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, dummyReplyBuffer,
-                        PacketStatus.Ok.value, 500);
+            callback.start();
 
-        callback.start();
+            // Wait for completion
+            var result = callback.request.waitForResult();
+            assertEquals(2, result.getLength());
 
-        // Wait for completion
-        var result = callback.request.waitForResult();
-        assertEquals(2, result.getLength());
+            assertTrue(result.next());
+            assertEquals(100L, result.getId(UInt128.LeastSignificant));
+            assertEquals(1000L, result.getId(UInt128.MostSignificant));
 
-        assertTrue(result.next());
-        assertEquals(100L, result.getId(UInt128.LeastSignificant));
-        assertEquals(1000L, result.getId(UInt128.MostSignificant));
-
-        assertTrue(result.next());
-        assertEquals(200L, result.getId(UInt128.LeastSignificant));
-        assertEquals(2000L, result.getId(UInt128.MostSignificant));
+            assertTrue(result.next());
+            assertEquals(200L, result.getId(UInt128.LeastSignificant));
+            assertEquals(2000L, result.getId(UInt128.MostSignificant));
+        }
     }
 
     @Test
     public void testFailedCompletion() throws InterruptedException {
+        try (var client = getDummyClient()) {
+            var batch = new IdBatch(1);
+            batch.add();
 
-        var client = getDummyClient();
-        var batch = new IdBatch(1);
-        batch.add();
+            var callback = new CallbackSimulator<TransferBatch>(
+                    BlockingRequest.lookupTransfers(client, batch),
+                    Request.Operations.LOOKUP_TRANSFERS.value, null, PacketStatus.TooMuchData.value,
+                    250);
 
-        var callback =
-                new CallbackSimulator<TransferBatch>(BlockingRequest.lookupTransfers(client, batch),
-                        Request.Operations.LOOKUP_TRANSFERS.value, null,
-                        PacketStatus.TooMuchData.value, 250);
+            callback.start();
 
-        callback.start();
+            try {
+                callback.request.waitForResult();
+                assert false;
+            } catch (RequestException requestException) {
 
-        try {
-            callback.request.waitForResult();
-            assert false;
-        } catch (RequestException requestException) {
+                assertEquals(PacketStatus.TooMuchData.value, requestException.getStatus());
+            }
 
-            assertEquals(PacketStatus.TooMuchData.value, requestException.getStatus());
         }
-
     }
 
     private static NativeClient getDummyClient() {


### PR DESCRIPTION
NativeClient holds onto native memory, it should be deleted explicitly!