### PR TITLE
Tidy: Ban std.mem.copy/copyForwards/copyBackwards

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -60,7 +60,10 @@ pub inline fn copy_left(
     if (!disjoint_slices(T, T, target, source)) {
         assert(@intFromPtr(target.ptr) < @intFromPtr(source.ptr));
     }
-    std.mem.copyForwards(T, target, source);
+
+    // (Bypass tidy's ban.)
+    const copyForwards = std.mem.copyForwards;
+    copyForwards(T, target, source);
 }
 
 test "copy_left" {
@@ -86,7 +89,10 @@ pub inline fn copy_right(
     if (!disjoint_slices(T, T, target, source)) {
         assert(@intFromPtr(target.ptr) > @intFromPtr(source.ptr));
     }
-    std.mem.copyBackwards(T, target, source);
+
+    // (Bypass tidy's ban.)
+    const copyBackwards = std.mem.copyBackwards;
+    copyBackwards(T, target, source);
 }
 
 test "copy_right" {

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -305,6 +305,18 @@ fn banned(source: []const u8) ?[]const u8 {
         return "use stdx." ++ "has_unique_representation instead of std version";
     }
 
+    if (std.mem.indexOf(u8, source, "mem." ++ "copy(") != null) {
+        return "use stdx." ++ "copy_disjoint instead of std version";
+    }
+
+    if (std.mem.indexOf(u8, source, "mem." ++ "copyForwards(") != null) {
+        return "use stdx." ++ "copy_left instead of std version";
+    }
+
+    if (std.mem.indexOf(u8, source, "mem." ++ "copyBackwards(") != null) {
+        return "use stdx." ++ "copy_right instead of std version";
+    }
+
     // Ban "fixme" comments. This allows using fixe as reminders with teeth --- when working on a
     // larger pull requests, it is often helpful to leave fixme comments as a reminder to oneself.
     // This tidy rule ensures that the reminder is acted upon before code gets into main. That is:


### PR DESCRIPTION
Ban `std.mem`'s copy functions, in favor of the corresponding `stdx` implementations. The `stdx` implementations have extra assertions.

- `std.mem.copy` → `stdx.copy_disjoint`
- `std.mem.copyForwards` → `stdx.copy_left`
- `std.mem.copyBackwards` → `stdx.copy_right`