### PR TITLE
CLI/LSM: Tune compaction memory

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -133,7 +133,6 @@ const ConfigProcess = struct {
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
     grid_scrubber_interval_ms_max: usize = std.time.ms_per_s * 10,
     aof_recovery: bool = false,
-    compaction_block_memory_default: usize = 256 * 1024 * 1024,
 };
 
 /// Configurations which are tunable per-cluster.
@@ -268,7 +267,6 @@ pub const configs = struct {
             .grid_scrubber_reads_max = 2,
             .grid_scrubber_cycle_ms = std.time.ms_per_hour,
             .verify = true,
-            .compaction_block_memory_default = 16 * 1024 * 1024,
         },
         .cluster = .{
             .clients_max = 4 + 3,

--- a/src/config.zig
+++ b/src/config.zig
@@ -133,7 +133,7 @@ const ConfigProcess = struct {
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
     grid_scrubber_interval_ms_max: usize = std.time.ms_per_s * 10,
     aof_recovery: bool = false,
-    compaction_block_memory: usize = 256 * 1024 * 1024,
+    compaction_block_memory_default: usize = 256 * 1024 * 1024,
 };
 
 /// Configurations which are tunable per-cluster.
@@ -268,7 +268,7 @@ pub const configs = struct {
             .grid_scrubber_reads_max = 2,
             .grid_scrubber_cycle_ms = std.time.ms_per_hour,
             .verify = true,
-            .compaction_block_memory = 16 * 1024 * 1024,
+            .compaction_block_memory_default = 16 * 1024 * 1024,
         },
         .cluster = .{
             .clients_max = 4 + 3,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -732,11 +732,12 @@ pub const aof_record = config.process.aof_record;
 /// replay our AOF.
 pub const aof_recovery = config.process.aof_recovery;
 
-/// The amount of memory allocated for compactions. Compactions will be deterministic regardless
-/// of how much memory you give them, but will run in fewer steps with more memory.
-// TODO: Expose this as a CLI flag, to allow tuning of compaction rate.
-// (And use this current value as the default.)
-pub const compaction_block_memory = config.process.compaction_block_memory;
+/// The amount default of memory allocated for compactions. Compactions will be deterministic
+/// regardless of how much memory you give them, but will run in fewer steps with more memory.
+pub const compaction_block_memory_default = config.process.compaction_block_memory_default;
+
+/// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
+pub const compaction_block_memory_size_max = std.math.maxInt(u32) * block_size;
 
 /// Maximum number of tree scans that can be performed by a single query.
 /// NOTE: Each condition in a query is a scan, for example `WHERE a=0 AND b=1` needs 2 scans.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -732,11 +732,7 @@ pub const aof_record = config.process.aof_record;
 /// replay our AOF.
 pub const aof_recovery = config.process.aof_recovery;
 
-/// The amount default of memory allocated for compactions. Compactions will be deterministic
-/// regardless of how much memory you give them, but will run in fewer steps with more memory.
-pub const compaction_block_memory_default = config.process.compaction_block_memory_default;
-
-/// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
+/// The maximum number of bytes to use for compaction blocks.
 pub const compaction_block_memory_size_max = std.math.maxInt(u32) * block_size;
 
 /// Maximum number of tree scans that can be performed by a single query.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -206,6 +206,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
         pub const Options = struct {
             node_count: u32,
+            /// The amount of blocks allocated for compactions. Compactions will be deterministic
+            /// regardless of how much blocks you give them, but will run in fewer steps with more
+            /// memory.
             compaction_block_count: u32,
 
             pub const compaction_block_count_min: u32 = CompactionPipeline.block_count_min;

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -81,6 +81,7 @@ const Environment = struct {
     const cache_entries_max = 2048;
     const forest_options = StateMachine.forest_options(.{
         .batch_size_limit = constants.message_body_size_max,
+        .lsm_forest_compaction_block_count = Forest.Options.compaction_block_count_min,
         .lsm_forest_node_count = node_count,
         .cache_entries_accounts = cache_entries_max,
         .cache_entries_transfers = cache_entries_max,
@@ -206,11 +207,8 @@ const Environment = struct {
         env.forest = try Forest.init(allocator, &env.grid, .{
             // TODO Test that the same sequence of events applied to forests with different
             // compaction_blocks result in identical grids.
-            .compaction_blocks = @divExact(
-                constants.compaction_block_memory_default,
-                constants.block_size,
-            ),
-            .node_count = node_count
+            .compaction_block_count = Forest.Options.compaction_block_count_min,
+            .node_count = node_count,
         }, forest_options);
         env.change_state(.forest_init, .forest_open);
         env.forest.open(forest_open_callback);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -203,7 +203,15 @@ const Environment = struct {
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
 
-        env.forest = try Forest.init(allocator, &env.grid, node_count, forest_options);
+        env.forest = try Forest.init(allocator, &env.grid, .{
+            // TODO Test that the same sequence of events applied to forests with different
+            // compaction_blocks result in identical grids.
+            .compaction_blocks = @divExact(
+                constants.compaction_block_memory_default,
+                constants.block_size,
+            ),
+            .node_count = node_count
+        }, forest_options);
         env.change_state(.forest_init, .forest_open);
         env.forest.open(forest_open_callback);
 

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -190,6 +190,8 @@ pub fn main() !void {
             },
             .accounting => .{
                 .batch_size_limit = batch_size_limit,
+                .lsm_forest_compaction_block_count = random.uintAtMost(u32, 256) +
+                    StateMachine.Forest.Options.compaction_block_count_min,
                 .lsm_forest_node_count = 4096,
                 .cache_entries_accounts = 2048,
                 .cache_entries_transfers = 2048,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -319,6 +319,7 @@ pub fn StateMachineType(
 
         pub const Options = struct {
             batch_size_limit: u32,
+            lsm_forest_compaction_block_count: u32,
             lsm_forest_node_count: u32,
             cache_entries_accounts: u32,
             cache_entries_transfers: u32,
@@ -424,7 +425,10 @@ pub fn StateMachineType(
             var forest = try Forest.init(
                 allocator,
                 grid,
-                options.lsm_forest_node_count,
+                .{
+                    .compaction_block_count = options.lsm_forest_compaction_block_count,
+                    .node_count = options.lsm_forest_node_count,
+                },
                 forest_options(options),
             );
             errdefer forest.deinit(allocator);
@@ -2339,6 +2343,7 @@ const TestContext = struct {
 
         ctx.state_machine = try StateMachine.init(allocator, &ctx.grid, .{
             .batch_size_limit = message_body_size_max,
+            .lsm_forest_compaction_block_count = StateMachine.Forest.Options.compaction_block_count_min,
             .lsm_forest_node_count = 1,
             .cache_entries_accounts = 0,
             .cache_entries_transfers = 0,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -112,7 +112,10 @@ pub fn StateMachineType(
             var forest = try Forest.init(
                 allocator,
                 grid,
-                options.lsm_forest_node_count,
+                .{
+                    .compaction_block_count = Forest.Options.compaction_block_count_min,
+                    .node_count = options.lsm_forest_node_count,
+                },
                 .{
                     .things = .{
                         .cache_entries_max = 2048,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -227,7 +227,10 @@ const start_defaults_production = StartDefaults{
     .cache_transfers_pending = .{ .value = constants.cache_transfers_pending_size_default },
     .cache_account_balances = .{ .value = constants.cache_account_balances_size_default },
     .cache_grid = .{ .value = constants.grid_cache_size_default },
-    .memory_lsm_compaction = .{ .value = constants.compaction_block_memory_default },
+    .memory_lsm_compaction = .{
+        // By default, add a few extra blocks for beat-scoped work.
+        .value = (lsm_compaction_block_count_min + 16) * constants.block_size,
+    },
 };
 
 const start_defaults_development = StartDefaults{
@@ -241,8 +244,8 @@ const start_defaults_development = StartDefaults{
     .memory_lsm_compaction = .{ .value = lsm_compaction_block_memory_min },
 };
 
-const lsm_compaction_block_memory_min =
-    constants.block_size * StateMachine.Forest.Options.compaction_block_count_min;
+const lsm_compaction_block_count_min = StateMachine.Forest.Options.compaction_block_count_min;
+const lsm_compaction_block_memory_min = lsm_compaction_block_count_min * constants.block_size;
 
 pub const Command = union(enum) {
     pub const Format = struct {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -64,6 +64,7 @@ const CliArgs = union(enum) {
         cache_transfers_pending: ?flags.ByteSize = null,
         cache_account_balances: ?flags.ByteSize = null,
         memory_lsm_manifest: ?flags.ByteSize = null,
+        memory_lsm_compaction: ?flags.ByteSize = null,
     },
 
     version: struct {
@@ -215,6 +216,7 @@ const StartDefaults = struct {
     cache_transfers_pending: flags.ByteSize,
     cache_account_balances: flags.ByteSize,
     cache_grid: flags.ByteSize,
+    memory_lsm_compaction: flags.ByteSize,
 };
 
 const start_defaults_production = StartDefaults{
@@ -225,6 +227,7 @@ const start_defaults_production = StartDefaults{
     .cache_transfers_pending = .{ .value = constants.cache_transfers_pending_size_default },
     .cache_account_balances = .{ .value = constants.cache_account_balances_size_default },
     .cache_grid = .{ .value = constants.grid_cache_size_default },
+    .memory_lsm_compaction = .{ .value = constants.compaction_block_memory_default },
 };
 
 const start_defaults_development = StartDefaults{
@@ -235,7 +238,11 @@ const start_defaults_development = StartDefaults{
     .cache_transfers_pending = .{ .value = 0 },
     .cache_account_balances = .{ .value = 0 },
     .cache_grid = .{ .value = constants.block_size * Grid.Cache.value_count_max_multiple },
+    .memory_lsm_compaction = .{ .value = lsm_compaction_block_memory_min },
 };
+
+const lsm_compaction_block_memory_min =
+    constants.block_size * StateMachine.Forest.Options.compaction_block_count_min;
 
 pub const Command = union(enum) {
     pub const Format = struct {
@@ -260,6 +267,7 @@ pub const Command = union(enum) {
         pipeline_requests_limit: u32,
         request_size_limit: u32,
         cache_grid_blocks: u32,
+        lsm_forest_compaction_block_count: u32,
         lsm_forest_node_count: u32,
         development: bool,
         experimental: bool,
@@ -527,6 +535,36 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 );
             }
 
+            const lsm_compaction_block_memory =
+                start.memory_lsm_compaction orelse defaults.memory_lsm_compaction;
+            const lsm_compaction_block_memory_max = constants.compaction_block_memory_size_max;
+            if (lsm_compaction_block_memory.bytes() > lsm_compaction_block_memory_max) {
+                flags.fatal("--memory-lsm-compaction: size {}{s} exceeds maximum: {}GiB", .{
+                    lsm_compaction_block_memory.value,
+                    lsm_compaction_block_memory.suffix(),
+                    @divFloor(lsm_compaction_block_memory_max, 1024 * 1024 * 1024),
+                });
+            }
+            if (lsm_compaction_block_memory.bytes() < lsm_compaction_block_memory_min) {
+                flags.fatal("--memory-lsm-compaction: size {}{s} is below minimum: {}KiB", .{
+                    lsm_compaction_block_memory.value,
+                    lsm_compaction_block_memory.suffix(),
+                    @divExact(lsm_compaction_block_memory_min, 1024),
+                });
+            }
+            if (lsm_compaction_block_memory.bytes() % constants.block_size != 0) {
+                flags.fatal(
+                    "--memory-lsm-compaction: size {}{s} must be a multiple of {}KiB",
+                    .{
+                        lsm_compaction_block_memory.value,
+                        lsm_compaction_block_memory.suffix(),
+                        @divExact(constants.block_size, 1024),
+                    },
+                );
+            }
+
+            const lsm_forest_compaction_block_count: u32 =
+                @intCast(@divExact(lsm_compaction_block_memory.bytes(), constants.block_size));
             const lsm_forest_node_count: u32 =
                 @intCast(@divExact(lsm_manifest_memory, constants.lsm_manifest_node_size));
 
@@ -562,6 +600,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                         Grid.Cache,
                         start.cache_grid orelse defaults.cache_grid,
                     ),
+                    .lsm_forest_compaction_block_count = lsm_forest_compaction_block_count,
                     .lsm_forest_node_count = lsm_forest_node_count,
                     .development = start.development,
                     .experimental = start.experimental,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -308,6 +308,7 @@ const Command = struct {
             .time = .{},
             .state_machine_options = .{
                 .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
+                .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
                 .lsm_forest_node_count = args.lsm_forest_node_count,
                 .cache_entries_accounts = args.cache_accounts,
                 .cache_entries_transfers = args.cache_transfers,


### PR DESCRIPTION
### CLI: Add `--memory-lsm-compaction` flag

Add a (deliberate undocumented) `--memory-lsm-compaction` flag to `tigerbeetle start`.

This overrides the `Forest`'s `compaction_blocks` count at runtime.

When `--development` is set, use the minimum possible value.
This reduces the RAM of `tigerbeetle start --development` by about 120MiB.

---

### LSM: Reduce default compaction_block_count

Most of the compaction blocks were not being used.

This reduces the RAM requirement of a production (non `--development`) replica by 112MiB.