### PR TITLE
Constants: Reduce connections_max by 1

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -209,7 +209,8 @@ comptime {
 }
 
 /// The maximum number of connections that can be held open by the server at any time:
-pub const connections_max = members_max + clients_max;
+/// -1 since we don't have a connection to ourself.
+pub const connections_max = members_max + clients_max - 1;
 
 /// The maximum size of a message in bytes:
 /// This is also the limit of all inflight data across multiple pipelined requests per connection.

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -107,7 +107,8 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             options: Options,
         ) !Self {
             // There must be enough connections for all replicas and at least one client.
-            assert(constants.connections_max > options.configuration.len);
+            // -1 since we don't need a connection to ourself.
+            assert(constants.connections_max > options.configuration.len - 1);
             assert(@as(vsr.ProcessType, process_id) == process_type);
 
             const connections = try allocator.alloc(Connection, constants.connections_max);


### PR DESCRIPTION
Since `MessagePool` never has a connection to itself.

Saves a whopping 5MiB of RAM :stuck_out_tongue: 
(This is a "bug" I found while working on a more impactful change -- to not allocate messages for extra connections when `replica_count < replica_count_max`.)