### PR TITLE
VSR/Eviction: Add Header.Eviction.reason

### DIFF
--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -542,8 +542,11 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(eviction.header.client == self.id);
             assert(eviction.header.view >= self.view);
 
-            log.err("{}: session evicted: too many concurrent client sessions", .{self.id});
-            @panic("session evicted: too many concurrent client sessions");
+            log.err("{}: session evicted: reason={s}", .{
+                self.id,
+                @tagName(eviction.header.reason),
+            });
+            @panic("session evicted");
         }
 
         fn on_pong_client(self: *Self, pong: *const Message.PongClient) void {


### PR DESCRIPTION
Allow the cluster to signal to the client why their request is being rejected.

Right now there is only `Reason.no_session`, but as part of upgrades the cluster will use eviction messages to inform clients that they are running an incompatible version.