### PR TITLE
CLI: Dedup "version --verbose" git sha

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -351,6 +351,14 @@ fn print_value(
     field: []const u8,
     value: anytype,
 ) !void {
+    if (@TypeOf(value) == ?[40]u8) {
+        assert(std.mem.eql(u8, field, "process.git_commit"));
+        return std.fmt.format(writer, "{s}=\"{?s}\"\n", .{
+            field,
+            value,
+        });
+    }
+
     switch (@typeInfo(@TypeOf(value))) {
         .Fn => {}, // Ignore the log() function.
         .Pointer => try std.fmt.format(writer, "{s}=\"{s}\"\n", .{

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -295,15 +295,6 @@ const Command = struct {
         try std.fmt.format(stdout, "TigerBeetle version {}\n", .{constants.semver});
 
         if (verbose) {
-            try std.fmt.format(
-                stdout,
-                \\
-                \\git_commit="{?s}"
-                \\
-            ,
-                .{constants.config.process.git_commit},
-            );
-
             try stdout.writeAll("\n");
             inline for (.{ "mode", "zig_version" }) |declaration| {
                 try print_value(stdout, "build." ++ declaration, @field(builtin, declaration));


### PR DESCRIPTION
Format the git commit sha properly when it is printed as part of the `ConfigProcess`.

Previously the `ConfigProcess` printed it as a byte array, e.g.:

    process.git_commit={ 49, 56, 54, 98, 97, 57, 50, 98, 101, 97, 98, 102, 101, 51, 55, 48, 49, 54, 48, 101, 48, 97, 55, 98, 49, 55, 55, 54, 100, 101, 49, 57, 99, 50, 54, 97, 98, 53, 56, 53 }

Remove the redundant `git_commit` from the beginning of `version --verbose` output.

<details>
<summary>So with this PR, the output looks like this:</summary>

```
TigerBeetle version 0.0.1+9bad6d6

build.mode=builtin.OptimizeMode.Debug
build.zig_version=0.12.0-dev.575+fb6fff256

cluster.cache_line_size=64
cluster.clients_max=64
cluster.pipeline_prepare_queue_max=8
cluster.view_change_headers_suffix_max=9
cluster.quorum_replication_max=3
cluster.journal_slot_count=1024
cluster.message_size_max=1048576
cluster.superblock_copies=4
cluster.block_size=524288
cluster.lsm_levels=7
cluster.lsm_growth_factor=8
cluster.lsm_batch_multiple=32
cluster.lsm_snapshots_max=32
cluster.lsm_manifest_compact_extra_blocks=1
cluster.vsr_releases_max=64
cluster.lsm_scans_max=2

process.log_level=log.Level.info
process.tracer_backend=config.TracerBackend.none
process.hash_log_mode=config.HashLogMode.none
process.verify=true
process.release=0.0.1
process.git_commit="9bad6d6917e8b7f07a6dead763c0aef5e1600938"
process.port=3001
process.address="127.0.0.1"
process.storage_size_limit_max=17592186044416
process.memory_size_max_default=1073741824
process.cache_accounts_size_default=134217728
process.cache_transfers_size_default=0
process.cache_transfers_pending_size_default=0
process.cache_account_balances_size_default=0
process.client_request_queue_max=2
process.lsm_manifest_node_size=16384
process.connection_delay_min_ms=50
process.connection_delay_max_ms=1000
process.tcp_backlog=64
process.tcp_rcvbuf=4194304
process.tcp_keepalive=true
process.tcp_keepidle=5
process.tcp_keepintvl=4
process.tcp_keepcnt=3
process.tcp_nodelay=true
process.direct_io=true
process.direct_io_required=false
process.journal_iops_read_max=8
process.journal_iops_write_max=8
process.client_replies_iops_read_max=1
process.client_replies_iops_write_max=2
process.tick_ms=10
process.rtt_ms=300
process.rtt_multiple=2
process.backoff_min_ms=100
process.backoff_max_ms=10000
process.clock_offset_tolerance_max_ms=10000
process.clock_epoch_max_ms=60000
process.clock_synchronization_window_min_ms=2000
process.clock_synchronization_window_max_ms=20000
process.grid_iops_read_max=16
process.grid_iops_write_max=16
process.grid_cache_size_default=1073741824
process.grid_repair_request_max=8
process.grid_repair_reads_max=8
process.grid_missing_blocks_max=30
process.grid_missing_tables_max=3
process.aof_record=false
process.aof_recovery=false
process.compaction_block_memory=268435456
```

</details>