### PR TITLE
vsr: checkpoint false assert

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8641,12 +8641,6 @@ pub fn ReplicaType(
                 self.transition_to_recovering_head();
             }
 
-            if (self.status == .normal) {
-                if (self.journal.header_with_op(self.op_checkpoint() + 1)) |header| {
-                    assert(header.parent == self.superblock.working.vsr_state.checkpoint.header.checksum);
-                }
-            }
-
             self.grid.open(grid_open_callback);
             self.sync_dispatch(.idle);
         }


### PR DESCRIPTION
The intention here was to eagerly check that, when we install a checkpoint, it hashchains to our log. But we actually can't check this: if we haven't finished repair, the op in our log after checkpoint might be incorrect. Starting the view only guarantees that the HEAD op is correct, but beyond the head, we need to finish repair to be sure.

Note that similar in spirit assert in `replace_header` should be correct --- when the replica replaces a header, it asserts that it hash chains all the way to the correct head op in the current view.

Seed: 8906003881324544584