### PR TITLE
Test/Replica: Predictable packet lifetime

### DIFF
--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -136,10 +136,6 @@ pub const Network = struct {
         network.packet_simulator.tick();
     }
 
-    pub fn clear(network: *Network) void {
-        network.packet_simulator.clear();
-    }
-
     pub fn transition_to_liveness_mode(network: *Network, core: Core) void {
         assert(core.count() > 0);
 
@@ -202,6 +198,13 @@ pub const Network = struct {
     pub fn process_disable(network: *Network, process: Process) void {
         assert(network.buses_enabled.items[network.process_to_address(process)]);
         network.buses_enabled.items[network.process_to_address(process)] = false;
+    }
+
+    pub fn link_clear(network: *Network, path: Path) void {
+        network.packet_simulator.link_clear(.{
+            .source = network.process_to_address(path.source),
+            .target = network.process_to_address(path.target),
+        });
     }
 
     pub fn link_filter(network: *Network, path: Path) *LinkFilter {

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -136,6 +136,10 @@ pub const Network = struct {
         network.packet_simulator.tick();
     }
 
+    pub fn clear(network: *Network) void {
+        network.packet_simulator.clear();
+    }
+
     pub fn transition_to_liveness_mode(network: *Network, core: Core) void {
         assert(core.count() > 0);
 

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -192,9 +192,10 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
         }
 
         /// Drop all pending packets.
-        pub fn clear(self: *Self) void {
-            for (self.links) |*link| {
-                while (link.queue.peek()) |_| link.queue.remove().packet.deinit();
+        pub fn link_clear(self: *Self, path: Path) void {
+            const link = &self.links[self.path_index(path)];
+            while (link.queue.peek()) |_| {
+                link.queue.remove().packet.deinit();
             }
         }
 

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -191,6 +191,13 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             allocator.free(self.auto_partition_nodes);
         }
 
+        /// Drop all pending packets.
+        pub fn clear(self: *Self) void {
+            for (self.links) |*link| {
+                while (link.queue.peek()) |_| link.queue.remove().packet.deinit();
+            }
+        }
+
         pub fn link_filter(self: *Self, path: Path) *LinkFilter {
             return &self.links[self.path_index(path)].filter;
         }

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -766,6 +766,10 @@ test "Cluster: view-change: DVC, 2/3 faulty header stall" {
     t.replica(.R1).stop();
     t.replica(.R2).stop();
 
+    // Make sure there are no commit messages with commit=24 lingering in the network, which would
+    // cause the deadlock to occur after the view-change (during repair).
+    t.cluster.network.clear();
+
     t.replica(.R1).corrupt(.{ .wal_prepare = 22 });
     t.replica(.R2).corrupt(.{ .wal_prepare = 22 });
 


### PR DESCRIPTION
### Bug

An innocuous, unrelated modification ([changing the timing of client registration](https://github.com/tigerbeetle/tigerbeetle/pull/1946)) caused the `"Cluster: view-change: DVC, 2/3 faulty header stall"` test to fail to hit the `"quorum received, deadlocked"` mark.

The reason turned out to be:
1. Before `R1`/`R2` were stopped, `R1` would broadcast a `command=commit` message advertising that it had committed up to `op=24`.
2. Then `R1`/`R2` are stopped.
3. Then `R0`/`R1`/`R2` are restarted.
4. `R2` receives the commit message from `R1`.

`R2` updates its `commit_max` accordingly to `24`. This means that `R2`'s DVC headers become:

```
vsr.message_header.Header.Prepare{ .checksum = 264409621967806856301762300292990577417, .checksum_padding = 0, .checksum_body = 89966029874040895367451914168563409790, .checksum_body_padding = 0, .nonce_reserved = 0, .cluster = 0, .size = 379, .epoch = 0, .view = 1, .release = 0.0.1, .protocol = 0, .command = vsr.Command.prepare, .replica = 1, .reserved_frame = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .parent = 214146373748106239317079081188694162527, .parent_padding = 0, .request_checksum = 210006865568540829977876627916414560011, .request_checksum_padding = 0, .checkpoint_id = 136527896694250438180833196259969425101, .client = 340282366920938463463374607431768211440, .op = 24, .commit = 22, .timestamp = 35840000000, .request = 3, .operation = vsr.Operation(128), .reserved = { 0, 0, 0 } }
```

...instead of:

```
vsr.message_header.Header.Prepare{ .checksum = 264409621967806856301762300292990577417, .checksum_padding = 0, .checksum_body = 89966029874040895367451914168563409790, .checksum_body_padding = 0, .nonce_reserved = 0, .cluster = 0, .size = 379, .epoch = 0, .view = 1, .release = 0.0.1, .protocol = 0, .command = vsr.Command.prepare, .replica = 1, .reserved_frame = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .parent = 214146373748106239317079081188694162527, .parent_padding = 0, .request_checksum = 210006865568540829977876627916414560011, .request_checksum_padding = 0, .checkpoint_id = 136527896694250438180833196259969425101, .client = 340282366920938463463374607431768211440, .op = 24, .commit = 22, .timestamp = 35840000000, .request = 3, .operation = vsr.Operation(128), .reserved = { 0, 0, 0 } }
vsr.message_header.Header.Prepare{ .checksum = 214146373748106239317079081188694162527, .checksum_padding = 0, .checksum_body = 89966029874040895367451914168563409790, .checksum_body_padding = 0, .nonce_reserved = 0, .cluster = 0, .size = 379, .epoch = 0, .view = 1, .release = 0.0.1, .protocol = 0, .command = vsr.Command.prepare, .replica = 1, .reserved_frame = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .parent = 134865215208318770849096203187531857857, .parent_padding = 0, .request_checksum = 154286848594512146187188626661010583027, .request_checksum_padding = 0, .checkpoint_id = 0, .client = 340282366920938463463374607431768211442, .op = 23, .commit = 20, .timestamp = 35540000000, .request = 3, .operation = vsr.Operation(128), .reserved = { 0, 0, 0 } }
vsr.message_header.Header.Prepare{ .checksum = 0, .checksum_padding = 0, .checksum_body = 0, .checksum_body_padding = 0, .nonce_reserved = 0, .cluster = 0, .size = 256, .epoch = 0, .view = 0, .release = 0.0.0, .protocol = 0, .command = vsr.Command.prepare, .replica = 0, .reserved_frame = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .parent = 0, .parent_padding = 0, .request_checksum = 0, .request_checksum_padding = 0, .checkpoint_id = 0, .client = 0, .op = 22, .commit = 0, .timestamp = 0, .request = 0, .operation = vsr.Operation.reserved, .reserved = { 0, 0, 0 } }
vsr.message_header.Header.Prepare{ .checksum = 187840535261548725990845965352319509672, .checksum_padding = 0, .checksum_body = 89966029874040895367451914168563409790, .checksum_body_padding = 0, .nonce_reserved = 0, .cluster = 0, .size = 379, .epoch = 0, .view = 1, .release = 0.0.1, .protocol = 0, .command = vsr.Command.prepare, .replica = 1, .reserved_frame = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .parent = 172563816644872299777755138672766274583, .parent_padding = 0, .request_checksum = 54725713356666992480259216686684662425, .request_checksum_padding = 0, .checkpoint_id = 0, .client = 340282366920938463463374607431768211441, .op = 21, .commit = 20, .timestamp = 35480000000, .request = 3, .operation = vsr.Operation(128), .reserved = { 0, 0, 0 } }
vsr.message_header.Header.Prepare{ .checksum = 172563816644872299777755138672766274583, .checksum_padding = 0, .checksum_body = 89966029874040895367451914168563409790, .checksum_body_padding = 0, .nonce_reserved = 0, .cluster = 0, .size = 379, .epoch = 0, .view = 1, .release = 0.0.1, .protocol = 0, .command = vsr.Command.prepare, .replica = 1, .reserved_frame = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .parent = 133384992365775047377174566611699747898, .parent_padding = 0, .request_checksum = 238455995778529916453800152376725855394, .request_checksum_padding = 0, .checkpoint_id = 0, .client = 340282366920938463463374607431768211442, .op = 20, .commit = 17, .timestamp = 5190000000, .request = 2, .operation = vsr.Operation(128), .reserved = { 0, 0, 0 } }
```

...which means the view change completes "successfully". (It gets stuck in repair instead, but that's not what this test is trying to exercise).

### Fix

My [first fix](https://github.com/tigerbeetle/tigerbeetle/commit/f14b8c7767a6ff2d8af086fd9113cd4d73d17163) was to add `Network.clear()` which was called explicitly in the test. But after some thought I replaced that with a [different approach](https://github.com/tigerbeetle/tigerbeetle/commit/0912e72a82c0e69e2482493ea949782651d71aad) which is more automatic/implicit, so hopefully we won't run into this type of issue again.