### PR TITLE
lsm: fuzzer compaction/checkpoint ratio fixed

### DIFF
--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -245,9 +245,9 @@ fn generate_events(
         }
 
         if (random.uintAtMost(usize, compacts_per_checkpoint) == 0) {
-            try events.append(.compact);
-        } else {
             try events.append(.checkpoint);
+        } else {
+            try events.append(.compact);
         }
     }
     log.info("event_count = {d}", .{events.items.len});


### PR DESCRIPTION
With 10 compactions per checkpoint we want every 10'th event to be checkpoint, and not vice verse.

In particular, the current code allows a mode where checkpoint is _never_ run, which eventually runs out of grid space

Seed: ./zig/zig build  fuzz -- lsm_manifest_log 11513941687764029474
Closes: #1942