### PR TITLE
docs: edit Deploy section

### DIFF
--- a/docs/deploy/cluster.md
+++ b/docs/deploy/cluster.md
@@ -2,9 +2,9 @@
 sidebar_position: 1
 ---
 
-# Cluster
+# The TigerBeetle Cluster
 
-A TigerBeetle cluster is a set of machines each running the TigerBeetle server for strict
+A TigerBeetle **cluster** is a set of machines each running the TigerBeetle server for strict
 serializability, high availability and durability. The TigerBeetle server is a single binary.
 
 Each server operates on a single local data file.

--- a/docs/deploy/cluster.md
+++ b/docs/deploy/cluster.md
@@ -4,45 +4,41 @@ sidebar_position: 1
 
 # Cluster
 
-A TigerBeetle cluster is 6 machines each running the TigerBeetle server for strict serializability,
-high availability and durability. The TigerBeetle server is a single binary.
+A TigerBeetle cluster is a set of machines each running the TigerBeetle server for strict
+serializability, high availability and durability. The TigerBeetle server is a single binary.
 
-Each server operates on a single local data file for a total of 6 data files across the cluster.
+Each server operates on a single local data file.
 
-The TigerBeetle server (the single binary) plus its single data file is called a replica.
-
-It is important to ensure independent fault domains for each replica's data file, that each
-replica's data file is stored on a separate disk (required), machine (required), rack (recommended),
-data center (recommended) etc.
-
-## Provisioning a cluster
+The TigerBeetle server binary plus its single data file is called a **replica**.
 
 A cluster guarantees strict serializability, the highest level of consistency, by automatically
 electing a primary replica to order and backup transactions across replicas in the cluster.
 
-The optimal, recommended size for any production cluster is 6 replicas, recognizing advances in
-flexible consensus quorums.
+## Fault Tolerance
 
-4/6 replicas are required to elect a new primary if the old primary fails.
+**The optimal, recommended size for any production cluster is 6 replicas.**
 
-A cluster remains highly available (able to process transactions), preserving strict
-serializability, provided that at least 3/6 machines have not failed (provided that the primary has
-not also failed) or provided that at least 4/6 machines have not failed (if the primary also failed
-and a new primary needs to be elected).
+Given a cluster of 6 replicas:
 
-A cluster preserves durability (surviving, detecting and repairing corruption of any data file)
-provided that the cluster remains available.
+- 4/6 replicas are required to elect a new primary if the old primary fails.
+- A cluster remains highly available (able to process transactions), preserving strict
+  serializability, provided that at least 3/6 machines have not failed (provided that the primary
+  has not also failed) or provided that at least 4/6 machines have not failed (if the primary also
+  failed and a new primary needs to be elected).
+- A cluster preserves durability (surviving, detecting and repairing corruption of any data file)
+  provided that the cluster remains available.
+- A cluster will correctly remain unavailable if too many machine failures have occurred to preserve
+  data. In other words, TigerBeetle is designed to operate correctly or else to shut down safely if
+  safe operation with respect to strict serializability is no longer possible due to permanent data
+  loss.
 
-A cluster will correctly remain unavailable if too many machine failures have occurred to preserve
-data. In other words, TigerBeetle is designed to operate correctly or else to shut down safely if
-safe operation with respect to strict serializability is no longer possible due to permanent data
-loss.
+### Geographic Fault Tolerance
 
 All 6 replicas may be within the same data center (zero geographic fault tolerance), or spread
 across 2 or more data centers, availability zones or regions (“sites”) for geographic fault
 tolerance.
 
-For mission critical availability, the optimal number of sites is 3, since each site would then
+**For mission critical availability, the optimal number of sites is 3**, since each site would then
 contain 2 replicas so that the loss of an entire site would not impair the availability of the
 cluster.
 
@@ -54,3 +50,9 @@ repaired once the lost site is restored.
 
 Sites should preferably be within a few milliseconds of each other, since each transaction must be
 replicated across sites before being committed.
+
+### Hardware Fault Tolerance
+
+It is important to ensure independent fault domains for each replica's data file, that each
+replica's data file is stored on a separate disk (required), machine (required), rack (recommended),
+data center (recommended) etc.

--- a/docs/deploy/cluster.md
+++ b/docs/deploy/cluster.md
@@ -25,8 +25,10 @@ Given a cluster of 6 replicas:
   serializability, provided that at least 3/6 machines have not failed (provided that the primary
   has not also failed) or provided that at least 4/6 machines have not failed (if the primary also
   failed and a new primary needs to be elected).
-- A cluster preserves durability (surviving, detecting and repairing corruption of any data file)
-  provided that the cluster remains available.
+- A cluster preserves durability (surviving, detecting, and repairing corruption of any data file)
+  provided that the cluster remains available. If machines go offline temporarily and the cluster
+  becomes available again later, the cluster will be able to repair data file corruption once
+  availability is restored.
 - A cluster will correctly remain unavailable if too many machine failures have occurred to preserve
   data. In other words, TigerBeetle is designed to operate correctly or else to shut down safely if
   safe operation with respect to strict serializability is no longer possible due to permanent data

--- a/docs/deploy/cluster.md
+++ b/docs/deploy/cluster.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 1
+---
+
+# Cluster
+
+A TigerBeetle cluster is 6 machines each running the TigerBeetle server for strict serializability,
+high availability and durability. The TigerBeetle server is a single binary.
+
+Each server operates on a single local data file for a total of 6 data files across the cluster.
+
+The TigerBeetle server (the single binary) plus its single data file is called a replica.
+
+It is important to ensure independent fault domains for each replica's data file, that each
+replica's data file is stored on a separate disk (required), machine (required), rack (recommended),
+data center (recommended) etc.
+
+## Provisioning a cluster
+
+A cluster guarantees strict serializability, the highest level of consistency, by automatically
+electing a primary replica to order and backup transactions across replicas in the cluster.
+
+The optimal, recommended size for any production cluster is 6 replicas, recognizing advances in
+flexible consensus quorums.
+
+4/6 replicas are required to elect a new primary if the old primary fails.
+
+A cluster remains highly available (able to process transactions), preserving strict
+serializability, provided that at least 3/6 machines have not failed (provided that the primary has
+not also failed) or provided that at least 4/6 machines have not failed (if the primary also failed
+and a new primary needs to be elected).
+
+A cluster preserves durability (surviving, detecting and repairing corruption of any data file)
+provided that the cluster remains available.
+
+A cluster will correctly remain unavailable if too many machine failures have occurred to preserve
+data. In other words, TigerBeetle is designed to operate correctly or else to shut down safely if
+safe operation with respect to strict serializability is no longer possible due to permanent data
+loss.
+
+All 6 replicas may be within the same data center (zero geographic fault tolerance), or spread
+across 2 or more data centers, availability zones or regions (“sites”) for geographic fault
+tolerance.
+
+For mission critical availability, the optimal number of sites is 3, since each site would then
+contain 2 replicas so that the loss of an entire site would not impair the availability of the
+cluster.
+
+If only 2 sites are able to be provisioned, it is recommended to tune the cluster so that at least
+4/6 replicas (instead of 3/6 replicas) acknowledge each transaction before commit. This would ensure
+that at least 1 replica in the other site will preserve data durability in the event that an entire
+site is permanently lost. Furthermore, this would ensure that the entire cluster would be able to be
+repaired once the lost site is restored.
+
+Sites should preferably be within a few milliseconds of each other, since each transaction must be
+replicated across sites before being committed.

--- a/docs/deploy/cluster.md
+++ b/docs/deploy/cluster.md
@@ -44,12 +44,6 @@ tolerance.
 contain 2 replicas so that the loss of an entire site would not impair the availability of the
 cluster.
 
-If only 2 sites are able to be provisioned, it is recommended to tune the cluster so that at least
-4/6 replicas (instead of 3/6 replicas) acknowledge each transaction before commit. This would ensure
-that at least 1 replica in the other site will preserve data durability in the event that an entire
-site is permanently lost. Furthermore, this would ensure that the entire cluster would be able to be
-repaired once the lost site is restored.
-
 Sites should preferably be within a few milliseconds of each other, since each transaction must be
 replicated across sites before being committed.
 

--- a/docs/deploy/hardware.md
+++ b/docs/deploy/hardware.md
@@ -16,7 +16,8 @@ lived, and the data file is expected to be large. There is no requirement for NV
 
 A 20 TiB disk containing a replica's data file is enough to address on the order of 50 billion
 accounts or transfers. It is more important to provision sufficient storage space for a replica’s
-data file, than to provision high performance storage.
+data file than to provision high performance storage. The data file is created before the server is
+initially run and grows automatically.
 
 A replica's data file may reside on local storage or else on remote storage. The most important
 concern is to ensure [independent fault domains](./cluster.md#hardware-fault-tolerance) across

--- a/docs/deploy/hardware.md
+++ b/docs/deploy/hardware.md
@@ -28,7 +28,7 @@ disk fails.
 
 ECC memory is recommended for production deployments.
 
-A replica requires at least 2 GiB RAM per machine. Between 16 GiB and 32 GiB or more (depending on
+A replica requires at least 6 GiB RAM per machine. Between 16 GiB and 32 GiB or more (depending on
 budget) is recommended to be allocated to each replica for caching. TigerBeetle uses static
 allocation and will use exactly how much memory is explicitly allocated to it for caching via
 command line argument.

--- a/docs/deploy/hardware.md
+++ b/docs/deploy/hardware.md
@@ -6,104 +6,85 @@ sidebar_position: 1
 
 ## Cluster of replicas
 
-A TigerBeetle cluster is 6 machines each running the TigerBeetle
-server for strict serializability, high availability and
-durability. The TigerBeetle server is a single binary.
+A TigerBeetle cluster is 6 machines each running the TigerBeetle server for strict serializability,
+high availability and durability. The TigerBeetle server is a single binary.
 
-Each server operates on a single local data file for a total of 6
-data files across the cluster.
+Each server operates on a single local data file for a total of 6 data files across the cluster.
 
-The TigerBeetle server (the single binary) plus its single data file
-is called a replica.
+The TigerBeetle server (the single binary) plus its single data file is called a replica.
 
-It is important to ensure independent fault domains for each replica's
-data file, that each replica's data file is stored on a separate disk
-(required), machine (required), rack (recommended), data center
-(recommended) etc.
+It is important to ensure independent fault domains for each replica's data file, that each
+replica's data file is stored on a separate disk (required), machine (required), rack (recommended),
+data center (recommended) etc.
 
 ## Provisioning a cluster
 
-A cluster guarantees strict serializability, the highest level of
-consistency, by automatically electing a primary replica to order and
-backup transactions across replicas in the cluster.
+A cluster guarantees strict serializability, the highest level of consistency, by automatically
+electing a primary replica to order and backup transactions across replicas in the cluster.
 
-The optimal, recommended size for any production cluster is 6
-replicas, recognizing advances in flexible consensus quorums.
+The optimal, recommended size for any production cluster is 6 replicas, recognizing advances in
+flexible consensus quorums.
 
-4/6 replicas are required to elect a new primary if the old primary
-fails.
+4/6 replicas are required to elect a new primary if the old primary fails.
 
-A cluster remains highly available (able to process transactions),
-preserving strict serializability, provided that at least 3/6 machines
-have not failed (provided that the primary has not also failed) or
-provided that at least 4/6 machines have not failed (if the primary
-also failed and a new primary needs to be elected).
+A cluster remains highly available (able to process transactions), preserving strict
+serializability, provided that at least 3/6 machines have not failed (provided that the primary has
+not also failed) or provided that at least 4/6 machines have not failed (if the primary also failed
+and a new primary needs to be elected).
 
-A cluster preserves durability (surviving, detecting and repairing
-corruption of any data file) provided that the cluster remains
-available.
+A cluster preserves durability (surviving, detecting and repairing corruption of any data file)
+provided that the cluster remains available.
 
-A cluster will correctly remain unavailable if too many machine
-failures have occurred to preserve data. In other words, TigerBeetle
-is designed to operate correctly or else to shut down safely if safe
-operation with respect to strict serializability is no longer possible
-due to permanent data loss.
+A cluster will correctly remain unavailable if too many machine failures have occurred to preserve
+data. In other words, TigerBeetle is designed to operate correctly or else to shut down safely if
+safe operation with respect to strict serializability is no longer possible due to permanent data
+loss.
 
-All 6 replicas may be within the same data center (zero geographic
-fault tolerance), or spread across 2 or more data centers,
-availability zones or regions (“sites”) for geographic fault
+All 6 replicas may be within the same data center (zero geographic fault tolerance), or spread
+across 2 or more data centers, availability zones or regions (“sites”) for geographic fault
 tolerance.
 
-For mission critical availability, the optimal number of sites is 3,
-since each site would then contain 2 replicas so that the loss of an
-entire site would not impair the availability of the cluster.
+For mission critical availability, the optimal number of sites is 3, since each site would then
+contain 2 replicas so that the loss of an entire site would not impair the availability of the
+cluster.
 
-If only 2 sites are able to be provisioned, it is recommended to tune
-the cluster so that at least 4/6 replicas (instead of 3/6 replicas)
-acknowledge each transaction before commit. This would ensure that at
-least 1 replica in the other site will preserve data durability in the
-event that an entire site is permanently lost. Furthermore, this would
-ensure that the entire cluster would be able to be repaired once the
-lost site is restored.
+If only 2 sites are able to be provisioned, it is recommended to tune the cluster so that at least
+4/6 replicas (instead of 3/6 replicas) acknowledge each transaction before commit. This would ensure
+that at least 1 replica in the other site will preserve data durability in the event that an entire
+site is permanently lost. Furthermore, this would ensure that the entire cluster would be able to be
+repaired once the lost site is restored.
 
-Sites should preferably be within a few milliseconds of each other,
-since each transaction must be replicated across sites before being
-committed.
+Sites should preferably be within a few milliseconds of each other, since each transaction must be
+replicated across sites before being committed.
 
 ## Provisioning a replica
 
-TigerBeetle is designed to operate and provide more than adequate
-performance even on commodity hardware.
+TigerBeetle is designed to operate and provide more than adequate performance even on commodity
+hardware.
 
 NVMe is preferred to SSD for high performance deployments.
 
-However, spinning rust is perfectly acceptable, especially where a
-cluster is expected to be long lived, and the data file is expected to
-be large. There is no requirement for NVMe or SSD.
+However, spinning rust is perfectly acceptable, especially where a cluster is expected to be long
+lived, and the data file is expected to be large. There is no requirement for NVMe or SSD.
 
-A 20 TiB disk containing a replica's data file is enough to address on
-the order of 50 billion accounts or transfers. It is more important to
-provision sufficient storage space for a replica’s data file, than to
-provision high performance storage.
+A 20 TiB disk containing a replica's data file is enough to address on the order of 50 billion
+accounts or transfers. It is more important to provision sufficient storage space for a replica’s
+data file, than to provision high performance storage.
 
-A replica's data file may reside on local storage or else on remote
-storage. The most important concern is to ensure independent fault
-domains across replicas.
+A replica's data file may reside on local storage or else on remote storage. The most important
+concern is to ensure independent fault domains across replicas.
 
-The operator may consider the use of RAID 10 to reduce the need for
-remote recovery if a replica's disk fails.
+The operator may consider the use of RAID 10 to reduce the need for remote recovery if a replica's
+disk fails.
 
 ECC memory is recommended for production deployments.
 
-TigerBeetle requires only a single core per replica
-machine. TigerBeetle at present does not utilize more cores, but may
-in future.
+TigerBeetle requires only a single core per replica machine. TigerBeetle at present does not utilize
+more cores, but may in future.
 
-There are no restrictions on sharing a server with other tenant
-processes.
+There are no restrictions on sharing a server with other tenant processes.
 
-A replica requires at least 2 GiB RAM per machine. Between 16 GiB and
-32 GiB or more (depending on budget) is recommended to be allocated to
-each replica for caching. TigerBeetle uses static allocation and will
-use exactly how much memory is explicitly allocated to it for caching
-via command line argument.
+A replica requires at least 2 GiB RAM per machine. Between 16 GiB and 32 GiB or more (depending on
+budget) is recommended to be allocated to each replica for caching. TigerBeetle uses static
+allocation and will use exactly how much memory is explicitly allocated to it for caching via
+command line argument.

--- a/docs/deploy/hardware.md
+++ b/docs/deploy/hardware.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 TigerBeetle is designed to operate and provide more than adequate performance even on commodity
 hardware.
 
+## Storage
+
 NVMe is preferred to SSD for high performance deployments.
 
 However, spinning rust is perfectly acceptable, especially where a cluster is expected to be long
@@ -22,14 +24,20 @@ concern is to ensure independent fault domains across replicas.
 The operator may consider the use of RAID 10 to reduce the need for remote recovery if a replica's
 disk fails.
 
+## Memory
+
 ECC memory is recommended for production deployments.
-
-TigerBeetle requires only a single core per replica machine. TigerBeetle at present does not utilize
-more cores, but may in future.
-
-There are no restrictions on sharing a server with other tenant processes.
 
 A replica requires at least 2 GiB RAM per machine. Between 16 GiB and 32 GiB or more (depending on
 budget) is recommended to be allocated to each replica for caching. TigerBeetle uses static
 allocation and will use exactly how much memory is explicitly allocated to it for caching via
 command line argument.
+
+## CPU
+
+TigerBeetle requires only a single core per replica machine. TigerBeetle at present does not utilize
+more cores, but may in future.
+
+## Multitenancy
+
+There are no restrictions on sharing a server with other tenant processes.

--- a/docs/deploy/hardware.md
+++ b/docs/deploy/hardware.md
@@ -19,7 +19,8 @@ accounts or transfers. It is more important to provision sufficient storage spac
 data file, than to provision high performance storage.
 
 A replica's data file may reside on local storage or else on remote storage. The most important
-concern is to ensure independent fault domains across replicas.
+concern is to ensure [independent fault domains](./cluster.md#hardware-fault-tolerance) across
+replicas.
 
 The operator may consider the use of RAID 10 to reduce the need for remote recovery if a replica's
 disk fails.

--- a/docs/deploy/hardware.md
+++ b/docs/deploy/hardware.md
@@ -1,63 +1,8 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Hardware
-
-## Cluster of replicas
-
-A TigerBeetle cluster is 6 machines each running the TigerBeetle server for strict serializability,
-high availability and durability. The TigerBeetle server is a single binary.
-
-Each server operates on a single local data file for a total of 6 data files across the cluster.
-
-The TigerBeetle server (the single binary) plus its single data file is called a replica.
-
-It is important to ensure independent fault domains for each replica's data file, that each
-replica's data file is stored on a separate disk (required), machine (required), rack (recommended),
-data center (recommended) etc.
-
-## Provisioning a cluster
-
-A cluster guarantees strict serializability, the highest level of consistency, by automatically
-electing a primary replica to order and backup transactions across replicas in the cluster.
-
-The optimal, recommended size for any production cluster is 6 replicas, recognizing advances in
-flexible consensus quorums.
-
-4/6 replicas are required to elect a new primary if the old primary fails.
-
-A cluster remains highly available (able to process transactions), preserving strict
-serializability, provided that at least 3/6 machines have not failed (provided that the primary has
-not also failed) or provided that at least 4/6 machines have not failed (if the primary also failed
-and a new primary needs to be elected).
-
-A cluster preserves durability (surviving, detecting and repairing corruption of any data file)
-provided that the cluster remains available.
-
-A cluster will correctly remain unavailable if too many machine failures have occurred to preserve
-data. In other words, TigerBeetle is designed to operate correctly or else to shut down safely if
-safe operation with respect to strict serializability is no longer possible due to permanent data
-loss.
-
-All 6 replicas may be within the same data center (zero geographic fault tolerance), or spread
-across 2 or more data centers, availability zones or regions (“sites”) for geographic fault
-tolerance.
-
-For mission critical availability, the optimal number of sites is 3, since each site would then
-contain 2 replicas so that the loss of an entire site would not impair the availability of the
-cluster.
-
-If only 2 sites are able to be provisioned, it is recommended to tune the cluster so that at least
-4/6 replicas (instead of 3/6 replicas) acknowledge each transaction before commit. This would ensure
-that at least 1 replica in the other site will preserve data durability in the event that an entire
-site is permanently lost. Furthermore, this would ensure that the entire cluster would be able to be
-repaired once the lost site is restored.
-
-Sites should preferably be within a few milliseconds of each other, since each transaction must be
-replicated across sites before being committed.
-
-## Provisioning a replica
 
 TigerBeetle is designed to operate and provide more than adequate performance even on commodity
 hardware.

--- a/docs/deploy/linux.md
+++ b/docs/deploy/linux.md
@@ -6,6 +6,8 @@ sidebar_position: 2
 
 ## systemd
 
-TigerBeetle includes an example [systemd unit](https://github.com/tigerbeetle/tigerbeetle/tree/main/tools/systemd/) for use with Linux systems that use systemd.
-The unit is configured to start a [single-node cluster](../quick-start/single-binary.md), so you may need to adjust it for other cluster configurations.
-Instructions to do so are in our GitHub repository.
+TigerBeetle includes an example [systemd
+unit](https://github.com/tigerbeetle/tigerbeetle/tree/main/tools/systemd/) for use with Linux
+systems that use systemd. The unit is configured to start a [single-node
+cluster](../quick-start/single-binary.md), so you may need to adjust it for other cluster
+configurations. Instructions to do so are in our GitHub repository.

--- a/docs/deploy/linux.md
+++ b/docs/deploy/linux.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Deploying on Linux

--- a/scripts/.cspell.json
+++ b/scripts/.cspell.json
@@ -87,6 +87,7 @@
 	"mlns",
 	"mojaloop's",
 	"mojaloop",
+	"multitenancy",
 	"munges",
 	"Musique",
 	"myscript",


### PR DESCRIPTION
- **docs: rewrap deploy pages to 100 chars**
- **docs: split hardware page into two**
- **docs: split cluster doc into sections about fault tolerance**
- **docs: clarify durability**
- **docs: split hardware page into sections**
- **docs: raise required RAM per machine**
- **docs: link from hardware page to cluster page for fault tolerance**
- **docs: change heading on cluster page**
- **docs: mention that the data file is elastic**
