### PR TITLE
Reproduce go memory corruption

### DIFF
--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -117,10 +117,12 @@ func doTestClient(t *testing.T, client Client) {
 	}
 
 	t.Run("can create accounts", func(t *testing.T) {
+		t.Parallel()
 		createTwoAccounts(t)
 	})
 
 	t.Run("can lookup accounts", func(t *testing.T) {
+		t.Parallel()
 		accountA, accountB := createTwoAccounts(t)
 
 		results, err := client.LookupAccounts([]types.Uint128{
@@ -155,6 +157,7 @@ func doTestClient(t *testing.T, client Client) {
 	})
 
 	t.Run("can create a transfer", func(t *testing.T) {
+		t.Parallel()
 		accountA, accountB := createTwoAccounts(t)
 
 		results, err := client.CreateTransfers([]types.Transfer{
@@ -193,6 +196,7 @@ func doTestClient(t *testing.T, client Client) {
 	})
 
 	t.Run("can create linked transfers", func(t *testing.T) {
+		t.Parallel()
 		accountA, accountB := createTwoAccounts(t)
 
 		id := types.ID()
@@ -247,6 +251,7 @@ func doTestClient(t *testing.T, client Client) {
 	t.Run("can create concurrent transfers", func(t *testing.T) {
 		accountA, accountB := createTwoAccounts(t)
 
+		// NB: this test is _not_ parallel, so can use up all the concurrency.
 		const TRANSFERS_MAX = 1_000_000
 		concurrencyMax := make(chan struct{}, TIGERBEETLE_CONCURRENCY_MAX)
 
@@ -301,6 +306,7 @@ func doTestClient(t *testing.T, client Client) {
 	})
 
 	t.Run("can query transfers for an account", func(t *testing.T) {
+		t.Parallel()
 		accountA, accountB := createTwoAccounts(t)
 
 		// Create a new account:

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -93,12 +93,12 @@ func TestClient(s *testing.T) {
 
 func doTestClient(s *testing.T, client Client) {
 	accountA := types.Account{
-		ID:     HexStringToUint128("a"),
+		ID:     types.ID(),
 		Ledger: 1,
 		Code:   1,
 	}
 	accountB := types.Account{
-		ID:     HexStringToUint128("b"),
+		ID:     types.ID(),
 		Ledger: 1,
 		Code:   2,
 	}
@@ -150,7 +150,7 @@ func doTestClient(s *testing.T, client Client) {
 	s.Run("can create a transfer", func(t *testing.T) {
 		results, err := client.CreateTransfers([]types.Transfer{
 			{
-				ID:              HexStringToUint128("a"),
+				ID:              types.ID(),
 				CreditAccountID: accountA.ID,
 				DebitAccountID:  accountB.ID,
 				Amount:          types.ToUint128(100),
@@ -184,8 +184,9 @@ func doTestClient(s *testing.T, client Client) {
 	})
 
 	s.Run("can create linked transfers", func(t *testing.T) {
+		id := types.ID()
 		transfer1 := types.Transfer{
-			ID:              HexStringToUint128("d"),
+			ID:              id,
 			CreditAccountID: accountA.ID,
 			DebitAccountID:  accountB.ID,
 			Amount:          types.ToUint128(50),
@@ -194,7 +195,7 @@ func doTestClient(s *testing.T, client Client) {
 			Ledger:          1,
 		}
 		transfer2 := types.Transfer{
-			ID:              HexStringToUint128("d"),
+			ID:              id,
 			CreditAccountID: accountA.ID,
 			DebitAccountID:  accountB.ID,
 			Amount:          types.ToUint128(50),
@@ -254,7 +255,7 @@ func doTestClient(s *testing.T, client Client) {
 				concurrencyMax <- struct{}{}
 				results, err := client.CreateTransfers([]types.Transfer{
 					{
-						ID:              types.ToUint128(uint64(TRANSFERS_MAX + i)),
+						ID:              types.ID(),
 						CreditAccountID: accountA.ID,
 						DebitAccountID:  accountB.ID,
 						Amount:          types.ToUint128(1),
@@ -289,7 +290,7 @@ func doTestClient(s *testing.T, client Client) {
 	s.Run("can query transfers for an account", func(t *testing.T) {
 		// Create a new account:
 		accountC := types.Account{
-			ID:     HexStringToUint128("c"),
+			ID:     types.ID(),
 			Ledger: 1,
 			Code:   1,
 			Flags: types.AccountFlags{
@@ -305,7 +306,7 @@ func doTestClient(s *testing.T, client Client) {
 		// Create transfers where the new account is either the debit or credit account:
 		transfers_created := make([]types.Transfer, 10)
 		for i := 0; i < 10; i++ {
-			transfer_id := types.ToUint128(uint64(i) + 10_000)
+			transfer_id := types.ID()
 
 			// Swap debit and credit accounts:
 			if i%2 == 0 {

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -92,18 +92,18 @@ func TestClient(t *testing.T) {
 }
 
 func doTestClient(t *testing.T, client Client) {
-	accountA := types.Account{
-		ID:     types.ID(),
-		Ledger: 1,
-		Code:   1,
-	}
-	accountB := types.Account{
-		ID:     types.ID(),
-		Ledger: 1,
-		Code:   2,
-	}
+	createTwoAccounts := func (t *testing.T) (types.Account, types.Account) {
+		accountA := types.Account{
+			ID:     types.ID(),
+			Ledger: 1,
+			Code:   1,
+		}
+		accountB := types.Account{
+			ID:     types.ID(),
+			Ledger: 1,
+			Code:   2,
+		}
 
-	t.Run("can create accounts", func(t *testing.T) {
 		results, err := client.CreateAccounts([]types.Account{
 			accountA,
 			accountB,
@@ -111,11 +111,18 @@ func doTestClient(t *testing.T, client Client) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		assert.Empty(t, results)
+
+		return accountA, accountB
+	}
+
+	t.Run("can create accounts", func(t *testing.T) {
+		createTwoAccounts(t)
 	})
 
 	t.Run("can lookup accounts", func(t *testing.T) {
+		accountA, accountB := createTwoAccounts(t)
+
 		results, err := client.LookupAccounts([]types.Uint128{
 			accountA.ID,
 			accountB.ID,
@@ -148,6 +155,8 @@ func doTestClient(t *testing.T, client Client) {
 	})
 
 	t.Run("can create a transfer", func(t *testing.T) {
+		accountA, accountB := createTwoAccounts(t)
+
 		results, err := client.CreateTransfers([]types.Transfer{
 			{
 				ID:              types.ID(),
@@ -184,6 +193,8 @@ func doTestClient(t *testing.T, client Client) {
 	})
 
 	t.Run("can create linked transfers", func(t *testing.T) {
+		accountA, accountB := createTwoAccounts(t)
+
 		id := types.ID()
 		transfer1 := types.Transfer{
 			ID:              id,
@@ -221,7 +232,7 @@ func doTestClient(t *testing.T, client Client) {
 		assert.Len(t, accounts, 2)
 
 		accountA = accounts[0]
-		assert.Equal(t, types.ToUint128(100), accountA.CreditsPosted)
+		assert.Equal(t, types.ToUint128(0), accountA.CreditsPosted)
 		assert.Equal(t, types.ToUint128(0), accountA.CreditsPending)
 		assert.Equal(t, types.ToUint128(0), accountA.DebitsPosted)
 		assert.Equal(t, types.ToUint128(0), accountA.DebitsPending)
@@ -229,11 +240,13 @@ func doTestClient(t *testing.T, client Client) {
 		accountB = accounts[1]
 		assert.Equal(t, types.ToUint128(0), accountB.CreditsPosted)
 		assert.Equal(t, types.ToUint128(0), accountB.CreditsPending)
-		assert.Equal(t, types.ToUint128(100), accountB.DebitsPosted)
+		assert.Equal(t, types.ToUint128(0), accountB.DebitsPosted)
 		assert.Equal(t, types.ToUint128(0), accountB.DebitsPending)
 	})
 
 	t.Run("can create concurrent transfers", func(t *testing.T) {
+		accountA, accountB := createTwoAccounts(t)
+
 		const TRANSFERS_MAX = 1_000_000
 		concurrencyMax := make(chan struct{}, TIGERBEETLE_CONCURRENCY_MAX)
 
@@ -288,6 +301,8 @@ func doTestClient(t *testing.T, client Client) {
 	})
 
 	t.Run("can query transfers for an account", func(t *testing.T) {
+		accountA, accountB := createTwoAccounts(t)
+
 		// Create a new account:
 		accountC := types.Account{
 			ID:     types.ID(),


### PR DESCRIPTION
```
$ CC="/home/matklad/p/tb/work/zig/zig cc" go test

0xc000149e40 free  unmarked
0xc000149e80 free  unmarked
0xc000149ec0 free  unmarked
0xc000149f00 free  unmarked
0xc000149f40 free  unmarked
0xc000149f80 free  unmarked
0xc000149fc0 free  unmarked
fatal error: found pointer to free object

runtime stack:
runtime.throw({0x24ade8?, 0xc0001480c0?})
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/panic.go:1023 +0x5c fp=0x7faaa9ffb9d0 sp=0x7faaa9ffb9a0 pc=0x398e9c
runtime.(*mspan).reportZombies(0x7faab33965e8)
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/mgcsweep.go:872 +0x2ea fp=0x7faaa9ffba50 sp=0x7faaa9ffb9d0 pc=0x38794a
runtime.(*sweepLocked).sweep(0x0?, 0x0)
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/mgcsweep.go:638 +0x3c6 fp=0x7faaa9ffbb68 sp=0x7faaa9ffba50 pc=0x386946
runtime.(*mcentral).uncacheSpan(0x0?, 0x0?)
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/mcentral.go:236 +0x98 fp=0x7faaa9ffbb90 sp=0x7faaa9ffbb68 pc=0x377178
runtime.(*mcache).releaseAll(0x7faafb629108)
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/mcache.go:291 +0x13e fp=0x7faaa9ffbbf8 sp=0x7faaa9ffbb90 pc=0x376abe
runtime.(*mcache).prepareForSweep(0x7faafb629108)
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/mcache.go:328 +0x35 fp=0x7faaa9ffbc20 sp=0x7faaa9ffbbf8 pc=0x376bb5
runtime.acquirep(0xc000052008)
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/proc.go:5748 +0x2a fp=0x7faaa9ffbc48 sp=0x7faaa9ffbc20 pc=0x3a79aa
runtime.stopm()
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/proc.go:2783 +0xb5 fp=0x7faaa9ffbc78 sp=0x7faaa9ffbc48 pc=0x3a0515
runtime.findRunnable()
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/proc.go:3512 +0xd5f fp=0x7faaa9ffbdf0 sp=0x7faaa9ffbc78 pc=0x3a205f
runtime.schedule()
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/proc.go:3868 +0xb1 fp=0x7faaa9ffbe28 sp=0x7faaa9ffbdf0 pc=0x3a3131
runtime.mstart1()
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/proc.go:1736 +0xcd fp=0x7faaa9ffbe50 sp=0x7faaa9ffbe28 pc=0x39ec2d
runtime.mstart0()
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/proc.go:1686 +0x76 fp=0x7faaa9ffbe80 sp=0x7faaa9ffbe50 pc=0x39eb36
runtime.mstart()
	/nix/store/9kriq85qac7phcxgpdqbqr25vlr61ifw-go-1.22.2/share/go/src/runtime/asm_amd64.s:394 +0x5 fp=0x7faaa9ffbe88 sp=0x7faaa9ffbe80 pc=0x3cfa45
```

This isn't great! Kudos to Lucian for finding the issue and identifying concurrency as the proximate cause!