### PR TITLE
Client: cleanup Demuxer wrapper

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -383,7 +383,7 @@ pub const AOFReplayClient = struct {
     fn replay_callback(
         user_data: u128,
         operation: StateMachine.Operation,
-        result: []const u8,
+        result: []u8,
     ) void {
         _ = operation;
         _ = result;

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -363,7 +363,7 @@ pub fn ContextType(
         fn on_result(
             raw_user_data: u128,
             op: StateMachine.Operation,
-            reply: []const u8,
+            reply: []u8,
         ) void {
             const user_data: UserData = @bitCast(raw_user_data);
             const self = user_data.self;

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -895,7 +895,7 @@ pub fn ReplType(comptime MessageBus: type) type {
         fn client_request_callback(
             user_data: u128,
             operation: StateMachine.Operation,
-            result: []const u8,
+            result: []u8,
         ) void {
             client_request_callback_error(
                 user_data,

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -630,7 +630,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         fn request_callback(
             user_data: u128,
             operation: StateMachine.Operation,
-            result: []const u8,
+            result: []u8,
         ) void {
             _ = user_data;
             _ = operation;

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -53,15 +53,15 @@ pub fn StateMachineType(
                 reply: []Result(operation),
                 offset: u32 = 0,
 
-                pub fn init(reply: []Result(operation)) Demuxer {
-                    return .{ .reply = reply };
+                pub fn init(reply: []u8) Demuxer {
+                    return .{ .reply = @alignCast(std.mem.bytesAsSlice(Result(operation), reply)) };
                 }
 
-                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []Result(operation) {
+                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []u8 {
                     assert(self.offset == event_offset);
                     assert(event_offset + event_count <= self.reply.len);
                     defer self.offset += event_count;
-                    return self.reply[self.offset..][0..event_count];
+                    return std.mem.sliceAsBytes(self.reply[self.offset..][0..event_count]);
                 }
             };
         }

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -484,7 +484,7 @@ const Benchmark = struct {
     fn send_complete(
         user_data: u128,
         operation: StateMachine.Operation,
-        result: []const u8,
+        result: []u8,
     ) void {
         const b: *Benchmark = @ptrFromInt(@as(usize, @intCast(user_data)));
         const callback = b.callback.?;

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -440,6 +440,9 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 }
             } else {
                 // The message is the result of raw_request(), so invoke the user callback.
+                // NOTE: the callback is allowed to mutate `reply.body()` so ensure the message has
+                // no other references or uses before this callback.
+                assert(reply.references == 1);
                 inflight.callback(
                     inflight.user_data,
                     inflight_vsr_operation.cast(StateMachine),

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -440,9 +440,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 }
             } else {
                 // The message is the result of raw_request(), so invoke the user callback.
-                // NOTE: the callback is allowed to mutate `reply.body()` so ensure the message has
-                // no other references or uses before this callback.
-                assert(reply.references == 1);
+                // NOTE: the callback is allowed to mutate `reply.body()` here.
                 inflight.callback(
                     inflight.user_data,
                     inflight_vsr_operation.cast(StateMachine),

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -21,44 +21,18 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
         const Self = @This();
 
         pub const StateMachine = StateMachine_;
-
+        pub const DemuxerType = StateMachine.DemuxerType;
         pub const Request = struct {
             pub const Callback = *const fn (
                 user_data: u128,
                 operation: StateMachine.Operation,
-                results: []const u8,
+                results: []u8,
             ) void;
 
             message: *Message.Request,
             user_data: u128,
             callback: Callback,
         };
-
-        /// Custom Demuxer which passes through to StateMachine.Demuxer.
-        ///
-        /// Clients re-expose their own DemuxerType over using StateMachine's as it allows them to
-        /// reinterpret the MessageBus reply bytes outside of the standard flow (i.e. to echo back
-        /// Events instead of Results in the case of `echo_client.zig`).
-        ///
-        /// TODO: Change StateMachine Demuxer to take/give bytes and re-export its alias instead.
-        pub fn DemuxerType(comptime operation: StateMachine.Operation) type {
-            return struct {
-                const Demuxer = @This();
-                const DemuxerBase = StateMachine.DemuxerType(operation);
-
-                base: DemuxerBase,
-
-                pub fn init(reply: []u8) Demuxer {
-                    const results = std.mem.bytesAsSlice(StateMachine.Result(operation), reply);
-                    return Demuxer{ .base = DemuxerBase.init(@alignCast(results)) };
-                }
-
-                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []u8 {
-                    const results = self.base.decode(event_offset, event_count);
-                    return std.mem.sliceAsBytes(results);
-                }
-            };
-        }
 
         allocator: mem.Allocator,
 
@@ -641,104 +615,4 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             );
         }
     };
-}
-
-// Stub StateMachine which supports one batchable and non-batchable Operation for testing.
-const TestStateMachine = struct {
-    const config = constants.state_machine_config;
-
-    pub const Operation = enum(u8) {
-        batched = config.vsr_operations_reserved + 0,
-        serial = config.vsr_operations_reserved + 1,
-    };
-
-    pub fn operation_from_vsr(operation: vsr.Operation) ?Operation {
-        if (operation.vsr_reserved()) return null;
-
-        return vsr.Operation.to(TestStateMachine, operation);
-    }
-
-    pub fn Event(comptime operation: Operation) type {
-        return switch (operation) {
-            .batched => [128]u8,
-            .serial => u128,
-        };
-    }
-
-    pub fn Result(comptime operation: Operation) type {
-        return switch (operation) {
-            .batched => u128,
-            .serial => u128,
-        };
-    }
-
-    pub const batch_logical_allowed = std.enums.EnumArray(Operation, bool).init(.{
-        .batched = true,
-        .serial = false,
-    });
-
-    // Demuxer which gives each Event a Result 1:1.
-    pub fn DemuxerType(comptime operation: Operation) type {
-        return struct {
-            const Demuxer = @This();
-            const alignment = @alignOf(Result(operation));
-
-            results: []Result(operation),
-            offset: u32 = 0,
-
-            pub fn init(reply: []Result(operation)) Demuxer {
-                return .{ .results = reply };
-            }
-
-            pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []Result(operation) {
-                assert(self.offset == event_offset);
-                assert(self.results[event_offset..].len >= event_count);
-
-                // .batched uses consumes via the demux count passed in while .serial consumes all.
-                const demuxed: u32 = if (batch_logical_allowed.get(operation))
-                    event_count
-                else
-                    @intCast(self.results.len);
-
-                defer self.offset += @intCast(demuxed);
-                return self.results[event_offset..][0..demuxed];
-            }
-        };
-    }
-};
-
-test "Result Demuxer" {
-    const StateMachine = TestStateMachine;
-    const Result = StateMachine.Result(.batched);
-
-    const MessageBus = @import("../message_bus.zig").MessageBusClient;
-    const VSRClient = Client(StateMachine, MessageBus);
-
-    var results: [@divExact(constants.message_body_size_max, @sizeOf(Result))]Result = undefined;
-    for (0..results.len) |i| {
-        results[i] = i;
-    }
-
-    var prng = std.rand.DefaultPrng.init(42);
-    for (0..1000) |_| {
-        const events_total = @max(1, prng.random().uintAtMost(usize, results.len));
-        var demuxer = VSRClient.DemuxerType(.batched).init(std.mem.sliceAsBytes(results[0..events_total]));
-
-        var events_offset: usize = 0;
-        while (events_offset < events_total) {
-            const events_limit = events_total - events_offset;
-            const events_count = @max(1, prng.random().uintAtMost(usize, events_limit));
-
-            const reply_bytes = demuxer.decode(@intCast(events_offset), @intCast(events_count));
-            const reply: []Result = @alignCast(std.mem.bytesAsSlice(Result, reply_bytes));
-            try testing.expectEqual(&reply[0], &results[events_offset]);
-            try testing.expectEqual(reply.len, results[events_offset..][0..events_count].len);
-
-            for (reply, 0..) |result, i| {
-                try testing.expectEqual(result, @as(Result, events_offset + i));
-            }
-
-            events_offset += events_count;
-        }
-    }
 }


### PR DESCRIPTION
The vsr.Client wrapper simply took/gave bytes over types. So instead the StateMachine's Demuxer API is changed and vsr.Client simply re-exports it. 

Additionally, Demuxer takes a mutable slice to fixup `Create{T}Result.index` but vsr.Client returned an immutable slice. So Client was also changed to return a mutable slice instead of Demuxer having to `@constCast`.