### PR TITLE
CLI: Move MessagePool.init() into Command.start()

### DIFF
--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -16,9 +16,9 @@ do
 
     ./scripts/install_zig.sh
 
-    # `unshare --pid` ensures that, if the parent process dies, all childrent die as well.
+    # `unshare --pid` ensures that, if the parent process dies, all children die as well.
     # `unshare --user` is needed to make `--pid` work without root.
-    # `|| true` because we want to be resilient to bugs in `cfo` itself. 
+    # `|| true` because we want to be resilient to bugs in `cfo` itself.
     unshare --user -f --pid \
         ./zig/zig build -Drelease scripts -- cfo \
         || true


### PR DESCRIPTION
This reduces the time-to-`tigerbeetle format` by about 150ms (on my laptop). (By not allocating the messages unnecessarily.)

But that was just a bonus. The main motivation for this change is I want to parameterize `MessagePool.init()` over `tigerbeetle start`'s CLI flags.