### PR TITLE
build: propagate version to clients

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,7 +68,7 @@ pub fn build(b: *std.Build) !void {
     ) orelse try shell.git_commit();
     options.addOption([]const u8, "git_commit", git_commit);
 
-    const release_version_string = b.option([]const u8, "version", "tigerbeetle --version");
+    const release_version_string = b.env_map.get("TIGERBEETLE_RELEASE");
     options.addOption([]const u8, "version", release_version_string orelse try shell.git_tag());
     options.addOption([]const u8, "release", release_version_string orelse "0.0.1");
 

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -65,6 +65,8 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     };
     log.info("version={s} sha={s}", .{ version_info.version, version_info.sha });
 
+    try shell.env.put("TIGERBEETLE_RELEASE", version_info.version);
+
     if (cli_args.build) {
         try build(shell, languages, version_info);
     }
@@ -159,12 +161,10 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 \\    -Dtarget={target}
                 \\    -Drelease={release}
                 \\    -Dgit-commit={commit}
-                \\    -Dversion={version}
             , .{
                 .target = target,
                 .release = if (debug) "false" else "true",
                 .commit = info.sha,
-                .version = info.version,
             });
 
             const windows = comptime std.mem.indexOf(u8, target, "windows") != null;
@@ -233,9 +233,7 @@ fn build_go(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     try shell.pushd("./src/clients/go");
     defer shell.popd();
 
-    try shell.zig("build go_client -Drelease -Dconfig=production -Dversion={version}", .{
-        .version = info.version,
-    });
+    try shell.zig("build go_client -Drelease -Dconfig=production", .{});
 
     const files = try shell.exec_stdout("git ls-files", .{});
     var files_lines = std.mem.tokenize(u8, files, "\n");


### PR DESCRIPTION
Inject version information through an env var, rather than an argument.

This is super hacky, but makes sure that the version propagates to all clients.