### PR TITLE
enforce generated file synchronization

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
       - run: zig/zig build test
+      - run: git diff --exit-code
 
   test_on_ubuntu:
     runs-on: ubuntu-latest
@@ -36,6 +37,7 @@ jobs:
       - run: ./scripts/install_zig.sh
       - run: zig/zig build test
       - run: zig/zig build -Dtracer-backend=tracy
+      - run: git diff --exit-code
 
   aof:
     runs-on: ubuntu-latest
@@ -50,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build c_sample -Drelease
+      - run: git diff --exit-code
 
   fuzz:
     runs-on: ubuntu-latest
@@ -57,6 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: zig/zig build fuzz -- smoke
+      - run: git diff --exit-code
 
   # Run simulator once for each state machine, using commit hash as a random, but also deterministic
   # seed.
@@ -67,3 +71,4 @@ jobs:
       - run: ./scripts/install_zig.sh
       - run: zig/zig build simulator_run -Dsimulator-state-machine=accounting -Drelease -- ${{ github.sha }}
       - run: zig/zig build simulator_run -Dsimulator-state-machine=testing    -Drelease -- ${{ github.sha }}
+      - run: git diff --exit-code

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build test
+      - run: git diff --exit-code
 
   c_sample:
     strategy:
@@ -29,3 +30,4 @@ jobs:
       - uses: actions/checkout@v4
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build c_sample -Drelease
+      - run: git diff --exit-code

--- a/.github/workflows/pipeline-core.yml
+++ b/.github/workflows/pipeline-core.yml
@@ -27,6 +27,7 @@ jobs:
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig fmt --check .
       - run: ./zig/zig build check
+      - run: git diff --exit-code
 
   linux:
     uses: ./.github/workflows/linux.yml
@@ -76,6 +77,7 @@ jobs:
 
       - run: ./scripts/install_zig.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
       - run: ./zig/zig build scripts -- ci --language=${{ matrix.language }}
+      - run: git diff --exit-code
 
   # Work around GitHub considering Skipped jobs success for "Require status checks before merging"
   # See also:

--- a/.github/workflows/pipeline-main.yml
+++ b/.github/workflows/pipeline-main.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           DEVHUBDB_PAT: ${{ secrets.DEVHUBDB_PAT }}
           NYRKIO_TOKEN: ${{ secrets.NYRKIO_TOKEN }}
+      - run: git diff --exit-code
 
       - uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
           NODE_AUTH_TOKEN: ${{ secrets.TIGERBEETLE_NODE_PUBLISH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: git diff --exit-code
 
   alert_failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: git diff --exit-code
 
   alert_failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - run: .\scripts\install_zig.bat
       - run: .\zig\zig build c_sample
+      - run: git diff --exit-code


### PR DESCRIPTION
This adds an extra check "git diff --exit-code" to various workflow jobs that will cause them to fail if they cause any files tracked by git to be modified.  This will help detect and reject any commits that failed to synchronize the generated files commited to the repo.

Here's an example of a bad CI run that would result from forgetting to update the generated header files with this change: https://github.com/tigerbeetle/tigerbeetle/actions/runs/9683291713/job/26718376550?pr=2048