### PR TITLE
Update Expand-Archive to extract to current working directory

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -20,7 +20,7 @@ if ($build) {
     echo ""
 
     curl.exe -Lo tigerbeetle.zip "https://github.com/tigerbeetle/tigerbeetle/releases/download/$version/tigerbeetle-x86_64-windows.zip"
-    Expand-Archive tigerbeetle.zip
+    Expand-Archive tigerbeetle.zip .
 }
 
 echo @"


### PR DESCRIPTION
The `bootstrap.ps1` script for Windows currently expands the downloaded pre-built executable into its own folder, which consequentially breaks the rest of the script and derails the documentations :D

Added a `.` argument to the Expand-Archive to have the executable at the same level as the repository folder.