### PR TITLE
VSR: Add `release` to grid block header

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -816,8 +816,11 @@ pub fn CompactionType(
                 // If the input is exhausted then we need to flush all blocks before finishing.
                 (input_exhausted and !table_builder.data_block_empty()))
             {
+                const release =
+                    compaction.context.grid.superblock.working.vsr_state.checkpoint.release;
                 table_builder.data_block_finish(.{
                     .cluster = compaction.context.grid.superblock.working.cluster,
+                    .release = release,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
                     .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
                     .tree_id = compaction.tree_config.id,
@@ -830,8 +833,11 @@ pub fn CompactionType(
                 // If the input is exhausted then we need to flush all blocks before finishing.
                 (input_exhausted and !table_builder.index_block_empty()))
             {
+                const release =
+                    compaction.context.grid.superblock.working.vsr_state.checkpoint.release;
                 const table = table_builder.index_block_finish(.{
                     .cluster = compaction.context.grid.superblock.working.cluster,
+                    .release = release,
                     .address = compaction.context.grid.acquire(compaction.grid_reservation.?),
                     .snapshot_min = snapshot_min_for_table_output(compaction.context.op_min),
                     .tree_id = compaction.tree_config.id,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -895,6 +895,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 .snapshot = 0, // TODO(snapshots): Set this properly; it is useful for debugging.
                 .size = undefined,
                 .command = .block,
+                .release = manifest_log.superblock.working.vsr_state.checkpoint.release,
                 .metadata_bytes = undefined, // Set by close_block().
                 .block_type = .manifest,
             };

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -47,6 +47,7 @@ pub inline fn header_from_block(block: BlockPtrConst) *const vsr.Header.Block {
     assert(header.size <= block.len);
     assert(header.block_type.valid());
     assert(header.block_type != .reserved);
+    assert(header.release > 0);
     return header;
 }
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -298,6 +298,7 @@ pub fn TableType(
 
             const DataFinishOptions = struct {
                 cluster: u128,
+                release: u16,
                 address: u64,
                 snapshot_min: u64,
                 tree_id: u16,
@@ -324,6 +325,7 @@ pub fn TableType(
                     .snapshot = options.snapshot_min,
                     .size = @sizeOf(vsr.Header) + builder.value_count * @sizeOf(Value),
                     .command = .block,
+                    .release = options.release,
                     .block_type = .data,
                 };
 
@@ -395,6 +397,7 @@ pub fn TableType(
 
             const IndexFinishOptions = struct {
                 cluster: u128,
+                release: u16,
                 address: u64,
                 snapshot_min: u64,
                 tree_id: u16,
@@ -424,6 +427,7 @@ pub fn TableType(
                     .snapshot = options.snapshot_min,
                     .size = index.size,
                     .command = .block,
+                    .release = options.release,
                     .block_type = .index,
                 };
 

--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -400,6 +400,7 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
                 .snapshot = 0, // TODO(snapshots): Set this properly; it is useful for debugging.
                 .size = @sizeOf(vsr.Header) + chunk_size,
                 .command = .block,
+                .release = trailer.grid.?.superblock.working.vsr_state.checkpoint.release,
                 .block_type = trailer.trailer_type.block_type(),
             };
             trailer.size_transferred += chunk_size;

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -669,6 +669,7 @@ pub fn GridType(comptime Storage: type) type {
         ) void {
             const header = schema.header_from_block(block.*);
             assert(header.cluster == grid.superblock.working.cluster);
+            assert(header.release <= grid.superblock.working.vsr_state.checkpoint.release);
 
             assert(grid.superblock.opened);
             assert(grid.callback != .cancel);

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -594,6 +594,7 @@ pub fn GridType(comptime Storage: type) type {
 
             const block_header = schema.header_from_block(block);
             assert(block_header.cluster == grid.superblock.working.cluster);
+            assert(block_header.release <= grid.superblock.working.vsr_state.checkpoint.release);
 
             var reads_iterator = grid.read_global_queue.peek();
             while (reads_iterator) |read| : (reads_iterator = read.next) {
@@ -822,6 +823,7 @@ pub fn GridType(comptime Storage: type) type {
             const header = schema.header_from_block(cache_block);
             assert(header.address == address);
             assert(header.cluster == grid.superblock.working.cluster);
+            assert(header.release <= grid.superblock.working.vsr_state.checkpoint.release);
 
             if (header.checksum == checksum) {
                 if (constants.verify and
@@ -1104,6 +1106,7 @@ pub fn GridType(comptime Storage: type) type {
             if (result == .valid) {
                 const header = schema.header_from_block(result.valid);
                 assert(header.cluster == grid.superblock.working.cluster);
+                assert(header.release <= grid.superblock.working.vsr_state.checkpoint.release);
                 assert(header.address == read.address);
                 assert(header.checksum == read.checksum);
             }

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1242,7 +1242,8 @@ pub const Header = extern struct {
         epoch: u32 = 0,
         view: u32 = 0, // Always 0.
         protocol: u16 = vsr.Version,
-        release: u16 = 0,
+        /// The release that generated this block.
+        release: u16,
         command: Command,
         replica: u8 = 0, // Always 0.
         reserved_frame: [14]u8 = [_]u8{0} ** 14,
@@ -1261,7 +1262,7 @@ pub const Header = extern struct {
             if (self.size > constants.block_size) return "size > block_size";
             if (self.size == @sizeOf(Header)) return "size = @sizeOf(Header)";
             if (self.view != 0) return "view != 0";
-            if (self.release != 0) return "release != 0";
+            if (self.release == 0) return "release == 0";
             if (self.replica != 0) return "replica != 0";
             if (self.address == 0) return "address == 0"; // address ≠ 0
             if (!self.block_type.valid()) return "block_type invalid";


### PR DESCRIPTION
Each block's `header.release` is set to the release that is running when the block is generated.

The purpose of including `release` on blocks is for assertions and debugging/forensics. It doesn't impact any logic.