### PR TITLE
Rename `fuzz scan` to `fuzz lsm_scan`

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -74,7 +74,6 @@ fn main_smoke() !void {
             .smoke => continue,
             .canary => continue,
 
-            .lsm_scan => 16,
             .lsm_cache_map => 20_000,
             .lsm_forest => 10_000,
             .lsm_manifest_log => 2_000,
@@ -87,6 +86,7 @@ fn main_smoke() !void {
             .lsm_manifest_level,
             .vsr_journal_format,
             .vsr_superblock_quorums,
+            .lsm_scan,
             => null,
         };
 

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -22,8 +22,8 @@ pub const std_options = .{
 };
 
 const Fuzzers = .{
-    .scan = @import("./lsm/scan_fuzz.zig"),
     .ewah = @import("./ewah_fuzz.zig"),
+    .lsm_scan = @import("./lsm/scan_fuzz.zig"),
     .lsm_cache_map = @import("./lsm/cache_map_fuzz.zig"),
     .lsm_forest = @import("./lsm/forest_fuzz.zig"),
     .lsm_manifest_log = @import("./lsm/manifest_log_fuzz.zig"),
@@ -74,7 +74,7 @@ fn main_smoke() !void {
             .smoke => continue,
             .canary => continue,
 
-            .scan => 16,
+            .lsm_scan => 16,
             .lsm_cache_map => 20_000,
             .lsm_forest => 10_000,
             .lsm_manifest_log => 2_000,

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -8,7 +8,7 @@ const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
 const allocator = fuzz.allocator;
 
-const log = std.log.scoped(.lsm_forest_fuzz);
+const log = std.log.scoped(.lsm_scan_fuzz);
 const lsm = @import("tree.zig");
 
 const Storage = @import("../testing/storage.zig").Storage;
@@ -360,13 +360,18 @@ const QuerySpecFuzzer = struct {
             query_specs.inner.capacity(),
         );
 
+        log.info("query_spec_count = {}", .{query_spec_count});
+
         for (0..query_spec_count) |prefix| {
             var fuzzer = QuerySpecFuzzer{
                 .random = random,
                 .prefix = @intCast(prefix + 1),
             };
 
-            query_specs.append_assume_capacity(fuzzer.generate_query_spec());
+            const query_spec = fuzzer.generate_query_spec();
+            log.info("query_specs[{}]: {}", .{ prefix, query_spec });
+
+            query_specs.append_assume_capacity(query_spec);
         }
 
         return query_specs;
@@ -656,6 +661,7 @@ const Environment = struct {
         repeat: u32,
     ) !void {
         assert(repeat > 0);
+        log.info("repeat = {}", .{repeat});
 
         var env: Environment = undefined;
         try env.init(storage, random);
@@ -1106,6 +1112,8 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
         random,
         repeat,
     );
+
+    log.info("Passed!", .{});
 }
 
 fn prefix_combine(prefix: u32, suffix: u32) u64 {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -290,10 +290,7 @@ const QuerySpec = struct {
             switch (query_part) {
                 .field => |field| {
                     print_operator = true;
-                    try writer.print("{s}={}", .{
-                        std.enums.tagName(Index, field.index).?,
-                        field.value,
-                    });
+                    try writer.print("{s}", .{std.enums.tagName(Index, field.index).?});
 
                     if (merge_current) |merge| {
                         merge.operand_count -= 1;


### PR DESCRIPTION
- Rename `./zig/zig build fuzz -- scan` to `./zig/zig build fuzz -- lsm_scan`, keeping the `lsm_` prefix consistent across all fuzzers.
- Standardize the `log.info` output with the fuzzer parameters.