### PR TITLE
vopr: liveness false positive when standby misses an op

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -600,7 +600,7 @@ pub const Simulator = struct {
 
         var missing_op: ?u64 = null;
         for (simulator.cluster.replicas) |replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.isSet(replica.replica) and !replica.standby()) {
                 assert(simulator.cluster.replica_health[replica.replica] == .up);
                 if (replica.op > replica.commit_min) {
                     for (replica.commit_min + 1..@min(replica.op, commit_max) + 1) |op| {


### PR DESCRIPTION
Consider the situation where R0 and R1 can't reparir op=171 because it is corrupted in core. R0 and R1 won't view-change (a primary would abdicate).

However, his prevents S4 (a standby) from repairing op=169, although op=169 might otherwise be available on R0 and R1.

When computing whether a prepare is corrupted in core, only consider active replicas.

Seed: 6926699575179089507

Closes: #1764