### PR TITLE
benchmark: allow setting seed on the CLI

### DIFF
--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -129,7 +129,11 @@ pub fn main(
         );
     }
 
-    var rng = std.rand.DefaultPrng.init(42);
+    // If no seed was given, use a default seed for reproducibility.
+    const seed: usize = cli_args.seed orelse 42;
+    log.info("Benchmark seed = {}", .{seed});
+
+    var rng = std.rand.DefaultPrng.init(seed);
     const random = rng.random();
     const account_id_permutation: IdPermutation = switch (cli_args.id_order) {
         .sequential => .{ .identity = {} },

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -214,6 +214,8 @@ const Benchmark = struct {
             return;
         }
 
+        const random = b.rng.random();
+
         // Reset batch.
         b.batch_accounts.clearRetainingCapacity();
 
@@ -223,9 +225,9 @@ const Benchmark = struct {
         {
             b.batch_accounts.appendAssumeCapacity(.{
                 .id = b.account_id_permutation.encode(b.account_index + 1),
-                .user_data_128 = 0,
-                .user_data_64 = 0,
-                .user_data_32 = 0,
+                .user_data_128 = random.int(u128),
+                .user_data_64 = random.int(u64),
+                .user_data_32 = random.int(u32),
                 .reserved = 0,
                 .ledger = 2,
                 .code = 1,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -86,6 +86,7 @@ const CliArgs = union(enum) {
         id_order: Command.Benchmark.IdOrder = .sequential,
         statsd: bool = false,
         addresses: ?[]const u8 = null,
+        seed: ?u64 = null,
     },
 
     // TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage
@@ -231,6 +232,7 @@ pub const Command = union(enum) {
         id_order: IdOrder = .sequential,
         statsd: bool = false,
         addresses: ?[]const net.Address = null,
+        seed: ?u64 = null,
     };
 
     format: struct {
@@ -453,6 +455,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     .id_order = benchmark.id_order,
                     .statsd = benchmark.statsd,
                     .addresses = addresses,
+                    .seed = benchmark.seed,
                 },
             };
         },


### PR DESCRIPTION
For now, it's still fixed. We might want to randomize this though with some future thought (or perhaps only combined with --verify in future).

Additionally, sets the account user_data_* fields to random values too.