### PR TITLE
LSM: Greedy level-0 table coalescing

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -165,6 +165,7 @@ const ConfigCluster = struct {
     lsm_batch_multiple: comptime_int = 32,
     lsm_snapshots_max: usize = 32,
     lsm_manifest_compact_extra_blocks: comptime_int = 1,
+    lsm_table_coalescing_threshold_percent: comptime_int = 50,
     vsr_releases_max: usize = 64,
 
     // Minimal value.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -572,6 +572,10 @@ comptime {
 /// factor of 8 for lower write amplification rather than the more typical growth factor of 10.
 pub const lsm_growth_factor = config.cluster.lsm_growth_factor;
 
+comptime {
+    assert(lsm_growth_factor > 1);
+}
+
 /// Size of nodes used by the LSM tree manifest implementation.
 /// TODO Double-check this with our "LSM Manifest" spreadsheet.
 pub const lsm_manifest_node_size = config.process.lsm_manifest_node_size;
@@ -645,6 +649,15 @@ pub const lsm_manifest_memory_size_multiplier = lsm_manifest_memory_multiplier: 
     assert(lsm_manifest_memory_multiplier == 1024 * 1024);
     break :lsm_manifest_memory_multiplier lsm_manifest_memory_multiplier;
 };
+
+/// The LSM will attempt to coalesce a table if it is less full than this threshold.
+pub const lsm_table_coalescing_threshold_percent =
+    config.cluster.lsm_table_coalescing_threshold_percent;
+
+comptime {
+    assert(lsm_table_coalescing_threshold_percent > 0); // Ensure that coalescing is possible.
+    assert(lsm_table_coalescing_threshold_percent < 100); // Don't coalesce full tables.
+}
 
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -576,6 +576,7 @@ pub fn CompactionType(
                 const range_b = tree.manifest.immutable_table_compaction_range(
                     tree.table_immutable.key_min(),
                     tree.table_immutable.key_max(),
+                    .{ .value_count = tree.table_immutable.count() },
                 );
 
                 // +1 to count the immutable table (level A).

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -360,7 +360,7 @@ pub fn CompactionType(
                     move_to_level_b,
                 },
                 table: TableInfo,
-            }, constants.lsm_growth_factor + 1) = .{},
+            }, compaction_tables_output_max) = .{},
 
             table_builder: Table.Builder = .{},
         };

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -470,13 +470,16 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         }) ?*const TreeTableInfo {
             assert(parameters.level < constants.lsm_levels);
             assert(parameters.key_min <= parameters.key_max);
-            return manifest.levels[parameters.level].next_table(.{
+
+            const table_info_reference = manifest.levels[parameters.level].next_table(.{
                 .snapshot = parameters.snapshot,
                 .key_min = parameters.key_min,
                 .key_max = parameters.key_max,
                 .key_exclusive = parameters.key_exclusive,
                 .direction = parameters.direction,
-            });
+            }) orelse return null;
+
+            return table_info_reference.table_info;
         }
 
         /// Returns the most optimal table from a level that is due for compaction.

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -596,6 +596,15 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             assert(range.key_min <= key_min);
             assert(key_max <= range.key_max);
 
+            if (range.tables.count() > 1) {
+                for (
+                    range.tables.const_slice()[0 .. range.tables.count() - 1],
+                    range.tables.const_slice()[1..],
+                ) |a, b| {
+                    assert(a.table_info.key_max < b.table_info.key_min);
+                }
+            }
+
             return .{
                 .key_min = range.key_min,
                 .key_max = range.key_max,

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -563,7 +563,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
                 var range = range_overlap;
                 outer: for ([_]Direction{ .descending, .ascending }) |direction| {
-                    inner: for (0..constants.lsm_growth_factor + 1) |_| {
+                    inner: for (0..constants.lsm_growth_factor) |_| {
                         if (range.tables.full()) break :outer;
                         if (value_count_output >= value_count_target) break :outer;
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -545,8 +545,9 @@ pub fn ManifestLevelType(
         /// is invoked and B is the other level), finds a table in Level A that
         /// overlaps with the least number of tables in Level B.
         ///
-        /// * Exits early if it finds a table that doesn't overlap with any
-        ///   tables in the second level.
+        /// As a tiebreaker between multiple tables with the same overlap, prefer to compact the
+        /// oldest (least-recently-created) table. This is primarily for the benefit of trees with
+        /// long runs of strictly monotonic key updates.
         pub fn table_with_least_overlap(
             level_a: *const Self,
             level_b: *const Self,
@@ -576,7 +577,11 @@ pub fn ManifestLevelType(
                 ) orelse continue;
                 assert(range.tables.count() <= max_overlapping_tables);
 
-                if (optimal == null or range.tables.count() < optimal.?.range.tables.count()) {
+                if (optimal == null or
+                    range.tables.count() < optimal.?.range.tables.count() or
+                    (range.tables.count() == optimal.?.range.tables.count() and
+                    table.snapshot_min < optimal.?.table.table_info.snapshot_min))
+                {
                     optimal = LeastOverlapTable{
                         .table = TableInfoReference{
                             .table_info = table,
@@ -585,8 +590,6 @@ pub fn ManifestLevelType(
                         .range = range,
                     };
                 }
-                // If the table can be moved directly between levels then that is already optimal.
-                if (optimal.?.range.tables.empty()) break;
             }
             assert(iterations > 0);
             assert(iterations == level_a.table_count_visible or

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -604,7 +604,7 @@ pub fn ManifestLevelType(
             key_max: Key,
             key_exclusive: ?Key,
             direction: Direction,
-        }) ?*const TableInfo {
+        }) ?TableInfoReference {
             const key_min = parameters.key_min;
             const key_max = parameters.key_max;
             const key_exclusive = parameters.key_exclusive;
@@ -621,7 +621,14 @@ pub fn ManifestLevelType(
                     direction,
                     KeyRange{ .key_min = key_min, .key_max = key_max },
                 );
-                return it.next();
+                if (it.next()) |table_info| {
+                    return .{
+                        .table_info = table_info,
+                        .generation = self.generation,
+                    };
+                } else {
+                    return null;
+                }
             }
 
             assert(key_min <= key_exclusive.?);
@@ -655,7 +662,12 @@ pub fn ManifestLevelType(
                     .ascending => table.key_min > key_exclusive.?,
                     .descending => table.key_max < key_exclusive.?,
                 };
-                if (next) return table;
+                if (next) {
+                    return .{
+                        .table_info = table,
+                        .generation = self.generation,
+                    };
+                }
             }
 
             return null;

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -662,8 +662,10 @@ pub fn ManifestLevelType(
         }
 
         /// Returns the smallest visible range of tables in the given level
-        /// that overlap with the given range: [key_min, key_max], or null
-        /// if the number of tables that intersect with the range is > max_overlapping_tables.
+        /// that overlap with the given range: [key_min, key_max]
+        ///
+        /// Returns null if the number of tables that intersect with the range intersects more than
+        /// max_overlapping_tables tables.
         ///
         /// The range keys are guaranteed to encompass all the relevant level A and level B tables:
         ///   range.key_min = min(a.key_min, b.key_min)

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -15,7 +15,7 @@ pub fn TableMemoryType(comptime Table: type) type {
         const TableMemory = @This();
 
         pub const ValueContext = struct {
-            count: usize = 0,
+            count: u32 = 0,
             sorted: bool = true,
         };
 
@@ -75,7 +75,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             };
         }
 
-        pub fn count(table: *const TableMemory) usize {
+        pub fn count(table: *const TableMemory) u32 {
             return table.value_context.count;
         }
 

--- a/src/stdx/bounded_array.zig
+++ b/src/stdx/bounded_array.zig
@@ -53,15 +53,15 @@ pub fn BoundedArray(comptime T: type, comptime capacity: usize) type {
             return array.inner.addOneAssumeCapacity();
         }
 
-        pub fn insert_assume_capacity(self: *Self, i: usize, item: T) void {
+        pub fn insert_assume_capacity(self: *Self, index: usize, item: T) void {
             assert(self.inner.len < capacity);
-            assert(i <= self.inner.len);
+            assert(index <= self.inner.len);
 
             self.inner.len += 1;
 
-            var s = self.slice();
-            stdx.copy_right(.exact, T, s[i + 1 ..], s[i .. s.len - 1]);
-            s[i] = item;
+            var slice_ = self.slice();
+            stdx.copy_right(.exact, T, slice_[index + 1 ..], slice_[index .. slice_.len - 1]);
+            slice_[index] = item;
         }
 
         pub inline fn append_assume_capacity(array: *Self, item: T) void {

--- a/src/stdx/bounded_array.zig
+++ b/src/stdx/bounded_array.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const stdx = @import("../stdx.zig");
 const assert = std.debug.assert;
 
 /// A version of standard `BoundedArray` with TigerBeetle-idiomatic APIs.
@@ -52,6 +53,17 @@ pub fn BoundedArray(comptime T: type, comptime capacity: usize) type {
             return array.inner.addOneAssumeCapacity();
         }
 
+        pub fn insert_assume_capacity(self: *Self, i: usize, item: T) void {
+            assert(self.inner.len < capacity);
+            assert(i <= self.inner.len);
+
+            self.inner.len += 1;
+
+            var s = self.slice();
+            stdx.copy_right(.exact, T, s[i + 1 ..], s[i .. s.len - 1]);
+            s[i] = item;
+        }
+
         pub inline fn append_assume_capacity(array: *Self, item: T) void {
             array.inner.appendAssumeCapacity(item);
         }
@@ -73,4 +85,37 @@ pub fn BoundedArray(comptime T: type, comptime capacity: usize) type {
             array.inner.len = 0;
         }
     };
+}
+
+test "BoundedArray.insert_assume_capacity" {
+    const items_max = 32;
+    const BoundedArrayU64 = BoundedArray(u64, items_max);
+
+    // Test lists of every size (less than the capacity).
+    for (0..items_max) |len| {
+        var list_base = BoundedArrayU64{};
+        for (0..len) |i| {
+            list_base.append_assume_capacity(i);
+        }
+
+        // Test an insert at every possible position (including an append).
+        for (0..list_base.count() + 1) |i| {
+            var list = list_base;
+
+            list.insert_assume_capacity(i, 12345);
+
+            // Verify the result:
+
+            try std.testing.expectEqual(list.count(), list_base.count() + 1);
+            try std.testing.expectEqual(list.get(i), 12345);
+
+            for (0..i) |j| {
+                try std.testing.expectEqual(list.get(j), j);
+            }
+
+            for (i + 1..list.count()) |j| {
+                try std.testing.expectEqual(list.get(j), j - 1);
+            }
+        }
+    }
 }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -10,6 +10,7 @@ comptime {
     _ = @import("ring_buffer.zig");
     _ = @import("shell.zig");
     _ = @import("stdx.zig");
+    _ = @import("stdx/bounded_array.zig");
     _ = @import("tidy.zig");
 
     _ = @import("clients/c/test.zig");


### PR DESCRIPTION
Currently trees with disjoint (or mostly-disjoint) tables have extremely high space amplification when `create_transfers` batches are not full (i.e. when `request.header.size << 1MiB`).

This PR is a stopgap fix, to mitigate space amp until a more considered/performant fix can land.
It patches the space amp issue, but at the cost of increasing write amp when batches are small.

### Context

#### Space Amplification

An immutable table is constructed from the updates that occur over a single bar.
The immutable table is then compacted down into level 0. (etc).

- Each table contains, at minimum, a single value. (1 index block -> 1 data block -> 1 value).
- All data blocks in a table except the final one are guaranteed to be full. (The final data block in a table is only guaranteed at least one value.)
- No matter how many values they hold, each data block occupies 512KiB.

This leads to the "space amplification" ratio -- the ratio of bytes actually occupied by values vs the total bytes (including the block padding up to 512KiB, since blocks are fixed-size). A high space amplification ratio means that there is a lot of space on disk wasted. Since TigerBeetle has a fixed maximum number of tables, "tiny tables" (i.e. tables with very few values / high space amplification) also effectively reduce the maximum number of accounts/transfers that the cluster can store.

For example, if a single transfer (128B) is created over 32 ops, the immutable table will be written to level 0, and will occupy 1MiB (512KiB index block + 512KiB data block).

#### Compaction

When tables are compacted, if the level-A input table has a disjoint key range the tables in level B, then:
- If level B is 0 (the level-A table is the immutable table), then just write the immutable table directly into level B -- no merging.
- If level B is >0, then "move-table": update the input table's level in the metadata (from A to B). (None of the values need to be copied. All of the value blocks are left untouched).

In the transfers object tree, these disjoint tables are guaranteed, since keys (timestamps) are strictly increasing and transfers are immutable. Other trees typically have (some degree of) overlapping tables, depending on workload.

Disjoint tables are the best case for compaction performance -- metadata updates are pretty much free -- _much_ cheaper than merge-compaction.
But the downside is that without merging, tiny tables are tiny forever.

#### Example

In the production config, with a 1MiB batch size and an `lsm_batch_multiple` of `32`, a transfers object table references as many as ~32MiB of transfers, split into 512KiB data blocks (modulo headers).

In the worst case, a table might hold only a single transfer, leading to a space amp ratio of 8192.

And unfortunately, this runaway-space-amp "bug" is extremely easy to hit:
- send batches of transfers that aren't totally full, or
- mix `create_transfers` with other operations.

### Fix (stopgap)

Aggressively coalesce adjacent small tables during the immutable-to-level-0 compaction -- merge them even if they are disjoint.

#### Benchmarks (before)

```
$ ./tigerbeetle benchmark --addresses=127.0.0.1:3000 --transfer-batch-size=256
...
load accepted = 42612 tx/s
...
$ du -h TB.0
18G     TB.0
```

<details>
<summary>inspect tables</summary>

```
$ ./tigerbeetle inspect tables --tree=transfers TB.0
info(io): opening "TB.0"...
I T=transfers L=0 K=1720039876632088569..1720039876843820531 S=38208..max V=__8192/262080 C=0f569c35311ced953e0bc16f6fde3d4c A=27089
I T=transfers L=0 K=1720039876854657855..1720039877075293984 S=38240..max V=__8192/262080 C=9a5082b42dd53e2aea13fcbdcb6596e1 A=28096
I T=transfers L=0 K=1720039877087292888..1720039877296023475 S=38272..max V=__8192/262080 C=78ff14bd4fac46b1138554881843d6b8 A=28952
I T=transfers L=0 K=1720039877306512984..1720039877513031082 S=38304..max V=__8192/262080 C=cb700200f9e6b8d3c107f1020039a0bb A=29860
I T=transfers L=0 K=1720039877523050206..1720039877738037682 S=38336..max V=__8192/262080 C=3cf3e168a9b759f2948ae2d1362058f9 A=30722
I T=transfers L=0 K=1720039877748400021..1720039877983918401 S=38368..max V=__8192/262080 C=d10536ff94b40c36b7d1e6fc162dbde1 A=31503
I T=transfers L=0 K=1720039877996530179..1720039878210308687 S=38400..max V=__8192/262080 C=1cecbfba83ab566bb6c204d28ace2daa A=32290
I T=transfers L=0 K=1720039878220000173..1720039878454032352 S=38432..max V=__8192/262080 C=e3cae91f04d73ff6e15a24f1c78e82ea A=33770
U T=transfers L=1 K=1720039863484154939..1720039863697325863 S=36192..max V=__8192/262080 C=560b86f6ecce7d1058028cb9edc47cba A=23953
U T=transfers L=1 K=1720039863706841477..1720039863898996353 S=36224..max V=__8192/262080 C=005e955ff3aa2f489c94e38597321967 A=24932
U T=transfers L=1 K=1720039863907840232..1720039864101189387 S=36256..max V=__8192/262080 C=7d682ca9516f92291e65dc263df2c887 A=25933
U T=transfers L=1 K=1720039864110309517..1720039864296981451 S=36288..max V=__8192/262080 C=507d6b78fcef15926c2a83b1f7a8d045 A=26864
U T=transfers L=1 K=1720039864305780576..1720039864494384591 S=36320..max V=__8192/262080 C=80c265408aef28fa5fb4a5805bb7b95a A=27693
U T=transfers L=1 K=1720039864504532407..1720039864694819503 S=36352..max V=__8192/262080 C=c5a6d114b9c7b4496eaacbec9eb2f779 A=28562
U T=transfers L=1 K=1720039864703747831..1720039864898438965 S=36384..max V=__8192/262080 C=a52af01f8ccbf7b351e28f37a03c6666 A=29406
U T=transfers L=1 K=1720039864907687978..1720039865094325417 S=36416..max V=__8192/262080 C=7bb7fc89a57feb808c8c1aab3e033e4a A=30180
U T=transfers L=1 K=1720039865104285840..1720039865288680384 S=36448..max V=__8192/262080 C=a4db402c24d8cc322c234dd7941cf612 A=30893
U T=transfers L=1 K=1720039865298563741..1720039865487033393 S=36480..max V=__8192/262080 C=6a0300c0d1702ad57f8d9ecbfd7716d4 A=31585
U T=transfers L=1 K=1720039865497584729..1720039865694743653 S=36512..max V=__8192/262080 C=58531c706a872dc6b72cc39ca476beff A=32964
U T=transfers L=1 K=1720039865705440103..1720039865963205269 S=36544..max V=__8192/262080 C=db450b8d4054d535777ba3621e6e03ef A=836
U T=transfers L=1 K=1720039865976077868..1720039866172851797 S=36576..max V=__8192/262080 C=89aded68b04f8b4cb6c36f7672f38590 A=2275
U T=transfers L=1 K=1720039866186153405..1720039866362527056 S=36608..max V=__8192/262080 C=bd8d1585d40b1777fb9b5fff076a16ae A=3506
U T=transfers L=1 K=1720039866374468251..1720039866555891486 S=36640..max V=__8192/262080 C=8b7564a4121537444c2e654527dfc6f1 A=4811
U T=transfers L=1 K=1720039866566511151..1720039866763642743 S=36672..max V=__8192/262080 C=7e98545fcc23e06c35b9a1da432185a2 A=5961
U T=transfers L=1 K=1720039866774753954..1720039866967647381 S=36704..max V=__8192/262080 C=1de028d27e0ad47a538c9fbfac587d27 A=7136
U T=transfers L=1 K=1720039866978262377..1720039867177026956 S=36736..max V=__8192/262080 C=8753c290be8bee70212cc0b82778d687 A=8298
U T=transfers L=1 K=1720039867188371747..1720039867381251469 S=36768..max V=__8192/262080 C=ed29a78f062c2b35fc1e4511adbcdf77 A=9600
(... snip -- there are 1200 tables total)
```
</details>

#### Benchmarks (after)

```
$ ./tigerbeetle benchmark --addresses=127.0.0.1:3000 --transfer-batch-size=256
...
load accepted = 39652 tx/s
...
$ du -h TB.0
16G     TB.0
```

<details>
<summary>inspect tables</summary>

```
$ ./tigerbeetle inspect tables --tree=transfers TB.0
info(io): opening "TB.0"...
I T=transfers L=0 K=1720039452035550893..1720039458943933466 S=32800..max V=253952/262080 C=62f694c4fbd6a95bfc05ad0394fadca5 A=4240
I T=transfers L=0 K=1720039458954000269..1720039465952802948 S=33792..max V=253952/262080 C=d2bbb5316ba261f84a0d1047ad903fec A=5223
I T=transfers L=0 K=1720039465962454990..1720039472838171825 S=34784..max V=253952/262080 C=6dfbab60e80ec8dbfd8f43e209a487db A=6607
I T=transfers L=0 K=1720039472848605139..1720039479857804537 S=35776..max V=253952/262080 C=c40a886b22cf5b4571b2a85e9d0aedf7 A=7529
I T=transfers L=0 K=1720039479869955928..1720039486888519299 S=36768..max V=253952/262080 C=9c9f76e18e71c46dee4d9e7b6ef656e7 A=8230
I T=transfers L=0 K=1720039486898997317..1720039494029021980 S=37760..max V=253952/262080 C=f8a89c31cbac0ad1fb4cb95a48631f4a A=8992
I T=transfers L=0 K=1720039494039345226..1720039498603926385 S=38432..max V=172032/262080 C=7d924d8850341ccb24f9dd4dbb7517df A=28908
U T=transfers L=1 K=1720039251011323578..1720039252996443210 S=1056..max V=260864/262080 C=634b07d169ab9a12ddb0b0241b86c571 A=388
U T=transfers L=1 K=1720039253000279754..1720039256122756813 S=2048..max V=253952/262080 C=b1ae762d33209d471144a89ecbccc172 A=958
U T=transfers L=1 K=1720039256126787022..1720039259987493455 S=3040..max V=253952/262080 C=382bd4b3c59f318c9cb027bdfb544530 A=1687
U T=transfers L=1 K=1720039259991859087..1720039264509089972 S=4032..max V=253952/262080 C=9379d2b2ca7b4c3fb992ad7d5ced16b4 A=2590
U T=transfers L=1 K=1720039264515295470..1720039269716190192 S=5024..max V=253952/262080 C=f8aa980192ebffecef6bb8cfea2b2274 A=3678
U T=transfers L=1 K=1720039269723076232..1720039275596627220 S=6016..max V=253952/262080 C=d0264fc685cd3b0b489a34a3fc3b64cc A=4938
U T=transfers L=1 K=1720039275605942527..1720039282295728444 S=7008..max V=253952/262080 C=336a287c5e4cfb99f6480239e7746ff7 A=6361
U T=transfers L=1 K=1720039282306009480..1720039289358438397 S=8000..max V=253952/262080 C=bf06e750366693854c0fe09ecfadb863 A=7326
U T=transfers L=1 K=1720039289371187233..1720039296179426472 S=8992..max V=253952/262080 C=99193d7cd5098edc29ab5d687c751bb6 A=8239
U T=transfers L=1 K=1720039296188242368..1720039303006678129 S=9984..max V=253952/262080 C=83611cead65730abf7db81fedddae879 A=9260
U T=transfers L=1 K=1720039303019268627..1720039309856712970 S=10976..max V=253952/262080 C=b7def9276d92961a543b07ac25391e58 A=10253
U T=transfers L=1 K=1720039309865869438..1720039316535925625 S=11968..max V=253952/262080 C=8f8de59e73f0662aaa9ddcd7d98b9308 A=10927
U T=transfers L=1 K=1720039316545996686..1720039322973726060 S=12960..max V=253952/262080 C=435c53c2c2b4c74ff46a687161181923 A=11589
U T=transfers L=1 K=1720039322985144299..1720039329463123082 S=13952..max V=253952/262080 C=10af336b36c1004591129819d326d756 A=12704
U T=transfers L=1 K=1720039329473552157..1720039336018006750 S=14944..max V=253952/262080 C=e083c2ead063228b2f997cdda978b8ac A=13690
U T=transfers L=1 K=1720039336030420936..1720039342548824826 S=15936..max V=253952/262080 C=e310f9d28b1fe6f3032572eda4104172 A=14229
U T=transfers L=1 K=1720039342560917836..1720039349152549860 S=16928..max V=253952/262080 C=94e721545b158f2df49e96202f546864 A=15209
U T=transfers L=1 K=1720039349164030507..1720039356035523644 S=17920..max V=253952/262080 C=8698f51eddb6823aec13d37c50822a4b A=16202
U T=transfers L=1 K=1720039356045269342..1720039362811597962 S=18912..max V=253952/262080 C=9f7c0717d49640eb338302a40b2065be A=17270
U T=transfers L=1 K=1720039362820432082..1720039369693826111 S=19904..max V=253952/262080 C=5027915f0ea742e0ad8d1e80222658f9 A=18496
U T=transfers L=1 K=1720039369701822443..1720039376652015494 S=20896..max V=253952/262080 C=de541849f75b1c9896eed9fa6810d723 A=19569
U T=transfers L=1 K=1720039376661065581..1720039383594244584 S=21888..max V=253952/262080 C=5cca4c8603af4aa628809e61452bbfbd A=20481
U T=transfers L=1 K=1720039383604595453..1720039390364250018 S=22880..max V=253952/262080 C=f9f27688735bc7040a402bcbbac2526d A=21142
U T=transfers L=1 K=1720039390374116303..1720039397204813053 S=23872..max V=253952/262080 C=7f39aa3eb10dd0612f176d919eec4f9b A=21859
U T=transfers L=1 K=1720039397214728761..1720039404052286709 S=24864..max V=253952/262080 C=43f1d372e2413bb43097a49641d395eb A=22549
U T=transfers L=1 K=1720039404064185905..1720039410868788559 S=25856..max V=253952/262080 C=c0a1bbb37d3c791c5ba6aa0cd19177ed A=23591
U T=transfers L=1 K=1720039410881824256..1720039417701980546 S=26848..max V=253952/262080 C=76d105963ccc4e093978db8937399902 A=24610
U T=transfers L=1 K=1720039417713946377..1720039424532410549 S=27840..max V=253952/262080 C=4aeed2bf1af8b3ca759bc2d7847276c8 A=26200
U T=transfers L=1 K=1720039424543424487..1720039431272764996 S=28832..max V=253952/262080 C=8e19fcc17405c5fa6227e6392de19d65 A=27224
U T=transfers L=1 K=1720039431284259609..1720039438127351403 S=29824..max V=253952/262080 C=6e1b7146ae57ca158b85fa2e124b972b A=1133
U T=transfers L=1 K=1720039438141534642..1720039445094703049 S=30816..max V=253952/262080 C=af17d68dc3956ab2b465ea43375a8f6c A=2071
U T=transfers L=1 K=1720039445103997958..1720039452026654786 S=31808..max V=253952/262080 C=2d1b3ded0171324b82e4db67bb3a041f A=2995
```
</details>

### Compaction selection

Also noteworthy:

~Break compaction-table selection ties via `snapshot_min`.~

~When selecting the "least overlap" table for compaction, if multiple level-A overlap with the same number of level-B tables, pick the oldest (least-recently-created) table as a tiebreaker.~

Rationale: Old tables are an approximation for cold tables. (Keep hot tables in upper levels, move cold tables down.)

This reduces the likelihood that coalescing disjoint tables at a high level will create a table that overlaps with a (formerly disjoint) table at a lower level.

**Edit:** Reverted; see https://github.com/tigerbeetle/tigerbeetle/pull/2070#issuecomment-2223512126 for explanation.

