### PR TITLE
ci: check x86_64 macos and clients on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,13 @@ jobs:
       - run: .\zig\zig build clients:c:sample
 
   test_macos:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - { os: 'macos-latest' }
+          - { os: 'macos-13' }
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,6 +108,13 @@ jobs:
           - { os: 'windows-latest', language: 'java',    language_version: '21'    }
           - { os: 'windows-latest', language: 'node',    language_version: '18.x'  }
           - { os: 'windows-latest', language: 'node',    language_version: '20.x'  }
+
+          # Limited matrix for macOS - runners are concurrency limited.
+          - { os: 'macos-latest',   language: 'go',      language_version: '1.21'  }
+          - { os: 'macos-latest',   language: 'node',    language_version: '20.x'  }
+
+          - { os: 'macos-13',       language: 'go',      language_version: '1.21'  }
+          - { os: 'macos-13',       language: 'node',    language_version: '20.x'  }
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
(This is on top of #2125)

We support x86_64 macOS, but don't run any tests on it. This runs our tests on `macos-13`, which is the last free GitHub runner to be on x86_64.

Both the test suite, and the go and Node clients (but also for macos-latest). Limited to those two, since concurrency limits mean that adding in more in the matrix will block waiting for runners...

This feels a bit icky, but we do need to:
* run our test suite on macOS,
* test macOS x86_64, if we support it. (or we drop it)