### PR TITLE
tidy: remove exceptions from Java

### DIFF
--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -25,8 +25,9 @@ First, create a directory for your project and `cd` into the directory.
 Then create `pom.xml` and copy this into it:
 
 ```xml
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.tigerbeetle</groupId>

--- a/src/clients/java/docs.zig
+++ b/src/clients/java/docs.zig
@@ -28,8 +28,9 @@ pub const JavaDocs = Docs{
 
     .project_file_name = "pom.xml",
     .project_file =
-    \\<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    \\         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    \\<project xmlns="http://maven.apache.org/POM/4.0.0"
+    \\         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    \\         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     \\  <modelVersion>4.0.0</modelVersion>
     \\
     \\  <groupId>com.tigerbeetle</groupId>

--- a/src/clients/java/src/main/java/com/tigerbeetle/AccountBalanceBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AccountBalanceBatch.java
@@ -53,7 +53,8 @@ public final class AccountBalanceBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -108,7 +109,8 @@ public final class AccountBalanceBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -163,7 +165,8 @@ public final class AccountBalanceBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -218,7 +221,8 @@ public final class AccountBalanceBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.

--- a/src/clients/java/src/main/java/com/tigerbeetle/AccountBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AccountBatch.java
@@ -57,7 +57,8 @@ public final class AccountBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -113,7 +114,8 @@ public final class AccountBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -168,7 +170,8 @@ public final class AccountBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -223,7 +226,8 @@ public final class AccountBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -278,7 +282,8 @@ public final class AccountBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -330,7 +335,8 @@ public final class AccountBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.

--- a/src/clients/java/src/main/java/com/tigerbeetle/AccountFilterBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AccountFilterBatch.java
@@ -49,7 +49,8 @@ final class AccountFilterBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.

--- a/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
@@ -57,7 +57,8 @@ public final class TransferBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -110,7 +111,8 @@ public final class TransferBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -163,7 +165,8 @@ public final class TransferBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -219,7 +222,8 @@ public final class TransferBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -271,7 +275,8 @@ public final class TransferBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.
@@ -324,7 +329,8 @@ public final class TransferBatch extends Batch {
     }
 
     /**
-     * @param part a {@link UInt128} enum indicating which part of the 128-bit value is to be retrieved.
+     * @param part a {@link UInt128} enum indicating which part of the 128-bit value
+              is to be retrieved.
      * @return a {@code long} representing the first 8 bytes of the 128-bit value if
      *         {@link UInt128#LeastSignificant} is informed, or the last 8 bytes if
      *         {@link UInt128#MostSignificant}.

--- a/src/java_bindings.zig
+++ b/src/java_bindings.zig
@@ -685,7 +685,8 @@ fn emit_u128_batch_accessors(
     // Get long:
     try buffer.writer().print(
         \\    /**
-        \\     * @param part a {{@link UInt128}} enum indicating which part of the 128-bit value is to be retrieved.
+        \\     * @param part a {{@link UInt128}} enum indicating which part of the 128-bit value
+        \\              is to be retrieved.
         \\     * @return a {{@code long}} representing the first 8 bytes of the 128-bit value if
         \\     *         {{@link UInt128#LeastSignificant}} is informed, or the last 8 bytes if
         \\     *         {{@link UInt128#MostSignificant}}.

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -98,7 +98,6 @@ const DeadDetector = struct {
     }
 
     fn deinit(detector: *DeadDetector) void {
-        assert(detector.files.count() == 0); // Sanity-check that `.finish` was called.
         detector.files.deinit();
     }
 
@@ -382,8 +381,6 @@ fn parse_multiline_string(line: []const u8) ?[]const u8 {
 }
 
 const naughty_list = [_][]const u8{
-    "clients/java/docs.zig", // Contains long XML.
-    "java_bindings.zig", // Contains Javadoc links.
     "lsm/binary_search.zig",
     "lsm/binary_search_benchmark.zig",
     "lsm/forest_fuzz.zig",


### PR DESCRIPTION
We already have carve out for `https://` URLS in tidy, so URLs per se won't be problematic.

What remains is:

* One instance where we legitimately have an overly-long doc line, just shorten it.
* pom.xml, which uses `http://` URLs. We intentionally don't allow non-S http in tidy! But, luckily, we can add some newlines and change one url to https to fix this. I am using https://github.com/quarkusio/quarkus/blob/0be9c09688329a32524526ff6b0819bdc83c0ca8/pom.xml#L2-L5 as the evidence that s is indeed valid there