### PR TITLE
vopr: false positive during upgrades

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -542,6 +542,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 maybe(replica.release.value < release.value);
             }
 
+            cluster.storages[replica.replica].reset();
             cluster.replica_upgrades[replica.replica] = release;
         }
 


### PR DESCRIPTION
Normally, executing upgrade is a noreturn function. In the simulator, it
is not, and instead the replica is restarted on the next tick.

The problem with this is that there might be some callbacks scheduled on
the storage, which fire before the actual upgrade happens, and observe
an inconsistent state (as, aftre transitioning to a new release replica
doesn't bother to repair local invariants).

Cancel the storage immediately upon scheduling upgrades to prevent those
callbacks from firing.

Seed: 2843879175163466061