### PR TITLE
Coalesce tables instead of compacting when possible

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -616,6 +616,12 @@ pub const lsm_manifest_memory_size_multiplier = lsm_manifest_memory_multiplier: 
     break :lsm_manifest_memory_multiplier lsm_manifest_memory_multiplier;
 };
 
+/// When attempting to coalesce tables (as an optimization to avoid compaction),
+/// search this many tables before giving up. This number is determined experimentally
+/// and attempts to keep the search time under 1ms.
+/// todo - this needs to be selected more carefully.
+pub const lsm_manifest_coalesce_max_tables_to_search = 1024;
+
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.
 pub const tick_ms = config.process.tick_ms;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -70,7 +70,7 @@ const half_bar_beat_count = @divExact(constants.lsm_batch_multiple, 2);
 pub const CompactionInfo = struct {
     /// How many values, across all input tables, need to be processed.
     /// This is the total – it is fixed for the duration of the compaction.
-    compaction_tables_value_count: usize,
+    compaction_tables_value_count: u64,
 
     // Keys are integers in TigerBeetle, with a maximum size of u256. Store these
     // here, instead of Key, to keep this unspecialized.
@@ -569,7 +569,7 @@ pub fn CompactionType(
                 .tables = tables.tables,
             };
 
-            var compaction_tables_value_count: usize = 0;
+            var compaction_tables_value_count: u64 = 0;
             for (range_b.tables.const_slice()) |*table| {
                 compaction_tables_value_count += table.table_info.value_count;
             }
@@ -644,7 +644,7 @@ pub fn CompactionType(
                     table_immutable_values_count,
                 });
 
-                var compaction_tables_value_count: usize = table_immutable_values_count;
+                var compaction_tables_value_count: u64 = table_immutable_values_count;
                 for (range_b.tables.const_slice()) |*table| {
                     compaction_tables_value_count += table.table_info.value_count;
                 }
@@ -687,7 +687,7 @@ pub fn CompactionType(
                     compaction.level_b,
                 });
 
-                var compaction_tables_value_count: usize = table_a.value_count;
+                var compaction_tables_value_count: u64 = table_a.value_count;
                 for (range_b.tables.const_slice()) |*table| {
                     compaction_tables_value_count += table.table_info.value_count;
                 }

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -2079,6 +2079,11 @@ pub fn CompactionType(
                 );
             }
 
+            // Coalescing should always result in a free table.
+            if (bar.table_info_a == .coalesce) {
+                manifest.assert_level_free_table(level_b);
+            }
+
             // Our bar is done!
             compaction.bar = null;
         }

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -457,9 +457,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             // that is requested.
             if (last_beat or last_half_beat) {
                 for (forest.compaction_pipeline.compactions.slice()) |*compaction| {
-                    if (compaction.level_b % 2 == 0 and last_half_beat) continue;
-                    if (compaction.level_b % 2 != 0 and last_beat) continue;
-
                     assert(forest.manifest_log_progress == .compacting or
                         forest.manifest_log_progress == .done);
                     switch (tree_id_cast(compaction.tree_id)) {
@@ -493,7 +490,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     // Ensure tables haven't overflowed.
                     tree.manifest.assert_level_table_counts();
                 }
+            }
 
+            if (last_beat or last_half_beat) {
                 // While we're here, check that all compactions have finished by the last beat, and
                 // reset our pipeline state.
                 assert(forest.compaction_pipeline.bar_active.count() == 0);
@@ -982,7 +981,7 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
             if ((first_beat or half_beat) and
                 !forest.grid.superblock.working.vsr_state.op_compacted(op))
             {
-                if (first_beat) {
+                if (first_beat or half_beat) {
                     assert(self.compactions.count() == 0);
                 }
 
@@ -1022,8 +1021,6 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
                 }
 
                 for (self.compactions.slice(), 0..) |*compaction, i| {
-                    if (compaction.level_b % 2 == 0 and first_beat) continue;
-                    if (compaction.level_b % 2 != 0 and half_beat) continue;
                     if (compaction.move_table) continue;
 
                     assert(

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -1001,7 +1001,7 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
 
                             // Try to coalesce tables in level_a before compacting into level_b.
                             if (level_b > 0) {
-                                var compaction = &tree.compactions[level_b - 1];
+                                const compaction = &tree.compactions[level_b - 1];
                                 if (compaction.maybe_coalesce(tree, op)) |info| {
                                     self.compactions.append_assume_capacity(info);
                                     log.debug("level_b={} tree={s} op={}", .{
@@ -1014,7 +1014,7 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
                             }
 
                             if (do_compaction) {
-                                var compaction = &tree.compactions[level_b];
+                                const compaction = &tree.compactions[level_b];
                                 if (compaction.bar_setup(tree, op)) |info| {
                                     self.compactions.append_assume_capacity(info);
                                     log.debug("level_b={} tree={s} op={}", .{

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -27,6 +27,8 @@ pub fn TreeTableInfoType(comptime Table: type) type {
     return struct {
         const TreeTableInfo = @This();
 
+        pub const value_count_max_actual = Table.value_count_max_actual;
+
         /// Checksum of the table's index block.
         checksum: u128,
         /// Address of the table's index block.

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -444,6 +444,13 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             }
         }
 
+        /// Assert there is space for at least one table in the level.
+        pub fn assert_level_free_table(manifest: *const Manifest, level: u8) void {
+            const table_count_visible_max = table_count_max_for_level(growth_factor, level);
+            const manifest_level = &manifest.levels[level];
+            assert(manifest_level.table_count_visible < table_count_visible_max);
+        }
+
         pub fn assert_no_invisible_tables(manifest: *const Manifest, snapshots: []const u64) void {
             for (manifest.levels, 0..) |_, level| {
                 manifest.assert_no_invisible_tables_at_level(@intCast(level), snapshots);

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -14,6 +14,11 @@ const Direction = @import("../direction.zig").Direction;
 const SegmentedArray = @import("segmented_array.zig").SegmentedArray;
 const SortedSegmentedArray = @import("segmented_array.zig").SortedSegmentedArray;
 
+// The maximum number of tables that can be coalesced is determined by
+// the number of tables supported by compaction, which is determined by `lsm_growth_factor`.
+const max_coalesce_window_size = constants.lsm_growth_factor;
+const max_coalesce_tables_to_search = constants.lsm_manifest_coalesce_max_tables_to_search;
+
 pub fn ManifestLevelType(
     comptime NodePool: type,
     comptime Key: type,
@@ -729,6 +734,336 @@ pub fn ManifestLevelType(
 
             return range;
         }
+
+        const TableCoalesceWindow = struct {
+            tables: stdx.BoundedArray(TableInfoReference, max_coalesce_window_size),
+        };
+
+        const TableCoalesceWindowCandidate = struct {
+            tables: stdx.BoundedArray(*const TableInfo, max_coalesce_window_size),
+            total_values: u64,
+        };
+
+        /// Attempt to find a range of visible tables that, when merged, will
+        /// free up an empty table. The compaction code uses this as an
+        /// optimization to avoid running a full compaction on a level.
+        ///
+        /// This will iterate up to `max_coalesce_tables_to_search` tables,
+        /// attempting to find the best window as defined by
+        /// `choose_coalesce_window_candidate`.
+        ///
+        /// For large levels, the index to begin iteration is chosen
+        /// pseudo-randomly but deterministically, seeded by the caller with a
+        /// number that is unique per compaction and deterministic across
+        /// replicas.
+        pub fn find_table_coalesce_window(
+            level: *const Self,
+            prng_seed: u64,
+        ) ?TableCoalesceWindow {
+            const num_tables = level.tables.len();
+
+            // todo need a heuristic to decide level is too full and not worth searching at all
+
+            if (num_tables <= 1) {
+                return null;
+            }
+
+            if (num_tables <= max_coalesce_tables_to_search) {
+                return level.find_table_coalesce_window_from_index(0);
+            } else {
+                var pcg = std.rand.Pcg.init(prng_seed);
+                var rng = pcg.random();
+
+                const max_start_table = num_tables - max_coalesce_tables_to_search;
+                const max_start_table_exclusive = max_start_table + 1;
+                const start_index = rng.uintLessThan(u32, max_start_table_exclusive);
+                return level.find_table_coalesce_window_from_index(start_index);
+            }
+        }
+
+        /// Iterate over tables looking for the best candidate coalesce window.
+        ///
+        /// This function relies on a pair of custom iterators,
+        /// `CoalesceTableIterator` and `CoalesceWindowIterator`, that
+        /// encapsulate some relatively complex bookkeeping, described
+        /// more in the their own doc comments.
+        fn find_table_coalesce_window_from_index(
+            level: *const Self,
+            start_index: u32,
+        ) ?TableCoalesceWindow {
+            var best_candidate: ?TableCoalesceWindowCandidate = null;
+
+            // This is an iterator of iterators, each sub-iterator iterating up to
+            // `max_coalesce_window_size` visible tables.
+            var table_iter = CoalesceTableIterator.from_index(&level.tables, start_index);
+
+            // Look at each window and decide if it is the best candidate.
+            while (table_iter.next()) |window_iter| {
+                const next_candidate = level.next_coalesce_window_candidate(
+                    window_iter,
+                );
+                if (next_candidate) |nc| {
+                    std.log.debug("candidate {} / tables {}", .{
+                        nc.total_values,
+                        nc.tables.count(),
+                    });
+                }
+                best_candidate = level.choose_coalesce_window_candidate(
+                    best_candidate,
+                    next_candidate,
+                );
+            }
+
+            if (best_candidate) |best_candidate_| {
+                std.log.debug("best candidate {} / tables {}", .{
+                    best_candidate_.total_values,
+                    best_candidate_.tables.count(),
+                });
+                var result = TableCoalesceWindow{
+                    .tables = .{},
+                };
+                for (best_candidate_.tables.const_slice()) |table| {
+                    var table_reference = TableInfoReference{
+                        // todo this cast is suspicious, but is done elsewhere in relation
+                        // to table iterators
+                        .table_info = @constCast(table),
+                        .generation = level.generation,
+                    };
+                    result.tables.append_assume_capacity(table_reference);
+                }
+                return result;
+            } else {
+                return null;
+            }
+        }
+
+        /// This function looks at a single iterator over visible tables
+        /// and decides if it is a coalesce candidate. It looks at no more
+        /// than `max_coalesce_tables_to_search` tables.
+        fn next_coalesce_window_candidate(
+            level: *const Self,
+            window_iter: CoalesceWindowIterator,
+        ) ?TableCoalesceWindowCandidate {
+            _ = level;
+            var window_iter_mut = window_iter;
+            var tables: stdx.BoundedArray(*const TableInfo, max_coalesce_window_size) = .{};
+            var value_count_sum: u64 = 0;
+
+            // todo - there's quite a lot of logic in this hot loop (the
+            // iterator `next` method itself is very complex) and it would be
+            // nice to avoid as much as possible. Most best candidates seem to
+            // be 2 tables, rarely (or effectively never) 8 tables. There may be
+            // opportunities to do less here.
+            //
+            // todo - the first iteration could be pulled out of this loop,
+            // along with the special first-iteration check, while also avoiding
+            // the can_free_table check. Need to measure if that's worth it.
+            while (window_iter_mut.next()) |table| {
+                // If the first table has max values then ignore this window
+                if (tables.count() == 0 and table.value_count == TableInfo.value_count_max_actual) {
+                    return null;
+                }
+
+                tables.append_assume_capacity(table);
+                value_count_sum += table.value_count;
+
+                const max_values = tables.count() * TableInfo.value_count_max_actual;
+                assert(value_count_sum <= max_values);
+                const free_value_slots = max_values - value_count_sum;
+                const can_free_table = free_value_slots >= TableInfo.value_count_max_actual;
+
+                if (can_free_table) {
+                    return TableCoalesceWindowCandidate{
+                        .tables = tables,
+                        .total_values = value_count_sum,
+                    };
+                }
+            }
+
+            return null;
+        }
+
+        fn choose_coalesce_window_candidate(
+            level: *const Self,
+            candidate_a: ?TableCoalesceWindowCandidate,
+            candidate_b: ?TableCoalesceWindowCandidate,
+        ) ?TableCoalesceWindowCandidate {
+            _ = level;
+            if (candidate_a) |candidate_a_| {
+                if (candidate_b) |candidate_b_| {
+                    // Choose the window with fewest values.
+                    // todo should we care about the table count?
+                    if (candidate_a_.total_values < candidate_b_.total_values) {
+                        return candidate_a_;
+                    } else {
+                        return candidate_b_;
+                    }
+                } else {
+                    return candidate_a_;
+                }
+            } else {
+                return candidate_b;
+            }
+        }
+
+        /// An iterator over tables used to find coalesce window candidates.
+        ///
+        /// Each iteration returns a sub-iterator, `CoalesceWindowIterator`,
+        /// both of which cooperate to achieve several goals:
+        ///
+        /// - counting both invisible and visible tables to only iterate
+        ///   up to `max_coalesce_tables_to_search` tables.
+        /// - only visiting visible tables
+        /// - iterating invisible tables only once - a naive implementation
+        ///   that creates new iterators for each window could see each
+        ///   invisible table up to a factor of `max_coalesce_tables_to_search` times.
+        ///
+        /// It uses a pair of queues to manage the backtracking:
+        /// during iteration, tables in `buffer` are visited first before pulling
+        /// from an inner iterator; as new tables are visited that will need to be
+        /// visited again in the future they are pushed onto `double_buffer` for
+        /// use by future iterators.
+        const CoalesceTableIterator = struct {
+            inner: Tables.Iterator,
+            /// Previously-visited tables that need to be re-visited in the next window,
+            /// prior to visiting those in double_buffer, enqueued by the prepare_buffer function.
+            buffer: stdx.BoundedArray(*const TableInfo, max_coalesce_window_size),
+            /// Previously-visited tables that need to be re-viseted in the next window,
+            /// after visiting those in buffer, enqueued by CoalesceWindowIterator.
+            double_buffer: stdx.BoundedArray(*const TableInfo, max_coalesce_window_size),
+            /// A counter of total tables (invisible and visible) retrieved from the
+            /// inner iterator. After this hits `max_coalesce_tables_to_search` we will
+            /// no longer defer to the inner iterator.
+            tables_visited: u32,
+            /// This indicates that we've taken as many tables from the inner
+            /// iterator as we can (either because it is empty or we've called
+            /// it `tables_visited` times) and there are no more buffered tables
+            /// to return, so we should not return any new
+            /// `CoalesceWindowIterator`s in the `next` method.
+            end_of_iter: bool,
+
+            pub fn from_index(tables: *const Tables, start_index: u32) CoalesceTableIterator {
+                return CoalesceTableIterator{
+                    .inner = tables.iterator_from_index(start_index, .ascending),
+                    .buffer = .{},
+                    .double_buffer = .{},
+                    .tables_visited = 0,
+                    .end_of_iter = false,
+                };
+            }
+
+            pub fn next(it: *CoalesceTableIterator) ?CoalesceWindowIterator {
+                if (it.end_of_iter) {
+                    assert(it.buffer.empty() and it.double_buffer.empty());
+                    return null;
+                }
+
+                it.prepare_buffer();
+
+                return CoalesceWindowIterator{
+                    .parent = it,
+                    .window_size = 0,
+                };
+            }
+
+            /// Prepare `buffer` from the contents of `buffer` and `double_buffer`.
+            fn prepare_buffer(it: *CoalesceTableIterator) void {
+                assert(it.buffer.count() + it.double_buffer.count() <= max_coalesce_window_size);
+                if (!it.double_buffer.empty()) {
+                    // Anything still in `buffer` needs to be visited after `double_buffer`.
+                    // This can happen if the contents of `buffer` were not fully iterated
+                    // by a previous CoalesceWindowIterator.
+                    while (it.pop_buffer_queue()) |table| {
+                        it.push_double_buffer_queue(table);
+                    }
+                    // Promote double_buffer to buffer.
+                    std.mem.swap(
+                        stdx.BoundedArray(*const TableInfo, max_coalesce_window_size),
+                        &it.buffer,
+                        &it.double_buffer,
+                    );
+                }
+            }
+
+            // todo - this is a hot function and might profit from memcpy optimization
+            fn pop_buffer_queue(it: *CoalesceTableIterator) ?*const TableInfo {
+                if (it.buffer.empty()) {
+                    return null;
+                }
+
+                const retval = it.buffer.get(0);
+
+                var index: usize = 0;
+                while (index < it.buffer.count() - 1) {
+                    it.buffer.slice()[index] = it.buffer.get(index + 1);
+                    index += 1;
+                }
+
+                it.buffer.truncate(it.buffer.count() - 1);
+
+                return retval;
+            }
+
+            fn push_double_buffer_queue(it: *CoalesceTableIterator, t: *const TableInfo) void {
+                assert(it.double_buffer.count() < max_coalesce_window_size);
+                it.double_buffer.append_assume_capacity(t);
+            }
+        };
+
+        const CoalesceWindowIterator = struct {
+            parent: *CoalesceTableIterator,
+            window_size: u32,
+
+            pub fn next(it: *CoalesceWindowIterator) ?*const TableInfo {
+                if (it.window_size == 0) {
+                    assert(it.parent.double_buffer.empty());
+                }
+
+                assert(it.window_size <= max_coalesce_window_size);
+                if (it.window_size == max_coalesce_window_size) {
+                    assert(it.parent.buffer.empty());
+                    return null;
+                }
+
+                // Start by visiting the buffered tables
+                if (it.parent.pop_buffer_queue()) |table| {
+                    // Save every table after the first for the next window iterator
+                    if (it.window_size != 0) {
+                        it.parent.push_double_buffer_queue(table);
+                    }
+                    it.window_size += 1;
+                    return table;
+                } else {
+                    assert(it.parent.tables_visited <= max_coalesce_tables_to_search);
+                    if (it.parent.tables_visited < max_coalesce_tables_to_search) {
+                        // Now go back to the inner iterator
+                        while (it.parent.inner.next()) |table| {
+                            it.parent.tables_visited += 1;
+
+                            if (table.visible(lsm.snapshot_latest)) {
+                                if (it.window_size != 0) {
+                                    it.parent.push_double_buffer_queue(table);
+                                }
+                                it.window_size += 1;
+                                return table;
+                            }
+
+                            if (it.parent.tables_visited == max_coalesce_tables_to_search) {
+                                break;
+                            }
+                        }
+                    }
+
+                    // There are no more tables in the main iterator and no more
+                    // tables in the buffer - do not generate any more window iterators.
+                    if (it.parent.double_buffer.count() == 0) {
+                        it.parent.end_of_iter = true;
+                    }
+
+                    return null;
+                }
+            }
+        };
     };
 }
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -104,6 +104,11 @@ pub fn TableType(
             assert(key_size == 8 or key_size == 16 or key_size == 24 or key_size == 32);
         }
 
+        const block_value_count_max = @divFloor(
+            block_body_size,
+            value_size,
+        );
+
         pub const layout = layout: {
             assert(block_size % constants.sector_size == 0);
             assert(math.isPowerOfTwo(block_size));
@@ -112,11 +117,6 @@ pub fn TableType(
             // the total index size is not 64 byte cache line aligned.
             assert(@sizeOf(Key) >= 4);
             assert(@sizeOf(Key) % 4 == 0);
-
-            const block_value_count_max = @divFloor(
-                block_body_size,
-                value_size,
-            );
 
             // We need enough blocks to hold `value_count_max` values.
             const data_blocks = div_ceil(value_count_max, block_value_count_max);
@@ -127,6 +127,11 @@ pub fn TableType(
                 .data_block_count_max = data_blocks,
             };
         };
+
+        /// The actual maximum number of values in the table,
+        /// according to the layout calculation above.
+        /// Contrast to Table.value_count_max, which may be less than this.
+        pub const value_count_max_actual = block_value_count_max * layout.data_block_count_max;
 
         const index_block_count = 1;
         pub const data_block_count_max = layout.data_block_count_max;


### PR DESCRIPTION
This patch adds table coalescing to the LSM. Prior to compacting level A of a tree into level B, it instead attempts to coalesce tables in level A such that one table in level A will be completely freed. This is assumed to be more efficient than doing the compaction.

As far as I can tell this patch is fully functional and passes all tests that I am aware of, but it has plenty of deficiencies I will describe. I think though that it is time to start getting some review.


## How the search works

The search is implemented in the second commit and is well documented. It is part of `manifest_level.zig`, with the entry point being `find_table_coalesce_window`.

This searches through windows of visible tables, the windows up to size `lsm_growth_factor`; with a limit on the maximum number of tables searched, both visible and invisible. This limit is set by `lsm_manifest_coalesce_max_tables_to_search` to 1024, but this number is not determined experimentally - it is intended to be "reasonably fast" to search (<1ms?), but I have not done any timing testing. The search never short circuits - it either searches all tables in the level (for small levels), or 1024 tables (for large levels).

On levels with more than 1024 tables it uses a deterministic random number to decide at what index to start the search; this is to spread the search out across table ranges, across compactions, but without the added bookkeeping of remembering the previously searched indexes. @jorangreef previously suggested to use a hash instead of a rng here, but I decided to stick with an rng because the rng has built-in facilities for picking a number in range with the correct statistical distribution, where a hash does not. I suspect the performance of a fast hash and a fast rng is similar, but have not done any testing. The RNG here is PCG, which is fast with good randomness.

Windows are chosen that can free up exactly one table - it never tries to find windows that free more than one table. Of those windows the best is chosen by the `choose_coalesce_window_candidate` function. This function currently just picks the window with the fewest values.

I don't really understand the I/O costs involved so am not confident that optimizing for fewest values is correct or not. We could alternately take table numbers into account, or short-circuit the search as soon as _any_ viable window is found.

The search logic is very straightforward, but it depends on a set of iterators for which the logic is somewhat complex. This is an intentional decision for the sake of making the search readable.

The `CoalasceTableIterator` and `CoalesceWindowIterator` are decently documented, and are designed to account for the cost of visiting invisible tables when limiting the amount of work done per search, and avoid revisiting invisible tables many times in pathological cases. The complexity of these iterators is unfortunate for both readability and performance, and I was reluctant to do it this way, but ultimately decided it was the cleanest way to correctly account for invisible tables. Even today I was tweaking the logic in these iterators so they deserve a close look.

Note that because iterating invisible tables counts toward the limits of the search, levels with many invisible tables will have their coalesce-window search significantly weakened. As I understand it snapshots are a theoretical feature right now, so this is just a consideration for the future.

## How integration with compaction works

It's plugged into `CompactionPipeline.beat`.

Compaction of levels is striped across half-bars. Prior to attempting to compact level b (a into b) with `bar_setup`, this function first "backs up" and checks whether it can instead coalesce level a.

When this happens it sets level "a"s `Compaction` object for coalescing (and from the view of `Compaction` and the rest of the forest code this level "a" will be seen as a level "b", with no level "a" compacting into it).

When coalescing happens, an "odd" level gets compacted in the same half-bar as other "even" levels (or vice-versa). e.g. if our half-bar is compacting levels (0, 2, 4), we might actually end up compacting (0, 1, 4) if it was determined that coalescing level 1 was better than compacting level 1 into level 2.

This mixing of odd and even compaction levels within a single half bar is the reason for the first commit of this patch that removes most of the checks for which level is allowed to be compacting during which half-bar.

This adds a new `coalesce` variant to `TableInfoA` that indicates that compaction is doing a coalesce and there is no table A.

## Limitations

I have not yet been able to test on large levels - I have only tested up to level 3. This means I haven't ever run the code path where the search randomly selects the table index to begin searching from. I don't even know how to generate a workload that builds deep enough levels to test this - I am running out of memory on large forest_fuzz workloads. I could test on a large-memory cloud VM if that's the right way to do it.

There are no new tests here. I think there should be some unit tests for the coalesce search but haven't tried to write them yet. I think there should also be an integration test that coalescing limits write amplification on small-batch workloads, but don't know how to write it. Also a smoke test that just confirms coalescing is on and doing something.

I don't know how long it takes to search 1024 tables. I think we should have some idea of the CPU time of this operation.

I don't know how often this optimization is triggered on real workloads, but suspect that there are workloads where it is ineffective, and that it may be more or less effective on different trees. It may be useful to completely avoid this search in some situations, and I have indicated this with a todo, but don't have enough evidence to know when or how to do it yet.

(The benchmark workload is ineffective at triggering this optimization, but the forest_fuzz triggers it at all levels).

Coalesced compaction objects never set `drop_tombstones` to `true`. I am not sure the impact of this. I note that coalescing always follows the "copy" path in the compactor, never merge, move, or, "copy_drop_tombstones".

Coalesce is never performed for the last level. This is mostly just because the structure of the compaction setup code doesn't lend itself easily to coalescing the last level.

This adds a new constant, `value_count_max_actual`, which contains the maximum number of values allowed in a particular table. Contrast this with the existing `value_count_max` constant, which is sometimes a lower value. I don't really understand the logic around these two constants but the dual names are quite confusing and I'm open to suggestions about how to rename one of them.