### PR TITLE
cfo: ensure seed stability

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -301,9 +301,9 @@ const SeedRecord = struct {
     commit_sha: [40]u8,
     fuzzer: Fuzzer,
     ok: bool,
-    seed: u64,
     seed_timestamp_start: u64,
     seed_timestamp_end: u64,
+    seed: u64,
     command: []const u8, // excluded from comparison
 
     fn order(a: SeedRecord, b: SeedRecord) std.math.Order {
@@ -502,9 +502,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "2222222222222222222222222222222222222222",
             \\    "fuzzer": "ewah",
             \\    "ok": false,
-            \\    "seed": 4,
             \\    "seed_timestamp_start": 4,
             \\    "seed_timestamp_end": 4,
+            \\    "seed": 4,
             \\    "command": "fuzz ewah"
             \\  },
             \\  {
@@ -512,9 +512,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "2222222222222222222222222222222222222222",
             \\    "fuzzer": "ewah",
             \\    "ok": true,
-            \\    "seed": 1,
             \\    "seed_timestamp_start": 1,
             \\    "seed_timestamp_end": 1,
+            \\    "seed": 1,
             \\    "command": "fuzz ewah"
             \\  },
             \\  {
@@ -522,9 +522,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "1111111111111111111111111111111111111111",
             \\    "fuzzer": "ewah",
             \\    "ok": false,
-            \\    "seed": 1,
             \\    "seed_timestamp_start": 1,
             \\    "seed_timestamp_end": 1,
+            \\    "seed": 1,
             \\    "command": "fuzz ewah"
             \\  },
             \\  {
@@ -532,9 +532,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "1111111111111111111111111111111111111111",
             \\    "fuzzer": "ewah",
             \\    "ok": false,
-            \\    "seed": 2,
             \\    "seed_timestamp_start": 2,
             \\    "seed_timestamp_end": 2,
+            \\    "seed": 2,
             \\    "command": "fuzz ewah"
             \\  }
             \\]
@@ -585,9 +585,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "3333333333333333333333333333333333333333",
             \\    "fuzzer": "ewah",
             \\    "ok": true,
-            \\    "seed": 1,
             \\    "seed_timestamp_start": 1,
             \\    "seed_timestamp_end": 1,
+            \\    "seed": 1,
             \\    "command": "fuzz ewah"
             \\  },
             \\  {
@@ -595,9 +595,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "2222222222222222222222222222222222222222",
             \\    "fuzzer": "ewah",
             \\    "ok": false,
-            \\    "seed": 1,
             \\    "seed_timestamp_start": 1,
             \\    "seed_timestamp_end": 1,
+            \\    "seed": 1,
             \\    "command": "fuzz ewah"
             \\  }
             \\]
@@ -637,9 +637,9 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "1111111111111111111111111111111111111111",
             \\    "fuzzer": "ewah",
             \\    "ok": false,
-            \\    "seed": 1,
             \\    "seed_timestamp_start": 1,
             \\    "seed_timestamp_end": 1,
+            \\    "seed": 1,
             \\    "command": "fuzz ewah"
             \\  }
             \\]

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -645,4 +645,66 @@ test "cfo: SeedRecord.merge" {
             \\]
         ),
     );
+
+    // Prefer older seeds rather than smaller seeds.
+    try T.check(
+        &.{
+            .{
+                .commit_timestamp = 1,
+                .commit_sha = .{'1'} ** 40,
+                .fuzzer = .ewah,
+                .ok = false,
+                .seed_timestamp_start = 10,
+                .seed_timestamp_end = 10,
+                .seed = 10,
+                .command = "fuzz ewah",
+            },
+            .{
+                .commit_timestamp = 1,
+                .commit_sha = .{'1'} ** 40,
+                .fuzzer = .ewah,
+                .ok = false,
+                .seed_timestamp_start = 20,
+                .seed_timestamp_end = 20,
+                .seed = 20,
+                .command = "fuzz ewah",
+            },
+        },
+        &.{
+            .{
+                .commit_timestamp = 1,
+                .commit_sha = .{'1'} ** 40,
+                .fuzzer = .ewah,
+                .ok = false,
+                .seed_timestamp_start = 5,
+                .seed_timestamp_end = 5,
+                .seed = 999,
+                .command = "fuzz ewah",
+            },
+        },
+        snap(@src(),
+            \\[
+            \\  {
+            \\    "commit_timestamp": 1,
+            \\    "commit_sha": "1111111111111111111111111111111111111111",
+            \\    "fuzzer": "ewah",
+            \\    "ok": false,
+            \\    "seed_timestamp_start": 5,
+            \\    "seed_timestamp_end": 5,
+            \\    "seed": 999,
+            \\    "command": "fuzz ewah"
+            \\  },
+            \\  {
+            \\    "commit_timestamp": 1,
+            \\    "commit_sha": "1111111111111111111111111111111111111111",
+            \\    "fuzzer": "ewah",
+            \\    "ok": false,
+            \\    "seed_timestamp_start": 10,
+            \\    "seed_timestamp_end": 10,
+            \\    "seed": 10,
+            \\    "command": "fuzz ewah"
+            \\  }
+            \\]
+        ),
+    );
 }


### PR DESCRIPTION
We don't want CFO to churn through different failing seeds. To make
seeds stable, compare by (real-time) seed timestamp first.

That is, prefer older seeds, rather than numerically smaller seeds.

This was the intention from the begging, and it's just a bug that the
order is different.

Example of seed churn this should prevent: https://github.com/tigerbeetle/devhubdb/commit/f261d938b161b6d59852e2ca334ef5ee9927efdc