### PR TITLE
LSM/Compaction: Assert data_block_empty at beat start

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -817,6 +817,7 @@ pub fn CompactionType(
             assert(compaction.beat != null);
             assert(compaction.beat.?.blocks == null);
             assert(!compaction.bar.?.move_table);
+            assert(compaction.bar.?.table_builder.data_block_empty());
 
             assert(blocks.source_value_blocks[0].count > 0);
             assert(blocks.source_value_blocks[1].count > 0);


### PR DESCRIPTION
At the start of each beat, assert that `table_builder.data_block_empty`.

This is guaranteed because the merge step always stops at a clean data-block boundary. (By "rounding up".)