### PR TITLE
lsm: assert that runtime block metadata matches comptime one

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -915,7 +915,7 @@ pub fn CompactionType(
             const compaction: *Compaction = @alignCast(@ptrCast(parent.target));
             assert(compaction.bar != null);
             assert(compaction.beat != null);
-            assert(compaction.tree_config.id == schema.TableIndex.metadata(index_block).tree_id);
+            assert(compaction.tree_config.id == Table.index.block_metadata(index_block).tree_id);
 
             const beat = &compaction.beat.?;
 
@@ -1060,6 +1060,7 @@ pub fn CompactionType(
         fn blip_read_data_callback(grid_read: *Grid.Read, value_block: BlockPtrConst) void {
             const parent = @fieldParentPtr(Helpers.CompactionBlock, "read", grid_read);
             const compaction: *Compaction = @alignCast(@ptrCast(parent.target));
+            assert(compaction.tree_config.id == Table.data.block_metadata(value_block).tree_id);
 
             assert(compaction.bar != null);
             assert(compaction.beat != null);

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -132,7 +132,7 @@ pub fn TableType(
         pub const data_block_count_max = layout.data_block_count_max;
         pub const block_count_max = index_block_count + data_block_count_max;
 
-        const index = schema.TableIndex.init(.{
+        pub const index = schema.TableIndex.init(.{
             .key_size = key_size,
             .data_block_count_max = data_block_count_max,
         });

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -416,7 +416,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block < context.index_block_count);
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
-                assert(schema.TableIndex.metadata(index_block).tree_id == context.tree.config.id);
+                assert(Table.index.block_metadata(index_block).tree_id == context.tree.config.id);
 
                 const blocks = Table.index_blocks_for_key(index_block, context.key) orelse {
                     // The key is not present in this table, check the next level.
@@ -444,7 +444,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block < context.index_block_count);
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
-                assert(schema.TableData.metadata(data_block).tree_id == context.tree.config.id);
+                assert(Table.data.block_metadata(data_block).tree_id == context.tree.config.id);
 
                 if (Table.data_block_search(data_block, context.key)) |value| {
                     context.callback(context, unwrap_tombstone(value));


### PR DESCRIPTION
Blocks on disk are type-erased. They store tree id, value/block count max and key/value size in the block header, such that the blocks can be processed, in an "untyped" manner.

When we access the blocks however, we statically know the corresponding values from the comptime type of the tree. Verify that the two match.

Noticed this today on Twitch!