### PR TITLE
cfo: actually make file non-blocking

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -210,10 +210,13 @@ fn run_fuzzers(
                         try seed_record.fuzzer.print_command(shell, seed_record.seed);
 
                     log.debug("will start '{s}'", .{seed_record.command});
+                    // Zig doesn't have non-blocking version of child.wait, so we use `BrokenPipe`
+                    // on writing to child's stdin to detect if a child is dead in a non-blocking
+                    // manner.
                     const child = try seed_record.fuzzer.spawn_command(shell, seed_record.seed);
                     _ = try std.os.fcntl(
                         child.stdin.?.handle,
-                        std.os.F.SETFD,
+                        std.os.F.SETFL,
                         @as(u32, std.os.O.NONBLOCK),
                     );
                     fuzzer_or_null.* = .{ .seed = seed_record, .child = child };


### PR DESCRIPTION
SETFD manipulates flags of the file _descriptor_ (a single file can have many descriptors pointing to it).

SETFL manipulates flags of the file itself (they are shared between all descriptors pointing at the file).

NonBlocking is sadly a property of file, and not of a file descriptor, though this isn't a problem for our use-case.

What is a problem is that I wrongly used SETFD instead of SETFL, which made this into a no-op (it worked in practice because the default pipe buffer was enough to accomodate one byte a second).