### PR TITLE
auditor: fix non-determinism 

### DIFF
--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -44,14 +44,14 @@ const PendingTransfer = struct {
 };
 
 const PendingExpiry = struct {
-    transfer: u128,
-    timestamp: u64,
+    transfer_id: u128,
+    expires_at: u64,
 };
 
 const PendingExpiryQueue = PriorityQueue(PendingExpiry, void, struct {
     /// Order by ascending timestamp.
     fn compare(_: void, a: PendingExpiry, b: PendingExpiry) std.math.Order {
-        return std.math.order(a.timestamp, b.timestamp);
+        return std.math.order(a.expires_at, b.expires_at);
     }
 }.compare);
 
@@ -214,12 +214,13 @@ pub const AccountingAuditor = struct {
 
         var expired_count: u32 = 0;
         while (self.pending_expiries.peek()) |expiration| {
-            if (timestamp < expiration.timestamp) break;
+            if (timestamp < expiration.expires_at) break;
             defer _ = self.pending_expiries.remove();
 
             // Ignore the transfer if it was already posted/voided.
-            const pending_transfer = self.pending_transfers.get(expiration.transfer) orelse continue;
-            assert(self.pending_transfers.remove(expiration.transfer));
+            const pending_transfer =
+                self.pending_transfers.get(expiration.transfer_id) orelse continue;
+            assert(self.pending_transfers.remove(expiration.transfer_id));
             assert(self.accounts_created[pending_transfer.debit_account_index]);
             assert(self.accounts_created[pending_transfer.credit_account_index]);
 
@@ -353,8 +354,8 @@ pub const AccountingAuditor = struct {
                             .credit_account_index = cr_index,
                         });
                         self.pending_expiries.add(.{
-                            .transfer = transfer.id,
-                            .timestamp = transfer_timestamp + transfer.timeout_ns(),
+                            .transfer_id = transfer.id,
+                            .expires_at = transfer_timestamp + transfer.timeout_ns(),
                         }) catch unreachable;
                         // PriorityQueue lacks an "unmanaged" API, so verify that the workload hasn't
                         // created more pending transfers than permitted.


### PR DESCRIPTION
Expiration timestamp might match between two transfers, so the order of
items in the priority queue is non-deterministic. The order is
important, because we expire a batchfull of transfers at a time at most.

Order the transfers by their (unique) timestamp, just like the state
machine!


This the second priority queue bug in a row!