### PR TITLE
MessagePool: Compute `messages_max` at runtime

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -208,10 +208,6 @@ comptime {
     assert(journal_size == journal_size_headers + journal_size_prepares);
 }
 
-/// The maximum number of connections that can be held open by the server at any time:
-/// -1 since we don't have a connection to ourself.
-pub const connections_max = members_max + clients_max - 1;
-
 /// The maximum size of a message in bytes:
 /// This is also the limit of all inflight data across multiple pipelined requests per connection.
 /// We may have one request of up to 2 MiB inflight or 2 pipelined requests of up to 1 MiB inflight.

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -106,12 +106,14 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             on_message_callback: *const fn (message_bus: *Self, message: *Message) void,
             options: Options,
         ) !Self {
-            // There must be enough connections for all replicas and at least one client.
-            // -1 since we don't need a connection to ourself.
-            assert(constants.connections_max > options.configuration.len - 1);
             assert(@as(vsr.ProcessType, process_id) == process_type);
 
-            const connections = try allocator.alloc(Connection, constants.connections_max);
+            // The maximum number of connections that can be held open by the server at any time.
+            // -1 since we don't need a connection to ourself.
+            const connections_max: u32 =
+                @intCast(options.configuration.len - 1 + constants.clients_max);
+
+            const connections = try allocator.alloc(Connection, connections_max);
             errdefer allocator.free(connections);
             @memset(connections, .{});
 
@@ -155,7 +157,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
             // Pre-allocate enough memory to hold all possible connections in the client map.
             if (process_type == .replica) {
-                try bus.process.clients.ensureTotalCapacity(allocator, constants.connections_max);
+                try bus.process.clients.ensureTotalCapacity(allocator, connections_max);
             }
 
             return bus;

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -108,10 +108,12 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         ) !Self {
             assert(@as(vsr.ProcessType, process_id) == process_type);
 
-            // The maximum number of connections that can be held open by the server at any time.
-            // -1 since we don't need a connection to ourself.
-            const connections_max: u32 =
-                @intCast(options.configuration.len - 1 + constants.clients_max);
+            const connections_max: u32 = switch (process_type) {
+                // The maximum number of connections that can be held open by the server at any
+                // time. -1 since we don't need a connection to ourself.
+                .replica => @intCast(options.configuration.len - 1 + constants.clients_max),
+                .client => @intCast(options.configuration.len),
+            };
 
             const connections = try allocator.alloc(Connection, connections_max);
             errdefer allocator.free(connections);

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -14,54 +14,63 @@ comptime {
     assert(constants.message_size_max % constants.sector_size == 0);
 }
 
-/// The number of full-sized messages allocated at initialization by the replica message pool.
-/// There must be enough messages to ensure that the replica can always progress, to avoid deadlock.
-const messages_max_replica = messages_max: {
-    var sum: usize = 0;
+pub const Options = union(vsr.ProcessType) {
+    replica,
+    client,
 
-    sum += constants.journal_iops_read_max; // Journal reads
-    sum += constants.journal_iops_write_max; // Journal writes
-    sum += constants.client_replies_iops_read_max; // Client-reply reads
-    sum += constants.client_replies_iops_write_max; // Client-reply writes
-    sum += constants.grid_repair_reads_max; // Replica.grid_reads (Replica.BlockRead)
-    sum += 1; // Replica.loopback_queue
-    sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
-    sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}
-    sum += 1; // Replica.commit_prepare
-    // Replica.do_view_change_from_all_replicas quorum:
-    // All other quorums are bitsets.
-    sum += constants.replicas_max;
-    sum += constants.connections_max; // Connection.recv_message
-    // Connection.send_queue:
-    sum += constants.connections_max * constants.connection_send_queue_max_replica;
-    sum += 1; // Handle bursts (e.g. Connection.parse_message)
-    // Handle Replica.commit_op's reply:
-    // (This is separate from the burst +1 because they may occur concurrently).
-    sum += 1;
+    /// The number of messages allocated at initialization by the message pool.
+    fn messages_max(options: *const Options) usize {
+        return switch (options.*) {
+            .client => messages_max: {
+                var sum: usize = 0;
 
-    break :messages_max sum;
+                sum += constants.replicas_max; // Connection.recv_message
+                // Connection.send_queue:
+                sum += constants.replicas_max * constants.connection_send_queue_max_client;
+                sum += 1; // Client.register_inflight
+                sum += 1; // Client.request_inflight
+                // Handle bursts.
+                // (e.g. Connection.parse_message(), or sending a ping when the send queue is full).
+                sum += 1;
+
+                // This conditions is necessary (but not sufficient) to prevent deadlocks.
+                assert(sum > 1);
+                break :messages_max sum;
+            },
+
+            // The number of full-sized messages allocated at initialization by the replica message
+            // pool. There must be enough messages to ensure that the replica can always progress,
+            // to avoid deadlock.
+            .replica => messages_max: {
+                var sum: usize = 0;
+
+                sum += constants.journal_iops_read_max; // Journal reads
+                sum += constants.journal_iops_write_max; // Journal writes
+                sum += constants.client_replies_iops_read_max; // Client-reply reads
+                sum += constants.client_replies_iops_write_max; // Client-reply writes
+                sum += constants.grid_repair_reads_max; // Replica.grid_reads (Replica.BlockRead)
+                sum += 1; // Replica.loopback_queue
+                sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
+                sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}
+                sum += 1; // Replica.commit_prepare
+                // Replica.do_view_change_from_all_replicas quorum:
+                // All other quorums are bitsets.
+                sum += constants.replicas_max;
+                sum += constants.connections_max; // Connection.recv_message
+                // Connection.send_queue:
+                sum += constants.connections_max * constants.connection_send_queue_max_replica;
+                sum += 1; // Handle bursts (e.g. Connection.parse_message)
+                // Handle Replica.commit_op's reply:
+                // (This is separate from the burst +1 because they may occur concurrently).
+                sum += 1;
+
+                // This conditions is necessary (but not sufficient) to prevent deadlocks.
+                assert(sum > constants.replicas_max);
+                break :messages_max sum;
+            },
+        };
+    }
 };
-
-/// The number of full-sized messages allocated at initialization by the client message pool.
-const messages_max_client = messages_max: {
-    var sum: usize = 0;
-
-    sum += constants.replicas_max; // Connection.recv_message
-    // Connection.send_queue:
-    sum += constants.replicas_max * constants.connection_send_queue_max_client;
-    sum += 1; // Client.register_inflight
-    sum += 1; // Client.request_inflight
-    // Handle bursts (e.g. Connection.parse_message, or sending a ping when the send queue is full).
-    sum += 1;
-
-    break :messages_max sum;
-};
-
-comptime {
-    // These conditions are necessary (but not sufficient) to prevent deadlocks.
-    assert(messages_max_replica > constants.replicas_max);
-    assert(messages_max_client > 1);
-}
 
 /// A pool of reference-counted Messages, memory for which is allocated only once during
 /// initialization and reused thereafter. The messages_max values determine the size of this pool.
@@ -147,12 +156,9 @@ pub const MessagePool = struct {
 
     pub fn init(
         allocator: mem.Allocator,
-        process_type: vsr.ProcessType,
+        options: Options,
     ) error{OutOfMemory}!MessagePool {
-        return MessagePool.init_capacity(allocator, switch (process_type) {
-            .replica => messages_max_replica,
-            .client => messages_max_client,
-        });
+        return MessagePool.init_capacity(allocator, options.messages_max());
     }
 
     pub fn init_capacity(

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -16,7 +16,7 @@ comptime {
 
 /// The number of full-sized messages allocated at initialization by the replica message pool.
 /// There must be enough messages to ensure that the replica can always progress, to avoid deadlock.
-pub const messages_max_replica = messages_max: {
+const messages_max_replica = messages_max: {
     var sum: usize = 0;
 
     sum += constants.journal_iops_read_max; // Journal reads
@@ -43,7 +43,7 @@ pub const messages_max_replica = messages_max: {
 };
 
 /// The number of full-sized messages allocated at initialization by the client message pool.
-pub const messages_max_client = messages_max: {
+const messages_max_client = messages_max: {
     var sum: usize = 0;
 
     sum += constants.replicas_max; // Connection.recv_message

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -218,7 +218,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
             for (replica_pools, 0..) |*pool, i| {
                 errdefer for (replica_pools[0..i]) |*p| p.deinit(allocator);
-                pool.* = try MessagePool.init(allocator, .replica);
+                pool.* = try MessagePool.init(allocator, .{ .replica = .{
+                    .members_count = options.replica_count + options.standby_count,
+                } });
             }
             errdefer for (replica_pools) |*pool| pool.deinit(allocator);
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -469,7 +469,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 var it = message_bus.pool.free_list;
                 while (it) |message| : (it = message.next) messages_in_pool += 1;
             }
-            assert(messages_in_pool == message_pool.messages_max_replica);
+            assert(messages_in_pool == message_bus.pool.messages_max);
         }
 
         fn replica_enable(cluster: *Self, replica_index: u8) void {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -246,7 +246,9 @@ const Command = struct {
         });
         defer command.deinit();
 
-        var message_pool = try MessagePool.init(allocator, .replica);
+        var message_pool = try MessagePool.init(allocator, .{ .replica = .{
+            .members_count = @intCast(args.addresses.len),
+        } });
         defer message_pool.deinit(allocator);
 
         var aof: AOFType = undefined;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -494,7 +494,7 @@ pub fn ReplicaType(
         /// (syncing≠idle)
         sync_message_timeout: Timeout,
 
-        /// The number of ticks on an idle cluester before injecting a `pulse` operation.
+        /// The number of ticks on an idle cluster before injecting a `pulse` operation.
         /// (status=normal and primary and !constants.aof_recovery)
         pulse_timeout: Timeout,
 


### PR DESCRIPTION
#### Lift `messages_max_{replica,client}` calculation to runtime.

To pave the way for upcoming memory optimizations.

#### Lift `connections_max` to runtime

`connections_max` accounts for all possible replicas (6) and standbys (6).
But at runtime, we know how many replicas and standbys exist (potentially <6).

This means that we can reduce the number of messages allocated based on how many replicas/standbys there actually are.

In the case of a single-replica cluster, this save 60 messages (60MiB):

- `5` from `Replica.do_view_change_from_all_replicas`
- `11` from `Connection.recv_message`
- `11 * 4` from `Connect.send_queue`

Weirdly, this causes the virtual memory to _increase_ (presumably due to the changed access pattern to the arena allocator).