### PR TITLE
vsr: commit_dispatch doesn't cancel cleanup

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3366,10 +3366,9 @@ pub fn ReplicaType(
             assert(self.commit_min <= self.commit_max);
             assert(self.commit_min <= self.op);
 
-            if (self.syncing == .canceling_commit) {
+            if (self.syncing == .canceling_commit and stage_new != .cleanup) {
                 return self.sync_cancel_commit_callback();
             }
-            assert(self.syncing == .idle);
 
             const stage_old = self.commit_stage;
             assert(stage_old != @as(std.meta.Tag(CommitStage), stage_new));
@@ -3381,6 +3380,7 @@ pub fn ReplicaType(
                     CommitStage.next_journal,
                 else => stage_new,
             };
+            assert(self.syncing == .idle or self.commit_stage == .cleanup);
 
             // Reset the repair-sync timeout anytime that a commit makes progress.
             if (self.commit_stage != .next_journal and


### PR DESCRIPTION
commit_dispatch starts off as

    fn commit_dispatch(self: *Self, stage_new: CommitStage) void {
      assert(self.commit_min <= self.commit_max);
      assert(self.commit_min <= self.op);
      if (self.syncing == .canceling_commit) {
          return self.sync_cancel_commit_callback();
      }

That is, every commit stage is a cancellation point. Notably, this includes the `.cleanup` stage, which:

* releases the commit_prepare
* transitions to the next release

Not rleasing prepare is ok --- sync_dispatch would handle that in cancelling grid stage

But not doing release transition is bad, as we rely on our release and superblock release being in sync all the time.

To fix this, just make the cleanup stage of commit flow sync.

Seed: 14169780878022532988