### PR TITLE
ci: improve client tests logging

### DIFF
--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -28,6 +28,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
 
     // Integration tests.
     inline for (.{ "basic", "two-phase", "two-phase-many", "walkthrough" }) |sample| {
+        log.info("testing sample '{s}'", .{sample});
+
         try shell.pushd("./samples/" ++ sample);
         defer shell.popd();
 
@@ -58,6 +60,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
 
         inline for (image_tags) |image_tag| {
             const image = "mcr.microsoft.com/dotnet/sdk:" ++ image_tag;
+            log.info("testing docker image: '{s}'", .{image});
 
             for (0..5) |attempt| {
                 if (attempt > 0) std.time.sleep(1 * std.time.ns_per_min);

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -33,8 +33,18 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     // Building the server before running the integrated tests:
     try shell.zig("build install -Drelease -Dconfig=production", .{});
     try shell.exec("go test", .{});
+    {
+        log.info("testing `types` package helpers", .{});
+
+        try shell.pushd("./pkg/types");
+        defer shell.popd();
+
+        try shell.exec("go test", .{});
+    }
 
     inline for (.{ "basic", "two-phase", "two-phase-many", "walkthrough" }) |sample| {
+        log.info("testing sample '{s}'", .{sample});
+
         try shell.pushd("./samples/" ++ sample);
         defer shell.popd();
 
@@ -46,14 +56,6 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         }
         try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
         try shell.exec("go run main.go", .{});
-    }
-
-    // Test the `types` package helpers
-    {
-        try shell.pushd("./pkg/types");
-        defer shell.popd();
-
-        try shell.exec("go test", .{});
     }
 }
 

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -19,6 +19,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     try shell.exec("mvn --batch-mode --file pom.xml --quiet install", .{});
 
     inline for (.{ "basic", "two-phase", "two-phase-many", "walkthrough" }) |sample| {
+        log.info("testing sample '{s}'", .{sample});
+
         try shell.pushd("./samples/" ++ sample);
         defer shell.popd();
 

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -37,7 +37,6 @@ test "repl integration" {
             const tigerbeetle = try tigerbeetle_exe(shell);
 
             var tmp_beetle = try TmpTigerBeetle.init(std.testing.allocator, .{
-                .echo = false,
                 .prebuilt = tigerbeetle,
             });
             errdefer tmp_beetle.deinit(std.testing.allocator);

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -24,7 +24,6 @@ process: std.ChildProcess,
 pub fn init(
     gpa: std.mem.Allocator,
     options: struct {
-        echo: bool = true,
         prebuilt: ?[]const u8 = null,
     },
 ) !TmpTigerBeetle {
@@ -64,7 +63,7 @@ pub fn init(
     defer gpa.free(data_file);
 
     try shell.exec_options(
-        .{ .echo = options.echo },
+        .{ .echo = false },
         "{tigerbeetle} format --cluster=0 --replica=0 --replica-count=1 {data_file}",
         .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
     );


### PR DESCRIPTION
- don't print noisy and useless logs from `tigerbeetle format` by default.
- but, if formatting fails, do print everything
- print _which_ test is being run on CI