### PR TITLE
Do not pulse when pipeline queue is full

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3043,8 +3043,8 @@ pub fn ReplicaType(
             assert(self.pulse_timeout.ticking);
 
             self.pulse_timeout.reset();
-            if (!self.pulse_needed()) return;
             if (self.pipeline.queue.full()) return;
+            if (!self.pulse_needed()) return;
 
             // To decide whether or not to `pulse` a time-dependant
             // operation, the State Machine needs an updated `prepare_timestamp`.
@@ -9300,6 +9300,7 @@ pub fn ReplicaType(
         fn pulse_needed(self: *Self) bool {
             assert(self.status == .normal);
             assert(self.primary());
+            assert(!self.pipeline.queue.full());
 
             // Pulses are replayed during `aof recovery`.
             if (constants.aof_recovery) return false;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3044,6 +3044,7 @@ pub fn ReplicaType(
 
             self.pulse_timeout.reset();
             if (!self.pulse_needed()) return;
+            if (self.pipeline.queue.full()) return;
 
             // To decide whether or not to `pulse` a time-dependant
             // operation, the State Machine needs an updated `prepare_timestamp`.


### PR DESCRIPTION
Crash

```
/home/batiati/tigerbeetle/src/vsr/replica.zig:9323:19: 0x471135 in send_request_pulse_to_self (simulator)
            assert(!self.pipeline.queue.full());
                  ^
/home/batiati/tigerbeetle/src/vsr/replica.zig:3055:44: 0x42603c in on_pulse_timeout (simulator)
            self.send_request_pulse_to_self();
                                           ^
/home/batiati/tigerbeetle/src/vsr/replica.zig:1257:66: 0x3e08f6 in tick (simulator)
            if (self.pulse_timeout.fired()) self.on_pulse_timeout();
```

SEED 7668991848053039090