### PR TITLE
vsr: assert that SV doesn't go past op_repiar_min

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -252,7 +252,7 @@ comptime {
 }
 
 /// Maximum number of headers from the WAL suffix to include in an SV message.
-/// Must at least cover the full pipeline.
+/// Must at least cover the full pipeline plus commit_min.
 /// Increasing this reduces likelihood that backups will need to repair their suffix's headers.
 ///
 /// CRITICAL:
@@ -261,6 +261,11 @@ comptime {
 ///   that cannot be repaired because they are gaps. See DVCQuorum for more detail.
 /// - +1 to leave room for commit_max, in case a backup converts the SV to a DVC.
 pub const view_change_headers_suffix_max = config.cluster.view_change_headers_suffix_max;
+comptime {
+    // lsm_batch_multiple is the lower bound on the size of primary's log, when the primary is at
+    // op=trigger+1.
+    assert(view_change_headers_max <= lsm_batch_multiple);
+}
 
 /// The number of prepare headers to include in the body of a DVC/SV.
 ///

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4428,6 +4428,7 @@ pub fn ReplicaType(
                 self.view_headers.append(self.journal.header_with_op(op).?);
             }
             assert(self.view_headers.array.count() + 2 <= constants.view_change_headers_max);
+            assert(op >= self.op_repair_min());
 
             // Determine the consecutive extent of the log that we can help recover.
             // This may precede op_repair_min if we haven't had a view-change recently.


### PR DESCRIPTION
We require that the primary always includes as much headers as fit into an SV. That is, the header can be omitted _only_ if we get all the way to op=0.

But primary doesn't have literally _all_ messages, its log cuts off at op_repair_min.

This all works out: if primary is at a checkpoint, it has at least lsm_batch_multiple headers on top of it, and that's larger than `view_change_headers_suffix_max`. But we should assert this!