### PR TITLE
tests: introduce explicit coverage marks

### DIFF
--- a/src/testing/covered.zig
+++ b/src/testing/covered.zig
@@ -1,0 +1,120 @@
+//! We'll get you covered!
+//!
+//! This file piggy-backs on the logging infrastructure to implement explicit coverage marks:
+//!     <https://ferrous-systems.com/blog/coverage-marks/>
+//!
+//! In production code, you can mark certain log lines as "this should be covered by a test".
+//! In test code, you can then assert that a _specific_ test covers a specific log line. The two
+//! benefits are:
+//! - tests are more resilient to refactors
+//! - production code is more readable (you can immediately jump to a specific test)
+test "tutorial" {
+    // Import by a qualified name.
+    const covered = @import("./covered.zig");
+
+    const production_code = struct {
+        // In production code, wrap the logger.
+        const log = covered.wrap_log(std.log.scoped(.my_module));
+
+        fn function_under_test(x: u32) void {
+            if (x % 2 == 0) {
+                // Both `log.info` and log.covered.info` are available.
+                // Only second version records coverage.
+                log.covered.info("x is even (x={})", .{x});
+            }
+        }
+    };
+
+    // Create a mark with the `mark` function...
+    const m = covered.mark("x is even");
+    production_code.function_under_test(92);
+    try m.expect_hit(); // ... and don't forget to assert at the end!
+}
+
+const std = @import("std");
+const assert = std.debug.assert;
+const builtin = @import("builtin");
+
+const GlobalStateType = if (builtin.is_test) struct {
+    mark_name: ?[]const u8 = null,
+    mark_hit_count: u32 = 0,
+} else void;
+
+/// Stores the currently active mark and its hit count. State is not synchronized and assumes
+/// single threaded execution.
+var global_state: GlobalStateType = .{};
+
+pub const Mark = struct {
+    name: []const u8,
+
+    pub fn expect_hit(m: Mark) !void {
+        comptime assert(builtin.is_test);
+        assert(global_state.mark_name.?.ptr == m.name.ptr);
+        defer global_state = .{};
+
+        if (global_state.mark_hit_count == 0) {
+            std.debug.print("mark '{s}' not hit", .{m.name});
+            return error.MarkNotHit;
+        }
+    }
+};
+
+pub fn mark(name: []const u8) Mark {
+    comptime assert(builtin.is_test);
+    assert(global_state.mark_name == null);
+    assert(global_state.mark_hit_count == 0);
+
+    global_state.mark_name = name;
+    return Mark{ .name = name };
+}
+
+pub fn wrap_log(comptime base: anytype) type {
+    if (builtin.is_test) {
+        return struct {
+            pub const err = warn;
+            pub const warn = base.warn;
+            pub const info = base.info;
+            pub const debug = base.debug;
+
+            pub const covered = struct {
+                pub fn err(comptime fmt: []const u8, args: anytype) void {
+                    record(fmt);
+                    base.err(fmt, args);
+                }
+
+                pub fn warn(comptime fmt: []const u8, args: anytype) void {
+                    record(fmt);
+                    base.warn(fmt, args);
+                }
+
+                pub fn info(comptime fmt: []const u8, args: anytype) void {
+                    record(fmt);
+                    base.info(fmt, args);
+                }
+
+                pub fn debug(comptime fmt: []const u8, args: anytype) void {
+                    record(fmt);
+                    base.debug(fmt, args);
+                }
+            };
+        };
+    } else {
+        return struct {
+            pub const err = warn;
+            pub const warn = base.warn;
+            pub const info = base.info;
+            pub const debug = base.debug;
+
+            pub const covered = base;
+        };
+    }
+}
+
+fn record(fmt: []const u8) void {
+    comptime assert(builtin.is_test);
+    if (global_state.mark_name) |mark_active| {
+        if (std.mem.indexOf(u8, fmt, mark_active) != null) {
+            global_state.mark_hit_count += 1;
+        }
+    }
+}

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -37,6 +37,7 @@ comptime {
     _ = @import("state_machine/auditor.zig");
     _ = @import("state_machine/workload.zig");
 
+    _ = @import("testing/covered.zig");
     _ = @import("testing/id.zig");
     _ = @import("testing/snaptest.zig");
     _ = @import("testing/storage.zig");

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -18,6 +18,7 @@ const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 const ForestTableIteratorType =
     @import("../lsm/forest_table_iterator.zig").ForestTableIteratorType;
 const TestStorage = @import("../testing/storage.zig").Storage;
+const covered = @import("../testing/covered.zig");
 
 const vsr = @import("../vsr.zig");
 const Header = vsr.Header;
@@ -29,7 +30,7 @@ const SyncStage = vsr.SyncStage;
 const SyncTarget = vsr.SyncTarget;
 const ClientSessions = vsr.ClientSessions;
 
-const log = stdx.log.scoped(.replica);
+const log = covered.wrap_log(std.log.scoped(.replica));
 const tracer = @import("../tracer.zig");
 
 pub const Status = enum {
@@ -4674,7 +4675,7 @@ pub fn ReplicaType(
                             // This SV is guaranteed to have originated after the replica crash,
                             // it is safe to use to determine the head op.
                         } else {
-                            log.debug("{}: on_{s}: ignoring (recovering_head, nonce mismatch)", .{
+                            log.covered.debug("{}: on_{s}: ignoring (recovering_head, nonce mismatch)", .{
                                 self.replica,
                                 command,
                             });

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -11,6 +11,7 @@ const vsr = @import("../vsr.zig");
 const Process = @import("../testing/cluster/message_bus.zig").Process;
 const Message = @import("../message_pool.zig").MessagePool.Message;
 const parse_table = @import("../testing/table.zig").parse;
+const covered = @import("../testing/covered.zig");
 const StateMachineType = @import("../testing/state_machine.zig").StateMachineType;
 const Cluster = @import("../testing/cluster.zig").ClusterType(StateMachineType);
 const LinkFilter = @import("../testing/cluster/network.zig").LinkFilter;
@@ -256,8 +257,7 @@ test "Cluster: recovery: recovering_head, outdated start view" {
     try expectEqual(b1.status(), .recovering_head);
     try expectEqual(b1.op_head(), 20);
 
-    // TODO Explicit code coverage marks: This should hit the
-    // "on_start_view: ignoring (recovering_head, nonce mismatch)"
+    const mark = covered.mark("ignoring (recovering_head, nonce mismatch)");
     a.stop();
     b1.replay_recorded();
     t.run();
@@ -270,6 +270,7 @@ test "Cluster: recovery: recovering_head, outdated start view" {
     t.run();
     try a.open();
     try c.request(22, 22);
+    try mark.expect_hit();
 }
 
 test "Cluster: recovery: recovering head: idle cluster" {


### PR DESCRIPTION
This file piggy-backs on the logging infrastructure to implement explicit coverage marks:
     <https://ferrous-systems.com/blog/coverage-marks/>

See the docs and tutorial test in `src/testing/covered.zig` for API details

This PR doesn't actually _use_ coverage marks much, as I want to nail down the API first.

Design notes:

- gate all the logic with `comptime if (builtin.test)`
- assume single-threaded test execution. It looks like, if Zig will run tests in parallel, it'll use separate processes https://github.com/ziglang/zig/issues/15953. And if it does multithreading, replacing this with thread-locals won't be hard (and we have a plan to thread our own logger instance anyway)
- intercept not all `log.debug` calls, but only explicitly marked ones: `log.covered.debug`. This makes prod code a touch noisier, but I think it's worth it, as it makes is easy to go to the relevant test
- match on `comptime fmt: []const u8` rather than on the actual formatted log line. This is less flexible, but faster and allows for grepping string literals. 
- do not `defer` checks that the mark was hit, require an explicit `try mark.expect_hit()` calls. I am ambivalent here, but feels like defers might introduce extra scopes where non would be necessary otherwise. Each mark does assert that it starts in a pristine state, so forgetting to assert the marks should be noticiable via an assertion failure in a subesquent test.
- this doesn't address the problem of "orphaned" marks. That's best addressed through a tidy checks that collects all allegedly `.covered` marks and cross-checks that set against what we actually `covered.mark()`. This is left as a future exercise. 