### PR TITLE
vopr: correct false assertion in liveness checker

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -521,8 +521,7 @@ pub const Simulator = struct {
         if (core_recovering_head == 0) return false;
 
         const quorums = vsr.quorums(simulator.options.cluster.replica_count);
-        assert(quorums.view_change > core_replicas - core_recovering_head);
-        return true;
+        return quorums.view_change > core_replicas - core_recovering_head;
     }
 
     // Returns a header for a prepare which can't be repaired by the core due to storage faults.


### PR DESCRIPTION
It might be the case that:

* cluster is stuck due to a missing prepare
* and yet there's a single replica in recovering head

Seed: 17563231628283278428
Context: https://github.com/tigerbeetle/tigerbeetle/pull/933
