### PR TITLE
vsr: restore op_repair_min=op=op_checkpoint special case

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5075,6 +5075,10 @@ pub fn ReplicaType(
                 // After state sync, commit_max might lag behind checkpoint_op.
                 maybe(self.commit_max < op_checkpoint_trigger);
                 if (self.commit_max > op_checkpoint_trigger) {
+                    if (self.op == self.op_checkpoint()) {
+                        // Don't allow "op_repair_min > op_head".
+                        break :op self.op_checkpoint();
+                    }
                     break :op self.op_checkpoint() + 1;
                 } else {
                     break :op (self.op_checkpoint() + 1) -| constants.vsr_checkpoint_interval;


### PR DESCRIPTION
If op=op_checkpoint, but we also know that the checkpoint is durable, we don't need to repair the op, we can proceed directly to op+1. But repairs can't advance the op, so we special case this and "pretend" that we are rearing "op".

As soon as we hear from view's primary, we'll advance our `op` past `op_checkpoint` and stop pretending that we want to repair `op`.

This pre-existing logic that was erronously removed in #1579

Seed: 15816179864814849519
Closes: #1588