### PR TITLE
README.md: Remove reference to --development flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ info(io): allocating 660.140625MiB...
 And start the replica.
 
 ```console
-./tigerbeetle start --addresses=3000 --development 0_0.tigerbeetle
+./tigerbeetle start --addresses=3000 0_0.tigerbeetle
 ```
 ```console
 info(io): opening "0_0.tigerbeetle"...


### PR DESCRIPTION
This flag is not present in the latest release, which can be confusing if following the README quickstart section.

---
I could also understand the argument for keeping it in the README since its in the main branch. However, the quickstart section mentions fetching the latest released binary, which is what I did and how I got into the error:

```
error: unexpected argument: '--development'
```