### PR TITLE
Grid/Scrubber: Downgrade log.info() to log.debug()

### DIFF
--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -442,7 +442,7 @@ pub fn GridScrubberType(comptime Forest: type) type {
 
             // Note that this is just the end of the tour.
             // (Some of the cycle's reads may still be in progress).
-            log.info("{}: tour_next: cycle done (toured_blocks={})", .{
+            log.debug("{}: tour_next: cycle done (toured_blocks={})", .{
                 scrubber.superblock.replica_index.?,
                 scrubber.tour_blocks_scrubbed_count,
             });


### PR DESCRIPTION
This is too noisy for small (especially empty) grids:

```
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
info(grid_scrubber): 0: tour_next: cycle done (toured_blocks=0)
```

I have an idea of how to improve this but I will implement it as part of some other scrubber changes in a few weeks. (Be smarter about how we compute the timer interval in `replica.zig`.) And in the mean time I want the log to be tidier.