### PR TITLE
Remove @constCast from lsm iteration

### DIFF
--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -383,7 +383,7 @@ pub fn ManifestLevelType(
             direction: Direction,
             key_range: ?KeyRange,
 
-            pub fn next(it: *Iterator) ?*const TableInfo {
+            pub fn next(it: *Iterator) ?*TableInfo {
                 while (it.inner.next()) |table| {
                     // We can't assert !it.inner.done as inner.next() may set done before returning.
 
@@ -576,7 +576,7 @@ pub fn ManifestLevelType(
                 if (optimal == null or range.tables.count() < optimal.?.range.tables.count()) {
                     optimal = LeastOverlapTable{
                         .table = TableInfoReference{
-                            .table_info = @constCast(table),
+                            .table_info = table,
                             .generation = level_a.generation,
                         },
                         .range = range,
@@ -710,11 +710,9 @@ pub fn ManifestLevelType(
                 if (table.key_max > range.key_max) {
                     range.key_max = table.key_max;
                 }
-                // This const cast is safe as we know that the memory pointed to is in fact
-                // mutable. That is, the table is not in the .text or .rodata section.
                 if (range.tables.count() < max_overlapping_tables) {
                     const table_info_reference = TableInfoReference{
-                        .table_info = @constCast(table),
+                        .table_info = table,
                         .generation = level.generation,
                     };
                     range.tables.append_assume_capacity(table_info_reference);
@@ -1024,7 +1022,7 @@ pub fn TestContext(
                 while (it.next()) |level_table| {
                     if (level_table.equal(table)) {
                         context.level.set_snapshot_max(snapshot, .{
-                            .table_info = @constCast(level_table),
+                            .table_info = level_table,
                             .generation = context.level.generation,
                         });
                         table.snapshot_max = snapshot;

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -388,7 +388,7 @@ pub fn EnvironmentType(comptime table_count_max: u32, comptime node_size: u32) t
                 assert(level_table.equal(env_table));
 
                 env.level.set_snapshot_max(env.snapshot, .{
-                    .table_info = @constCast(level_table),
+                    .table_info = level_table,
                     .generation = env.level.generation,
                 });
                 // This is required to keep the table in the fuzzer's environment consistent with

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -765,7 +765,7 @@ fn SegmentedArrayType(
             /// if the returned table info is outside the key range.
             done: bool = false,
 
-            pub fn next(it: *Iterator) ?*const T {
+            pub fn next(it: *Iterator) ?*T {
                 if (it.done) return null;
 
                 assert(it.cursor.node < it.array.node_count);


### PR DESCRIPTION
The LSM tree's TableInfo iterator iterates `const` pointers to `TableInfo`s. Many uses of these iterators then `@constCast` these pointers to mutable pointers. It seems this is sound in zig but I think it looks suspicious and being const-correct would be more understandable. This patch just changes the iterator to return mutable pointers, allowing the callers to avoid the cast.