### PR TITLE
cfo: vopr no longer hangs

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -95,7 +95,7 @@ const Fuzzer = enum {
         if (fuzzer == .vopr or fuzzer == .vopr_testing) {
             const state_machine: []const []const u8 =
                 if (fuzzer == .vopr) &.{} else &.{"-Dsimulator-state-machine=testing"};
-            return try shell.spawn_options(
+            return try shell.spawn(
                 .{ .stdin_behavior = .Pipe },
                 "{zig} build -Drelease {state_machine} simulator_run -- {seed}",
                 .{
@@ -105,7 +105,7 @@ const Fuzzer = enum {
                 },
             );
         }
-        return try shell.spawn_options(
+        return try shell.spawn(
             .{ .stdin_behavior = .Pipe },
             "{zig} build -Drelease fuzz -- --seed={seed} {fuzzer}",
             .{

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -559,20 +559,12 @@ pub fn exec_raw(
     });
 }
 
-/// Spawns the process, piping its stdout and stderr.
-///
-/// The caller must `.kill()` and `.wait()` the child, to minimize the chance of process leak (
-/// sadly, child will still be leaked if the parent process is killed itself, because POSIX doesn't
-/// have nice APIs for structured concurrency).
-pub fn spawn(shell: Shell, comptime cmd: []const u8, cmd_args: anytype) !std.ChildProcess {
-    return try shell.spawn_options(.{}, cmd, cmd_args);
-}
-
-pub fn spawn_options(
+pub fn spawn(
     shell: Shell,
     options: struct {
         stdin_behavior: std.ChildProcess.StdIo = .Ignore,
-        stderr_behavior: std.ChildProcess.StdIo = .Pipe,
+        stdout_behavior: std.ChildProcess.StdIo = .Ignore,
+        stderr_behavior: std.ChildProcess.StdIo = .Ignore,
     },
     comptime cmd: []const u8,
     cmd_args: anytype,
@@ -590,7 +582,7 @@ pub fn spawn_options(
     child.cwd = cwd_path;
     child.env_map = &shell.env;
     child.stdin_behavior = options.stdin_behavior;
-    child.stdout_behavior = .Pipe;
+    child.stdout_behavior = options.stdout_behavior;
     child.stderr_behavior = options.stderr_behavior;
 
     try child.spawn();

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -69,9 +69,10 @@ pub fn init(
     );
 
     // Pass `--addresses=0` to let the OS pick a port for us.
-    var process = try shell.spawn_options(
+    var process = try shell.spawn(
         .{
             .stdin_behavior = .Pipe,
+            .stdout_behavior = .Pipe,
             // TODO(Zig): ignoring stderr is broken in 0.11, fixed in 0.12:
             //     https://github.com/ziglang/zig/pull/15565
             .stderr_behavior = if (builtin.os.tag == .windows) .Inherit else .Ignore,


### PR DESCRIPTION
Currently vopr hangs in the CFO. This due to the classical bug of systems programming: VOPR logs to the stderr, but no one reads the stderr, so it fills up and then the process deadlocks.

Good news is that we have a fix for these classes of programs: shell.zig intends to wrap raw child process spawning API in a set of well-defined high-level operations, which are protected from these kinds of footguns.

The bad news is that the actual API there is buggy, and defaults to piping by default. Fix this and make each caller that wants to interract with the streams explicitly request that.