### PR TITLE
Fix build in test_min config

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -277,7 +277,7 @@ pub const configs = struct {
             .verify = true,
         },
         .cluster = .{
-            .clients_max = 4 + 4,
+            .clients_max = 4 + 3,
             .pipeline_prepare_queue_max = 4,
             .view_change_headers_suffix_max = 4 + 1,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,

--- a/src/config.zig
+++ b/src/config.zig
@@ -277,7 +277,7 @@ pub const configs = struct {
             .verify = true,
         },
         .cluster = .{
-            .clients_max = 4 + 3,
+            .clients_max = 4 + 4,
             .pipeline_prepare_queue_max = 4,
             .view_change_headers_suffix_max = 4 + 1,
             .journal_slot_count = Config.Cluster.journal_slot_count_min,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -496,11 +496,19 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             const request_size_limit_min = 4096;
             const request_size_limit_max = constants.message_size_max;
             if (request_size_limit.bytes() > request_size_limit_max) {
-                flags.fatal("--limit-request: size {}{s} exceeds maximum: {}MiB", .{
-                    request_size_limit.value,
-                    request_size_limit.suffix(),
-                    @divExact(request_size_limit_max, 1024 * 1024),
-                });
+                if (comptime (request_size_limit_max >= 1024 * 1024)) {
+                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}MiB", .{
+                        request_size_limit.value,
+                        request_size_limit.suffix(),
+                        @divExact(request_size_limit_max, 1024 * 1024),
+                    });
+                } else {
+                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}KiB", .{
+                        request_size_limit.value,
+                        request_size_limit.suffix(),
+                        @divExact(request_size_limit_max, 1024),
+                    });
+                }
             }
             if (request_size_limit.bytes() < request_size_limit_min) {
                 flags.fatal("--limit-request: size {}{s} is below minimum: {}B", .{

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -220,7 +220,7 @@ const StartDefaults = struct {
 };
 
 const start_defaults_production = StartDefaults{
-    .limit_pipeline_requests = @divExact(constants.clients_max, 2) -
+    .limit_pipeline_requests = vsr.stdx.div_ceil(constants.clients_max, 2) -
         constants.pipeline_prepare_queue_max,
     .limit_request = .{ .value = constants.message_size_max },
     .cache_accounts = .{ .value = constants.cache_accounts_size_default },

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -257,9 +257,15 @@ const Command = struct {
         // `constants.block_size` and `SetAssociativeCache.value_count_max_multiple`,
         // and it may have been converted to zero if a smaller value is passed in.
         if (grid_cache_size == 0) {
-            fatal("Grid cache must be greater than {}MiB. See --cache-grid", .{
-                @divExact(grid_cache_size_min, 1024 * 1024),
-            });
+            if (comptime (grid_cache_size_min >= 1024 * 1024)) {
+                fatal("Grid cache must be greater than {}MiB. See --cache-grid", .{
+                    @divExact(grid_cache_size_min, 1024 * 1024),
+                });
+            } else {
+                fatal("Grid cache must be greater than {}KiB. See --cache-grid", .{
+                    @divExact(grid_cache_size_min, 1024),
+                });
+            }
         }
         assert(grid_cache_size >= grid_cache_size_min);
 


### PR DESCRIPTION
This fixes three compile-time divExact failures in the test_min configuration (`zig/zig build check -Dtest_min`).

Two of them are fixed with an ugly comptime conditional to change cli error messages from `MiB` to `KiB`.

The other is a change to the `clients_max` value from `4 + 3` to `4 + 4`. This prevents the following failure:

```zig
src/tigerbeetle/cli.zig:223:32: error: exact division produced remainder
    .limit_pipeline_requests = @divExact(constants.clients_max, 2) -
```

I don't know the significance of `4 + 3` being split into two values in this expression or whether 8 is an appropriate constant here.