### PR TITLE
cfo: add orchestrator script

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -537,8 +537,9 @@ pub fn build(b: *std.Build) !void {
         const scripts_exe = b.addExecutable(.{
             .name = "scripts",
             .root_source_file = .{ .path = "src/scripts/main.zig" },
-            .target = target,
             .main_pkg_path = .{ .path = "src" },
+            .target = target,
+            .optimize = mode,
         });
         const scripts_run = b.addRunArtifact(scripts_exe);
         if (b.args) |args| scripts_run.addArgs(args);

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -25,7 +25,8 @@
 //!
 //! It is important that the caller (systemd typically) arranges for CFO to be a process group
 //! leader. It is not possible to reliably wait for (grand) children with POSIX, so its on the
-//! call-site to cleanup any run-away subprocesses
+//! call-site to cleanup any run-away subprocesses. See `./cfo_supervisor.sh` for one way to
+//! arrange that.
 //!
 //! After the fuzzing loop, CFO collects a list of seeds, some of which are failing. Next, it
 //! merges, this list into previous set of seeds (persisting seeds is to be implemented, at the

--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Scripts that runs `zig/zig build scripts -- cfo` in a loop.
+# This is intentionally written in POSIX sh, as this is a bootstrap script that needs
+# to be manually `scp`ed to the target machine.
+
+set -eu
+
+git --version
+
+while true
+do
+    rm -rf ./tigerbeetle
+    git clone https://github.com/tigerbeetle/tigerbeetle tigerbeetle
+    cd tigerbeetle
+
+    ./scripts/install_zig.sh
+
+    # `unshare --pid` ensures that, if the parent process dies, all childrent die as well.
+    # `unshare --user` is needed to make `--pid` work without root.
+    # `|| true` because we want to be resilient to bugs in `cfo` itself. 
+    unshare --user -f --pid \
+        ./zig/zig build -Drelease scripts -- cfo \
+        || true
+
+    cd ../
+done


### PR DESCRIPTION
cfo.zig takes care of running the fuzzers, but someone needs to run cfo!

Long term, this _probably_ should be integrated into some kind of infrastructure as code setup, but, to start small, we'll be running cfo in a persistent tmux session. Rather then relying on systemd or some such, we'll write our own tiny "process manager" --- the only thing we really need is:

* running in a loop
* ensuring that there are no orphaned processes

and both are easy to achieve with just sh. Note that it has to be sh, rather than Zig, as this is bootstrap code that needs to be run with what we have on a machine built-in (hence, POSIX sh and not bash)