### PR TITLE
lsm: drop unused fuzzer config

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -30,8 +30,6 @@ const SuperBlock = vsr.SuperBlockType(Storage);
 const FreeSet = vsr.FreeSet;
 const CheckpointTrailer = vsr.CheckpointTrailerType(Storage);
 
-pub const tigerbeetle_config = @import("../config.zig").configs.fuzz_min;
-
 const FuzzOpAction = union(enum) {
     // TODO Test secondary index lookups and range queries.
     compact: struct {

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -63,8 +63,6 @@ const Table = @import("table.zig").TableType(
     .general,
 );
 
-pub const tigerbeetle_config = @import("../config.zig").configs.test_min;
-
 pub fn main(args: fuzz.FuzzArgs) !void {
     var prng = std.rand.DefaultPrng.init(args.seed);
     const random = prng.random();


### PR DESCRIPTION
`tigerbeetle_config` overrides compile-time configuration, but it only takes effect if specified in the root file. For fuzzers, that's `fuzz_tests.zig`.