### PR TITLE
VSR: Log the view that we compare against (view_durable)

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1162,10 +1162,10 @@ pub fn ReplicaType(
             // Switch on the header type so that we don't log opaque bytes for the per-command data.
             switch (message.header.into_any()) {
                 inline else => |header| {
-                    log.debug("{}: on_message: view={} status={} {}", .{
+                    log.debug("{}: on_message: view={} status={s} {}", .{
                         self.replica,
                         self.view,
-                        self.status,
+                        @tagName(self.status),
                         header,
                     });
                 },

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8392,10 +8392,11 @@ pub fn ReplicaType(
 
             if (candidate.view > self.view_durable()) {
                 log.mark.debug("{}: on_{s}: jump_sync_target: ignoring, newer view" ++
-                    " (view={} candidate.view={})", .{
+                    " (view={} view_durable={} candidate.view={})", .{
                     self.replica,
                     @tagName(header.command),
                     self.view,
+                    self.view_durable(),
                     candidate.view,
                 });
                 return;


### PR DESCRIPTION
Ran into this on my upgrade branch:

```
[debug] (replica): 5: on_ping: jump_sync_target: ignoring, newer view (view=27 candidate.view=27)
```