### PR TITLE
VSR/Client: Add `vsr.Client.register()`

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -323,6 +323,12 @@ pub const AOFReplayClient = struct {
         );
         errdefer client.deinit(allocator);
 
+        client.register(register_callback, undefined);
+        while (client.request_inflight != null) {
+            client.tick();
+            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        }
+
         return Self{
             .io = io,
             .message_pool = message_pool,
@@ -378,6 +384,14 @@ pub const AOFReplayClient = struct {
                 try self.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
             }
         }
+    }
+
+    fn register_callback(
+        user_data: u128,
+        result: *const vsr.RegisterResult,
+    ) void {
+        _ = user_data;
+        _ = result;
     }
 
     fn replay_callback(

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -30,7 +30,6 @@ pub const Options = union(vsr.ProcessType) {
                 sum += constants.replicas_max; // Connection.recv_message
                 // Connection.send_queue:
                 sum += constants.replicas_max * constants.connection_send_queue_max_client;
-                sum += 1; // Client.register_inflight
                 sum += 1; // Client.request_inflight
                 // Handle bursts.
                 // (e.g. Connection.parse_message(), or sending a ping when the send queue is full).

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -460,7 +460,6 @@ pub const Simulator = struct {
         assert(simulator.requests_sent == simulator.options.requests_max);
         assert(simulator.reply_sequence.empty());
         for (simulator.cluster.clients) |*client| {
-            assert(client.register_inflight == null);
             assert(client.request_inflight == null);
         }
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -460,7 +460,13 @@ pub const Simulator = struct {
         assert(simulator.requests_sent == simulator.options.requests_max);
         assert(simulator.reply_sequence.empty());
         for (simulator.cluster.clients) |*client| {
-            assert(client.request_inflight == null);
+            if (client.request_inflight) |request| {
+                // Registration isn't counted by requests_sent, so an operation=register may still
+                // be in-flight. Any other requests should already be complete before done() is
+                // called.
+                assert(request.message.header.operation == .register);
+                return false;
+            }
         }
 
         // Even though there are no client requests in progress, the cluster may be upgrading.

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -358,6 +358,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 client.on_reply_context = cluster;
                 client.on_reply_callback = client_on_reply;
                 network.link(client.message_bus.process, &client.message_bus);
+                // TODO Move this up a level -- I think we could simplify/improve replica_test if
+                // this wasn't automatic.
+                client.register(register_callback, undefined);
             }
 
             return cluster;
@@ -634,7 +637,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         /// instead because:
         /// - Cluster needs access to the request
         /// - Cluster needs access to the reply message (not just the body)
-        /// - Cluster needs to know about command=register messages
         ///
         /// See `on_reply`.
         fn request_callback(
@@ -644,6 +646,15 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         ) void {
             _ = user_data;
             _ = operation;
+            _ = result;
+        }
+
+        /// See request_callback().
+        fn register_callback(
+            user_data: u128,
+            result: *const vsr.RegisterResult,
+        ) void {
+            _ = user_data;
             _ = result;
         }
 

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -179,13 +179,11 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                     if (client.id == header_b.?.client) break client;
                 } else unreachable;
 
-                if (client.register_inflight == null and
-                    client.request_inflight == null)
-                {
+                if (client.request_inflight == null) {
                     return error.ReplicaTransitionedToInvalidState;
                 }
 
-                const request = client.register_inflight orelse client.request_inflight.?.message;
+                const request = client.request_inflight.?.message;
                 assert(request.header.client == header_b.?.client);
                 assert(request.header.checksum == header_b.?.request_checksum);
                 assert(request.header.request == header_b.?.request);

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -173,6 +173,13 @@ pub fn main(
         .id_order = cli_args.id_order,
     };
 
+    benchmark.client.register(Benchmark.register_callback, @intCast(@intFromPtr(&benchmark)));
+    while (!benchmark.done) {
+        benchmark.client.tick();
+        try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+    }
+    benchmark.done = false;
+
     benchmark.create_accounts();
 
     while (!benchmark.done) {
@@ -497,6 +504,17 @@ const Benchmark = struct {
         b.callback = null;
 
         callback(b, operation, result);
+    }
+
+    fn register_callback(
+        user_data: u128,
+        result: *const vsr.RegisterResult,
+    ) void {
+        _ = result;
+
+        const b: *Benchmark = @ptrFromInt(@as(usize, @intCast(user_data)));
+        assert(!b.done);
+        b.done = true;
     }
 };
 


### PR DESCRIPTION
### Context

Clients (at the level above `vsr.Client`) are responsible for automatically coalescing user operations into batches. The maximum batch size is currently `message_body_size_max`.

In order to minimize replica memory usage when maximum throughput is not needed (e.g. during development), the replica is going to support running with a lower, _runtime-defined_ batch size limit. Since this batch size limit impacts the clients, the replica must communicate it to clients. This will occur via the result of the `register` request. (Note that this is not implemented in this PR – this PR is a prerequisite.)

Previously, `vsr.Client` would send its `command=request operation=register` message when the first of the following occurred:

  1. `vsr.Client.request()` is called, or
  2. the client receives a `pong_client` message.

But that means that the first batch created by the client would potentially precede the client actually knowing the batch limit.

### Solution

Add `vsr.Client.register(callback, user_data)`. `vsr.Client.request()` cannot be called until `.register()` has invoked its callback.

`tb_client` invoked `vsr.Client.register` automatically during its setup – no waiting until `request()`/`on_pong()`. It will refrain from generating/sending any batches until the register reply arrives.

### Future Work (Maybe?)

The above opens up some nice possibilities for UX of the client API:

- If `.register` takes too long, we could bubble up an exception/warning to the application suggesting that they might have misconfigured TB (e.g. wrong host/port/cluster_id). (Right now the client just hangs silently forever, which is not a great developer experience.)
- We could expose `.register()`, to allow developers to (optionally) wait until the connection is established before they start generating work – since any generated work would just be buffered in memory until `register` arrives.

---

~Note that CI (`replica_test.zig`) is failing on this branch. This is semi-unrelated; it is addressed in a [separate PR](https://github.com/tigerbeetle/tigerbeetle/pull/1947).~