### PR TITLE
ci: sanity-check level code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,20 @@ jobs:
           path: ./src/devhub
       - uses: actions/deploy-pages@v1
 
+  kcov:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2147483647
+      - run: sudo apt install kcov
+      - run: ./scripts/install_zig.sh
+      - run: ./zig/zig build scripts -- kcov
+      - uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: zig-out/kcov
 
   # Work around GitHub considering Skipped jobs success for "Require status checks before merging"
   # See also:

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -21,6 +21,7 @@ const cfo = @import("./scripts/cfo.zig");
 const ci = @import("./scripts/ci.zig");
 const release = @import("./scripts/release.zig");
 const devhub = @import("./scripts/devhub.zig");
+const kcov = @import("./scripts/kcov.zig");
 const changelog = @import("./scripts/changelog.zig");
 
 const CliArgs = union(enum) {
@@ -28,6 +29,7 @@ const CliArgs = union(enum) {
     ci: ci.CliArgs,
     release: release.CliArgs,
     devhub: devhub.CliArgs,
+    kcov: kcov.CliArgs,
     changelog: void,
 };
 
@@ -53,6 +55,7 @@ pub fn main() !void {
         .ci => |args_ci| try ci.main(shell, gpa, args_ci),
         .release => |args_release| try release.main(shell, gpa, args_release),
         .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
+        .kcov => |args_kcov| try kcov.main(shell, gpa, args_kcov),
         .changelog => try changelog.main(shell, gpa),
     }
 }

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -1,13 +1,13 @@
-/// Runs a set of macro-benchmarks whose result is displayed at <https://tigerbeetle.github.io>.
-///
-/// Specifically:
-///
-/// - This script is run by the CI infrastructure on every merge to main.
-/// - It runs a set of "benchmarks", where a "benchmark" can be anything (eg, measuring the size of
-///   the binary).
-/// - The results of all measurements are serialized as a single JSON object, `Run`.
-/// - The key part: this JSON is then stored in a "distributed database" for our visualization
-///   front-end to pick up. This "database" is just a newline-delimited JSON file in a git repo
+//! Runs a set of macro-benchmarks whose result is displayed at <https://tigerbeetle.github.io>.
+//!
+//! Specifically:
+//!
+//! - This script is run by the CI infrastructure on every merge to main.
+//! - It runs a set of "benchmarks", where a "benchmark" can be anything (eg, measuring the size of
+//!   the binary).
+//! - The results of all measurements are serialized as a single JSON object, `Run`.
+//! - The key part: this JSON is then stored in a "distributed database" for our visualization
+//!   front-end to pick up. This "database" is just a newline-delimited JSON file in a git repo
 const std = @import("std");
 
 const stdx = @import("../stdx.zig");

--- a/src/scripts/kcov.zig
+++ b/src/scripts/kcov.zig
@@ -1,0 +1,37 @@
+//! Runs a subset of TigerBeetle tests with kcov. While we don't rigorously track coverage
+//! information, this is useful to run as a one-off sanity check.
+//!
+//! # Usage
+//!
+//! This script is run by CI for each merge to the main branch. That CI jobs uploads the results
+//! as GitHub Actions artifact. To view the results, open the CI run in the browser, find the link
+//! to the artifact, download `code-coverage-report.zig` file, unpack it, and open the `index.html`
+//! in the browser.
+const std = @import("std");
+
+const Shell = @import("../shell.zig");
+
+const log = std.log;
+
+pub const CliArgs = struct {};
+
+pub fn main(shell: *Shell, _: std.mem.Allocator, _: CliArgs) !void {
+    const kcov_version = shell.exec_stdout("kcov --version", .{}) catch {
+        log.err("can't find kcov", .{});
+        std.process.exit(1);
+    };
+    log.info("kcov version {s}", .{kcov_version});
+
+    try shell.zig("build test:unit:build", .{});
+    try shell.zig("build vopr:build", .{});
+    try shell.zig("build fuzz:build", .{});
+
+    try shell.project_root.deleteTree("./zig-out/kcov");
+    try shell.project_root.makePath("./zig-out/kcov");
+
+    const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./zig-out/kcov" };
+    try shell.exec("{kcov} ./zig-out/bin/test", .{ .kcov = kcov });
+    try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_tree 92", .{ .kcov = kcov });
+    try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_forest 92", .{ .kcov = kcov });
+    try shell.exec("{kcov} ./zig-out/bin/vopr 92", .{ .kcov = kcov });
+}


### PR DESCRIPTION
It's easy to just run kcov, so let's just do that without thinking to
much about how it's best to integrate this into our overall dev process.

For now, let's just run a handful of test on main post merge, and upload
the results as a GitHub artifact (so, you can download the HTML report
manually).