### PR TITLE
repl: drop unused import

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
-const build_options = @import("vsr_options");
-
 const vsr = @import("vsr.zig");
 const stdx = vsr.stdx;
 const constants = vsr.constants;


### PR DESCRIPTION
It's very surprising to see repl poking at the build options! Luckily, it doesn't actually do that!