### PR TITLE
lsm: fix false positive fuzz failure

### DIFF
--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -464,8 +464,8 @@ pub fn ManifestLevelType(
 
             if (level.keys.len() == 0) return null;
 
-            // Ascending:  Find the first table where table.key_max ≤ iterator.key_min.
-            // Descending: Find the first table where table.key_max ≤ iterator.key_max.
+            // Ascending:  Find the first table where table.key_max ≥ iterator.key_min.
+            // Descending: Find the first table where table.key_max ≥ iterator.key_max.
             const target = level.keys.search(switch (direction) {
                 .ascending => key_min,
                 .descending => key_max,

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -423,9 +423,8 @@ pub fn ManifestLevelType(
                                 //
                                 // Unlike in the ascending case, it is not guaranteed that
                                 // table.key_min is less than or equal to key_range.key_max on the
-                                // first iteration as only the key_max of a table is stored in our
-                                // key nodes. On subsequent iterations this check will always
-                                // be false.
+                                // first iteration as the underlying SegmentedArray.search uses
+                                // .upper_bound regardless of .direction.
                                 if (table.key_min > key_range.key_max) {
                                     continue;
                                 }

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -1255,6 +1255,21 @@ fn FuzzContextType(
                 );
                 try testing.expectEqual(iterator_end.next(), null);
             }
+
+            {
+                // 0 is not symmetric with maxInt, because `array.search` doesn't take direction
+                // into account.
+                var iterator_start = context.array.iterator_from_cursor(
+                    context.array.search(0),
+                    .descending,
+                );
+                if (context.reference.items.len == 0) {
+                    try testing.expectEqual(iterator_start.next(), null);
+                } else {
+                    try testing.expect(iterator_start.next() != null);
+                    try testing.expectEqual(iterator_start.next(), null);
+                }
+            }
         }
 
         fn reference_index(context: *const Self, key: Key) u32 {


### PR DESCRIPTION
For this seed, the array ends up containing maxInt purely by accident.

Seed: ./zig/zig build -Drelease fuzz -- --seed=13934190539457735373 lsm_segmented_array

Closes #1876 