### PR TITLE
build: dev builds use superblock version 0

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -75,6 +75,7 @@ pub const Release = extern struct {
     }
 
     pub const zero = Release.from(.{ .major = 0, .minor = 0, .patch = 0 });
+    // Minimum is used for all development builds, to distinguish them from production deployments.
     pub const minimum = Release.from(.{ .major = 0, .minor = 0, .patch = 1 });
 
     pub fn from(release_triple: ReleaseTriple) Release {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -45,7 +45,9 @@ pub const Quorums = @import("superblock_quorums.zig").QuorumsType(.{
     .superblock_copies = constants.superblock_copies,
 });
 
-pub const SuperBlockVersion: u16 = 1;
+pub const SuperBlockVersion: u16 =
+    // Make sure that data files created by development builds are distinguished through version.
+    if (constants.config.process.release.value == vsr.Release.minimum.value) 0 else 1;
 
 const vsr_headers_reserved_size = constants.sector_size -
     ((constants.view_change_headers_max * @sizeOf(vsr.Header)) % constants.sector_size);


### PR DESCRIPTION
We bumped this to 1 for the release, but what we actually want is this logic:

* release builds use the real version which we bump manually.
* dev builds always use 0, so that they are easily distinguishable from prod builds.

Use `-Dtigerbeetle-release` to distinguish which case we are in.