### PR TITLE
VSR: Add `pipeline_limit`/`--limit-pipeline`

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -237,11 +237,11 @@ comptime {
 /// The maximum number of Viewstamped Replication prepare messages that can be inflight at a time.
 /// This is immutable once assigned per cluster, as replicas need to know how many operations might
 /// possibly be uncommitted during a view change, and this must be constant for all replicas.
-pub const pipeline_prepare_queue_max = config.cluster.pipeline_prepare_queue_max;
+pub const pipeline_prepare_queue_max: u32 = config.cluster.pipeline_prepare_queue_max;
 
 /// The maximum number of Viewstamped Replication request messages that can be queued at a primary,
 /// waiting to prepare.
-pub const pipeline_request_queue_max = clients_max -| pipeline_prepare_queue_max;
+pub const pipeline_request_queue_max: u32 = clients_max -| pipeline_prepare_queue_max;
 
 comptime {
     // A prepare-queue capacity larger than clients_max is wasted.

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -17,6 +17,7 @@ comptime {
 pub const Options = union(vsr.ProcessType) {
     replica: struct {
         members_count: u8,
+        pipeline_limit: u32,
     },
     client,
 
@@ -46,12 +47,14 @@ pub const Options = union(vsr.ProcessType) {
             .replica => |*replica| messages_max: {
                 assert(replica.members_count > 0);
                 assert(replica.members_count <= constants.members_max);
+                assert(replica.pipeline_limit > 0);
+                assert(replica.pipeline_limit <= constants.clients_max);
 
                 var sum: usize = 0;
 
                 // The maximum number of simultaneous open connections on the server.
                 // -1 since we never connect to ourself.
-                const connections_max = replica.members_count + constants.clients_max - 1;
+                const connections_max = replica.members_count + replica.pipeline_limit - 1;
 
                 sum += constants.journal_iops_read_max; // Journal reads
                 sum += constants.journal_iops_write_max; // Journal writes
@@ -59,8 +62,7 @@ pub const Options = union(vsr.ProcessType) {
                 sum += constants.client_replies_iops_write_max; // Client-reply writes
                 sum += constants.grid_repair_reads_max; // Replica.grid_reads (Replica.BlockRead)
                 sum += 1; // Replica.loopback_queue
-                sum += constants.pipeline_prepare_queue_max; // Replica.Pipeline{Queue|Cache}
-                sum += constants.pipeline_request_queue_max; // Replica.Pipeline{Queue|Cache}
+                sum += replica.pipeline_limit; // Replica.Pipeline{Queue|Cache}
                 sum += 1; // Replica.commit_prepare
                 // Replica.do_view_change_from_all_replicas quorum:
                 // All other quorums are bitsets.

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -216,11 +216,14 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             var replica_pools = try allocator.alloc(MessagePool, node_count);
             errdefer allocator.free(replica_pools);
 
+            const pipeline_requests_limit =
+                options.client_count -| constants.pipeline_prepare_queue_max;
+
             for (replica_pools, 0..) |*pool, i| {
                 errdefer for (replica_pools[0..i]) |*p| p.deinit(allocator);
                 pool.* = try MessagePool.init(allocator, .{ .replica = .{
                     .members_count = options.replica_count + options.standby_count,
-                    .pipeline_limit = options.client_count,
+                    .pipeline_requests_limit = pipeline_requests_limit,
                 } });
             }
             errdefer for (replica_pools) |*pool| pool.deinit(allocator);
@@ -494,12 +497,15 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 }
             } else unreachable;
 
+            const pipeline_requests_limit =
+                cluster.options.client_count -| constants.pipeline_prepare_queue_max;
+
             var replica = &cluster.replicas[replica_index];
             try replica.open(
                 cluster.allocator,
                 .{
                     .node_count = cluster.options.replica_count + cluster.options.standby_count,
-                    .pipeline_limit = cluster.options.client_count,
+                    .pipeline_requests_limit = pipeline_requests_limit,
                     .storage = &cluster.storages[replica_index],
                     .aof = &cluster.aofs[replica_index],
                     // TODO Test restarting with a higher storage limit.

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -220,6 +220,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 errdefer for (replica_pools[0..i]) |*p| p.deinit(allocator);
                 pool.* = try MessagePool.init(allocator, .{ .replica = .{
                     .members_count = options.replica_count + options.standby_count,
+                    .pipeline_limit = options.client_count,
                 } });
             }
             errdefer for (replica_pools) |*pool| pool.deinit(allocator);
@@ -498,6 +499,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 cluster.allocator,
                 .{
                     .node_count = cluster.options.replica_count + cluster.options.standby_count,
+                    .pipeline_limit = cluster.options.client_count,
                     .storage = &cluster.storages[replica_index],
                     .aof = &cluster.aofs[replica_index],
                     // TODO Test restarting with a higher storage limit.

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -206,7 +206,7 @@ const StartDefaults = struct {
 };
 
 const start_defaults_production = StartDefaults{
-    .limit_pipeline = constants.pipeline_prepare_queue_max + constants.pipeline_request_queue_max,
+    .limit_pipeline = constants.pipeline_request_queue_max,
     .cache_accounts = .{ .value = constants.cache_accounts_size_default },
     .cache_transfers = .{ .value = constants.cache_transfers_size_default },
     .cache_transfers_pending = .{ .value = constants.cache_transfers_pending_size_default },
@@ -215,7 +215,7 @@ const start_defaults_production = StartDefaults{
 };
 
 const start_defaults_development = StartDefaults{
-    .limit_pipeline = constants.pipeline_prepare_queue_max,
+    .limit_pipeline = 0,
     .cache_accounts = .{ .value = 0 },
     .cache_transfers = .{ .value = 0 },
     .cache_transfers_pending = .{ .value = 0 },
@@ -243,7 +243,7 @@ pub const Command = union(enum) {
         cache_transfers_pending: u32,
         cache_account_balances: u32,
         storage_size_limit: u64,
-        pipeline_limit: u32,
+        pipeline_requests_limit: u32,
         cache_grid_blocks: u32,
         lsm_forest_node_count: u32,
         development: bool,
@@ -411,7 +411,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             }
 
             const pipeline_limit = start.limit_pipeline orelse defaults.limit_pipeline;
-            const pipeline_limit_min = constants.pipeline_prepare_queue_max;
+            const pipeline_limit_min = 0;
             const pipeline_limit_max =
                 constants.pipeline_prepare_queue_max + constants.pipeline_request_queue_max;
             if (pipeline_limit > pipeline_limit_max) {
@@ -464,7 +464,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     .addresses = addresses,
                     .addresses_zero = std.mem.eql(u8, start.addresses, "0"),
                     .storage_size_limit = storage_size_limit,
-                    .pipeline_limit = pipeline_limit,
+                    .pipeline_requests_limit = pipeline_limit,
                     .cache_accounts = parse_cache_size_to_count(
                         tigerbeetle.Account,
                         AccountsValuesCache,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -44,7 +44,7 @@ const CliArgs = union(enum) {
     start: struct {
         addresses: []const u8,
         limit_storage: flags.ByteSize = .{ .value = constants.storage_size_limit_max },
-        limit_pipeline: ?u32 = null,
+        limit_pipeline_requests: ?u32 = null,
         cache_accounts: ?flags.ByteSize = null,
         cache_transfers: ?flags.ByteSize = null,
         cache_transfers_pending: ?flags.ByteSize = null,
@@ -91,7 +91,7 @@ const CliArgs = union(enum) {
     },
 
     // TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage,
-    // --limit-pipeline
+    // --limit-pipeline-requests
     pub const help = fmt.comptimePrint(
         \\Usage:
         \\
@@ -197,7 +197,7 @@ const CliArgs = union(enum) {
 };
 
 const StartDefaults = struct {
-    limit_pipeline: u32,
+    limit_pipeline_requests: u32,
     cache_accounts: flags.ByteSize,
     cache_transfers: flags.ByteSize,
     cache_transfers_pending: flags.ByteSize,
@@ -206,7 +206,7 @@ const StartDefaults = struct {
 };
 
 const start_defaults_production = StartDefaults{
-    .limit_pipeline = constants.pipeline_request_queue_max,
+    .limit_pipeline_requests = constants.pipeline_request_queue_max,
     .cache_accounts = .{ .value = constants.cache_accounts_size_default },
     .cache_transfers = .{ .value = constants.cache_transfers_size_default },
     .cache_transfers_pending = .{ .value = constants.cache_transfers_pending_size_default },
@@ -215,7 +215,7 @@ const start_defaults_production = StartDefaults{
 };
 
 const start_defaults_development = StartDefaults{
-    .limit_pipeline = 0,
+    .limit_pipeline_requests = 0,
     .cache_accounts = .{ .value = 0 },
     .cache_transfers = .{ .value = 0 },
     .cache_transfers_pending = .{ .value = 0 },
@@ -410,18 +410,18 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 );
             }
 
-            const pipeline_limit = start.limit_pipeline orelse defaults.limit_pipeline;
+            const pipeline_limit =
+                start.limit_pipeline_requests orelse defaults.limit_pipeline_requests;
             const pipeline_limit_min = 0;
-            const pipeline_limit_max =
-                constants.pipeline_prepare_queue_max + constants.pipeline_request_queue_max;
+            const pipeline_limit_max = constants.pipeline_request_queue_max;
             if (pipeline_limit > pipeline_limit_max) {
-                flags.fatal("--limit-pipeline: count {} exceeds maximum: {}", .{
+                flags.fatal("--limit-pipeline-requests: count {} exceeds maximum: {}", .{
                     pipeline_limit,
                     pipeline_limit_max,
                 });
             }
             if (pipeline_limit < pipeline_limit_min) {
-                flags.fatal("--limit-pipeline: count {} is below minimum: {}", .{
+                flags.fatal("--limit-pipeline-requests: count {} is below minimum: {}", .{
                     pipeline_limit,
                     pipeline_limit_min,
                 });

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -44,6 +44,7 @@ const CliArgs = union(enum) {
     start: struct {
         addresses: []const u8,
         limit_storage: flags.ByteSize = .{ .value = constants.storage_size_limit_max },
+        limit_pipeline: ?u32 = null,
         cache_accounts: ?flags.ByteSize = null,
         cache_transfers: ?flags.ByteSize = null,
         cache_transfers_pending: ?flags.ByteSize = null,
@@ -89,7 +90,8 @@ const CliArgs = union(enum) {
         seed: ?u64 = null,
     },
 
-    // TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage
+    // TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage,
+    // --limit-pipeline
     pub const help = fmt.comptimePrint(
         \\Usage:
         \\
@@ -195,6 +197,7 @@ const CliArgs = union(enum) {
 };
 
 const StartDefaults = struct {
+    limit_pipeline: u32,
     cache_accounts: flags.ByteSize,
     cache_transfers: flags.ByteSize,
     cache_transfers_pending: flags.ByteSize,
@@ -203,6 +206,7 @@ const StartDefaults = struct {
 };
 
 const start_defaults_production = StartDefaults{
+    .limit_pipeline = constants.pipeline_prepare_queue_max + constants.pipeline_request_queue_max,
     .cache_accounts = .{ .value = constants.cache_accounts_size_default },
     .cache_transfers = .{ .value = constants.cache_transfers_size_default },
     .cache_transfers_pending = .{ .value = constants.cache_transfers_pending_size_default },
@@ -211,6 +215,7 @@ const start_defaults_production = StartDefaults{
 };
 
 const start_defaults_development = StartDefaults{
+    .limit_pipeline = constants.pipeline_prepare_queue_max,
     .cache_accounts = .{ .value = 0 },
     .cache_transfers = .{ .value = 0 },
     .cache_transfers_pending = .{ .value = 0 },
@@ -238,6 +243,7 @@ pub const Command = union(enum) {
         cache_transfers_pending: u32,
         cache_account_balances: u32,
         storage_size_limit: u64,
+        pipeline_limit: u32,
         cache_grid_blocks: u32,
         lsm_forest_node_count: u32,
         development: bool,
@@ -404,6 +410,23 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 );
             }
 
+            const pipeline_limit = start.limit_pipeline orelse defaults.limit_pipeline;
+            const pipeline_limit_min = constants.pipeline_prepare_queue_max;
+            const pipeline_limit_max =
+                constants.pipeline_prepare_queue_max + constants.pipeline_request_queue_max;
+            if (pipeline_limit > pipeline_limit_max) {
+                flags.fatal("--limit-pipeline: count {} exceeds maximum: {}", .{
+                    pipeline_limit,
+                    pipeline_limit_max,
+                });
+            }
+            if (pipeline_limit < pipeline_limit_min) {
+                flags.fatal("--limit-pipeline: count {} is below minimum: {}", .{
+                    pipeline_limit,
+                    pipeline_limit_min,
+                });
+            }
+
             const lsm_manifest_memory = start.memory_lsm_manifest.bytes();
             const lsm_manifest_memory_max = constants.lsm_manifest_memory_size_max;
             const lsm_manifest_memory_min = constants.lsm_manifest_memory_size_min;
@@ -441,6 +464,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     .addresses = addresses,
                     .addresses_zero = std.mem.eql(u8, start.addresses, "0"),
                     .storage_size_limit = storage_size_limit,
+                    .pipeline_limit = pipeline_limit,
                     .cache_accounts = parse_cache_size_to_count(
                         tigerbeetle.Account,
                         AccountsValuesCache,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -248,7 +248,7 @@ const Command = struct {
 
         var message_pool = try MessagePool.init(allocator, .{ .replica = .{
             .members_count = @intCast(args.addresses.len),
-            .pipeline_limit = args.pipeline_limit,
+            .pipeline_requests_limit = args.pipeline_requests_limit,
         } });
         defer message_pool.deinit(allocator);
 
@@ -299,7 +299,7 @@ const Command = struct {
             .release_client_min = release_client_min,
             .releases_bundled = releases_bundled,
             .release_execute = replica_release_execute,
-            .pipeline_limit = args.pipeline_limit,
+            .pipeline_requests_limit = args.pipeline_requests_limit,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .aof = &aof,
@@ -316,7 +316,7 @@ const Command = struct {
             .message_bus_options = .{
                 .configuration = args.addresses,
                 .io = &command.io,
-                .clients_limit = args.pipeline_limit,
+                .clients_limit = args.pipeline_requests_limit,
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
         }) catch |err| switch (err) {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -292,6 +292,8 @@ const Command = struct {
         log_main.info("releases_bundled={any}", .{releases_bundled.*});
         log_main.info("git_commit={?s}", .{config.process.git_commit});
 
+        const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
+
         var replica: Replica = undefined;
         replica.open(allocator, .{
             .node_count = @intCast(args.addresses.len),
@@ -316,7 +318,7 @@ const Command = struct {
             .message_bus_options = .{
                 .configuration = args.addresses,
                 .io = &command.io,
-                .clients_limit = args.pipeline_requests_limit,
+                .clients_limit = clients_limit,
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
         }) catch |err| switch (err) {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -248,7 +248,7 @@ const Command = struct {
 
         var message_pool = try MessagePool.init(allocator, .{ .replica = .{
             .members_count = @intCast(args.addresses.len),
-            .pipeline_limit = constants.clients_max,
+            .pipeline_limit = args.pipeline_limit,
         } });
         defer message_pool.deinit(allocator);
 
@@ -299,7 +299,7 @@ const Command = struct {
             .release_client_min = release_client_min,
             .releases_bundled = releases_bundled,
             .release_execute = replica_release_execute,
-            .pipeline_limit = constants.clients_max,
+            .pipeline_limit = args.pipeline_limit,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .aof = &aof,
@@ -316,7 +316,7 @@ const Command = struct {
             .message_bus_options = .{
                 .configuration = args.addresses,
                 .io = &command.io,
-                .clients_limit = constants.clients_max,
+                .clients_limit = args.pipeline_limit,
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
         }) catch |err| switch (err) {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -248,6 +248,7 @@ const Command = struct {
 
         var message_pool = try MessagePool.init(allocator, .{ .replica = .{
             .members_count = @intCast(args.addresses.len),
+            .pipeline_limit = constants.clients_max,
         } });
         defer message_pool.deinit(allocator);
 
@@ -298,6 +299,7 @@ const Command = struct {
             .release_client_min = release_client_min,
             .releases_bundled = releases_bundled,
             .release_execute = replica_release_execute,
+            .pipeline_limit = constants.clients_max,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
             .aof = &aof,
@@ -314,6 +316,7 @@ const Command = struct {
             .message_bus_options = .{
                 .configuration = args.addresses,
                 .io = &command.io,
+                .clients_limit = constants.clients_max,
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
         }) catch |err| switch (err) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -179,14 +179,15 @@ pub fn ReplicaType(
         /// Invariant: replica < node_count
         replica: u8,
 
-        /// Runtime upper-bound number of prepares/requests in the pipeline.
+        /// Runtime upper-bound number of requests in the pipeline.
         /// Does not change after initialization.
         /// Invariants:
         /// - pipeline_request_queue_limit ≥ 0
         /// - pipeline_request_queue_limit ≤ pipeline_request_queue_max
         ///
-        /// The former invariant is critical since we don't guarantee that all replicas in a cluster
-        /// are started with the same `pipeline_request_queue_limit`.
+        /// The *total* runtime pipeline size is never less than the pipeline_prepare_queue_max.
+        /// This is critical since we don't guarantee that all replicas in a cluster are started
+        /// with the same `pipeline_request_queue_limit`.
         pipeline_request_queue_limit: u32,
 
         /// The minimum number of replicas required to form a replication quorum:


### PR DESCRIPTION
Add a runtime `pipeline_limit`. Context: Our default pipeline size is `clients_max`, which is 64 for the prod/dev config. This is much higher than even production clusters are expected to need (as a margin of safety). We can trim the value down at runtime to save some memory.

Constraints:

1. `pipeline_limit ≥ constants.pipeline_prepare_queue_max`: We don't guarantee that all replicas in a cluster run with the same `pipeline_limit`.
2. `pipeline_limit ≤ constants.pipeline_prepare_queue_max + constants.pipeline_request_queue_max = clients_max`: There is no reason to have a pipeline larger than the `clients_max`.

Set `pipeline_limit` via `--limit-pipeline`, a CLI flag to `tigerbeetle start`. (`--limit-pipeline` is deliberately omitted from `tigerbeetle --help`.)

- When the `--development` flag is set, use the minimum `pipeline_limit` by default.
- When the `--development` flag is not set, use the maximum `pipeline_limit` by default.

For `--development` replicas, this reduces RSS by 336MiB as fewer messages are allocated.

> One man's constant is another man's variable.
> – Alan Perlis