### PR TITLE
docs: move two-phase transfers out of reference and into guide

### DIFF
--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -74,7 +74,7 @@ What specific guarantees does TigerBeetle provide to applications?
 
 - Transfers are immutable — once created, they are never modified.
 - There is at most one `Transfer` with a particular `id`.
-- A [pending transfer](../reference/transfers.md#pending-transfer) resolves at most once.
+- A [pending transfer](./two-phase-transfers.md#reserve-funds-pending-transfer) resolves at most once.
 - Transfer [timeouts](../reference/transfers.md#timeout) are deterministic, driven
   by the cluster's timestamp.
 

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -137,10 +137,7 @@ If this transfer will post or void a pending transfer, `pending_id`
 references that pending transfer. If this is not a post or void
 transfer, it must be zero.
 
-See also:
-* [Pending Transfer](#pending-transfer)
-* [Post-Pending Transfer](#post-pending-transfer)
-* [Void-Pending Transfer](#void-pending-transfer)
+See the section on [Two-Phase Transfers](../design/two-phase-transfers.md) for more information on how the `pending_id` is used.
 
 Constraints:
 
@@ -306,15 +303,15 @@ fields.
 
 #### `flags.pending`
 
-Mark the transfer as a [pending transfer](#pending-transfer).
+Mark the transfer as a [pending transfer](../design/two-phase-transfers.md#reserve-funds-pending-transfer).
 
 #### `flags.post_pending_transfer`
 
-Mark the transfer as a [post-pending transfer](#post-pending-transfer).
+Mark the transfer as a [post-pending transfer](../design/two-phase-transfers.md#post-pending-transfer).
 
 #### `flags.void_pending_transfer`
 
-Mark the transfer as a [void-pending transfer](#void-pending-transfer).
+Mark the transfer as a [void-pending transfer](../design/two-phase-transfers.md#void-pending-transfer).
 
 #### `flags.balancing_debit`
 


### PR DESCRIPTION
There is a fair amount of detail about two-phase transfers in the reference section. This attempts to centralize all of the information about them in the dedicated guide page.