### PR TITLE
Tidy two lsm files

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -792,60 +792,24 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
             // Otherwise pick a random FuzzOp.
             fuzz.random_enum(random, FuzzOpActionTag, action_distribution);
         const action = switch (action_tag) {
-            .compact => compact: {
-                const compact_op = op;
+            .compact => action: {
+                const action = generate_compact(random, .{
+                    .op = op,
+                    .persisted_op = persisted_op,
+                });
                 op += 1;
-                const checkpoint =
-                    // Can only checkpoint on the last beat of the bar.
-                    compact_op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
-                    compact_op > constants.lsm_batch_multiple and
-                    // Never checkpoint at the same op twice
-                    compact_op > persisted_op + constants.lsm_batch_multiple and
-                    // Checkpoint at roughly the same rate as log wraparound.
-                    random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
-                if (checkpoint) {
+                if (action.compact.checkpoint) {
                     persisted_op = op - constants.lsm_batch_multiple;
                 }
-                break :compact FuzzOpAction{
-                    .compact = .{
-                        .op = compact_op,
-                        .checkpoint = checkpoint,
-                    },
-                };
+                break :action action;
             },
-            .put_account => put_account: {
-                const id = random_id(random, u128);
-                var account = id_to_account.get(id) orelse Account{
-                    .id = id,
-                    // `timestamp` must be unique.
-                    .timestamp = fuzz_op_index,
-                    .user_data_128 = random_id(random, u128),
-                    .user_data_64 = random_id(random, u64),
-                    .user_data_32 = random_id(random, u32),
-                    .reserved = 0,
-                    .ledger = random_id(random, u32),
-                    .code = random_id(random, u16),
-                    .flags = .{
-                        .debits_must_not_exceed_credits = random.boolean(),
-                        .credits_must_not_exceed_debits = random.boolean(),
-                    },
-                    .debits_pending = 0,
-                    .debits_posted = 0,
-                    .credits_pending = 0,
-                    .credits_posted = 0,
-                };
-
-                // These are the only fields we are allowed to change on existing accounts.
-                account.debits_pending = random.int(u64);
-                account.debits_posted = random.int(u64);
-                account.credits_pending = random.int(u64);
-                account.credits_posted = random.int(u64);
-
-                try id_to_account.put(account.id, account);
-                break :put_account FuzzOpAction{ .put_account = .{
+            .put_account => action: {
+                const action = generate_put_account(random, &id_to_account, .{
                     .op = op,
-                    .account = account,
-                } };
+                    .timestamp = fuzz_op_index,
+                });
+                try id_to_account.put(action.put_account.account.id, action.put_account.account);
+                break :action action;
             },
             .get_account => FuzzOpAction{ .get_account = random_id(random, u128) },
             .scan_account => blk: {
@@ -918,6 +882,61 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
     }
 
     return fuzz_ops;
+}
+
+fn generate_compact(
+    random: std.rand.Random,
+    options: struct { op: u64, persisted_op: u64 },
+) FuzzOpAction {
+    const checkpoint =
+        // Can only checkpoint on the last beat of the bar.
+        options.op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
+        options.op > constants.lsm_batch_multiple and
+        // Never checkpoint at the same op twice
+        options.op > options.persisted_op + constants.lsm_batch_multiple and
+        // Checkpoint at roughly the same rate as log wraparound.
+        random.uintLessThan(usize, Environment.compacts_per_checkpoint) == 0;
+    return FuzzOpAction{ .compact = .{
+        .op = options.op,
+        .checkpoint = checkpoint,
+    } };
+}
+
+fn generate_put_account(
+    random: std.rand.Random,
+    id_to_account: *const std.AutoHashMap(u128, Account),
+    options: struct { op: u64, timestamp: u64 },
+) FuzzOpAction {
+    const id = random_id(random, u128);
+    var account = id_to_account.get(id) orelse Account{
+        .id = id,
+        // `timestamp` must be unique.
+        .timestamp = options.timestamp,
+        .user_data_128 = random_id(random, u128),
+        .user_data_64 = random_id(random, u64),
+        .user_data_32 = random_id(random, u32),
+        .reserved = 0,
+        .ledger = random_id(random, u32),
+        .code = random_id(random, u16),
+        .flags = .{
+            .debits_must_not_exceed_credits = random.boolean(),
+            .credits_must_not_exceed_debits = random.boolean(),
+        },
+        .debits_pending = 0,
+        .debits_posted = 0,
+        .credits_pending = 0,
+        .credits_posted = 0,
+    };
+
+    // These are the only fields we are allowed to change on existing accounts.
+    account.debits_pending = random.int(u64);
+    account.debits_posted = random.int(u64);
+    account.credits_pending = random.int(u64);
+    account.credits_posted = random.int(u64);
+    return FuzzOpAction{ .put_account = .{
+        .op = options.op,
+        .account = account,
+    } };
 }
 
 const io_latency_mean = 20;

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -174,8 +174,10 @@ pub fn GrooveType(
         // See if we should ignore this field from the options.
         //
         // By default, we ignore the "timestamp" field since it's a special identifier.
-        // Since the "timestamp" is ignored by default, it shouldn't be provided in groove_options.ignored.
-        comptime var ignored = mem.eql(u8, field.name, "timestamp") or mem.eql(u8, field.name, "id");
+        // Since the "timestamp" is ignored by default, it shouldn't be provided
+        // in groove_options.ignored.
+        comptime var ignored =
+            mem.eql(u8, field.name, "timestamp") or mem.eql(u8, field.name, "id");
         for (groove_options.ignored) |ignored_field_name| {
             comptime assert(!std.mem.eql(u8, ignored_field_name, "timestamp"));
             comptime assert(!std.mem.eql(u8, ignored_field_name, "id"));

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -383,7 +383,6 @@ fn parse_multiline_string(line: []const u8) ?[]const u8 {
 const naughty_list = [_][]const u8{
     "lsm/binary_search.zig",
     "lsm/binary_search_benchmark.zig",
-    "lsm/forest_fuzz.zig",
     "lsm/level_data_iterator.zig",
     "lsm/manifest_level.zig",
     "lsm/segmented_array_benchmark.zig",

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -384,7 +384,6 @@ const naughty_list = [_][]const u8{
     "lsm/binary_search.zig",
     "lsm/binary_search_benchmark.zig",
     "lsm/forest_fuzz.zig",
-    "lsm/groove.zig",
     "lsm/level_data_iterator.zig",
     "lsm/manifest_level.zig",
     "lsm/segmented_array_benchmark.zig",


### PR DESCRIPTION
Mostly straighforward except the first commit: generate_fuzz_op contained a long line that was seemingly not possible to shorten locally in a way that read better than the existing expression, so I extracted the generate_fuzz_op_action function.

The resulting code is perhaps better for having shorter functions, but the extracted function signature is pretty ugly: worst is that I couldn't figure out how to name the HashMap type this function uses so I just provided it as _some_ comptime type and called the hashmap methods on it.