### PR TITLE
Scripts/Changelog: Allow nonexistent ./zig-cache

### DIFF
--- a/src/scripts/changelog.zig
+++ b/src/scripts/changelog.zig
@@ -17,6 +17,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator) !void {
     const merges = try shell.exec_stdout(
         \\git log --merges --first-parent origin/release..origin/main
     , .{});
+    try shell.project_root.makePath("./zig-cache");
     try shell.project_root.writeFile("./zig-cache/merges.txt", merges);
     log.info("merged PRs: ./zig-cache/merges.txt", .{});
 


### PR DESCRIPTION
Don't fail to build the changelog if the `./zig-cache` directory doesn't exist.

I ran into this as I was building the [changelog](https://github.com/tigerbeetle/tigerbeetle/pull/1966) from within a brand-new worktree, so `zig-cache` didn't exist yet.