### PR TITLE
docs: make sure the repo is cloned before bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ First, download a prebuilt copy of TigerBeetle.
 On macOS/Linux:
 
 ```console
-git clone https://github.com/tigerbeetle/tigerbeetle; cd tigerbeetle; ./bootstrap.sh
+git clone https://github.com/tigerbeetle/tigerbeetle && cd tigerbeetle && ./bootstrap.sh
 ```
 
 On Windows:
 
 ```console
-git clone https://github.com/tigerbeetle/tigerbeetle; cd tigerbeetle; .\bootstrap.ps1
+git clone https://github.com/tigerbeetle/tigerbeetle && cd tigerbeetle && .\bootstrap.ps1
 ```
 
 Want to build from source locally? Add `-build` as an argument to the bootstrap script.


### PR DESCRIPTION
using `;` continue to the next command if the previous exited successfully or failed. But using `&&` makes sure that the next command will be executed only if the previous one is completed successfully.