### PR TITLE
lsm_fuzz: speed it up

### DIFF
--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -34,6 +34,7 @@ const SuperBlock = vsr.SuperBlockType(Storage);
 const ScanBuffer = @import("scan_buffer.zig").ScanBuffer;
 const ScanTreeType = @import("scan_tree.zig").ScanTreeType;
 const FreeSetEncoded = vsr.FreeSetEncodedType(Storage);
+const SortedSegmentedArray = @import("./segmented_array.zig").SortedSegmentedArray;
 
 const CompactionHelperType = @import("compaction.zig").CompactionHelperType;
 const CompactionHelper = CompactionHelperType(Grid);
@@ -95,6 +96,7 @@ const replica = 4;
 const replica_count = 6;
 const node_count = 1024;
 const scan_results_max = 4096;
+const events_max = 10_000_000;
 const tree_options = .{
     // This is the smallest size that set_associative_cache will allow us.
     .cache_entries_max = 2048,
@@ -159,6 +161,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         scan_buffer: ScanBuffer,
         scan_results: []Value,
         scan_results_count: u32,
+        scan_results_model: []Value,
         compaction_exhausted: bool = false,
 
         block_pool: CompactionHelper.CompactionBlockFIFO,
@@ -201,6 +204,9 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.scan_results = try allocator.alloc(Value, scan_results_max);
             env.scan_results_count = 0;
             defer allocator.free(env.scan_results);
+
+            env.scan_results_model = try allocator.alloc(Value, scan_results_max);
+            defer allocator.free(env.scan_results_model);
 
             // TODO: Pull out these constants. 3 is block_count_bar_single, 8 is
             // minimum_block_count_beat.
@@ -514,7 +520,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         }
 
         pub fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
-            var model = Model.init(table_usage);
+            var model = try Model.init(table_usage);
             defer model.deinit();
 
             for (fuzz_ops, 0..) |fuzz_op, fuzz_op_index| {
@@ -536,8 +542,23 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                         if (c.checkpoint) env.checkpoint(c.op);
                     },
                     .put => |value| {
-                        env.tree.put(&value);
-                        try model.put(&value);
+                        if (table_usage == .secondary_index) {
+                            // Secondary index requires that the key implies the value (typically
+                            // key ≡ value), and that there are no updates.
+                            const canonical_value: Value = .{
+                                .id = value.id,
+                                .value = 0,
+                                .tombstone = value.tombstone,
+                            };
+                            if (model.contains(&canonical_value)) {
+                                env.tree.remove(&canonical_value);
+                            }
+                            env.tree.put(&canonical_value);
+                            try model.put(&canonical_value);
+                        } else {
+                            env.tree.put(&value);
+                            try model.put(&value);
+                        }
                     },
                     .remove => |value| {
                         if (table_usage == .secondary_index and !model.contains(&value)) {
@@ -556,23 +577,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                         if (model_value == null) {
                             assert(tree_value == null);
                         } else {
-                            switch (table_usage) {
-                                .general => {
-                                    assert(std.mem.eql(
-                                        u8,
-                                        std.mem.asBytes(&model_value.?),
-                                        std.mem.asBytes(&tree_value.?),
-                                    ));
-                                },
-                                .secondary_index => {
-                                    // secondary_index only preserves keys - may return old values
-                                    assert(std.mem.eql(
-                                        u8,
-                                        std.mem.asBytes(&Value.key_from_value(&model_value.?)),
-                                        std.mem.asBytes(&Value.key_from_value(&tree_value.?)),
-                                    ));
-                                },
-                            }
+                            assert(stdx.equal_bytes(Value, &model_value.?, &tree_value.?));
                         }
                     },
                     .scan => |scan_range| try env.apply_scan(&model, scan_range),
@@ -589,142 +594,151 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 scan_range.direction,
             );
 
-            // Asserting the positive space:
-            // all keys found by the scan must exist in our model.
-            var tree_value_last: ?Value = null;
-            for (tree_values) |tree_value| {
-
-                // Asserting boundaries.
-                assert(scan_range.min <= Table.key_from_value(&tree_value));
-                assert(Table.key_from_value(&tree_value) <= scan_range.max);
-
-                // Asserting direction.
-                if (tree_value_last) |value_last| {
-                    switch (scan_range.direction) {
-                        .ascending => assert(Table.key_from_value(&tree_value) >
-                            Table.key_from_value(&value_last)),
-                        .descending => assert(Table.key_from_value(&tree_value) <
-                            Table.key_from_value(&value_last)),
-                    }
-                }
-                tree_value_last = tree_value;
-
-                // Compare result to model.
-                if (model.get(Table.key_from_value(&tree_value))) |model_value| {
-                    switch (table_usage) {
-                        .general => {
-                            assert(std.mem.eql(
-                                u8,
-                                std.mem.asBytes(&model_value),
-                                std.mem.asBytes(&tree_value),
-                            ));
-                        },
-                        .secondary_index => {
-                            // secondary_index only preserves keys - may return old values
-                            assert(Table.key_from_value(&model_value) ==
-                                Table.key_from_value(&tree_value));
-                        },
-                    }
-                } else {
-                    assert(Table.tombstone(&tree_value));
-                }
-            }
-
-            // Asserting the negative space:
-            // All keys existing in our model must be checked against the scan range.
-            if (scan_range.direction == .descending) std.mem.reverse(
-                Value,
-                tree_values,
+            const model_values = model.scan(
+                scan_range.min,
+                scan_range.max,
+                scan_range.direction,
+                env.scan_results_model,
             );
 
-            var it = model.iterator();
-            while (it.next()) |entry| {
-                const model_value_key = Value.key_from_value(entry.value_ptr);
-                const in_range = model_value_key >= scan_range.min and
-                    model_value_key <= scan_range.max;
-
-                if (tree_values.len == 0) {
-                    assert(!in_range);
-                } else if (model_value_key <
-                    Table.key_from_value(&tree_values[0]))
-                {
-                    if (in_range) {
-                        assert(tree_values.len == scan_results_max);
-                        assert(scan_range.direction == .descending);
-                    } else {
-                        assert(model_value_key < scan_range.min);
-                    }
-                } else if (model_value_key >
-                    Table.key_from_value(&tree_values[tree_values.len - 1]))
-                {
-                    if (in_range) {
-                        assert(tree_values.len == scan_results_max);
-                        assert(scan_range.direction == .ascending);
-                    } else {
-                        assert(model_value_key > scan_range.max);
-                    }
+            // Unlike the model, the tree can return some amount of tombstones in the result set.
+            // They must be filtered out before comparison!
+            var tombstone_count: usize = 0;
+            for (tree_values, 0..) |tree_value, index| {
+                assert(scan_range.min <= Table.key_from_value(&tree_value));
+                assert(Table.key_from_value(&tree_value) <= scan_range.max);
+                if (Table.tombstone(&tree_value)) {
+                    tombstone_count += 1;
                 } else {
-                    assert(in_range);
-                    const value_maybe = binary_search.binary_search_values(
-                        u64,
-                        Value,
-                        Table.key_from_value,
-                        tree_values,
-                        model_value_key,
-                        .{},
-                    );
-                    assert(value_maybe != null);
+                    if (tombstone_count > 0) {
+                        tree_values[index - tombstone_count] = tree_value;
+                    }
                 }
             }
+
+            const tombstone_evicted = (model_values.len + tombstone_count) -| scan_results_max;
+            try testing.expectEqualSlices(
+                Value,
+                tree_values[0 .. tree_values.len - tombstone_count],
+                model_values[0 .. model_values.len - tombstone_evicted],
+            );
+            assert(tree_values.len >= model_values.len);
         }
     };
 }
 
-// The tree should behave like a simple key-value data-structure.
-// We'll compare it to a hash map.
+// A tree is a sorted set. The ideal model would have been an in-memory B-tree, but there isn't
+// one in Zig's standard library. Use a SortedSegmentedArray instead which is essentially a stunted
+// B-tree one-level deep.
 const Model = struct {
-    const Map = std.hash_map.AutoHashMap(u64, Value);
+    const Array = SortedSegmentedArray(
+        Value,
+        NodePool,
+        events_max,
+        u64,
+        Value.key_from_value,
+        .{ .verify = false },
+    );
 
-    map: Map,
+    array: Array,
+    node_pool: NodePool,
     table_usage: TableUsage,
 
-    fn init(table_usage: TableUsage) Model {
+    fn init(table_usage: TableUsage) !Model {
         return .{
-            .map = Map.init(allocator),
+            .array = try Array.init(allocator),
+            .node_pool = try NodePool.init(allocator, 1_000),
             .table_usage = table_usage,
         };
     }
 
-    fn count(model: *const Model) usize {
-        return model.map.count();
+    fn count(model: *const Model) u32 {
+        return model.array.len();
     }
 
     fn contains(model: *Model, value: *const Value) bool {
-        return model.map.contains(Value.key_from_value(value));
+        return model.get(Value.key_from_value(value)) != null;
     }
 
     fn get(model: *const Model, key: u64) ?Value {
-        return model.map.get(key);
+        const cursor = model.array.search(key);
+        if (cursor.node == model.array.node_count) return null;
+        if (cursor.relative_index == model.array.node_elements(cursor.node).len) return null;
+        const cursor_element = model.array.element_at_cursor(cursor);
+        if (Value.key_from_value(&cursor_element) == key) {
+            return cursor_element;
+        } else {
+            return null;
+        }
     }
 
-    fn iterator(model: *const Model) Map.Iterator {
-        return model.map.iterator();
+    fn scan(
+        model: *const Model,
+        key_min: u64,
+        key_max: u64,
+        direction: Direction,
+        result: []Value,
+    ) []Value {
+        var result_count: usize = 0;
+        switch (direction) {
+            .ascending => {
+                const cursor = model.array.search(key_min);
+                var it = model.array.iterator_from_cursor(cursor, .ascending);
+                while (it.next()) |element| {
+                    const element_key = Value.key_from_value(element);
+                    if (element_key <= key_max) {
+                        assert(element_key >= key_min);
+                        result[result_count] = element.*;
+                        result_count += 1;
+                        if (result_count == result.len) break;
+                    } else {
+                        break;
+                    }
+                }
+            },
+            .descending => {
+                const cursor = model.array.search(key_max);
+                var it = model.array.iterator_from_cursor(cursor, .descending);
+                while (it.next()) |element| {
+                    const element_key = Value.key_from_value(element);
+                    if (element_key >= key_min) {
+                        if (element_key <= key_max) {
+                            result[result_count] = element.*;
+                            result_count += 1;
+                            if (result_count == result.len) break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            },
+        }
+        return result[0..result_count];
     }
 
     fn put(model: *Model, value: *const Value) !void {
-        if (model.table_usage == .secondary_index) {
-            // Not allowed to put a present key without removing the old value first.
-            _ = model.map.remove(Value.key_from_value(value));
-        }
-        try model.map.put(Value.key_from_value(value), value.*);
+        model.remove(value);
+        _ = model.array.insert_element(&model.node_pool, value.*);
     }
 
     fn remove(model: *Model, value: *const Value) void {
-        _ = model.map.remove(Value.key_from_value(value));
+        const key = Value.key_from_value(value);
+        const cursor = model.array.search(key);
+        if (cursor.node == model.array.node_count) return;
+        if (cursor.relative_index == model.array.node_elements(cursor.node).len) return;
+
+        if (Value.key_from_value(&model.array.element_at_cursor(cursor)) == key) {
+            model.array.remove_elements(
+                &model.node_pool,
+                model.array.absolute_index_for_cursor(cursor),
+                1,
+            );
+        }
     }
 
     fn deinit(model: *Model) void {
-        model.map.deinit();
+        model.array.deinit(allocator, &model.node_pool);
+        model.node_pool.deinit(allocator);
         model.* = undefined;
     }
 };
@@ -854,7 +868,7 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     };
 
     const fuzz_op_count = @min(
-        fuzz_args.events_max orelse @as(usize, 1E7),
+        fuzz_args.events_max orelse events_max,
         fuzz.random_int_exponential(random, usize, 1E6),
     );
 


### PR DESCRIPTION
The core reason why it is slow is that it is using a HashMap as a model,
but, since then introduction of scans, we really need a data structure
supporting range queries.

While Zig's stdlib doesn't have such a datastructure, we do! We can use
SortedSegmentedArray.

The following seed now finishes in under 5 minutes on my machine:

Seed: ./zig/zig build -Drelease fuzz -- --seed=17470417632183688204 lsm_tree

I have a suspicion that this change might still not be enough, and that
we should change our event generation to just make scans more _costly_
(one scan is equivalent to scan_result_max puts), but lets postpone that
until CFO finds a failing seed.