### PR TITLE
lsm: fix fuzz false positive

### DIFF
--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -943,6 +943,92 @@ fn SegmentedArrayType(
     };
 }
 
+test "SortedSegmentedArray duplicate elements" {
+    // Create [0, 0, 0, 100, 100, 100, ~0, ~0, ~0] array, verify that the search is left-biased.
+    const testing = std.testing;
+
+    const NodePool = @import("node_pool.zig").NodePool;
+    const TestPool = NodePool(128 * @sizeOf(u32), 2 * @alignOf(u32));
+    const TestArray = SortedSegmentedArray(
+        u32,
+        TestPool,
+        1024,
+        u32,
+        struct {
+            inline fn key_from_value(value: *const u32) u32 {
+                return value.*;
+            }
+        }.key_from_value,
+        .{ .verify = true },
+    );
+
+    var pool = try TestPool.init(testing.allocator, TestArray.node_count_max);
+    defer pool.deinit(testing.allocator);
+
+    var array = try TestArray.init(testing.allocator);
+    defer array.deinit(testing.allocator, &pool);
+
+    for (0..3) |index| {
+        // Elements are inserted to the left of a row of duplicates.
+        var inserted_at = array.insert_element(&pool, 0);
+        try testing.expectEqual(inserted_at, 0);
+
+        inserted_at = array.insert_element(&pool, 100);
+        try testing.expectEqual(inserted_at, @as(u32, @intCast(index + 1)));
+
+        inserted_at = array.insert_element(&pool, math.maxInt(u32));
+        try testing.expectEqual(inserted_at, @as(u32, @intCast((index + 1) * 2)));
+    }
+    try testing.expectEqual(array.len(), 9);
+
+    // Search finds the leftmost element.
+    try testing.expectEqual(array.absolute_index_for_cursor(array.search(0)), 0);
+    try testing.expectEqual(array.absolute_index_for_cursor(array.search(100)), 3);
+    try testing.expectEqual(array.absolute_index_for_cursor(array.search(math.maxInt(u32))), 6);
+
+    // Ascending iterators pick the leftmost element.
+    // Descending iterators are weird --- they _also_ pick the leftmost element, although the
+    // rightmost makes more sense.
+    {
+        const target: u32 = 0;
+        var it = array.iterator_from_cursor(array.search(target), .ascending);
+        try testing.expectEqual(it.next().?.*, 0);
+        try testing.expectEqual(it.next().?.*, 0);
+        try testing.expectEqual(it.next().?.*, 0);
+        try testing.expectEqual(it.next().?.*, 100);
+
+        it = array.iterator_from_cursor(array.search(target), .descending);
+        try testing.expectEqual(it.next().?.*, 0);
+        try testing.expectEqual(it.next(), null);
+    }
+
+    {
+        const target: u32 = 100;
+        var it = array.iterator_from_cursor(array.search(target), .ascending);
+        try testing.expectEqual(it.next().?.*, 100);
+        try testing.expectEqual(it.next().?.*, 100);
+        try testing.expectEqual(it.next().?.*, 100);
+        try testing.expectEqual(it.next().?.*, math.maxInt(u32));
+
+        it = array.iterator_from_cursor(array.search(target), .descending);
+        try testing.expectEqual(it.next().?.*, 100);
+        try testing.expectEqual(it.next().?.*, 0);
+    }
+
+    {
+        const target: u32 = math.maxInt(u32);
+        var it = array.iterator_from_cursor(array.search(target), .ascending);
+        try testing.expectEqual(it.next().?.*, math.maxInt(u32));
+        try testing.expectEqual(it.next().?.*, math.maxInt(u32));
+        try testing.expectEqual(it.next().?.*, math.maxInt(u32));
+        try testing.expectEqual(it.next(), null);
+
+        it = array.iterator_from_cursor(array.search(target), .descending);
+        try testing.expectEqual(it.next().?.*, math.maxInt(u32));
+        try testing.expectEqual(it.next().?.*, 100);
+    }
+}
+
 /// In order to avoid making internal details of segmented array public, the fuzzing code is defined
 /// in this file an is driven by =segmented_array_fuzz.zig`.
 fn FuzzContextType(

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -1339,7 +1339,9 @@ fn FuzzContextType(
                     context.array.search(math.maxInt(Key)),
                     .ascending,
                 );
-                try testing.expectEqual(iterator_end.next(), null);
+                while (iterator_end.next()) |item| {
+                    try testing.expectEqual(key_from_value(item), math.maxInt(Key));
+                }
             }
 
             {


### PR DESCRIPTION
The check fails if there are several intMaxes in the array. I believe
that the check bellow for 0 is already correct in the face of the
duplicates.

See also the previous commit where I added explicit unit-tests for the
behavior in the face of duplicates.

Seed: ./zig/zig build  fuzz -- lsm_segmented_array 5619264251929892618
Closes: #2015

This is basically the same as #1876, but now our fuzzer lucked to generate _two_ maxInts :rofl: