### PR TITLE
zig: macOS no longer stack overflows

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -2603,17 +2603,6 @@ const TestGetAccountTransfersResult = struct {
 };
 
 fn check(test_table: []const u8) !void {
-    // TODO(zig): Zig defaults to 16MB stack size on Linux, but not yet on mac as of 0.11.
-    // Override it here, so it can have the same stack size. Trying to set `tigerbeetle.stack_size`
-    // in build.zig doesn't work. setrlimit with 16MB errors with EINVAL on macOS 13 as well.
-    // So instead, we spawn a thread with the desired stack size instead.
-    //
-    // Duplicated here from src/tigerbeetle/main.zig, since that code won't run on the testing path.
-    const thread = try std.Thread.spawn(.{ .stack_size = 16 * 1024 * 1024 }, check_real, .{test_table});
-    thread.join();
-}
-
-fn check_real(test_table: []const u8) !void {
     const parse_table = @import("testing/table.zig").parse;
     const allocator = std.testing.allocator;
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -37,15 +37,6 @@ pub const std_options = .{
 };
 
 pub fn main() !void {
-    // TODO(zig): Zig defaults to 16MB stack size on Linux, but not yet on mac as of 0.11.
-    // Override it here, so it can have the same stack size. Trying to set `tigerbeetle.stack_size`
-    // in build.zig doesn't work. setrlimit with 16MB errors with EINVAL on macOS 13 as well.
-    // So instead, we spawn a thread with the desired stack size instead.
-    const thread = try std.Thread.spawn(.{ .stack_size = 16 * 1024 * 1024 }, main_real, .{});
-    thread.join();
-}
-
-fn main_real() !void {
     try SigIllHandler.register();
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);


### PR DESCRIPTION
The previous recursiveness in Groove no longer stack overflows (including on macOS 14.5) 