### PR TITLE
nyrkiö

### DIFF
--- a/.github/workflows/pipeline-main.yml
+++ b/.github/workflows/pipeline-main.yml
@@ -24,6 +24,8 @@ jobs:
       - run: ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
         env:
           DEVHUBDB_PAT: ${{ secrets.DEVHUBDB_PAT }}
+          NYRKIO_TOKEN: ${{ secrets.NYRKIO_TOKEN }}
+
       - uses: actions/upload-pages-artifact@v1
         with:
           path: ./src/devhub

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -19,9 +19,12 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     try shell.exec(
         \\dotnet test
         \\    /p:CollectCoverage=false
-        \\    /p:Threshold="95,85,95"
-        \\    /p:ThresholdType="line,branch,method"
-    , .{});
+        \\    /p:Threshold={threshold}
+        \\    /p:ThresholdType={threshold_type}
+    , .{
+        .threshold = "\"95,85,95\"", // sic, coverlet wants quotes inside the argument
+        .threshold_type = "\"line,branch,method\"",
+    });
 
     // Integration tests.
     inline for (.{ "basic", "two-phase", "two-phase-many", "walkthrough" }) |sample| {

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -684,6 +684,8 @@ fn expand_argv(argv: *Argv, comptime cmd: []const u8, cmd_args: anytype) !void {
 
     const arg_count = std.meta.fields(@TypeOf(cmd_args)).len;
     comptime var args_used = std.StaticBitSet(arg_count).initEmpty();
+    comptime assert(std.mem.indexOf(u8, cmd, "'") == null); // Quoting isn't supported yet.
+    comptime assert(std.mem.indexOf(u8, cmd, "\"") == null);
     inline while (pos < cmd.len) {
         inline while (pos < cmd.len and (cmd[pos] == ' ' or cmd[pos] == '\n')) {
             pos += 1;


### PR DESCRIPTION
https://nyrk.io/ is a cloud CI benchmark tracking service.

It is very similar to what devhub is doing, except that it actually is a
real project, and not just me copy-pasting JavaScript from
https://deno.com/benchmarks.

Otherwise, it is very similar --- their data model is isomorphic to what
we already use.

In this PR, we duplicate data to both devhubdb and nyrk. I think we'll
continue in this mode for some time, but I can see us switching to nyrk
100% in the future.

In a follow up, I do want to switch to nyrk-shaped json for devhubdb as
well, as I like their version more (esp grouping attributes _separately_
from the timestamp, which is the primary key), but I don't want to
change stuff on our end right away.

As nyrk is a 3rd party service, I don't fail CI job if we fail to
upload.