### PR TITLE
manifest: speed up manifest log fuzzer

### DIFF
--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -262,7 +262,16 @@ pub const Storage = struct {
         assert(storage.size == origin.size);
 
         storage.ticks = origin.ticks;
-        stdx.copy_disjoint(.exact, u8, storage.memory, origin.memory);
+
+        var it = origin.memory_written.iterator(.{});
+        while (it.next()) |sector| {
+            stdx.copy_disjoint(
+                .exact,
+                u8,
+                storage.memory[sector * constants.sector_size ..][0..constants.sector_size],
+                origin.memory[sector * constants.sector_size ..][0..constants.sector_size],
+            );
+        }
         storage.memory_written.toggleSet(storage.memory_written);
         storage.memory_written.toggleSet(origin.memory_written);
         storage.faults.toggleSet(storage.faults);


### PR DESCRIPTION
It spends most of its time memcpying test storage around. Speed it up by copying only initialized bits

Seed: ./zig/zig build -Drelease fuzz -- --seed=12824282943652364185 lsm_manifest_log