### PR TITLE
Scripts: Use ZIG_EXE environment variable

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -504,6 +504,7 @@ pub fn build(b: *std.Build) !void {
             .optimize = mode,
         });
         const scripts_run = b.addRunArtifact(scripts_exe);
+        scripts_run.setEnvironmentVariable("ZIG_EXE", b.zig_exe);
         if (b.args) |args| scripts_run.addArgs(args);
         const scripts_step = b.step("scripts", "Run automation scripts");
         scripts_step.dependOn(&scripts_run.step);

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -24,8 +24,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     //     <https://github.com/ziglang/zig/issues/15438>
     switch (builtin.os.tag) {
         .linux, .windows => {
-            const zig_exe = try shell.zig_exe_alloc(shell.arena.allocator());
-            const zig_cc = try shell.print("{s} cc", .{zig_exe});
+            const zig_cc = try shell.print("{s} cc", .{shell.zig_exe.?});
             try shell.env.put("CC", zig_cc);
         },
         .macos => {},
@@ -81,8 +80,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
         shell.cwd,
         "main.go",
     );
-    const zig_exe = try shell.zig_exe_alloc(shell.arena.allocator());
-    const zig_cc = try shell.print("{s} cc", .{zig_exe});
+    const zig_cc = try shell.print("{s} cc", .{shell.zig_exe.?});
 
     try shell.env.put("CC", zig_cc);
     try shell.exec("go run main.go", .{});

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -24,10 +24,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     //     <https://github.com/ziglang/zig/issues/15438>
     switch (builtin.os.tag) {
         .linux, .windows => {
-            const zig_exe = try shell.project_root.realpathAlloc(
-                shell.arena.allocator(),
-                comptime "zig/zig" ++ builtin.target.exeFileExt(),
-            );
+            const zig_exe = try shell.zig_exe_alloc(shell.arena.allocator());
             const zig_cc = try shell.print("{s} cc", .{zig_exe});
             try shell.env.put("CC", zig_cc);
         },
@@ -84,10 +81,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
         shell.cwd,
         "main.go",
     );
-    const zig_exe = try shell.project_root.realpathAlloc(
-        shell.arena.allocator(),
-        comptime "zig/zig" ++ builtin.target.exeFileExt(),
-    );
+    const zig_exe = try shell.zig_exe_alloc(shell.arena.allocator());
     const zig_cc = try shell.print("{s} cc", .{zig_exe});
 
     try shell.env.put("CC", zig_cc);

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -118,7 +118,6 @@ fn run_fuzzers(
         hang_seconds: u64,
     },
 ) !void {
-    const zig_exe = try shell.zig_exe_alloc(shell.arena.allocator());
     // Fuzz an independent clone of the repository, so that CFO and the fuzzer could be on
     // different branches (to fuzz PRs and releases).
     shell.project_root.deleteTree("working") catch {};
@@ -189,7 +188,7 @@ fn run_fuzzers(
                         .{ .stdin_behavior = .Pipe },
                         "{zig} build -Drelease fuzz -- --seed={seed} {fuzzer}",
                         .{
-                            .zig = zig_exe,
+                            .zig = shell.zig_exe.?,
                             .seed = try shell.print("{d}", .{seed}),
                             .fuzzer = @tagName(fuzzer),
                         },

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -97,7 +97,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         .{},
     );
     const tag = stdx.cut(release_info, "\t").?.prefix;
-    log.info("validateing release {s}", .{tag});
+    log.info("validating release {s}", .{tag});
 
     try shell.exec(
         "gh release --repo tigerbeetle/tigerbeetle download {tag}",

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -51,6 +51,9 @@ env: std.process.EnvMap,
 /// True if the process is run in CI (the CI env var is set)
 ci: bool,
 
+/// Absolute path to the Zig binary.
+zig_exe: ?[]const u8,
+
 pub fn create(gpa: std.mem.Allocator) !*Shell {
     var arena = std.heap.ArenaAllocator.init(gpa);
     errdefer arena.deinit();
@@ -78,6 +81,7 @@ pub fn create(gpa: std.mem.Allocator) !*Shell {
         .cwd_stack_count = 0,
         .env = env,
         .ci = ci,
+        .zig_exe = env.get("ZIG_EXE"),
     };
 
     return result;
@@ -596,39 +600,12 @@ pub fn spawn_options(
     return child;
 }
 
-pub fn zig_exe_alloc(shell: Shell, allocator: std.mem.Allocator) ![]const u8 {
-    _ = shell;
-
-    // ZIG_EXE is set in `build.zig`, so it is available when using the run step for `zig build
-    // scripts`.
-    // ZIG_EXE is already an absolute path, but zig/zig is not.
-    const zig_exe_default = comptime "zig/zig" ++ builtin.target.exeFileExt();
-
-    const zig_exe_env: ?[]u8 = std.process.getEnvVarOwned(
-        allocator,
-        "ZIG_EXE",
-    ) catch |err| switch (err) {
-        error.OutOfMemory => return err,
-        error.InvalidUtf8 => return err,
-        error.EnvironmentVariableNotFound => null,
-    };
-    defer if (zig_exe_env) |str| allocator.free(str);
-
-    const zig_exe = try std.fs.realpathAlloc(allocator, zig_exe_env orelse zig_exe_default);
-    errdefer allocator.free(zig_exe);
-
-    return zig_exe;
-}
-
 /// Runs the zig compiler.
 pub fn zig(shell: Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
-    const zig_exe = try shell.zig_exe_alloc(shell.gpa);
-    defer shell.gpa.free(zig_exe);
-
     var argv = Argv.init(shell.gpa);
     defer argv.deinit();
 
-    try argv.append_new_arg(zig_exe);
+    try argv.append_new_arg(shell.zig_exe.?);
     try expand_argv(&argv, cmd, cmd_args);
 
     // TODO(Zig): use cwd_dir once that is available https://github.com/ziglang/zig/issues/5190


### PR DESCRIPTION
I use (many) git worktrees, and rather than giving each their own zig binary, I install it once in my PATH, so `./zig/zig` doesn't exist.
`ZIG_EXE` is compatible with both workflows.

(`ZIG_EXE` is set automatically for `zig run ...`  – but not `zig build ...` with Run steps, so it needs to be explicitly set in `build.zig`.)