### PR TITLE
Fix panic when the replica receives a reserved command.

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -745,6 +745,12 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         return null;
                     }
 
+                    if (header.command == .reserved) {
+                        log.err("reserved command received from {}", .{connection.peer});
+                        connection.terminate(bus, .shutdown);
+                        return null;
+                    }
+
                     if (header.cluster != bus.cluster) {
                         log.err("message addressed to the wrong cluster: {}", .{header.cluster});
                         connection.terminate(bus, .shutdown);
@@ -837,6 +843,8 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 header: *const Header,
             ) bool {
                 comptime assert(process_type == .replica);
+
+                assert(header.command != .reserved);
 
                 assert(bus.cluster == header.cluster);
                 assert(bus.connections_used > 0);


### PR DESCRIPTION
Fixes a panic when a replica receives a `command == .reserved` from the client  (occurs when a client < 0.15.3 connects to the cluster).

https://github.com/tigerbeetle/tigerbeetle/blob/f7c9a8735417a07ce0fc5addbf41b82300068a94/src/vsr/message_header.zig#L192-L216