### PR TITLE
vopr: trivial bug in workload

### DIFF
--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -751,7 +751,8 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                             // The transfer was delivered; it must exist.
                             assert(result != null);
                         } else {
-                            for (self.transfers_delivered_recently.items) |delivered| {
+                            var it = self.transfers_delivered_recently.iterator();
+                            while (it.next()) |delivered| {
                                 if (transfer_index >= delivered.min and
                                     transfer_index <= delivered.max)
                                 {


### PR DESCRIPTION
transfers_delivered_recently is a heap. Its `items` refers to the entire allocation, an not just to the initialized part. That is, there's
    transfers_delivered_recently.len
and
    transfers_delivered_recently.items.len

So we are essentially poking private implementation details here, and getting what we've asked for (zero-initialized data).

Sometimes one can wish for private fields in Zig indeed!

Seed: ./zig/zig build simulator_run -- --lite 3712666001180766802
Closes: #1944