### PR TITLE
VSR: Header.release

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -367,6 +367,7 @@ pub const AOFReplayClient = struct {
                 .parent = 0,
                 .session = 0,
                 .request = 0,
+                .release = 1, // TODO Use the real release number.
             };
 
             self.client.raw_request(@intFromPtr(self), AOFReplayClient.replay_callback, message);
@@ -612,6 +613,7 @@ test "aof write / read" {
         .cluster = 0,
         .timestamp = 0,
         .checkpoint_id = 0,
+        .release = 1, // TODO Use the real release number.
         .command = .prepare,
         .operation = @enumFromInt(4),
         .size = @intCast(@sizeOf(Header) + demo_payload.len),

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -96,6 +96,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
                 .command = .request,
                 .operation = vsr.Operation.from(Self.StateMachine, operation),
                 .size = @intCast(@sizeOf(Header) + body_size),
+                .release = 1, // TODO Use the real release number.
             };
 
             return Batch{ .message = message_request };

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -448,6 +448,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             const message = request_message.build(.request);
 
             message.header.* = .{
+                .release = 1, // TODO Use the real release number.
                 .client = client.id,
                 .request = undefined, // Set by client.raw_request.
                 .cluster = client.cluster,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1057,6 +1057,7 @@ pub const Headers = struct {
     fn dvc_blank(op: u64) Header.Prepare {
         return .{
             .command = .prepare,
+            .release = 0,
             .operation = .reserved,
             .op = op,
             .cluster = 0,
@@ -1214,6 +1215,7 @@ test "Headers.ViewChangeSlice.view_for_op" {
             .client = 6,
             .request = 7,
             .command = .prepare,
+            .release = 1,
             .operation = @as(Operation, @enumFromInt(constants.vsr_operations_reserved + 8)),
             .op = 9,
             .view = 10,
@@ -1226,6 +1228,7 @@ test "Headers.ViewChangeSlice.view_for_op" {
             .client = 3,
             .request = 4,
             .command = .prepare,
+            .release = 1,
             .operation = @as(Operation, @enumFromInt(constants.vsr_operations_reserved + 5)),
             .op = 6,
             .view = 7,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -373,6 +373,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 .request = undefined,
                 .cluster = self.cluster,
                 .command = .request,
+                .release = 1, // TODO Use the real release number.
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @intCast(@sizeOf(Header) + body_size),
             };
@@ -698,6 +699,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             const ping = Header.PingClient{
                 .command = .ping_client,
                 .cluster = self.cluster,
+                .release = 1, // TODO Use the real release number.
                 .client = self.id,
             };
 
@@ -768,6 +770,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 .cluster = self.cluster,
                 .command = .request,
                 .operation = .register,
+                .release = 1, // TODO Use the real release number.
             };
 
             assert(self.request_number == 0);
@@ -1046,6 +1049,7 @@ test "Client Batching" {
                 .view = message.header.view,
                 .command = .reply,
                 .replica = message.header.replica,
+                .release = 1, // TODO Use the real release number.
                 .request_checksum = message.header.checksum,
                 .client = message.header.client,
                 .context = undefined, // computed below.

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -543,9 +543,10 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(eviction.header.client == self.id);
             assert(eviction.header.view >= self.view);
 
-            log.err("{}: session evicted: reason={s}", .{
+            log.err("{}: session evicted: reason={s} (cluster_release={})", .{
                 self.id,
                 @tagName(eviction.header.reason),
+                eviction.header.release,
             });
             @panic("session evicted");
         }

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -48,7 +48,7 @@ pub const Header = extern struct {
     view: u32,
 
     /// The version of the protocol implementation that originated this message.
-    version: u16,
+    protocol: u16,
 
     /// The Viewstamped Replication protocol command for this message.
     command: Command,
@@ -162,7 +162,7 @@ pub const Header = extern struct {
         if (self.checksum_padding != 0) return "checksum_padding != 0";
         if (self.checksum_body_padding != 0) return "checksum_body_padding != 0";
         if (self.nonce_reserved != 0) return "nonce_reserved != 0";
-        if (self.version != vsr.Version) return "version != Version";
+        if (self.protocol != vsr.Version) return "protocol != Version";
         if (self.size < @sizeOf(Header)) return "size < @sizeOf(Header)";
         if (self.epoch != 0) return "epoch != 0";
         if (!stdx.zeroed(&self.reserved_frame)) return "reserved_frame != 0";
@@ -259,7 +259,7 @@ pub const Header = extern struct {
         size: u32,
         epoch: u32 = 0,
         view: u32 = 0,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
         reserved_frame: [16]u8,
@@ -286,7 +286,7 @@ pub const Header = extern struct {
         // NB: unlike every other message, pings and pongs use on disk view, rather than in-memory
         // view, to avoid disrupting clock synchronization while the view is being updated.
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -325,7 +325,7 @@ pub const Header = extern struct {
         // NB: unlike every other message, pings and pongs use on disk view, rather than in-memory
         // view, to avoid disrupting clock synchronization while the view is being updated.
         view: u32 = 0,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -358,7 +358,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0, // Always 0.
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -390,7 +390,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -418,7 +418,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0, // Always 0.
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -511,7 +511,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -663,7 +663,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -733,7 +733,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -790,7 +790,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -835,7 +835,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -863,7 +863,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -907,7 +907,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -942,7 +942,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -972,7 +972,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1006,7 +1006,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1039,7 +1039,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1074,7 +1074,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1101,7 +1101,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32,
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1149,7 +1149,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1181,7 +1181,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8 = 0, // Always 0.
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1221,7 +1221,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,
@@ -1252,7 +1252,7 @@ pub const Header = extern struct {
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
-        version: u16 = vsr.Version,
+        protocol: u16 = vsr.Version,
         command: Command,
         replica: u8,
         reserved_frame: [16]u8 = [_]u8{0} ** 16,

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -166,10 +166,15 @@ pub const Header = extern struct {
         if (self.checksum_padding != 0) return "checksum_padding != 0";
         if (self.checksum_body_padding != 0) return "checksum_body_padding != 0";
         if (self.nonce_reserved != 0) return "nonce_reserved != 0";
-        if (self.protocol != vsr.Version) return "protocol != Version";
         if (self.size < @sizeOf(Header)) return "size < @sizeOf(Header)";
         if (self.epoch != 0) return "epoch != 0";
         if (!stdx.zeroed(&self.reserved_frame)) return "reserved_frame != 0";
+
+        if (self.command == .block) {
+            if (self.protocol > vsr.Version) return "block: protocol > Version";
+        } else {
+            if (self.protocol != vsr.Version) return "protocol != Version";
+        }
 
         switch (self.into_any()) {
             inline else => |command_header| return command_header.invalid_header(),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2417,6 +2417,8 @@ pub fn ReplicaType(
             assert(message.header.command == .block);
             assert(message.header.size <= constants.block_size);
             assert(message.header.address > 0);
+            assert(message.header.protocol <= vsr.Version);
+            maybe(message.header.protocol < vsr.Version);
 
             if (self.grid.callback == .cancel) {
                 assert(self.grid.read_global_queue.count == 0);
@@ -6573,6 +6575,12 @@ pub fn ReplicaType(
             }
 
             assert(message.header.cluster == self.cluster);
+
+            if (message.header.command == .block) {
+                assert(message.header.protocol <= vsr.Version);
+            } else {
+                assert(message.header.protocol == vsr.Version);
+            }
 
             // TODO According to message.header.command, assert on the destination replica.
             switch (message.header.into_any()) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1259,6 +1259,7 @@ pub fn ReplicaType(
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view_durable(), // Don't drop pongs while the view is being updated.
+                .release = 1, // TODO Use the real release number.
                 // Copy the ping's monotonic timestamp to our pong and add our wall clock sample:
                 .ping_timestamp_monotonic = message.header.ping_timestamp_monotonic,
                 .pong_timestamp_wall = @bitCast(self.clock.realtime()),
@@ -1294,6 +1295,7 @@ pub fn ReplicaType(
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view,
+                .release = 1, // TODO Use the real release number.
             }));
         }
 
@@ -2540,6 +2542,7 @@ pub fn ReplicaType(
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .view = self.view_durable(), // Don't drop pings while the view is being updated.
+                .release = 1, // TODO Use the real release number.
                 .checkpoint_id = self.superblock.working.checkpoint_id(),
                 .checkpoint_op = self.op_checkpoint(),
                 .ping_timestamp_monotonic = self.clock.monotonic(),
@@ -3793,6 +3796,7 @@ pub fn ReplicaType(
                 .cluster = prepare.header.cluster,
                 .replica = prepare.header.replica,
                 .view = prepare.header.view,
+                .release = 1, // TODO Use the real release number.
                 .op = prepare.header.op,
                 .timestamp = prepare.header.timestamp,
                 .commit = prepare.header.op,
@@ -5187,6 +5191,7 @@ pub fn ReplicaType(
                 .cluster = self.cluster,
                 .size = request_header.size,
                 .view = self.view,
+                .release = 1, // TODO Use the real release number.
                 .command = .prepare,
                 .replica = self.replica,
                 .parent = latest_entry.checksum,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6446,6 +6446,7 @@ pub fn ReplicaType(
             self.send_header_to_client(client, @bitCast(Header.Eviction{
                 .command = .eviction,
                 .cluster = self.cluster,
+                .release = 1, // TODO Use the real release number.
                 .replica = self.replica,
                 .view = self.view,
                 .client = client,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -344,6 +344,7 @@ const Environment = struct {
             .client = 1,
             .request = 1,
             .command = .prepare,
+            .release = 1,
             .operation = @as(vsr.Operation, @enumFromInt(constants.vsr_operations_reserved + 1)),
             .op = env.superblock.staging.vsr_state.checkpoint.commit_min + 1,
             .timestamp = 1,


### PR DESCRIPTION
### Rename `Header.version` to `Header.protocol`

To disambiguate from the "release" version.

The difference is:

- (Wire) protocol version changes very infrequently.
- Release version changes with every (weekly) release, and is independent per state-machine/release-infrastructure.

### Add `Header.release`

Not all header types set a (nonzero) `release`. Similar to `Header.view`, there are enough headers that _do_ require a `release` that we include it in the frame anyway.

Rationale for which messages have `release == 0` vs `release != 0`:

- `Request.release` is the client's `release`.
- `Prepare.release` and ~`PrepareOk.release`~ `Reply.release` are _the same as_ `Request.release`. This is _not necessarily_ the same as the release that the cluster is running as it commits this op.
- Clients inform the cluster of their release.
- The cluster informs the clients of their release. (So this can be escalated to a upgrade warning/error if necessary.)

Nonzero `Header.release` fields are currently set to a placeholder (`1`).

### Ease protocol restriction for grid blocks

Even if we make a breaking protocol change, the legacy grid blocks must be handled indefinitely, since blocks are sent unwrapped over the network.