### PR TITLE
Config: Double default NodePool memory

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -587,7 +587,7 @@ pub const lsm_table_data_blocks_max = table_blocks_max: {
 /// The default size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
     // TODO Tune this better.
-    const lsm_forest_node_count: u32 = 4096;
+    const lsm_forest_node_count: u32 = 8192;
     break :lsm_manifest_memory lsm_forest_node_count * lsm_manifest_node_size;
 };
 

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -504,6 +504,7 @@ pub const ManifestNode = struct {
         reserved: [1]u8 = .{0} ** 1,
 
         comptime {
+            assert(@sizeOf(TableInfo) == 128);
             assert(@alignOf(TableInfo) == 16);
             assert(stdx.no_padding(TableInfo));
         }


### PR DESCRIPTION
    table_count_max=2396744 * @size(TableInfo)=128 = ~293MiB

    lsm_manifest_memory_size_default = lsm_forest_node_count=8192 * lsm_manifest_node_size=16KiB = 128MiB