### PR TITLE
vsr: SuperbBlock version = 0 is reserved for dev builds

### DIFF
--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -45,7 +45,7 @@ pub const Quorums = @import("superblock_quorums.zig").QuorumsType(.{
     .superblock_copies = constants.superblock_copies,
 });
 
-pub const SuperBlockVersion: u16 = 0;
+pub const SuperBlockVersion: u16 = 1;
 
 const vsr_headers_reserved_size = constants.sector_size -
     ((constants.view_change_headers_max * @sizeOf(vsr.Header)) % constants.sector_size);
@@ -1485,6 +1485,7 @@ test "SuperBlockHeader" {
     const expect = std.testing.expect;
 
     var a = std.mem.zeroes(SuperBlockHeader);
+    a.version = SuperBlockVersion;
     a.set_checksum();
 
     assert(a.copy == 0);


### PR DESCRIPTION
We are almost ready for the first release which guarantees no data loss, so let's bump superblock version to 1. The 0 remains reserved dev builds.

I'll implement a follow up for a build-time toggle for the version next week.