### PR TITLE
Docs: Revert documentation for `--development` flag

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -30,13 +30,13 @@ for exactly what we're benchmarking.
 Launch a TigerBeetle cluster on your local machine by running each of these commands in a new terminal tab:
 
 ```console
-./tigerbeetle format --cluster=0 --replica=0 --replica-count=3 --development 0_0.tigerbeetle
-./tigerbeetle format --cluster=0 --replica=1 --replica-count=3 --development 0_1.tigerbeetle
-./tigerbeetle format --cluster=0 --replica=2 --replica-count=3 --development 0_2.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=3 0_0.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=1 --replica-count=3 0_1.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=2 --replica-count=3 0_2.tigerbeetle
 
-./tigerbeetle start --addresses=3001,3002,3003 --development 0_0.tigerbeetle
-./tigerbeetle start --addresses=3001,3002,3003 --development 0_1.tigerbeetle
-./tigerbeetle start --addresses=3001,3002,3003 --development 0_2.tigerbeetle
+./tigerbeetle start --addresses=3001,3002,3003 0_0.tigerbeetle
+./tigerbeetle start --addresses=3001,3002,3003 0_1.tigerbeetle
+./tigerbeetle start --addresses=3001,3002,3003 0_2.tigerbeetle
 ```
 
 Run the TigerBeetle binary to see all command line arguments:

--- a/docs/getting-started/single-binary-three.md
+++ b/docs/getting-started/single-binary-three.md
@@ -25,23 +25,23 @@ Want to build from source locally? Add `-build` as an argument to the bootstrap 
 Now create the TigerBeetle [data file](../about/internals/data_file.md) for each replica:
 
 ```console
-./tigerbeetle format --cluster=0 --replica=0 --replica-count=3 --development 0_0.tigerbeetle
-./tigerbeetle format --cluster=0 --replica=1 --replica-count=3 --development 0_1.tigerbeetle
-./tigerbeetle format --cluster=0 --replica=2 --replica-count=3 --development 0_2.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=3 0_0.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=1 --replica-count=3 0_1.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=2 --replica-count=3 0_2.tigerbeetle
 ```
 
 And start each server in a new terminal window:
 
 ```console
-./tigerbeetle start --addresses=3000,3001,3002 --development 0_0.tigerbeetle
+./tigerbeetle start --addresses=3000,3001,3002 0_0.tigerbeetle
 ```
 
 ```console
-./tigerbeetle start --addresses=3000,3001,3002 --development 0_1.tigerbeetle
+./tigerbeetle start --addresses=3000,3001,3002 0_1.tigerbeetle
 ```
 
 ```console
-./tigerbeetle start --addresses=3000,3001,3002 --development 0_2.tigerbeetle
+./tigerbeetle start --addresses=3000,3001,3002 0_2.tigerbeetle
 ```
 
 TigerBeetle uses the `--replica` that's stored in the data file as an index into the `--addresses`

--- a/docs/getting-started/single-binary.md
+++ b/docs/getting-started/single-binary.md
@@ -25,7 +25,7 @@ Want to build from source locally? Add `-build` as an argument to the bootstrap 
 Now create the TigerBeetle [data file](../about/internals/data_file.md):
 
 ```console
-./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 --development 0_0.tigerbeetle
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
 ```
 
 ```console
@@ -36,7 +36,7 @@ info(io): allocating 660.140625MiB...
 And start the server:
 
 ```console
-./tigerbeetle start --addresses=3000 --development 0_0.tigerbeetle
+./tigerbeetle start --addresses=3000 0_0.tigerbeetle
 ```
 
 ```console

--- a/docs/getting-started/with-docker-compose.md
+++ b/docs/getting-started/with-docker-compose.md
@@ -7,9 +7,9 @@ sidebar_position: 5
 First, provision the [data file](../about/internals/data_file.md) for each node:
 
 ```console
-docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle format --cluster=0 --replica=0 --replica-count=3 --development /data/0_0.tigerbeetle
-docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle format --cluster=0 --replica=1 --replica-count=3 --development /data/0_1.tigerbeetle
-docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle format --cluster=0 --replica=2 --replica-count=3 --development /data/0_2.tigerbeetle
+docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle format --cluster=0 --replica=0 --replica-count=3 /data/0_0.tigerbeetle
+docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle format --cluster=0 --replica=1 --replica-count=3 /data/0_1.tigerbeetle
+docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle format --cluster=0 --replica=2 --replica-count=3 /data/0_2.tigerbeetle
 ```
 
 Then create a docker-compose.yml file:
@@ -34,21 +34,21 @@ version: "3.7"
 services:
   tigerbeetle_0:
     image: ghcr.io/tigerbeetle/tigerbeetle
-    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 --development /data/0_0.tigerbeetle"
+    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_0.tigerbeetle"
     network_mode: host
     volumes:
       - ./data:/data
 
   tigerbeetle_1:
     image: ghcr.io/tigerbeetle/tigerbeetle
-    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 --development /data/0_1.tigerbeetle"
+    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_1.tigerbeetle"
     network_mode: host
     volumes:
       - ./data:/data
 
   tigerbeetle_2:
     image: ghcr.io/tigerbeetle/tigerbeetle
-    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 --development /data/0_2.tigerbeetle"
+    command: "start --addresses=0.0.0.0:3001,0.0.0.0:3002,0.0.0.0:3003 /data/0_2.tigerbeetle"
     network_mode: host
     volumes:
       - ./data:/data

--- a/docs/getting-started/with-docker.md
+++ b/docs/getting-started/with-docker.md
@@ -8,7 +8,7 @@ First provision TigerBeetle's [data file](../about/internals/data_file.md):
 
 ```console
 docker run -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle \
-    format --cluster=0 --replica=0 --replica-count=1 --development /data/0_0.tigerbeetle
+    format --cluster=0 --replica=0 --replica-count=1 /data/0_0.tigerbeetle
 ```
 
 ```console
@@ -20,7 +20,7 @@ Then run the server:
 
 ```console
 docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle \
-    start --addresses=0.0.0.0:3000 --development /data/0_0.tigerbeetle
+    start --addresses=0.0.0.0:3000 /data/0_0.tigerbeetle
 ```
 
 ```console
@@ -65,5 +65,5 @@ to a debug image (by using the `:debug` Docker image tag).
 
 ```console
 docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle:debug \
-    start --addresses=0.0.0.0:3000 --development /data/0_0.tigerbeetle
+    start --addresses=0.0.0.0:3000 /data/0_0.tigerbeetle
 ```

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -129,7 +129,7 @@ pub fn GridScrubberType(comptime Forest: type) type {
         tour_index_block: BlockPtr,
 
         /// These counters reset after every tour cycle.
-        tour_blocks_scrubbed_count: usize,
+        tour_blocks_scrubbed_count: u64,
 
         pub fn init(
             allocator: std.mem.Allocator,


### PR DESCRIPTION
This flag is in `main` but is not released yet, so documenting it is confusing users.
Remove it from the docs for now, to be added back once we tag another release.

(Also includes [this code review change](https://github.com/tigerbeetle/tigerbeetle/pull/1851#discussion_r1574671798)).

After this PR merges I will re-deploy the docs site.