### PR TITLE
dotnet: Build for .NET 8, the current LTS version

### DIFF
--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'ubuntu-latest',  language: 'dotnet',  language_version: '7.0.x' }
+          - { os: 'ubuntu-latest',  language: 'dotnet',  language_version: '8.0.x' }
           - { os: 'ubuntu-latest',  language: 'go',      language_version: '1.18'  }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '11'    }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '21'    }
           - { os: 'ubuntu-latest',  language: 'node',    language_version: '18.x'  }
           - { os: 'ubuntu-latest',  language: 'node',    language_version: '20.x'  }
 
-          - { os: 'windows-latest', language: 'dotnet',  language_version: '7.0.x' }
+          - { os: 'windows-latest', language: 'dotnet',  language_version: '8.0.x' }
           - { os: 'windows-latest', language: 'go',      language_version: '1.18'  }
           - { os: 'windows-latest', language: 'java',    language_version: '11'    }
           - { os: 'windows-latest', language: 'java',    language_version: '21'    }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version:
-            7.0.x
+            8.0.x
 
       - uses: actions/setup-go@v5
         with:

--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -11,7 +11,7 @@ The TigerBeetle client for .NET.
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* .NET >= 7.0.
+* .NET >= 8.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:

--- a/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
+++ b/src/clients/dotnet/TigerBeetle.Tests/TigerBeetle.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="TigerBeetle.props" />
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="TigerBeetle.props" />
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -57,8 +57,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         try shell.exec("dotnet pack --configuration Release", .{});
 
         const image_tags = .{
-            "7.0",        "8.0",
-            "7.0-alpine", "8.0-alpine",
+            "8.0", "8.0-alpine",
         };
 
         inline for (image_tags) |image_tag| {

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -20,7 +20,7 @@ pub const DotnetDocs = Docs{
     ,
 
     .prerequisites =
-    \\* .NET >= 7.0.
+    \\* .NET >= 8.0.
     \\
     \\And if you do not already have NuGet.org as a package
     \\source, make sure to add it:

--- a/src/clients/dotnet/samples/basic/Basic.csproj
+++ b/src/clients/dotnet/samples/basic/Basic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>

--- a/src/clients/dotnet/samples/basic/README.md
+++ b/src/clients/dotnet/samples/basic/README.md
@@ -7,7 +7,7 @@ Code for this sample is in [./Program.cs](./Program.cs).
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* .NET >= 7.0.
+* .NET >= 8.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:

--- a/src/clients/dotnet/samples/two-phase-many/README.md
+++ b/src/clients/dotnet/samples/two-phase-many/README.md
@@ -7,7 +7,7 @@ Code for this sample is in [./Program.cs](./Program.cs).
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* .NET >= 7.0.
+* .NET >= 8.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:

--- a/src/clients/dotnet/samples/two-phase-many/TwoPhaseMany.csproj
+++ b/src/clients/dotnet/samples/two-phase-many/TwoPhaseMany.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>

--- a/src/clients/dotnet/samples/two-phase/README.md
+++ b/src/clients/dotnet/samples/two-phase/README.md
@@ -7,7 +7,7 @@ Code for this sample is in [./Program.cs](./Program.cs).
 
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
-* .NET >= 7.0.
+* .NET >= 8.0.
 
 And if you do not already have NuGet.org as a package
 source, make sure to add it:

--- a/src/clients/dotnet/samples/two-phase/TwoPhase.csproj
+++ b/src/clients/dotnet/samples/two-phase/TwoPhase.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>

--- a/src/clients/dotnet/samples/walkthrough/Walkthrough.csproj
+++ b/src/clients/dotnet/samples/walkthrough/Walkthrough.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RollForward>LatestMajor</RollForward>


### PR DESCRIPTION
Simply update the .NET client project to build for net8.0 alongside the previous version, 7.0 and change the GitHub Workflow to use dotnet tool version 8.0.x instead ofo 7.0.x

.NET 7 is already out of support and .NET 8 is the current LTS version
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle
