### PR TITLE
vsr: assert that view headers have correct command on the write path

### DIFF
--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -884,6 +884,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
             assert(superblock.staging.vsr_state.log_view <= update.log_view);
             assert(superblock.staging.vsr_state.log_view < update.log_view or
                 superblock.staging.vsr_state.view < update.view);
+            assert((update.headers.command == .start_view and update.log_view == update.view) or
+                (update.headers.command == .do_view_change and update.log_view < update.view));
             // Usually the op-head is ahead of the commit_min. But this may not be the case, due to
             // state sync that ran after the view_durable_update was queued, but before it executed.
             maybe(superblock.staging.vsr_state.checkpoint.commit_min >


### PR DESCRIPTION
In the superblock, we do

    pub fn vsr_headers(superblock: *const SuperBlockHeader) vsr.Headers.ViewChangeSlice {
        return vsr.Headers.ViewChangeSlice.init(
            if (superblock.vsr_state.log_view < superblock.vsr_state.view)
                .do_view_change
            else
                .start_view,
            superblock.vsr_headers_all[0..superblock.vsr_headers_count],
        );
    }

Let's assert that this command-deducing logic is consistent with what we actually write.