### PR TITLE
vsr: crash during solo upgrades is fixed

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3157,7 +3157,15 @@ pub fn ReplicaType(
                 //   progress, it needs to start preparing more upgrades.
                 const release_next = self.release_for_next_checkpoint();
                 if (release_next == null or release_next.?.value != upgrade_release.value) {
-                    self.send_request_upgrade_to_self();
+                    if (self.solo() and self.view_durable_updating()) {
+                        // Solo replica just after recovering is still updating its view and ignores
+                        // requests, postpone until the next timer expiry.
+                        log.debug("{}: on_upgrade_timeout: ignoring (still persisting view)", .{
+                            self.replica,
+                        });
+                    } else {
+                        self.send_request_upgrade_to_self();
+                    }
                 } else {
                     // (Don't send an upgrade to ourself if we are already ready to upgrade and just
                     // waiting on the last commit + checkpoint before we restart.)


### PR DESCRIPTION
A Solo replica after restart is weird: it commits WAL while in `.recovery` state. In particular, this means that it _doesn't_ chain `request_upgrade_to_self`. This is normal, as we have a timer to restart the upgrade sequence (technically, this falls under "a primary starts a new view", as after restart, Solo needs to bump its view).

But this timer actually leads to a crash, when we unexpectedly ignore the request due to this special case:

    if (self.solo()) {
        if (self.view_durable_updating()) {
            log.debug("{}: on_request: ignoring (still persisting view)", .{self.replica});
            return true;
        }
    }

Fix this in straightforward way by not sending the request if its going to get ignored anyway.

Seed: ./zig/zig build -Dsimulator-state-machine=testing simulator_run -- 16421311959593547585