### PR TITLE
vsr: add entire header to checkpoint state 

### DIFF
--- a/docs/internals/sync.md
+++ b/docs/internals/sync.md
@@ -49,7 +49,7 @@ Checkpoints:
 5. Begin [sync-superblock protocol](./vsr.md#protocol-sync-superblock).
 6. [Request superblock checkpoint state](#6-request-superblock-checkpoint-state).
 7. Update the superblock headers with:
-    - Bump `vsr_state.checkpoint.commit_min`/`vsr_state.checkpoint.commit_min_checksum` to the sync target op/op-checksum.
+    - Bump `vsr_state.checkpoint.header` to the sync target header.
     - Bump `vsr_state.checkpoint.parent_checkpoint_id` to the checkpoint id that is previous to our sync target (i.e. it isn't _our_ previous checkpoint).
     - Bump `replica.commit_min`. (If `replica.commit_min` exceeds `replica.op`, transition to `status=recovering_head`).
     - Set `vsr_state.sync_op_min` to the minimum op which has not been repaired.

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -279,6 +279,12 @@ const Environment = struct {
         try env.tick_until_state_change(.grid_checkpoint, .superblock_checkpoint);
 
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
+            .header = header: {
+                var header = vsr.Header.Prepare.root(cluster);
+                header.op = env.checkpoint_op.?;
+                header.set_checksum();
+                break :header header;
+            },
             .manifest_references = env.forest.manifest_log.checkpoint_references(),
             .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
             .client_sessions_reference = .{
@@ -287,8 +293,6 @@ const Environment = struct {
                 .trailer_size = 0,
                 .checksum = vsr.checksum(&.{}),
             },
-            .commit_min_checksum = env.superblock.working.vsr_state.checkpoint.commit_min_checksum + 1,
-            .commit_min = env.checkpoint_op.?,
             .commit_max = env.checkpoint_op.? + 1,
             .sync_op_min = 0,
             .sync_op_max = 0,

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -433,7 +433,7 @@ const Environment = struct {
         env.manifest_log.compact(
             manifest_log_compact_callback,
             vsr.Checkpoint.checkpoint_after(
-                env.manifest_log.superblock.working.vsr_state.checkpoint.commit_min,
+                env.manifest_log.superblock.working.vsr_state.checkpoint.header.op,
             ) + 1,
         );
         env.wait(&env.manifest_log);

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -468,6 +468,13 @@ const Environment = struct {
             checkpoint_superblock_callback,
             &env.superblock_context,
             .{
+                .header = header: {
+                    var header = vsr.Header.Prepare.root(0);
+                    header.op = vsr.Checkpoint.checkpoint_after(vsr_state.checkpoint.header.op);
+                    header.set_checksum();
+                    break :header header;
+                },
+
                 .manifest_references = env.manifest_log.checkpoint_references(),
                 .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
                 .client_sessions_reference = .{
@@ -476,8 +483,6 @@ const Environment = struct {
                     .trailer_size = 0,
                     .checksum = vsr.checksum(&.{}),
                 },
-                .commit_min_checksum = vsr_state.checkpoint.commit_min_checksum + 1,
-                .commit_min = vsr.Checkpoint.checkpoint_after(vsr_state.checkpoint.commit_min),
                 .commit_max = vsr.Checkpoint.checkpoint_after(vsr_state.commit_max),
                 .sync_op_min = 0,
                 .sync_op_max = 0,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -557,7 +557,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(tree.compaction_op == null);
             assert(tree.key_range == null);
 
-            tree.compaction_op = tree.grid.superblock.working.vsr_state.checkpoint.commit_min;
+            tree.compaction_op = tree.grid.superblock.working.vsr_state.checkpoint.header.op;
             tree.key_range = tree.manifest.key_range();
 
             tree.manifest.verify(snapshot_latest);
@@ -614,7 +614,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(tree.compaction_callback == .none);
             assert(op != 0);
             assert(op == tree.compaction_op.? + 1);
-            assert(op > tree.grid.superblock.working.vsr_state.checkpoint.commit_min);
+            assert(op > tree.grid.superblock.working.vsr_state.checkpoint.header.op);
 
             tracer.start(
                 &tree.tracer_slot,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -307,6 +307,12 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
             const checkpoint_op = op - constants.lsm_batch_multiple;
             env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
+                .header = header: {
+                    var header = vsr.Header.Prepare.root(cluster);
+                    header.op = checkpoint_op;
+                    header.set_checksum();
+                    break :header header;
+                },
                 .manifest_references = std.mem.zeroes(vsr.SuperBlockManifestReferences),
                 .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
                 .client_sessions_reference = .{
@@ -315,8 +321,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     .trailer_size = 0,
                     .checksum = vsr.checksum(&.{}),
                 },
-                .commit_min_checksum = env.superblock.working.vsr_state.checkpoint.commit_min_checksum + 1,
-                .commit_min = checkpoint_op,
                 .commit_max = checkpoint_op + 1,
                 .sync_op_min = 0,
                 .sync_op_max = 0,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1738,7 +1738,7 @@ const TestContext = struct {
 
         // Pretend that the superblock is open so that the Forest can initialize.
         ctx.superblock.opened = true;
-        ctx.superblock.working.vsr_state.checkpoint.commit_min = 0;
+        ctx.superblock.working.vsr_state.checkpoint.header.op = 0;
 
         ctx.grid = try Grid.init(allocator, .{
             .superblock = &ctx.superblock,

--- a/src/testing/cluster/manifest_checker.zig
+++ b/src/testing/cluster/manifest_checker.zig
@@ -35,7 +35,7 @@ pub fn ManifestCheckerType(comptime Forest: type) type {
             assert(forest.grid.superblock.opened);
             assert(forest.manifest_log.opened);
 
-            const checkpoint_op = forest.grid.superblock.working.vsr_state.checkpoint.commit_min;
+            const checkpoint_op = forest.grid.superblock.working.vsr_state.checkpoint.header.op;
             const checksum_stored = checker.checkpoints.getOrPut(checkpoint_op) catch @panic("oom");
             const checksum_current = manifest_levels_checksum(forest);
 

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -114,8 +114,8 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                     (replica.view == head_max.view and replica.op >= head_max.op));
             }
 
-            const commit_root_op = replica.superblock.working.vsr_state.checkpoint.commit_min;
-            const commit_root = replica.superblock.working.vsr_state.checkpoint.commit_min_checksum;
+            const commit_root_op = replica.superblock.working.vsr_state.checkpoint.header.op;
+            const commit_root = replica.superblock.working.vsr_state.checkpoint.header.checksum;
 
             const commit_a = state_checker.commit_mins[replica_index];
             const commit_b = replica.commit_min;
@@ -130,7 +130,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             // committed (it might be left over from before sync).
             const checksum_b = if (commit_b == commit_root_op) commit_root else header_b.?.checksum;
 
-            assert(checksum_b != commit_root or replica.commit_min == replica.superblock.working.vsr_state.checkpoint.commit_min);
+            assert(checksum_b != commit_root or replica.commit_min == replica.superblock.working.vsr_state.checkpoint.header.op);
             assert((commit_a == commit_b) == (checksum_a == checksum_b));
 
             if (checksum_a == checksum_b) return;

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -156,7 +156,7 @@ pub const StorageChecker = struct {
             break :checkpoint checkpoint;
         };
 
-        const replica_checkpoint_op = superblock.working.vsr_state.checkpoint.commit_min;
+        const replica_checkpoint_op = superblock.working.vsr_state.checkpoint.header.op;
         for (std.enums.values(CheckpointArea)) |area| {
             log.debug("{}: {s}: checkpoint={} area={s} value={?x:0>32}", .{
                 superblock.replica_index.?,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3720,8 +3720,7 @@ pub fn ReplicaType(
                 commit_op_checkpoint_superblock_callback,
                 &self.superblock_context,
                 .{
-                    .commit_min_checksum = self.journal.header_with_op(vsr_state_commit_min).?.checksum,
-                    .commit_min = vsr_state_commit_min,
+                    .header = self.journal.header_with_op(vsr_state_commit_min).?.*,
                     .commit_max = self.commit_max,
                     .sync_op_min = vsr_state_sync_op.min,
                     .sync_op_max = vsr_state_sync_op.max,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2613,10 +2613,15 @@ pub fn ReplicaType(
                 stage.target.checkpoint_id,
             });
 
-            self.sync_requesting_checkpoint_callback(std.mem.bytesAsValue(
+            assert(message.body().len == @sizeOf(vsr.CheckpointState));
+            const checkpoint_state = std.mem.bytesAsValue(
                 vsr.CheckpointState,
                 message.body()[0..@sizeOf(vsr.CheckpointState)],
-            ));
+            );
+            assert(checkpoint_state.header.valid_checksum());
+            assert(checkpoint_state.header.command == .prepare);
+            assert(checkpoint_state.header.invalid() == null);
+            self.sync_requesting_checkpoint_callback(checkpoint_state);
         }
 
         fn on_ping_timeout(self: *Self) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1022,7 +1022,7 @@ pub fn ReplicaType(
                 .view = self.superblock.working.vsr_state.view,
                 .log_view = self.superblock.working.vsr_state.log_view,
                 .op = undefined,
-                .commit_min = self.superblock.working.vsr_state.checkpoint.commit_min,
+                .commit_min = self.superblock.working.vsr_state.checkpoint.header.op,
                 .commit_max = self.superblock.working.vsr_state.commit_max,
                 .pipeline = .{ .cache = .{} },
                 .view_headers = vsr.Headers.ViewChangeArray.init_from_slice(
@@ -2591,7 +2591,7 @@ pub fn ReplicaType(
             if (self.ignore_request_sync_checkpoint_message(message)) return;
 
             assert(message.header.checkpoint_op ==
-                self.superblock.staging.vsr_state.checkpoint.commit_min);
+                self.superblock.staging.vsr_state.checkpoint.header.op);
             assert(message.header.checkpoint_id == self.superblock.staging.checkpoint_id());
 
             self.send_sync_checkpoint(.{ .replica = message.header.replica });
@@ -2773,8 +2773,8 @@ pub fn ReplicaType(
             }
 
             const latest_committed_entry = checksum: {
-                if (self.commit_max == self.superblock.working.vsr_state.checkpoint.commit_min) {
-                    break :checksum self.superblock.working.vsr_state.checkpoint.commit_min_checksum;
+                if (self.commit_max == self.superblock.working.vsr_state.checkpoint.header.op) {
+                    break :checksum self.superblock.working.vsr_state.checkpoint.header.checksum;
                 } else {
                     break :checksum self.journal.header_with_op(self.commit_max).?.checksum;
                 }
@@ -2788,7 +2788,7 @@ pub fn ReplicaType(
                 .commit = self.commit_max,
                 .commit_checksum = latest_committed_entry,
                 .timestamp_monotonic = self.clock.monotonic(),
-                .checkpoint_op = self.superblock.working.vsr_state.checkpoint.commit_min,
+                .checkpoint_op = self.superblock.working.vsr_state.checkpoint.header.op,
                 .checkpoint_id = self.superblock.working.checkpoint_id(),
             }));
         }
@@ -3568,8 +3568,8 @@ pub fn ReplicaType(
         fn commit_op_compact_callback(state_machine: *StateMachine) void {
             const self = @fieldParentPtr(Self, "state_machine", state_machine);
             assert(self.commit_stage == .compact_state_machine);
-            assert(self.op_checkpoint() == self.superblock.staging.vsr_state.checkpoint.commit_min);
-            assert(self.op_checkpoint() == self.superblock.working.vsr_state.checkpoint.commit_min);
+            assert(self.op_checkpoint() == self.superblock.staging.vsr_state.checkpoint.header.op);
+            assert(self.op_checkpoint() == self.superblock.working.vsr_state.checkpoint.header.op);
 
             if (self.event_callback) |hook| hook(self, .compaction_completed);
 
@@ -3740,8 +3740,8 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.commit_min);
 
             assert(self.op_checkpoint() == self.commit_min - constants.lsm_batch_multiple);
-            assert(self.op_checkpoint() == self.superblock.staging.vsr_state.checkpoint.commit_min);
-            assert(self.op_checkpoint() == self.superblock.working.vsr_state.checkpoint.commit_min);
+            assert(self.op_checkpoint() == self.superblock.staging.vsr_state.checkpoint.header.op);
+            assert(self.op_checkpoint() == self.superblock.working.vsr_state.checkpoint.header.op);
             self.grid.assert_only_repairing();
 
             log.debug("{}: commit_op_compact_callback: checkpoint done (op={} new_checkpoint={})", .{
@@ -3801,7 +3801,7 @@ pub fn ReplicaType(
                 // op_checkpoint's slot may have been overwritten in the WAL — but we can
                 // always use the VSRState to anchor the hash chain.
                 assert(prepare.header.parent ==
-                    self.superblock.working.vsr_state.checkpoint.commit_min_checksum);
+                    self.superblock.working.vsr_state.checkpoint.header.checksum);
             } else {
                 assert(prepare.header.parent ==
                     self.journal.header_with_op(self.commit_min).?.checksum);
@@ -3912,7 +3912,7 @@ pub fn ReplicaType(
                 // We are recovering from a checkpoint. Prior to the crash, the client table was
                 // updated with entries for one bar beyond the op_checkpoint.
                 assert(self.op_checkpoint() ==
-                    self.superblock.working.vsr_state.checkpoint.commit_min);
+                    self.superblock.working.vsr_state.checkpoint.header.op);
                 if (self.client_sessions.get(prepare.header.client)) |entry| {
                     assert(entry.header.command == .reply);
                     assert(entry.header.op >= prepare.header.op);
@@ -4889,7 +4889,7 @@ pub fn ReplicaType(
                 return true;
             }
 
-            if (self.superblock.staging.vsr_state.checkpoint.commit_min != message.header.checkpoint_op) {
+            if (self.superblock.staging.vsr_state.checkpoint.header.op != message.header.checkpoint_op) {
                 log.debug("{}: on_{s}: ignoring different checkpoint (local={} message={})", .{
                     self.replica,
                     command,
@@ -5102,7 +5102,7 @@ pub fn ReplicaType(
 
         /// The op of the highest checkpointed prepare.
         pub fn op_checkpoint(self: *const Self) u64 {
-            return self.superblock.working.vsr_state.checkpoint.commit_min;
+            return self.superblock.working.vsr_state.checkpoint.header.op;
         }
 
         /// Returns the op that will be `op_checkpoint` after the next checkpoint.
@@ -7032,7 +7032,7 @@ pub fn ReplicaType(
             assert(!self.view_durable_updating());
             assert(self.superblock.working.vsr_state.view <= self.view);
             assert(self.superblock.working.vsr_state.log_view <= self.log_view);
-            assert(self.superblock.working.vsr_state.checkpoint.commit_min <= self.commit_min);
+            assert(self.superblock.working.vsr_state.checkpoint.header.op <= self.commit_min);
             assert(self.superblock.working.vsr_state.commit_max <= self.commit_max);
 
             log.debug("{}: view_durable_update_callback: " ++
@@ -8172,7 +8172,7 @@ pub fn ReplicaType(
                 &stage.checkpoint_state,
             ));
 
-            self.commit_min = self.superblock.working.vsr_state.checkpoint.commit_min;
+            self.commit_min = self.superblock.working.vsr_state.checkpoint.header.op;
             assert(self.commit_min == self.op_checkpoint());
             if (self.op < self.op_checkpoint()) {
                 self.transition_to_recovering_head();
@@ -8397,9 +8397,9 @@ pub fn ReplicaType(
 
             // The op immediately after the checkpoint always connects to the checkpoint.
             if (op_min <= self.op_checkpoint() + 1 and op_max > self.op_checkpoint()) {
-                assert(self.superblock.working.vsr_state.checkpoint.commit_min ==
+                assert(self.superblock.working.vsr_state.checkpoint.header.op ==
                     self.op_checkpoint());
-                assert(self.superblock.working.vsr_state.checkpoint.commit_min_checksum ==
+                assert(self.superblock.working.vsr_state.checkpoint.header.checksum ==
                     self.journal.header_with_op(self.op_checkpoint() + 1).?.parent);
             }
 

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -255,7 +255,7 @@ test "format" {
             superblock_header.vsr_state.checkpoint.storage_size,
             storage.size,
         );
-        try std.testing.expectEqual(superblock_header.vsr_state.checkpoint.commit_min, 0);
+        try std.testing.expectEqual(superblock_header.vsr_state.checkpoint.header.op, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.commit_max, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.view, 0);
         try std.testing.expectEqual(superblock_header.vsr_state.log_view, 0);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -87,7 +87,7 @@ pub const SuperBlockHeader = extern struct {
     /// The number of headers in vsr_headers_all.
     vsr_headers_count: u32,
 
-    reserved: [3380]u8 = [_]u8{0} ** 3380,
+    reserved: [3172]u8 = [_]u8{0} ** 3172,
 
     /// SV/DVC header suffix. Headers are ordered from high-to-low op.
     /// Unoccupied headers (after vsr_headers_count) are zeroed.
@@ -143,7 +143,7 @@ pub const SuperBlockHeader = extern struct {
         reserved: [15]u8 = [_]u8{0} ** 15,
 
         comptime {
-            assert(@sizeOf(VSRState) == 608);
+            assert(@sizeOf(VSRState) == 816);
             // Assert that there is no implicit padding in the struct.
             assert(stdx.no_padding(VSRState));
         }
@@ -299,9 +299,9 @@ pub const SuperBlockHeader = extern struct {
     /// This struct is sent in a `sync_checkpoint` message from a healthy replica to a syncing
     /// replica.
     pub const CheckpointState = extern struct {
-        /// The vsr.Header.checksum of commit_min's message.
-        commit_min_checksum: u128,
-        commit_min_checksum_padding: u128 = 0,
+        /// The last prepare of the checkpoint committed to the state machine.
+        /// At startup, replay the log hereafter.
+        header: vsr.Header.Prepare,
 
         free_set_last_block_checksum: u128,
         free_set_last_block_checksum_padding: u128 = 0,
@@ -336,9 +336,6 @@ pub const SuperBlockHeader = extern struct {
         manifest_newest_address: u64,
         snapshots_block_address: u64,
 
-        /// The last operation committed to the state machine. At startup, replay the log hereafter.
-        commit_min: u64,
-
         // Logical storage size in bytes.
         //
         // If storage_size is less than the data file size, then the grid blocks beyond storage_size
@@ -363,11 +360,11 @@ pub const SuperBlockHeader = extern struct {
         release: u16,
 
         // TODO Reserve some more extra space before locking in storage layout.
-        reserved: [18]u8 = [_]u8{0} ** 18,
+        reserved: [10]u8 = [_]u8{0} ** 10,
 
         comptime {
-            assert(@sizeOf(CheckpointState) == 352);
             assert(@sizeOf(CheckpointState) % @sizeOf(u128) == 0);
+            assert(@sizeOf(CheckpointState) == 560);
             assert(stdx.no_padding(CheckpointState));
         }
     };

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -2,9 +2,9 @@
 //!
 //!   * vsr_state
 //!     - vsr_state.replica and vsr_state.replica_count are immutable for now.
-//!     - vsr_state.checkpoint.commit_min is initially 0 (for a newly-formatted replica).
-//!     - vsr_state.checkpoint.commit_min ≤ vsr_state.commit_max
-//!     - vsr_state.checkpoint.commit_min_before ≤ vsr_state.checkpoint.commit_min
+//!     - vsr_state.checkpoint.header.op is initially 0 (for a newly-formatted replica).
+//!     - vsr_state.checkpoint.header.op ≤ vsr_state.commit_max
+//!     - vsr_state.checkpoint.header.op_before ≤ vsr_state.checkpoint.header.op
 //!     - vsr_state.log_view ≤ vsr_state.view
 //!     - vsr_state.sync_op_min ≤ vsr_state.sync_op_max
 //!
@@ -19,13 +19,13 @@
 //!       vsr_state.checkpoint.manifest_oldest_address>0
 //!       vsr_state.checkpoint.manifest_newest_address>0
 //!
-//!     - checkpoint() must advance the superblock's vsr_state.checkpoint.commit_min.
-//!     - view_change() must not advance the superblock's vsr_state.checkpoint.commit_min.
+//!     - checkpoint() must advance the superblock's vsr_state.checkpoint.header.op.
+//!     - view_change() must not advance the superblock's vsr_state.checkpoint.header.op.
 //!     - The following are monotonically increasing:
 //!       - vsr_state.log_view
 //!       - vsr_state.view
 //!       - vsr_state.commit_max
-//!     - vsr_state.checkpoint.commit_min may backtrack due to state sync.
+//!     - vsr_state.checkpoint.header.op may backtrack due to state sync.
 //!
 const std = @import("std");
 const assert = std.debug.assert;
@@ -191,7 +191,7 @@ pub const SuperBlockHeader = extern struct {
         }
 
         pub fn assert_internally_consistent(state: VSRState) void {
-            assert(state.commit_max >= state.checkpoint.commit_min);
+            assert(state.commit_max >= state.checkpoint.header.op);
             assert(state.sync_op_max >= state.sync_op_min);
             assert(state.view >= state.log_view);
             assert(state.replica_count > 0);
@@ -202,7 +202,6 @@ pub const SuperBlockHeader = extern struct {
             assert(state.checkpoint.snapshots_block_checksum == 0);
             assert(state.checkpoint.snapshots_block_address == 0);
 
-            assert(state.checkpoint.commit_min_checksum_padding == 0);
             assert(state.checkpoint.manifest_oldest_checksum_padding == 0);
             assert(state.checkpoint.manifest_newest_checksum_padding == 0);
             assert(state.checkpoint.snapshots_block_checksum_padding == 0);
@@ -248,8 +247,8 @@ pub const SuperBlockHeader = extern struct {
         pub fn monotonic(old: VSRState, new: VSRState) bool {
             old.assert_internally_consistent();
             new.assert_internally_consistent();
-            if (old.checkpoint.commit_min == new.checkpoint.commit_min) {
-                if (old.checkpoint.commit_min_checksum == 0 and old.checkpoint.commit_min == 0) {
+            if (old.checkpoint.header.op == new.checkpoint.header.op) {
+                if (old.checkpoint.header.checksum == 0 and old.checkpoint.header.op == 0) {
                     // "old" is the root VSRState.
                     assert(old.commit_max == 0);
                     assert(old.sync_op_min == 0);
@@ -260,7 +259,7 @@ pub const SuperBlockHeader = extern struct {
                     assert(stdx.equal_bytes(CheckpointState, &old.checkpoint, &new.checkpoint));
                 }
             } else {
-                assert(old.checkpoint.commit_min_checksum != new.checkpoint.commit_min_checksum);
+                assert(old.checkpoint.header.checksum != new.checkpoint.header.checksum);
                 assert(old.checkpoint.parent_checkpoint_id !=
                     new.checkpoint.parent_checkpoint_id);
             }
@@ -268,7 +267,7 @@ pub const SuperBlockHeader = extern struct {
             assert(old.replica_count == new.replica_count);
             assert(stdx.equal_bytes([constants.members_max]u128, &old.members, &new.members));
 
-            if (old.checkpoint.commit_min > new.checkpoint.commit_min) return false;
+            if (old.checkpoint.header.op > new.checkpoint.header.op) return false;
             if (old.view > new.view) return false;
             if (old.log_view > new.log_view) return false;
             if (old.commit_max > new.commit_max) return false;
@@ -289,8 +288,8 @@ pub const SuperBlockHeader = extern struct {
         /// to ensure deterministic storage.
         pub fn op_compacted(state: VSRState, op: u64) bool {
             // If commit_min is 0, we have never checkpointed, so no compactions are checkpointed.
-            return state.checkpoint.commit_min > 0 and
-                op <= vsr.Checkpoint.trigger_for_checkpoint(state.checkpoint.commit_min).?;
+            return state.checkpoint.header.op > 0 and
+                op <= vsr.Checkpoint.trigger_for_checkpoint(state.checkpoint.header.op).?;
         }
     };
 
@@ -817,9 +816,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
         ) void {
             assert(superblock.opened);
             assert(update.commit_min <= update.commit_max);
-            assert(update.commit_min > superblock.staging.vsr_state.checkpoint.commit_min);
+            assert(update.commit_min > superblock.staging.vsr_state.checkpoint.header.op);
             assert(update.commit_min_checksum !=
-                superblock.staging.vsr_state.checkpoint.commit_min_checksum);
+                superblock.staging.vsr_state.checkpoint.header.checksum);
             assert(update.sync_op_min <= update.sync_op_max);
 
             assert(update.storage_size <= superblock.storage_size_limit);
@@ -898,7 +897,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 (update.headers.command == .do_view_change and update.log_view < update.view));
             // Usually the op-head is ahead of the commit_min. But this may not be the case, due to
             // state sync that ran after the view_durable_update was queued, but before it executed.
-            maybe(superblock.staging.vsr_state.checkpoint.commit_min >
+            maybe(superblock.staging.vsr_state.checkpoint.header.op >
                 update.headers.array.get(0).op);
 
             update.headers.verify();
@@ -935,17 +934,17 @@ pub fn SuperBlockType(comptime Storage: type) type {
             update: UpdateSync,
         ) void {
             assert(superblock.opened);
-            assert(update.checkpoint.commit_min >=
-                superblock.staging.vsr_state.checkpoint.commit_min);
-            assert(update.checkpoint.commit_min <= update.commit_max);
+            assert(update.checkpoint.header.op >=
+                superblock.staging.vsr_state.checkpoint.header.op);
+            assert(update.checkpoint.header.op <= update.commit_max);
             assert(
-                (update.checkpoint.commit_min ==
-                    superblock.staging.vsr_state.checkpoint.commit_min) ==
-                    (update.checkpoint.commit_min_checksum ==
-                    superblock.staging.vsr_state.checkpoint.commit_min_checksum),
+                (update.checkpoint.header.op ==
+                    superblock.staging.vsr_state.checkpoint.header.op) ==
+                    (update.checkpoint.header.checksum ==
+                    superblock.staging.vsr_state.checkpoint.header.checksum),
             );
             assert(update.sync_op_min <= update.sync_op_max);
-            assert(update.sync_op_max > update.checkpoint.commit_min);
+            assert(update.sync_op_max > update.checkpoint.header.op);
 
             var vsr_state = superblock.staging.vsr_state;
             vsr_state.checkpoint = update.checkpoint;
@@ -1168,12 +1167,12 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
                 if (context.caller == .format) {
                     assert(working.sequence == 1);
-                    assert(working.vsr_state.checkpoint.commit_min_checksum ==
+                    assert(working.vsr_state.checkpoint.header.checksum ==
                         vsr.Header.Prepare.root(working.cluster).checksum);
                     assert(working.vsr_state.checkpoint.free_set_size == 0);
                     assert(working.vsr_state.checkpoint.client_sessions_size == 0);
                     assert(working.vsr_state.checkpoint.storage_size == data_file_size_min);
-                    assert(working.vsr_state.checkpoint.commit_min == 0);
+                    assert(working.vsr_state.checkpoint.header.op == 0);
                     assert(working.vsr_state.commit_max == 0);
                     assert(working.vsr_state.log_view == 0);
                     assert(working.vsr_state.view == 0);
@@ -1219,8 +1218,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         .free_set_size = superblock.working.vsr_state.checkpoint.free_set_size,
                         .client_sessions_size = superblock.working.vsr_state.checkpoint.client_sessions_size,
                         .checkpoint_id = superblock.working.checkpoint_id(),
-                        .commit_min_checksum = superblock.working.vsr_state.checkpoint.commit_min_checksum,
-                        .commit_min = superblock.working.vsr_state.checkpoint.commit_min,
+                        .commit_min_checksum = superblock.working.vsr_state.checkpoint.header.checksum,
+                        .commit_min = superblock.working.vsr_state.checkpoint.header.op,
                         .commit_max = superblock.working.vsr_state.commit_max,
                         .log_view = superblock.working.vsr_state.log_view,
                         .view = superblock.working.vsr_state.view,
@@ -1414,14 +1413,14 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .replica = superblock.replica_index,
                 .caller = @tagName(context.caller),
 
-                .commit_min_old = superblock.staging.vsr_state.checkpoint.commit_min,
-                .commit_min_new = context.vsr_state.?.checkpoint.commit_min,
+                .commit_min_old = superblock.staging.vsr_state.checkpoint.header.op,
+                .commit_min_new = context.vsr_state.?.checkpoint.header.op,
 
                 .commit_max_old = superblock.staging.vsr_state.commit_max,
                 .commit_max_new = context.vsr_state.?.commit_max,
 
-                .commit_min_checksum_old = superblock.staging.vsr_state.checkpoint.commit_min_checksum,
-                .commit_min_checksum_new = context.vsr_state.?.checkpoint.commit_min_checksum,
+                .commit_min_checksum_old = superblock.staging.vsr_state.checkpoint.header.checksum,
+                .commit_min_checksum_new = context.vsr_state.?.checkpoint.header.checksum,
 
                 .log_view_old = superblock.staging.vsr_state.log_view,
                 .log_view_new = context.vsr_state.?.log_view,

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -132,8 +132,14 @@ fn test_quorums_working(
                 .replica_id = members[1],
                 .members = members,
                 .replica_count = 6,
+                .commit_max = 123,
                 .checkpoint = std.mem.zeroInit(SuperBlockHeader.CheckpointState, .{
-                    .commit_min_checksum = 123,
+                    .header = header: {
+                        var checkpoint_header = vsr.Header.Prepare.root(0);
+                        checkpoint_header.op = 123;
+                        checkpoint_header.set_checksum();
+                        break :header checkpoint_header;
+                    },
                     .free_set_checksum = vsr.checksum(&.{}),
                     .client_sessions_checksum = vsr.checksum(&.{}),
                     .storage_size = superblock.data_file_size_min,
@@ -280,7 +286,12 @@ pub fn fuzz_quorum_repairs(
                     .members = members,
                     .replica_count = 6,
                     .checkpoint = std.mem.zeroInit(SuperBlockHeader.CheckpointState, .{
-                        .commit_min_checksum = 123,
+                        .header = header: {
+                            var checkpoint_header = vsr.Header.Prepare.root(0);
+                            checkpoint_header.op = 123;
+                            checkpoint_header.set_checksum();
+                            break :header checkpoint_header;
+                        },
                     }),
                 }),
             });


### PR DESCRIPTION
To function, a replica needs a checkpoint and a header in WAL. A header
is required to make "head op is in journal" invariant work.

Currently after state sync a replica has only the checkpoint, with the
headers absent. We paper over this by transitioning the replica to
`.recovering_head`, but that creates availability issues, as in

    test "Cluster: sync: view-change with lagging replica in recovering_head"

To make the cluster more available, we include an entire header with the
checkpoint, and not just op/checksum pair.


This PR is just storage stability part of that change --- adding a header to the checkpoint state on disk and to the sync_checkpoint_target message, without any functional changes otherwise. 

In particular, the header _isn't_ used for determining the head op upon restart: doing that now will trip the invariant that DVC includes the head op.


One alternative design would be to ensure that view headers always include some header from the current checkpoint, but that would require updating the headers during checkpoint. It seems better to keep vsr and checkpoint headers separate and verify them against each other.