### PR TITLE
vsr: new state sync protocol 

### DIFF
--- a/docs/about/internals/testing.md
+++ b/docs/about/internals/testing.md
@@ -17,7 +17,6 @@ Documentation for (roughly) code in the `src/testing` directory.
     - ` `: commit
     - `[`: checkpoint start
     - `]`: checkpoint done
-    - `<`: sync start (or change target)
     - `>`: sync done
 3. Role (according to the replica itself):
     - `/`: primary
@@ -66,7 +65,6 @@ Documentation for (roughly) code in the `src/testing` directory.
  2 ] \   .         3V  95/_99/_99C  68:_99Jo  0/_0J!  68:_99Wo <__0:__0> v1:2   167Ga  0G!   0G?
  1   \  .          3V  71/_99/_99C  68:_99Jo  0/_1J!  67:_98Wo <__0:__0> v1:2   183Ga  0G!   0G?
  1 [ \  .          3V  71/_99/_99C  68:_99Jo  0/_1J!  67:_98Wo <__0:__0> v1:2   183Ga  0G!   0G?
- 4 < ~     v       3V  23/_23/_46C  19:_50Jo  0/_0J!  19:_50Wo <__0:__0> v1:2    66Ga  0G!   0G?
  5   |      .      3V  71/_99/_99C  68:_99Jo  0/_0J!  68:_99Wo <__0:__0> v1:2   183Ga  0G!   0G?
  5 [ |      .      3V  71/_99/_99C  68:_99Jo  0/_0J!  68:_99Wo <__0:__0> v1:2   183Ga  0G!   0G?
 ```

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -322,7 +322,10 @@ comptime {
     assert(view_change_headers_max > 0);
     assert(view_change_headers_max >= pipeline_prepare_queue_max + 3);
     assert(view_change_headers_max <= journal_slot_count);
-    assert(view_change_headers_max <= @divFloor(message_body_size_max, @sizeOf(vsr.Header)));
+    assert(view_change_headers_max <= @divFloor(
+        message_body_size_max - @sizeOf(vsr.CheckpointState),
+        @sizeOf(vsr.Header),
+    ));
     assert(view_change_headers_max > view_change_headers_suffix_max);
 }
 

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -76,6 +76,7 @@ pub const Options = union(vsr.ProcessType) {
                 // Connection.send_queue:
                 sum += connections_max * constants.connection_send_queue_max_replica;
                 sum += 1; // Handle bursts (e.g. Connection.parse_message)
+                sum += 1; // Extra burst from sending two SV variants.
                 // Handle Replica.commit_op's reply:
                 // (This is separate from the burst +1 because they may occur concurrently).
                 sum += 1;
@@ -105,6 +106,10 @@ pub const MessagePool = struct {
         pub const StartViewChange = MessageType(.start_view_change);
         pub const DoViewChange = MessageType(.do_view_change);
         pub const StartView = MessageType(.start_view);
+        pub const StartViewDeprecated = MessageType(.start_view_deprecated);
+        comptime {
+            assert(StartView == StartViewDeprecated);
+        }
         pub const RequestStartView = MessageType(.request_start_view);
         pub const RequestHeaders = MessageType(.request_headers);
         pub const RequestPrepare = MessageType(.request_prepare);
@@ -280,9 +285,11 @@ pub const MessagePool = struct {
 };
 
 fn MessageType(comptime command: vsr.Command) type {
+    const CommandHeaderUnified = Header.Type(command);
+
     return extern struct {
         const CommandMessage = @This();
-        const CommandHeader = Header.Type(command);
+        const CommandHeader = CommandHeaderUnified;
         const Message = MessagePool.Message;
 
         // The underlying structure of Message and CommandMessage should be identical, so that their

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -796,10 +796,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     };
                 },
                 .sync_stage_changed => switch (replica.syncing) {
-                    .requesting_checkpoint => cluster.log_replica(
-                        .sync_commenced,
-                        replica.replica,
-                    ),
                     .idle => cluster.log_replica(.sync_completed, replica.replica),
                     else => {},
                 },

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -825,7 +825,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 commit = ' ',
                 checkpoint_commenced = '[',
                 checkpoint_completed = ']',
-                sync_commenced = '<',
                 sync_completed = '>',
             },
             replica_index: u8,

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -97,7 +97,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
         /// Returns whether the replica's state changed since the last check_state().
         pub fn check_state(state_checker: *Self, replica_index: u8) !void {
             const replica = &state_checker.replicas[replica_index];
-            if (replica.syncing.target()) |sync_target| {
+            if (replica.syncing == .updating_superblock) {
                 // Allow a syncing replica to fast-forward its commit.
                 //
                 // But "fast-forwarding" may actually move commit_min slightly backwards:
@@ -106,7 +106,8 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 //    the cluster anymore.
                 // 3. When we sync, `commit_min` "backtracks", to `X - lsm_batch_multiple`.
                 const commit_min_source = state_checker.commit_mins[replica_index];
-                const commit_min_target = sync_target.checkpoint_op;
+                const commit_min_target =
+                    replica.syncing.updating_superblock.checkpoint_state.header.op;
                 assert(commit_min_source <= commit_min_target + constants.lsm_batch_multiple);
                 state_checker.commit_mins[replica_index] = commit_min_target;
                 return;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -203,7 +203,7 @@ pub const Command = enum(u8) {
 
     start_view_change = 10,
     do_view_change = 11,
-    start_view = 12,
+    start_view_deprecated = 12,
 
     request_start_view = 13,
     request_headers = 14,
@@ -222,7 +222,7 @@ pub const Command = enum(u8) {
     // A reserved command for the new state sync protocol. At the moment, replica ignores this
     // command (as opposed to panicking on an unknown command), to allow the next release to send
     // both versions of StartView.
-    start_view2 = 23,
+    start_view = 23,
 
     comptime {
         for (std.enums.values(Command), 0..) |result, index| {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -203,6 +203,8 @@ pub const Command = enum(u8) {
 
     start_view_change = 10,
     do_view_change = 11,
+    // Historical version of SV, without checkpoint. Currently  both `start_view_deprecated` and
+    // `start_view` are handled. Next release will ignore `start_view_deprecated`.
     start_view_deprecated = 12,
 
     request_start_view = 13,
@@ -219,9 +221,6 @@ pub const Command = enum(u8) {
     request_sync_checkpoint = 21,
     sync_checkpoint = 22,
 
-    // A reserved command for the new state sync protocol. At the moment, replica ignores this
-    // command (as opposed to panicking on an unknown command), to allow the next release to send
-    // both versions of StartView.
     start_view = 23,
 
     comptime {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4638,7 +4638,7 @@ pub fn ReplicaType(
         /// Construct a SV message, including attached headers from the current log_view.
         /// The caller owns the returned message, if any, which has exactly 1 reference.
         fn create_start_view_message(self: *Self, nonce: u128) struct {
-            current: *Message.StartView,
+            current: *Message.StartViewDeprecated,
             next: *Message.StartView,
         } {
             assert(self.status == .normal);
@@ -4689,6 +4689,7 @@ pub fn ReplicaType(
             message.header.set_checksum_body(message.body());
             message.header.set_checksum();
 
+            comptime assert(Message.StartView == Message.StartViewDeprecated);
             const message_copy = self.message_bus.get_message(.start_view);
             defer self.message_bus.unref(message_copy);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2225,11 +2225,7 @@ pub fn ReplicaType(
             }
             assert(self.view == message.header.view);
 
-            const view_checkpoint = std.mem.bytesAsValue(
-                vsr.CheckpointState,
-                message.body()[message.body().len -
-                    @sizeOf(vsr.CheckpointState) ..][0..@sizeOf(vsr.CheckpointState)],
-            );
+            const view_checkpoint = start_view_message_checkpoint(message);
             if (vsr.Checkpoint.trigger_for_checkpoint(view_checkpoint.header.op)) |trigger| {
                 assert(message.header.commit >= trigger);
             }
@@ -2239,10 +2235,9 @@ pub fn ReplicaType(
                 ).?,
             );
 
-            const view_headers = message_body_as_view_headers(message.base_const());
-            assert(view_headers.command == .start_view);
-            assert(view_headers.slice[0].op == message.header.op);
-            assert(view_headers.slice[0].op >= view_headers.slice[view_headers.slice.len - 1].op);
+            const view_headers = start_view_message_headers(message);
+            assert(view_headers[0].op == message.header.op);
+            assert(view_headers[0].op >= view_headers[view_headers.len - 1].op);
 
             if (message.header.commit > self.op_prepare_max() and (
             //  Cluster is far ahead, replica's WAL no longer intersects primary's WAL.
@@ -2312,10 +2307,10 @@ pub fn ReplicaType(
                 // Replace our log with the suffix from SV. Transition to sync above guarantees
                 // that there's at least one message that fits the effective checkpoint, but some
                 // messages might be beyond its prepare_max.
-                maybe(view_headers.slice[0].op > self.op_prepare_max_sync());
+                maybe(view_headers[0].op > self.op_prepare_max_sync());
 
                 // Find the first message that fits, make it our new head.
-                for (view_headers.slice) |*header| {
+                for (view_headers) |*header| {
                     assert(header.commit <= message.header.commit);
 
                     if (header.op <= self.op_prepare_max_sync()) {
@@ -2330,7 +2325,7 @@ pub fn ReplicaType(
                     }
                 } else unreachable;
 
-                for (view_headers.slice) |*header| {
+                for (view_headers) |*header| {
                     if (header.op <= self.op_prepare_max_sync()) {
                         self.replace_header(header);
                     }
@@ -2343,7 +2338,7 @@ pub fn ReplicaType(
                 self.commit_min = self.syncing.updating_superblock.checkpoint_state.header.op;
             }
 
-            self.view_headers.replace(.start_view, view_headers.slice);
+            self.view_headers.replace(.start_view, view_headers);
             assert(self.view_headers.array.get(0).view <= self.view);
             assert(self.view_headers.array.get(0).op == message.header.op);
             maybe(self.view_headers.array.get(0).op > self.op_prepare_max_sync());
@@ -4616,6 +4611,7 @@ pub fn ReplicaType(
         /// The caller owns the returned message, if any, which has exactly 1 reference.
         fn create_start_view_message(self: *Self, nonce: u128) *Message.StartView {
             assert(self.status == .normal);
+            assert(self.syncing != .updating_superblock);
             assert(self.replica == self.primary_index(self.view));
             assert(self.commit_min == self.commit_max);
             assert(self.commit_min <= self.op);
@@ -4632,8 +4628,8 @@ pub fn ReplicaType(
             defer self.message_bus.unref(message);
 
             message.header.* = .{
-                .size = @sizeOf(Header) * (1 + self.view_headers.array.count_as(u32)) +
-                    @sizeOf(vsr.CheckpointState),
+                .size = @sizeOf(Header) + @sizeOf(vsr.CheckpointState) +
+                    @sizeOf(Header) * self.view_headers.array.count_as(u32),
                 .command = .start_view,
                 .cluster = self.cluster,
                 .replica = self.replica,
@@ -4644,20 +4640,18 @@ pub fn ReplicaType(
                 .nonce = nonce,
             };
 
-            const body_headers_size = self.view_headers.array.count_as(usize) * @sizeOf(vsr.Header);
-            const body_headers = message.body()[0..body_headers_size];
-            const body_checkpoint = message.body()[body_headers_size..];
-            stdx.copy_disjoint(
-                .exact,
-                Header.Prepare,
-                std.mem.bytesAsSlice(Header.Prepare, body_headers),
-                self.view_headers.array.const_slice(),
-            );
             stdx.copy_disjoint(
                 .exact,
                 u8,
-                body_checkpoint,
+                message.body()[0..@sizeOf(vsr.CheckpointState)],
                 std.mem.asBytes(&self.superblock.working.vsr_state.checkpoint),
+            );
+            comptime assert(@sizeOf(vsr.CheckpointState) % @sizeOf(Header) == 0);
+            stdx.copy_disjoint(
+                .exact,
+                u8,
+                message.body()[@sizeOf(vsr.CheckpointState)..],
+                std.mem.sliceAsBytes(self.view_headers.array.const_slice()),
             );
             message.header.set_checksum_body(message.body());
             message.header.set_checksum();
@@ -10208,13 +10202,11 @@ const DVCQuorum = struct {
 
 fn message_body_as_view_headers(message: *const Message) vsr.Headers.ViewChangeSlice {
     assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
-    assert(message.header.command == .do_view_change or
-        message.header.command == .start_view);
+    assert(message.header.command == .do_view_change);
 
     return vsr.Headers.ViewChangeSlice.init(
         switch (message.header.command) {
             .do_view_change => .do_view_change,
-            .start_view => .start_view,
             else => unreachable,
         },
         message_body_as_headers_unchecked(message),
@@ -10225,8 +10217,7 @@ fn message_body_as_view_headers(message: *const Message) vsr.Headers.ViewChangeS
 /// The headers may contain gaps and/or breaks.
 fn message_body_as_prepare_headers(message: *const Message) []const Header.Prepare {
     assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
-    assert(message.header.command == .start_view or
-        message.header.command == .headers);
+    assert(message.header.command == .headers);
 
     const headers = message_body_as_headers_unchecked(message);
     var child: ?*const Header.Prepare = null;
@@ -10250,18 +10241,40 @@ fn message_body_as_prepare_headers(message: *const Message) []const Header.Prepa
 fn message_body_as_headers_unchecked(message: *const Message) []const Header.Prepare {
     assert(message.header.size > @sizeOf(Header)); // Body must contain at least one header.
     assert(message.header.command == .do_view_change or
-        message.header.command == .start_view or
         message.header.command == .headers);
-
-    const headers_end_offset = switch (message.header.command) {
-        .start_view => message.header.size - @sizeOf(vsr.CheckpointState),
-        else => message.header.size,
-    };
 
     return std.mem.bytesAsSlice(
         Header.Prepare,
-        message.buffer[@sizeOf(Header)..headers_end_offset],
+        message.body(),
     );
+}
+
+fn start_view_message_checkpoint(message: *const Message.StartView) *const vsr.CheckpointState {
+    assert(message.header.command == .start_view);
+    const checkpoint = std.mem.bytesAsValue(
+        vsr.CheckpointState,
+        message.body()[0..@sizeOf(vsr.CheckpointState)],
+    );
+    assert(checkpoint.header.valid_checksum());
+    assert(stdx.zeroed(&checkpoint.reserved));
+    return checkpoint;
+}
+
+fn start_view_message_headers(message: *const Message.StartView) []const Header.Prepare {
+    assert(message.header.command == .start_view);
+    // Body must contain at least one header.
+    assert(message.header.size > @sizeOf(Header) + @sizeOf(vsr.CheckpointState));
+
+    const headers = std.mem.bytesAsSlice(
+        Header.Prepare,
+        message.body()[@sizeOf(vsr.CheckpointState)..],
+    );
+    // To run verification.
+    _ = vsr.Headers.ViewChangeSlice.init(.start_view, headers);
+    if (constants.verify) {
+        for (headers) |header| assert(header.valid_checksum());
+    }
+    return headers;
 }
 
 /// The PipelineQueue belongs to a normal-status primary. It consists of two queues:

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -302,9 +302,6 @@ pub fn ReplicaType(
         opened: bool,
 
         syncing: SyncStage = .idle,
-        /// The latest discovered checkpoint that would be safe to sync to.
-        /// Kept up-to-date during every status, while syncing or healthy.
-        sync_target_max: ?SyncTarget = null,
         /// Invariants:
         /// - If syncing≠idle then sync_tables=null.
         sync_tables: ?ForestTableIterator = null,
@@ -507,7 +504,7 @@ pub fn ReplicaType(
         /// (status=normal or (status=view-change and primary))
         repair_timeout: Timeout,
 
-        /// The number of ticks before triggering state sync.
+        /// The number of ticks before checking whether state sync should be requested.
         /// This allows the replica to attempt WAL/grid repair before falling back, even if it
         /// is lagging behind the primary, to try to avoid unnecessary state sync.
         ///
@@ -521,10 +518,6 @@ pub fn ReplicaType(
 
         /// (always running)
         grid_scrub_timeout: Timeout,
-
-        /// The number of ticks before sending a sync message (message types depend on syncing).
-        /// (syncing≠idle)
-        sync_message_timeout: Timeout,
 
         /// The number of ticks on an idle cluster before injecting a `pulse` operation.
         /// (status=normal and primary and !constants.aof_recovery)
@@ -771,27 +764,22 @@ pub fn ReplicaType(
                     self.transition_to_normal_from_recovering_status();
                 }
             } else {
-                if (self.log_view < self.superblock.working.vsr_state.sync_view) {
-                    // During state sync, the replica installed CheckpointState from a future view.
-                    self.transition_to_recovering_head();
-                } else {
-                    // Even if op_head_certain() returns false, a DVC always has a certain head op.
-                    if ((self.log_view < self.view and self.op_checkpoint() <= self.op) or
-                        (self.log_view == self.view and self.op_head_certain()))
-                    {
-                        if (self.log_view == self.view) {
-                            if (self.primary_index(self.view) == self.replica) {
-                                self.transition_to_view_change_status(self.view + 1);
-                            } else {
-                                self.transition_to_normal_from_recovering_status();
-                            }
+                // Even if op_head_certain() returns false, a DVC always has a certain head op.
+                if ((self.log_view < self.view and self.op_checkpoint() <= self.op) or
+                    (self.log_view == self.view and self.op_head_certain()))
+                {
+                    if (self.log_view == self.view) {
+                        if (self.primary_index(self.view) == self.replica) {
+                            self.transition_to_view_change_status(self.view + 1);
                         } else {
-                            assert(self.view > self.log_view);
-                            self.transition_to_view_change_status(self.view);
+                            self.transition_to_normal_from_recovering_status();
                         }
                     } else {
-                        self.transition_to_recovering_head();
+                        assert(self.view > self.log_view);
+                        self.transition_to_view_change_status(self.view);
                     }
+                } else {
+                    self.transition_to_recovering_head();
                 }
             }
 
@@ -1223,11 +1211,6 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 50, // (`after` will be adjusted at runtime to tune the scrubber pace.)
                 },
-                .sync_message_timeout = Timeout{
-                    .name = "sync_message_timeout",
-                    .id = replica_index,
-                    .after = 50,
-                },
                 .pulse_timeout = Timeout{
                     .name = "pulse_timeout",
                     .id = replica_index,
@@ -1332,7 +1315,6 @@ pub fn ReplicaType(
                 .{ &self.repair_sync_timeout, on_repair_sync_timeout },
                 .{ &self.grid_repair_message_timeout, on_grid_repair_message_timeout },
                 .{ &self.upgrade_timeout, on_upgrade_timeout },
-                .{ &self.sync_message_timeout, on_sync_message_timeout },
                 .{ &self.pulse_timeout, on_pulse_timeout },
                 .{ &self.grid_scrub_timeout, on_grid_scrub_timeout },
             };
@@ -1404,7 +1386,6 @@ pub fn ReplicaType(
             }
 
             self.jump_view(message.header);
-            self.jump_sync_target(message.header);
 
             assert(message.header.replica < self.node_count);
             switch (message.into_any()) {
@@ -1427,11 +1408,16 @@ pub fn ReplicaType(
                 .headers => |m| self.on_headers(m),
                 .request_blocks => |m| self.on_request_blocks(m),
                 .block => |m| self.on_block(m),
-                .request_sync_checkpoint => |m| self.on_request_sync_checkpoint(m),
-                .sync_checkpoint => |m| self.on_sync_checkpoint(m),
                 // A replica should never handle misdirected messages intended for a client:
                 .pong_client, .eviction => {
                     log.warn("{}: on_message: misdirected message ({s})", .{
+                        self.replica,
+                        @tagName(message.header.command),
+                    });
+                    return;
+                },
+                .request_sync_checkpoint, .sync_checkpoint => {
+                    log.warn("{}: on_message: ignoring old protocol ({s})", .{
                         self.replica,
                         @tagName(message.header.command),
                     });
@@ -1615,6 +1601,11 @@ pub fn ReplicaType(
             assert(message.header.command == .prepare);
             assert(message.header.replica < self.replica_count);
             assert(message.header.operation != .reserved);
+
+            if (self.syncing == .updating_superblock) {
+                log.debug("{}: on_prepare: ignoring (sync)", .{self.replica});
+                return;
+            }
 
             if (message.header.view < self.view or
                 (self.status == .normal and
@@ -2183,13 +2174,14 @@ pub fn ReplicaType(
             }
         }
 
-        /// When other replicas receive the start_view message, they replace their log with the one
-        /// in the message, set their op number to that of the latest entry in the log, set their
-        /// view number to the view number in the message, change their status to normal, and update
-        /// the information in their client table. If there are non-committed operations in the log,
-        /// they send a ⟨prepare_ok v, n, i⟩ message to the primary; here n is the op-number. Then
-        /// they execute all operations known to be committed that they haven’t executed previously,
-        /// advance their commit number, and update the information in their client table.
+        // When other replicas receive the start_view message, they replace their log and
+        // checkpoint with the ones in the message, set their op number to that of the latest entry
+        // in the log, set their view number to the view number in the message, change their status
+        // to normal, and update the information in their client table. If there are non-committed
+        // operations in the log, they send a ⟨prepare_ok v, n, i⟩ message to the primary; here n
+        // is the op-number. Then they execute all operations known to be committed that they
+        // haven’t executed previously, advance their commit number, and update the information in
+        // their client table.
         fn on_start_view(self: *Self, message: *const Message.StartView) void {
             assert(message.header.command == .start_view);
             if (self.ignore_view_change_message(message.base_const())) return;
@@ -2233,53 +2225,130 @@ pub fn ReplicaType(
             }
             assert(self.view == message.header.view);
 
+            const view_checkpoint = std.mem.bytesAsValue(
+                vsr.CheckpointState,
+                message.body()[message.body().len -
+                    @sizeOf(vsr.CheckpointState) ..][0..@sizeOf(vsr.CheckpointState)],
+            );
+            if (vsr.Checkpoint.trigger_for_checkpoint(view_checkpoint.header.op)) |trigger| {
+                assert(message.header.commit >= trigger);
+            }
+            assert(
+                message.header.op <= vsr.Checkpoint.prepare_max_for_checkpoint(
+                    vsr.Checkpoint.checkpoint_after(view_checkpoint.header.op),
+                ).?,
+            );
+
             const view_headers = message_body_as_view_headers(message.base_const());
             assert(view_headers.command == .start_view);
             assert(view_headers.slice[0].op == message.header.op);
+            assert(view_headers.slice[0].op >= view_headers.slice[view_headers.slice.len - 1].op);
 
-            for (view_headers.slice) |*header| {
-                assert(header.commit <= message.header.commit);
+            if (message.header.commit > self.op_prepare_max() and (
+            //  Cluster is far ahead, replica's WAL no longer intersects primary's WAL.
+                message.header.commit > self.op_prepare_max() + constants.vsr_checkpoint_interval or
+                // Cluster is a bit ahead. The replica might still be able to repair WAL, but that
+                // is not certain.
+                (self.syncing == .idle and self.repair_stuck()) or
+                // Completing previously starting state sync.
+                self.syncing == .awaiting_checkpoint))
+            {
+                // State sync: at this point, the we know we want to replace our checkpoint
+                // with the one from SV.
 
-                if (header.op <= self.op_prepare_max()) {
-                    if (self.log_view < self.view or
-                        (self.log_view == self.view and header.op >= self.op))
-                    {
-                        self.set_op_and_commit_max(header.op, message.header.commit, @src());
-                        assert(self.op == header.op);
-                        assert(self.commit_max >= message.header.commit);
-                        break;
+                assert(message.header.commit > self.op_checkpoint_next_trigger());
+                assert(view_checkpoint.header.op > self.op_checkpoint());
+
+                if (self.syncing == .idle) {
+                    // If we are already checkpointing, let that finish first --- perhaps we won't
+                    // need state sync after all.
+                    if (self.commit_stage == .checkpoint_superblock) return;
+                    if (self.commit_stage == .checkpoint_data) return;
+                    // Otherwise, cancel in progress commit and prepare to sync
+                    self.sync_start_from_committing();
+                    assert(self.syncing != .idle);
+                }
+                switch (self.syncing) {
+                    .idle => unreachable,
+                    .canceling_commit,
+                    .canceling_grid,
+                    .updating_superblock,
+                    => {
+                        log.debug(
+                            \\{}: on_start_view sync {s} view={} op_checkpoint={} op_checkpoint_new={}
+                        , .{
+                            self.replica,
+                            @tagName(self.syncing),
+                            self.log_view,
+                            self.op_checkpoint(),
+                            view_checkpoint.header.op,
+                        });
+                        return;
+                    },
+                    .awaiting_checkpoint => {},
+                }
+
+                log.debug(
+                    \\{}: on_start_view sync started view={} op_checkpoint={} op_checkpoint_new={}
+                , .{
+                    self.replica,
+                    self.log_view,
+                    self.op_checkpoint(),
+                    view_checkpoint.header.op,
+                });
+
+                self.sync_dispatch(.{ .updating_superblock = .{
+                    .checkpoint_state = view_checkpoint.*,
+                } });
+
+                // The new checkpoint would we written to the superblock asynchronously.
+                // From this point on, we are in a delicate state where we must be using this
+                // in-memory checkpoint to check validity of log messages.
+                assert(self.syncing == .updating_superblock);
+                assert(!self.state_machine_opened);
+            }
+
+            {
+                // Replace our log with the suffix from SV. Transition to sync above guarantees
+                // that there's at least one message that fits the effective checkpoint, but some
+                // messages might be beyond its prepare_max.
+                maybe(view_headers.slice[0].op > self.op_prepare_max_sync());
+
+                // Find the first message that fits, make it our new head.
+                for (view_headers.slice) |*header| {
+                    assert(header.commit <= message.header.commit);
+
+                    if (header.op <= self.op_prepare_max_sync()) {
+                        if (self.log_view < self.view or
+                            (self.log_view == self.view and header.op >= self.op))
+                        {
+                            self.set_op_and_commit_max(header.op, message.header.commit, @src());
+                            assert(self.op == header.op);
+                            assert(self.commit_max >= message.header.commit);
+                            break;
+                        }
+                    }
+                } else unreachable;
+
+                for (view_headers.slice) |*header| {
+                    if (header.op <= self.op_prepare_max_sync()) {
+                        self.replace_header(header);
                     }
                 }
-            } else {
-                // This replica is too far behind, i.e. the new `self.op` is too far ahead of
-                // the last checkpoint. If we wrap now, we overwrite un-checkpointed transfers
-                // in the WAL, precluding recovery.
-                if (self.syncing == .idle) {
-                    log.warn("{}: on_start_view: start sync; lagging behind cluster " ++
-                        "(op_prepare_max={} quorum_head={})", .{
-                        self.replica,
-                        self.op_prepare_max(),
-                        view_headers.slice[0].op,
-                    });
-                    self.sync_start_from_committing();
-                }
-                return;
             }
 
-            for (view_headers.slice) |*header| {
-                if (header.op <= self.op_prepare_max()) {
-                    self.replace_header(header);
-                }
+            if (self.syncing == .updating_superblock) {
+                maybe(self.commit_min >
+                    self.syncing.updating_superblock.checkpoint_state.header.op);
+                self.commit_min = self.syncing.updating_superblock.checkpoint_state.header.op;
             }
 
-            if (self.status != .normal) {
-                self.view_headers.replace(.start_view, view_headers.slice);
-                assert(self.view_headers.array.get(0).view <= self.view);
-                assert(self.view_headers.array.get(0).op == message.header.op);
-                maybe(self.view_headers.array.get(0).op > self.op_prepare_max());
-                assert(self.view_headers.array.get(self.view_headers.array.count() - 1).op <=
-                    self.op_prepare_max());
-            }
+            self.view_headers.replace(.start_view, view_headers.slice);
+            assert(self.view_headers.array.get(0).view <= self.view);
+            assert(self.view_headers.array.get(0).op == message.header.op);
+            maybe(self.view_headers.array.get(0).op > self.op_prepare_max_sync());
+            assert(self.view_headers.array.get(self.view_headers.array.count() - 1).op <=
+                self.op_prepare_max_sync());
 
             switch (self.status) {
                 .view_change => {
@@ -2289,9 +2358,16 @@ pub fn ReplicaType(
                 },
                 .recovering_head => {
                     self.transition_to_normal_from_recovering_head_status(message.header.view);
+                    if (self.syncing == .updating_superblock) {
+                        self.view_durable_update();
+                    }
                     self.commit_journal();
                 },
-                .normal => {},
+                .normal => {
+                    if (self.syncing == .updating_superblock) {
+                        self.view_durable_update();
+                    }
+                },
                 .recovering => unreachable,
             }
 
@@ -2299,8 +2375,9 @@ pub fn ReplicaType(
             assert(message.header.view == self.log_view);
             assert(message.header.view == self.view);
             assert(self.backup());
+            if (self.syncing == .updating_superblock) assert(self.view_durable_updating());
 
-            self.repair();
+            if (self.syncing == .idle) self.repair();
         }
 
         fn on_request_start_view(
@@ -2793,47 +2870,6 @@ pub fn ReplicaType(
             self.sync_reclaim_tables();
         }
 
-        fn on_request_sync_checkpoint(
-            self: *Self,
-            message: *Message.RequestSyncCheckpoint,
-        ) void {
-            assert(message.header.command == .request_sync_checkpoint);
-            if (self.ignore_request_sync_checkpoint_message(message)) return;
-
-            assert(message.header.checkpoint_op ==
-                self.superblock.staging.vsr_state.checkpoint.header.op);
-            assert(message.header.checkpoint_id == self.superblock.staging.checkpoint_id());
-
-            self.send_sync_checkpoint(.{ .replica = message.header.replica });
-        }
-
-        fn on_sync_checkpoint(self: *Self, message: *const Message.SyncCheckpoint) void {
-            assert(message.header.replica < self.replica_count);
-            assert(message.header.command == .sync_checkpoint);
-            if (self.ignore_sync_checkpoint_message(message)) return;
-
-            const stage: *const SyncStage.RequestingCheckpoint =
-                &self.syncing.requesting_checkpoint;
-            assert(stage.target.checkpoint_id == message.header.checkpoint_id);
-            assert(stage.target.checkpoint_id == message.header.checksum_body);
-
-            log.debug("{}: on_sync_checkpoint: checkpoint_op={} checkpoint_id={x:0>32}", .{
-                self.replica,
-                stage.target.checkpoint_op,
-                stage.target.checkpoint_id,
-            });
-
-            assert(message.body().len == @sizeOf(vsr.CheckpointState));
-            const checkpoint_state = std.mem.bytesAsValue(
-                vsr.CheckpointState,
-                message.body()[0..@sizeOf(vsr.CheckpointState)],
-            );
-            assert(checkpoint_state.header.valid_checksum());
-            assert(checkpoint_state.header.command == .prepare);
-            assert(checkpoint_state.header.invalid() == null);
-            self.sync_requesting_checkpoint_callback(checkpoint_state);
-        }
-
         fn on_ping_timeout(self: *Self) void {
             self.ping_timeout.reset();
 
@@ -3088,57 +3124,28 @@ pub fn ReplicaType(
             assert(self.status == .normal);
             assert(self.backup());
             assert(self.repair_sync_timeout.ticking);
-
             self.repair_sync_timeout.reset();
 
-            if (self.syncing != .idle) return;
-            // May as well wait for an in-progress checkpoint to complete —
-            // we would need to wait for it before sync starts anyhow, and the newer
-            // checkpoint might sidestep the need for sync anyhow.
-            if (self.commit_stage == .checkpoint_superblock) return;
-            if (self.commit_stage == .checkpoint_data) return;
-
-            // TODO Test connectivity to cluster to rule out a network partition.
-
-            // Even if we want to transition to sync, there is no point if we don't have
-            // a target yet (or if our latest target would not advance our state).
-            if (self.sync_target_max == null) return;
-            if (self.sync_target_max.?.checkpoint_op <= self.op_checkpoint()) return;
-
-            {
-                const commit_next = self.commit_min + 1;
-                const commit_next_slot = self.journal.slot_with_op(commit_next);
-
-                // "stuck" is not actually certain, merely likely (see below).
-                const stuck_header = !self.valid_hash_chain(@src());
-
-                const stuck_prepare =
-                    (commit_next_slot == null or self.journal.dirty.bit(commit_next_slot.?));
-
-                const stuck_grid = !self.grid.read_global_queue.empty();
-
-                if (!stuck_header and !stuck_prepare and !stuck_grid) return;
+            if (self.syncing == .awaiting_checkpoint or self.repair_stuck()) {
+                log.warn("{}: on_repair_sync_timeout: request sync; lagging behind cluster " ++
+                    "(op_head={} commit_min={} commit_max={} commit_stage={s})", .{
+                    self.replica,
+                    self.op,
+                    self.commit_min,
+                    self.commit_max,
+                    @tagName(self.commit_stage),
+                });
+                self.send_header_to_replica(
+                    self.primary_index(self.view),
+                    @bitCast(Header.RequestStartView{
+                        .command = .request_start_view,
+                        .cluster = self.cluster,
+                        .replica = self.replica,
+                        .view = self.view,
+                        .nonce = self.nonce,
+                    }),
+                );
             }
-
-            // At this point:
-            // - we know that the cluster committed atop of a future a checkpoint, and
-            // - we have not made any progress committing for some interval.
-            // It is possible that we could in fact repair and progress anyway, but this is not
-            // guaranteed: the rest of the cluster no longer repairs the relevant prepares.
-            // We might be stuck waiting for a prepare or block which will never arrive.
-
-            log.warn("{}: on_repair_sync_timeout: start sync; lagging behind cluster " ++
-                "(op_head={} commit_min={} commit_max={} commit_stage={s})", .{
-                self.replica,
-                self.op,
-                self.commit_min,
-                self.commit_max,
-                @tagName(self.commit_stage),
-            });
-
-            // It is possible that we trigger state sync even though we could have repaired.
-            // For example, if a block we are trying to repair keeps getting dropped by the network.
-            self.sync_start_from_committing();
         }
 
         fn on_grid_repair_message_timeout(self: *Self) void {
@@ -3191,25 +3198,6 @@ pub fn ReplicaType(
                 const scrub_next = self.grid_scrubber.read_next();
                 if (!scrub_next) break;
             } else unreachable;
-        }
-
-        fn on_sync_message_timeout(self: *Self) void {
-            assert(!self.solo());
-            assert(self.syncing != .idle);
-            assert(self.sync_message_timeout.ticking);
-
-            self.sync_message_timeout.reset();
-
-            switch (self.syncing) {
-                .idle => unreachable,
-                .canceling_commit,
-                .canceling_grid,
-                .requesting_target,
-                .updating_superblock,
-                => return,
-
-                .requesting_checkpoint => self.send_request_sync_checkpoint(),
-            }
         }
 
         fn on_pulse_timeout(self: *Self) void {
@@ -4644,7 +4632,8 @@ pub fn ReplicaType(
             defer self.message_bus.unref(message);
 
             message.header.* = .{
-                .size = @sizeOf(Header) * (1 + self.view_headers.array.count_as(u32)),
+                .size = @sizeOf(Header) * (1 + self.view_headers.array.count_as(u32)) +
+                    @sizeOf(vsr.CheckpointState),
                 .command = .start_view,
                 .cluster = self.cluster,
                 .replica = self.replica,
@@ -4655,11 +4644,20 @@ pub fn ReplicaType(
                 .nonce = nonce,
             };
 
+            const body_headers_size = self.view_headers.array.count_as(usize) * @sizeOf(vsr.Header);
+            const body_headers = message.body()[0..body_headers_size];
+            const body_checkpoint = message.body()[body_headers_size..];
             stdx.copy_disjoint(
                 .exact,
                 Header.Prepare,
-                std.mem.bytesAsSlice(Header.Prepare, message.body()),
+                std.mem.bytesAsSlice(Header.Prepare, body_headers),
                 self.view_headers.array.const_slice(),
+            );
+            stdx.copy_disjoint(
+                .exact,
+                u8,
+                body_checkpoint,
+                std.mem.asBytes(&self.superblock.working.vsr_state.checkpoint),
             );
             message.header.set_checksum_body(message.body());
             message.header.set_checksum();
@@ -5857,6 +5855,17 @@ pub fn ReplicaType(
             return vsr.Checkpoint.prepare_max_for_checkpoint(self.op_checkpoint_next()).?;
         }
 
+        /// Like prepare_max, but takes into account yet the in-memory checkpoint during sync.
+        fn op_prepare_max_sync(self: *const Self) u64 {
+            if (self.syncing != .updating_superblock) return self.op_prepare_max();
+
+            return vsr.Checkpoint.prepare_max_for_checkpoint(
+                vsr.Checkpoint.checkpoint_after(
+                    self.syncing.updating_superblock.checkpoint_state.header.op,
+                ),
+            ).?;
+        }
+
         /// Returns checkpoint id associated with the op.
         ///
         /// Specifically, returns the checkpoint id corresponding to the checkpoint with:
@@ -5911,8 +5920,8 @@ pub fn ReplicaType(
         /// for ensuring that replica.op is valid.
         fn op_repair_min(self: *const Self) u64 {
             if (self.status == .recovering) assert(self.solo());
-            assert(self.op >= self.op_checkpoint());
-            assert(self.op <= self.op_prepare_max());
+            assert(self.syncing == .updating_superblock or self.op >= self.op_checkpoint());
+            assert(self.op <= self.op_prepare_max_sync());
             assert(self.commit_max >= self.op -| constants.pipeline_prepare_queue_max);
 
             const repair_min = repair_min: {
@@ -5941,7 +5950,8 @@ pub fn ReplicaType(
             assert(repair_min <= self.op);
             assert(repair_min <= self.commit_min + 1);
             assert(repair_min <= self.op_checkpoint() + 1);
-            assert(self.op - repair_min < constants.journal_slot_count);
+            assert(self.syncing == .updating_superblock or
+                self.op - repair_min < constants.journal_slot_count);
             assert(self.checkpoint_id_for_op(repair_min) != null);
             return repair_min;
         }
@@ -5952,10 +5962,10 @@ pub fn ReplicaType(
         fn op_repair_max(self: *const Self) u64 {
             assert(self.status != .recovering_head);
             assert(self.op >= self.op_checkpoint());
-            assert(self.op <= self.op_prepare_max());
+            assert(self.op <= self.op_prepare_max_sync());
             assert(self.op <= self.commit_max + constants.pipeline_prepare_queue_max);
 
-            return @min(self.commit_max, self.op_prepare_max());
+            return @min(self.commit_max, self.op_prepare_max_sync());
         }
 
         /// Panics if immediate neighbors in the same view would have a broken hash chain.
@@ -6210,6 +6220,8 @@ pub fn ReplicaType(
             }
 
             self.repair_timeout.reset();
+            if (self.syncing == .updating_superblock) return;
+            if (!self.state_machine_opened) return;
 
             assert(self.status == .normal or self.status == .view_change);
             assert(self.repairs_allowed());
@@ -6414,6 +6426,7 @@ pub fn ReplicaType(
             assert(header.valid_checksum());
             assert(header.invalid() == null);
             assert(header.command == .prepare);
+            if (self.syncing == .updating_superblock) return false;
 
             if (header.view > self.view) {
                 log.debug("{}: repair_header: op={} checksum={} view={} (newer view)", .{
@@ -6959,6 +6972,36 @@ pub fn ReplicaType(
             }
         }
 
+        // Determines if the repair can not make further progress. Used to decide to abandon WAL
+        // repair and decide to state sync. This is a semi heuristic:
+        // - if WAL repair is impossible, this function must eventually returns true.
+        // - but sometimes it may return true even if WAL repair could, in principle, succeed
+        //   later.
+        fn repair_stuck(self: *const Self) bool {
+            if (self.commit_min == self.commit_max) return false;
+
+            // May as well wait for an in-progress checkpoint to complete —
+            // we would need to wait for it before sync starts anyhow, and the newer
+            // checkpoint might sidestep the need for sync anyhow.
+            if (self.commit_stage == .checkpoint_superblock) return false;
+            if (self.commit_stage == .checkpoint_data) return false;
+
+            if (self.status == .recovering_head) return false;
+
+            const commit_next = self.commit_min + 1;
+            const commit_next_slot = self.journal.slot_with_op(commit_next);
+
+            // "stuck" is not actually certain, merely likely.
+            const stuck_header = !self.valid_hash_chain(@src());
+
+            const stuck_prepare =
+                (commit_next_slot == null or self.journal.dirty.bit(commit_next_slot.?));
+
+            const stuck_grid = !self.grid.read_global_queue.empty();
+
+            return stuck_header or stuck_prepare or stuck_grid;
+        }
+
         /// Replaces the header if the header is different and at least op_repair_min.
         /// The caller must ensure that the header is trustworthy (part of the current view's log).
         fn replace_header(self: *Self, header: *const Header.Prepare) void {
@@ -6971,11 +7014,11 @@ pub fn ReplicaType(
             assert(header.command == .prepare);
             assert(header.view <= self.view);
             assert(header.op <= self.op); // Never advance the op.
-            assert(header.op <= self.op_prepare_max());
+            assert(header.op <= self.op_prepare_max_sync());
 
             // If we already committed this op, the repair must be the identical message.
             if (self.op_checkpoint() < header.op and header.op <= self.commit_min) {
-                assert(self.journal.has(header));
+                assert(self.syncing == .updating_superblock or self.journal.has(header));
             }
 
             if (header.op == self.op_checkpoint() + 1) {
@@ -7797,7 +7840,8 @@ pub fn ReplicaType(
             return self.superblock.updating(.view_change);
         }
 
-        /// Persist the current view and log_view to the superblock.
+        /// Persist the current view and log_view to the superblock and/or updates checkpoint
+        /// during state sync.
         /// `view_durable` and `log_view_durable` will update asynchronously, when their respective
         /// updates are durable.
         fn view_durable_update(self: *Self) void {
@@ -7806,7 +7850,11 @@ pub fn ReplicaType(
             assert(self.view >= self.log_view);
             assert(self.view >= self.view_durable());
             assert(self.log_view >= self.log_view_durable());
-            assert(self.log_view > self.log_view_durable() or self.view > self.view_durable());
+            assert(
+                self.log_view > self.log_view_durable() or
+                    self.view > self.view_durable() or
+                    self.syncing == .updating_superblock,
+            );
             // The primary must only persist the SV headers after repairs are done.
             // Otherwise headers could be nacked, truncated, then restored after a crash.
             assert(self.log_view < self.view or self.replica != self.primary_index(self.view) or
@@ -7833,6 +7881,38 @@ pub fn ReplicaType(
                     .view = self.view,
                     .log_view = self.log_view,
                     .headers = &self.view_headers,
+                    .checkpoint = switch (self.syncing) {
+                        .updating_superblock => |*stage| &stage.checkpoint_state,
+                        else => &self.superblock.staging.vsr_state.checkpoint,
+                    },
+                    .sync_op_max = switch (self.syncing) {
+                        .updating_superblock => |*stage| vsr.Checkpoint.trigger_for_checkpoint(
+                            stage.checkpoint_state.header.op,
+                        ).?,
+                        else => self.superblock.staging.vsr_state.sync_op_max,
+                    },
+                    .sync_op_min = switch (self.syncing) {
+                        .updating_superblock => |_| sync_op_min: {
+                            const syncing_already =
+                                self.superblock.staging.vsr_state.sync_op_max > 0;
+                            const sync_min_old = self.superblock.staging.vsr_state.sync_op_min;
+
+                            const sync_min_new = if (vsr.Checkpoint.trigger_for_checkpoint(
+                                self.op_checkpoint(),
+                            )) |trigger|
+                                // +1 because sync_op_min is inclusive, but (when !syncing_already)
+                                // `vsr_state.commit_min` itself does not need to be synced.
+                                trigger + 1
+                            else
+                                0;
+
+                            break :sync_op_min if (syncing_already)
+                                @min(sync_min_old, sync_min_new)
+                            else
+                                sync_min_new;
+                        },
+                        else => self.superblock.staging.vsr_state.sync_op_min,
+                    },
                 },
             );
             assert(self.view_durable_updating());
@@ -7860,6 +7940,15 @@ pub fn ReplicaType(
             assert(self.log_view_durable() <= self.view_durable());
             assert(self.log_view_durable() <= self.log_view);
 
+            switch (self.syncing) {
+                .updating_superblock => |stage| {
+                    if (stage.checkpoint_state.header.op == self.op_checkpoint()) {
+                        self.sync_superblock_update_finish();
+                    }
+                },
+                else => {},
+            }
+
             // recovering_head here is triggered by state sync.
             if (self.status == .recovering_head) return;
 
@@ -7871,7 +7960,10 @@ pub fn ReplicaType(
                 (self.replica != self.primary_index(self.view) or self.status == .normal);
             assert(!(update_dvc and update_sv));
 
-            if (update_dvc or update_sv) self.view_durable_update();
+            const update_checkpoint = self.syncing == .updating_superblock and
+                self.syncing.updating_superblock.checkpoint_state.header.op > self.op_checkpoint();
+
+            if (update_dvc or update_sv or update_checkpoint) self.view_durable_update();
 
             // Reset SVC timeout in case the view-durable update took a long time.
             if (self.view_change_status_timeout.ticking) self.view_change_status_timeout.reset();
@@ -7907,7 +7999,7 @@ pub fn ReplicaType(
             assert(self.status == .view_change or self.status == .normal or
                 self.status == .recovering_head);
 
-            assert(op <= self.op_prepare_max());
+            assert(op <= self.op_prepare_max_sync());
             maybe(op >= self.commit_max);
             maybe(op >= commit_max);
 
@@ -8196,25 +8288,13 @@ pub fn ReplicaType(
 
         fn transition_to_recovering_head(self: *Self) void {
             assert(!self.solo());
+            assert(self.status == .recovering);
             assert(self.commit_stage == .idle);
+            assert(self.syncing == .idle);
+            assert(self.pipeline == .cache);
             assert(self.journal.header_with_op(self.op) != null);
-
-            if (self.log_view < self.superblock.working.vsr_state.sync_view) {
-                // Transitioning to recovering head after state sync --- checkpoint is from a
-                // "future" view, so the replica needs to truncate its log.
-                assert(self.commit_min == self.op_checkpoint());
-            } else {
-                if (self.status == .recovering) {
-                    assert(self.pipeline == .cache);
-                    if (self.log_view < self.view) {
-                        assert(self.op < self.commit_min);
-                    }
-                } else {
-                    // During state sync, we may use recovering_head to avoid violating invariants
-                    // when the checkpoint jumps ahead.
-                    assert(self.syncing != .idle);
-                    assert(self.op < self.commit_min);
-                }
+            if (self.log_view < self.view) {
+                assert(self.op < self.commit_min);
             }
 
             self.status = .recovering_head;
@@ -8394,7 +8474,7 @@ pub fn ReplicaType(
             assert(self.journal.header_with_op(self.op) != null);
             assert(!self.primary_abdicating);
             assert(self.view_headers.command == .start_view);
-            assert(self.log_view >= self.superblock.working.vsr_state.checkpoint.header.view);
+            assert(self.log_view >= self.superblock.working.vsr_state.sync_view);
 
             self.status = .normal;
 
@@ -8688,15 +8768,6 @@ pub fn ReplicaType(
 
             self.sync_tables = null;
 
-            // We learned that we are lagging behind the cluster, so we know we shouldn't actually
-            // be the primary. But we can't join a new view until the view's headers are within our
-            // `op_prepare_max`. We need to bump our `op_checkpoint` first – but that is
-            // async. So even if we are arriving at `sync_start_from_committing` via
-            // `on_start_view`, `on_start_view` leaves us as the "primary" for now.
-            if (self.status == .normal and self.primary()) {
-                self.transition_to_view_change_status(self.view + 1);
-            }
-
             // Abort grid operations.
             // Wait for non-grid operations to finish.
             switch (self.commit_stage) {
@@ -8720,51 +8791,6 @@ pub fn ReplicaType(
             }
         }
 
-        /// Transition from "syncing" to "syncing" — a new target was discovered.
-        fn sync_start_from_sync(self: *Self) void {
-            assert(!self.solo());
-            assert(self.status != .recovering);
-            assert(self.syncing != .idle);
-            assert(self.sync_tables == null);
-
-            log.debug("{}: sync_start_from_sync " ++
-                "(checkpoint_op={} checkpoint_id={x:0>32})", .{
-                self.replica,
-                self.op_checkpoint(),
-                self.superblock.staging.checkpoint_id(),
-            });
-
-            switch (self.syncing) {
-                .idle => unreachable,
-
-                // Uninterruptible states:
-                .canceling_commit, // No sync target selected yet.
-                .canceling_grid, // No sync target selected yet.
-                .updating_superblock, // Hopefully won't need to resync.
-                => return,
-
-                .requesting_target => {
-                    assert(self.commit_stage == .idle);
-                    assert(self.grid_repair_tables.executing() == 0);
-                    assert(self.sync_target_max != null);
-                    self.sync_dispatch(.requesting_target);
-                },
-
-                // We had a sync target already, but we discovered a newer one.
-                // Re-sync to the new target.
-                .requesting_checkpoint => |*stage| {
-                    assert(self.commit_stage == .idle);
-                    assert(self.grid_repair_tables.executing() == 0);
-                    assert(self.sync_target_max.?.checkpoint_op >= stage.target.checkpoint_op);
-                    if (self.sync_target_max.?.checkpoint_op == stage.target.checkpoint_op) return;
-
-                    self.sync_dispatch(.{ .requesting_checkpoint = .{
-                        .target = self.sync_target_max.?,
-                    } });
-                },
-            }
-        }
-
         /// sync_dispatch() is called between every sync-state transition.
         fn sync_dispatch(self: *Self, state_new: SyncStage) void {
             assert(!self.solo());
@@ -8774,53 +8800,11 @@ pub fn ReplicaType(
             const state_old = self.syncing;
             self.syncing = state_new;
 
-            // We were already syncing, but discovered a newer target:
-            if (self.syncing.target()) |target| {
-                assert(self.commit_stage == .idle);
-
-                if (target.checkpoint_op < self.sync_target_max.?.checkpoint_op) {
-                    log.debug("{}: sync_dispatch: change target op={}..{} id={x:0>32}..{x:0>32}", .{
-                        self.replica,
-                        target.checkpoint_op,
-                        self.sync_target_max.?.checkpoint_op,
-                        target.checkpoint_id,
-                        self.sync_target_max.?.checkpoint_id,
-                    });
-                    self.syncing =
-                        .{ .requesting_checkpoint = .{ .target = self.sync_target_max.? } };
-                }
-            }
-
-            // We have been waiting for a target:
-            if (self.syncing == .requesting_target) {
-                assert(self.commit_stage == .idle);
-
-                if (self.sync_target_max) |target| {
-                    if (target.checkpoint_op > self.op_checkpoint() or
-                        (target.checkpoint_op == self.op_checkpoint() and
-                        target.checkpoint_id != self.superblock.working.checkpoint_id()))
-                    {
-                        self.syncing = .{ .requesting_checkpoint = .{ .target = target } };
-                    }
-                }
-            }
-
-            if (self.syncing.target()) |target| {
-                log.debug("{}: sync_dispatch: {s}..{s}: " ++
-                    "(target_op={} target_id={x:0>32})", .{
-                    self.replica,
-                    @tagName(state_old),
-                    @tagName(self.syncing),
-                    target.checkpoint_op,
-                    target.checkpoint_id,
-                });
-            } else {
-                log.debug("{}: sync_dispatch: {s}..{s}", .{
-                    self.replica,
-                    @tagName(state_old),
-                    @tagName(self.syncing),
-                });
-            }
+            log.debug("{}: sync_dispatch: {s}..{s}", .{
+                self.replica,
+                @tagName(state_old),
+                @tagName(self.syncing),
+            });
 
             if (self.event_callback) |hook| hook(self, .sync_stage_changed);
 
@@ -8834,9 +8818,8 @@ pub fn ReplicaType(
                     assert(self.grid_repair_tables.executing() == 0);
                     assert(self.grid.read_global_queue.empty());
                 },
-                .requesting_target => {}, // Waiting for a usable sync target.
-                .requesting_checkpoint => self.sync_message_timeout.start(),
-                .updating_superblock => self.sync_superblock_update(),
+                .awaiting_checkpoint => {}, // Waiting for a usable sync target.
+                .updating_superblock => self.sync_superblock_update_start(),
             }
         }
 
@@ -8898,7 +8881,7 @@ pub fn ReplicaType(
             var grid_repair_writes = self.grid_repair_writes.iterate();
             while (grid_repair_writes.next()) |write| self.grid_repair_writes.release(write);
 
-            self.sync_dispatch(.requesting_target);
+            self.sync_dispatch(.awaiting_checkpoint);
         }
 
         fn sync_requesting_checkpoint_callback(
@@ -8952,10 +8935,9 @@ pub fn ReplicaType(
             } });
         }
 
-        fn sync_superblock_update(self: *Self) void {
+        fn sync_superblock_update_start(self: *Self) void {
             assert(!self.solo());
             assert(self.syncing == .updating_superblock);
-            assert(self.sync_message_timeout.ticking);
             assert(self.sync_tables == null);
             assert(self.grid.read_global_queue.empty());
             assert(self.grid.write_queue.empty());
@@ -8964,8 +8946,6 @@ pub fn ReplicaType(
             assert(self.grid.blocks_missing.faulty_blocks.count() == 0);
             maybe(self.state_machine_opened);
 
-            const stage: *const SyncStage.UpdatingSuperBlock = &self.syncing.updating_superblock;
-
             self.state_machine_opened = false;
             self.state_machine.reset();
 
@@ -8973,51 +8953,9 @@ pub fn ReplicaType(
             self.grid.free_set_checkpoint.reset();
             self.client_sessions_checkpoint.reset();
             self.client_sessions.reset();
-
-            // Bump commit_max before the superblock update so that a view_durable_update()
-            // during the sync_start update uses the correct (new) commit_max.
-            self.advance_commit_max(stage.target.checkpoint_op, @src());
-
-            const sync_op_max =
-                vsr.Checkpoint.trigger_for_checkpoint(stage.target.checkpoint_op).?;
-            const sync_op_min = sync_op_min: {
-                const syncing_already = self.superblock.staging.vsr_state.sync_op_max > 0;
-                const sync_min_old = self.superblock.staging.vsr_state.sync_op_min;
-
-                const sync_min_new = if (vsr.Checkpoint.trigger_for_checkpoint(
-                    self.op_checkpoint(),
-                )) |trigger|
-                    // +1 because sync_op_min is inclusive, but (when !syncing_already)
-                    // `vsr_state.commit_min` itself does not need to be synced.
-                    trigger + 1
-                else
-                    0;
-
-                break :sync_op_min if (syncing_already)
-                    @min(sync_min_old, sync_min_new)
-                else
-                    sync_min_new;
-            };
-            const sync_view = stage.target.view;
-
-            log.info("{}: sync: ops={}..{}", .{ self.replica, sync_op_min, sync_op_max });
-
-            self.sync_message_timeout.stop();
-            self.superblock.sync(
-                sync_superblock_update_callback,
-                &self.superblock_context,
-                .{
-                    .checkpoint = stage.checkpoint_state,
-                    .commit_max = self.commit_max,
-                    .sync_op_max = sync_op_max,
-                    .sync_op_min = sync_op_min,
-                    .sync_view = sync_view,
-                },
-            );
         }
 
-        fn sync_superblock_update_callback(superblock_context: *SuperBlock.Context) void {
-            const self: *Self = @fieldParentPtr("superblock_context", superblock_context);
+        fn sync_superblock_update_finish(self: *Self) void {
             assert(self.sync_tables == null);
             assert(self.grid.read_global_queue.empty());
             assert(self.grid.write_queue.empty());
@@ -9031,15 +8969,15 @@ pub fn ReplicaType(
 
             const stage: *const SyncStage.UpdatingSuperBlock = &self.syncing.updating_superblock;
 
-            assert(self.superblock.working.checkpoint_id() == stage.target.checkpoint_id);
+            assert(self.superblock.working.vsr_state.checkpoint.header.checksum ==
+                stage.checkpoint_state.header.checksum);
             assert(stdx.equal_bytes(
                 vsr.CheckpointState,
                 &self.superblock.working.vsr_state.checkpoint,
                 &stage.checkpoint_state,
             ));
 
-            const commit_min_previous = self.commit_min;
-            self.commit_min = self.superblock.working.vsr_state.checkpoint.header.op;
+            assert(self.commit_min == self.superblock.working.vsr_state.checkpoint.header.op);
 
             if (self.release.value <
                 self.superblock.working.vsr_state.checkpoint.release.value)
@@ -9063,7 +9001,6 @@ pub fn ReplicaType(
                 //   have executed at least one (but not all) of the upgrades in that last bar.
                 // As we replay the bar immediately after this checkpoint, we will set
                 // `upgrade_release` "again", so we reset it now to keep the assertions simple.
-                assert(commit_min_previous > self.op_checkpoint() + 1);
                 assert(self.superblock.working.vsr_state.checkpoint.header.operation != .upgrade);
 
                 self.upgrade_release = null;
@@ -9073,12 +9010,17 @@ pub fn ReplicaType(
 
             // The head op must be in the Journal and there should not be a break between the
             // checkpoint header and the Journal.
-            if (self.op < self.op_checkpoint() or self.log_view < stage.target.view) {
-                self.transition_to_recovering_head();
-            }
+            assert(self.op >= self.op_checkpoint());
+
+            log.info("{}: sync: ops={}..{}", .{
+                self.replica,
+                self.superblock.working.vsr_state.sync_op_min,
+                self.superblock.working.vsr_state.sync_op_max,
+            });
 
             self.grid.open(grid_open_callback);
             self.sync_dispatch(.idle);
+            assert(self.op <= self.op_prepare_max());
         }
 
         /// We have just:
@@ -9291,7 +9233,7 @@ pub fn ReplicaType(
         /// Whether it is safe to commit or send prepare_ok messages.
         /// Returns true if the hash chain is valid and up to date for the current view.
         /// This is a stronger guarantee than `valid_hash_chain_between()` below.
-        fn valid_hash_chain(self: *Self, source: SourceLocation) bool {
+        fn valid_hash_chain(self: *const Self, source: SourceLocation) bool {
             assert(self.op_checkpoint() <= self.commit_min);
             assert(self.op_checkpoint() <= self.op);
 
@@ -9494,83 +9436,6 @@ pub fn ReplicaType(
                     self.transition_to_view_change_status(header.view);
                 },
                 else => unreachable,
-            }
-        }
-
-        fn jump_sync_target(self: *Self, header: *const Header) void {
-            if (header.into_const(.commit)) |h| assert(h.commit >= h.checkpoint_op);
-
-            if (header.replica >= self.replica_count) return; // Ignore messages from standbys.
-            if (header.replica == self.replica) return; // Ignore messages from self (misdirected).
-
-            const candidate: SyncTarget = switch (header.into_any()) {
-                inline .commit, .ping => |h| .{
-                    .checkpoint_id = h.checkpoint_id,
-                    .checkpoint_op = h.checkpoint_op,
-                    .view = h.view,
-                },
-                else => return,
-            };
-
-            if (candidate.checkpoint_op == self.op_checkpoint() and
-                candidate.checkpoint_id != self.superblock.working.checkpoint_id())
-            {
-                log.err("{}: on_{s}: jump_sync_target: checkpoint diverged " ++
-                    "(op={} id_from_superblock={x:0>32} id_from_commit={x:0>32})", .{
-                    self.replica,
-                    @tagName(header.command),
-                    candidate.checkpoint_op,
-                    self.superblock.working.checkpoint_id(),
-                    candidate.checkpoint_id,
-                });
-
-                // Either this replica, the header's replica, or both, have diverged.
-                @panic("checkpoint diverged");
-            }
-
-            // Don't sync backwards, or to our current checkpoint.
-            if (candidate.checkpoint_op <= self.op_checkpoint()) return;
-
-            // Don't sync to the immediately-next checkpoint unless it has been committed atop.
-            // - If the checkpoint has been committed atop, that guarantees that at least a
-            //   commit-quorum of replicas has reached that exact checkpoint.
-            // - If the next checkpoint has *not* been committed atop yet, then we can (and should)
-            //   sync via WAL replay instead to maximize durability.
-            //
-            // To understand why this is critical, consider the case (R=3) where:
-            // 1. R₀ is primary.
-            // 2. R₀ prepares and acks all ops.
-            // 3. R₁ prepares and acks odd ops.
-            // 4. R₂ prepares and acks even ops.
-            // 5. R₀ is able to commit an entire checkpoint, but not beyond that.
-            // If R₁/R₂ state-sync to R₀'s latest checkpoint, then a single block corruption on R₀
-            // could lead to permanent unavailability.
-            if (candidate.checkpoint_op == self.op_checkpoint_next()) {
-                if (header.into_const(.commit)) |h| {
-                    if (h.commit <= self.op_prepare_max()) return;
-                } else {
-                    return;
-                }
-            }
-
-            if (self.sync_target_max != null and
-                self.sync_target_max.?.checkpoint_op >= candidate.checkpoint_op)
-            {
-                return;
-            }
-
-            log.debug("{}: on_{s}: jump_sync_target: op={} id={x:0>32} (syncing={s})", .{
-                self.replica,
-                @tagName(header.command),
-                candidate.checkpoint_op,
-                candidate.checkpoint_id,
-                @tagName(self.syncing),
-            });
-
-            self.sync_target_max = candidate;
-
-            if (self.syncing != .idle) {
-                self.sync_start_from_sync();
             }
         }
 
@@ -10388,9 +10253,14 @@ fn message_body_as_headers_unchecked(message: *const Message) []const Header.Pre
         message.header.command == .start_view or
         message.header.command == .headers);
 
+    const headers_end_offset = switch (message.header.command) {
+        .start_view => message.header.size - @sizeOf(vsr.CheckpointState),
+        else => message.header.size,
+    };
+
     return std.mem.bytesAsSlice(
         Header.Prepare,
-        message.buffer[@sizeOf(Header)..message.header.size],
+        message.buffer[@sizeOf(Header)..headers_end_offset],
     );
 }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1916,6 +1916,7 @@ pub fn ReplicaType(
 
         fn on_repair(self: *Self, message: *Message.Prepare) void {
             assert(message.header.command == .prepare);
+            assert(self.syncing != .updating_superblock);
 
             if (self.status != .normal and self.status != .view_change) {
                 log.debug("{}: on_repair: ignoring ({})", .{ self.replica, self.status });
@@ -2240,16 +2241,19 @@ pub fn ReplicaType(
             assert(view_headers[0].op >= view_headers[view_headers.len - 1].op);
 
             if (message.header.commit > self.op_prepare_max() and (
-            //  Cluster is far ahead, replica's WAL no longer intersects primary's WAL.
+            //  Cluster is at least two checkpoints ahead. Although SV's checkpoint is not
+            //  guaranteed to be durable on a quorum of replicas, it is safe to sync to it, because
+            //  prepares in this replica's WAL are no longer needed.
                 message.header.commit > self.op_prepare_max() + constants.vsr_checkpoint_interval or
-                // Cluster is a bit ahead. The replica might still be able to repair WAL, but that
-                // is not certain.
+                // Cluster is on the next checkpoint, and that checkpoint is durable and is safe to
+                // sync to. Try to optimistically avoid state sync and prefer WAL repair, unless
+                // there's evidence that the repair can't be completed.
                 (self.syncing == .idle and self.repair_stuck()) or
                 // Completing previously starting state sync.
                 self.syncing == .awaiting_checkpoint))
             {
-                // State sync: at this point, the we know we want to replace our checkpoint
-                // with the one from SV.
+                // State sync: at this point, we know we want to replace our checkpoint
+                // with the one from this SV.
 
                 assert(message.header.commit > self.op_checkpoint_next_trigger());
                 assert(view_checkpoint.header.op > self.op_checkpoint());
@@ -2259,7 +2263,7 @@ pub fn ReplicaType(
                     // need state sync after all.
                     if (self.commit_stage == .checkpoint_superblock) return;
                     if (self.commit_stage == .checkpoint_data) return;
-                    // Otherwise, cancel in progress commit and prepare to sync
+                    // Otherwise, cancel in progress commit and prepare to sync.
                     self.sync_start_from_committing();
                     assert(self.syncing != .idle);
                 }
@@ -2270,7 +2274,7 @@ pub fn ReplicaType(
                     .updating_superblock,
                     => {
                         log.debug(
-                            \\{}: on_start_view sync {s} view={} op_checkpoint={} op_checkpoint_new={}
+                            \\{}: on_start_view: sync {s} view={} op_checkpoint={} op_checkpoint_new={}
                         , .{
                             self.replica,
                             @tagName(self.syncing),
@@ -2284,7 +2288,7 @@ pub fn ReplicaType(
                 }
 
                 log.debug(
-                    \\{}: on_start_view sync started view={} op_checkpoint={} op_checkpoint_new={}
+                    \\{}: on_start_view sync: started view={} op_checkpoint={} op_checkpoint_new={}
                 , .{
                     self.replica,
                     self.log_view,
@@ -2296,7 +2300,7 @@ pub fn ReplicaType(
                     .checkpoint_state = view_checkpoint.*,
                 } });
 
-                // The new checkpoint would we written to the superblock asynchronously.
+                // The new checkpoint will be written to the superblock asynchronously.
                 // From this point on, we are in a delicate state where we must be using this
                 // in-memory checkpoint to check validity of log messages.
                 assert(self.syncing == .updating_superblock);
@@ -7895,7 +7899,8 @@ pub fn ReplicaType(
                                 self.op_checkpoint(),
                             )) |trigger|
                                 // +1 because sync_op_min is inclusive, but (when !syncing_already)
-                                // `vsr_state.commit_min` itself does not need to be synced.
+                                // `vsr_state.checkpoint.commit_min` itself does not need to be
+                                // synced.
                                 trigger + 1
                             else
                                 0;
@@ -7942,9 +7947,6 @@ pub fn ReplicaType(
                 },
                 else => {},
             }
-
-            // recovering_head here is triggered by state sync.
-            if (self.status == .recovering_head) return;
 
             // The view/log_view incremented while the previous view-change update was being saved.
             const update = self.log_view_durable() < self.log_view or
@@ -8932,13 +8934,17 @@ pub fn ReplicaType(
         fn sync_superblock_update_start(self: *Self) void {
             assert(!self.solo());
             assert(self.syncing == .updating_superblock);
+            assert(self.superblock.working.vsr_state.checkpoint.header.op <
+                self.syncing.updating_superblock.checkpoint_state.header.checksum);
             assert(self.sync_tables == null);
+            assert(self.commit_stage == .idle);
             assert(self.grid.read_global_queue.empty());
             assert(self.grid.write_queue.empty());
             assert(self.grid_repair_tables.executing() == 0);
             assert(self.grid_repair_writes.executing() == 0);
             assert(self.grid.blocks_missing.faulty_blocks.count() == 0);
             maybe(self.state_machine_opened);
+            maybe(self.view_durable_updating());
 
             self.state_machine_opened = false;
             self.state_machine.reset();
@@ -8951,6 +8957,7 @@ pub fn ReplicaType(
 
         fn sync_superblock_update_finish(self: *Self) void {
             assert(self.sync_tables == null);
+            assert(self.commit_stage == .idle);
             assert(self.grid.read_global_queue.empty());
             assert(self.grid.write_queue.empty());
             assert(self.grid_repair_tables.executing() == 0);
@@ -8964,6 +8971,8 @@ pub fn ReplicaType(
             const stage: *const SyncStage.UpdatingSuperBlock = &self.syncing.updating_superblock;
 
             assert(self.superblock.working.vsr_state.checkpoint.header.checksum ==
+                stage.checkpoint_state.header.checksum);
+            assert(self.superblock.staging.vsr_state.checkpoint.header.checksum ==
                 stage.checkpoint_state.header.checksum);
             assert(stdx.equal_bytes(
                 vsr.CheckpointState,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2010,6 +2010,7 @@ const TestReplicas = struct {
     ) void {
         const paths = t.peer_paths(peer, direction);
         for (paths.const_slice()) |path| t.cluster.network.link_filter(path).insert(command);
+        if (command == .start_view) t.pass(peer, direction, .start_view_deprecated);
     }
 
     pub fn drop(
@@ -2020,6 +2021,7 @@ const TestReplicas = struct {
     ) void {
         const paths = t.peer_paths(peer, direction);
         for (paths.const_slice()) |path| t.cluster.network.link_filter(path).remove(command);
+        if (command == .start_view) t.drop(peer, direction, .start_view_deprecated);
     }
 
     pub fn filter(

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -929,13 +929,13 @@ test "Cluster: view-change: nack older view" {
 
 test "Cluster: sync: partition, lag, sync (transition from idle)" {
     for ([_]u64{
-        // Normal case: the cluster has committed atop the checkpoint trigger.
+        // Normal case: the cluster has prepared beyond the checkpoint.
         // The lagging replica can learn the latest checkpoint from a commit message.
-        checkpoint_2_trigger + 1,
-        // Idle case: the idle cluster has not committed atop the checkpoint trigger.
+        checkpoint_2_prepare_max + 1,
+        // Idle case: the idle cluster has not prepared beyond the checkpoint.
         // The lagging replica is far enough behind the cluster that it can sync to the latest
         // checkpoint anyway, since it cannot possibly recover via WAL repair.
-        checkpoint_2_trigger,
+        checkpoint_2_prepare_max,
     }) |cluster_commit_max| {
         log.info("test cluster_commit_max={}", .{cluster_commit_max});
 
@@ -963,39 +963,6 @@ test "Cluster: sync: partition, lag, sync (transition from idle)" {
         t.run(); // (Wait for grid sync to finish.)
         try TestReplicas.expect_sync_done(t.replica(.R_));
     }
-}
-
-test "Cluster: sync: sync, bump target, sync" {
-    const t = try TestContext.init(.{ .replica_count = 3 });
-    defer t.deinit();
-
-    var c = t.clients(0, t.cluster.clients.len);
-
-    t.replica(.R2).drop_all(.R_, .bidirectional);
-    try c.request(checkpoint_2_trigger, checkpoint_2_trigger);
-
-    // Allow R2 to complete SyncStage.requesting_target, but get stuck
-    // during SyncStage.requesting_checkpoint.
-    t.replica(.R2).pass_all(.R_, .bidirectional);
-    t.replica(.R2).drop(.R_, .outgoing, .request_sync_checkpoint);
-    t.run();
-    try expectEqual(t.replica(.R2).sync_status(), .requesting_checkpoint);
-    try expectEqual(t.replica(.R2).sync_target_checkpoint_op(), checkpoint_2);
-
-    // R2 discovers the newer sync target and restarts sync.
-    try c.request(checkpoint_3_trigger, checkpoint_3_trigger);
-    try expectEqual(t.replica(.R2).sync_status(), .requesting_checkpoint);
-    try expectEqual(t.replica(.R2).sync_target_checkpoint_op(), checkpoint_3);
-
-    t.replica(.R2).pass(.R_, .bidirectional, .request_sync_checkpoint);
-    t.run();
-
-    try expectEqual(t.replica(.R_).status(), .normal);
-    try expectEqual(t.replica(.R_).commit(), checkpoint_3_trigger);
-    try expectEqual(t.replica(.R_).sync_status(), .idle);
-
-    t.run(); // (Wait for grid sync to finish.)
-    try TestReplicas.expect_sync_done(t.replica(.R_));
 }
 
 test "Cluster: repair: R=2 (primary checkpoints, but backup lags behind)" {
@@ -1073,55 +1040,47 @@ test "Cluster: sync: R=4, 2/4 ahead + idle, 2/4 lagging, sync" {
     try TestReplicas.expect_sync_done(t.replica(.R_));
 }
 
-// TODO: Replicas in recovering_head cannot (currently) participate in view-change, even when
-// they arrived at recovering_head via state sync, not corruption+crash. As a result, it is possible
-// for a 2/3 cluster to get stuck without any corruptions or crashes.
-// See: https://github.com/tigerbeetle/tigerbeetle/pull/933#discussion_r1245440623,
-// https://github.com/tigerbeetle/tigerbeetle/issues/1376, and `Simulator.core_missing_quorum()`.
-test "Cluster: sync: view-change with lagging replica in recovering_head" {
+test "Cluster: sync: view-change with lagging replica" {
+    // Check that a cluster can view change even if view-change quorum contains syncing replicas.
+    // This used to be a special case for an older sync protocol, but now this mostly holds by
+    // construction.
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
 
     var c = t.clients(0, t.cluster.clients.len);
-    // B2 will need at least one commit to ensure it ends up in recovering_head.
-    try c.request(1, 1);
+    try c.request(1, 1); // Make sure that the logic doesn't depend on the root prepare.
     try expectEqual(t.replica(.R_).commit(), 1);
 
     var a0 = t.replica(.A0);
     var b1 = t.replica(.B1);
     var b2 = t.replica(.B2);
 
-    b2.drop_all(.R_, .bidirectional);
+    b2.drop_all(.R_, .bidirectional); // Isolate B2.
     try c.request(checkpoint_2_trigger, checkpoint_2_trigger);
 
     // Allow B2 to join, but partition A0 to force a view change.
-    // B2 is lagging far enough behind that it must state sync – it will transition to
-    // recovering_head. Despite this, the cluster of B1/B2 should recover to normal status.
+    // B2 is lagging far enough behind that it must state sync.
+    // Despite this, the cluster of B1/B2 should recover to normal status.
     b2.pass_all(.R_, .bidirectional);
     a0.drop_all(.R_, .bidirectional);
 
-    // When B2 rejoins, it will race between:
-    // - Discovering that it is lagging, and requesting a sync_checkpoint (which transitions B2 to
-    //   recovering_head).
-    // - Participating in a view-change with B1 (while we are still in status=normal in the original
-    //   view).
-    // For this test, we want the former to occur before the latter (since the latter would always
-    // work).
-    b2.drop(.R_, .bidirectional, .start_view_change);
+    // Let the cluster run for some time without B2 state syncing.
+    b2.drop(.R_, .bidirectional, .start_view);
     t.run();
-    b2.pass(.R_, .bidirectional, .start_view_change);
-    t.run();
+    try expectEqual(b2.op_checkpoint(), 0);
 
-    // try expectEqual(b1.role(), .primary);
-    try expectEqual(b1.status(), .normal);
-    try expectEqual(b2.status(), .recovering_head);
-    // try expectEqual(t.replica(.R_).status(), .normal);
+    // Let B2 state sync. This unblocks the cluster.
+    b2.pass(.R_, .bidirectional, .start_view);
+    t.run();
+    try expectEqual(b1.role(), .primary);
+    try expectEqual(t.replica(.R_).status(), .normal);
     try expectEqual(t.replica(.R_).sync_status(), .idle);
-    try expectEqual(b2.commit(), checkpoint_2);
-    // try expectEqual(t.replica(.R_).commit(), checkpoint_2_trigger);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_2_trigger);
     try expectEqual(t.replica(.R_).op_checkpoint(), checkpoint_2);
 
-    // try TestReplicas.expect_sync_done(t.replica(.R_));
+    // Note: we need to commit more --- state sync status is cleared only at checkpoint.
+    try c.request(checkpoint_3_trigger, checkpoint_3_trigger);
+    try TestReplicas.expect_sync_done(t.replica(.R_));
 }
 
 test "Cluster: sync: slightly lagging replica" {
@@ -1206,18 +1165,11 @@ test "Cluster: sync: checkpoint from a newer view" {
         b1.drop(.R_, .incoming, .ping);
         b1.drop(.R_, .incoming, .pong);
 
-        const b1_view_before = b1.view();
         try c.request(checkpoint_2_trigger - 1, checkpoint_2_trigger - 1);
-        try expectEqual(b1_view_before, b1.view());
-        try expectEqual(b1.op_checkpoint(), checkpoint_1);
-        try expectEqual(b1.status(), .recovering_head);
 
         b1.stop();
         try b1.open();
         t.run();
-        try expectEqual(b1_view_before, b1.view());
-        try expectEqual(b1.op_checkpoint(), checkpoint_1);
-        try expectEqual(b1.status(), .recovering_head);
     }
 
     t.replica(.R_).pass_all(.R_, .bidirectional);
@@ -2129,7 +2081,7 @@ const TestReplicas = struct {
 
         for (t.replicas.const_slice()) |replica_index| {
             const replica: *const Cluster.Replica = &t.cluster.replicas[replica_index];
-            assert(replica.sync_content_done());
+            if (!replica.sync_content_done()) return error.SyncContentPending;
 
             // If the replica has finished syncing, but not yet checkpointed, then it might not have
             // updated its sync_op_max.

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -902,10 +902,15 @@ pub fn SuperBlockType(comptime Storage: type) type {
             sync_op_max: u64,
         };
 
-        /// The replica calls view_change() to persist its view/log_view — it cannot
-        /// advertise either value until it is certain they will never backtrack.
+        /// The replica calls view_change():
         ///
-        /// The update must advance view/log_view (monotonically increasing).
+        /// - to persist its view/log_view — it cannot advertise either value until it is certain
+        ///   they will never backtrack.
+        /// - to update checkpoint during sync
+        ///
+        /// The update must advance view/log_view (monotonically increasing) or checkpoint.
+        // TODO: the current naming confusing and needs changing: during sync, this function doesn't
+        //       necessary advance the view.
         pub fn view_change(
             superblock: *SuperBlock,
             callback: *const fn (context: *Context) void,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -372,6 +372,9 @@ const Environment = struct {
                 .command = .do_view_change,
                 .array = vsr_headers,
             },
+            .checkpoint = &vsr_state.checkpoint,
+            .sync_op_min = vsr_state.sync_op_min,
+            .sync_op_max = vsr_state.sync_op_max,
         });
     }
 

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -18,18 +18,19 @@ pub const Stage = union(enum) {
     /// Waiting for `Grid.cancel()`.
     canceling_grid,
 
-    /// We need to sync, but are waiting for a usable `sync_target_max`.
-    requesting_target,
+    /// We received an SV, decided to sync, but were committing at that point. So instead we
+    /// requested cancelletion of the commit process and entered `awaiting_checkpoint` to get
+    /// a new SV in the future, while commit stage is idle.
+    ///
+    /// TODO: Right now this works by literally requesting a new SV from the primary, but it would
+    ///       be better to hold onto the original SV in memory and re-trigger `on_start_view` after
+    ///       cancellation is done.
+    awaiting_checkpoint,
 
-    requesting_checkpoint: RequestingCheckpoint,
+    /// We received a new checkpoint and a log suffix are in process of writing them to disk.
     updating_superblock: UpdatingSuperBlock,
 
-    pub const RequestingCheckpoint = struct {
-        target: Target,
-    };
-
     pub const UpdatingSuperBlock = struct {
-        target: Target,
         checkpoint_state: vsr.CheckpointState,
     };
 
@@ -37,37 +38,11 @@ pub const Stage = union(enum) {
         return switch (from) {
             .idle => to == .canceling_commit or
                 to == .canceling_grid or
-                to == .requesting_target,
+                to == .awaiting_checkpoint,
             .canceling_commit => to == .canceling_grid,
-            .canceling_grid => to == .requesting_target,
-            .requesting_target => to == .requesting_target or
-                to == .requesting_checkpoint,
-            .requesting_checkpoint => to == .requesting_checkpoint or
-                to == .updating_superblock,
-            .updating_superblock => to == .requesting_checkpoint or
-                to == .idle,
+            .canceling_grid => to == .awaiting_checkpoint,
+            .awaiting_checkpoint => to == .awaiting_checkpoint or to == .updating_superblock,
+            .updating_superblock => to == .idle,
         };
     }
-
-    pub fn target(stage: *const Stage) ?Target {
-        return switch (stage.*) {
-            .idle,
-            .canceling_commit,
-            .canceling_grid,
-            .requesting_target,
-            => null,
-            .requesting_checkpoint => |s| s.target,
-            .updating_superblock => |s| s.target,
-        };
-    }
-};
-
-pub const Target = struct {
-    /// The target's checkpoint identifier.
-    checkpoint_id: u128,
-    /// The op_checkpoint() that corresponds to the checkpoint id.
-    checkpoint_op: u64,
-    /// The view where the target's checkpoint is committed.
-    /// It might be greater than `checkpoint.header.view`.
-    view: u32,
 };

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -19,7 +19,7 @@ pub const Stage = union(enum) {
     canceling_grid,
 
     /// We received an SV, decided to sync, but were committing at that point. So instead we
-    /// requested cancelletion of the commit process and entered `awaiting_checkpoint` to get
+    /// requested cancellation of the commit process and entered `awaiting_checkpoint` to get
     /// a new SV in the future, while commit stage is idle.
     ///
     /// TODO: Right now this works by literally requesting a new SV from the primary, but it would


### PR DESCRIPTION
This commit implements the new state sync protocol, which fixes a couple
of long-standing liveness issues. As an unintended bonus, the new
implementation ends up being simpler, at least if measured in lines of
code!

 ## Old Protocol Problems

The original thinking was to implement state-sync as a separate
protocol, mostly orthogonal to the rest of VSR. VSR maintains the log,
state sync maintains the checkpoint. Checkpoints are committed, so
there's no doubt regarding _what_ to sync, so a separate protocol sounds
easy enough, right?

Well, turns out its' not that simple, as the two issues were discovered:

_First_, the log and the checkpoint might become physically disjoint
(checkpoint ahead of the log). The implementation fixed this case by
maneuvering the replica into recovering_head, but that sadly created a
liveness issue --- recovering_head replicas don't participate in
consensus, so it is possible for cluster to get stuck (with most of the
cluster in recovering_head) even without any storage faults!

_Second_, the log and the checkpoint might become logically inconsistent
(the message in the log for the checkpoint's slot might be from the
different view). Although checkpoint is committed, that's not true about
the log! This issue manifested itself as assertion failures in
`valid_hash_chain`. There were several band-aid fixes for the failures,
which boiled down to maneuvering replica into recovering_head if
checkpoint's view and log view are different. But we weren't able to
plug all the wholes, as it slowly became apparent that fixing everything
would require duplicating VSR-specfic SV handling logic when dealing
with checkpoints.

 ## The New Protocol

The idea is rather simple --- add primary's checkpoint to SV and handle
state sync in `on_start_view`. This makes it so that the checkpoint and
log are consistent by construction. This also yields an unexpected
benefit: a replica no longer ignores SV's which are too far in the
future, it is always possible to install a header from SV (although you
might need to update the checkpoint as well).

The implementation is somewhat tricky --- we update checkpoint
asynchronously, but we update replica state immediately, so there's a
window while our `op` is consistent with in-memory checkpoint, but not
on-disc checkpoint. This signalled by

    self.syncing == .updating_superblock

state. While in this state, the replica mostly just waits for the
superblock update to finish and doesn't do much else.

Additionally, the implementation right now is optimized for smaller
diff, rather than for path dependent perfection. For example, we still
call it `Superblock.view_change`, even though now this function can be
called _only_ to advance the checkpoint state. I want to do a follow up
cleanup PR. There's perhaps more code/asserts that needs to be adjusted
now that `.recovering_head` is again possible only after `.recovering`.

The equivalent code have been running in VOPR for quite some time, and I
think any sync-consistency related issues are fixed. The one current
outstading VOPR bug (with several seeds) is an orthogonal issue where we
allow to sync to a checkpoint before it's sync_content is done.

This particular commit has some extra assertions and cleanups, so they
might still blow up, but hopefully would be trivial to fix.