### PR TITLE
test: merge config.test_min and config.fuzz_min

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -262,7 +262,7 @@ pub const configs = struct {
     /// Not suitable for production, but good for testing code that would be otherwise hard to reach.
     pub const test_min = Config{
         .process = .{
-            .storage_size_limit_max = 200 * 1024 * 1024,
+            .storage_size_limit_max = 1 * 1024 * 1024 * 1024,
             .direct_io = false,
             .cache_accounts_size_default = @sizeOf(vsr.tigerbeetle.Account) * 256,
             .cache_transfers_size_default = 0,
@@ -289,14 +289,6 @@ pub const configs = struct {
             // (This is higher than the production default value because the block size is smaller.)
             .lsm_manifest_compact_extra_blocks = 5,
         },
-    };
-
-    /// Mostly-minimal configuration, with a higher storage limit to ensure that the fuzzers are
-    /// able to max out the LSM levels.
-    pub const fuzz_min = config: {
-        var base = test_min;
-        base.process.storage_size_limit_max = 1 * 1024 * 1024 * 1024;
-        break :config base;
     };
 
     const default = if (@hasDecl(root, "tigerbeetle_config"))

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -9,7 +9,7 @@ const fatal = flags.fatal;
 const log = std.log.scoped(.fuzz);
 
 // NB: this changes values in `constants.zig`!
-pub const tigerbeetle_config = @import("config.zig").configs.fuzz_min;
+pub const tigerbeetle_config = @import("config.zig").configs.test_min;
 comptime {
     assert(constants.storage_size_limit_max == tigerbeetle_config.process.storage_size_limit_max);
 }

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -90,18 +90,6 @@ pub const Storage = struct {
         grid_checker: ?*GridChecker = null,
     };
 
-    /// Compile-time upper bound on the size of a testing Storage.
-    ///
-    /// For convenience, it is rounded to an even number of free set shards so that it is possible
-    /// to create a `FreeSet` covering exactly this amount of blocks.
-    pub const grid_blocks_max = grid_blocks_max: {
-        const free_set_shard_count = @divFloor(
-            constants.storage_size_limit_max - superblock.data_file_size_min,
-            constants.block_size * FreeSet.shard_bits,
-        );
-        break :grid_blocks_max free_set_shard_count * FreeSet.shard_bits;
-    };
-
     /// See usage in Journal.write_sectors() for details.
     /// TODO: allow testing in both modes.
     pub const synchronicity: enum {
@@ -241,6 +229,25 @@ pub const Storage = struct {
 
         storage.reads.items.len = 0;
         storage.next_tick_queue.reset();
+    }
+
+    /// Compile-time upper bound on the size of a grid of a testing Storage.
+    pub const grid_blocks_max =
+        grid_blocks_for_storage_size(constants.storage_size_limit_max);
+
+    /// Runtime bound on the size of the grid of a testing Storage.
+    pub fn grid_blocks(storage: *const Storage) u64 {
+        return grid_blocks_for_storage_size(storage.size);
+    }
+
+    /// How many grid blocks fit in the Storage of the specified size.
+    fn grid_blocks_for_storage_size(size: u64) u64 {
+        assert(size <= constants.storage_size_limit_max);
+        const free_set_shard_count = @divFloor(
+            size - superblock.data_file_size_min,
+            constants.block_size * FreeSet.shard_bits,
+        );
+        return free_set_shard_count * FreeSet.shard_bits;
     }
 
     /// Returns the number of bytes that have been written to, assuming that (the simulated)

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -134,14 +134,17 @@ pub fn main() !void {
         batch_size_limit_min +
             random.uintAtMost(u32, constants.message_body_size_max - batch_size_limit_min);
 
+    const MiB = 1024 * 1024;
+    const storage_size_limit = vsr.sector_floor(
+        200 * MiB - random.uintLessThan(u64, 20 * MiB),
+    );
+
     const cluster_options = Cluster.Options{
         .cluster_id = cluster_id,
         .replica_count = replica_count,
         .standby_count = standby_count,
         .client_count = client_count,
-        .storage_size_limit = vsr.sector_floor(
-            constants.storage_size_limit_max - random.uintLessThan(u64, constants.storage_size_limit_max / 10),
-        ),
+        .storage_size_limit = storage_size_limit,
         .seed = random.int(u64),
         .releases = &releases,
         .network = .{


### PR DESCRIPTION
This PR reduces comptime-dimensionality of TigerBeetle by unifying test_min and fuzz_min.

The two configs differ in the size of the storage: test_min is 200MiBs, while fuzz_min is 1GiB, to allow hitting the lowest level of LSM tree. Historically, this difference required a comptime split, because the total size of the data file was a comptime parameter.

Nowadays though the storage size is elastic, and storage_size_limit is a runtime parameter, so we no longer need to different comptime configs.

Implementation notes:

* bump test_min storage_limit to 1GiB, so that it can accomodate fuzzers.
* Don't change fuzzers: they use `constants.storage_size_limit_max` to pick the runtime size of the storage, which stays the same.
* Change the VOPR and replica test to explicitly request smaller grid sizes.
* FaultAtlas allocates a static bitsef of faults, which grows to 1GiB / sector_size, which is 2MiB, which feels acceptable.