### PR TITLE
Fix typos

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -157,7 +157,7 @@ When submitting pull request, _assign_ a single person to be its reviewer. Unpac
 * Only a single person is assigned to any particular pull request, to avoid diffusion of
   responsibility and the bystander effect.
 
-* Pull request author choses the reviewer. The author ha the most context about who is the best
+* Pull request author chooses the reviewer. The author has the most context about who is the best
   person to request review from. When picking a reviewer, think about sharing knowledge, balancing
   review load, and maximizing correctness of the code.
 

--- a/docs/TALKS.md
+++ b/docs/TALKS.md
@@ -45,7 +45,7 @@ This week on The Data Stack Show, Eric and Kostas chatted with Joran
 Greef, Founder & CEO of Tiger Beetle. During the episode, Joran
 discusses his journey from accounting to coding, why double-entry
 accounting is important for databases, safety issues in financial
-softwares, the need for low latency and high throughput, and more.
+software, the need for low latency and high throughput, and more.
 
 https://datastackshow.com/podcast/why-accounting-needs-its-own-database-with-joran-greef-of-tiger-beetle/
 

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -230,7 +230,7 @@ test "c_client tb_status" {
     try assert_status(1, "invalid", c.TB_STATUS_ADDRESS_INVALID);
     try assert_status(1, "", c.TB_STATUS_ADDRESS_INVALID);
 
-    // More addresses thant "replicas_max" should return "TB_STATUS_ADDRESS_LIMIT_EXCEEDED":
+    // More addresses than "replicas_max" should return "TB_STATUS_ADDRESS_LIMIT_EXCEEDED":
     try assert_status(
         1,
         ("3000," ** constants.replicas_max) ++ "3001",

--- a/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
@@ -12,7 +12,7 @@ namespace TigerBeetle.Tests;
 public class UInt128Tests
 {
     [TestMethod]
-    public void GuidConvertion()
+    public void GuidConversion()
     {
         Guid guid = Guid.Parse("A945C62A-4CC7-425B-B44A-893577632902");
         UInt128 value = guid.ToUInt128();
@@ -22,7 +22,7 @@ public class UInt128Tests
     }
 
     [TestMethod]
-    public void GuidMaxConvertion()
+    public void GuidMaxConversion()
     {
         Guid guid = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
         UInt128 value = guid.ToUInt128();
@@ -32,7 +32,7 @@ public class UInt128Tests
     }
 
     [TestMethod]
-    public void ArrayConvertion()
+    public void ArrayConversion()
     {
         byte[] array = new byte[16] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10 };
         UInt128 value = array.ToUInt128();
@@ -44,7 +44,7 @@ public class UInt128Tests
 
     [TestMethod]
     [ExpectedException(typeof(ArgumentNullException))]
-    public void NullArrayConvertion()
+    public void NullArrayConversion()
     {
         byte[] array = null!;
         _ = array.ToUInt128();
@@ -52,7 +52,7 @@ public class UInt128Tests
 
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
-    public void EmptyArrayConvertion()
+    public void EmptyArrayConversion()
     {
         byte[] array = new byte[0];
         _ = array.ToUInt128();
@@ -60,7 +60,7 @@ public class UInt128Tests
 
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
-    public void InvalidArrayConvertion()
+    public void InvalidArrayConversion()
     {
         // Expected ArgumentException.
         byte[] array = new byte[17];
@@ -69,9 +69,9 @@ public class UInt128Tests
 
 
     [TestMethod]
-    public void BigIntegerConvertion()
+    public void BigIntegerConversion()
     {
-        var checkConvertion = (BigInteger bigInteger) =>
+        var checkConversion = (BigInteger bigInteger) =>
         {
             UInt128 uint128 = bigInteger.ToUInt128();
 
@@ -80,11 +80,11 @@ public class UInt128Tests
             Assert.IsTrue(uint128.Equals(bigInteger.ToUInt128()));
         };
 
-        checkConvertion(BigInteger.Parse("0"));
-        checkConvertion(BigInteger.Parse("1"));
-        checkConvertion(BigInteger.Parse("123456789012345678901234567890123456789"));
-        checkConvertion(new BigInteger(uint.MaxValue));
-        checkConvertion(new BigInteger(ulong.MaxValue));
+        checkConversion(BigInteger.Parse("0"));
+        checkConversion(BigInteger.Parse("1"));
+        checkConversion(BigInteger.Parse("123456789012345678901234567890123456789"));
+        checkConversion(new BigInteger(uint.MaxValue));
+        checkConversion(new BigInteger(ulong.MaxValue));
     }
 
 

--- a/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
@@ -142,7 +142,7 @@ public static class ID
             // Increment the u80 stored in lastRandom using a u64 increment then u16 increment.
             // Throws an exception if the entire u80 represented with both overflows.
             // We rely on unsigned arithmetic wrapping on overflow by detecting for zero after inc.
-            // Unsigned types wrap by default but can be overriden by compiler flag so be explicit. 
+            // Unsigned types wrap by default but can be overridden by compiler flag so be explicit.
             unchecked
             {
                 randomLo += 1;

--- a/src/clients/java/src/jni.zig
+++ b/src/clients/java/src/jni.zig
@@ -713,7 +713,7 @@ pub const JNIEnv = opaque {
         /// Index 230: GetDirectBufferAddress
         get_direct_buffer_address = 230,
 
-        /// GetDirectBufferCapacity - Index 231 in the JNIEnv interface function tabl
+        /// GetDirectBufferCapacity - Index 231 in the JNIEnv interface function table
         get_direct_buffer_capacity = 231,
 
         /// Index 232: GetObjectRefType

--- a/src/clients/java/src/jni_tests.zig
+++ b/src/clients/java/src/jni_tests.zig
@@ -284,7 +284,7 @@ test "JNI: LocalFrame" {
     const local_ref = env.alloc_object(boolean_class);
     try testing.expect(local_ref != null);
 
-    // All local references must be invalidated after this frame being droped,
+    // All local references must be invalidated after this frame being dropped,
     // except by the frame result.
     const pop_local_frame_result = env.pop_local_frame(local_ref);
     try testing.expect(pop_local_frame_result != null);
@@ -1534,17 +1534,17 @@ test "JNI: primitive arrays" {
                 }
 
                 pub fn assert(env: *JNIEnv) !void {
-                    const lenght = 32;
+                    const length = 32;
 
                     const array = switch (PrimitiveType) {
-                        jni.JBoolean => env.new_boolean_array(lenght),
-                        jni.JByte => env.new_byte_array(lenght),
-                        jni.JChar => env.new_char_array(lenght),
-                        jni.JShort => env.new_short_array(lenght),
-                        jni.JInt => env.new_int_array(lenght),
-                        jni.JLong => env.new_long_array(lenght),
-                        jni.JFloat => env.new_float_array(lenght),
-                        jni.JDouble => env.new_double_array(lenght),
+                        jni.JBoolean => env.new_boolean_array(length),
+                        jni.JByte => env.new_byte_array(length),
+                        jni.JChar => env.new_char_array(length),
+                        jni.JShort => env.new_short_array(length),
+                        jni.JInt => env.new_int_array(length),
+                        jni.JLong => env.new_long_array(length),
+                        jni.JFloat => env.new_float_array(length),
+                        jni.JDouble => env.new_double_array(length),
                         else => unreachable,
                     };
 
@@ -1552,7 +1552,7 @@ test "JNI: primitive arrays" {
                     defer env.delete_local_ref(array);
 
                     const len = env.get_array_length(array);
-                    try testing.expect(len == lenght);
+                    try testing.expect(len == length);
 
                     // Change the array:
                     {

--- a/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/NativeClient.java
@@ -64,7 +64,7 @@ final class NativeClient implements AutoCloseable {
                             Thread.onSpinWait();
                         }
 
-                        // This function waits until all submited requests are completed, and no
+                        // This function waits until all submitted requests are completed, and no
                         // more packets can be acquired after that.
                         clientDeinit(handle);
                     }

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -46,7 +46,7 @@ abstract class Request<TResponse extends Batch> {
         }
     }
 
-    // Used ony by the JNI side
+    // Used only by the JNI side
     @Native
     private final ByteBuffer sendBuffer;
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -246,7 +246,7 @@ pub const IO = struct {
     ) void {
         const onCompleteFn = struct {
             fn onComplete(io: *IO, _completion: *Completion) void {
-                // Perform the actual operaton
+                // Perform the actual operation
                 const op_data = &@field(_completion.operation, @tagName(operation_tag));
                 const result = OperationImpl.do_operation(op_data);
 

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -697,7 +697,7 @@ test "binary search: random" {
 test "binary search: explicit range" {
     if (test_binary_search.log) std.debug.print("\n", .{});
 
-    // Exact inverval:
+    // Exact interval:
     try test_binary_search.explicit_range_search(
         &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
         3,
@@ -708,7 +708,7 @@ test "binary search: explicit range" {
         },
     );
 
-    // Larger inverval:
+    // Larger interval:
     try test_binary_search.explicit_range_search(
         &[_]u32{ 3, 4, 10, 15, 20, 25, 30, 100, 1000 },
         2,

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -128,8 +128,8 @@ const Environment = struct {
             // Compare from cache_map, if found:
             const cache_map_value = env.cache_map.get(kv.key_ptr.*);
             stdx.maybe(cache_map_value != null);
-            if (cache_map_value) |cache_map_value_unwraped| {
-                assert(std.meta.eql(kv.value_ptr.value, cache_map_value_unwraped.*));
+            if (cache_map_value) |cache_map_value_unwrapped| {
+                assert(std.meta.eql(kv.value_ptr.value, cache_map_value_unwrapped.*));
             } else {
                 // .compact() support:
                 assert(env.model.compacts > kv.value_ptr.op);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -857,7 +857,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
         // * See the state from that checkpoint.
         // * See the state from the previous checkpoint.
         // But this is difficult to test, so for now we'll avoid it.
-        const modifer_tag = if (action == .compact and !action.compact.checkpoint)
+        const modifier_tag = if (action == .compact and !action.compact.checkpoint)
             fuzz.random_enum(
                 random,
                 FuzzOpModifierTag,
@@ -865,7 +865,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
             )
         else
             FuzzOpModifierTag.normal;
-        const modifier = switch (modifer_tag) {
+        const modifier = switch (modifier_tag) {
             .normal => FuzzOpModifier{ .normal = {} },
             .crash_after_ticks => FuzzOpModifier{
                 .crash_after_ticks = fuzz.random_int_exponential(random, usize, io_latency_mean),

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -791,7 +791,7 @@ pub fn GrooveType(
         pub const PrefetchWorker = struct {
             // Since lookup contexts are used one at a time, it's safe to access
             // the union's fields and reuse the same memory for all context instances.
-            // Can't use extern/packed union as the LookupContextes aren't ABI compliant.
+            // Can't use extern/packed union as the LookupContexts aren't ABI compliant.
             const LookupContext = union(enum) {
                 id: if (has_id) IdTree.LookupContext else void,
                 object: ObjectTree.LookupContext,

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -203,7 +203,7 @@ const GenerateContext = struct {
                     return ctx.next(.remove_invisible);
                 }
 
-                // Decide if all tables visible ot snapshot_latest should be removed.
+                // Decide if all tables visible to snapshot_latest should be removed.
                 const amount = if (ctx.random.boolean())
                     visible_latest
                 else

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -317,7 +317,7 @@ pub fn ScanType(
         };
 
         /// Comptime dispatcher for all scan implementations that share the same interface.
-        /// Generates a tagged union with an specialized `ScanTreeType` for each queriable field in
+        /// Generates a tagged union with an specialized `ScanTreeType` for each queryable field in
         /// the `Groove` (e.g. `timestamp`, `id` if present, and secondary indexes), plus a
         /// `ScanMergeType` for each merge operation (e.g. union, intersection, and difference).
         ///

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -349,7 +349,7 @@ pub fn ScanTreeType(
                 .idle => {},
                 .seeking, .needs_data => {
                     for (&self.levels) |*level| {
-                        // Fowarding the `probe` to each level.
+                        // Forwarding the `probe` to each level.
                         level.probe(probe_key);
                     }
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -649,7 +649,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                             Parser.Error.BadKeyValuePair,
                             Parser.Error.MissingEqualBetweenKeyValuePair,
                             Parser.Error.NoSyntaxMatch,
-                            // TODO: This wil be more convenient to express
+                            // TODO: This will be more convenient to express
                             // once https://github.com/ziglang/zig/issues/2473 is
                             // in.
                             => std.posix.exit(1),

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -159,7 +159,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
     //     });
     //     try shell.pushd_dir(tmp_dir.dir);
 
-    //     // Slice the output to supress the names.
+    //     // Slice the output to suppress the names.
     //     if (!std.mem.eql(u8, checksum_downloaded[0..64], checksum_built[0..64])) {
     //         std.debug.panic("checksum mismatch - {s}: downloaded {s}, built {s}", .{
     //             artifact,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1595,7 +1595,7 @@ pub fn StateMachineType(
             //
             // This is a special case in the idempotency check:
             // When _resubmitting_ the same balancing transfer, the amount will likely be different
-            // from what was previously commited, but as long it is within the range of possible
+            // from what was previously committed, but as long as it is within the range of possible
             // values it should fail with `exists` rather than `exists_with_different_amount`.
             if (t.flags.balancing_debit or t.flags.balancing_credit) {
                 if (t.amount > 0 and t.amount < e.amount) return .exists_with_different_amount;

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -1048,7 +1048,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                 assert(result_count == @min(account_filter.limit, batch_size, transfer_count));
             } else {
                 // If timestamp range is set, then the limit is exactly the number of transfer
-                // at the time the filter was generated, but new transfers could heve been
+                // at the time the filter was generated, but new transfers could have been
                 // inserted since then.
                 assert(account_filter.limit <= transfer_count);
                 assert(account_filter.timestamp_max >= account_filter.timestamp_min);

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -322,7 +322,7 @@ fn banned(source: []const u8) ?[]const u8 {
         return "use stdx." ++ "copy_right instead of std version";
     }
 
-    // Ban "fixme" comments. This allows using fixe as reminders with teeth --- when working on a
+    // Ban "fixme" comments. This allows using fixme as reminders with teeth --- when working on a
     // larger pull requests, it is often helpful to leave fixme comments as a reminder to oneself.
     // This tidy rule ensures that the reminder is acted upon before code gets into main. That is:
     // - use fixme for issues to be fixed in the same pull request,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -792,7 +792,7 @@ pub const Simulator = struct {
         request: *Message.Request,
         reply: *Message.Reply,
     ) void {
-        // TODO(Zig) Use @returnAddress to initialzie the cluster, then this can just use @fieldParentPtr().
+        // TODO(Zig) Use @returnAddress to initialize the cluster, then this can just use @fieldParentPtr().
         const simulator: *Simulator = @ptrCast(@alignCast(cluster.context.?));
         simulator.reply_sequence.insert(reply_client, request, reply);
 

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -923,7 +923,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 //   * The requested op's slot is faulty, but the prepare is valid. Since the
                 //     prepare is valid, WAL recovery set `prepare_checksums[slot]`. But on reading
                 //     this entry it turns out not to have the right op.
-                //   (This case (and the accompanying unnessary read) could be prevented by storing
+                //   (This case (and the accompanying unnecessary read) could be prevented by storing
                 //   the op along with the checksum in `prepare_checksums`.)
                 assert(slot == null);
 


### PR DESCRIPTION
Fixed typos by manually going through the output of [this spell checker](https://github.com/crate-ci/typos).