### PR TITLE
Balancing transfers `amount` validation

### DIFF
--- a/docs/reference/requests/create_transfers.md
+++ b/docs/reference/requests/create_transfers.md
@@ -284,8 +284,9 @@ A transfer with the same `id` already exists, but with a different
 A transfer with the same `id` already exists, but with a different
 [`amount`](../transfer.md#amount).
 
-If the transfer has `flags.balancing_debit` or `flags.balancing_credit` set, this error refers to
-the actual amount transferred, not the original (possibly higher) balancing amount.
+If the transfer has [`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) or
+[`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) set, then the actual amount
+transferred exceeded the maximum amount of the transfer in the request.
 
 ### `exists_with_different_pending_id`
 
@@ -318,7 +319,14 @@ A transfer with the same `id` already exists, but with a different [`code`](../t
 
 ### `exists`
 
-A transfer with the same `id` already exists, and is identical to the transfer in the request.
+A transfer with the same `id` already exists.
+
+If the transfer has [`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) or
+[`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) set, then the existing
+transfer may have a different [`amount`](../transfer.md#amount), limited to the maximum
+(if non-zero) `amount` of the transfer in the request.
+
+Otherwise, the existing transfer is identical to the transfer in the request.
 
 To correctly [recover from application crashes](../../coding/reliable-transaction-submission.md),
 many applications should handle `exists` exactly as [`ok`](#ok).

--- a/docs/reference/requests/create_transfers.md
+++ b/docs/reference/requests/create_transfers.md
@@ -285,8 +285,8 @@ A transfer with the same `id` already exists, but with a different
 [`amount`](../transfer.md#amount).
 
 If the transfer has [`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) or
-[`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) set, then the actual amount
-transferred exceeded the maximum amount of the transfer in the request.
+[`flags.balancing_credit`](../transfer.md#flagsbalancing_credit) set, then the actual amount
+transferred exceeds this failed transfer's `amount`.
 
 ### `exists_with_different_pending_id`
 
@@ -322,7 +322,7 @@ A transfer with the same `id` already exists, but with a different [`code`](../t
 A transfer with the same `id` already exists.
 
 If the transfer has [`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) or
-[`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) set, then the existing
+[`flags.balancing_credit`](../transfer.md#flagsbalancing_credit) set, then the existing
 transfer may have a different [`amount`](../transfer.md#amount), limited to the maximum
 (if non-zero) `amount` of the transfer in the request.
 

--- a/docs/reference/transfer.md
+++ b/docs/reference/transfer.md
@@ -330,12 +330,15 @@ such that
 If the highest amount transferable is `0`, returns
 [`exceeds_credits`](./requests/create_transfers.md#exceeds_credits).
 
-Retrying a balancing transfer will return
-[`exists_with_different_amount`](./requests/create_transfers.md#exists_with_different_amount) if the
-amount of the retry differs from the amount that was actually transferred.
-
 The `amount` of the recorded transfer is set to the actual amount that was transferred, which is
 less than or equal to the amount that was passed to `create_transfers`.
+
+Retrying a balancing transfer will return
+[`exists_with_different_amount`](./requests/create_transfers.md#exists_with_different_amount)
+only when the maximum amount passed to `create_transfers` is insufficient to fulfill the amount
+that was actually transferred.
+Otherwise it may return [`exists`](./requests/create_transfers.md#exists) even if the retry amount
+differs from the original value.
 
 `flags.balancing_debit` is exclusive with the
 `flags.post_pending_transfer`/`flags.void_pending_transfer` flags because posting or voiding a
@@ -357,12 +360,15 @@ such that
 If the highest amount transferable is `0`, returns
 [`exceeds_debits`](./requests/create_transfers.md#exceeds_debits).
 
-Retrying a balancing transfer will return
-[`exists_with_different_amount`](./requests/create_transfers.md#exists_with_different_amount) if the
-amount of the retry differs from the amount that was actually transferred.
-
 The `amount` of the recorded transfer is set to the actual amount that was transferred, which is
 less than or equal to the amount that was passed to `create_transfers`.
+
+Retrying a balancing transfer will return
+[`exists_with_different_amount`](./requests/create_transfers.md#exists_with_different_amount)
+only when the maximum amount passed to `create_transfers` is insufficient to fulfill the amount
+that was actually transferred.
+Otherwise it may return [`exists`](./requests/create_transfers.md#exists) even if the retry amount
+differs from the original value.
 
 `flags.balancing_credit` is exclusive with the
 `flags.post_pending_transfer`/`flags.void_pending_transfer` flags because posting or voiding a

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1572,20 +1572,32 @@ pub fn StateMachineType(
         fn create_transfer_exists(t: *const Transfer, e: *const Transfer) CreateTransferResult {
             assert(t.id == e.id);
             // The flags change the behavior of the remaining comparisons, so compare the flags first.
-            if (@as(u16, @bitCast(t.flags)) != @as(u16, @bitCast(e.flags))) return .exists_with_different_flags;
+            if (@as(u16, @bitCast(t.flags)) != @as(u16, @bitCast(e.flags))) {
+                return .exists_with_different_flags;
+            }
+            // We know that the flags are the same.
+            assert(t.pending_id == 0 and e.pending_id == 0);
+
             if (t.debit_account_id != e.debit_account_id) {
                 return .exists_with_different_debit_account_id;
             }
             if (t.credit_account_id != e.credit_account_id) {
                 return .exists_with_different_credit_account_id;
             }
-            if (t.amount != e.amount) return .exists_with_different_amount;
-            assert(t.pending_id == 0 and e.pending_id == 0); // We know that the flags are the same.
+            // If the accounts are the same, the ledger must be the same.
+            assert(t.ledger == e.ledger);
+
+            // Balancing transfers with `amount=0` must not raise `exists_with_different_amount`.
+            const balancing_transfer = t.amount == 0 and
+                (t.flags.balancing_debit or t.flags.balancing_credit);
+            if (t.amount != e.amount and !balancing_transfer) {
+                return .exists_with_different_amount;
+            }
+
             if (t.user_data_128 != e.user_data_128) return .exists_with_different_user_data_128;
             if (t.user_data_64 != e.user_data_64) return .exists_with_different_user_data_64;
             if (t.user_data_32 != e.user_data_32) return .exists_with_different_user_data_32;
             if (t.timeout != e.timeout) return .exists_with_different_timeout;
-            assert(t.ledger == e.ledger); // If the accounts are the same, the ledger must be the same.
             if (t.code != e.code) return .exists_with_different_code;
             return .exists;
         }
@@ -3141,8 +3153,15 @@ test "create/lookup 2-phase transfers" {
         \\ transfer T103 A1 A2   15  T3 U1 U1 U1    _ L1 C1   _   _   _ VOI   _   _  _ _ ok
         \\ transfer T102 A1 A2   13  T3 U1 U1 U1    _ L1 C1   _   _ POS   _   _   _  _ _ pending_transfer_already_voided
         \\ transfer T102 A1 A2   15  T4 U1 U1 U1    _ L1 C1   _   _   _ VOI   _   _  _ _ pending_transfer_expired
+
+        // Transfers posted/voided with optional fields must not raise `exists_with_different_*`.
         \\ transfer T105 A0 A0    _  T5 U0 U0 U0    _ L0 C0   _   _ POS   _   _   _  _ _ ok
+        \\ transfer T105 A0 A0    _  T5 U0 U0 U0    _ L0 C0   _   _ POS   _   _   _  _ _ exists
+        \\ transfer T105 A0 A0    7  T5 U0 U0 U0    _ L1 C1   _   _ POS   _   _   _  _ _ exists
         \\ transfer T106 A0 A0    0  T6 U0 U0 U0    _ L1 C1   _   _ POS   _   _   _  _ _ ok
+        \\ transfer T106 A0 A0    0  T6 U0 U0 U0    _ L1 C1   _   _ POS   _   _   _  _ _ exists
+        \\ transfer T106 A0 A0    0  T6 U0 U0 U0    _ L1 C1   _   _ POS   _   _   _  _ _ exists
+        \\ transfer T106 A0 A0    1  T6 U0 U0 U0    _ L0 C0   _   _ POS   _   _   _  _ _ exists
         \\ commit create_transfers
 
         // Check balances after resolving.
@@ -3305,14 +3324,14 @@ test "create_transfers: balancing_debit | balancing_credit (*_must_not_exceed_*)
         \\ transfer   T5 A1 A3  1     _  _  _  _    _ L1 C1   _   _   _   _ BDR BCR  _ _ exceeds_credits
         \\ transfer   T5 A3 A2  1     _  _  _  _    _ L1 C1   _   _   _   _   _ BCR  _ _ exceeds_debits
         \\ transfer   T5 A1 A2  1     _  _  _  _    _ L1 C1   _   _   _   _ BDR BCR  _ _ exceeds_credits
-
-        // "exists" requires that the amount matches exactly, even when BDR/BCR is set.
         \\ transfer   T1 A1 A3    2   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ exists_with_different_amount
         \\ transfer   T1 A1 A3    4   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ exists_with_different_amount
         \\ transfer   T1 A1 A3    3   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ exists
         \\ transfer   T2 A1 A3    6   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ exists
+        \\ transfer   T2 A1 A3    0   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ exists
         \\ transfer   T3 A3 A2    3   _  _  _  _    _ L1 C1   _   _   _   _   _ BCR  _ _ exists
         \\ transfer   T4 A3 A2    5   _  _  _  _    _ L1 C1   _   _   _   _   _ BCR  _ _ exists
+        \\ transfer   T4 A3 A2    0   _  _  _  _    _ L1 C1   _   _   _   _   _ BCR  _ _ exists
         \\ commit create_transfers
         \\
         \\ lookup_account A1 1  9 0 10
@@ -3374,8 +3393,11 @@ test "create_transfers: balancing_debit | balancing_credit (amount=0)" {
         \\ setup A3 0 10 2  0
         \\
         \\ transfer   T1 A1 A4    0   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ ok
+        \\ transfer   T1 A1 A4    0   _  _  _  _    _ L1 C1   _   _   _   _ BDR   _  _ _ exists
         \\ transfer   T2 A4 A2    0   _  _  _  _    _ L1 C1   _   _   _   _   _ BCR  _ _ ok
+        \\ transfer   T2 A4 A2    0   _  _  _  _    _ L1 C1   _   _   _   _   _ BCR  _ _ exists
         \\ transfer   T3 A4 A3    0   _  _  _  _    _ L1 C1   _ PEN   _   _   _ BCR  _ _ ok
+        \\ transfer   T3 A4 A3    0   _  _  _  _    _ L1 C1   _ PEN   _   _   _ BCR  _ _ exists
         \\ commit create_transfers
         \\
         \\ lookup_account A1 1  9  0 10


### PR DESCRIPTION
Removes the `amount` field from the idempotency check for balancing transfers with `amount=0`. It allows resubmitted balancing transfers to fail with `.exists` instead of `exists_with_different_amount`.

Also adds unit tests asserting the behavior of zeroed fields for balancing and two-phase transfers.