### PR TITLE
vsr: advance op_prepare_max when checkpoint is durable on a commit-quorum of replicas

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1480,7 +1480,7 @@ pub const Checkpoint = struct {
         assert(constants.journal_slot_count > constants.lsm_batch_multiple);
         assert(constants.journal_slot_count % constants.lsm_batch_multiple == 0);
     }
-    /// Checkpoint identifier.
+    /// Checksum of the CheckpointState in the superblock.
     id: u128,
     /// The op_checkpoint() that corresponds to the checkpoint id.
     op: u64,
@@ -1502,9 +1502,8 @@ pub const Checkpoint = struct {
                 }
 
                 // Ignore repeat candidate.
-                if (checkpoint.op == checkpoint_existing.op and
-                    checkpoint.id == checkpoint_existing.id)
-                {
+                if (checkpoint.op == checkpoint_existing.op) {
+                    assert(checkpoint.id == checkpoint_existing.id);
                     return false;
                 }
             }
@@ -1515,10 +1514,8 @@ pub const Checkpoint = struct {
         pub fn count(quorum: *const Quorum, checkpoint: *const Checkpoint) usize {
             var matching: usize = 0;
             for (quorum.checkpoints) |checkpoint_existing| {
-                if (checkpoint_existing != null and
-                    checkpoint_existing.?.op == checkpoint.op and
-                    checkpoint_existing.?.id == checkpoint.id)
-                {
+                if (checkpoint_existing != null and checkpoint_existing.?.op == checkpoint.op) {
+                    assert(checkpoint_existing.?.id == checkpoint.id);
                     assert(std.meta.eql(checkpoint.*, checkpoint_existing.?));
                     matching += 1;
                 }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1480,48 +1480,24 @@ pub const Checkpoint = struct {
         assert(constants.journal_slot_count > constants.lsm_batch_multiple);
         assert(constants.journal_slot_count % constants.lsm_batch_multiple == 0);
     }
-    /// Checkpoint identifier.
-    id: u128,
-    /// The op_checkpoint() that corresponds to the checkpoint id.
-    op: u64,
-
     pub const Quorum = struct {
-        /// The latest known checkpoint identifier from every *other* replica.
-        checkpoints: [constants.replicas_max]?Checkpoint =
-            [_]?Checkpoint{null} ** constants.replicas_max,
+        /// The latest known checkpoint operation from every *other* replica.
+        checkpoints: [constants.replicas_max]u128 = [_]u128{0} ** constants.replicas_max,
 
-        pub fn replace(
-            quorum: *Quorum,
-            replica: u8,
-            checkpoint: *const Checkpoint,
-        ) bool {
-            if (quorum.checkpoints[replica]) |checkpoint_existing| {
-                // Ignore old candidate.
-                if (checkpoint.op < checkpoint_existing.op) {
-                    return false;
-                }
-
-                // Ignore repeat candidate.
-                if (checkpoint.op == checkpoint_existing.op and
-                    checkpoint.id == checkpoint_existing.id)
-                {
-                    return false;
-                }
+        pub fn replace(quorum: *Quorum, replica: u8, checkpoint_op: u128) bool {
+            const checkpoint_op_existing: u128 = quorum.checkpoints[replica];
+            // Ignore old and repeat checkpoints.
+            if (checkpoint_op < checkpoint_op_existing or checkpoint_op == checkpoint_op_existing) {
+                return false;
             }
-            quorum.checkpoints[replica] = checkpoint.*;
+            quorum.checkpoints[replica] = checkpoint_op;
             return true;
         }
 
-        pub fn count(quorum: *const Quorum, checkpoint: *const Checkpoint) usize {
-            var matching: usize = 0;
-            for (quorum.checkpoints) |checkpoint_existing| {
-                if (checkpoint_existing != null and
-                    checkpoint_existing.?.op == checkpoint.op and
-                    checkpoint_existing.?.id == checkpoint.id)
-                {
-                    assert(std.meta.eql(checkpoint.*, checkpoint_existing.?));
-                    matching += 1;
-                }
+        pub fn count(quorum: *const Quorum, checkpoint_op: u128) u8 {
+            var matching: u8 = 0;
+            for (quorum.checkpoints) |checkpoint_op_existing| {
+                if (checkpoint_op_existing == checkpoint_op) matching += 1;
             }
             return matching;
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3242,6 +3242,7 @@ pub fn ReplicaType(
                 // Already upgrading.
                 // Normally we chain send-upgrade-to-self via the commit chain.
                 // But there are a couple special cases where we need to restart the chain:
+                // - The request-to-self might have been dropped due to lack of space in the WAL.
                 // - The request-to-self might have been dropped if the clock is not synchronized.
                 // - Alternatively, if a primary starts a new view, and an upgrade is already in
                 //   progress, it needs to start preparing more upgrades.
@@ -5859,6 +5860,7 @@ pub fn ReplicaType(
                 return true;
             }
 
+            assert(self.checkpoint_from_all_replicas.checkpoints[self.replica] == null);
             const matching =
                 self.checkpoint_from_all_replicas.count(&.{
                 .id = self.superblock.working.checkpoint_id(),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -659,7 +659,9 @@ pub fn ReplicaType(
 
             // A replication quorum of replicas have committed atop op_prepare_max, op_checkpoint
             // is guaranteed to be durable on a commit quorum of replicas.
-            if (self.op_checkpoint() == 0 or self.commit_max > self.op_prepare_max()) {
+            if (self.op_checkpoint() == 0 or self.solo() or
+                self.commit_max > self.op_prepare_max())
+            {
                 self.checkpoint_quorum = true;
             }
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1145,12 +1145,12 @@ test "Cluster: sync: slightly lagging replica" {
     // Corrupt all copies of a checkpointed prepare.
     a0.corrupt(.{ .wal_prepare = checkpoint_1 });
     b1.corrupt(.{ .wal_prepare = checkpoint_1 });
-    try c.request(checkpoint_1_trigger + 2, checkpoint_1_trigger + 2);
+    try c.request(checkpoint_1_prepare_max + 1, checkpoint_1_prepare_max + 1);
 
     // At this point, b2 won't be able to repair WAL and must state sync.
     b2.pass_all(.R_, .bidirectional);
-    try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger + 3);
-    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger + 3);
+    try c.request(checkpoint_1_prepare_max + 2, checkpoint_1_prepare_max + 2);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_prepare_max + 2);
 }
 
 test "Cluster: sync: checkpoint from a newer view" {


### PR DESCRIPTION
### Problem

Currently, we allow overwriting a prepare that a replica has already checkpointed. This builds on the understanding that the prepares that have already checkpointed are *durable* in the LSM tree. The key problem is that *op_prepare_max* is maintained *independently* on each replica according to their *op_checkpoint*. However, this can compromise availability in the presence of storage faults. Consider the following scenario in a 3-replica cluster:

A prepare `P` is replicated to R1 & R2, but not to R3. R1 decides to evict and overwrite `P` since it is in R1's checkpoint. However, R2 hasn't reached this checkpoint yet, so it still has `P` in its WAL.  Further, assume a pair of uncorrelated storage faults - a storage corruption of `P` in R2's WAL, combined with a storage corruption in R1's LSM. This can render the cluster unavailable. The core issue here is that even though even have *logical* durability of data across a commit-quorum of replicas (`P` is durable in R1's checkpoint in the LSM tree and in R2's WAL), the *physical* durability of the data is compromised, since the data is present across a commit-quorum of replicas in *different* forms.

### Solution

The solution to this problem is to allow the overwrite of a prepare only if a *commit-quorum* of replicas has already checkpointed that prepare. Specifically, The *primary* only prepares past *op_prepare_max* when it hears from at least a commit quorum of replicas at the current checkpoint.

### Example
Assume:
* journal_slot_count=10
* lsm_batch_multiple=2
* pipeline_prepare_queue_max=2
*  checkpoint_interval = journal_slot_count - (lsm_batch_multiple + pipeline_prepare_queue_max) = 6

Based on the aforementioned configuration we can compute the following:
```
      checkpoint() call           0   1   2   3
      op_checkpoint               0   5  11  17
      op_checkpoint_next          5  11  17  23
      op_checkpoint_next_trigger  7  13  19  25
```

Now, let's assume a 3-replica cluster. Here, *replication quorum* is *2*. All replicas start with op_checkpoint as 0.

Let's say R1 is the primary. R1 commits *op=7* (*op_checkpoint_next_trigger* for op_checkpoint=5) and updates its *op_checkpoint* to *5*. Now, R1 does not immediately prepare to past the current *op_prepare_max* (9). Instead, it waits till either R2 or R3 also update their *op_checkpoint* to *5* (via ping/commit messages). Once R1 hears from a replication quorum of replicas on op_checkpoint=5, it sets its op_prepare_max to 15.