### PR TITLE
vsr: fix liveness issue when recovering head replica can't state sync

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -689,7 +689,7 @@ pub fn ReplicaType(
                     self.transition_to_normal_from_recovering_status();
                 }
             } else {
-                if (self.view < self.superblock.working.vsr_state.checkpoint.header.view) {
+                if (self.log_view < self.superblock.working.vsr_state.checkpoint.header.view) {
                     self.transition_to_recovering_head();
                 } else {
                     // Even if op_head_certain() returns false, a DVC always has a certain head op.
@@ -7392,16 +7392,21 @@ pub fn ReplicaType(
             assert(self.commit_stage == .idle);
             assert(self.journal.header_with_op(self.op) != null);
 
-            if (self.status == .recovering) {
-                assert(self.pipeline == .cache);
-                if (self.log_view < self.view) {
+            if (self.log_view < self.superblock.working.vsr_state.checkpoint.header.view) {
+                // Transitioning to recovering head after state sync --- checkpoint is from a
+                // "future" view, so we might need to truncate our log.
+            } else {
+                if (self.status == .recovering) {
+                    assert(self.pipeline == .cache);
+                    if (self.log_view < self.view) {
+                        assert(self.op < self.commit_min);
+                    }
+                } else {
+                    // During state sync, we may use recovering_head to avoid violating invariants when
+                    // the checkpoint jumps ahead.
+                    assert(self.syncing != .idle);
                     assert(self.op < self.commit_min);
                 }
-            } else {
-                // During state sync, we may use recovering_head to avoid violating invariants when
-                // the checkpoint jumps ahead.
-                assert(self.syncing != .idle);
-                assert(self.op < self.commit_min);
             }
 
             self.status = .recovering_head;
@@ -7446,6 +7451,7 @@ pub fn ReplicaType(
             assert(self.journal.header_with_op(self.op) != null);
             assert(self.pipeline == .cache);
             assert(self.view_headers.command == .start_view);
+            assert(self.log_view >= self.superblock.working.vsr_state.checkpoint.header.view);
 
             self.status = .normal;
 
@@ -7515,6 +7521,7 @@ pub fn ReplicaType(
             assert(self.journal.header_with_op(self.op) != null);
             assert(self.pipeline == .cache);
             assert(self.view_headers.command == .start_view);
+            defer assert(self.log_view >= self.superblock.working.vsr_state.checkpoint.header.view);
 
             log.debug(
                 "{}: transition_to_normal_from_recovering_head_status: view={}..{} backup",
@@ -7563,6 +7570,8 @@ pub fn ReplicaType(
             assert(self.journal.header_with_op(self.op) != null);
             assert(!self.primary_abdicating);
             assert(self.view_headers.command == .start_view);
+            assert(self.log_view >= self.superblock.working.vsr_state.checkpoint.header.view);
+
 
             self.status = .normal;
 
@@ -8186,7 +8195,9 @@ pub fn ReplicaType(
 
             self.commit_min = self.superblock.working.vsr_state.checkpoint.header.op;
             assert(self.commit_min == self.op_checkpoint());
-            if (self.op < self.op_checkpoint()) {
+            if (self.op < self.op_checkpoint() or
+                self.log_view < self.superblock.working.vsr_state.checkpoint.header.view)
+            {
                 self.transition_to_recovering_head();
             }
 
@@ -8549,18 +8560,6 @@ pub fn ReplicaType(
 
                 // Either this replica, the header's replica, or both, have diverged.
                 @panic("checkpoint diverged");
-            }
-
-            if (candidate.view > self.view_durable() and self.status != .recovering_head) {
-                log.mark.debug("{}: on_{s}: jump_sync_target: ignoring, newer view" ++
-                    " (view={} view_durable={} candidate.view={})", .{
-                    self.replica,
-                    @tagName(header.command),
-                    self.view,
-                    self.view_durable(),
-                    candidate.view,
-                });
-                return;
             }
 
             // Don't sync backwards, or to our current checkpoint.

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1191,19 +1191,17 @@ test "Cluster: sync: checkpoint from a newer view" {
         b1.drop(.R_, .incoming, .pong);
 
         const b1_view_before = b1.view();
-        var mark = marks.check("jump_sync_target: ignoring, newer view");
         try c.request(checkpoint_2_trigger - 1, checkpoint_2_trigger - 1);
         try expectEqual(b1_view_before, b1.view());
-        try expectEqual(b1.op_checkpoint(), 0); // B1 ignores new checkpoint.
-        try mark.expect_hit();
+        try expectEqual(b1.op_checkpoint(), checkpoint_1);
+        try expectEqual(b1.status(), .recovering_head);
 
-        mark = marks.check("jump_sync_target: ignoring, newer view");
-        b1.stop(); // It should be ignored even after restart.
+        b1.stop();
         try b1.open();
         t.run();
         try expectEqual(b1_view_before, b1.view());
-        try expectEqual(b1.op_checkpoint(), 0);
-        try mark.expect_hit();
+        try expectEqual(b1.op_checkpoint(), checkpoint_1);
+        try expectEqual(b1.status(), .recovering_head);
     }
 
     t.replica(.R_).pass_all(.R_, .bidirectional);


### PR DESCRIPTION
To recap, the issue:

* we can't persist checkpoint until our view is up to date, otherwise we
  observe a header break between the log and and checkpoint
* so we wait until our view_durable is up-to-date
* but that doesn't work for recovering head replicas, as it doesn't update its view durable
* and we _can't_ just excempt recevering head replica from this logic,
  as it might crash and restart into .normal due to transient failure

The new insight is that we can actually fix the latter, and make
`.recovering_head` case sticky across restarts! If a replica reastarts
and notices that it's checkpoint.header view is greater than view/view
durable, that necessary means that it crashed in recovering head state,
and needs to continue to recover its head!