### PR TITLE
Nit: remove deprecated `std.mem.copy`

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -60,7 +60,7 @@ pub inline fn copy_left(
     if (!disjoint_slices(T, T, target, source)) {
         assert(@intFromPtr(target.ptr) < @intFromPtr(source.ptr));
     }
-    std.mem.copy(T, target, source);
+    std.mem.copyForwards(T, target, source);
 }
 
 test "copy_left" {
@@ -110,7 +110,7 @@ pub inline fn copy_disjoint(
     }
 
     assert(disjoint_slices(T, T, target, source));
-    std.mem.copy(T, target, source);
+    @memcpy(target[0..source.len], source);
 }
 
 pub inline fn disjoint_slices(comptime A: type, comptime B: type, a: []const A, b: []const B) bool {


### PR DESCRIPTION
`std.mem.copy` is an alias to `copyForwards`, while the former behavior can now be achieved using the built-in `@memcpy`.

https://github.com/ziglang/zig/blob/aeb866687d3bd982c78022de77fc8381b8658e75/lib/std/mem.zig#L195-L197