### PR TITLE
Fix incorrect `timestamp_max` max value.

### DIFF
--- a/docs/reference/account-filter.md
+++ b/docs/reference/account-filter.md
@@ -27,7 +27,7 @@ Optional; set to zero to disable the lower-bound filter.
 Constraints:
 
 - Type is 64-bit unsigned integer (8 bytes)
-- Must not be `2^64 - 1`
+- Must not overflow a 64-bit signed integer (`2^63 - 1`).
 
 ### `timestamp_max`
 
@@ -37,7 +37,7 @@ Optional; set to zero to disable the upper-bound filter.
 Constraints:
 
 - Type is 64-bit unsigned integer (8 bytes)
-- Must not be `2^64 - 1`
+- Must not overflow a 64-bit signed integer (`2^63 - 1`).
 
 ### `limit`
 

--- a/docs/reference/account-filter.md
+++ b/docs/reference/account-filter.md
@@ -27,7 +27,7 @@ Optional; set to zero to disable the lower-bound filter.
 Constraints:
 
 - Type is 64-bit unsigned integer (8 bytes)
-- Must not overflow a 64-bit signed integer (`2^63 - 1`).
+- Must be less than `2^63`.
 
 ### `timestamp_max`
 
@@ -37,7 +37,7 @@ Optional; set to zero to disable the upper-bound filter.
 Constraints:
 
 - Type is 64-bit unsigned integer (8 bytes)
-- Must not overflow a 64-bit signed integer (`2^63 - 1`).
+- Must be less than `2^63`.
 
 ### `limit`
 

--- a/docs/reference/requests/create_transfers.md
+++ b/docs/reference/requests/create_transfers.md
@@ -366,7 +366,7 @@ The transfer was not created.
 ### `overflows_timeout`
 
 The transfer was not created. `transfer.timestamp + (transfer.timeout * 1_000_000_000)` would
-overflow a 64-bit unsigned integer.
+overflow a 64-bit signed integer (`2^63 - 1`).
 
 [`Transfer.timeout`](../transfer.md#timeout) is converted to nanoseconds.
 

--- a/docs/reference/requests/create_transfers.md
+++ b/docs/reference/requests/create_transfers.md
@@ -366,7 +366,7 @@ The transfer was not created.
 ### `overflows_timeout`
 
 The transfer was not created. `transfer.timestamp + (transfer.timeout * 1_000_000_000)` would
-overflow a 64-bit signed integer (`2^63 - 1`).
+exceed `2^63`.
 
 [`Transfer.timeout`](../transfer.md#timeout) is converted to nanoseconds.
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -806,7 +806,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
             .put_account => action: {
                 const action = generate_put_account(random, &id_to_account, .{
                     .op = op,
-                    .timestamp = fuzz_op_index,
+                    .timestamp = fuzz_op_index + 1, // Timestamp cannot be zero.
                 });
                 try id_to_account.put(action.put_account.account.id, action.put_account.account);
                 break :action action;

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -8,6 +8,7 @@ const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 
 const TableType = @import("table.zig").TableType;
+const TimestampRange = @import("timestamp_range.zig").TimestampRange;
 const TreeType = @import("tree.zig").TreeType;
 const GridType = @import("../vsr/grid.zig").GridType;
 const CompositeKeyType = @import("composite_key.zig").CompositeKeyType;
@@ -914,6 +915,8 @@ pub fn GrooveType(
         /// Insert the value into the objects tree and associated index trees. It's up to the
         /// caller to ensure it doesn't already exist.
         pub fn insert(groove: *Groove, object: *const Object) void {
+            assert(object.timestamp >= TimestampRange.timestamp_min);
+            assert(object.timestamp <= TimestampRange.timestamp_max);
             if (constants.verify) {
                 assert(!groove.objects_cache.has(@field(object, primary_field)));
             }
@@ -964,6 +967,8 @@ pub fn GrooveType(
 
             if (has_id) assert(old.id == new.id);
             assert(old.timestamp == new.timestamp);
+            assert(new.timestamp >= TimestampRange.timestamp_min);
+            assert(new.timestamp <= TimestampRange.timestamp_max);
 
             // The ID can't change, so no need to update the ID tree. Update the object tree entry
             // if any of the fields (even ignored) are different. We assume the caller will pass in
@@ -1017,6 +1022,8 @@ pub fn GrooveType(
             assert(false);
 
             const object = groove.objects_cache.get(key).?;
+            assert(object.timestamp >= TimestampRange.timestamp_min);
+            assert(object.timestamp <= TimestampRange.timestamp_max);
 
             groove.objects.remove(object);
             if (has_id) {

--- a/src/lsm/timestamp_range.zig
+++ b/src/lsm/timestamp_range.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub const TimestampRange = struct {
     pub const timestamp_min = 1;
-    pub const timestamp_max = std.math.maxInt(u64) - 1;
+    pub const timestamp_max = std.math.maxInt(u63); // The last bit is the tombstone flag.
 
     min: u64, // Inclusive.
     max: u64, // Inclusive.

--- a/src/lsm/timestamp_range.zig
+++ b/src/lsm/timestamp_range.zig
@@ -1,8 +1,13 @@
 const std = @import("std");
 
 pub const TimestampRange = struct {
+    /// The minimum timestamp allowed (inclusive).
     pub const timestamp_min = 1;
-    pub const timestamp_max = std.math.maxInt(u63); // The last bit is the tombstone flag.
+
+    /// The maximum timestamp allowed (inclusive).
+    /// It is `maxInt(u63)` because the most significant bit of the `u64` timestamp
+    /// is used as the tombstone flag.
+    pub const timestamp_max = std.math.maxInt(u63);
 
     min: u64, // Inclusive.
     max: u64, // Inclusive.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1469,6 +1469,8 @@ pub fn StateMachineType(
                     if (event.timestamp != 0) break :blk .timestamp_must_be_zero;
 
                     event.timestamp = timestamp - events.len + index + 1;
+                    assert(event.timestamp >= TimestampRange.timestamp_min);
+                    assert(event.timestamp <= TimestampRange.timestamp_max);
 
                     break :blk switch (operation) {
                         .create_accounts => self.create_account(&event),
@@ -3043,8 +3045,7 @@ fn check(test_table: []const u8) !void {
                 context.state_machine.prepare_timestamp += if (ticks.value > 0)
                     interval_ns
                 else
-                    // The last bit is the tombstone flag.
-                    std.math.maxInt(u63) - interval_ns;
+                    TimestampRange.timestamp_max - interval_ns;
             },
 
             .account => |a| {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1219,7 +1219,7 @@ pub fn StateMachineType(
             assert(self.scan_lookup_result_count == null);
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
             assert(self.prefetch_timestamp >= TimestampRange.timestamp_min);
-            assert(self.prefetch_timestamp < TimestampRange.timestamp_max);
+            assert(self.prefetch_timestamp <= TimestampRange.timestamp_max);
 
             // We must be constrained to the same limit as `create_transfers`.
             const scan_buffer_size = @divFloor(

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1841,6 +1841,15 @@ pub fn StateMachineType(
                 return .overflows_credits;
             }
 
+            // Comptime asserts that the max value of the timeout expressed in seconds cannot
+            // overflow a `u63` when converted to nanoseconds.
+            // It is `u63` because the most significant bit of the `u64` timestamp
+            // is used as the tombstone flag.
+            comptime assert(!std.meta.isError(std.math.mul(
+                u63,
+                @as(u63, std.math.maxInt(@TypeOf(t.timeout))),
+                std.time.ns_per_s,
+            )));
             if (sum_overflows(
                 u63,
                 @intCast(t.timestamp),
@@ -1848,6 +1857,7 @@ pub fn StateMachineType(
             )) {
                 return .overflows_timeout;
             }
+
             if (dr_account.debits_exceed_credits(amount)) return .exceeds_credits;
             if (cr_account.credits_exceed_debits(amount)) return .exceeds_debits;
 


### PR DESCRIPTION
Since the most significant bit of the timestamp is the tombstone flag, we need to fix the `timestamp_max` as a `maxInt(u63)`.