### PR TITLE
Fix `pulse` in idle clusters.

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -604,13 +604,12 @@ pub fn StateMachineType(
             };
         }
 
-        pub fn pulse(self: *const StateMachine) bool {
+        pub fn pulse_needed(self: *const StateMachine, timestamp: u64) bool {
             assert(!global_constants.aof_recovery);
             assert(self.expire_pending_transfers.pulse_next_timestamp >=
                 TimestampRange.timestamp_min);
 
-            return self.expire_pending_transfers.pulse_next_timestamp <=
-                self.prepare_timestamp;
+            return self.expire_pending_transfers.pulse_next_timestamp <= timestamp;
         }
 
         pub fn prefetch(
@@ -3267,7 +3266,7 @@ fn check(test_table: []const u8) !void {
                 context.state_machine.prepare_timestamp += 1;
                 context.state_machine.prepare(commit_operation, request.items);
 
-                if (context.state_machine.pulse()) {
+                if (context.state_machine.pulse_needed(context.state_machine.prepare_timestamp)) {
                     const pulse_size = context.execute(
                         op,
                         vsr.Operation.pulse.cast(TestContext.StateMachine),

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -165,8 +165,9 @@ pub fn StateMachineType(
             callback(state_machine);
         }
 
-        pub fn pulse(state_machine: *const StateMachine) bool {
+        pub fn pulse_needed(state_machine: *const StateMachine, timestamp: u64) bool {
             _ = state_machine;
+            _ = timestamp;
             return false;
         }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9718,6 +9718,8 @@ pub fn ReplicaType(
             assert(self.primary());
             assert(!self.pipeline.queue.full());
             assert(!self.pipeline.queue.contains_operation(.pulse));
+            assert(self.pulse_enabled());
+            assert(self.state_machine.pulse_needed(self.state_machine.prepare_timestamp));
 
             self.send_request_to_self(.pulse, &.{});
             assert(self.pipeline.queue.contains_operation(.pulse));


### PR DESCRIPTION
The state machine depended on `prepare_timestamp` to evaluate `pulse()`, but in an idle cluster, `prepare_timestamp` would only be set if `pulse` returned true!

Added unity tests for clients (except Go which does not have integration tests for any of the two-phase transfer scenarios)

Closes #2118 