### PR TITLE
ewah: fix off-by-one in fuzzer's code

### DIFF
--- a/src/ewah_fuzz.zig
+++ b/src/ewah_fuzz.zig
@@ -15,19 +15,19 @@ pub fn main(args: fuzz.FuzzArgs) !void {
         const random = prng.random();
 
         const decoded_size_max = @divExact(1024 * 1024, @sizeOf(Word));
-        const decoded_size = random.uintLessThan(usize, 1 + decoded_size_max);
+        const decoded_size = random.intRangeAtMost(usize, 1, decoded_size_max);
         const decoded = try allocator.alloc(Word, decoded_size);
         defer allocator.free(decoded);
 
         const decoded_bits_total = decoded_size * @bitSizeOf(Word);
-        const decoded_bits = random.uintLessThan(usize, decoded_bits_total);
+        const decoded_bits = random.uintAtMost(usize, decoded_bits_total);
         generate_bits(random, std.mem.sliceAsBytes(decoded[0..decoded_size]), decoded_bits);
 
         var context = try ContextType(Word).init(allocator, decoded.len);
         defer context.deinit(allocator);
 
-        const encode_chunk_words_count = 1 + random.uintLessThan(usize, decoded_size);
-        const decode_chunk_words_count = 1 + random.uintLessThan(usize, decoded_size);
+        const encode_chunk_words_count = random.intRangeAtMost(usize, 1, decoded_size);
+        const decode_chunk_words_count = random.intRangeAtMost(usize, 1, decoded_size);
 
         const encoded_size = try context.test_encode_decode(decoded, .{
             .encode_chunk_words_count = encode_chunk_words_count,


### PR DESCRIPTION
If decoded_size is `0`, we try to generate then 0 bits, which panics. Furthermore, our encoding/decoding assumes that the size is non zero (a zero-sized disk write is slower than no write at all).

Make sure that the input buffer is at least one byte long. Note that the number of bits actually set is allowed to be zero: ewah is symmetric between 0 and one, and all bits set is a reasonable configuration.

Seed: ./zig/zig build -Drelease fuzz -- --seed=1459624380881812643 ewah

This is the first CFO trophy