### PR TITLE
test: fix fragile tests

### DIFF
--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -878,6 +878,8 @@ test "Cluster: view-change: nack older view" {
     try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger);
     try expectEqual(a0.op_head(), checkpoint_1_trigger + 3);
 
+    t.replica(.R_).pass(.R_, .bidirectional, .ping);
+    t.replica(.R_).pass(.R_, .bidirectional, .pong);
     b1.pass(.R_, .bidirectional, .start_view_change);
     b1.pass(.R_, .incoming, .do_view_change);
     b1.pass(.R_, .outgoing, .start_view);


### PR DESCRIPTION
When isolating replicas from each other, the test unintentionally breaks clock synchronization as well. The test currently pass, but slight variation might make it fail with b1 rejecting requests due to unsynchronized clocks.