### PR TITLE
[Go] Add a new line to the repo notice

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -267,6 +267,7 @@ fn build_go(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
         \\This repo has been automatically generated from
         \\[tigerbeetle/tigerbeetle@{[sha]s}](https://github.com/tigerbeetle/tigerbeetle/commit/{[sha]s})
         \\to keep binary blobs out of the monorepo.
+        \\
         \\Please see
         \\<https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/go>
         \\for documentation and contributions.


### PR DESCRIPTION
A new line would help to make the documentation link more visible.
Ref: https://github.com/tigerbeetle/tigerbeetle-go/pull/20#issuecomment-2038120250