### PR TITLE
VSR/Header: Remove unused default

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -285,7 +285,7 @@ pub const Header = extern struct {
         epoch: u32 = 0,
         // NB: unlike every other message, pings and pongs use on disk view, rather than in-memory
         // view, to avoid disrupting clock synchronization while the view is being updated.
-        view: u32 = 0,
+        view: u32,
         version: u16 = vsr.Version,
         command: Command,
         replica: u8,


### PR DESCRIPTION
https://github.com/tigerbeetle/tigerbeetle/pull/1598 reminded me that pings include a view number now, so this default isn't ever used.