### PR TITLE
build: drop shellcheck 

### DIFF
--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build lint
+      - run: ./zig/zig fmt --check .
       - run: ./zig/zig build check
 
   linux:

--- a/build.zig
+++ b/build.zig
@@ -236,20 +236,6 @@ pub fn build(b: *std.Build) !void {
         run_step.dependOn(&run_cmd.step);
     }
 
-    // Linting targets
-    // We currently have: lint_zig_fmt.
-    // The meta-target lint runs them all
-    {
-        // lint_zig_fmt
-        const lint_zig_fmt = b.addFmt(.{ .paths = &.{"."}, .check = true });
-        const lint_zig_fmt_step = b.step("lint_zig_fmt", "Run zig fmt");
-        lint_zig_fmt_step.dependOn(&lint_zig_fmt.step);
-
-        // lint
-        const lint_step = b.step("lint", "Run all defined linters");
-        lint_step.dependOn(lint_zig_fmt_step);
-    }
-
     // Executable which generates src/clients/c/tb_client.h
     const tb_client_header_generate = blk: {
         const tb_client_header = b.addExecutable(.{
@@ -299,11 +285,15 @@ pub fn build(b: *std.Build) !void {
         const integration_tests_step = b.step("test:integration", "Run the integration tests");
         integration_tests_step.dependOn(&run_integration_tests.step);
 
+        const run_fmt = b.addFmt(.{ .paths = &.{"."}, .check = true });
+        const fmt_test_step = b.step("test:fmt", "Check formatting");
+        fmt_test_step.dependOn(&run_fmt.step);
+
         const test_step = b.step("test", "Run the unit tests");
         test_step.dependOn(&run_unit_tests.step);
-
         if (test_filter == null) {
             test_step.dependOn(&run_integration_tests.step);
+            test_step.dependOn(&run_fmt.step);
         }
     }
 

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,6 @@ const CrossTarget = std.zig.CrossTarget;
 const Mode = std.builtin.Mode;
 
 const config = @import("./src/config.zig");
-const Shell = @import("./src/shell.zig");
 
 // TigerBeetle binary requires certain CPU feature and supports a closed set of CPUs. Here, we
 // specify exactly which features the binary needs. Client shared libraries might be more lax with
@@ -238,7 +237,7 @@ pub fn build(b: *std.Build) !void {
     }
 
     // Linting targets
-    // We currently have: lint_zig_fmt, lint_shellcheck.
+    // We currently have: lint_zig_fmt.
     // The meta-target lint runs them all
     {
         // lint_zig_fmt
@@ -246,15 +245,9 @@ pub fn build(b: *std.Build) !void {
         const lint_zig_fmt_step = b.step("lint_zig_fmt", "Run zig fmt");
         lint_zig_fmt_step.dependOn(&lint_zig_fmt.step);
 
-        // lint_shellcheck
-        const lint_shellcheck = ShellcheckStep.add(b);
-        const lint_shellcheck_step = b.step("lint_shellcheck", "Run shellcheck on **.sh");
-        lint_shellcheck_step.dependOn(&lint_shellcheck.step);
-
         // lint
         const lint_step = b.step("lint", "Run all defined linters");
         lint_step.dependOn(lint_zig_fmt_step);
-        lint_step.dependOn(lint_shellcheck_step);
     }
 
     // Executable which generates src/clients/c/tb_client.h
@@ -930,47 +923,6 @@ const FailStep = struct {
         const self: *FailStep = @fieldParentPtr("step", step);
         std.log.err("{s}", .{self.message});
         return error.FailStep;
-    }
-};
-
-const ShellcheckStep = struct {
-    step: std.Build.Step,
-    gpa: std.mem.Allocator,
-
-    fn add(b: *std.Build) *ShellcheckStep {
-        const result = b.allocator.create(ShellcheckStep) catch unreachable;
-        result.* = .{
-            .step = std.Build.Step.init(.{
-                .id = .custom,
-                .name = "run shellcheck",
-                .owner = b,
-                .makeFn = ShellcheckStep.make,
-            }),
-            .gpa = b.allocator,
-        };
-        return result;
-    }
-
-    fn make(step: *std.Build.Step, _: std.Progress.Node) anyerror!void {
-        const self: *ShellcheckStep = @fieldParentPtr("step", step);
-
-        var shell = try Shell.create(self.gpa);
-        defer shell.destroy();
-
-        if (!try shell.exec_status_ok("shellcheck --version", .{})) {
-            shell.echo(
-                "{ansi-red}Please install shellcheck - https://www.shellcheck.net/{ansi-reset}",
-                .{},
-            );
-            return error.NoShellcheck;
-        }
-
-        const scripts = try shell.find(.{
-            .where = &.{ "src", "scripts", ".github" },
-            .extension = ".sh",
-        });
-
-        try shell.exec("shellcheck {scripts}", .{ .scripts = scripts });
     }
 };
 


### PR DESCRIPTION
We currently have the following shellchecked scripts:

scripts/install_zig.sh

src/scripts/cfo_supervisor.sh
src/docs_website/scripts/build.sh
.github/ci/docs_check.sh
.github/ci/test_aof.sh

All of them except `install_zig` are run only our our machines. We don't
need to lint those, "works on my machine" is the only thing we need from
those scripts.

install_zig is run on the user's machine, and we do need to make it a
good script, but I think we can manage one decent script without a
linter, and this script hasn't seen much changes lately anyway.