### PR TITLE
cfo: reduce chattiness

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -211,7 +211,7 @@ fn run_fuzzers(
                         args.clearRetainingCapacity();
                         try args.appendSlice(&.{ "build", "-Drelease" });
                         try seed_record.fuzzer.fill_args_build(&args);
-                        shell.exec("{zig} {args}", .{
+                        shell.exec_options(.{ .echo = false }, "{zig} {args}", .{
                             .zig = shell.zig_exe.?,
                             .args = args.items,
                         }) catch {


### PR DESCRIPTION
exec echos the command, but its quiet useless to see hundreds of build commands in cfo's log. Note that this'll still log stderr in the case of the error!