### PR TITLE
Config: Change production clients_max from 32 → 64

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -217,7 +217,7 @@ pub const configs = struct {
             .verify = false,
         },
         .cluster = .{
-            .clients_max = 32,
+            .clients_max = 64,
         },
     };
 


### PR DESCRIPTION
Rationale: 32 should be plenty, but 64 adds a margin for applications that don't take advantage of batching.

Once we support `clients_limit`, the default limit will be 32.