### PR TITLE
docs: data modeling tweaks

### DIFF
--- a/docs/design/client-requests.md
+++ b/docs/design/client-requests.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Client Requests
 
 A _request_ is a [batch](#batching-events) of one or more

--- a/docs/design/client-sessions.md
+++ b/docs/design/client-sessions.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Client Sessions
 
 A _client session_ is a sequence of alternating [requests](./client-requests.md) and replies between a

--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Consistency
 
 TigerBeetle is designed to guard against bugs not only in its

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Data modeling
+# Data Modeling
 
 TigerBeetle is a domain-specific database — its schema of [`Account`s](../reference/accounts.md)
 and [`Transfer`s](../reference/transfers.md) is built-in and fixed. In return for this prescriptive

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -1,9 +1,14 @@
+---
+sidebar_position: 1
+---
+
 # Data modeling
 
 TigerBeetle is a domain-specific database — its schema of [`Account`s](../reference/accounts.md)
 and [`Transfer`s](../reference/transfers.md) is built-in and fixed. In return for this prescriptive
 design, it provides excellent performance, integrated business logic, and powerful invariants.
-This section is a sample of techniques for mapping an application's requirements onto TigerBeetle's
+
+This section is a sample of techniques for mapping your application's requirements onto TigerBeetle's
 data model. Which (if any) of these techniques are suitable is highly application-specific.
 
 When possible, round trips and coordination can be minimized by encoding application invariants

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -181,3 +181,17 @@ Random identifiers are not recommended – they can't take advantage of all of t
 
 For maximum throughput, use [time-based identifiers](#time-based-identifiers) instead.
 (Random identifiers have ~10% lower throughput than strictly-increasing ULIDs).
+
+## `ledger`
+
+The `ledger` identifier on [`Account`s](../reference/accounts.md#ledger) partitions sets of accounts
+that can directly transact with one another. This is used to separate accounts representing
+different currencies or other asset types.
+
+[Currency exchange](../recipes/currency-exchange.md) or cross-ledger transfers are implemented with
+two or more linked transfers.
+
+You can also use different ledgers to further partition accounts, beyond asset type. For example, if
+you have a multi-tenant setup where you are tracking balances for your customers' end-users, you
+might have a ledger for each of your customers. If customers have end-user accounts in multiple
+currencies, each of your customers would have multiple ledgers.

--- a/docs/design/two-phase-transfers.md
+++ b/docs/design/two-phase-transfers.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Two-Phase Transfers
 
 A two-phase transfer moves funds in stages:

--- a/docs/reference/account_balances.md
+++ b/docs/reference/account_balances.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Account Balances

--- a/docs/reference/account_filter.md
+++ b/docs/reference/account_filter.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 4
 ---
 
 # Account Filter

--- a/docs/reference/accounts.md
+++ b/docs/reference/accounts.md
@@ -187,7 +187,7 @@ result set to
 
 
 After the chain of account operations has executed, the fact that they were
-linked will not be saved by default.
+linked will not be saved.
 To save the association between accounts, it must be
 [encoded into the data model](../design/data-modeling.md), for example by
 adding an ID to one of the [user data](../design/data-modeling.md#user_data)

--- a/docs/reference/accounts.md
+++ b/docs/reference/accounts.md
@@ -7,12 +7,6 @@ sidebar_position: 1
 An `Account` is a record storing the cumulative effect of committed
 [transfers](./transfers.md).
 
-TigerBeetle uses the same data structures internally and externally. This means
-that when creating accounts, you will need to set temporary values for certain
-fields that TigerBeetle is responsible for. For example, you will set the
-[`timestamp`](#timestamp) field to `0` when creating an account and then
-TigerBeetle will set the field to the timestamp when the operation was executed.
-
 ### Updates
 
 Account fields *cannot be changed by the user* after

--- a/docs/reference/accounts.md
+++ b/docs/reference/accounts.md
@@ -29,8 +29,7 @@ Constraints:
 
 * Type is 128-bit unsigned integer (16 bytes)
 * Must not be zero or `2^128 - 1` (the highest 128-bit unsigned integer)
-* Must not conflict with another account (note that an account MAY have the same `id` as a transfer,
-but we would recommend avoiding this)
+* Must not conflict with another account
 
 See the [`id` section in the data modeling doc](../design/data-modeling.md#id) for more
 recommendations on choosing an ID scheme.

--- a/docs/reference/accounts.md
+++ b/docs/reference/accounts.md
@@ -120,16 +120,10 @@ Constraints:
 ### `ledger`
 
 This is an identifier that partitions the sets of accounts that can
-transact with each other. Put another way, money cannot transfer
-between two accounts with different `ledger` values. See:
-[`accounts_must_have_the_same_ledger`](./operations/create_transfers.md#accounts_must_have_the_same_ledger).
+transact with each other.
 
-[Currency exchange](../recipes/currency-exchange.md) is implemented with two or more linked
-transfers.
-
-In a typical use case:
-* Map each asset or currency tracked within the database to a distinct ledger. And,
-* Tag each account with the `ledger` indicating the currency in which the balance is denominated.
+See [data modeling](../design/data-modeling.md#ledger) for more details
+about how to think about setting up your ledgers.
 
 Constraints:
 * Type is 32-bit unsigned integer (4 bytes)

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -206,12 +206,10 @@ on YouTube for more details.)
 ### `ledger`
 
 This is an identifier that partitions the sets of accounts that can
-transact with each other. Put another way, money cannot transfer
-between two accounts with different `ledger` values. See:
-[`accounts_must_have_the_same_ledger`](./operations/create_transfers.md#accounts_must_have_the_same_ledger).
+transact with each other.
 
-[Currency exchange](../recipes/currency-exchange.md) is implemented with two or more linked
-transfers.
+See [data modeling](../design/data-modeling.md#ledger) for more details
+about how to think about setting up your ledgers.
 
 Constraints:
 

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -62,8 +62,10 @@ Constraints:
 
 * Type is 128-bit unsigned integer (16 bytes)
 * Must not be zero or `2^128 - 1`
-* Must not conflict with another transfer (note that a transfer MAY have the same `id` as an
-account, but we would recommend avoiding this)
+* Must not conflict with another transfer
+
+See the [`id` section in the data modeling doc](../design/data-modeling.md#id) for more
+recommendations on choosing an ID scheme.
 
 ### `debit_account_id`
 

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -43,12 +43,6 @@ Fields used by each mode of transfer:
 | `flags.balancing_credit`      | optional     | optional | false        | false        |
 | `timestamp`                   | none         | none     | none         | none         |
 
-TigerBeetle uses the same data structures internally and externally. This means 
-that when creating transfers, you will need to set temporary values for certain 
-fields that TigerBeetle is responsible for. For example, you will set the 
-[`timestamp`](#timestamp) field to `0` when creating a transfer and then
-TigerBeetle will set the field to the timestamp when the transfer was executed.
-
 ## Fields
 
 ### `id`

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -291,7 +291,7 @@ Transfers `A` and `E` fail or succeed independently of `B`, `C`, `D`,
 and each other.
 
 After the chain of linked transfers has executed, the fact that they were
-linked will not be saved by default.
+linked will not be saved.
 To save the association between transfers, it must be
 [encoded into the data model](../design/data-modeling.md), for example by
 adding an ID to one of the [user data](../design/data-modeling.md#user_data)


### PR DESCRIPTION
- **docs: set order of pages in design section**
- **docs: remove 'not saved by default'**
- **docs: remove note about accounts and transfers sharing id space**
- **docs: remove note about using same data structures internally**
- **docs: title case Data Modeling**
- **docs: move  details to data modeling**
- **docs: put accounts and transfers first in reference section**
