### PR TITLE
ci: unspecial-case minor benchmark

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,6 +32,7 @@ jobs:
           fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
       - run: zig/zig build test
+      - run: zig/zig build -Dtracer-backend=tracy
 
   aof:
     runs-on: ubuntu-latest
@@ -53,21 +54,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build fuzz -- smoke
-
-  # Check some build steps that would otherwise not get checked.
-  # Things like "go_client", "java_client", "dotnet_client" are excluded here
-  # because they get run in their own CI
-  verify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - run: ./scripts/install_zig.sh
-      - run: zig/zig build build_benchmark_ewah
-      - run: zig/zig build build_benchmark_binary_search
-      - run: zig/zig build build_benchmark_segmented_array
-      - run: zig/zig build -Dtracer-backend=tracy
 
   # Run simulator once for each state machine, using commit hash as a random, but also deterministic
   # seed.

--- a/build.zig
+++ b/build.zig
@@ -495,44 +495,6 @@ pub fn build(b: *std.Build) !void {
         fuzz_build_step.dependOn(&fuzz_install_step.step);
     }
 
-    inline for (.{
-        .{
-            .name = "benchmark_ewah",
-            .file = "src/ewah_benchmark.zig",
-            .description = "EWAH codec",
-        },
-        .{
-            .name = "benchmark_binary_search",
-            .file = "src/lsm/binary_search_benchmark.zig",
-            .description = "Array search",
-        },
-        .{
-            .name = "benchmark_segmented_array",
-            .file = "src/lsm/segmented_array_benchmark.zig",
-            .description = "SegmentedArray search",
-        },
-    }) |benchmark| {
-        const exe = b.addExecutable(.{
-            .name = benchmark.name,
-            .root_source_file = .{ .path = benchmark.file },
-            .target = target,
-            .optimize = .ReleaseSafe,
-            .main_pkg_path = .{ .path = "src" },
-        });
-        exe.addOptions("vsr_options", options);
-        link_tracer_backend(exe, git_clone_tracy, tracer_backend, target);
-
-        const build_step = b.step(
-            "build_" ++ benchmark.name,
-            "Build " ++ benchmark.description ++ " benchmark",
-        );
-        build_step.dependOn(&exe.step);
-
-        const run_cmd = b.addRunArtifact(exe);
-        const step = b.step(benchmark.name, "Benchmark " ++ benchmark.description);
-        step.dependOn(&run_cmd.step);
-    }
-
     { // Free-form automation: `zig build scripts -- ci --language=java`
         const scripts_exe = b.addExecutable(.{
             .name = "scripts",

--- a/src/ewah_benchmark.zig
+++ b/src/ewah_benchmark.zig
@@ -2,14 +2,17 @@ const std = @import("std");
 const assert = std.debug.assert;
 const ewah = @import("ewah.zig").ewah(usize);
 
+const log = std.log;
+
 const BitSetConfig = struct {
     words: usize,
     run_length_e: usize,
     literals_length_e: usize,
 };
 
-const samples = 100;
-const repeats: usize = 100_000;
+// Bump these up if you want to use this as a real benchmark rather than as a test.
+const samples = 10;
+const repeats: usize = 1_000;
 
 // Explanation of fields:
 // - "n": Number of randomly generate bitsets to test.
@@ -28,9 +31,7 @@ const configs = [_]BitSetConfig{
 
 var prng = std.rand.DefaultPrng.init(42);
 
-pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
-
+test "benchmark: ewah" {
     for (configs) |config| {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
@@ -90,9 +91,8 @@ pub fn main() !void {
             total_compressed += @as(f64, @floatFromInt(bitset_lengths[i]));
         }
 
-        try stdout.print(
+        log.info(
             \\Words={:_>3} E(Run)={:_>3} E(Literal)={:_>3} EncTime={:_>6}ns DecTime={:_>6}ns Ratio={d:_>6.2}
-            \\
         , .{
             config.words,
             config.run_length_e,

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -26,9 +26,9 @@ const body_fmt = "K={:_>2}B V={:_>3}B N={:_>4} {s}{s}: WT={:_>6}ns UT={:_>6}ns" 
     " CY={:_>6} IN={:_>6} CR={:_>5} CM={:_>5} BM={}";
 
 test "benchmark: binary search" {
-    if (builtin.os.tag != .windows) {
+    if (builtin.os.tag != .linux) {
         // Benchmark uses perf_event_open and only runs on Linux.
-        // return;
+        return;
     }
 
     log.info("Samples: {}", .{searches});

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -172,8 +172,8 @@ fn shuffled_index(comptime n: usize, rand: std.rand.Random) [n]usize {
 
 fn timeval_to_ns(tv: std.os.timeval) u64 {
     const ns_per_us = std.time.ns_per_s / std.time.us_per_s;
-    return @as(u64, @bitCast(tv.tv_sec)) * std.time.ns_per_s +
-        @as(u64, @bitCast(tv.tv_usec)) * ns_per_us;
+    return @as(u64, @intCast(tv.tv_sec)) * std.time.ns_per_s +
+        @as(u64, @intCast(tv.tv_usec)) * ns_per_us;
 }
 
 fn readPerfFd(fd: std.os.fd_t) !usize {

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -7,7 +7,10 @@ const table_count_max_for_level = @import("tree.zig").table_count_max_for_level;
 const table_count_max_for_tree = @import("tree.zig").table_count_max_for_tree;
 const SortedSegmentedArray = @import("segmented_array.zig").SortedSegmentedArray;
 
-const samples = 5_000_000;
+const log = std.log;
+
+// Bump this up if you want to use this as a real benchmark rather than as a test.
+const samples = 5_000;
 
 const Options = struct {
     Key: type,
@@ -62,8 +65,7 @@ const configs = [_]Options{
     },
 };
 
-pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
+test "benchmark: segmented array" {
     var prng = std.rand.DefaultPrng.init(42);
 
     inline for (configs) |options| {
@@ -123,7 +125,7 @@ pub fn main() !void {
         }
         const time = timer.read() / repetitions / queries.len;
 
-        try stdout.print("KeyType={} ValueCount={:_>7} ValueSize={:_>2}B NodeSize={:_>6}B LookupTime={:_>6}ns\n", .{
+        log.err("KeyType={} ValueCount={:_>7} ValueSize={:_>2}B NodeSize={:_>6}B LookupTime={:_>6}ns", .{
             options.Key,
             options.value_count,
             options.value_size,

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -125,7 +125,7 @@ test "benchmark: segmented array" {
         }
         const time = timer.read() / repetitions / queries.len;
 
-        log.err("KeyType={} ValueCount={:_>7} ValueSize={:_>2}B NodeSize={:_>6}B LookupTime={:_>6}ns", .{
+        log.info("KeyType={} ValueCount={:_>7} ValueSize={:_>2}B NodeSize={:_>6}B LookupTime={:_>6}ns", .{
             options.Key,
             options.value_count,
             options.value_size,

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -148,14 +148,11 @@ const DeadDetector = struct {
     fn is_entry_point(file: FileName) bool {
         const entry_points: []const []const u8 = &.{
             "benchmark.zig",
-            "binary_search_benchmark.zig",
-            "ewah_benchmark.zig",
             "fuzz_tests.zig",
             "integration_tests.zig",
             "jni_tests.zig",
             "main.zig",
             "node.zig",
-            "segmented_array_benchmark.zig",
             "tb_client_header.zig",
             "unit_tests.zig",
             "vopr.zig",

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -1,6 +1,7 @@
 comptime {
     _ = @import("aof.zig");
     _ = @import("copyhound.zig");
+    _ = @import("ewah_benchmark.zig");
     _ = @import("ewah.zig");
     _ = @import("fifo.zig");
     _ = @import("flags.zig");
@@ -22,6 +23,7 @@ comptime {
     _ = @import("io/test.zig");
 
     _ = @import("lsm/binary_search.zig");
+    _ = @import("lsm/binary_search_benchmark.zig");
     _ = @import("lsm/cache_map.zig");
     _ = @import("lsm/composite_key.zig");
     _ = @import("lsm/forest.zig");
@@ -32,6 +34,7 @@ comptime {
     _ = @import("lsm/manifest_level.zig");
     _ = @import("lsm/node_pool.zig");
     _ = @import("lsm/segmented_array.zig");
+    _ = @import("lsm/segmented_array_benchmark.zig");
     _ = @import("lsm/set_associative_cache.zig");
     _ = @import("lsm/table.zig");
     _ = @import("lsm/table_memory.zig");


### PR DESCRIPTION
We have three "minor", "unit" benchmarks for specific data structures. These benchmarks are not being run continuously, and are an odd addition to our build infrastructure.

I don't think they would provide a lot of value even if we track them --- the specific code is changed rarely, and if it does change, we'll hopefully catch any big regressions in our macro benchmarks.

These benchmarks could still be valueable for someone explicitly hacking on the data structures though.

So, in this PR then benchmark are instead recast as smoke tests. This way:

- they are run by our CI infrastructure and are protected from bitrot
- they don't need any special handling in our build and CI infrastructure
- they still can be used for ad-hoc benchmarking (by manually adjusting the corresponding limits)