### PR TITLE
vsr: unify checking for production config

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -69,6 +69,14 @@ pub const Config = struct {
 
     cluster: ConfigCluster,
     process: ConfigProcess,
+
+    /// Returns true if the configuration is intended for "production".
+    /// Intended solely for extra sanity-checks: all meaningful decisions should be driven by
+    /// specific fields of the config.
+    pub fn is_production(config: *const Config) bool {
+        _ = config;
+        return build_options.config_base == .production;
+    }
 };
 
 /// Configurations which are tunable per-replica (or per-client).

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -14,8 +14,6 @@ pub const std_options = .{
     .log_level = .info,
 };
 
-const build_options = @import("vsr_options");
-
 const vsr = @import("vsr");
 const constants = vsr.constants;
 const stdx = vsr.stdx;
@@ -43,12 +41,11 @@ pub fn main(
     if (builtin.mode != .ReleaseSafe and builtin.mode != .ReleaseFast) {
         try stderr.print("Benchmark must be built with '-Drelease' for reasonable results.\n", .{});
     }
-    if (build_options.config_base != .production) {
+    if (!vsr.constants.config.is_production()) {
         try stderr.print(
             \\Benchmark must be built with '-Dconfig=production' for reasonable results.
-            \\Benchmark was built with -Dconfig={s} instead.
             \\
-        , .{@tagName(build_options.config_base)});
+        , .{});
     }
 
     if (cli_args.account_count < 2) flags.fatal(

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -121,11 +121,11 @@ comptime {
     // Normally, this guarantee falls out naturally out of the fact that there are fewer journal
     // writes available than there are sectors. This is not the case for the simulator, which only
     // has two sectors worth of headers. Rather than adding simulator-only locking to the journal,
-    // the simulator itself prevents correlated torn writes at runtime. The `direct_io` condition
-    // excludes the simulator case.
+    // the simulator itself prevents correlated torn writes at runtime, and we just exclude the
+    // simulator from the assert:
     assert(
         @divExact(headers_size, constants.sector_size) > constants.journal_iops_write_max or
-            !constants.direct_io,
+            !constants.config.is_production(),
     );
 
     assert(prepares_size > 0);


### PR DESCRIPTION
"Is this a production config?" is a somewhat ill-formed question, as, physically, a config is just a set of many _specific_ options rather than a broad toggle. But there are a couple of places where we need an answer to that question to enable better sanity checking! This PR introduces a specific function for this check, but it _should not_ be used in "real" code --- instead, check for specific properties like `config.verify`.

The main motivation here is preventing benchmark from poking into `vsr_options`, which would allow us to simplify build.zig