### PR TITLE
fix: broken link in `account-balance.md`

### DIFF
--- a/docs/reference/account-balance.md
+++ b/docs/reference/account-balance.md
@@ -8,7 +8,7 @@ An `AccountBalance` is a record storing the [`Account`](./account.md)'s balance 
 time.
 
 Only Accounts with the flag [`history`](./account.md#flagshistory) set retain
-[historical balances](https://docs.tigerbeetle.com/reference/operations/get_account_balances).
+[historical balances](https://docs.tigerbeetle.com/reference/requests/get_account_balances).
 
 ## Fields
 


### PR DESCRIPTION
I noticed this link was broken when I was looking through the nodejs docs