### PR TITLE
devhub: don't delete tigerbeetle anymore

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -38,7 +38,6 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
         \\build scripts -- release --build --run-number=189 --sha={sha}
         \\    --language=zig
     , .{ .sha = cli_args.sha });
-    try shell.project_root.deleteFile("tigerbeetle");
     try shell.exec("unzip dist/tigerbeetle/tigerbeetle-x86_64-linux.zip", .{});
 
     const benchmark_result = try shell.exec_stdout(


### PR DESCRIPTION
The release build script now cleans up, and doesn't leave a dangling tigerbeetle binary around