### PR TITLE
vsr: ensure flexible quorums actually work

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -996,16 +996,16 @@ pub fn ReplicaType(
             // To do this:
             //   - an active replica clock tracks only other active replicas,
             //   - a standby clock tracks active replicas and the standby itself.
-            self.clock = try if (replica_index < replica_count) Clock.init(
+            self.clock = try Clock.init(
                 allocator,
-                replica_count,
-                replica_index,
                 &self.time,
-            ) else Clock.init(
-                allocator,
-                replica_count + 1,
-                replica_count,
-                &self.time,
+                if (replica_index < replica_count) .{
+                    .replica_count = replica_count,
+                    .replica = replica_index,
+                } else .{
+                    .replica_count = replica_count + 1,
+                    .replica = replica_count,
+                },
             );
             errdefer self.clock.deinit(allocator);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1002,9 +1002,11 @@ pub fn ReplicaType(
                 if (replica_index < replica_count) .{
                     .replica_count = replica_count,
                     .replica = replica_index,
+                    .quorum = quorum_replication,
                 } else .{
                     .replica_count = replica_count + 1,
                     .replica = replica_count,
+                    .quorum = quorum_replication + 1,
                 },
             );
             errdefer self.clock.deinit(allocator);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -433,6 +433,21 @@ test "Cluster: network: partition client-primary (asymmetric, drop replies)" {
     try c.request(1, 0);
 }
 
+test "Cluster: network: partition flexible quorum" {
+    // Two out of four replicas should be able to carry on as long the pair includes the primary.
+    const t = try TestContext.init(.{ .replica_count = 4 });
+    defer t.deinit();
+
+    var c = t.clients(0, t.cluster.clients.len);
+
+    t.run();
+    t.replica(.B2).stop();
+    t.replica(.B3).stop();
+    for (0..3) |_| t.run(); // Give enough time for the clocks to desync.
+
+    try c.request(4, 4);
+}
+
 test "Cluster: repair: partition 2-1, then backup fast-forward 1 checkpoint" {
     // A backup that has fallen behind by two checkpoints can catch up, without using state sync.
     const t = try TestContext.init(.{ .replica_count = 3 });


### PR DESCRIPTION
Change the Clock to use replication_quorum, rather than simple majority.

Clocks were implemented before flexible quorum, and, with simple
majority, they'll actually prevent a flexible quorum from committing!

Thanks to dj for writing the test here!