### PR TITLE
MessagePool: Remove old assert

### DIFF
--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -60,7 +60,6 @@ pub const messages_max_client = messages_max: {
 comptime {
     // These conditions are necessary (but not sufficient) to prevent deadlocks.
     assert(messages_max_replica > constants.replicas_max);
-    assert(messages_max_client > constants.client_request_queue_max);
 }
 
 /// A pool of reference-counted Messages, memory for which is allocated only once during

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -60,6 +60,7 @@ pub const messages_max_client = messages_max: {
 comptime {
     // These conditions are necessary (but not sufficient) to prevent deadlocks.
     assert(messages_max_replica > constants.replicas_max);
+    assert(messages_max_client > 1);
 }
 
 /// A pool of reference-counted Messages, memory for which is allocated only once during


### PR DESCRIPTION
`vsr.Client` doesn't depend on `constants.client_request_queue_max`.