### PR TITLE
tests: terminology change covered -> marks

### DIFF
--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -37,8 +37,8 @@ comptime {
     _ = @import("state_machine/auditor.zig");
     _ = @import("state_machine/workload.zig");
 
-    _ = @import("testing/covered.zig");
     _ = @import("testing/id.zig");
+    _ = @import("testing/marks.zig");
     _ = @import("testing/snaptest.zig");
     _ = @import("testing/storage.zig");
     _ = @import("testing/table.zig");

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -18,7 +18,7 @@ const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 const ForestTableIteratorType =
     @import("../lsm/forest_table_iterator.zig").ForestTableIteratorType;
 const TestStorage = @import("../testing/storage.zig").Storage;
-const covered = @import("../testing/covered.zig");
+const marks = @import("../testing/marks.zig");
 
 const vsr = @import("../vsr.zig");
 const Header = vsr.Header;
@@ -30,7 +30,7 @@ const SyncStage = vsr.SyncStage;
 const SyncTarget = vsr.SyncTarget;
 const ClientSessions = vsr.ClientSessions;
 
-const log = covered.wrap_log(std.log.scoped(.replica));
+const log = marks.wrap_log(std.log.scoped(.replica));
 const tracer = @import("../tracer.zig");
 
 pub const Status = enum {
@@ -4675,7 +4675,7 @@ pub fn ReplicaType(
                             // This SV is guaranteed to have originated after the replica crash,
                             // it is safe to use to determine the head op.
                         } else {
-                            log.covered.debug("{}: on_{s}: ignoring (recovering_head, nonce mismatch)", .{
+                            log.mark.debug("{}: on_{s}: ignoring (recovering_head, nonce mismatch)", .{
                                 self.replica,
                                 command,
                             });

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -12,7 +12,7 @@ const vsr = @import("../vsr.zig");
 const Process = @import("../testing/cluster/message_bus.zig").Process;
 const Message = @import("../message_pool.zig").MessagePool.Message;
 const parse_table = @import("../testing/table.zig").parse;
-const covered = @import("../testing/covered.zig");
+const marks = @import("../testing/marks.zig");
 const StateMachineType = @import("../testing/state_machine.zig").StateMachineType;
 const Cluster = @import("../testing/cluster.zig").ClusterType(StateMachineType);
 const LinkFilter = @import("../testing/cluster/network.zig").LinkFilter;
@@ -258,7 +258,7 @@ test "Cluster: recovery: recovering_head, outdated start view" {
     try expectEqual(b1.status(), .recovering_head);
     try expectEqual(b1.op_head(), 20);
 
-    const mark = covered.mark("ignoring (recovering_head, nonce mismatch)");
+    const mark = marks.check("ignoring (recovering_head, nonce mismatch)");
     a.stop();
     b1.replay_recorded();
     t.run();


### PR DESCRIPTION
After chatting today with Joran I realized that "coverage" is the wrong word here. This is a very poor implementation of coverage indeed, as it requires you to manually annotate the code, instead of relying on the computer to do the job.

But coverage isn't the point. What we actually do here is traceability --- linking two artifacts, source code and tests, together, to make sure that they motivate each over.

Coverage answers the question "Is this tested?". Marks answer "Why this code needs to exist?"