### PR TITLE
CI: Make generated artifacts reproducable

### DIFF
--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -125,6 +125,50 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         assert(shell.file_exists(artifact));
     }
 
+    // Enable this once deterministic zip generation has been merged in and released.
+    // const raw_run_number = stdx.cut(stdx.cut(tag, ".").?.suffix, ".").?.suffix;
+
+    // // The +185 comes from how release.zig calculates the version number.
+    // const run_number = try std.fmt.allocPrint(
+    //     shell.arena.allocator(),
+    //     "{}",
+    //     .{try std.fmt.parseInt(u32, raw_run_number, 10) + 185},
+    // );
+
+    // const sha = try shell.exec_stdout("git rev-parse HEAD", .{});
+    // try shell.zig("build scripts -- release --build  --run-number={run_number} " ++
+    //     "--sha={sha} --language=zig", .{
+    //     .run_number = run_number,
+    //     .sha = sha,
+    // });
+    // for (artifacts) |artifact| {
+    //     // Zig only guarantees release builds to be deterministic.
+    //     if (std.mem.indexOf(u8, artifact, "-debug.zip") != null) continue;
+
+    //     // TODO(Zig): Determinism is broken on Windows:
+    //     // https://github.com/ziglang/zig/issues/9432
+    //     if (std.mem.indexOf(u8, artifact, "-windows.zip") != null) continue;
+
+    //     const checksum_downloaded = try shell.exec_stdout("sha256sum {artifact}", .{
+    //         .artifact = artifact,
+    //     });
+
+    //     shell.popd();
+    //     const checksum_built = try shell.exec_stdout("sha256sum dist/tigerbeetle/{artifact}", .{
+    //         .artifact = artifact,
+    //     });
+    //     try shell.pushd_dir(tmp_dir.dir);
+
+    //     // Slice the output to supress the names.
+    //     if (!std.mem.eql(u8, checksum_downloaded[0..64], checksum_built[0..64])) {
+    //         std.debug.panic("checksum mismatch - {s}: downloaded {s}, built {s}", .{
+    //             artifact,
+    //             checksum_downloaded[0..64],
+    //             checksum_built[0..64],
+    //         });
+    //     }
+    // }
+
     try shell.exec("unzip tigerbeetle-x86_64-linux.zip", .{});
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -49,6 +49,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
 
     // Run number is a monotonically incremented integer. Map it to a three-component version
     // number.
+    // If you change this, make sure to change the validation code in release_validate.zig!
     const release_triple = .{
         .major = 0,
         .minor = 15,
@@ -180,7 +181,10 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 );
             } else {
                 const zip_name = "tigerbeetle-" ++ target ++ debug_suffix ++ ".zip";
-                try shell.exec("zip -9 {zip_path} {exe_name}", .{
+                try shell.exec("touch -d 1970-01-01T00:00:00Z {exe_name}", .{
+                    .exe_name = "tigerbeetle" ++ if (windows) ".exe" else "",
+                });
+                try shell.exec("zip -9 -oX {zip_path} {exe_name}", .{
                     .zip_path = try shell.print("{s}/{s}", .{ dist_dir_path, zip_name }),
                     .exe_name = "tigerbeetle" ++ if (windows) ".exe" else "",
                 });
@@ -195,7 +199,10 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
         try shell.project_root.deleteFile("tigerbeetle-aarch64-macos");
         try shell.project_root.deleteFile("tigerbeetle-x86_64-macos");
         const zip_name = "tigerbeetle-universal-macos" ++ debug_suffix ++ ".zip";
-        try shell.exec("zip -9 {zip_path} {exe_name}", .{
+        try shell.exec("touch -d 1970-01-01T00:00:00Z {exe_name}", .{
+            .exe_name = "tigerbeetle",
+        });
+        try shell.exec("zip -9 -oX {zip_path} {exe_name}", .{
             .zip_path = try shell.print("{s}/{s}", .{ dist_dir_path, zip_name }),
             .exe_name = "tigerbeetle",
         });


### PR DESCRIPTION
`zig build -Drelease install` is itself deterministic¹:

```
$ zig build -Drelease install
$ sha256sum tigerbeetle
843aa2a5d7dceec6fb2de730beffcc2e11fde3918fd885736a2e03d04b6e6a78  tigerbeetle
$ rm -rf zig-cache zig-out/
$ zig build -Drelease install
843aa2a5d7dceec6fb2de730beffcc2e11fde3918fd885736a2e03d04b6e6a78  tigerbeetle
```

Yay! But our releases are unfortunately not - Zip files embed a timestamp into the archive. Set this timestamp explicitly now, to get fully deterministic release builds.

Additionally, add a commented out section in our release validation that checks this doesn't regress. It can be enabled once a release has been published with these changes.

¹ excluding debug builds and [Windows](https://github.com/ziglang/zig/issues/9432).