### PR TITLE
CLI: Log version early in `tigerbeetle start`

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -184,13 +184,22 @@ const Command = struct {
         const nonce = std.crypto.random.int(u128);
         assert(nonce != 0); // Broken CSPRNG is the likeliest explanation for zero.
 
+        // TODO Where should this be set?
+        const release_client_min = config.process.release;
+        const releases_bundled = &[_]vsr.Release{config.process.release};
+
+        log_main.info("version={}", .{constants.semver});
+        log_main.info("release={}", .{config.process.release});
+        log_main.info("release_client_min={}", .{release_client_min});
+        log_main.info("releases_bundled={any}", .{releases_bundled.*});
+        log_main.info("git_commit={?s}", .{config.process.git_commit});
+
         var replica: Replica = undefined;
         replica.open(allocator, .{
             .node_count = @intCast(args.addresses.len),
             .release = config.process.release,
-            // TODO Where should this be set?
-            .release_client_min = config.process.release,
-            .releases_bundled = &[_]vsr.Release{config.process.release},
+            .release_client_min = release_client_min,
+            .releases_bundled = releases_bundled,
             .release_execute = replica_release_execute,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -188,7 +188,6 @@ const Command = struct {
         const release_client_min = config.process.release;
         const releases_bundled = &[_]vsr.Release{config.process.release};
 
-        log_main.info("version={}", .{constants.semver});
         log_main.info("release={}", .{config.process.release});
         log_main.info("release_client_min={}", .{release_client_min});
         log_main.info("releases_bundled={any}", .{releases_bundled.*});


### PR DESCRIPTION
Print critical information like the binary's release before the superblock is even opened.

My objective here is to minimize round trips with developers when troubleshooting. (If someone runs into a bug, they will send us the replica logs. If there is anything we would ask them immediately after that (e.g. "What release are you running?") then we should just include that information in the default logs.)

The new logs look something like this:

    info(main): version=0.0.1+f28ec34
    info(main): release=0.0.1
    info(main): release_client_min=0.0.1
    info(main): releases_bundled={ 0.0.1 }
    info(main): git_commit=f28ec344691748d60824d3becfa21d9d1d1c0bf7