### PR TITLE
VSR: SuperBlock reserved space; RegisterResult

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -286,6 +286,16 @@ pub const Operation = enum(u8) {
     }
 };
 
+pub const RegisterResult = extern struct {
+    reserved: [64]u8 = [_]u8{0} ** 64,
+
+    comptime {
+        assert(@sizeOf(RegisterResult) == 64);
+        assert(@sizeOf(RegisterResult) <= constants.message_body_size_max);
+        assert(stdx.no_padding(RegisterResult));
+    }
+};
+
 pub const BlockRequest = extern struct {
     block_checksum: u128,
     block_address: u64,
@@ -551,6 +561,7 @@ pub const UpgradeRequest = extern struct {
 
     comptime {
         assert(@sizeOf(UpgradeRequest) == 16);
+        assert(@sizeOf(UpgradeRequest) <= constants.message_body_size_max);
         assert(stdx.no_padding(UpgradeRequest));
     }
 };

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -1028,9 +1028,13 @@ test "Client Batching" {
 
             // Figure out how many zeroes to write to reply.
             // StateMachine requests get an equal amount of empty Results per Event.
-            const body_size = if (message.header.operation.vsr_reserved()) blk: {
+            const body_size: usize = if (message.header.operation.vsr_reserved()) blk: {
                 assert(message.body().len == 0);
-                break :blk 0;
+                if (message.header.operation == .register) {
+                    break :blk @sizeOf(vsr.RegisterResult);
+                } else {
+                    break :blk 0;
+                }
             } else switch (message.header.operation.cast(StateMachine)) {
                 inline else => |operation| result_size: {
                     const event_count = @divExact(

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -833,6 +833,9 @@ pub const Header = extern struct {
             if (self.op != self.commit) return "op != commit";
             if (self.timestamp == 0) return "timestamp == 0";
             if (self.operation == .register) {
+                if (self.size != @sizeOf(Header) + @sizeOf(vsr.RegisterResult)) {
+                    return "register: size != @sizeOf(Header) + @sizeOf(vsr.RegisterResult)";
+                }
                 // In this context, the commit number is the newly registered session number.
                 // The `0` commit number is reserved for cluster initialization.
                 if (self.commit == 0) return "commit == 0";

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -87,7 +87,7 @@ pub const SuperBlockHeader = extern struct {
     /// The number of headers in vsr_headers_all.
     vsr_headers_count: u32,
 
-    reserved: [3172]u8 = [_]u8{0} ** 3172,
+    reserved: [2708]u8 = [_]u8{0} ** 2708,
 
     /// SV/DVC header suffix. Headers are ordered from high-to-low op.
     /// Unoccupied headers (after vsr_headers_count) are zeroed.
@@ -143,7 +143,7 @@ pub const SuperBlockHeader = extern struct {
         reserved: [15]u8 = [_]u8{0} ** 15,
 
         comptime {
-            assert(@sizeOf(VSRState) == 816);
+            assert(@sizeOf(VSRState) == 1280);
             // Assert that there is no implicit padding in the struct.
             assert(stdx.no_padding(VSRState));
         }
@@ -357,12 +357,11 @@ pub const SuperBlockHeader = extern struct {
         /// `lsm_batch_multiple` before a checkpoint trigger may be replayed by a different release.
         release: u16,
 
-        // TODO Reserve some more extra space before locking in storage layout.
-        reserved: [10]u8 = [_]u8{0} ** 10,
+        reserved: [474]u8 = [_]u8{0} ** 474,
 
         comptime {
             assert(@sizeOf(CheckpointState) % @sizeOf(u128) == 0);
-            assert(@sizeOf(CheckpointState) == 560);
+            assert(@sizeOf(CheckpointState) == 1024);
             assert(stdx.no_padding(CheckpointState));
         }
     };

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -87,7 +87,7 @@ pub const SuperBlockHeader = extern struct {
     /// The number of headers in vsr_headers_all.
     vsr_headers_count: u32,
 
-    reserved: [2708]u8 = [_]u8{0} ** 2708,
+    reserved: [1940]u8 = [_]u8{0} ** 1940,
 
     /// SV/DVC header suffix. Headers are ordered from high-to-low op.
     /// Unoccupied headers (after vsr_headers_count) are zeroed.
@@ -140,10 +140,10 @@ pub const SuperBlockHeader = extern struct {
         /// Number of replicas (determines sizes of the quorums), part of VSR configuration.
         replica_count: u8,
 
-        reserved: [15]u8 = [_]u8{0} ** 15,
+        reserved: [783]u8 = [_]u8{0} ** 783,
 
         comptime {
-            assert(@sizeOf(VSRState) == 1280);
+            assert(@sizeOf(VSRState) == 2048);
             // Assert that there is no implicit padding in the struct.
             assert(stdx.no_padding(VSRState));
         }


### PR DESCRIPTION
- Increase reserved bytes in `CheckpointState`
- Increase reserved bytes in `VSRState`
- Reserve space after each superblock copy
- Add `RegisterResult`

Is there anything else we should reserve space for in the superblock zone/copies?