### PR TITLE
Test/Marks: Log err vs warn

### DIFF
--- a/src/testing/marks.zig
+++ b/src/testing/marks.zig
@@ -77,10 +77,7 @@ pub fn check(name: []const u8) Mark {
 pub fn wrap_log(comptime base: anytype) type {
     if (builtin.is_test) {
         return struct {
-            pub const err = warn;
-            pub const warn = base.warn;
-            pub const info = base.info;
-            pub const debug = base.debug;
+            pub usingnamespace base;
 
             pub const mark = struct {
                 pub fn err(comptime fmt: []const u8, args: anytype) void {
@@ -106,11 +103,7 @@ pub fn wrap_log(comptime base: anytype) type {
         };
     } else {
         return struct {
-            pub const err = warn;
-            pub const warn = base.warn;
-            pub const info = base.info;
-            pub const debug = base.debug;
-
+            pub usingnamespace base;
             pub const mark = base;
         };
     }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -30,7 +30,7 @@ const SyncStage = vsr.SyncStage;
 const SyncTarget = vsr.SyncTarget;
 const ClientSessions = vsr.ClientSessions;
 
-const log = marks.wrap_log(std.log.scoped(.replica));
+const log = marks.wrap_log(stdx.log.scoped(.replica));
 const tracer = @import("../tracer.zig");
 
 pub const Status = enum {


### PR DESCRIPTION
https://github.com/tigerbeetle/tigerbeetle/pull/1607 changed `replica.zig`'s logger from

    const log = stdx.log.scoped(.replica);

to

    const log = covered.wrap_log(std.log.scoped(.replica));

`stdx.log`'s job was to downgrade `log.err()` to `log.warn()` during tests, since the former will trigger a test failure. (See `test_runner.zig` `log_err_count`). `marks.wrap_log()` handled this properly for `wrap_log().err`, but not `wrap_log().mark.err()`.

...But it (unexpectedly) works anyway (in Zig 0.11). That is, the test (`"Cluster: view-change: DVC, 2/3 faulty header stall"`) hit the `log.err()` (`"quorum received, deadlocked"`), and the test runner prints the messages as errors, but then it doesn't exit with code 1. I don't understand this!

Zig `0.12.0-dev.575+fb6fff256` failed as I would expect, but I don't see any differences in the test runner code that would account for this.