### PR TITLE
Docs: Don't refer to WAL entries as "journal entries"

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -11,13 +11,13 @@ const schema = @import("../lsm/schema.zig");
 
 const checksum_body_empty = vsr.checksum(&.{});
 
-/// Network message and journal entry header:
+/// Network message, prepare, and grid block header:
 /// We reuse the same header for both so that prepare messages from the primary can simply be
 /// journalled as is by the backups without requiring any further modification.
 pub const Header = extern struct {
     /// A checksum covering only the remainder of this header.
     /// This allows the header to be trusted without having to recv() or read() the associated body.
-    /// This checksum is enough to uniquely identify a network message or journal entry.
+    /// This checksum is enough to uniquely identify a network message or prepare.
     checksum: u128,
 
     // TODO(zig): When Zig supports u256 in extern-structs, merge this into `checksum`.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -200,7 +200,7 @@ pub fn ReplicaType(
         /// A distributed fault-tolerant clock for lower and upper bounds on the primary's wall clock:
         clock: Clock,
 
-        /// The persistent log of hash-chained journal entries:
+        /// The persistent log of hash-chained prepares:
         journal: Journal,
 
         /// ClientSessions records for each client the latest session and the latest committed reply.


### PR DESCRIPTION
Avoid overloading the term "journal entry" – "journal entries" can mean financial transactions/transfers too!

(Note that in `journal.zig` we still refer to these as "entries"... my goal here is just to not let that spread outside journal.zig!)