### PR TITLE
test: fix flaky replica test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -286,6 +286,9 @@ pub fn build(b: *std.Build) !void {
 
         const run_unit_tests = b.addRunArtifact(unit_tests);
         run_unit_tests.setEnvironmentVariable("ZIG_EXE", b.graph.zig_exe);
+        if (b.args != null) { // Don't cache test results if running a specific test.
+            run_unit_tests.has_side_effects = true;
+        }
         build_steps.test_unit.dependOn(&run_unit_tests.step);
 
         const integration_tests = b.addTest(.{

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1464,11 +1464,11 @@ const TestContext = struct {
         replica_count: u8,
         standby_count: u8 = 0,
         client_count: u8 = constants.clients_max,
+        seed: u64 = 123,
     }) !*TestContext {
         const log_level_original = std.testing.log_level;
         std.testing.log_level = log_level;
-
-        var prng = std.rand.DefaultPrng.init(123);
+        var prng = std.rand.DefaultPrng.init(options.seed);
         const random = prng.random();
 
         const cluster = try Cluster.init(allocator, TestContext.on_client_reply, .{

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -443,7 +443,7 @@ test "Cluster: repair: partition 2-1, then backup fast-forward 1 checkpoint" {
     try expectEqual(t.replica(.R_).commit(), 3);
 
     var r_lag = t.replica(.B2);
-    r_lag.drop_all(.__, .bidirectional);
+    r_lag.stop();
 
     // Commit enough ops to checkpoint once, and then nearly wrap around, leaving enough slack
     // that the lagging backup can repair (without state sync).
@@ -452,11 +452,11 @@ test "Cluster: repair: partition 2-1, then backup fast-forward 1 checkpoint" {
     try expectEqual(t.replica(.A0).op_checkpoint(), checkpoint_1);
     try expectEqual(t.replica(.B1).op_checkpoint(), checkpoint_1);
 
+    try r_lag.open();
     try expectEqual(r_lag.status(), .normal);
     try expectEqual(r_lag.op_checkpoint(), 0);
 
     // Allow repair, but ensure that state sync doesn't run.
-    r_lag.pass_all(.__, .bidirectional);
     r_lag.drop(.__, .bidirectional, .sync_checkpoint);
     t.run();
 


### PR DESCRIPTION
In this test, the replica can either state-sync or fast-forward the log.
Right now, the choice between the two depends on timing:
`on_repair_sync` timeout might force the replica to state sync.

Fix this by completely stopping the replica, instead of just
partitioning it.

One alternative I've tried is preventing the replica from learning about
the new checkpoint by dropping commits and pings, but that _also_
prevents log forwariding from working.