### PR TITLE
VSR/Journal: Recover to decision=fix for some ops before checkpoint

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1336,7 +1336,7 @@ const ViewChangeHeadersSlice = struct {
     /// - When these are DVC headers for a log_view=V, we must be in view_change status working to
     ///   transition to a view beyond V. So we will never prepare anything else as part of view V.
     /// - When these are SV headers for a log_view=V, we can continue to add to them (by preparing
-    ///   more ops), but those ops will laways be part of the log_view. If they were prepared during
+    ///   more ops), but those ops will always be part of the log_view. If they were prepared during
     ///   a view prior to the log_view, they would already be part of the headers.
     pub fn view_for_op(headers: ViewChangeHeadersSlice, op: u64, log_view: u32) ViewRange {
         const header_newest = &headers.slice[0];

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -627,7 +627,7 @@ pub fn ReplicaType(
             // the last record in WAL. As a special case, during  the first open the last (and the
             // only) record in WAL is the root prepare.
             //
-            // Otherwise, the head is recovered from the superblock. When transitioninig to a
+            // Otherwise, the head is recovered from the superblock. When transitioning to a
             // view_change, replicas encode the current head into vsr_headers.
             //
             // It is a possibility that the head can't be recovered from the local data.
@@ -5569,7 +5569,7 @@ pub fn ReplicaType(
         /// Safety condition: repairing an old op must not overwrite a newer op from the next wrap.
         ///
         /// Availability condition: each committed op must be present either in a quorum of WALs or
-        /// it in a quorum of checkpoints.
+        /// in a quorum of checkpoints.
         ///
         /// If op=trigger+1 is committed, the corresponding checkpoint is durably present on
         /// a quorum of replicas. Repairing all ops since the latest durable checkpoint satisfies


### PR DESCRIPTION
Fixes https://github.com/tigerbeetle/tigerbeetle/issues/1787.

## Background

In https://github.com/tigerbeetle/tigerbeetle/issues/1787, `Simulator.restart_replica` crashes when a replica recovers into `status=recovering_head` unexpectedly:

1. Replica 6 state syncs a new superblock.
2. Replica 6 crashes. (And is down for a long time, until eventually...)
3. ...`Simulator.transition_to_liveness_mode()`: replica 6 restarts with faults disabled.
4. Replica 6 recovers its journal. Slot 2 recovers to case `@L` (`decision=vsr`), which is: both prepare and header are valid and have the same `op`, but they have different view numbers.
5. `!op_head_certain` → `status=recovering_head`.

Both versions of the `@L` header in the WAL are for the same op number, and that op precedes the replica's `op_checkpoint`.

Which means:
- the op is definitely not `op_head`, and
- the replica will never need to replay that op.

## Fix

Rename WAL recovery case `@M` to `@N`.

Split WAL recovery case `@L` into `@L` and `@M`:

- `@L` is the same as before, with the added condition that `header.op >= op_checkpoint`. `decision=vsr`.
- `@N` is the same as `@L`, except with the condition `header.op < op_checkpoint`. `decision=fix`.