### PR TITLE
cfo: don't forget to actually clone the pull request

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -423,6 +423,7 @@ fn run_fuzzers_prepare_repository(shell: *Shell, target: union(enum) {
             break :commit commit;
         },
         .pull_request => |pr_number| commit: {
+            try shell.exec("git clone https://github.com/tigerbeetle/tigerbeetle .", .{});
             try shell.exec(
                 "git fetch origin refs/pull/{pr_number}/head",
                 .{ .pr_number = pr_number },


### PR DESCRIPTION
Slipped-in the regression in https://github.com/tigerbeetle/tigerbeetle/commit/ad7f4de93532a0db3e7ae6408b7ece8d273e742e.

Was caught by the `assert(try shell.dir_exists(".git") or shell.file_exists(".git"));` assert!