### PR TITLE
docs: clarify more language in the Design section

### DIFF
--- a/docs/design/client-requests.md
+++ b/docs/design/client-requests.md
@@ -31,7 +31,7 @@ outcome of the next one in the request. These chains of events will all succeed 
 
 The last Transfer or Account in a batch may never have the `flags.linked` set, as it would leave a
 chain open-ended. Attempting to do so will result in the
-[`linked_event_chain_open`](./operations/create_transfers.md#linked_event_chain_open) error.
+[`linked_event_chain_open`](../reference/operations/create_transfers.md#linked_event_chain_open) error.
 
 Multiple chains of events may coexist within a batch to succeed or fail independently. 
 
@@ -39,7 +39,7 @@ Events within a chain are executed in order, or are rolled back on error, so tha
 event in the chain is visible to the next. Each chain is either visible or invisible as a unit to
 subsequent transfers after the chain. The event that was the first to fail within a chain will have
 a unique error result. Other events in the chain will have their error result set to
-[`linked_event_failed`](./operations/create_transfers.md#linked_event_failed).
+[`linked_event_failed`](../reference/operations/create_transfers.md#linked_event_failed).
 
 Consider this set of Transfers as part of a batch:
 
@@ -52,7 +52,7 @@ Consider this set of Transfers as part of a batch:
 | `E`      | `4`                | `false`      |
 
 If any of transfers `B`, `C`, or `D` fail (for example, due to
-[`exceeds_credits`](./operations/create_transfers.md#exceeds_credits), then `B`, `C`, and `D` will
+[`exceeds_credits`](../reference/operations/create_transfers.md#exceeds_credits), then `B`, `C`, and `D` will
 all fail. They are linked.
 
 Transfers `A` and `E` fail or succeed independently of `B`, `C`, `D`, and each other.

--- a/docs/design/client-requests.md
+++ b/docs/design/client-requests.md
@@ -7,16 +7,60 @@ sidebar_position: 3
 A _request_ is a [batch](#batching-events) of one or more [operation
 events](../reference/operations/index.md) sent to the cluster in a single message.
 
-- All events within a request batch must be of the same
-  [operation](../reference/operations/index.md) type. You cannot, for example, create accounts and
-  transfers in the same request.
-- The cluster commits an entire batch at once. Events are applied in series, such that successive
-  events observe the effects of previous ones and event timestamps are [totally
-  ordered](time.md#timestamps-are-totally-ordered).
-- Events within a request [succeed or fail](../reference/operations/create_transfers.md#result)
-  independently unless they are explicitly [linked](../reference/transfers.md#flagslinked).
-- The cluster returns a single reply for each unique request it commits. The reply contains a
-  [result](../reference/operations/create_transfers.md#result) for each event in the request.
+All events within a request batch must be of the same [operation](../reference/operations/index.md)
+type. You cannot, for example, create accounts and transfers in the same request.
+
+The cluster commits an entire batch at once. Events are applied in series, such that successive
+events observe the effects of previous ones and event timestamps are [totally
+ordered](time.md#timestamps-are-totally-ordered).
+
+The cluster returns a single reply for each unique request it commits. The reply contains a
+[result](../reference/operations/create_transfers.md#result) for each event in the request.
+
+## Linked Events
+
+Events within a request [succeed or fail](../reference/operations/create_transfers.md#result)
+independently unless they are explicitly linked using the `flags.linked`
+([`Account.flags.linked`](../reference/accounts.md#flagslinked) or
+[`Transfer.flags.linked`](../reference/transfers.md#flagslinked)).
+
+When the `linked` flag is specified, it links the outcome of a Transfer or Account creation with the
+outcome of the next one in the request. These chains of events will all succeed or fail together.
+
+**The last event in a chain is denoted by the first Transfer or Account without this flag.**
+
+The last Transfer or Account in a batch may never have the `flags.linked` set, as it would leave a
+chain open-ended. Attempting to do so will result in the
+[`linked_event_chain_open`](./operations/create_transfers.md#linked_event_chain_open) error.
+
+Multiple chains of events may coexist within a batch to succeed or fail independently. 
+
+Events within a chain are executed in order, or are rolled back on error, so that the effect of each
+event in the chain is visible to the next. Each chain is either visible or invisible as a unit to
+subsequent transfers after the chain. The event that was the first to fail within a chain will have
+a unique error result. Other events in the chain will have their error result set to
+[`linked_event_failed`](./operations/create_transfers.md#linked_event_failed).
+
+Consider this set of Transfers as part of a batch:
+
+| Transfer | Index within batch | flags.linked |
+|----------|--------------------|--------------|
+| `A`      | `0`                | `false`      |
+| `B`      | `1`                | `true`       |
+| `C`      | `2`                | `true`       |
+| `D`      | `3`                | `false`      |
+| `E`      | `4`                | `false`      |
+
+If any of transfers `B`, `C`, or `D` fail (for example, due to
+[`exceeds_credits`](./operations/create_transfers.md#exceeds_credits), then `B`, `C`, and `D` will
+all fail. They are linked.
+
+Transfers `A` and `E` fail or succeed independently of `B`, `C`, `D`, and each other.
+
+After the chain of linked events has executed, the fact that they were linked will not be saved. To
+save the association between Transfers or Accounts, it must be [encoded into the data
+model](../design/data-modeling.md), for example by adding an ID to one of the [user
+data](../design/data-modeling.md#user_data) fields.
 
 ## Batching Events
 

--- a/docs/design/client-requests.md
+++ b/docs/design/client-requests.md
@@ -52,7 +52,7 @@ Consider this set of Transfers as part of a batch:
 | `E`      | `4`                | `false`      |
 
 If any of transfers `B`, `C`, or `D` fail (for example, due to
-[`exceeds_credits`](../reference/operations/create_transfers.md#exceeds_credits), then `B`, `C`, and `D` will
+[`exceeds_credits`](../reference/operations/create_transfers.md#exceeds_credits)), then `B`, `C`, and `D` will
 all fail. They are linked.
 
 Transfers `A` and `E` fail or succeed independently of `B`, `C`, `D`, and each other.

--- a/docs/design/client-sessions.md
+++ b/docs/design/client-sessions.md
@@ -4,8 +4,8 @@ sidebar_position: 4
 
 # Client Sessions
 
-A _client session_ is a sequence of [requests](./client-requests.md) and replies sent between a client
-and a cluster.
+A _client session_ is a sequence of [requests](./client-requests.md) and replies sent between a
+client and a cluster.
 
 A client session may have **at most one in-flight request** — i.e. at most one unique request on the
 network for which a reply has not been received. This simplifies consistency and allows the cluster

--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -38,15 +38,15 @@ applications?
   or [`flags.linked`](../reference/transfers.md#flagslinked)).
 - Multiple client sessions may receive replies [out of order](#reply-order) relative to one another.
   For example, if two clients submit requests around the same time, the client whose request is
-  commmitted first might receive the reply later.
+  committed first might receive the reply later.
 - A client session can consider a request executed when it receives a reply for the request.
 
 #### [Requests](./client-requests.md)
-> Note that a request refers to a batch, rather than a single operation.
+> Note that a request refers to a batch, rather than a single event.
 
 - A request executes within the cluster at most once.
-- Requests do not [time out](#retries) (a timeout typically implies failure, which cannot be
-  conclusively determined in the context of network faults). Note that individual [pending
+- Requests do not [time out](#retries). A timeout typically implies failure, which cannot be
+  conclusively determined in the context of network faults. Note that individual [pending
   transfers](./two-phase-transfers.md) within a request may have
   [timeouts](../reference/transfers.md#timeout).
 - Requests retried by their original client session receive identical replies.
@@ -64,9 +64,9 @@ applications?
 
 - Once committed, an event will always be committed — the cluster's state never backtracks.
 - Within a cluster, object [timestamps are unique and strictly
-  increasing](./time.md#timestamps-are-totally-ordered). For all objects `A` and `B` belonging to
-  the same cluster, `A.timestamp ≠ B.timestamp` and if `A.timestamp < B.timestamp`, then `A` was
-  committed earlier than `B`.
+  increasing](./time.md#timestamps-are-totally-ordered). No two objects within the same cluster will
+  have the same timestamp. Furthermore, the order of the timestamps indicates the order in which the
+  objects were committed.
 - If a client session is terminated and restarts, it is guaranteed to see the effects of updates for
   which the corresponding reply was received prior to termination.
 - If a client session is terminated and restarts, it is _not_ guaranteed to see the effects of
@@ -207,7 +207,8 @@ But suppose the application crashes and restarts immediately after sending its r
   3. _Application_: Crash. Restart.
   4. _Cluster_: Create `A₁`; reply `ok` — but the application session has reset, so this reply never
     reaches the application.
-  5. _Application_: Send "create account" request `A₁` to the cluster with the same ID as in step 1.
+  5. _Application_: Send "create account" request `A₁` to the cluster. The request uses the same ID
+     as in step 1.
   6. _Cluster_: Create `A₁`; reply `exists`.
   7. _Application_: Receive reply `A₁: exists` from the cluster.
   8. _Application_: Set `U₁.account_exists = true`.

--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -22,10 +22,10 @@ to each [client session](./client-sessions.md).
 But consistency models can seem arcane.
 What specific guarantees does TigerBeetle provide to applications?
 
-#### Sessions
+#### [Sessions](./client-sessions.md)
 
-- A client session may have at most one in-flight request.
-- A client session reads its own writes.
+- A client session may have at most one in-flight [request](./client-requests.md).
+- A client session [reads its own writes](https://jepsen.io/consistency/models/read-your-writes), meaning that read operations that happen after a given write operation will observe the effects of the write.
 - A client session observes writes in the order that they occur on the cluster.
 - A client session observes [`debits_posted`](../reference/accounts.md#debits_posted) and
   [`credits_posted`](../reference/accounts.md#credits_posted) as monotonically increasing.
@@ -34,53 +34,53 @@ What specific guarantees does TigerBeetle provide to applications?
 - A client session never observes a broken invariant (e.g.
   [`flags.credits_must_not_exceed_debits`](../reference/accounts.md#flagscredits_must_not_exceed_debits)
   or [`flags.linked`](../reference/transfers.md#flagslinked)).
-- Multiple client sessions may receive replies [out of order](#reply-order) relative to one another.
+- Multiple client sessions may receive replies [out of order](#reply-order) relative to one another. For example, if two clients submit requests around the same time, the client whose request is commmitted first might receive the reply later.
 - A client session can consider a request executed when it receives a reply for the request.
 
-#### Requests
+#### [Requests](./client-requests.md)
+> Note that a request refers to a batch, rather than a single operation.
 
 - A request executes within the cluster at most once.
-- Requests do not [time out](#retries) — a timeout typically implies failure, which cannot be
-  conclusively determined in the context of network faults.
+- Requests do not [time out](#retries) (a timeout typically implies failure, which cannot be
+  conclusively determined in the context of network faults). Note that individual [pending transfers](./two-phase-transfers.md)
+  within a request may have [timeouts](../reference/transfers.md#timeout).
 - Requests retried by their original client session receive identical replies.
 - Requests retried by a different client (same request body, different session) may receive
   [different replies](#consistency-with-foreign-databases).
-- Events within a request are executed in sequential order.
+- Events within a request are executed in sequential order. The effects of a given event will be observable when the next event within that request is applied.
 - Events within a request do not interleave with events from other requests.
   (TODO: Can timeouts interleave batches, or should we shift the batch so that timeouts land
   entirely before/after?)
-- All events within a request batch are committed, or none are.
+- All events within a request batch are committed, or none are. Note that this does not mean that all of the events in a batch will either succeed or fail. Events succeed or fail independently unless they are explicitly [linked](./client-requests.md#linked-events)
 
-#### Events
+#### [Events](../reference/operations/index.md)
 
 - Once committed, an event will always be committed — the cluster's state never backtracks.
-- Within a cluster, object timestamps are unique.
-  For all objects `A` and `B` belonging to the same cluster, `A.timestamp ≠ B.timestamp`.
-- Within a cluster, object timestamps are strictly increasing.
-  For all objects `A` and `B` belonging to the same cluster, if `A.timestamp < B.timestamp`,
-  then `A` was committed earlier than `B`.
-- If a client session is terminated and restarts, it is guaranteed to see updates for which the
+- Within a cluster, object [timestamps are unique and strictly increasing](./time.md#timestamps-are-totally-ordered).
+  For all objects `A` and `B` belonging to the same cluster, `A.timestamp ≠ B.timestamp` and
+  if `A.timestamp < B.timestamp`, then `A` was committed earlier than `B`.
+- If a client session is terminated and restarts, it is guaranteed to see the effects of updates for which the
   corresponding reply was received prior to termination.
-- If a client session is terminated and restarts, it is _not_ guaranteed to see updates for
+- If a client session is terminated and restarts, it is _not_ guaranteed to see the effects of updates for
   which the corresponding reply was _not_ received prior to the restart. Those updates may
   occur at any point in the future, or never. Handling application crash recovery safely requires
   [using `id`s to idempotently retry events](#consistency-with-foreign-databases).
 
-#### Accounts
+#### [Accounts](../reference/accounts.md)
 
-- Accounts are immutable — once created, they are never modified
+- Accounts are immutable. They are never modified once they are successfully created
   (excluding balance fields, which are modified by transfers).
-- There is at most one `Account` with a particular `id`.
-- The sum of all accounts' `debits_pending` equals the sum of all accounts' `credits_pending`.
-- The sum of all accounts' `debits_posted` equals the sum of all accounts' `credits_posted`.
+- There is at most one `Account` with a particular [`id`](../reference/accounts.md#id).
+- The sum of all accounts' [`debits_pending`](../reference/accounts.md#debits_pending) equals the sum of all accounts' [`credits_pending`](../reference/accounts.md#credits_pending).
+- The sum of all accounts' [`debits_posted`](../reference/accounts.md#debits_posted) equals the sum of all accounts' [`credits_posted`](../reference/accounts.md#credits_posted).
 
-#### Transfers
+#### [Transfers](../reference/transfers.md)
 
-- Transfers are immutable — once created, they are never modified.
-- There is at most one `Transfer` with a particular `id`.
+- Transfers are immutable. They are never modified once they are successfully created.
+- There is at most one `Transfer` with a particular [`id`](../reference/transfers.md#id).
 - A [pending transfer](./two-phase-transfers.md#reserve-funds-pending-transfer) resolves at most once.
 - Transfer [timeouts](../reference/transfers.md#timeout) are deterministic, driven
-  by the cluster's timestamp.
+  by the [cluster's timestamp](./time.md#why-tigerbeetle-manages-timestamps).
 
 ### Reply Order
 
@@ -165,8 +165,8 @@ would be misleading. An error would imply that a request did not execute, when t
 TigerBeetle objects may correspond to objects in a foreign data store (e.g. another DBMS). Keeping
 multiple data stores consistent (in sync) is subtle in the context of application process faults.
 
-Object creation events are idempotent, but only the first attempt will return `.ok`,
-while all successive identical attempts return `.exists`. The client may crash after creating
+Object creation events are idempotent, but only the first attempt will return [`.ok`](../reference/operations/create_transfers.md#ok),
+while all successive identical attempts return [`.exists`](../reference/operations/create_transfers.md#exists). The client may crash after creating
 the object, but before receiving the `.ok` reply. Because the session resets, neither that client
 nor any others will see the object's corresponding `.ok` result.
 
@@ -176,7 +176,7 @@ between multiple data stores must treat `.exists` as equivalent to `.ok`.
 #### Example
 
 Suppose that an application creates users within Postgres, and for each user a
-corresponding `Account` in TigerBeetle.
+corresponding `Account` in the TigerBeetle cluster.
 
 This scenario depicts the typical case:
 
@@ -194,8 +194,8 @@ But suppose the application crashes and restarts immediately after sending its r
   2. _Application_: Send "create account" request `A₁` to the cluster.
   3. _Application_: Crash. Restart.
   4. _Cluster_: Create `A₁`; reply `ok` — but the application session has reset,
-    so this reply never reaches the application).
-  5. _Application_: Send "create account" request `A₁` to the cluster.
+    so this reply never reaches the application.
+  5. _Application_: Send "create account" request `A₁` to the cluster with the same ID as in step 1.
   6. _Cluster_: Create `A₁`; reply `exists`.
   7. _Application_: Receive reply `A₁: exists` from the cluster.
   8. _Application_: Set `U₁.account_exists = true`.
@@ -203,8 +203,7 @@ But suppose the application crashes and restarts immediately after sending its r
 In the second case, the application observes that the account is created by receiving `.exists`
 (step 6) instead of `.ok`.
 
-Note that the retry (step 5) reused the same account `id` from the original request (step 2).
-An alternate approach is to generate a new account `id` for each "create account" attempt,
-and perhaps store the account's `id` on `U₁` when it is successfully created.
-Then account creation could be restricted to the `.ok` code — but application restarts would leave
-orphaned accounts in TigerBeetle, which may be confusing for auditing and debugging.
+Note that the retry (step 5) reused the same account `id` from the original request (step 2). We
+recommend using the same `id`, as opposed to generating a new one for each "create account" attempt,
+to avoid leaving orphaned accounts in TigerBeetle if the application were to restart before
+receiving the `.ok` code.

--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -54,13 +54,12 @@ applications?
 - Requests retried by their original client session receive identical replies.
 - Requests retried by a different client (same request body, different session) may receive
   [different replies](#consistency-with-foreign-databases).
-- Events within a request are executed in sequential order. The effects of a given event will be
-  observable when the next event within that request is applied.
-- Events within a request do not interleave with events from other requests. (TODO: Can timeouts
-  interleave batches, or should we shift the batch so that timeouts land entirely before/after?)
+- Events within a request are executed in sequence. The effects of a given event are observable when
+  the next event within that request is applied.
+- Events within a request do not interleave with events from other requests.
 - All events within a request batch are committed, or none are. Note that this does not mean that
-  all of the events in a batch will either succeed or fail. Events succeed or fail independently
-  unless they are explicitly [linked](./client-requests.md#linked-events)
+  all of the events in a batch will succeed, or that all will fail. Events succeed or fail
+  independently unless they are explicitly [linked](./client-requests.md#linked-events)
 
 #### [Events](../reference/operations/index.md)
 

--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -4,37 +4,41 @@ sidebar_position: 5
 
 # Consistency
 
-TigerBeetle is designed to guard against bugs not only in its
-[own code](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md), but
-at the boundaries, in the application code which interfaces with TigerBeetle.
-This is exhibited by the client's API design, which may be surprising (see [Retries](#retries)) when
-contrasted with a more conventional database.
+TigerBeetle is designed to guard against bugs not only in its [own
+code](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md), but at the
+boundaries, in the application code which interfaces with TigerBeetle. This is exhibited by the
+client's API design, which may be surprising (see [Retries](#retries)) when contrasted with a more
+conventional database.
 
-Strict consistency guarantees (at the database level) simplify 1) application logic and 2) error handling
-farther up the stack.
+Strict consistency guarantees (at the database level) simplify 1) application logic and 2) error
+handling farther up the stack.
 
 ## Guarantees
 
-TigerBeetle provides strict serializability
-([serializability + linearizability](http://www.bailis.org/blog/linearizability-versus-serializability/))
-to each [client session](./client-sessions.md).
+TigerBeetle provides strict serializability ([serializability +
+linearizability](http://www.bailis.org/blog/linearizability-versus-serializability/)) to each
+[client session](./client-sessions.md).
 
-But consistency models can seem arcane.
-What specific guarantees does TigerBeetle provide to applications?
+But consistency models can seem arcane. What specific guarantees does TigerBeetle provide to
+applications?
 
 #### [Sessions](./client-sessions.md)
 
 - A client session may have at most one in-flight [request](./client-requests.md).
-- A client session [reads its own writes](https://jepsen.io/consistency/models/read-your-writes), meaning that read operations that happen after a given write operation will observe the effects of the write.
+- A client session [reads its own writes](https://jepsen.io/consistency/models/read-your-writes),
+  meaning that read operations that happen after a given write operation will observe the effects of
+  the write.
 - A client session observes writes in the order that they occur on the cluster.
 - A client session observes [`debits_posted`](../reference/accounts.md#debits_posted) and
-  [`credits_posted`](../reference/accounts.md#credits_posted) as monotonically increasing.
-  That is, a client session will never see `credits_posted` or `debits_posted` decrease.
+  [`credits_posted`](../reference/accounts.md#credits_posted) as monotonically increasing. That is,
+  a client session will never see `credits_posted` or `debits_posted` decrease.
 - A client session never observes uncommitted updates.
 - A client session never observes a broken invariant (e.g.
   [`flags.credits_must_not_exceed_debits`](../reference/accounts.md#flagscredits_must_not_exceed_debits)
   or [`flags.linked`](../reference/transfers.md#flagslinked)).
-- Multiple client sessions may receive replies [out of order](#reply-order) relative to one another. For example, if two clients submit requests around the same time, the client whose request is commmitted first might receive the reply later.
+- Multiple client sessions may receive replies [out of order](#reply-order) relative to one another.
+  For example, if two clients submit requests around the same time, the client whose request is
+  commmitted first might receive the reply later.
 - A client session can consider a request executed when it receives a reply for the request.
 
 #### [Requests](./client-requests.md)
@@ -42,45 +46,52 @@ What specific guarantees does TigerBeetle provide to applications?
 
 - A request executes within the cluster at most once.
 - Requests do not [time out](#retries) (a timeout typically implies failure, which cannot be
-  conclusively determined in the context of network faults). Note that individual [pending transfers](./two-phase-transfers.md)
-  within a request may have [timeouts](../reference/transfers.md#timeout).
+  conclusively determined in the context of network faults). Note that individual [pending
+  transfers](./two-phase-transfers.md) within a request may have
+  [timeouts](../reference/transfers.md#timeout).
 - Requests retried by their original client session receive identical replies.
 - Requests retried by a different client (same request body, different session) may receive
   [different replies](#consistency-with-foreign-databases).
-- Events within a request are executed in sequential order. The effects of a given event will be observable when the next event within that request is applied.
-- Events within a request do not interleave with events from other requests.
-  (TODO: Can timeouts interleave batches, or should we shift the batch so that timeouts land
-  entirely before/after?)
-- All events within a request batch are committed, or none are. Note that this does not mean that all of the events in a batch will either succeed or fail. Events succeed or fail independently unless they are explicitly [linked](./client-requests.md#linked-events)
+- Events within a request are executed in sequential order. The effects of a given event will be
+  observable when the next event within that request is applied.
+- Events within a request do not interleave with events from other requests. (TODO: Can timeouts
+  interleave batches, or should we shift the batch so that timeouts land entirely before/after?)
+- All events within a request batch are committed, or none are. Note that this does not mean that
+  all of the events in a batch will either succeed or fail. Events succeed or fail independently
+  unless they are explicitly [linked](./client-requests.md#linked-events)
 
 #### [Events](../reference/operations/index.md)
 
 - Once committed, an event will always be committed — the cluster's state never backtracks.
-- Within a cluster, object [timestamps are unique and strictly increasing](./time.md#timestamps-are-totally-ordered).
-  For all objects `A` and `B` belonging to the same cluster, `A.timestamp ≠ B.timestamp` and
-  if `A.timestamp < B.timestamp`, then `A` was committed earlier than `B`.
-- If a client session is terminated and restarts, it is guaranteed to see the effects of updates for which the
-  corresponding reply was received prior to termination.
-- If a client session is terminated and restarts, it is _not_ guaranteed to see the effects of updates for
-  which the corresponding reply was _not_ received prior to the restart. Those updates may
-  occur at any point in the future, or never. Handling application crash recovery safely requires
-  [using `id`s to idempotently retry events](#consistency-with-foreign-databases).
+- Within a cluster, object [timestamps are unique and strictly
+  increasing](./time.md#timestamps-are-totally-ordered). For all objects `A` and `B` belonging to
+  the same cluster, `A.timestamp ≠ B.timestamp` and if `A.timestamp < B.timestamp`, then `A` was
+  committed earlier than `B`.
+- If a client session is terminated and restarts, it is guaranteed to see the effects of updates for
+  which the corresponding reply was received prior to termination.
+- If a client session is terminated and restarts, it is _not_ guaranteed to see the effects of
+  updates for which the corresponding reply was _not_ received prior to the restart. Those updates
+  may occur at any point in the future, or never. Handling application crash recovery safely
+  requires [using `id`s to idempotently retry events](#consistency-with-foreign-databases).
 
 #### [Accounts](../reference/accounts.md)
 
-- Accounts are immutable. They are never modified once they are successfully created
-  (excluding balance fields, which are modified by transfers).
+- Accounts are immutable. They are never modified once they are successfully created (excluding
+  balance fields, which are modified by transfers).
 - There is at most one `Account` with a particular [`id`](../reference/accounts.md#id).
-- The sum of all accounts' [`debits_pending`](../reference/accounts.md#debits_pending) equals the sum of all accounts' [`credits_pending`](../reference/accounts.md#credits_pending).
-- The sum of all accounts' [`debits_posted`](../reference/accounts.md#debits_posted) equals the sum of all accounts' [`credits_posted`](../reference/accounts.md#credits_posted).
+- The sum of all accounts' [`debits_pending`](../reference/accounts.md#debits_pending) equals the
+  sum of all accounts' [`credits_pending`](../reference/accounts.md#credits_pending).
+- The sum of all accounts' [`debits_posted`](../reference/accounts.md#debits_posted) equals the sum
+  of all accounts' [`credits_posted`](../reference/accounts.md#credits_posted).
 
 #### [Transfers](../reference/transfers.md)
 
 - Transfers are immutable. They are never modified once they are successfully created.
 - There is at most one `Transfer` with a particular [`id`](../reference/transfers.md#id).
-- A [pending transfer](./two-phase-transfers.md#reserve-funds-pending-transfer) resolves at most once.
-- Transfer [timeouts](../reference/transfers.md#timeout) are deterministic, driven
-  by the [cluster's timestamp](./time.md#why-tigerbeetle-manages-timestamps).
+- A [pending transfer](./two-phase-transfers.md#reserve-funds-pending-transfer) resolves at most
+  once.
+- Transfer [timeouts](../reference/transfers.md#timeout) are deterministic, driven by the [cluster's
+  timestamp](./time.md#why-tigerbeetle-manages-timestamps).
 
 ### Reply Order
 
@@ -120,8 +131,8 @@ sequenceDiagram
     (Network)->>Client A: A₁ (reply)
 ```
 
-Suppose instead `A₁` arrives and executes before `B₁`.
-The replies may be delivered in the same order (`A₁` then `B₁`), or they may be reordered, as shown below:
+Suppose instead `A₁` arrives and executes before `B₁`. The replies may be delivered in the same
+order (`A₁` then `B₁`), or they may be reordered, as shown below:
 
 ```mermaid
 sequenceDiagram
@@ -165,23 +176,24 @@ would be misleading. An error would imply that a request did not execute, when t
 TigerBeetle objects may correspond to objects in a foreign data store (e.g. another DBMS). Keeping
 multiple data stores consistent (in sync) is subtle in the context of application process faults.
 
-Object creation events are idempotent, but only the first attempt will return [`.ok`](../reference/operations/create_transfers.md#ok),
-while all successive identical attempts return [`.exists`](../reference/operations/create_transfers.md#exists). The client may crash after creating
-the object, but before receiving the `.ok` reply. Because the session resets, neither that client
-nor any others will see the object's corresponding `.ok` result.
+Object creation events are idempotent, but only the first attempt will return
+[`.ok`](../reference/operations/create_transfers.md#ok), while all successive identical attempts
+return [`.exists`](../reference/operations/create_transfers.md#exists). The client may crash after
+creating the object, but before receiving the `.ok` reply. Because the session resets, neither that
+client nor any others will see the object's corresponding `.ok` result.
 
 Therefore, to recover to the correct state after a crash, an application that synchronizes updates
 between multiple data stores must treat `.exists` as equivalent to `.ok`.
 
 #### Example
 
-Suppose that an application creates users within Postgres, and for each user a
-corresponding `Account` in the TigerBeetle cluster.
+Suppose that an application creates users within Postgres, and for each user a corresponding
+`Account` in the TigerBeetle cluster.
 
 This scenario depicts the typical case:
 
-  1. _Application_: Create user `U₁` in Postgres with `U₁.account_id = A₁` and
-    `U₁.account_exists = false`.
+  1. _Application_: Create user `U₁` in Postgres with `U₁.account_id = A₁` and `U₁.account_exists =
+    false`.
   2. _Application_: Send "create account" request `A₁` to the cluster.
   3. _Cluster_: Create `A₁`; reply `ok`.
   4. _Application_: Receive reply `A₁: ok` from the cluster.
@@ -189,12 +201,12 @@ This scenario depicts the typical case:
 
 But suppose the application crashes and restarts immediately after sending its request (step 2):
 
-  1. _Application_: Create user `U₁` in Postgres with `U₁.account_id = A₁` and
-    `U₁.account_exists = false`.
+  1. _Application_: Create user `U₁` in Postgres with `U₁.account_id = A₁` and `U₁.account_exists =
+    false`.
   2. _Application_: Send "create account" request `A₁` to the cluster.
   3. _Application_: Crash. Restart.
-  4. _Cluster_: Create `A₁`; reply `ok` — but the application session has reset,
-    so this reply never reaches the application.
+  4. _Cluster_: Create `A₁`; reply `ok` — but the application session has reset, so this reply never
+    reaches the application.
   5. _Application_: Send "create account" request `A₁` to the cluster with the same ID as in step 1.
   6. _Cluster_: Create `A₁`; reply `exists`.
   7. _Application_: Receive reply `A₁: exists` from the cluster.

--- a/docs/design/consistency.md
+++ b/docs/design/consistency.md
@@ -45,8 +45,10 @@ applications?
 > Note that a request refers to a batch, rather than a single event.
 
 - A request executes within the cluster at most once.
-- Requests do not [time out](#retries). A timeout typically implies failure, which cannot be
-  conclusively determined in the context of network faults. Note that individual [pending
+- Requests do not [time out](#retries). Clients will continuously retry requests until they receive
+  a reply from the cluster. This is because in the case of a network partition, a lack of response
+  from the cluster could either indicate that the request was dropped before it was processed or
+  that the reply was dropped after the request was processed. Note that individual [pending
   transfers](./two-phase-transfers.md) within a request may have
   [timeouts](../reference/transfers.md#timeout).
 - Requests retried by their original client session receive identical replies.

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -152,17 +152,20 @@ When selecting an `id` scheme:
 ### Examples (Recommended)
 #### Time-Based Identifiers
 
-A time-based identifier (such as ULID or UUIDv7) are recommended for most applications.
+A time-based identifier (such as ULID or UUIDv7) is recommended for most applications.
+
+TigerBeetle clients include an `id()` function to generate IDs using these recommendations.
 
 A ULID ("Universally Unique Lexicographically Sortable identifier") consists of:
 
 - 48 bits of (millisecond) timestamp (high-order bits)
 - 80 bits of randomness (low-order bits)
 
-**Important**: When creating multiple objects during the same millisecond, increment the random bytes
-(instead of generating new random bytes). Make sure to also store random bytes first, timestamp bytes 
-second, and both in little-endian. These details ensure that a sequence of objects have strictly 
-increasing ids according to the server. (Such ids are amenable to LSM optimizations, 
+**Important**: If you generate IDs yourself instead of using the `id()` function provided by the
+client libraries, **increment the random bytes** when creating multiple objects during the same
+millisecond (instead of generating new random bytes). Make sure to also store random bytes first,
+timestamp bytes second, and both in little-endian. These details ensure that a sequence of objects
+have strictly increasing ids according to the server. (Such ids are amenable to LSM optimizations,
 leading to higher database throughput).
 
 - ULIDs have an insignificant risk of collision.

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -22,17 +22,33 @@ In double-entry accounting, an account balance is the difference between the two
 either `debits - credits` or `credits - debits` depending on the type of account. It is up to the
 application to compute the balance from the cumulative debits/credits.
 
-From the database's perspective the distinction is arbitrary, but by convention:
+From the database's perspective the distinction is arbitrary, but accounting conventions recommend
+using a certain balance type for certain types of accounts.
 
-  - `balance = debits - credits` for accounts representing the database operator's assets.
-    - Known as a "debit balance".
-    - Accounts with limits use
-      [`flags.credits_must_not_exceed_debits`](../reference/accounts.md#flagscredits_must_not_exceed_debits).
-  - `balance = credits - debits` for accounts representing the database operator's liabilities.
-    - Known as a "credit balance".
-    - Accounts with limits use
-      [`flags.debits_must_not_exceed_credits`](../reference/accounts.md#flagsdebits_must_not_exceed_credits).
-  - A transfer "from" account `A` "to" account `B` credits account `A` and debits account `B`.
+### Debit Balances
+
+`balance = debits - credits`
+
+By convention, debit balances are used to represent:
+- Operator's Assets
+- Operator's Expenses
+
+To limit the balance for this type of account, use
+[`flags.credits_must_not_exceed_debits`](../reference/accounts.md#flagscredits_must_not_exceed_debits).
+
+### Credit Balances
+
+`balance = credits - debits`
+
+By convention, credit balances are used to represent:
+- Operators's Liabilities
+- Equity in the Operator's Business
+- Operator's Income
+
+To limit the balance for this type of account, use
+[`flags.debits_must_not_exceed_credits`](../reference/accounts.md#flagsdebits_must_not_exceed_credits).
+For example, a customer account that is represented as an Operator's Liability would use this flag
+to ensure that the balance cannot go negative.
 
 ### Example
 
@@ -49,6 +65,8 @@ ledger might look something like this:
 - Alice and Bob have deposited money ($20 and $10 respectively) in the bank — from the bank's
   perspective this is a liability.
 - Alice and Bob cannot "overdraw" their account — that is, their balance will never be negative.
+- A transfer from Alice to Bob would debit Alice's account and credit Bob's (decreasing the bank's
+  liability to Alice while increasing the bank's liability to Bob).
 
 ## Fractional Amounts and Asset Scale
 

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -111,13 +111,28 @@ Each `user_data` field's contents are arbitrary, interpreted only by the applica
 
 Each `user_data` field is indexed for efficient point and range queries.
 
-Example uses:
+While the usage of each field is entirely up to you, one way of thinking about each of the fields
+is:
 
-- Set `user_data_128` or `user_data_64` to a "foreign key" — that is, the identifier of a corresponding object within
-  a [control plane](https://en.wikipedia.org/wiki/Control_plane) database.
-- Set `user_data_64` to an external timestamp if you need to model [bitemporality](https://en.wikipedia.org/wiki/Bitemporal_modeling).
-- Set `user_data_32` to the identifier of a timezone or locale where the event originated.
-- Set `user_data_128`, `user_data_64` or `user_data_32` to a group identifier for objects that will be queried together.
+- `user_data_128` - this might store the "who" and/or "what" of a transfer. For example, it could be
+  a pointer to a business entity stored within the [control
+  plane](https://en.wikipedia.org/wiki/Control_plane) database.
+- `user_data_64` - this might store a second timestamp for "when" the transaction originated in the
+  real world, rather than when the transfer was [timestamped by
+  TigerBeetle](./time.md#why-tigerbeetle-manages-timestamps). This can be used if you need to model
+  [bitemporality](https://en.wikipedia.org/wiki/Bitemporal_modeling). Alternatively, if you do not
+  need this to be used for a timestamp, you could use this field in place of the `user_data_128` to
+  store the "who"/"what".
+- `user_data_32` - this might store the "where" of a transfer. For example, it could store the
+  jurisdiction where the transaction originated in the real world. In certain cases, such as for
+  cross-border remittances, it might not be enough to have the UTC timestamp and you may want to
+  know the transfer's locale.
+
+(Note that the [`code`](#code) can be used to encode the "why" of a transfer.)
+
+Any of the `user_data` fields can be used as a group identifier for objects that will be queried
+together. For example, for multiple transfers used for [currency
+exchange](../recipes/currency-exchange.md).
 
 ## `id`
 
@@ -262,15 +277,13 @@ currencies, each of your customers would have multiple ledgers.
 
 ## `code`
 
-[`Account`s](../reference/accounts.md#code) and [`Transfer`s](../reference/transfers.md#code) both
-have a `code` field. While they have slightly different meanings, both can be used to represent
-different types of `Account`s and `Transfer`s within your system.
+The `code` identifier represents the "why" for an Account or Transfer.
 
-The `code` on an `Account` can be used to indicate the type, such as assets, liabilities, equity,
-income, or expenses, and subcategories within those classifications.
+On an [`Account`](../reference/accounts.md#code), the `code` indicates the account type, such as
+assets, liabilities, equity, income, or expenses, and subcategories within those classification.
 
-The `code` on a `Transfer` can be used to indicate the reason why a given transfer is happening,
-such as a purchase, refund, currency exchange, etc.
+On a [`Transfer`](../reference/transfers.md#code), the `code` indicates why a given transfer is
+happening, such as a purchase, refund, currency exchange, etc.
 
 When you start building out your application on top of TigerBeetle, you may find it helpful to list
 out all of the known types of accounts and movements of funds and mapping each of these to `code`

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -4,12 +4,13 @@ sidebar_position: 1
 
 # Data Modeling
 
-TigerBeetle is a domain-specific database — its schema of [`Account`s](../reference/accounts.md)
-and [`Transfer`s](../reference/transfers.md) is built-in and fixed. In return for this prescriptive
+TigerBeetle is a domain-specific database — its schema of [`Account`s](../reference/accounts.md) and
+[`Transfer`s](../reference/transfers.md) is built-in and fixed. In return for this prescriptive
 design, it provides excellent performance, integrated business logic, and powerful invariants.
 
-This section is a sample of techniques for mapping your application's requirements onto TigerBeetle's
-data model. Which (if any) of these techniques are suitable is highly application-specific.
+This section is a sample of techniques for mapping your application's requirements onto
+TigerBeetle's data model. Which (if any) of these techniques are suitable is highly
+application-specific.
 
 When possible, round trips and coordination can be minimized by encoding application invariants
 directly in TigerBeetle rather than implementing them in the application itself (or with a foreign
@@ -17,9 +18,9 @@ database). This is useful for both maintaining consistency and performance.
 
 ## Debits vs Credits
 
-TigerBeetle tracks each account's cumulative posted debits and cumulative posted credits.
-In double-entry accounting, an account balance is the difference between the two — computed as
-either `debits - credits` or `credits - debits` depending on the type of account. It is up to the
+TigerBeetle tracks each account's cumulative posted debits and cumulative posted credits. In
+double-entry accounting, an account balance is the difference between the two — computed as either
+`debits - credits` or `credits - debits` depending on the type of account. It is up to the
 application to compute the balance from the cumulative debits/credits.
 
 From the database's perspective the distinction is arbitrary, but accounting conventions recommend
@@ -52,8 +53,8 @@ to ensure that the balance cannot go negative.
 
 ### Example
 
-For example, if TigerBeetle is operated by a bank, with customers Alice and Bob, its
-ledger might look something like this:
+For example, if TigerBeetle is operated by a bank, with customers Alice and Bob, its ledger might
+look something like this:
 
 | Account Owner | Debits Posted | Credits Posted | Flags                            |
 | :------------ | ------------: | -------------: | :------------------------------- |
@@ -105,9 +106,9 @@ The 128-bit representation defines the precision, but not the scale.
 
 ## `user_data`
 
-`user_data_128`, `user_data_64` and `user_data_32` are the most flexible fields in the schema (for both
-[accounts](../reference/accounts.md) and [transfers](../reference/transfers.md)).
-Each `user_data` field's contents are arbitrary, interpreted only by the application.
+`user_data_128`, `user_data_64` and `user_data_32` are the most flexible fields in the schema (for
+both [accounts](../reference/accounts.md) and [transfers](../reference/transfers.md)). Each
+`user_data` field's contents are arbitrary, interpreted only by the application.
 
 Each `user_data` field is indexed for efficient point and range queries.
 
@@ -139,9 +140,9 @@ exchange](../recipes/currency-exchange.md).
 The `id` field uniquely identifies each [`Account`](../reference/accounts.md#id) and
 [`Transfer`](../reference/transfers.md#id) within the cluster.
 
-The primary purpose of an `id` is to serve as an "idempotency key" — to avoid
-executing an event twice. For example, if a client creates a transfer but the server's reply is
-lost, the client (or application) will retry — the database must not transfer the money twice.
+The primary purpose of an `id` is to serve as an "idempotency key" — to avoid executing an event
+twice. For example, if a client creates a transfer but the server's reply is lost, the client (or
+application) will retry — the database must not transfer the money twice.
 
 Note that `id`s are unique per cluster -- not per ledger. You should attach a separate identifier in
 the [`user_data`](#user_data) field if you want to store a connection between multiple `Account`s or
@@ -153,18 +154,18 @@ exchange](../recipes/currency-exchange.md).
 
 When selecting an `id` scheme:
 
-- Idempotency is particularly important (and difficult) in the context of
-  [application crash recovery](./consistency.md#consistency-with-foreign-databases).
+- Idempotency is particularly important (and difficult) in the context of [application crash
+  recovery](./consistency.md#consistency-with-foreign-databases).
 - Be careful to [avoid `id` collisions](https://en.wikipedia.org/wiki/Birthday_problem).
-- An account and a transfer may share the same `id` (they belong to different "namespaces"),
-  but this is not recommended because other systems (that you may later connect to TigerBeetle)
-  may use a single "namespace" for all objects.
-- Avoid requiring a central oracle to generate each unique `id` (e.g. an auto-increment field in SQL).
-  A central oracle may become a performance bottleneck when creating accounts/transfers.
+- An account and a transfer may share the same `id` (they belong to different "namespaces"), but
+  this is not recommended because other systems (that you may later connect to TigerBeetle) may use
+  a single "namespace" for all objects.
+- Avoid requiring a central oracle to generate each unique `id` (e.g. an auto-increment field in
+  SQL). A central oracle may become a performance bottleneck when creating accounts/transfers.
 - Sequences of identifiers with long runs of strictly increasing (or strictly decreasing) values are
   amenable to optimization, leading to higher database throughput.
-- Random identifiers are not recommended – they can't take advantage of all of the LSM's optimizations.
-  (Random identifiers have ~10% lower throughput than strictly-increasing ULIDs).
+- Random identifiers are not recommended – they can't take advantage of all of the LSM's
+  optimizations. (Random identifiers have ~10% lower throughput than strictly-increasing ULIDs).
 
 ### Time-Based Identifiers (Recommended)
 
@@ -194,8 +195,8 @@ See also: [ULID specification](https://github.com/ulid/spec).
 
 ### Reuse Foreign Identifier
 
-This technique is most appropriate when integrating TigerBeetle with an existing application
-where TigerBeetle accounts or transfers map one-to-one with an entity in the foreign database.
+This technique is most appropriate when integrating TigerBeetle with an existing application where
+TigerBeetle accounts or transfers map one-to-one with an entity in the foreign database.
 
 Set `id` to a "foreign key" — that is, reuse an identifier of a corresponding object from another
 database. For example, if every user (within the application's database) has a single account, then

--- a/docs/design/data-modeling.md
+++ b/docs/design/data-modeling.md
@@ -183,7 +183,7 @@ TigerBeetle IDs consist of:
 
 When creating multiple objects during the same millisecond, we increment the random bytes rather
 than generating new random bytes. Furthermore, it is important that IDs are stored in little-endian
-with the random bytes as the lower-order bits and the timestamp as the higher-order bits.  These
+with the random bytes as the lower-order bits and the timestamp as the higher-order bits. These
 details ensure that a sequence of objects have strictly increasing IDs according to the server,
 which improves database optimization.
 

--- a/docs/design/two-phase-transfers.md
+++ b/docs/design/two-phase-transfers.md
@@ -7,19 +7,18 @@ sidebar_position: 2
 A two-phase transfer moves funds in stages:
 
 1. Reserve funds ([pending](#reserve-funds-pending-transfer))
-2. Resolve funds ([post](#post-pending-transfer), [void](#void-pending-transfer), or [timeout](#timeout))
+2. Resolve funds ([post](#post-pending-transfer), [void](#void-pending-transfer), or
+   [timeout](#timeout))
 
-The name "two-phase transfer" is a reference to the [two-phase commit
-protocol for distributed
+The name "two-phase transfer" is a reference to the [two-phase commit protocol for distributed
 transactions](https://en.wikipedia.org/wiki/Two-phase_commit_protocol).
 
 ## Reserve Funds (Pending Transfer)
 
-A pending transfer, denoted by [`flags.pending`](../reference/transfers.md#flagspending),
-reserves its `amount` in the debit/credit accounts'
+A pending transfer, denoted by [`flags.pending`](../reference/transfers.md#flagspending), reserves
+its `amount` in the debit/credit accounts'
 [`debits_pending`](../reference/accounts.md#debits_pending)/[`credits_pending`](../reference/accounts.md#credits_pending)
-fields, respectively. Pending transfers leave the
-`debits_posted`/`credits_posted` unmodified.
+fields, respectively. Pending transfers leave the `debits_posted`/`credits_posted` unmodified.
 
 ## Resolve Funds
 
@@ -27,22 +26,26 @@ Pending transfers can be posted, voided, or they may time out.
 
 ### Post-Pending Transfer
 
-A post-pending transfer, denoted by [`flags.post_pending_transfer`](../reference/transfers.md#flagspost_pending_transfer),
-causes a pending transfer to "post", transferring some or all of the pending transfer's reserved amount to its destination.
+A post-pending transfer, denoted by
+[`flags.post_pending_transfer`](../reference/transfers.md#flagspost_pending_transfer), causes a
+pending transfer to "post", transferring some or all of the pending transfer's reserved amount to
+its destination.
 
-* If the posted [`amount`](../reference/transfers.md#amount) is 0, the full pending transfer's amount is
-  posted.
-* If the posted [`amount`](../reference/transfers.md#amount) is nonzero, then only this amount is posted,
-  and the remainder is restored to its original accounts. It must be
-  less than or equal to the pending transfer's amount.
+* If the posted [`amount`](../reference/transfers.md#amount) is 0, the full pending transfer's
+  amount is posted.
+* If the posted [`amount`](../reference/transfers.md#amount) is nonzero, then only this amount is
+  posted, and the remainder is restored to its original accounts. It must be less than or equal to
+  the pending transfer's amount.
 
 Additionally, when `flags.post_pending_transfer` is set:
 
-* [`pending_id`](../reference/transfers.md#pending_id) must reference a [pending transfer](#reserve-funds-pending-transfer).
-* [`flags.void_pending_transfer`](../reference/transfers.md#flagsvoid_pending_transfer) must not be set.
+* [`pending_id`](../reference/transfers.md#pending_id) must reference a [pending
+  transfer](#reserve-funds-pending-transfer).
+* [`flags.void_pending_transfer`](../reference/transfers.md#flagsvoid_pending_transfer) must not be
+  set.
 
-The following fields may either be zero or they must match the
-value of the pending transfer's field:
+The following fields may either be zero or they must match the value of the pending transfer's
+field:
 
 * [`debit_account_id`](../reference/transfers.md#debit_account_id)
 * [`credit_account_id`](../reference/transfers.md#credit_account_id)
@@ -51,15 +54,17 @@ value of the pending transfer's field:
 
 ### Void-Pending Transfer
 
-A void-pending transfer, denoted by [`flags.void_pending_transfer`](../reference/transfers.md#flagsvoid_pending_transfer),
-restores the pending amount its original accounts.
-Additionally, when this field is set:
+A void-pending transfer, denoted by
+[`flags.void_pending_transfer`](../reference/transfers.md#flagsvoid_pending_transfer), restores the
+pending amount its original accounts. Additionally, when this field is set:
 
-* [`pending_id`](../reference/transfers.md#pending_id) must reference a [pending transfer](#reserve-funds-pending-transfer).
-* [`flags.post_pending_transfer`](../reference/transfers.md#flagspost_pending_transfer) must not be set.
+* [`pending_id`](../reference/transfers.md#pending_id) must reference a [pending
+  transfer](#reserve-funds-pending-transfer).
+* [`flags.post_pending_transfer`](../reference/transfers.md#flagspost_pending_transfer) must not be
+  set.
 
-The following fields may either be zero or they must match the
-value of the pending transfer's field:
+The following fields may either be zero or they must match the value of the pending transfer's
+field:
 
 * [`debit_account_id`](../reference/transfers.md#debit_account_id)
 * [`credit_account_id`](../reference/transfers.md#credit_account_id)
@@ -68,17 +73,17 @@ value of the pending transfer's field:
 
 ### Timeout
 
-A pending transfer may optionally be created with a
-[timeout](../reference/transfers.md#timeout). If the timeout interval passes
-before the transfer is either posted or voided, the full amount will be voided.
+A pending transfer may optionally be created with a [timeout](../reference/transfers.md#timeout). If
+the timeout interval passes before the transfer is either posted or voided, the full amount will be
+voided.
 
 Note that `timeout`s are given as intervals, specified in seconds, rather than as absolute
 timestamps. For more details on why, read the page about [Time in TigerBeetle](./time.md).
 
 ### Errors
 
-A pending transfer can only be posted or voided once. It cannot be
-posted twice or voided then posted, etc.
+A pending transfer can only be posted or voided once. It cannot be posted twice or voided then
+posted, etc.
 
 Attempting to resolve a pending transfer more than once will return the applicable error result:
 - [`pending_transfer_already_posted`](../reference/operations/create_transfers.md#pending_transfer_already_posted)
@@ -87,41 +92,34 @@ Attempting to resolve a pending transfer more than once will return the applicab
 
 ## Interaction with Account Invariants
 
-The pending transfer's amount is reserved in a way that the second
-step in a two-phase transfer will never cause the accounts' configured
-balance invariants
-([`credits_must_not_exceed_debits`](../reference/accounts.md#flagscredits_must_not_exceed_debits)
-or
-[`debits_must_not_exceed_credits`](../reference/accounts.md#flagsdebits_must_not_exceed_credits))
-to be broken, whether the second step is a post or void.
+The pending transfer's amount is reserved in a way that the second step in a two-phase transfer will
+never cause the accounts' configured balance invariants
+([`credits_must_not_exceed_debits`](../reference/accounts.md#flagscredits_must_not_exceed_debits) or
+[`debits_must_not_exceed_credits`](../reference/accounts.md#flagsdebits_must_not_exceed_credits)) to
+be broken, whether the second step is a post or void.
 
 ### Pessimistic Pending Transfers
 
 If an account with
-[`debits_must_not_exceed_credits`](../reference/accounts.md#flagsdebits_must_not_exceed_credits)
-has `credits_posted = 100` and `debits_posted = 70` and a pending
-transfer is started causing the account to have `debits_pending = 50`,
-the *pending* transfer will fail. It will not wait to get to *posted*
-status to fail.
+[`debits_must_not_exceed_credits`](../reference/accounts.md#flagsdebits_must_not_exceed_credits) has
+`credits_posted = 100` and `debits_posted = 70` and a pending transfer is started causing the
+account to have `debits_pending = 50`, the *pending* transfer will fail. It will not wait to get to
+*posted* status to fail.
 
 ## All Transfers Are Immutable
 
-To reiterate, completing a two-phase transfer (by either marking it
-void or posted) does not involve modifying the pending
-transfer. Instead you create a new transfer.
+To reiterate, completing a two-phase transfer (by either marking it void or posted) does not involve
+modifying the pending transfer. Instead you create a new transfer.
 
-The first transfer that is marked pending will always have its pending
-flag set.
+The first transfer that is marked pending will always have its pending flag set.
 
 The second transfer will have a
-[`post_pending_transfer`](../reference/transfers.md#flagspost_pending_transfer)
-or
-[`void_pending_transfer`](../reference/transfers.md#flagsvoid_pending_transfer)
-flag set and a [`pending_id`](../reference/transfers.md#pending_id) field
-set to the [`id`](../reference/transfers.md#id) of the first transfer. The
-[`id`](../reference/transfers.md#id) of the second transfer will be
-unique, not the same [`id`](../reference/transfers.md#id) as the initial
-pending transfer.
+[`post_pending_transfer`](../reference/transfers.md#flagspost_pending_transfer) or
+[`void_pending_transfer`](../reference/transfers.md#flagsvoid_pending_transfer) flag set and a
+[`pending_id`](../reference/transfers.md#pending_id) field set to the
+[`id`](../reference/transfers.md#id) of the first transfer. The [`id`](../reference/transfers.md#id)
+of the second transfer will be unique, not the same [`id`](../reference/transfers.md#id) as the
+initial pending transfer.
 
 ## Examples
 

--- a/docs/design/two-phase-transfers.md
+++ b/docs/design/two-phase-transfers.md
@@ -8,7 +8,7 @@ A two-phase transfer moves funds in stages:
 
 1. Reserve funds ([pending](#reserve-funds-pending-transfer))
 2. Resolve funds ([post](#post-pending-transfer), [void](#void-pending-transfer), or
-   [timeout](#timeout))
+   [expire](#expire-pending-transfer))
 
 The name "two-phase transfer" is a reference to the [two-phase commit protocol for distributed
 transactions](https://en.wikipedia.org/wiki/Two-phase_commit_protocol).
@@ -71,11 +71,11 @@ field:
 * [`ledger`](../reference/transfers.md#ledger)
 * [`code`](../reference/transfers.md#code)
 
-### Timeout
+### Expire Pending Transfer
 
 A pending transfer may optionally be created with a [timeout](../reference/transfers.md#timeout). If
-the timeout interval passes before the transfer is either posted or voided, the full amount will be
-voided.
+the timeout interval passes before the transfer is either posted or voided, the transfer expires and
+the full amount is returned to the original account.
 
 Note that `timeout`s are given as intervals, specified in seconds, rather than as absolute
 timestamps. For more details on why, read the page about [Time in TigerBeetle](./time.md).

--- a/docs/reference/accounts.md
+++ b/docs/reference/accounts.md
@@ -170,31 +170,12 @@ Constraints:
 
 #### `flags.linked`
 
-When the `linked` flag is specified, it links an account with the next
-account in the batch, to create a chain of accounts, of arbitrary
-length, which all succeed or fail in creation together. The tail of a
-chain is denoted by the first account without this flag. The last
-account in a batch may therefore never have `flags.linked` set as
-this would leave a chain open-ended (see
-[`linked_event_chain_open`](./operations/create_accounts.md#linked_event_chain_open)).
+This flag links the result of this account creation to the result of the next one in the request,
+such that they will either succeed or fail together.
 
-Multiple chains or individual accounts may coexist within a batch to
-succeed or fail independently. Accounts within a chain are executed
-in order, or are rolled back on error, so that the effect of each
-account in the chain is visible to the next, and so that the chain is
-either visible or invisible as a unit to subsequent accounts after the
-chain. The account that was the first to break the chain will have a
-unique error result. Other accounts in the chain will have their error
-result set to
-[`linked_event_failed`](./operations/create_accounts.md#linked_event_failed).
+The last account in a chain of linked accounts does **not** have this flag set.
 
-
-After the chain of account operations has executed, the fact that they were
-linked will not be saved.
-To save the association between accounts, it must be
-[encoded into the data model](../design/data-modeling.md), for example by
-adding an ID to one of the [user data](../design/data-modeling.md#user_data)
-fields.
+You can read more about [linked events](../design/client-requests.md#linked-events).
 
 #### `flags.debits_must_not_exceed_credits`
 

--- a/docs/reference/accounts.md
+++ b/docs/reference/accounts.md
@@ -89,8 +89,9 @@ Constraints:
 This is an optional 128-bit secondary identifier to link this account to an
 external entity or event.
 
-As an example, you might use a [ULID](../design/data-modeling.md#time-based-identifiers)
-that ties together a group of accounts.
+As an example, you might use a
+[ULID](../design/data-modeling.md#tigerbeetle-time-based-identifiers-recommended) that ties together
+a group of accounts.
 
 For more information, see [Data Modeling](../design/data-modeling.md#user_data).
 

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -49,9 +49,6 @@ Fields used by each mode of transfer:
 
 This is a unique identifier for the transaction.
 
-As an example, you might generate a [ULID](../design/data-modeling.md#time-based-identifiers) to
-identify each transaction.
-
 Constraints:
 
 * Type is 128-bit unsigned integer (16 bytes)
@@ -151,8 +148,9 @@ Constraints:
 This is an optional 128-bit secondary identifier to link this transfer to an
 external entity or event.
 
-As an example, you might use a [ULID](../design/data-modeling.md#time-based-identifiers)
-that ties together a group of transfers.
+As an example, you might generate a [TigerBeetle Time-Based
+Identifier](../design/data-modeling.md#tigerbeetle-time-based-identifiers-recommended) that ties
+together a group of transfers.
 
 For more information, see [Data Modeling](../design/data-modeling.md#user_data).
 

--- a/docs/reference/transfers.md
+++ b/docs/reference/transfers.md
@@ -272,47 +272,12 @@ Constraints:
 
 #### `flags.linked`
 
-When the `linked` flag is specified, it links a transfer with the next
-transfer in the batch, to create a chain of transfers, of arbitrary
-length, which all succeed or fail in creation together. The tail of a
-chain is denoted by the first transfer without this flag. The last
-transfer in a batch may therefore never have `flags.linked` set as
-this would leave a chain open-ended (see
-[`linked_event_chain_open`](./operations/create_transfers.md#linked_event_chain_open)).
+This flag links the result of this transfer to the outcome of the next transfer in the request such
+that they will either succeed or fail together.
 
-Multiple chains of individual transfers may coexist within a batch to
-succeed or fail independently. Transfers within a chain are executed
-within order, or are rolled back on error, so that the effect of each
-transfer in the chain is visible to the next, and so that the chain is
-either visible or invisible as a unit to subsequent transfers after the
-chain. The transfer that was the first to break the chain will have a
-unique error result. Other transfers in the chain will have their error
-result set to
-[`linked_event_failed`](./operations/create_transfers.md#linked_event_failed).
+The last transfer in a chain of linked transfers does **not** have this flag set.
 
-Consider this set of transfers as part of a batch:
-
-| Transfer | Index within batch | flags.linked |
-|----------|--------------------|--------------|
-| `A`      | `0`                | `false`      |
-| `B`      | `1`                | `true`       |
-| `C`      | `2`                | `true`       |
-| `D`      | `3`                | `false`      |
-| `E`      | `4`                | `false`      |
-
-If any of transfers `B`, `C`, or `D` fail (for example, due to
-[`exceeds_credits`](./operations/create_transfers.md#exceeds_credits),
-then `B`, `C`, and `D` will all fail. They are linked.
-
-Transfers `A` and `E` fail or succeed independently of `B`, `C`, `D`,
-and each other.
-
-After the chain of linked transfers has executed, the fact that they were
-linked will not be saved.
-To save the association between transfers, it must be
-[encoded into the data model](../design/data-modeling.md), for example by
-adding an ID to one of the [user data](../design/data-modeling.md#user_data)
-fields.
+You can read more about [linked events](../design/client-requests.md#linked-events).
 
 ##### Examples
 


### PR DESCRIPTION
- **docs: move details about linked events into Client Requests doc**
- **docs: clarify language in Consistency doc**
- **docs: rewrap consistency doc at 100 chars**
- **docs: flesh out debits and credits section**
- **docs: mention clients' id() function**
- **docs: reword user_data section**
- **docs: remove advanced ID examples**
- **docs: rewrap at 100 chars**
