### PR TITLE
ci: run the benchmark, with --validate, in CI

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -150,7 +150,7 @@ test "benchmark smoke" {
 
     const tigerbeetle = try tigerbeetle_exe(shell);
     const status_ok = try shell.exec_status_ok(
-        "{tigerbeetle} benchmark --transfer-count=4000",
+        "{tigerbeetle} benchmark --transfer-count=10_000 --transfer-batch-size=10 --validate",
         .{ .tigerbeetle = tigerbeetle },
     );
     try std.testing.expect(status_ok);

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -32,7 +32,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
 
     const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;
 
-    const benchmark_result = try shell.exec_stdout("./tigerbeetle benchmark", .{});
+    const benchmark_result = try shell.exec_stdout("./tigerbeetle benchmark --validate", .{});
     const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
     const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
     const query_p100_ms = try get_measurement(benchmark_result, "query latency p100", "ms");

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -126,7 +126,11 @@ pub fn main(
     }
 
     // If no seed was given, use a default seed for reproducibility.
-    const seed: usize = cli_args.seed orelse 42;
+    const seed = seed_from_arg: {
+        const seed_argument = cli_args.seed orelse break :seed_from_arg 42;
+        break :seed_from_arg vsr.testing.parse_seed(seed_argument);
+    };
+
     log.info("Benchmark seed = {}", .{seed});
 
     var rng = std.rand.DefaultPrng.init(seed);

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -106,7 +106,7 @@ const CliArgs = union(enum) {
         id_order: Command.Benchmark.IdOrder = .sequential,
         statsd: bool = false,
         addresses: ?[]const u8 = null,
-        seed: ?u64 = null,
+        seed: ?[]const u8 = null,
     },
 
     // TODO Document --cache-accounts, --cache-transfers, --cache-transfers-posted, --limit-storage,
@@ -314,7 +314,7 @@ pub const Command = union(enum) {
         id_order: IdOrder,
         statsd: bool,
         addresses: ?[]const net.Address,
-        seed: ?u64,
+        seed: ?[]const u8,
     };
 
     format: Format,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -35,6 +35,7 @@ pub const testing = .{
     .cluster = @import("testing/cluster.zig"),
     .random_int_exponential = @import("testing/fuzz.zig").random_int_exponential,
     .IdPermutation = @import("testing/id.zig").IdPermutation,
+    .parse_seed = @import("testing/fuzz.zig").parse_seed,
 };
 
 pub const ReplicaType = @import("vsr/replica.zig").ReplicaType;


### PR DESCRIPTION
With #2088, we can now run the benchmark each time in CI and have it validate its results. It takes around ~3.5 minutes end to end and runs in parallel with the other (longer) steps so there's no slowdown.

I've made it use the git SHA like the vopr does, as the seed for the benchmark. But I'm not sure if maybe a fixed seed is better :thinking: 

It would also be nice to kill the replica, and restart it (to ensure that caches are flushed) before validating, but that can be a future TODO.