### PR TITLE
CLI: Small caches for `tigerbeetle start --development`

### DIFF
--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -160,7 +160,7 @@ const CliArgs = union(enum) {
         \\  --development
         \\        Allow the replica to format/start even when Direct IO is unavailable.
         \\        For safety, production replicas should always enforce Direct IO -- this flag should only be
-        \\        used for testing and development.
+        \\        used for testing and development. It should not be used for production or benchmarks.
         \\
         \\Examples:
         \\


### PR DESCRIPTION
When `--development` is passed to `tigerbeetle start`, use minimal cache sizes.

This reduces the RSS of a single-replica with `--development` from ~3.30GiB to ~2.41GiB.

I left `limit_storage` and `memory_lsm_manifest` untouched since reducing them could prevent you from opening a data file that works without `--development`.