### PR TITLE
vsr: commit cancelation cleanup happens in commit_dispatch 

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3366,7 +3366,7 @@ pub fn ReplicaType(
             assert(self.commit_min <= self.commit_max);
             assert(self.commit_min <= self.op);
 
-            if (self.syncing == .canceling_commit) {
+            if (self.syncing == .canceling_commit and stage_new != .cleanup) {
                 return self.sync_cancel_commit_callback();
             }
             assert(self.syncing == .idle);


### PR DESCRIPTION
Follow up to https://github.com/tigerbeetle/tigerbeetle/pull/1736

The current code where commit_stage is reset in `sync_cancel_grid_callback` looks very puzzling to me, feels _much_ more natural to do that immediately upon the cancellation. 

Am I missing the reason while we need the commit prepare to live while the grid is being canceled? 