### PR TITLE
VSR: Grid Scrubber

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -76,6 +76,7 @@ pub const Config = struct {
 /// - Replica configs can change between restarts.
 ///
 /// Fields are documented within constants.zig.
+// TODO: Some of these could be runtime parameters (e.g. grid_scrubber_cycle_ms).
 const ConfigProcess = struct {
     log_level: std.log.Level = .info,
     tracer_backend: TracerBackend = .none,
@@ -124,6 +125,10 @@ const ConfigProcess = struct {
     grid_missing_blocks_max: usize = 30,
     grid_missing_tables_max: usize = 3,
     aof_record: bool = false,
+    grid_scrubber_reads_max: usize = 1,
+    grid_scrubber_cycle_ms: usize = std.time.ms_per_day * 90,
+    grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
+    grid_scrubber_interval_ms_max: usize = std.time.ms_per_s * 10,
     aof_recovery: bool = false,
     compaction_block_memory: usize = 256 * 1024 * 1024,
 };
@@ -257,6 +262,8 @@ pub const configs = struct {
             .grid_repair_reads_max = 4,
             .grid_missing_blocks_max = 3,
             .grid_missing_tables_max = 2,
+            .grid_scrubber_reads_max = 2,
+            .grid_scrubber_cycle_ms = std.time.ms_per_hour,
             .verify = true,
             .compaction_block_memory = 16 * 1024 * 1024,
         },

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -356,6 +356,39 @@ comptime {
     assert(grid_missing_tables_max > 0);
 }
 
+/// The maximum number of concurrent scrubber reads.
+///
+/// Unless the scrubber cycle is extremely short and the data file very large there is no need to
+/// set this higher than 1.
+pub const grid_scrubber_reads_max = config.process.grid_scrubber_reads_max;
+
+/// `grid_scrubber_cycle_ms` is the (approximate, target) total milliseconds per scrub of each
+/// replica's entire grid. Scrubbing work is spread evenly across this duration.
+///
+/// Napkin math for the "worst case" scrubber read overhead as a function of cycle duration
+/// (assuming a fully-loaded data file – maximum size and 100% acquired):
+///
+///   storage_size_limit_max      = 16TiB
+///   grid_scrubber_cycle_seconds = 90 days * 24 hr/day * 60 min/hr * 60 s/min (1 cycle/year)
+///   read_bytes_per_second       = storage_size_max / grid_scrubber_cycle_seconds ≈ 2.16 MiB/s
+///
+pub const grid_scrubber_cycle_ticks = config.process.grid_scrubber_cycle_ms / tick_ms;
+
+/// Accelerate/throttle scrubber reads if they are less/more frequent than this range.
+/// (This is to keep the timeouts from being too extreme when the grid is tiny or huge.)
+pub const grid_scrubber_interval_ticks_min = config.process.grid_scrubber_interval_ms_min / tick_ms;
+pub const grid_scrubber_interval_ticks_max = config.process.grid_scrubber_interval_ms_max / tick_ms;
+
+comptime {
+    assert(grid_scrubber_reads_max > 0);
+    assert(grid_scrubber_reads_max <= grid_iops_read_max);
+    assert(grid_scrubber_cycle_ticks > 0);
+    assert(grid_scrubber_cycle_ticks > @divFloor(std.time.ms_per_min, tick_ms)); // Sanity-check.
+    assert(grid_scrubber_interval_ticks_min > 0);
+    assert(grid_scrubber_interval_ticks_min <= grid_scrubber_interval_ticks_max);
+    assert(grid_scrubber_interval_ticks_max > 0);
+}
+
 /// The minimum and maximum amount of time in milliseconds to wait before initiating a connection.
 /// Exponential backoff and jitter are applied within this range.
 pub const connection_delay_min_ms = config.process.connection_delay_min_ms;

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -183,7 +183,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
     return struct {
         const Forest = @This();
 
-        const ManifestLog = ManifestLogType(Storage);
+        pub const ManifestLog = ManifestLogType(Storage);
         const CompactionPipeline = CompactionPipelineType(Forest, Grid);
 
         const Callback = *const fn (*Forest) void;

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -52,6 +52,7 @@ comptime {
     _ = @import("vsr/clock.zig");
     _ = @import("vsr/checksum.zig");
     _ = @import("vsr/grid_blocks_missing.zig");
+    _ = @import("vsr/grid_scrubber.zig");
     _ = @import("vsr/journal.zig");
     _ = @import("vsr/marzullo.zig");
     _ = @import("vsr/replica_format.zig");

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -57,6 +57,7 @@ pub const ChecksumStream = @import("vsr/checksum.zig").ChecksumStream;
 pub const Header = @import("vsr/message_header.zig").Header;
 pub const FreeSet = @import("vsr/free_set.zig").FreeSet;
 pub const CheckpointTrailerType = @import("vsr/checkpoint_trailer.zig").CheckpointTrailerType;
+pub const GridScrubberType = @import("vsr/grid_scrubber.zig").GridScrubberType;
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -20,6 +20,7 @@
 //!
 //! TODO Start replicas scrubbing from distinct/random offsets in the tour to farther minimize risk
 //! of cluster data loss. (Right now replicas will often have identical scrubbing schedules.)
+//! TODO Accelerate scrubbing rate (at runtime) if faults are detected frequently.
 const std = @import("std");
 const assert = std.debug.assert;
 const maybe = stdx.maybe;

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -351,6 +351,8 @@ pub fn GridScrubberType(comptime Forest: type) type {
                         .block_type = .data,
                     };
                 } else {
+                    assert(data_block_index ==
+                        index_schema.data_blocks_used(scrubber.tour_index_block));
                     tour.* = .table_index;
                 }
             }
@@ -405,6 +407,9 @@ pub fn GridScrubberType(comptime Forest: type) type {
                         .block_type = .free_set,
                     };
                 } else {
+                    // A checkpoint can reduce the number of trailer blocks while we are scrubbing
+                    // the trailer.
+                    maybe(tour.free_set.index > free_set_trailer.block_count());
                     tour.* = .{ .client_sessions = .{} };
                 }
             }
@@ -421,6 +426,9 @@ pub fn GridScrubberType(comptime Forest: type) type {
                         .block_type = .client_sessions,
                     };
                 } else {
+                    // A checkpoint can reduce the number of trailer blocks while we are scrubbing
+                    // the trailer.
+                    maybe(tour.client_sessions.index > client_sessions.block_count());
                     tour.* = .done;
                 }
             }

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -1,0 +1,474 @@
+//! Scrub grid blocks.
+//!
+//! A "data scrubber" is a background task that gradually/incrementally reads the disk and validates
+//! what it finds. Its purpose is to discover faults proactively – as early as possibly – rather
+//! than waiting for them to be discovered by normal database operation (e.g. during compaction).
+//!
+//! The most common type of disk fault is a latent sector error:
+//!
+//! - A "latent sector error" is the temporary or permanent inability to access the data of a
+//!   particular sector. That is, the disk as a whole continues to function, but a small section of
+//!   data is unavailable.
+//! - "Latent" refers to: the error is not discoverable until the sector is actually read.
+//! - "An Analysis of Latent Sector Errors in Disk Drives" (2007) found that >60% of latent sector
+//!   errors were discovered by a scrubber that cycles every 2 weeks.
+//!
+//! Finding and repairing errors proactively minimizes the risk of cluster data loss due to multiple
+//! intersecting faults (analogous to a "double-fault") – a scenario where we fail to read a block,
+//! and try to repair the block from another replica, only to discover that the copy of the block on
+//! the remote replica's disk is *also* faulty.
+//!
+//! TODO Start replicas scrubbing from distinct/random offsets in the tour to farther minimize risk
+//! of cluster data loss. (Right now replicas will often have identical scrubbing schedules.)
+const std = @import("std");
+const assert = std.debug.assert;
+const maybe = stdx.maybe;
+const log = std.log.scoped(.grid_scrubber);
+
+const stdx = @import("../stdx.zig");
+const vsr = @import("../vsr.zig");
+const schema = @import("../lsm/schema.zig");
+const FIFO = @import("../fifo.zig").FIFO;
+const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
+
+const allocate_block = @import("./grid.zig").allocate_block;
+const GridType = @import("./grid.zig").GridType;
+const BlockPtr = @import("./grid.zig").BlockPtr;
+const ForestTableIteratorType = @import("../lsm/forest_table_iterator.zig").ForestTableIteratorType;
+const snapshot_from_op = @import("../lsm/manifest.zig").snapshot_from_op;
+const TestStorage = @import("../testing/storage.zig").Storage;
+
+pub fn GridScrubberType(comptime Forest: type) type {
+    return struct {
+        const GridScrubber = @This();
+        const Grid = GridType(Forest.Storage);
+        const ForestTableIterator = ForestTableIteratorType(Forest);
+        const SuperBlock = vsr.SuperBlockType(Forest.Storage);
+        const ManifestBlockIterator = ManifestBlockIteratorType(Forest.ManifestLog);
+        const CheckpointTrailer = vsr.CheckpointTrailerType(Forest.Storage);
+
+        pub const BlockId = struct {
+            block_checksum: u128,
+            block_address: u64,
+            block_type: schema.BlockType,
+        };
+
+        pub const Read = struct {
+            scrubber: *GridScrubber,
+            read: Grid.Read = undefined,
+            block_type: ?schema.BlockType,
+
+            /// Set to true before the read completes if the scrub result should be ignored:
+            /// - The scrub succeeded – no need for repair.
+            /// - The block was freed by a checkpoint in the time that the read was in progress.
+            ///   (At checkpoint, the FreeSet frees blocks released during the preceding checkpoint.
+            ///   We can scrub released blocks, but not free blocks. Setting this flag ensures that
+            ///   GridScrubber doesn't require a read-barrier at checkpoint.)
+            ignore: bool,
+            /// Whether the read is ready to be released.
+            done: bool,
+
+            /// "next" belongs to the FIFOs.
+            next: ?*Read = null,
+        };
+
+        superblock: *SuperBlock,
+        forest: *Forest,
+        client_sessions_checkpoint: *const CheckpointTrailer,
+
+        /// A list of reads that are in progress.
+        reads_busy: FIFO(Read) = .{ .name = "grid_scrubber_reads_busy" },
+        /// A list of reads that are ready to be released.
+        reads_done: FIFO(Read) = .{ .name = "grid_scrubber_reads_done" },
+
+        /// Track the progress through the grid.
+        /// - On an idle replica (i.e. not committing), a full tour from "init" to "done" scrubs
+        ///   every acquired block in the grid.
+        /// - On a non-idle replica, a full tour from "init" to "done" scrubs all blocks that
+        ///   survived the entire span of the tour, but may not scrub blocks that were added during
+        ///   the tour.
+        tour: union(enum) {
+            init,
+            done,
+            table_index: struct { tables: ForestTableIterator },
+            table_data: struct {
+                tables: ForestTableIterator,
+                index_checksum: u128,
+                index_address: u64,
+                /// Points to `tour_index_block` once the index block has been read.
+                index_block: ?BlockPtr = null,
+                data_block_index: u32 = 0,
+            },
+            /// The manifest log tour iterates manifest blocks in reverse order.
+            /// (To ensure that manifest compaction doesn't lead to missed blocks.)
+            manifest_log: struct { iterator: ManifestBlockIterator = .init },
+            free_set: struct { index: usize = 0 },
+            client_sessions: struct { index: usize = 0 },
+        },
+
+        /// Contains a table index block when tour=table_data.
+        tour_index_block: BlockPtr,
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            forest: *Forest,
+            client_sessions_checkpoint: *const CheckpointTrailer,
+        ) error{OutOfMemory}!GridScrubber {
+            var tour_index_block = try allocate_block(allocator);
+            errdefer allocator.free(tour_index_block);
+
+            return .{
+                .superblock = forest.grid.superblock,
+                .forest = forest,
+                .client_sessions_checkpoint = client_sessions_checkpoint,
+                .tour = .init,
+                .tour_index_block = tour_index_block,
+            };
+        }
+
+        pub fn deinit(scrubber: *GridScrubber, allocator: std.mem.Allocator) void {
+            allocator.free(scrubber.tour_index_block);
+
+            scrubber.* = undefined;
+        }
+
+        pub fn cancel(scrubber: *GridScrubber) void {
+            for ([_]FIFO(Read){ scrubber.reads_busy, scrubber.reads_done }) |reads_fifo| {
+                var reads_iterator = reads_fifo.peek();
+                while (reads_iterator) |read| : (reads_iterator = read.next) {
+                    read.ignore = true;
+                }
+            }
+
+            scrubber.tour = .init;
+        }
+
+        /// Cancel queued reads to blocks that will be released by the imminent checkpoint.
+        /// (The read still runs, but the results will be ignored.)
+        pub fn checkpoint(scrubber: *GridScrubber) void {
+            assert(scrubber.superblock.opened);
+            // GridScrubber.checkpoint() is called immediately before FreeSet.checkpoint().
+            // All released blocks are about to be freed.
+            assert(scrubber.forest.grid.callback == .none);
+
+            for ([_]FIFO(Read){ scrubber.reads_busy, scrubber.reads_done }) |reads_fifo| {
+                var reads_iterator = reads_fifo.peek();
+                while (reads_iterator) |read| : (reads_iterator = read.next) {
+                    if (!read.ignore) {
+                        assert(!scrubber.forest.grid.free_set.is_free(read.read.address));
+
+                        if (scrubber.forest.grid.free_set.is_released(read.read.address)) {
+                            read.ignore = true;
+                        }
+                    }
+                }
+            }
+
+            if (scrubber.tour == .table_data) {
+                const index_address = scrubber.tour.table_data.index_address;
+                assert(!scrubber.forest.grid.free_set.is_free(index_address));
+
+                if (scrubber.forest.grid.free_set.is_released(index_address)) {
+                    scrubber.tour_skip_table_data();
+                }
+            }
+        }
+
+        pub fn read_next(scrubber: *GridScrubber, read: *Read) void {
+            assert(scrubber.superblock.opened);
+            assert(scrubber.forest.grid.callback != .cancel);
+            assert(!scrubber.reads_busy.contains(read));
+            assert(!scrubber.reads_done.contains(read));
+
+            const block_id = scrubber.tour_next() orelse {
+                read.* = .{
+                    .scrubber = scrubber,
+                    .block_type = null,
+                    .ignore = true,
+                    .done = true,
+                };
+                scrubber.reads_done.push(read);
+
+                return;
+            };
+
+            log.debug("{}: read_next: address={} checksum={x:0>32} type={s}", .{
+                scrubber.superblock.replica_index.?,
+                block_id.block_address,
+                block_id.block_checksum,
+                @tagName(block_id.block_type),
+            });
+
+            read.* = .{
+                .scrubber = scrubber,
+                .block_type = block_id.block_type,
+                .ignore = false,
+                .done = false,
+            };
+            scrubber.reads_busy.push(read);
+
+            scrubber.forest.grid.read_block(
+                .{ .from_local_storage = read_next_callback },
+                &read.read,
+                block_id.block_address,
+                block_id.block_checksum,
+                .{ .cache_read = false, .cache_write = false },
+            );
+        }
+
+        fn read_next_callback(grid_read: *Grid.Read, result: Grid.ReadBlockResult) void {
+            const read = @fieldParentPtr(Read, "read", grid_read);
+            const scrubber = read.scrubber;
+            assert(scrubber.reads_busy.contains(read));
+            assert(!scrubber.reads_done.contains(read));
+            assert(!read.done);
+            maybe(read.ignore);
+
+            log.debug("{}: read_next_callback: result={s} " ++
+                "(address={} checksum={x:0>32} type={s} ignore={})", .{
+                scrubber.superblock.replica_index.?,
+                @tagName(result),
+                read.read.address,
+                read.read.checksum,
+                @tagName(read.block_type.?),
+                read.ignore,
+            });
+
+            if (!read.ignore and
+                scrubber.tour == .table_data and
+                scrubber.tour.table_data.index_block == null and
+                scrubber.tour.table_data.index_checksum == read.read.checksum and
+                scrubber.tour.table_data.index_address == read.read.address)
+            {
+                assert(scrubber.tour.table_data.data_block_index == 0);
+
+                if (result == .valid) {
+                    stdx.copy_disjoint(.inexact, u8, scrubber.tour_index_block, result.valid);
+                    scrubber.tour.table_data.index_block = scrubber.tour_index_block;
+                } else {
+                    scrubber.tour_skip_table_data();
+                }
+            }
+
+            read.ignore = read.ignore or result == .valid;
+            read.done = true;
+            scrubber.reads_busy.remove(read);
+            scrubber.reads_done.push(read);
+        }
+
+        pub fn read_reclaim(scrubber: *GridScrubber) ?struct {
+            read: *Read,
+            repair: ?BlockId,
+        } {
+            const read = scrubber.reads_done.pop() orelse return null;
+            assert(read.done);
+
+            return .{
+                .read = read,
+                .repair = if (read.ignore) null else .{
+                    .block_address = read.read.address,
+                    .block_checksum = read.read.checksum,
+                    .block_type = read.block_type.?,
+                },
+            };
+        }
+
+        fn tour_next(scrubber: *GridScrubber) ?BlockId {
+            const tour = &scrubber.tour;
+            if (tour.* == .init) {
+                tour.* = .{ .table_index = .{ .tables = ForestTableIterator{} } };
+            }
+
+            if (tour.* == .table_data) {
+                const index_block = tour.table_data.index_block orelse {
+                    // The table index is `null` if:
+                    // - It was corrupt when we just scrubbed it.
+                    // - Or `grid_scrubber_reads > 1`.
+                    // Keep trying until either we find it, or a checkpoint removes it.
+                    // (See read_next_callback() for more detail.)
+                    return .{
+                        .block_checksum = tour.table_data.index_checksum,
+                        .block_address = tour.table_data.index_address,
+                        .block_type = .index,
+                    };
+                };
+
+                const index_schema = schema.TableIndex.from(index_block);
+                const data_block_index = tour.table_data.data_block_index;
+                if (data_block_index <
+                    index_schema.data_blocks_used(scrubber.tour_index_block))
+                {
+                    tour.table_data.data_block_index += 1;
+
+                    const data_block_addresses =
+                        index_schema.data_addresses_used(scrubber.tour_index_block);
+                    const data_block_checksums =
+                        index_schema.data_checksums_used(scrubber.tour_index_block);
+                    return .{
+                        .block_checksum = data_block_checksums[data_block_index].value,
+                        .block_address = data_block_addresses[data_block_index],
+                        .block_type = .data,
+                    };
+                } else {
+                    const tables = tour.table_data.tables;
+                    tour.* = .{ .table_index = .{ .tables = tables } };
+                }
+            }
+
+            if (tour.* == .table_index) {
+                if (tour.table_index.tables.next(scrubber.forest)) |table_info| {
+                    if (Forest.Storage == TestStorage) {
+                        scrubber.superblock.storage.verify_table(
+                            table_info.address,
+                            table_info.checksum,
+                        );
+                    }
+
+                    const tables = tour.table_index.tables;
+                    tour.* = .{ .table_data = .{
+                        .index_checksum = table_info.checksum,
+                        .index_address = table_info.address,
+                        .tables = tables,
+                    } };
+
+                    return .{
+                        .block_checksum = table_info.checksum,
+                        .block_address = table_info.address,
+                        .block_type = .index,
+                    };
+                } else {
+                    tour.* = .{ .manifest_log = .{} };
+                }
+            }
+
+            if (tour.* == .manifest_log) {
+                if (tour.manifest_log.iterator.next(
+                    &scrubber.forest.manifest_log,
+                )) |block_reference| {
+                    return .{
+                        .block_checksum = block_reference.checksum,
+                        .block_address = block_reference.address,
+                        .block_type = .manifest,
+                    };
+                } else {
+                    tour.* = .{ .free_set = .{} };
+                }
+            }
+
+            if (tour.* == .free_set) {
+                const free_set_trailer = &scrubber.forest.grid.free_set_checkpoint;
+                if (free_set_trailer.callback != .none) return null;
+                if (tour.free_set.index < free_set_trailer.block_count()) {
+                    const index = tour.free_set.index;
+                    tour.free_set.index += 1;
+                    return .{
+                        .block_checksum = free_set_trailer.block_checksums[index],
+                        .block_address = free_set_trailer.block_addresses[index],
+                        .block_type = .free_set,
+                    };
+                } else {
+                    tour.* = .{ .client_sessions = .{} };
+                }
+            }
+
+            if (tour.* == .client_sessions) {
+                const client_sessions = scrubber.client_sessions_checkpoint;
+                if (client_sessions.callback != .none) return null;
+                if (tour.client_sessions.index < client_sessions.block_count()) {
+                    const index = tour.client_sessions.index;
+                    tour.client_sessions.index += 1;
+                    return .{
+                        .block_checksum = client_sessions.block_checksums[index],
+                        .block_address = client_sessions.block_addresses[index],
+                        .block_type = .client_sessions,
+                    };
+                } else {
+                    tour.* = .done;
+                }
+            }
+
+            // Wrap around to the next cycle.
+            assert(tour.* == .done);
+            tour.* = .init;
+
+            return null;
+        }
+
+        fn tour_skip_table_data(scrubber: *GridScrubber) void {
+            assert(scrubber.tour == .table_data);
+
+            const tables = scrubber.tour.table_data.tables;
+            scrubber.tour = .{ .table_index = .{ .tables = tables } };
+        }
+    };
+}
+
+/// Iterate over every manifest block address/checksum in the manifest log.
+///
+/// This iterator is stable across ManifestLog mutation – that is, it is guaranteed to iterate over
+/// every manifest block that survives the entire iteration.
+fn ManifestBlockIteratorType(comptime ManifestLog: type) type {
+    return union(enum) {
+        const ManifestBlockIterator = @This();
+
+        init,
+        done,
+        state: struct {
+            /// The last-known index (within the manifest blocks) of the address/checksum.
+            index: usize,
+            /// The address/checksum of the most-recently iterated manifest block.
+            address: u64,
+            checksum: u128,
+        },
+
+        fn next(
+            iterator: *ManifestBlockIterator,
+            manifest_log: *const ManifestLog,
+        ) ?vsr.BlockReference {
+            // Don't scrub the trailing `blocks_closed`; they are not yet flushed to disk.
+            const log_block_count =
+                manifest_log.log_block_addresses.count - manifest_log.blocks_closed;
+
+            const position: ?usize = switch (iterator.*) {
+                .done => null,
+                .init => if (log_block_count == 0) null else log_block_count - 1,
+                .state => |state| position: {
+                    // `index` may be beyond the limit due to blocks removed by manifest compaction.
+                    maybe(state.index >= log_block_count);
+
+                    // The block that we most recently scrubbed may:
+                    // - be in the same position, or
+                    // - have shifted earlier in the list (due to manifest compaction), or
+                    // - have been removed from the list (due to manifest compaction).
+                    // Use the block's old position to find its current position.
+                    var position: usize = @min(state.index, log_block_count -| 1);
+                    while (position > 0) : (position -= 1) {
+                        if (manifest_log.log_block_addresses.get(position).? == state.address and
+                            manifest_log.log_block_checksums.get(position).? == state.checksum)
+                        {
+                            break :position if (position == 0) null else position - 1;
+                        }
+                    } else {
+                        break :position null;
+                    }
+                },
+            };
+
+            if (position) |index| {
+                iterator.* = .{ .state = .{
+                    .index = index,
+                    .address = manifest_log.log_block_addresses.get(index).?,
+                    .checksum = manifest_log.log_block_checksums.get(index).?,
+                } };
+
+                return .{
+                    .address = iterator.state.address,
+                    .checksum = iterator.state.checksum,
+                };
+            } else {
+                iterator.* = .done;
+                return null;
+            }
+        }
+    };
+}

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3055,7 +3055,7 @@ pub fn ReplicaType(
                 @divFloor(
                     constants.grid_scrubber_cycle_ticks,
                     @max(1, self.grid.free_set.count_acquired()),
-                ),
+                ) * constants.grid_scrubber_reads_max,
                 constants.grid_scrubber_interval_ticks_min,
                 constants.grid_scrubber_interval_ticks_max,
             );
@@ -3078,8 +3078,10 @@ pub fn ReplicaType(
                 );
             }
 
-            const scrub_next = self.grid_scrubber.read_next();
-            maybe(scrub_next);
+            for (0..constants.grid_scrubber_reads_max + 1) |_| {
+                const scrub_next = self.grid_scrubber.read_next();
+                if (!scrub_next) break;
+            } else unreachable;
         }
 
         fn on_sync_message_timeout(self: *Self) void {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1355,6 +1355,68 @@ test "Cluster: upgrade: state-sync to new release" {
     try expectEqual(t.replica(.R2).commit(), t.replica(.R_).commit());
 }
 
+test "Cluster: scrub: background scrubber, fully corrupt grid" {
+    const t = try TestContext.init(.{ .replica_count = 3 });
+    defer t.deinit();
+
+    var c = t.clients(0, t.cluster.clients.len);
+    try c.request(checkpoint_2_trigger, checkpoint_2_trigger);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_2_trigger);
+
+    var a0 = t.replica(.A0);
+    var b2 = t.replica(.B2);
+
+    const a0_free_set = &t.cluster.replicas[a0.replicas.get(0)].grid.free_set;
+    const b2_free_set = &t.cluster.replicas[b2.replicas.get(0)].grid.free_set;
+    const b2_storage = &t.cluster.storages[b2.replicas.get(0)];
+
+    // Corrupt B2's entire grid.
+    // Note that we intentionally do *not* shut down B2 for this – the intent is to test the
+    // scrubber, without leaning on Grid.read_block()'s `from_local_or_global_storage`.
+    {
+        var address: u64 = 1;
+        while (address <= Storage.grid_blocks_max) : (address += 1) {
+            b2.corrupt(.{ .grid_block = address });
+        }
+    }
+
+    // Disable new read/write faults so that we can use `storage.faults` to track repairs.
+    // (That is, as the scrubber runs, the number of faults will monotonically decrease.)
+    b2_storage.options.read_fault_probability = 0;
+    b2_storage.options.write_fault_probability = 0;
+
+    // Tick until B2's grid repair stops making progress.
+    // (This may take multiple scrubber cycles, since when a table index is corrupt, we skip over
+    // scrubbing its data for that cycle.)
+    {
+        var faults_before = b2_storage.faults.count();
+        while (true) {
+            t.run();
+
+            var faults_after = b2_storage.faults.count();
+            assert(faults_after <= faults_before);
+            if (faults_after == faults_before) break;
+
+            faults_before = faults_after;
+        }
+    }
+
+    // Verify that B2 repaired all blocks.
+    var address: u64 = 1;
+    while (address <= Storage.grid_blocks_max) : (address += 1) {
+        if (a0_free_set.is_free(address)) {
+            assert(b2_free_set.is_free(address));
+            assert(b2_storage.area_faulty(.{ .grid = .{ .address = address } }));
+        } else {
+            assert(!b2_free_set.is_free(address));
+            assert(!b2_storage.area_faulty(.{ .grid = .{ .address = address } }));
+        }
+    }
+
+    try TestReplicas.expect_equal_grid(a0, b2);
+    try TestReplicas.expect_equal_grid(b2, b2);
+}
+
 const ProcessSelector = enum {
     __, // all replicas, standbys, and clients
     R_, // all (non-standby) replicas
@@ -1916,6 +1978,32 @@ const TestReplicas = struct {
             maybe(replica.superblock.staging.vsr_state.sync_op_max > 0);
 
             try t.cluster.storage_checker.replica_sync(&replica.superblock);
+        }
+    }
+
+    fn expect_equal_grid(want: TestReplicas, got: TestReplicas) !void {
+        assert(want.replicas.count() == 1);
+        assert(got.replicas.count() > 0);
+
+        const want_replica: *const Cluster.Replica = &want.cluster.replicas[want.replicas.get(0)];
+
+        for (got.replicas.const_slice()) |replica_index| {
+            const got_replica: *const Cluster.Replica = &got.cluster.replicas[replica_index];
+
+            var address: u64 = 1;
+            while (address <= Storage.grid_blocks_max) : (address += 1) {
+                const address_free = want_replica.grid.free_set.is_free(address);
+                assert(address_free == got_replica.grid.free_set.is_free(address));
+                if (address_free) continue;
+
+                const block_want = want_replica.superblock.storage.grid_block(address).?;
+                const block_got = got_replica.superblock.storage.grid_block(address).?;
+
+                try expectEqual(
+                    std.mem.bytesToValue(vsr.Header, block_want[0..@sizeOf(vsr.Header)]),
+                    std.mem.bytesToValue(vsr.Header, block_got[0..@sizeOf(vsr.Header)]),
+                );
+            }
         }
     }
 };

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1364,6 +1364,7 @@ test "Cluster: scrub: background scrubber, fully corrupt grid" {
     try expectEqual(t.replica(.R_).commit(), checkpoint_2_trigger);
 
     var a0 = t.replica(.A0);
+    var b1 = t.replica(.B1);
     var b2 = t.replica(.B2);
 
     const a0_free_set = &t.cluster.replicas[a0.replicas.get(0)].grid.free_set;
@@ -1386,8 +1387,6 @@ test "Cluster: scrub: background scrubber, fully corrupt grid" {
     b2_storage.options.write_fault_probability = 0;
 
     // Tick until B2's grid repair stops making progress.
-    // (This may take multiple scrubber cycles, since when a table index is corrupt, we skip over
-    // scrubbing its data for that cycle.)
     {
         var faults_before = b2_storage.faults.count();
         while (true) {
@@ -1414,7 +1413,7 @@ test "Cluster: scrub: background scrubber, fully corrupt grid" {
     }
 
     try TestReplicas.expect_equal_grid(a0, b2);
-    try TestReplicas.expect_equal_grid(b2, b2);
+    try TestReplicas.expect_equal_grid(b1, b2);
 }
 
 const ProcessSelector = enum {


### PR DESCRIPTION
## Context

A "data scrubber" is a background task that gradually/incrementally reads the disk and validates what it finds. Its purpose is to discover faults proactively – as early as possibly – rather than waiting for them to be discovered by normal database operation (e.g. during compaction).

["An Analysis of Latent Sector Errors in Disk Drives" (2007)](https://research.cs.wisc.edu/adsl/Publications/latent-sigmetrics07.pdf) found that >60% of latent sector errors (the most common type of disk fault) were discovered by a scrubber that cycles every 2 weeks. (Note that this data was collected on HDDs, not SSDs.)

Finding and repairing errors proactively minimizes the risk of cluster-wide data loss due to multiple intersecting faults (analogous to a "double-fault") – a scenario where we fail to read a block, and try to repair that block from another replica, only to discover that the copy of the block on the remote replica's disk is *also* faulty.

## Grid Scrubber

- Only acquired blocks are scrubbed.
- Scrubbing is driven by a replica timer (`grid_scrub_timeout`).
- The replica adjusts the scrubber's timer interval at runtime, based on:
  - The number of grid blocks.
  - The `grid_scrubber_cycle_ms` constant.
- `grid_scrubber_cycle_ms` is the (approximate) goal for how long it takes to scrub the entire grid.
  - Currently set to a default of 90 days: 90 days ≈ 2 weeks * 6 replicas.
  - We can scrub a 16TiB data file every 90 days via ~2.16 MiB/s of reads.
  - (We can set it higher, but another goal is to keep the disk-throughput overhead of the scrubber very low.)
  - See `grid_scrubber_cycle_ticks` in `constants.zig` for more detail.
- The grid scrubber tours across all block types:
  - Scrub table index blocks via `ForestTableIterator`.
  - Immediately after scrubbing a table index block, scrub each of its data blocks in sequence.
  - Scrub flushed manifest blocks.
  - Scrub the freeset and client-sessions trailers from the latest checkpoint.
  - `replica_test.zig` has a test which verifies that all blocks (and thus all block types) are covered by the scrubber.
- When the scrubber encounters a fault (i.e. we find an unexpected or corrupt block), it reports it to the replica, which queues the block in `GridBlocksMissing` for repair.

### Scrubber Invariant

Scrubber cycles have the invariant:

- On an idle replica (i.e. not committing), a full tour from "init" to "done" scrubs every acquired block in the grid.
- On a non-idle replica, a full tour from "init" to "done" scrubs all blocks that survived the entire span of the tour, but may not scrub blocks that were added during the tour.