### PR TITLE
java: correctly raise asynchronous assertion error

### DIFF
--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -109,14 +109,14 @@ abstract class Request<TResponse extends Batch> {
                     case CREATE_ACCOUNTS: {
                         result = replyBuffer == null ? CreateAccountResultBatch.EMPTY
                                 : new CreateAccountResultBatch(ByteBuffer.wrap(replyBuffer));
-                        checkResultLength(result);
+                        exception = checkResultLength(result);
                         break;
                     }
 
                     case CREATE_TRANSFERS: {
                         result = replyBuffer == null ? CreateTransferResultBatch.EMPTY
                                 : new CreateTransferResultBatch(ByteBuffer.wrap(replyBuffer));
-                        checkResultLength(result);
+                        exception = checkResultLength(result);
                         break;
                     }
 
@@ -124,7 +124,7 @@ abstract class Request<TResponse extends Batch> {
                     case LOOKUP_ACCOUNTS: {
                         result = replyBuffer == null ? AccountBatch.EMPTY
                                 : new AccountBatch(ByteBuffer.wrap(replyBuffer));
-                        checkResultLength(result);
+                        exception = checkResultLength(result);
                         break;
                     }
 
@@ -132,7 +132,7 @@ abstract class Request<TResponse extends Batch> {
                     case LOOKUP_TRANSFERS: {
                         result = replyBuffer == null ? TransferBatch.EMPTY
                                 : new TransferBatch(ByteBuffer.wrap(replyBuffer));
-                        checkResultLength(result);
+                        exception = checkResultLength(result);
                         break;
                     }
 
@@ -165,11 +165,13 @@ abstract class Request<TResponse extends Batch> {
         }
     }
 
-    final void checkResultLength(Batch result) {
+    private AssertionError checkResultLength(Batch result) {
         if (result.getLength() > requestLen) {
-            setException(new AssertionError(
+            return new AssertionError(
                     "Amount of results is greater than the amount of requests: resultLen=%d, requestLen=%d",
-                    result.getLength(), requestLen));
+                    result.getLength(), requestLen);
+        } else {
+            return null;
         }
     }
 


### PR DESCRIPTION
Before, the code could `setException` through `checkResultLength`, and the _also_ `setResult`, which trips a recently added assert.

Make sure there's only one place where result or exception are set