### PR TITLE
StorageChecker: Verify grid at bar boundaries

### DIFF
--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -892,6 +892,9 @@ pub fn ManifestLogType(comptime Storage: type) type {
             manifest_log.blocks.advance_tail();
 
             const block: BlockPtr = manifest_log.blocks.tail().?;
+            // The ManifestLog acquires block addresses eagerly here, rather than deferring until
+            // close_block(). This is because the open block's address must be inserted into
+            // `table_extents` at the same time the entry is appended to the open block.
             const block_address = manifest_log.grid.acquire(manifest_log.grid_reservation.?);
 
             const header = mem.bytesAsValue(vsr.Header.Block, block[0..@sizeOf(vsr.Header)]);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -674,7 +674,11 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                         fatal(.correctness, "state checker error: {}", .{err});
                     };
                 },
-                .compaction_completed => {},
+                .compaction_completed => {
+                    cluster.storage_checker.replica_compact(Replica, replica) catch |err| {
+                        fatal(.correctness, "storage checker error: {}", .{err});
+                    };
+                },
                 .checkpoint_commenced => {
                     cluster.log_replica(.checkpoint_commenced, replica.replica);
                 },


### PR DESCRIPTION
### Background

[The compaction pacing PR](https://github.com/tigerbeetle/tigerbeetle/pull/1660) noted (as part of the s/measure/bar rename I'm guessing) that `storage_checker.zig` contained a comment implying that it was verifying storage stability at bar boundaries, but no such verification was written.

This check was implemented at one point in the past (see https://github.com/tigerbeetle/tigerbeetle/commit/41c90b29c22522d827aeb150dcd9aa0d4771850c for an old version of it). The check was removed (in that commit, though it was disabled for some time previously) because it didn't work with the manifest log.

I originally thought that the unified manifest would solve that issue and it could be re-enabled but that expectation turned out to be incorrect. (Or so I thought at the time.)

The reason that the manifest log conflicts with running `StorageChecker` on the grid at bar boundaries:

- The manifest log acquires a block address, but then it doesn't write the block it immediately.
- It needs the block address well in advance (often >1 bar) of writing the block so that it can maintain the `table_extents` index in memory.
- So the grid _is_ deterministic at bar boundaries.
- But the `StorageChecker` checks the grid by iterating all of the freeset's acquired blocks and computing the cumulative checksum of their data in storage.
- The `ManifestLog`'s open block is acquired, but not yet written – the content of the corresponding block in storage is undefined.

### Fix

So to work around this, `StorageChecker` can explicitly ignore the manifest log's open block when it is computing the grid's acquire blocks' cumulative checksum.

<details>
<summary>Another approach I tried before settling on this current one:</summary>

- Defer address acquisition until `ManifestLog.close_block`.
- There is only at most one open manifest block.
- So in the table extents, we can set new table extent's manifest block address to `null` initially.

Then during `close_block`:

1. Acquire the block's address, and
2. Iterate the body of the manifest log block, and for each update, set the corresponding table extent's manifest block address.

This works! But at the cost of:

- Adding an extra hashmap lookup for each entry in the manifest block.
- Imposing a change to `ManifestLog` block acquisition solely to accommodate testing. (And net-adding a bunch of lines of code in the process.)

</details>