### PR TITLE
devhub: update nyrk.io URI

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -152,7 +152,7 @@ fn upload_nyrkio(shell: *Shell, run: NyrkioRun) !void {
         \\curl -s -X POST --fail-with-body
         \\    -H {content_type}
         \\    -H {authorization}
-        \\    https://nyrk.io/api/v0/result/devhub
+        \\    https://nyrkio.com/api/v0/result/devhub
         \\    -d {payload}
     , .{
         .content_type = "Content-type: application/json",


### PR DESCRIPTION
```
$ curl -s -X POST --fail-with-body -H Content-type: application/json -H Authorization: *** https://nyrk.io/api/v0/result/devhub -d [{"timestamp":1709055349,"metrics":[{"name":"build time","unit":"ms","value":55449},{"name":"executable size","unit":"bytes","value":1976432},{"name":"TPS","unit":"count","value":157392},{"name":"batch p90","unit":"ms","value":54},{"name":"query p90","unit":"ms","value":1011},{"name":"RSS","unit":"bytes","value":3598897152}],"attributes":{"git_repo":"https://github.com/tigerbeetle/tigerbeetle","branch":"main","git_commit":"c2059d0df23c6062bf2459c9bc867fca2c34d176"}}]
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.25.4</center>
</body>
</html>
````

Seems they moved off .io into .com

https://nyrkio.com/docs/getting-started

They did setup a redirect, but redirects on POST are iffy (and they use 301 rather than 307)

https://everything.curl.dev/http/redirects