### PR TITLE
stdx: add custom formatter for displaying units in error messages

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -749,12 +749,12 @@ pub fn comptime_slice(comptime slice: anytype, comptime len: usize) []const @Typ
 /// Return a Formatter for a u64 value representing a file size.
 /// This formatter statically checks that the number is a multiple of 1024,
 /// and represents it using the IEC measurement units (KiB, MiB, GiB, ...).
-pub fn fmtIntSizeBinExact(comptime value: u64) std.fmt.Formatter(formatIntSizeBinExact) {
+pub fn fmt_int_size_bin_exact(comptime value: u64) std.fmt.Formatter(format_int_size_bin_exact) {
     comptime assert(value % 1024 == 0);
     return .{ .data = value };
 }
 
-fn formatIntSizeBinExact(
+fn format_int_size_bin_exact(
     value: u64,
     comptime fmt: []const u8,
     options: std.fmt.FormatOptions,
@@ -771,9 +771,9 @@ fn formatIntSizeBinExact(
     var buf: [7]u8 = undefined;
 
     const mags_iec = " KMGTPEZY";
-    const magnitude = @min(std.math.log2(value) / 10, mags_iec.len - 1);
+    const magnitude = @min(@divFloor(std.math.log2(value), 10), mags_iec.len - 1);
     const suffix = mags_iec[magnitude];
-    const new_value = value / std.math.pow(u64, 1024, magnitude);
+    const new_value = @divExact(value, std.math.pow(u64, 1024, magnitude));
 
     const i = std.fmt.formatIntBuf(&buf, new_value, 10, .lower, .{});
     buf[i..][0..3].* = [_]u8{ suffix, 'i', 'B' };
@@ -781,9 +781,9 @@ fn formatIntSizeBinExact(
     return std.fmt.formatBuf(buf[0 .. i + 3], options, writer);
 }
 
-test fmtIntSizeBinExact {
-    try std.testing.expectFmt("0B", "{}", .{fmtIntSizeBinExact(0)});
-    try std.testing.expectFmt("8KiB", "{}", .{fmtIntSizeBinExact(8 * 1024)});
-    try std.testing.expectFmt("42MiB", "{}", .{fmtIntSizeBinExact(42 * 1024 * 1024)});
-    try std.testing.expectFmt("999GiB", "{}", .{fmtIntSizeBinExact(999 * 1024 * 1024 * 1024)});
+test fmt_int_size_bin_exact {
+    try std.testing.expectFmt("0B", "{}", .{fmt_int_size_bin_exact(0)});
+    try std.testing.expectFmt("8KiB", "{}", .{fmt_int_size_bin_exact(8 * 1024)});
+    try std.testing.expectFmt("42MiB", "{}", .{fmt_int_size_bin_exact(42 * 1024 * 1024)});
+    try std.testing.expectFmt("999GiB", "{}", .{fmt_int_size_bin_exact(999 * 1024 * 1024 * 1024)});
 }

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -768,6 +768,7 @@ fn format_int_size_bin_exact(
     // The worst case in terms of space needed is 20 bytes,
     // since `maxInt(u64)` is the highest number,
     // + 3 bytes for the measurement units suffix.
+    comptime assert(std.fmt.comptimePrint("{}GiB", .{std.math.maxInt(u64)}).len == 23);
     var buf: [23]u8 = undefined;
 
     var magnitude: u8 = 0;
@@ -791,4 +792,7 @@ test fmt_int_size_bin_exact {
     try std.testing.expectFmt("1025KiB", "{}", .{fmt_int_size_bin_exact(1025 * 1024)});
     try std.testing.expectFmt("12345KiB", "{}", .{fmt_int_size_bin_exact(12345 * 1024)});
     try std.testing.expectFmt("42MiB", "{}", .{fmt_int_size_bin_exact(42 * 1024 * 1024)});
+    try std.testing.expectFmt("18014398509481983KiB", "{}", .{
+        fmt_int_size_bin_exact(std.math.maxInt(u64) - 1023),
+    });
 }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -603,7 +603,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             if (pipeline_limit > pipeline_limit_max) {
                 flags.fatal("--limit-pipeline-requests: count {} exceeds maximum: {}", .{
                     pipeline_limit,
-                    vsr.stdx.fmtIntSizeBinExact(pipeline_limit_max),
+                    pipeline_limit_max,
                 });
             }
             if (pipeline_limit < pipeline_limit_min) {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -609,7 +609,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             if (pipeline_limit < pipeline_limit_min) {
                 flags.fatal("--limit-pipeline-requests: count {} is below minimum: {}", .{
                     pipeline_limit,
-                    vsr.stdx.fmt_int_size_bin_exact(pipeline_limit_min),
+                    pipeline_limit_min,
                 });
             }
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -575,13 +575,14 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 flags.fatal("--limit-storage: size {}{s} exceeds maximum: {}", .{
                     start_limit_storage.value,
                     start_limit_storage.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(storage_size_limit_max),
+                    vsr.stdx.fmt_int_size_bin_exact(storage_size_limit_max),
                 });
-            } else if (storage_size_limit < storage_size_limit_min) {
+            }
+            if (storage_size_limit < storage_size_limit_min) {
                 flags.fatal("--limit-storage: size {}{s} is below minimum: {}", .{
                     start_limit_storage.value,
                     start_limit_storage.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(storage_size_limit_min),
+                    vsr.stdx.fmt_int_size_bin_exact(storage_size_limit_min),
                 });
             }
             if (storage_size_limit % constants.sector_size != 0) {
@@ -590,7 +591,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     .{
                         start_limit_storage.value,
                         start_limit_storage.suffix(),
-                        vsr.stdx.fmtIntSizeBinExact(constants.sector_size),
+                        vsr.stdx.fmt_int_size_bin_exact(constants.sector_size),
                     },
                 );
             }
@@ -604,10 +605,11 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     pipeline_limit,
                     pipeline_limit_max,
                 });
-            } else if (pipeline_limit < pipeline_limit_min) {
+            }
+            if (pipeline_limit < pipeline_limit_min) {
                 flags.fatal("--limit-pipeline-requests: count {} is below minimum: {}", .{
                     pipeline_limit,
-                    vsr.stdx.fmtIntSizeBinExact(pipeline_limit_min),
+                    vsr.stdx.fmt_int_size_bin_exact(pipeline_limit_min),
                 });
             }
 
@@ -619,13 +621,14 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 flags.fatal("--limit-request: size {}{s} exceeds maximum: {}", .{
                     request_size_limit.value,
                     request_size_limit.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(request_size_limit_max),
+                    vsr.stdx.fmt_int_size_bin_exact(request_size_limit_max),
                 });
-            } else if (request_size_limit.bytes() < request_size_limit_min) {
+            }
+            if (request_size_limit.bytes() < request_size_limit_min) {
                 flags.fatal("--limit-request: size {}{s} is below minimum: {}", .{
                     request_size_limit.value,
                     request_size_limit.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(request_size_limit_min),
+                    vsr.stdx.fmt_int_size_bin_exact(request_size_limit_min),
                 });
             }
 
@@ -637,13 +640,14 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 flags.fatal("--memory-lsm-manifest: size {}{s} exceeds maximum: {}", .{
                     start_memory_lsm_manifest.value,
                     start_memory_lsm_manifest.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_max),
+                    vsr.stdx.fmt_int_size_bin_exact(lsm_manifest_memory_max),
                 });
-            } else if (lsm_manifest_memory < lsm_manifest_memory_min) {
+            }
+            if (lsm_manifest_memory < lsm_manifest_memory_min) {
                 flags.fatal("--memory-lsm-manifest: size {}{s} is below minimum: {}", .{
                     start_memory_lsm_manifest.value,
                     start_memory_lsm_manifest.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_min),
+                    vsr.stdx.fmt_int_size_bin_exact(lsm_manifest_memory_min),
                 });
             }
             if (lsm_manifest_memory % lsm_manifest_memory_multiplier != 0) {
@@ -652,7 +656,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     .{
                         start_memory_lsm_manifest.value,
                         start_memory_lsm_manifest.suffix(),
-                        vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_multiplier),
+                        vsr.stdx.fmt_int_size_bin_exact(lsm_manifest_memory_multiplier),
                     },
                 );
             }
@@ -664,13 +668,14 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 flags.fatal("--memory-lsm-compaction: size {}{s} exceeds maximum: {}", .{
                     lsm_compaction_block_memory.value,
                     lsm_compaction_block_memory.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(lsm_compaction_block_memory_max),
+                    vsr.stdx.fmt_int_size_bin_exact(lsm_compaction_block_memory_max),
                 });
-            } else if (lsm_compaction_block_memory.bytes() < lsm_compaction_block_memory_min) {
+            }
+            if (lsm_compaction_block_memory.bytes() < lsm_compaction_block_memory_min) {
                 flags.fatal("--memory-lsm-compaction: size {}{s} is below minimum: {}", .{
                     lsm_compaction_block_memory.value,
                     lsm_compaction_block_memory.suffix(),
-                    vsr.stdx.fmtIntSizeBinExact(lsm_compaction_block_memory_min),
+                    vsr.stdx.fmt_int_size_bin_exact(lsm_compaction_block_memory_min),
                 });
             }
             if (lsm_compaction_block_memory.bytes() % constants.block_size != 0) {
@@ -679,7 +684,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     .{
                         lsm_compaction_block_memory.value,
                         lsm_compaction_block_memory.suffix(),
-                        vsr.stdx.fmtIntSizeBinExact(constants.block_size),
+                        vsr.stdx.fmt_int_size_bin_exact(constants.block_size),
                     },
                 );
             }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -572,26 +572,26 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             const storage_size_limit_min = data_file_size_min;
             const storage_size_limit_max = constants.storage_size_limit_max;
             if (storage_size_limit > storage_size_limit_max) {
-                flags.fatal("--limit-storage: size {}{s} exceeds maximum: {}MiB", .{
+                flags.fatal("--limit-storage: size {}{s} exceeds maximum: {}", .{
                     start_limit_storage.value,
                     start_limit_storage.suffix(),
-                    @divExact(storage_size_limit_max, 1024 * 1024),
+                    vsr.stdx.fmtIntSizeBinExact(storage_size_limit_max),
                 });
             }
             if (storage_size_limit < storage_size_limit_min) {
-                flags.fatal("--limit-storage: size {}{s} is below minimum: {}KiB", .{
+                flags.fatal("--limit-storage: size {}{s} is below minimum: {}", .{
                     start_limit_storage.value,
                     start_limit_storage.suffix(),
-                    @divExact(storage_size_limit_min, 1024),
+                    vsr.stdx.fmtIntSizeBinExact(storage_size_limit_min),
                 });
             }
             if (storage_size_limit % constants.sector_size != 0) {
                 flags.fatal(
-                    "--limit-storage: size {}{s} must be a multiple of sector size ({}KiB)",
+                    "--limit-storage: size {}{s} must be a multiple of sector size ({})",
                     .{
                         start_limit_storage.value,
                         start_limit_storage.suffix(),
-                        @divExact(constants.sector_size, 1024),
+                        vsr.stdx.fmtIntSizeBinExact(constants.sector_size),
                     },
                 );
             }
@@ -603,13 +603,13 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             if (pipeline_limit > pipeline_limit_max) {
                 flags.fatal("--limit-pipeline-requests: count {} exceeds maximum: {}", .{
                     pipeline_limit,
-                    pipeline_limit_max,
+                    vsr.stdx.fmtIntSizeBinExact(pipeline_limit_max),
                 });
             }
             if (pipeline_limit < pipeline_limit_min) {
                 flags.fatal("--limit-pipeline-requests: count {} is below minimum: {}", .{
                     pipeline_limit,
-                    pipeline_limit_min,
+                    vsr.stdx.fmtIntSizeBinExact(pipeline_limit_min),
                 });
             }
 
@@ -619,24 +619,24 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             const request_size_limit_max = constants.message_size_max;
             if (request_size_limit.bytes() > request_size_limit_max) {
                 if (comptime (request_size_limit_max >= 1024 * 1024)) {
-                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}MiB", .{
+                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}", .{
                         request_size_limit.value,
                         request_size_limit.suffix(),
-                        @divExact(request_size_limit_max, 1024 * 1024),
+                        vsr.stdx.fmtIntSizeBinExact(request_size_limit_max),
                     });
                 } else {
-                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}KiB", .{
+                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}", .{
                         request_size_limit.value,
                         request_size_limit.suffix(),
-                        @divExact(request_size_limit_max, 1024),
+                        vsr.stdx.fmtIntSizeBinExact(request_size_limit_max),
                     });
                 }
             }
             if (request_size_limit.bytes() < request_size_limit_min) {
-                flags.fatal("--limit-request: size {}{s} is below minimum: {}B", .{
+                flags.fatal("--limit-request: size {}{s} is below minimum: {}", .{
                     request_size_limit.value,
                     request_size_limit.suffix(),
-                    request_size_limit_min,
+                    vsr.stdx.fmtIntSizeBinExact(request_size_limit_min),
                 });
             }
 
@@ -645,26 +645,26 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             const lsm_manifest_memory_min = constants.lsm_manifest_memory_size_min;
             const lsm_manifest_memory_multiplier = constants.lsm_manifest_memory_size_multiplier;
             if (lsm_manifest_memory > lsm_manifest_memory_max) {
-                flags.fatal("--memory-lsm-manifest: size {}{s} exceeds maximum: {}MiB", .{
+                flags.fatal("--memory-lsm-manifest: size {}{s} exceeds maximum: {}", .{
                     start_memory_lsm_manifest.value,
                     start_memory_lsm_manifest.suffix(),
-                    @divExact(lsm_manifest_memory_max, 1024 * 1024),
+                    vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_max),
                 });
             }
             if (lsm_manifest_memory < lsm_manifest_memory_min) {
-                flags.fatal("--memory-lsm-manifest: size {}{s} is below minimum: {}MiB", .{
+                flags.fatal("--memory-lsm-manifest: size {}{s} is below minimum: {}", .{
                     start_memory_lsm_manifest.value,
                     start_memory_lsm_manifest.suffix(),
-                    @divExact(lsm_manifest_memory_min, 1024 * 1024),
+                    vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_min),
                 });
             }
             if (lsm_manifest_memory % lsm_manifest_memory_multiplier != 0) {
                 flags.fatal(
-                    "--memory-lsm-manifest: size {}{s} must be a multiple of {}MiB",
+                    "--memory-lsm-manifest: size {}{s} must be a multiple of {}",
                     .{
                         start_memory_lsm_manifest.value,
                         start_memory_lsm_manifest.suffix(),
-                        @divExact(lsm_manifest_memory_multiplier, 1024 * 1024),
+                        vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_multiplier),
                     },
                 );
             }
@@ -673,26 +673,26 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                 start.memory_lsm_compaction orelse defaults.memory_lsm_compaction;
             const lsm_compaction_block_memory_max = constants.compaction_block_memory_size_max;
             if (lsm_compaction_block_memory.bytes() > lsm_compaction_block_memory_max) {
-                flags.fatal("--memory-lsm-compaction: size {}{s} exceeds maximum: {}GiB", .{
+                flags.fatal("--memory-lsm-compaction: size {}{s} exceeds maximum: {}", .{
                     lsm_compaction_block_memory.value,
                     lsm_compaction_block_memory.suffix(),
-                    @divFloor(lsm_compaction_block_memory_max, 1024 * 1024 * 1024),
+                    vsr.stdx.fmtIntSizeBinExact(lsm_compaction_block_memory_max),
                 });
             }
             if (lsm_compaction_block_memory.bytes() < lsm_compaction_block_memory_min) {
-                flags.fatal("--memory-lsm-compaction: size {}{s} is below minimum: {}KiB", .{
+                flags.fatal("--memory-lsm-compaction: size {}{s} is below minimum: {}", .{
                     lsm_compaction_block_memory.value,
                     lsm_compaction_block_memory.suffix(),
-                    @divExact(lsm_compaction_block_memory_min, 1024),
+                    vsr.stdx.fmtIntSizeBinExact(lsm_compaction_block_memory_min),
                 });
             }
             if (lsm_compaction_block_memory.bytes() % constants.block_size != 0) {
                 flags.fatal(
-                    "--memory-lsm-compaction: size {}{s} must be a multiple of {}KiB",
+                    "--memory-lsm-compaction: size {}{s} must be a multiple of {}",
                     .{
                         lsm_compaction_block_memory.value,
                         lsm_compaction_block_memory.suffix(),
-                        @divExact(constants.block_size, 1024),
+                        vsr.stdx.fmtIntSizeBinExact(constants.block_size),
                     },
                 );
             }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -577,8 +577,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     start_limit_storage.suffix(),
                     vsr.stdx.fmtIntSizeBinExact(storage_size_limit_max),
                 });
-            }
-            if (storage_size_limit < storage_size_limit_min) {
+            } else if (storage_size_limit < storage_size_limit_min) {
                 flags.fatal("--limit-storage: size {}{s} is below minimum: {}", .{
                     start_limit_storage.value,
                     start_limit_storage.suffix(),
@@ -605,8 +604,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     pipeline_limit,
                     pipeline_limit_max,
                 });
-            }
-            if (pipeline_limit < pipeline_limit_min) {
+            } else if (pipeline_limit < pipeline_limit_min) {
                 flags.fatal("--limit-pipeline-requests: count {} is below minimum: {}", .{
                     pipeline_limit,
                     vsr.stdx.fmtIntSizeBinExact(pipeline_limit_min),
@@ -618,21 +616,12 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
             const request_size_limit_min = 4096;
             const request_size_limit_max = constants.message_size_max;
             if (request_size_limit.bytes() > request_size_limit_max) {
-                if (comptime (request_size_limit_max >= 1024 * 1024)) {
-                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}", .{
-                        request_size_limit.value,
-                        request_size_limit.suffix(),
-                        vsr.stdx.fmtIntSizeBinExact(request_size_limit_max),
-                    });
-                } else {
-                    flags.fatal("--limit-request: size {}{s} exceeds maximum: {}", .{
-                        request_size_limit.value,
-                        request_size_limit.suffix(),
-                        vsr.stdx.fmtIntSizeBinExact(request_size_limit_max),
-                    });
-                }
-            }
-            if (request_size_limit.bytes() < request_size_limit_min) {
+                flags.fatal("--limit-request: size {}{s} exceeds maximum: {}", .{
+                    request_size_limit.value,
+                    request_size_limit.suffix(),
+                    vsr.stdx.fmtIntSizeBinExact(request_size_limit_max),
+                });
+            } else if (request_size_limit.bytes() < request_size_limit_min) {
                 flags.fatal("--limit-request: size {}{s} is below minimum: {}", .{
                     request_size_limit.value,
                     request_size_limit.suffix(),
@@ -650,8 +639,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     start_memory_lsm_manifest.suffix(),
                     vsr.stdx.fmtIntSizeBinExact(lsm_manifest_memory_max),
                 });
-            }
-            if (lsm_manifest_memory < lsm_manifest_memory_min) {
+            } else if (lsm_manifest_memory < lsm_manifest_memory_min) {
                 flags.fatal("--memory-lsm-manifest: size {}{s} is below minimum: {}", .{
                     start_memory_lsm_manifest.value,
                     start_memory_lsm_manifest.suffix(),
@@ -678,8 +666,7 @@ pub fn parse_args(allocator: std.mem.Allocator, args_iterator: *std.process.ArgI
                     lsm_compaction_block_memory.suffix(),
                     vsr.stdx.fmtIntSizeBinExact(lsm_compaction_block_memory_max),
                 });
-            }
-            if (lsm_compaction_block_memory.bytes() < lsm_compaction_block_memory_min) {
+            } else if (lsm_compaction_block_memory.bytes() < lsm_compaction_block_memory_min) {
                 flags.fatal("--memory-lsm-compaction: size {}{s} is below minimum: {}", .{
                     lsm_compaction_block_memory.value,
                     lsm_compaction_block_memory.suffix(),


### PR DESCRIPTION
Closes https://github.com/tigerbeetle/tigerbeetle/issues/2050

Implemented custom formatter `fmtIntSizeBinExact` and incorporated it into `cli.zig`.