### PR TITLE
flags: add tests for underscores in numbers

### DIFF
--- a/src/flags.zig
+++ b/src/flags.zig
@@ -1033,9 +1033,41 @@ test "flags" {
         \\
     ));
 
+    try t.check(&.{ "values", "--int=-92" }, snap(@src(),
+        \\status: 1
+        \\stderr:
+        \\error: --int: value exceeds 32-bit unsigned integer: '-92'
+        \\
+    ));
+
+    try t.check(&.{ "values", "--int=_92" }, snap(@src(),
+        \\status: 1
+        \\stderr:
+        \\error: --int: expected an integer value, but found '_92' (invalid digit)
+        \\
+    ));
+
+    try t.check(&.{ "values", "--int=92_" }, snap(@src(),
+        \\status: 1
+        \\stderr:
+        \\error: --int: expected an integer value, but found '92_' (invalid digit)
+        \\
+    ));
+
     try t.check(&.{ "values", "--int=92" }, snap(@src(),
         \\stdout:
         \\int: 92
+        \\size: 0
+        \\boolean: false
+        \\path: not-set
+        \\optional: null
+        \\choice: marlowe
+        \\
+    ));
+
+    try t.check(&.{ "values", "--int=900_200" }, snap(@src(),
+        \\stdout:
+        \\int: 900200
         \\size: 0
         \\boolean: false
         \\path: not-set
@@ -1055,6 +1087,13 @@ test "flags" {
         \\status: 1
         \\stderr:
         \\error: --int: value exceeds 32-bit unsigned integer: '44444444444444444444'
+        \\
+    ));
+
+    try t.check(&.{ "values", "--size=1_000KiB" }, snap(@src(),
+        \\status: 1
+        \\stderr:
+        \\error: --size: invalid unit in size '1_000KiB', (needed KiB, MiB, GiB or TiB)
         \\
     ));
 


### PR DESCRIPTION
For numerical CLI arguments, we support readability underscores like 10_000_000. We get for free from Zig's std.parseInt function.

At the time of writing, this wasn't intentional, but we might as well officially support this (I was actually thinking about _adding_ this feature the other day, this is very useful for ticks_max argument of the simulator).

So let's add tests here to make sure this won't regress in the future!

Note that underscores are _not_ supported for byte sizes. It won't be hard to add support for `_`` for sizes, but we already support scale suffixes, so adding underscores is in some sence redundant