### PR TITLE
vopr: default to short log

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -438,8 +438,6 @@ pub fn build(b: *std.Build) !void {
         );
 
         const SimulatorLog = enum { full, short };
-        const default_simulator_log =
-            if (simulator_mode == .ReleaseSafe) SimulatorLog.short else .full;
         simulator_options.addOption(
             SimulatorLog,
             "log",
@@ -447,7 +445,7 @@ pub fn build(b: *std.Build) !void {
                 SimulatorLog,
                 "simulator-log",
                 "Log only state transitions (short) or everything (full).",
-            ) orelse default_simulator_log,
+            ) orelse .short,
         );
 
         const simulator = b.addExecutable(.{


### PR DESCRIPTION
It seems the original logic here was "when we debug a seed, we run in debug, and we want full log for a single seed", but this doesn't work well in practice, because full log is much too verbose. If I run with log-full, I pretty much always want `-Drelease` and also to pipe the log to a file.

Let's simplify this.