### PR TITLE
build: remove TIGERBEETLE_RELEASE env var hack

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,11 +65,11 @@ pub fn build(b: *std.Build) !void {
         []const u8,
         "git-commit",
         "The git commit revision of the source code.",
-    ) orelse try shell.git_commit();
-    options.addOption([]const u8, "git_commit", git_commit);
+    ) orelse std.mem.trimRight(u8, b.exec(&.{ "git", "rev-parse", "--verify", "HEAD" }), "\n");
+    assert(git_commit.len == 40);
+    options.addOption(?[40]u8, "git_commit", git_commit[0..40].*);
 
     const release_version_string = b.env_map.get("TIGERBEETLE_RELEASE");
-    options.addOption([]const u8, "version", release_version_string orelse try shell.git_tag());
     options.addOption([]const u8, "release", release_version_string orelse "0.0.1");
 
     options.addOption(

--- a/build.zig
+++ b/build.zig
@@ -69,8 +69,11 @@ pub fn build(b: *std.Build) !void {
     assert(git_commit.len == 40);
     options.addOption(?[40]u8, "git_commit", git_commit[0..40].*);
 
-    const release_version_string = b.env_map.get("TIGERBEETLE_RELEASE");
-    options.addOption([]const u8, "release", release_version_string orelse "0.0.1");
+    options.addOption(
+        []const u8,
+        "release",
+        b.option([]const u8, "tigerbeetle-release", "Release triple.") orelse "0.0.1",
+    );
 
     options.addOption(
         config.ConfigBase,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -11,6 +11,14 @@ const stdx = @import("stdx.zig");
 
 pub const config = @import("config.zig").configs.current;
 
+pub const semver = std.SemanticVersion{
+    .major = config.process.release.triple().major,
+    .minor = config.process.release.triple().minor,
+    .patch = config.process.release.triple().patch,
+    .pre = null,
+    .build = if (config.process.git_commit) |sha_full| sha_full[0..7] else null,
+};
+
 /// The maximum log level.
 /// One of: .err, .warn, .info, .debug
 pub const log_level: std.log.Level = config.process.log_level;

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -564,8 +564,7 @@ pub fn ReplType(comptime MessageBus: type) type {
         }
 
         fn display_help(repl: *Repl) !void {
-            const version = build_options.version;
-            try repl.printer.print("TigerBeetle CLI Client " ++ version ++ "\n" ++
+            try repl.printer.print("TigerBeetle CLI Client {}\n" ++
                 \\  Hit enter after a semicolon to run a command.
                 \\
                 \\Examples:
@@ -578,7 +577,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                 \\  get_account_balances account_id=1 flags=debits|credits;
                 \\
                 \\
-            , .{});
+            , .{constants.semver});
         }
 
         pub fn run(

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -637,20 +637,6 @@ fn echo_command(argv: []const []const u8) void {
     std.debug.print("\n", .{});
 }
 
-/// Returns current git commit hash as an ASCII string.
-pub fn git_commit(shell: *Shell) ![]const u8 {
-    const stdout = try shell.exec_stdout("git rev-parse --verify HEAD", .{});
-    if (stdout.len != 40) return error.InvalidCommitFormat;
-    return stdout;
-}
-
-/// Returns current git tag.
-pub fn git_tag(shell: *Shell) ![]const u8 {
-    // --always is necessary in cases where we haven't yet `git fetch`-ed.
-    const stdout = try shell.exec_stdout("git describe --tags --always", .{});
-    return stdout;
-}
-
 /// On GitHub Actions runners, `git commit` fails with an "Author identity unknown" error.
 ///
 /// This function sets up appropriate environmental variables to correct that error.

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -6,8 +6,6 @@ const mem = std.mem;
 const os = std.os;
 const log_main = std.log.scoped(.main);
 
-const build_options = @import("vsr_options");
-
 const vsr = @import("vsr");
 const constants = vsr.constants;
 const config = constants.config;
@@ -294,20 +292,16 @@ const Command = struct {
 
         var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
         const stdout = stdout_buffer.writer();
-        try std.fmt.format(
-            stdout,
-            "TigerBeetle version {s}\n",
-            .{build_options.version},
-        );
+        try std.fmt.format(stdout, "TigerBeetle version {}\n", .{constants.semver});
 
         if (verbose) {
             try std.fmt.format(
                 stdout,
                 \\
-                \\git_commit="{s}"
+                \\git_commit="{?s}"
                 \\
             ,
-                .{build_options.git_commit},
+                .{constants.config.process.git_commit},
             );
 
             try stdout.writeAll("\n");


### PR DESCRIPTION
Overhaul version handling:

* `tigerbeetle --version` uses proper semver syntax of `x.y.z+sha`
  rather than `git describe` default format.
* default to version 0.0.1 for dev builds (the commit is still included
  as build info in semver syntax).
* add version with git commit to `constants`, so that there's no need to
  import build_config directly to get at it
* use `-D` option rather the an env var to thread release info

The latter became possible after #1799 