### PR TITLE
Multiversion: backport execing and hardcode 0.15.3 as having 0.15.4 available

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -650,6 +650,9 @@ pub const IO = struct {
         const fd = try os.socket(family, sock_type | os.SOCK.NONBLOCK, protocol);
         errdefer os.closeSocket(fd);
 
+        // darwin doesn't support SOCK_CLOEXEC.
+        _ = try os.fcntl(fd, os.F.SETFD, os.FD_CLOEXEC);
+
         // darwin doesn't support os.MSG_NOSIGNAL, but instead a socket option to avoid SIGPIPE.
         try os.setsockopt(fd, os.SOL.SOCKET, os.SO.NOSIGPIPE, &mem.toBytes(@as(c_int, 1)));
         return fd;

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -972,7 +972,7 @@ pub const IO = struct {
     /// Creates a socket that can be used for async operations with the IO instance.
     pub fn open_socket(self: *IO, family: u32, sock_type: u32, protocol: u32) !os.socket_t {
         _ = self;
-        return os.socket(family, sock_type, protocol);
+        return os.socket(family, sock_type | os.SOCK.CLOEXEC, protocol);
     }
 
     /// Opens a directory with read only access.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -601,6 +601,19 @@ pub fn ReplicaType(
 
             const release_target = self.superblock.working.vsr_state.checkpoint.release;
             assert(release_target.value >= self.superblock.working.release_format.value);
+
+            // For this transitional release, it can only ever be executed as a lower version by a
+            // higher version; therefore the superblock must either be minimum or 0.15.3. If it's
+            // not, it has been invoked incorrectly.
+            assert(
+                release_target.value == vsr.Release.minimum.value or
+                    release_target.value == vsr.Release.from(.{
+                    .major = 0,
+                    .minor = 15,
+                    .patch = 3,
+                }).value,
+            );
+
             if (release_target.value != self.release.value) {
                 self.release_transition(@src());
                 return;


### PR DESCRIPTION
0.15.4 will be the first version with the ability to read the multiversion metadata embedded in TigerBeetle. This presents a bit of a bootstrapping problem:

* Operator replaces 0.15.3 with 0.15.4,
* 0.15.4 starts up, re-execs into 0.15.3,
* 0.15.3 knows nothing about 0.15.4 or how to check it's available, so we just hang.

Work around this by hardcoding that if 0.15.3 is present in a pack, 0.15.4 must be too.

Additionally, fix up setting `CLOEXEC` on the listening sockets. We were only setting it correctly on the accepted sockets. 