### PR TITLE
Replace non-mutated `var`s with `const`

### DIFF
--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -122,7 +122,7 @@ test "c_client echo" {
 
     var prng = std.rand.DefaultPrng.init(tb_context);
 
-    var requests: []RequestContext = try testing.allocator.alloc(RequestContext, concurrency_max);
+    const requests: []RequestContext = try testing.allocator.alloc(RequestContext, concurrency_max);
     defer testing.allocator.free(requests);
 
     // Repeating the same test multiple times to stress the

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -33,14 +33,14 @@ const Context = struct {
 const NativeClient = struct {
     /// On JVM loads this library.
     fn on_load(vm: *jni.JavaVM) jni.JInt {
-        var env = JNIHelper.get_env(vm);
+        const env = JNIHelper.get_env(vm);
         ReflectionHelper.load(env);
         return jni_version;
     }
 
     /// On JVM unloads this library.
     fn on_unload(vm: *jni.JavaVM) void {
-        var env = JNIHelper.get_env(vm);
+        const env = JNIHelper.get_env(vm);
         ReflectionHelper.unload(env);
     }
 
@@ -61,7 +61,7 @@ const NativeClient = struct {
         };
         defer env.release_string_utf_chars(addresses_obj, addresses.ptr);
 
-        var context = global_allocator.create(Context) catch {
+        const context = global_allocator.create(Context) catch {
             ReflectionHelper.initialization_exception_throw(env, tb.tb_status_t.out_of_memory);
             return null;
         };
@@ -143,12 +143,12 @@ const NativeClient = struct {
         result_len: u32,
     ) callconv(.C) void {
         _ = client;
-        var context: *Context = @ptrFromInt(context_ptr);
+        const context: *Context = @ptrFromInt(context_ptr);
         var env = JNIHelper.attach_current_thread(context.jvm);
 
         // Retrieves the request instance, and drops the GC reference.
         assert(packet.user_data != null);
-        var request_obj: jni.JObject = @ptrCast(packet.user_data);
+        const request_obj: jni.JObject = @ptrCast(packet.user_data);
         defer env.delete_global_ref(request_obj);
 
         const packet_operation = packet.operation;
@@ -204,7 +204,7 @@ comptime {
             const cluster_id_elements = env.get_byte_array_elements(cluster_id, null).?;
             defer env.release_byte_array_elements(cluster_id, cluster_id_elements, .abort);
 
-            var context = NativeClient.client_init(
+            const context = NativeClient.client_init(
                 false,
                 env,
                 @bitCast(cluster_id_elements[0..16].*),
@@ -227,7 +227,7 @@ comptime {
             const cluster_id_elements = env.get_byte_array_elements(cluster_id, null).?;
             defer env.release_byte_array_elements(cluster_id, cluster_id_elements, .abort);
 
-            var context = NativeClient.client_init(
+            const context = NativeClient.client_init(
                 true,
                 env,
                 @as(u128, @bitCast(cluster_id_elements[0..16].*)),
@@ -382,7 +382,7 @@ const ReflectionHelper = struct {
         assert(initialization_exception_class != null);
         assert(initialization_exception_ctor_id != null);
 
-        var exception = env.new_object(
+        const exception = env.new_object(
             initialization_exception_class,
             initialization_exception_ctor_id,
             &[_]jni.JValue{jni.JValue.to_jvalue(@as(jni.JInt, @bitCast(@intFromEnum(status))))},
@@ -421,14 +421,14 @@ const ReflectionHelper = struct {
         assert(request_send_buffer_field_id != null);
         assert(request_send_buffer_len_field_id != null);
 
-        var buffer_obj = env.get_object_field(this_obj, request_send_buffer_field_id) orelse
+        const buffer_obj = env.get_object_field(this_obj, request_send_buffer_field_id) orelse
             return null;
         defer env.delete_local_ref(buffer_obj);
 
-        var direct_buffer: []u8 = JNIHelper.get_direct_buffer(env, buffer_obj) orelse
+        const direct_buffer: []u8 = JNIHelper.get_direct_buffer(env, buffer_obj) orelse
             return null;
 
-        var buffer_len = env.get_long_field(this_obj, request_send_buffer_len_field_id);
+        const buffer_len = env.get_long_field(this_obj, request_send_buffer_len_field_id);
         if (buffer_len < 0 or buffer_len > direct_buffer.len)
             return null;
 
@@ -440,7 +440,7 @@ const ReflectionHelper = struct {
         assert(request_reply_buffer_field_id != null);
         assert(reply.len > 0);
 
-        var reply_buffer_obj = env.new_byte_array(
+        const reply_buffer_obj = env.new_byte_array(
             @intCast(reply.len),
         ) orelse {
             // Cannot allocate an array, it's likely the JVM has run out of resources.
@@ -612,7 +612,7 @@ const JNIHelper = struct {
     }
 
     pub inline fn find_class(env: *jni.JNIEnv, comptime class_name: [:0]const u8) jni.JClass {
-        var class_obj = env.find_class(class_name.ptr) orelse {
+        const class_obj = env.find_class(class_name.ptr) orelse {
             vm_panic(
                 env,
                 "Unexpected result calling JNIEnv.FindClass for {s}",
@@ -662,10 +662,10 @@ const JNIHelper = struct {
         env: *jni.JNIEnv,
         buffer_obj: jni.JObject,
     ) ?[]u8 {
-        var buffer_capacity = env.get_direct_buffer_capacity(buffer_obj);
+        const buffer_capacity = env.get_direct_buffer_capacity(buffer_obj);
         if (buffer_capacity < 0) return null;
 
-        var buffer_address = env.get_direct_buffer_address(buffer_obj) orelse return null;
+        const buffer_address = env.get_direct_buffer_address(buffer_obj) orelse return null;
         return buffer_address[0..@as(u32, @intCast(buffer_capacity))];
     }
 

--- a/src/clients/node/src/translate.zig
+++ b/src/clients/node/src/translate.zig
@@ -20,7 +20,7 @@ pub fn register_function(
 
 const TranslationError = error{ExceptionThrown};
 pub fn throw(env: c.napi_env, comptime message: [:0]const u8) TranslationError {
-    var result = c.napi_throw_error(env, null, @as([*c]const u8, @ptrCast(message)));
+    const result = c.napi_throw_error(env, null, @as([*c]const u8, @ptrCast(message)));
     switch (result) {
         c.napi_ok, c.napi_pending_exception => {},
         else => unreachable,

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -55,8 +55,8 @@ pub fn main() !void {
 
     const cli_args = flags.parse(&args, CliArgs);
 
-    var line_buffer = try allocator.alloc(u8, 1024 * 1024);
-    var func_buf = try allocator.alloc(u8, 4096);
+    const line_buffer = try allocator.alloc(u8, 1024 * 1024);
+    const func_buf = try allocator.alloc(u8, 4096);
 
     const stdin = std.io.getStdIn();
     var buf_reader = std.io.bufferedReader(stdin.reader());

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -38,7 +38,7 @@ test "benchmark: binary search" {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
 
-    var blob = try arena.allocator().alloc(u8, blob_size);
+    const blob = try arena.allocator().alloc(u8, blob_size);
 
     inline for (kv_types) |kv| {
         inline for (values_per_page) |values_count| {
@@ -63,12 +63,12 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, random: std.rand.Random) !
     const page_count = layout.blob_size / @sizeOf(Page);
 
     // Search pages and keys in random order.
-    var page_picker = shuffled_index(page_count, random);
-    var value_picker = shuffled_index(layout.values_count, random);
+    const page_picker = shuffled_index(page_count, random);
+    const value_picker = shuffled_index(layout.values_count, random);
 
     // Generate 1GiB worth of 24KiB pages.
     var blob_alloc = std.heap.FixedBufferAllocator.init(blob);
-    var pages = try blob_alloc.allocator().alloc(Page, page_count);
+    const pages = try blob_alloc.allocator().alloc(Page, page_count);
     random.bytes(std.mem.sliceAsBytes(pages));
     for (pages) |*page| {
         for (&page.values, 0..) |*value, i| value.key = i;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1057,7 +1057,7 @@ pub fn CompactionType(
                     2,
                 );
                 while (i < value_blocks_used and free_blocks_used < half_blocks_count) {
-                    var maybe_source_value_block =
+                    const maybe_source_value_block =
                         beat.blocks.?.source_value_blocks[1].free_to_pending();
                     free_blocks_used += 1;
 
@@ -2052,7 +2052,7 @@ pub fn CompactionType(
             else
                 beat.source_b_values.?;
             const values_out = bar.table_builder.data_block_values();
-            var values_out_index = bar.table_builder.value_count;
+            const values_out_index = bar.table_builder.value_count;
 
             assert(source_local.len > 0);
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -409,8 +409,8 @@ const Environment = struct {
                 env: *Environment,
                 params: ScanParams,
             ) ![]const tb.Account {
-                var min: Prefix = @intCast(params.min);
-                var max: Prefix = @intCast(params.max);
+                const min: Prefix = @intCast(params.min);
+                const max: Prefix = @intCast(params.max);
                 assert(min <= max);
 
                 const scan_buffer_pool = &env.forest.scan_buffer_pool;

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -155,7 +155,7 @@ fn run_fuzzers(
         seed: SeedRecord,
     };
 
-    var fuzzers = try shell.arena.allocator().alloc(?FuzzerChild, options.concurrency);
+    const fuzzers = try shell.arena.allocator().alloc(?FuzzerChild, options.concurrency);
     @memset(fuzzers, null);
     defer for (fuzzers) |*fuzzer_or_null| {
         if (fuzzer_or_null.*) |*fuzzer| {
@@ -591,7 +591,7 @@ const SeedRecord = struct {
         current: []const SeedRecord,
         new: []const SeedRecord,
     ) !union(enum) { updated: []const SeedRecord, up_to_date } {
-        var current_and_new = try std.mem.concat(arena, SeedRecord, &.{ current, new });
+        const current_and_new = try std.mem.concat(arena, SeedRecord, &.{ current, new });
         std.mem.sort(SeedRecord, current_and_new, {}, SeedRecord.less_than);
 
         var result = try std.ArrayList(SeedRecord).initCapacity(arena, current.len);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1013,7 +1013,7 @@ pub fn StateMachineType(
             assert(self.prefetch_timestamp >= TimestampRange.timestamp_min);
             assert(self.prefetch_timestamp != TimestampRange.timestamp_max);
 
-            var scan_lookup_buffer = std.mem.bytesAsSlice(
+            const scan_lookup_buffer = std.mem.bytesAsSlice(
                 Transfer,
                 self.scan_lookup_buffer[0 .. @sizeOf(Transfer) *
                     // We must be constrained to the same limit as `create_transfers`.

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -131,7 +131,7 @@ const DeadDetector = struct {
     }
 
     fn file_state(detector: *DeadDetector, path: []const u8) !*FileState {
-        var gop = try detector.files.getOrPut(path_to_name(path));
+        const gop = try detector.files.getOrPut(path_to_name(path));
         if (!gop.found_existing) gop.value_ptr.* = .{ .import_count = 0, .definition_count = 0 };
         return gop.value_ptr;
     }
@@ -241,9 +241,9 @@ test "tidy no large blobs" {
     while (lines.next()) |line| {
         // Parsing lines like
         //     blob 1032 client/package.json
-        var blob = stdx.cut_prefix(line, "blob ") orelse continue;
+        const blob = stdx.cut_prefix(line, "blob ") orelse continue;
 
-        var cut = stdx.cut(blob, " ").?;
+        const cut = stdx.cut(blob, " ").?;
         const size = try std.fmt.parseInt(u64, cut.prefix, 10);
         const path = cut.suffix;
 

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -533,7 +533,7 @@ fn print_percentiles_histogram(
 
     const percentiles = [_]u64{ 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100 };
     for (percentiles) |percentile| {
-        var histogram_percentile: usize = @divTrunc(histogram_total * percentile, 100);
+        const histogram_percentile: usize = @divTrunc(histogram_total * percentile, 100);
 
         // Since each bucket in our histogram represents 1ms, the bucket we're in is the ms value.
         var sum: usize = 0;

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -138,7 +138,7 @@ pub fn GridScrubberType(comptime Forest: type) type {
             forest: *Forest,
             client_sessions_checkpoint: *const CheckpointTrailer,
         ) error{OutOfMemory}!GridScrubber {
-            var tour_index_block = try allocate_block(allocator);
+            const tour_index_block = try allocate_block(allocator);
             errdefer allocator.free(tour_index_block);
 
             return .{

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1452,7 +1452,7 @@ const TestContext = struct {
         standby_count: u8 = 0,
         client_count: u8 = constants.clients_max,
     }) !*TestContext {
-        cnst log_level_original = std.testing.log_level;
+        const log_level_original = std.testing.log_level;
         std.testing.log_level = log_level;
 
         var prng = std.rand.DefaultPrng.init(123);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1364,7 +1364,7 @@ test "Cluster: scrub: background scrubber, fully corrupt grid" {
     try expectEqual(t.replica(.R_).commit(), checkpoint_2_trigger);
 
     var a0 = t.replica(.A0);
-    var b1 = t.replica(.B1);
+    const b1 = t.replica(.B1);
     var b2 = t.replica(.B2);
 
     const a0_free_set = &t.cluster.replicas[a0.replicas.get(0)].grid.free_set;
@@ -1392,7 +1392,7 @@ test "Cluster: scrub: background scrubber, fully corrupt grid" {
         while (true) {
             t.run();
 
-            var faults_after = b2_storage.faults.count();
+            const faults_after = b2_storage.faults.count();
             assert(faults_after <= faults_before);
             if (faults_after == faults_before) break;
 
@@ -1452,7 +1452,7 @@ const TestContext = struct {
         standby_count: u8 = 0,
         client_count: u8 = constants.clients_max,
     }) !*TestContext {
-        var log_level_original = std.testing.log_level;
+        cnst log_level_original = std.testing.log_level;
         std.testing.log_level = log_level;
 
         var prng = std.rand.DefaultPrng.init(123);
@@ -1497,7 +1497,7 @@ const TestContext = struct {
 
         for (cluster.storages) |*storage| storage.faulty = true;
 
-        var context = try allocator.create(TestContext);
+        const context = try allocator.create(TestContext);
         errdefer allocator.destroy(context);
 
         context.* = .{


### PR DESCRIPTION
In preparation for the Zig 0.13 upgrade as the change is 1) compatible with 0.11 and 2) allows more careful review of `var`s which *should've* been mutated.