### PR TITLE
Fix 10142189824643962383

### DIFF
--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -10,7 +10,8 @@ const AOFEntry = @import("../aof.zig").AOFEntry;
 const Message = @import("../message_pool.zig").MessagePool.Message;
 const log = std.log.scoped(.aof);
 
-const backing_size = 10 * 1024 * 1024;
+// Arbitrary value.
+const backing_size = 32 * 1024 * 1024;
 
 const InMemoryAOF = struct {
     const Self = @This();


### PR DESCRIPTION
It looks like we just need more room for AOF testing after we introduced `.upgrade` and `.pulse` messages.

```
thread 818678 panic: reached unreachable code
/home/batiati/tigerbeetle/zig/lib/std/debug.zig:343:14: 0x3077c2 in assert (simulator)
    if (!ok) unreachable; // assertion failure
             ^
/home/batiati/tigerbeetle/src/testing/aof.zig:124:15: 0x5156c2 in write (simulator)
        assert(self.index + disk_size <= self.backing_store.len);
              ^
/home/batiati/tigerbeetle/src/vsr/replica.zig:4039:31: 0x4cfc3f in commit_op (simulator)
                self.aof.write(prepare, .{
                              ^
/home/batiati/tigerbeetle/src/vsr/replica.zig:3704:27: 0x493846 in commit_op_client_replies_ready_callback (simulator)
            self.commit_op(self.commit_prepare.?);
                          ^
/home/batiati/tigerbeetle/src/vsr/replica.zig:3403:64: 0x44c744 in commit_dispatch (simulator)
                        commit_op_client_replies_ready_callback(&self.client_replies);
                                                               ^
/home/batiati/tigerbeetle/src/vsr/replica.zig:3694:33: 0x4cf572 in commit_op_prefetch_callback (simulator)
            self.commit_dispatch(.setup_client_replies);
                                ^
/home/batiati/tigerbeetle/src/state_machine.zig:635:21: 0x5a1e1e in prefetch_finish (simulator)
            callback(self);
                    ^
/home/batiati/tigerbeetle/src/state_machine.zig:1158:33: 0x6818f0 in prefetch_expire_pending_transfers_posted_callback (simulator)
            self.prefetch_finish();
                                ^
/home/batiati/tigerbeetle/src/lsm/groove.zig:784:33: 0x68eadc in finish (simulator)
                context.callback(context);
                                ^
/home/batiati/tigerbeetle/src/lsm/groove.zig:769:31: 0x6628f5 in worker_next_tick (simulator)
                context.finish();
                              ^
/home/batiati/tigerbeetle/src/testing/storage.zig:299:31: 0x310693 in tick (simulator)
            next_tick.callback(next_tick);
                              ^
/home/batiati/tigerbeetle/src/testing/cluster.zig:398:59: 0x38a1e9 in tick (simulator)
            for (cluster.storages) |*storage| storage.tick();
                                                          ^
/home/batiati/tigerbeetle/src/simulator.zig:501:31: 0x35a489 in tick (simulator)
        simulator.cluster.tick();
                              ^
/home/batiati/tigerbeetle/src/simulator.zig:297:23: 0x3585af in main (simulator)
        simulator.tick();
                      ^
/home/batiati/tigerbeetle/zig/lib/std/start.zig:574:37: 0x30681e in posixCallMainAndExit (simulator)
            const result = root.main() catch |err| {
                                    ^
/home/batiati/tigerbeetle/zig/lib/std/start.zig:243:5: 0x306301 in _start (simulator)
    asm volatile (switch (native_arch) {
```

After the fix

```
 0 [ \ .     3224V 1775/1803/1803C 1772:1803Jo  0/_0J! 1772:1803Wo <__0:__0> v3:3    95Ga  0G!   0G?
 0 ] \ .     3224V 1799/1803/1803C 1772:1803Jo  0/_0J! 1772:1803Wo <__0:__0> v3:3    88Ga  0G!   0G?
 0   / .     3225V 1799/1804/1804C 1773:1804Jo  0/_0J! 1773:1804Wo <__0:__0> v3:3    88Ga  0G!   0G?   0/4Pp  0/3Rq
 2   \   .   3225V 1799/1804/1804C 1773:1804Jo  0/_0J! 1773:1804Wo <__0:__0> v3:3    88Ga  0G!   0G?
 1   /  v    3226V 1799/1804/1804C 1773:1804Jo  0/_0J! 1773:1804Wo <124:483> v3:3    88Ga  0G!   2G?
 1   /  .    3226V 1799/1805/1805C 1774:1805Jo  0/_0J! 1774:1805Wo <124:483> v3:3    90Ga  0G!   2G?   0/4Pp  0/3Rq
 2   \   .   3226V 1799/1805/1805C 1774:1805Jo  0/_0J! 1774:1805Wo <__0:__0> v3:3    90Ga  0G!   0G?
no liveness, 2 blocks are not available in core

          PASSED (12605530 ticks)
```

SEED 10142189824643962383