### PR TITLE
Add SIGILL handler, to give context to the crashes on older CPUs

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -37,6 +37,8 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
+    try SigIllHandler.register();
+
     // TODO(zig): Zig defaults to 16MB stack size on Linux, but not yet on mac as of 0.11.
     // Override it here, so it can have the same stack size. Trying to set `tigerbeetle.stack_size`
     // in build.zig doesn't work.
@@ -74,6 +76,74 @@ pub fn main() !void {
         .benchmark => |*args| try benchmark_driver.main(allocator, args),
     }
 }
+
+const SigIllHandler = struct {
+    var original_posix_sigill_handler: ?*const fn (
+        i32,
+        *const os.siginfo_t,
+        ?*const anyopaque,
+    ) callconv(.C) void = null;
+
+    fn handle_sigill_windows(
+        info: *std.os.windows.EXCEPTION_POINTERS,
+    ) callconv(std.os.windows.WINAPI) c_long {
+        if (info.ExceptionRecord.ExceptionCode == std.os.windows.EXCEPTION_ILLEGAL_INSTRUCTION) {
+            display_message();
+        }
+        return std.os.windows.EXCEPTION_CONTINUE_SEARCH;
+    }
+
+    fn handle_sigill_posix(
+        sig: i32,
+        info: *const os.siginfo_t,
+        ctx_ptr: ?*const anyopaque,
+    ) callconv(.C) noreturn {
+        display_message();
+        original_posix_sigill_handler.?(sig, info, ctx_ptr);
+        unreachable;
+    }
+
+    fn display_message() void {
+        std.log.err("", .{});
+        std.log.err("TigerBeetle's binary releases are compiled targeting modern CPU", .{});
+        std.log.err("instructions such as NEON / AES on ARM and x86_64_v3 / AES-NI on", .{});
+        std.log.err("x86-64.", .{});
+        std.log.err("", .{});
+        std.log.err("These instructions can be unsupported on older processors, leading to", .{});
+        std.log.err("\"illegal instruction\" panics.", .{});
+        std.log.err("", .{});
+        std.log.err("If you'd like to try TigerBeetle on an older processor, you can", .{});
+        std.log.err("compile from source with the changes detailed at", .{});
+        std.log.err("https://github.com/tigerbeetle/tigerbeetle/issues/1592", .{});
+        std.log.err("", .{});
+    }
+
+    fn register() !void {
+        switch (builtin.os.tag) {
+            .windows => {
+                // The 1 indicates this will run first, before Zig's built in handler. Internally,
+                // it returns EXCEPTION_CONTINUE_SEARCH so that Zig's handler is called next.
+                _ = std.os.windows.kernel32.AddVectoredExceptionHandler(1, handle_sigill_windows);
+            },
+            .linux, .macos => {
+                // For Linux / macOS, save the original signal handler so it can be called by this
+                // new handler once the log message has been printed.
+                assert(original_posix_sigill_handler == null);
+                var act = os.Sigaction{
+                    .handler = .{ .sigaction = handle_sigill_posix },
+                    .mask = os.empty_sigset,
+                    .flags = (os.SA.SIGINFO | os.SA.RESTART | os.SA.RESETHAND),
+                };
+
+                var oact: os.Sigaction = undefined;
+
+                try os.sigaction(os.SIG.ILL, &act, &oact);
+                original_posix_sigill_handler = oact.handler.sigaction.?;
+            },
+            else => unreachable,
+        }
+    }
+};
 
 const Command = struct {
     dir_fd: os.fd_t,


### PR DESCRIPTION
A [common](https://github.com/tigerbeetle/tigerbeetle/issues/1592) [problem](https://github.com/tigerbeetle/tigerbeetle/issues/1839) is the cryptic "Illegal Instruction" message on older CPUs, caused by targeting modern CPU instruction sets and additions like AES-NI and AVX2.

This PR adds a signal handler (and Windows equivalent) to print out a friendly message. I went for the signal handler route as it's the most robust; trying to check features at runtime can invoke code that uses autovectorization and thus panics itself.

Modifying `build.zig` to use unsupported features for my CPU (`x86_64_v3+aes+avx512cd`):

```
zig build install && ./tigerbeetle start --addresses="127.0.0.1:3001" /tmp/0_0.tigerbeetle
error:
error: TigerBeetle's binary releases are compiled targeting modern CPU
error: instructions such as NEON / AES on ARM and x86_64_v3 / AES-NI on
error: x86-64.
error:
error: These instructions can be unsupported on older processors, leading to
error: "illegal instruction" panics.
error:
error: If you'd like to try TigerBeetle on an older processor, you can
error: compile from source with the changes detailed at
error: https://github.com/tigerbeetle/tigerbeetle/issues/1592
error:
Illegal instruction at address 0x465840
fish: Job 1, './tigerbeetle start --addresses…' terminated by signal SIGILL (Illegal instruction)
```

Tested on Windows using Wine, but untested on macOS currently.