### PR TITLE
Bring back shellcheck for `install_zig.sh`

### DIFF
--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: shellcheck ./scripts/install_zig.sh
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig fmt --check .
       - run: ./zig/zig build check

--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build lint
+      - run: ./zig/zig fmt --check .
       - run: ./zig/zig build check
 
   linux:

--- a/build.zig
+++ b/build.zig
@@ -236,20 +236,6 @@ pub fn build(b: *std.Build) !void {
         run_step.dependOn(&run_cmd.step);
     }
 
-    // Linting targets
-    // We currently have: lint_zig_fmt.
-    // The meta-target lint runs them all
-    {
-        // lint_zig_fmt
-        const lint_zig_fmt = b.addFmt(.{ .paths = &.{"."}, .check = true });
-        const lint_zig_fmt_step = b.step("lint_zig_fmt", "Run zig fmt");
-        lint_zig_fmt_step.dependOn(&lint_zig_fmt.step);
-
-        // lint
-        const lint_step = b.step("lint", "Run all defined linters");
-        lint_step.dependOn(lint_zig_fmt_step);
-    }
-
     // Executable which generates src/clients/c/tb_client.h
     const tb_client_header_generate = blk: {
         const tb_client_header = b.addExecutable(.{
@@ -299,11 +285,15 @@ pub fn build(b: *std.Build) !void {
         const integration_tests_step = b.step("test:integration", "Run the integration tests");
         integration_tests_step.dependOn(&run_integration_tests.step);
 
+        const run_fmt = b.addFmt(.{ .paths = &.{"."}, .check = true });
+        const fmt_test_step = b.step("test:fmt", "Check formatting");
+        fmt_test_step.dependOn(&run_fmt.step);
+
         const test_step = b.step("test", "Run the unit tests");
         test_step.dependOn(&run_unit_tests.step);
-
         if (test_filter == null) {
             test_step.dependOn(&run_integration_tests.step);
+            test_step.dependOn(&run_fmt.step);
         }
     }
 

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,6 @@ const CrossTarget = std.zig.CrossTarget;
 const Mode = std.builtin.Mode;
 
 const config = @import("./src/config.zig");
-const Shell = @import("./src/shell.zig");
 
 // TigerBeetle binary requires certain CPU feature and supports a closed set of CPUs. Here, we
 // specify exactly which features the binary needs. Client shared libraries might be more lax with
@@ -238,7 +237,7 @@ pub fn build(b: *std.Build) !void {
     }
 
     // Linting targets
-    // We currently have: lint_zig_fmt, lint_shellcheck.
+    // We currently have: lint_zig_fmt.
     // The meta-target lint runs them all
     {
         // lint_zig_fmt
@@ -246,15 +245,9 @@ pub fn build(b: *std.Build) !void {
         const lint_zig_fmt_step = b.step("lint_zig_fmt", "Run zig fmt");
         lint_zig_fmt_step.dependOn(&lint_zig_fmt.step);
 
-        // lint_shellcheck
-        const lint_shellcheck = ShellcheckStep.add(b);
-        const lint_shellcheck_step = b.step("lint_shellcheck", "Run shellcheck on **.sh");
-        lint_shellcheck_step.dependOn(&lint_shellcheck.step);
-
         // lint
         const lint_step = b.step("lint", "Run all defined linters");
         lint_step.dependOn(lint_zig_fmt_step);
-        lint_step.dependOn(lint_shellcheck_step);
     }
 
     // Executable which generates src/clients/c/tb_client.h
@@ -930,47 +923,6 @@ const FailStep = struct {
         const self: *FailStep = @fieldParentPtr("step", step);
         std.log.err("{s}", .{self.message});
         return error.FailStep;
-    }
-};
-
-const ShellcheckStep = struct {
-    step: std.Build.Step,
-    gpa: std.mem.Allocator,
-
-    fn add(b: *std.Build) *ShellcheckStep {
-        const result = b.allocator.create(ShellcheckStep) catch unreachable;
-        result.* = .{
-            .step = std.Build.Step.init(.{
-                .id = .custom,
-                .name = "run shellcheck",
-                .owner = b,
-                .makeFn = ShellcheckStep.make,
-            }),
-            .gpa = b.allocator,
-        };
-        return result;
-    }
-
-    fn make(step: *std.Build.Step, _: std.Progress.Node) anyerror!void {
-        const self: *ShellcheckStep = @fieldParentPtr("step", step);
-
-        var shell = try Shell.create(self.gpa);
-        defer shell.destroy();
-
-        if (!try shell.exec_status_ok("shellcheck --version", .{})) {
-            shell.echo(
-                "{ansi-red}Please install shellcheck - https://www.shellcheck.net/{ansi-reset}",
-                .{},
-            );
-            return error.NoShellcheck;
-        }
-
-        const scripts = try shell.find(.{
-            .where = &.{ "src", "scripts", ".github" },
-            .extension = ".sh",
-        });
-
-        try shell.exec("shellcheck {scripts}", .{ .scripts = scripts });
     }
 };
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -262,16 +262,22 @@ test "tidy extensions" {
     const allowed_extensions = std.StaticStringMap(void).initComptime(.{
         .{".bat"}, .{".c"},     .{".cs"},   .{".csproj"},  .{".css"},  .{".go"},
         .{".h"},   .{".hcl"},   .{".java"}, .{".js"},      .{".json"}, .{".md"},
-        .{".mod"}, .{".props"}, .{".ps1"},  .{".service"}, .{".sh"},   .{".sln"},
-        .{".sum"}, .{".ts"},    .{".txt"},  .{".xml"},     .{".yml"},  .{".zig"},
+        .{".mod"}, .{".props"}, .{".ps1"},  .{".service"}, .{".sln"},  .{".sum"},
+        .{".ts"},  .{".txt"},   .{".xml"},  .{".yml"},     .{".zig"},
     });
 
     const exceptions = std.StaticStringMap(void).initComptime(.{
-        .{".editorconfig"},          .{".gitattributes"},   .{".gitignore"},
-        .{".nojekyll"},              .{"CNAME"},            .{"Dockerfile"},
-        .{"exclude-pmd.properties"}, .{"favicon.ico"},      .{"favicon.png"},
-        .{"LICENSE"},                .{"module-info.test"}, .{"index.html"},
-        .{"logo.svg"},               .{"logo-white.svg"},   .{"logo-with-text-white.svg"},
+        .{".editorconfig"},                          .{".gitattributes"},
+        .{".gitignore"},                             .{".nojekyll"},
+        .{"CNAME"},                                  .{"Dockerfile"},
+        .{"exclude-pmd.properties"},                 .{"favicon.ico"},
+        .{"favicon.png"},                            .{"LICENSE"},
+        .{"module-info.test"},                       .{"index.html"},
+        .{"logo.svg"},                               .{"logo-white.svg"},
+        .{"logo-with-text-white.svg"},               .{"scripts/install_zig.sh"},
+        .{"src/scripts/cfo_supervisor.sh"},          .{"src/docs_website/scripts/build.sh"},
+        .{".github/ci/docs_check.sh"},               .{".github/ci/test_aof.sh"},
+        .{"tools/systemd/tigerbeetle-pre-start.sh"}, .{"tools/vscode/format_debug_server.sh"},
     });
 
     const allocator = std.testing.allocator;
@@ -286,7 +292,7 @@ test "tidy extensions" {
         const extension = std.fs.path.extension(path);
         if (!allowed_extensions.has(extension)) {
             const basename = std.fs.path.basename(path);
-            if (!exceptions.has(basename)) {
+            if (!exceptions.has(basename) and !exceptions.has(path)) {
                 std.debug.print("bad extension: {s}\n", .{path});
                 bad_extension = true;
             }


### PR DESCRIPTION
@matklad here's my delayed comment, in code form!

I don't think we should remove shellcheck for `install_zig.sh`: it might run on weird who-knows-what systems that we can't control, so we want to avoid something like a Steam `rm -rf` and shellcheck is an easy way to help us towards that goal. (the fact that we use it in CI ourselves gives me good enough confidence that it's tested!)

But, this file is really outside our build system entirely, and I'm in favour of removing it from _there_ - so I think it makes sense if the CI checks it directly.

While we're here, we might as well ban `.sh` entirely too :shrug:.