### PR TITLE
build: unbreak CPU feature selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
         with:
           fetch-depth: 2147483647
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build test -Dcpu=baseline+neon+aes
-      - run: ./zig/zig build clients:c:sample -Drelease -Dcpu=baseline+neon+aes
+      - run: ./zig/zig build test
+      - run: ./zig/zig build clients:c:sample -Drelease
 
 
   clients:
@@ -143,7 +143,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
       - run: ./scripts/install_zig.sh
-      - run: ./zig/zig build scripts -- release --build --run-number=${{ github.run_number }} --sha=${{ github.sha }} --language=zig
       - run: ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
         env:
           DEVHUBDB_PAT: ${{ secrets.DEVHUBDB_PAT }}

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -34,6 +34,11 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;
     try shell.project_root.deleteFile("tigerbeetle");
 
+    try shell.zig(
+        \\build scripts -- release --build --run-number=189 --sha={sha}
+        \\    --language=zig
+    , .{ .sha = cli_args.sha });
+    try shell.project_root.deleteFile("tigerbeetle");
     try shell.exec("unzip dist/tigerbeetle/tigerbeetle-x86_64-linux.zip", .{});
 
     const benchmark_result = try shell.exec_stdout(


### PR DESCRIPTION
This fixes the issue when, after Zig 0.13, TigerBeetle would sometimes fall back to software implementaiton of AEGIS.

What we need to do is to just enable a couple of CPU features. Previously, the logic worked by first performing normal target resolution in build.zig, and then patching the target to what we need.

However, after 0.13 the patching no longer works: the features is enabled in build.zig, but not in the actual binary. This is _probably_ due to discrepancy between Target.Query and ResolvedTarget, but I wasn't able to trace this to the root.

Instead, the entire logic is re-written to just pick one of the set of hard-coded targets.

As a bonus, `scripts -- release` now accepts optional `--target` and `--mode` flags, to compile only subset of release binaries.