### PR TITLE
go: work around windows CI failure

### DIFF
--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -57,7 +57,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
 
         try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
-        try shell.exec("go run main.go", .{});
+        try shell.exec("go build main.go", .{});
+        try shell.exec("./main" ++ builtin.target.exeFileExt(), .{});
     }
 }
 


### PR DESCRIPTION
go run on windows _occasionally_ fails with

$ go run main.go
> fork/exec C:\Users\RUNNER~1\AppData\Local\Temp\go-build1166602505\b001\exe\main.exe: The request is not supported.

I don't understand what could be happening there. It seems that `go run` itself fails when it tries to spawn a subprocess? But why it does that only occasionally?

Try working around that by splitting `go run` into explicit build&run.