### PR TITLE
tidy: blob check vs shallow clone

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,9 @@ jobs:
       # https://github.com/actions/checkout/issues/1169
       - run: git config --system --add safe.directory '*'
       - uses: actions/checkout@v4
+        # Fetch the entire history of the commit in question for tidy.
+        with:
+          fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
       - run: zig/zig build test
 
@@ -25,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
       - run: zig/zig build test
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v4
+        # Fetch the entire history of the commit in question for tidy.
+        with:
+          fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build test
       - run: ./scripts/install.sh

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -217,6 +217,11 @@ test "tidy no large blobs" {
     //
     // Zig's std doesn't provide a cross platform abstraction for piping two commands together, so
     // we begrudgingly pass the data through this intermediary process.
+    const shallow = try shell.exec_stdout("git rev-parse --is-shallow-repository", .{});
+    if (!std.mem.eql(u8, shallow, "false")) {
+        return error.ShallowRepository;
+    }
+
     const MiB = 1024 * 1024;
     const rev_list = try shell.exec_stdout_options(
         .{ .max_output_bytes = 50 * MiB },


### PR DESCRIPTION
We want to avoid large files in the repository. Naively listing just the files won't work: if the file is added in one commit and removed in a subsequent one, it will be absent from the working tree, but will still be perpetually present in the Git history.

For this reason, tidy is smart --- it asks git itself to list large git objects.

But GitHub outsmarts tidy, as it does a shallow clone by default.

Fix this treachery within treachery within treachery with a proper clone

See https://stackoverflow.com/a/6802238/1936422 for why this specific depth.