### PR TITLE
vopr: false assert

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -458,7 +458,6 @@ pub const Simulator = struct {
                 maybe(simulator.cluster.replica_health[replica.replica] == .down);
 
                 if (replica.release.value != release_max.value) return false;
-                assert(simulator.cluster.replica_health[replica.replica] == .up);
             }
         }
 


### PR DESCRIPTION
Even if replica.release == core_release_max, it might still be in the process of upgrading to a release originating from outside of core.