### PR TITLE
CLI: Print memory usage more accurately

### DIFF
--- a/src/counting_allocator.zig
+++ b/src/counting_allocator.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const Self = @This();
+
+parent_allocator: std.mem.Allocator,
+size: usize = 0,
+
+pub fn init(parent_allocator: std.mem.Allocator) Self {
+    return .{ .parent_allocator = parent_allocator };
+}
+
+pub fn deinit(self: *Self) void {
+    self.* = undefined;
+}
+
+pub fn allocator(self: *Self) std.mem.Allocator {
+    return .{
+        .ptr = self,
+        .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .free = free,
+        },
+    };
+}
+
+fn alloc(ctx: *anyopaque, len: usize, ptr_align: u8, ret_addr: usize) ?[*]u8 {
+    const self: *Self = @alignCast(@ptrCast(ctx));
+    self.size += len;
+    return self.parent_allocator.rawAlloc(len, ptr_align, ret_addr);
+}
+
+fn resize(ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, ret_addr: usize) bool {
+    const self: *Self = @alignCast(@ptrCast(ctx));
+    self.size = (self.size - buf.len) + new_len;
+    return self.parent_allocator.rawResize(buf, buf_align, new_len, ret_addr);
+}
+
+fn free(ctx: *anyopaque, buf: []u8, buf_align: u8, ret_addr: usize) void {
+    const self: *Self = @alignCast(@ptrCast(ctx));
+    self.size -= buf.len;
+    return self.parent_allocator.rawFree(buf, buf_align, ret_addr);
+}

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -261,6 +261,14 @@ const Command = struct {
                 allocation_size += node.data;
                 node_maybe = node.next;
             }
+            if (arena.state.buffer_list.first) |node_first| {
+                // The "first" node in the linked list is actually the last one to be created, and
+                // is also the largest. Subtract the part of it that is not actually in use (and so;
+                // will not be page-faulted in – it is just virtual memory).
+                //
+                // Most of the other nodes also have unused space too, but we can't tell how much.
+                allocation_size -= node_first.data - arena.state.end_index;
+            }
         }
         log_main.info("{}: Allocated {}MiB in {} regions during replica init", .{
             replica.replica,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -68,7 +68,7 @@ pub fn main() !void {
             .replica_count = args.replica_count,
             .release = config.process.release,
         }),
-        .start => |*args| try Command.start(&arena, args),
+        .start => |*args| try Command.start(arena.allocator(), args),
         .version => |*args| try Command.version(allocator, args.verbose),
         .repl => |*args| try Command.repl(&arena, args),
         .benchmark => |*args| try benchmark_driver.main(allocator, args),
@@ -162,11 +162,13 @@ const Command = struct {
         });
     }
 
-    pub fn start(arena: *std.heap.ArenaAllocator, args: *const cli.Command.Start) !void {
+    pub fn start(base_allocator: std.mem.Allocator, args: *const cli.Command.Start) !void {
+        var counting_allocator = vsr.CountingAllocator.init(base_allocator);
+
         var traced_allocator = if (constants.tracer_backend == .tracy)
-            tracer.TracyAllocator("tracy").init(arena.allocator())
+            tracer.TracyAllocator("tracy").init(counting_allocator.allocator())
         else
-            arena;
+            &counting_allocator;
 
         // TODO Panic if the data file's size is larger that args.storage_size_limit.
         // (Here or in Replica.open()?).
@@ -250,30 +252,11 @@ const Command = struct {
             else => |e| return e,
         };
 
-        // Calculate how many bytes are allocated inside `arena`.
-        // TODO This does not account for the fact that any allocations will be rounded up to the nearest page by `std.heap.page_allocator`.
-        var allocation_count: usize = 0;
-        var allocation_size: usize = 0;
-        {
-            var node_maybe = arena.state.buffer_list.first;
-            while (node_maybe) |node| {
-                allocation_count += 1;
-                allocation_size += node.data;
-                node_maybe = node.next;
-            }
-            if (arena.state.buffer_list.first) |node_first| {
-                // The "first" node in the linked list is actually the last one to be created, and
-                // is also the largest. Subtract the part of it that is not actually in use (and so;
-                // will not be page-faulted in – it is just virtual memory).
-                //
-                // Most of the other nodes also have unused space too, but we can't tell how much.
-                allocation_size -= node_first.data - arena.state.end_index;
-            }
-        }
-        log_main.info("{}: Allocated {}MiB in {} regions during replica init", .{
+        // Note that this does not account for the fact that any allocations will be rounded up to
+        // the nearest page by `std.heap.page_allocator`.
+        log_main.info("{}: Allocated {}MiB during replica init", .{
             replica.replica,
-            @divFloor(allocation_size, 1024 * 1024),
-            allocation_count,
+            @divFloor(counting_allocator.size, 1024 * 1024),
         });
         log_main.info("{}: Grid cache: {}MiB, LSM-tree manifests: {}MiB", .{
             replica.replica,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -58,6 +58,7 @@ pub const Header = @import("vsr/message_header.zig").Header;
 pub const FreeSet = @import("vsr/free_set.zig").FreeSet;
 pub const CheckpointTrailerType = @import("vsr/checkpoint_trailer.zig").CheckpointTrailerType;
 pub const GridScrubberType = @import("vsr/grid_scrubber.zig").GridScrubberType;
+pub const CountingAllocator = @import("counting_allocator.zig");
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).


### PR DESCRIPTION
More accurately print memory usage at startup.

Before:

```
info(main): 0: Allocated 4255MiB in 16 regions during replica init
```

After:

```
info(main): 0: Allocated 3404MiB in 16 regions during replica init
```

To be very clear, the actual memory allocated has not changed. Before we were effectively printing the virtual memory – over-allocation by the arena allocator which will never be page-faulted in. The new number is _closer_ to RSS (though still overestimates it – arena doesn't store enough info for us to be more accurate).