### PR TITLE
Multiversion: make release_client_min a parameter, set by release.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -70,9 +70,15 @@ pub fn build(b: *std.Build) !void {
     options.addOption(?[40]u8, "git_commit", git_commit[0..40].*);
 
     options.addOption(
-        []const u8,
+        ?[]const u8,
         "release",
-        b.option([]const u8, "config-release", "Release triple.") orelse "0.0.1",
+        b.option([]const u8, "config-release", "Release triple."),
+    );
+
+    options.addOption(
+        ?[]const u8,
+        "release_client_min",
+        b.option([]const u8, "config-release-client-min", "Minimum client release triple."),
     );
 
     options.addOption(

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -692,6 +692,7 @@ const Argv = struct {
 ///
 /// This avoids shell injection by construction as it doesn't concatenate strings.
 fn expand_argv(argv: *Argv, comptime cmd: []const u8, cmd_args: anytype) !void {
+    @setEvalBranchQuota(5000);
     // Mostly copy-paste from std.fmt.format
 
     comptime var pos: usize = 0;

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -336,6 +336,8 @@ pub fn StateMachineType(
             Storage,
         );
 
+        // Looking to make backwards incompatible changes here? Make sure to check release.zig for
+        // `release_triple_client_min`.
         pub const Operation = enum(u8) {
             /// Operations exported by TigerBeetle:
             pulse = config.vsr_operations_reserved + 0,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -282,12 +282,10 @@ const Command = struct {
         const nonce = std.crypto.random.int(u128);
         assert(nonce != 0); // Broken CSPRNG is the likeliest explanation for zero.
 
-        // TODO Where should this be set?
-        const release_client_min = config.process.release;
         const releases_bundled = &[_]vsr.Release{config.process.release};
 
         log_main.info("release={}", .{config.process.release});
-        log_main.info("release_client_min={}", .{release_client_min});
+        log_main.info("release_client_min={}", .{config.process.release_client_min});
         log_main.info("releases_bundled={any}", .{releases_bundled.*});
         log_main.info("git_commit={?s}", .{config.process.git_commit});
 
@@ -295,7 +293,7 @@ const Command = struct {
         replica.open(allocator, .{
             .node_count = @intCast(args.addresses.len),
             .release = config.process.release,
-            .release_client_min = release_client_min,
+            .release_client_min = config.process.release_client_min,
             .releases_bundled = releases_bundled,
             .release_execute = replica_release_execute,
             .storage_size_limit = args.storage_size_limit,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -270,6 +270,9 @@ pub const BlockReference = struct {
 
 /// Viewstamped Replication protocol commands:
 pub const Command = enum(u8) {
+    // Looking to make backwards incompatible changes here? Make sure to check release.zig for
+    // `release_triple_client_min`.
+
     reserved = 0,
 
     ping = 1,
@@ -312,6 +315,9 @@ pub const Command = enum(u8) {
 /// This type exists to avoid making the Header type dependant on the state
 /// machine used, which would cause awkward circular type dependencies.
 pub const Operation = enum(u8) {
+    // Looking to make backwards incompatible changes here? Make sure to check release.zig for
+    // `release_triple_client_min`.
+
     /// Operations reserved by VR protocol (for all state machines):
     /// The value 0 is reserved to prevent a spurious zero from being interpreted as an operation.
     reserved = 0,


### PR DESCRIPTION
There was a bit of back and forth thinking as to where it should be set. 

Figured release.zig was the most natural place, although it does feel a bit strange to have a hard-coded constant there, we need it _somewhere_ and tying it in to the code directly felt worse off.