### PR TITLE
CLI: Reduce `--limit-pipeline-requests` for production replica

### DIFF
--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -218,7 +218,8 @@ const StartDefaults = struct {
 };
 
 const start_defaults_production = StartDefaults{
-    .limit_pipeline_requests = constants.pipeline_request_queue_max,
+    .limit_pipeline_requests = @divExact(constants.clients_max, 2) -
+        constants.pipeline_prepare_queue_max,
     .limit_request = .{ .value = constants.message_size_max },
     .cache_accounts = .{ .value = constants.cache_accounts_size_default },
     .cache_transfers = .{ .value = constants.cache_transfers_size_default },


### PR DESCRIPTION
Our replicas have a `clients_max` of 64, as a margin of safety. (It impacts storage, so we overestimate the requirement).

But in practice, if users are batching properly, they probably have far fewer than 64 clients. So we could reduce the default value of `--limit-pipeline-requests`, (and allow users who need more to set the flag manually). This reduces production replica RSS. (For example, if we set `--limit-pipeline-requests=24` (for a total pipeline size of 32) then RSS drops by ~190MiB.)

The choice of `24` (for a total pipeline size of `32`) is somewhat arbitrary. That is probably still on the high side, but I think we still want our default to overestimate what the typical user will need, to leave a margin.