### PR TITLE
VSR/Journal: Document recovery case `@L`

### DIFF
--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -61,7 +61,7 @@ pub fn ManifestLevelType(
             );
 
             // The tables are ordered by (key_max,snapshot_min),
-            // fields are declared from the least siginificant to the most significant:
+            // fields are declared from the least significant to the most significant:
 
             snapshot_min: u64,
             key_max: Key,


### PR DESCRIPTION
Add explanation for why case `@L` doesn't use `decision=fix`.