### PR TITLE
multiversioning: bring up mac and windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,6 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
 
-      # TODO(multiversioning): llvm-lipo is only needed for _extracting_ fat Mac binaries for
-      # building releases. We already implement generating fat Mac binaries ourselves.
-      - run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build scripts -- release --build --publish --run-number=${{ github.run_number }} --sha=${{ github.sha }}
         env:

--- a/src/config.zig
+++ b/src/config.zig
@@ -141,7 +141,13 @@ const ConfigProcess = struct {
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
     grid_scrubber_interval_ms_max: usize = std.time.ms_per_s * 10,
     aof_recovery: bool = false,
-    multiversion_binary_size_max: u64 = 64 * 1024 * 1024,
+    multiversion_binary_platform_size_max: u64 = blk: {
+        // {Linux, Windows} get 64MB. macOS gets 128MB since it has universal binaries. Both of
+        // these are doubled in debug.
+        var size_max_mb = if (builtin.target.os.tag == .macos) 128 else 64;
+        if (builtin.mode != .ReleaseSafe) size_max_mb *= 2;
+        break :blk size_max_mb;
+    } * 1024 * 1024,
     multiversion_poll_interval_ms: u64 = 1000,
 };
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -141,13 +141,7 @@ const ConfigProcess = struct {
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
     grid_scrubber_interval_ms_max: usize = std.time.ms_per_s * 10,
     aof_recovery: bool = false,
-    multiversion_binary_platform_size_max: u64 = blk: {
-        // {Linux, Windows} get 64MB. macOS gets 128MB since it has universal binaries. Both of
-        // these are doubled in debug.
-        var size_max_mb = if (builtin.target.os.tag == .macos) 128 else 64;
-        if (builtin.mode != .ReleaseSafe) size_max_mb *= 2;
-        break :blk size_max_mb;
-    } * 1024 * 1024,
+    multiversion_binary_platform_size_max: u64 = 64 * 1024 * 1024,
     multiversion_poll_interval_ms: u64 = 1000,
 };
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -104,7 +104,14 @@ pub const vsr_releases_max = config.cluster.vsr_releases_max;
 
 /// The maximum cumulative size of a final TigerBeetle output binary - including potential past
 /// releases and metadata.
-pub const multiversion_binary_size_max = config.process.multiversion_binary_size_max;
+pub const multiversion_binary_platform_size_max =
+    config.process.multiversion_binary_platform_size_max;
+
+/// The maximum size, like above, but for any platform.
+pub const multiversion_binary_size_max = 256 * 1024 * 1024;
+comptime {
+    assert(multiversion_binary_platform_size_max <= multiversion_binary_size_max);
+}
 
 pub const multiversion_poll_interval_ms = config.process.multiversion_poll_interval_ms;
 

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -282,8 +282,7 @@ test "help/version smoke" {
         .{ .command = "{tigerbeetle} --help", .substring = "tigerbeetle repl" },
         .{ .command = "{tigerbeetle} inspect --help", .substring = "tables --tree" },
         .{ .command = "{tigerbeetle} version", .substring = "TigerBeetle version" },
-        // TODO(Multiversioning): Uncomment once this is fixed.
-        // .{ .command = "{tigerbeetle} version --verbose", .substring = "process.aof_recovery=" },
+        .{ .command = "{tigerbeetle} version --verbose", .substring = "process.aof_recovery=" },
     }) |check| {
         const output = try shell.exec_stdout(check.command, .{ .tigerbeetle = tigerbeetle });
         try std.testing.expect(output.len > 0);

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -428,6 +428,8 @@ pub const IO = struct {
         );
     }
 
+    pub const OpenatError = posix.OpenError || posix.UnexpectedError;
+
     pub const ReadError = error{
         WouldBlock,
         NotOpenForReading,

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -765,6 +765,8 @@ pub const IO = struct {
         );
     }
 
+    pub const OpenatError = std.posix.OpenError || std.posix.UnexpectedError;
+
     pub const ReadError = error{
         WouldBlock,
         NotOpenForReading,

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -27,6 +27,7 @@ const Shell = @import("../shell.zig");
 const multiversioning = @import("../multiversioning.zig");
 
 const multiversion_binary_size_max = multiversioning.multiversion_binary_size_max;
+const section_to_macho_cpu = multiversioning.section_to_macho_cpu;
 
 const Language = enum { dotnet, go, java, node, zig, docker };
 const LanguageSet = std.enums.EnumSet(Language);
@@ -59,7 +60,8 @@ const multiversion_epoch = "0.15.3";
 /// This commit references https://github.com/tigerbeetle/tigerbeetle/pull/1935.
 const multiversion_epoch_commit = "035c895bf85f5106d94f08cac49719994344880e";
 
-/// As does this tag. Have it as an explicit tag, so it's not just a random commit SHA that's
+/// This tag references https://github.com/tigerbeetle/tigerbeetle/pull/1935. Have it as an explicit
+/// tag in addition to multiversion_epoch_commit, so it's not just a random commit SHA that's
 /// important. This is later asserted to resolve to the same commit.
 const multiversion_epoch_tag = "0.15.3-multiversion-1";
 
@@ -412,24 +414,24 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                     .path = "tigerbeetle-x86_64-macos",
                 },
                 .{
-                    .cpu_type = 0x00000001, // VAX == .tb_mvb for aarch64
+                    .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvb_aarch64),
                     .cpu_subtype = 0x00000000,
                     .path = "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++
                         ".body",
                 },
                 .{
-                    .cpu_type = 0x00000002, // ROMP == .tb_mvh for aarch64
+                    .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvh_aarch64),
                     .cpu_subtype = 0x00000000,
                     .path = "multiversion-build/multiversion-empty.header",
                 },
                 .{
-                    .cpu_type = 0x00000004, // NS32032 == .tb_mvb for x86_64
+                    .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvb_x86_64),
                     .cpu_subtype = 0x00000000,
                     .path = "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++
                         ".body",
                 },
                 .{
-                    .cpu_type = 0x00000005, // NS32332 == .tb_mvh for x86_64
+                    .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvh_x86_64),
                     .cpu_subtype = 0x00000000,
                     .path = "multiversion-build/multiversion-empty.header",
                 },
@@ -487,23 +489,23 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 .path = "tigerbeetle-x86_64-macos",
             },
             .{
-                .cpu_type = 0x00000001, // VAX == .tb_mvb for aarch64
+                .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvb_aarch64),
                 .cpu_subtype = 0x00000000,
                 .path = "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++ ".body",
             },
             .{
-                .cpu_type = 0x00000002, // ROMP == .tb_mvh for aarch64
+                .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvh_aarch64),
                 .cpu_subtype = 0x00000000,
                 .path = "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++
                     ".header",
             },
             .{
-                .cpu_type = 0x00000004, // NS32032 == .tb_mvb for x86_64
+                .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvb_x86_64),
                 .cpu_subtype = 0x00000000,
                 .path = "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++ ".body",
             },
             .{
-                .cpu_type = 0x00000005, // NS32332 == .tb_mvh for x86_64
+                .cpu_type = @intFromEnum(section_to_macho_cpu.tb_mvh_x86_64),
                 .cpu_subtype = 0x00000000,
                 .path = "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++ ".header",
             },

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -25,6 +25,7 @@ const flags = @import("../flags.zig");
 const fatal = flags.fatal;
 const Shell = @import("../shell.zig");
 const multiversioning = @import("../multiversioning.zig");
+
 const multiversion_binary_size_max = multiversioning.multiversion_binary_size_max;
 
 const Language = enum { dotnet, go, java, node, zig, docker };
@@ -57,6 +58,10 @@ const multiversion_epoch = "0.15.3";
 
 /// This commit references https://github.com/tigerbeetle/tigerbeetle/pull/1935.
 const multiversion_epoch_commit = "035c895bf85f5106d94f08cac49719994344880e";
+
+/// As does this tag. Have it as an explicit tag, so it's not just a random commit SHA that's
+/// important. This is later asserted to resolve to the same commit.
+const multiversion_epoch_tag = "0.15.3-multiversion-1";
 
 pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     assert(builtin.target.os.tag == .linux);
@@ -182,6 +187,11 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
         fatal("can't find llvm-objcopy", .{});
     };
 
+    shell.project_root.deleteTree("multiversion-build") catch {};
+    var multiversion_build_dir = try shell.project_root.makeOpenPath("multiversion-build", .{});
+    defer shell.project_root.deleteTree("multiversion-build") catch {};
+    defer multiversion_build_dir.close();
+
     // We shell out to `zip` for creating archives, so we need an absolute path here.
     const dist_dir_path = try dist_dir.realpathAlloc(shell.arena.allocator(), ".");
 
@@ -204,11 +214,20 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
         "aarch64-linux",
     };
 
+    // Explicitly write out zeros for the header, to compute the checksum.
+    var header = std.mem.zeroes(multiversioning.MultiversionHeader);
+
+    var header_file_empty = try shell.project_root.createFile(
+        "multiversion-build/multiversion-empty.header",
+        .{ .exclusive = true },
+    );
+    try header_file_empty.writeAll(std.mem.asBytes(&header));
+    header_file_empty.close();
+
     // Build tigerbeetle binary for all OS/CPU combinations we support and copy the result to
     // `dist`. MacOS is special cased below --- we use an extra step to merge x86 and arm binaries
     // into one.
     // TODO: use std.Target here
-    defer shell.project_root.deleteFile("dist/tigerbeetle-multiversion-test") catch {};
     inline for (.{ true, false }) |debug| {
         const debug_suffix = if (debug) "-debug" else "";
         inline for (targets) |target| {
@@ -245,109 +264,88 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
             );
             defer shell.project_root.deleteFile(exe_name) catch {};
 
-            if (!windows) {
-                const allocator = shell.arena.allocator();
-                const current_checksum: u128 = blk: {
-                    const current_binary = try shell.project_root.openFile(exe_name, .{
-                        .mode = .read_only,
-                    });
-                    defer current_binary.close();
+            const current_checksum = try checksum_file(
+                shell,
+                exe_name,
+                multiversion_binary_size_max,
+            );
 
-                    const current_binary_contents = try current_binary.readToEndAlloc(
-                        allocator,
-                        multiversion_binary_size_max,
-                    );
-                    break :blk multiversioning.checksum.checksum(current_binary_contents);
-                };
+            const header_path = "multiversion-build/multiversion-" ++ target ++ debug_suffix ++
+                ".header";
+            const body_path = "multiversion-build/multiversion-" ++ target ++ debug_suffix ++
+                ".body";
 
-                const past_versions = try build_multiversion_body(
-                    shell,
-                    target,
-                    debug,
-                    "multiversion.body",
-                );
-                defer shell.project_root.deleteFile("multiversion.body") catch {};
+            const past_versions = try build_multiversion_body(
+                shell,
+                target,
+                debug,
+                body_path,
+            );
 
-                // Explicitly write out zeros for the header, to compute the checksum.
-                var header = std.mem.zeroes(multiversioning.MultiversionHeader);
+            // Use objcopy to add in our new body, as well as its header - even though the
+            // header is still zero!
+            try shell.exec("{llvm_objcopy} --enable-deterministic-archives --keep-undefined" ++
+                " --add-section .tb_mvb={body_path}" ++
+                " --set-section-flags .tb_mvb=contents,noload,readonly" ++
+                " --add-section .tb_mvh=multiversion-build/multiversion-empty.header" ++
+                " --set-section-flags .tb_mvh=contents,noload,readonly {exe_name}", .{
+                .body_path = body_path,
+                .llvm_objcopy = llvm_objcopy,
+                .exe_name = exe_name,
+            });
 
-                var header_file = try shell.project_root.createFile("multiversion.header", .{
-                    .truncate = true,
-                });
-                defer shell.project_root.deleteFile("multiversion.header") catch {};
-                try header_file.writeAll(std.mem.asBytes(&header));
-                header_file.close();
+            // Take the checksum of the binary, with the zeroed header.
+            const checksum_binary_without_header = try checksum_file(
+                shell,
+                exe_name,
+                multiversion_binary_size_max,
+            );
 
-                // Use objcopy to add in our new body, as well as its header - even though the
-                // header is still zero!
-                try shell.exec("{llvm_objcopy} --enable-deterministic-archives --keep-undefined" ++
-                    " --add-section .tb_mvb=multiversion.body" ++
-                    " --set-section-flags .tb_mvb=contents,noload,readonly" ++
-                    " --add-section .tb_mvh=multiversion.header" ++
-                    " --set-section-flags .tb_mvh=contents,noload,readonly {exe_name}", .{
-                    .llvm_objcopy = llvm_objcopy,
-                    .exe_name = exe_name,
-                });
+            header = multiversioning.MultiversionHeader{
+                .current_release = (try multiversioning.Release.parse(
+                    info.release_triple,
+                )).value,
+                .current_checksum = current_checksum,
+                .current_flags = .{
+                    .debug = debug,
+                    .visit = true,
+                },
+                .past = past_versions,
+                .checksum_binary_without_header = checksum_binary_without_header,
+            };
+            header.checksum_header = header.calculate_header_checksum();
 
-                // Take the checksum of the binary, with the zero'd header.
-                const checksum_binary_without_header: u128 = blk: {
-                    const current_binary = try shell.project_root.openFile(exe_name, .{
-                        .mode = .read_only,
-                    });
-                    defer current_binary.close();
+            const header_file = try shell.project_root.createFile(header_path, .{
+                .exclusive = true,
+            });
 
-                    const current_binary_contents = try current_binary.readToEndAlloc(
-                        allocator,
-                        multiversion_binary_size_max,
-                    );
-                    break :blk multiversioning.checksum.checksum(current_binary_contents);
-                };
+            try header_file.writeAll(std.mem.asBytes(&header));
+            header_file.close();
 
-                header = multiversioning.MultiversionHeader{
-                    .current_release = (try multiversioning.Release.parse(
-                        info.release_triple,
-                    )).value,
-                    .current_checksum = current_checksum,
-                    .current_flags = .{
-                        .debug = debug,
-                        .visit = true,
-                    },
-                    .past = past_versions,
-                    .checksum_binary_without_header = checksum_binary_without_header,
-                };
-                header.checksum_header = header.calculate_header_checksum();
+            // Replace the header with the final version.
+            try shell.exec("{llvm_objcopy} --enable-deterministic-archives --keep-undefined" ++
+                " --remove-section .tb_mvh --add-section .tb_mvh={header_path}" ++
+                " --set-section-flags .tb_mvh=contents,noload,readonly {exe_name}", .{
+                .header_path = header_path,
+                .llvm_objcopy = llvm_objcopy,
+                .exe_name = exe_name,
+            });
+            shell.project_root.deleteFile("multiversion.header") catch {};
 
-                header_file = try shell.project_root.createFile("multiversion.header", .{
-                    .truncate = true,
-                });
-                // Cleaned up by a defer higher up.
-
-                try header_file.writeAll(std.mem.asBytes(&header));
-                header_file.close();
-
-                // Replace the header with the final version.
-                try shell.exec("{llvm_objcopy} --enable-deterministic-archives --keep-undefined" ++
-                    " --remove-section .tb_mvh --add-section .tb_mvh=multiversion.header" ++
-                    " --set-section-flags .tb_mvh=contents,noload,readonly {exe_name}", .{
-                    .llvm_objcopy = llvm_objcopy,
-                    .exe_name = exe_name,
-                });
-
-                // If running on x86_64-linux (our only supported CI system, asserted in main())
-                // copy the binary somewhere to use it to test built multiversion binaries.
-                if (std.mem.eql(u8, target, "x86_64-linux")) {
-                    try shell.exec("cp {exe_name} dist/tigerbeetle-multiversion-test", .{
-                        .exe_name = exe_name,
-                    });
-                }
-
-                // Finally, check the binary produced using both the old and new versions.
-                // TODO(multiversioning): Do the check with the old binary downloaded, if it wasn't
-                // the epoch.
-                try shell.exec("dist/tigerbeetle-multiversion-test multiversion {exe_name}", .{
+            // If running on x86_64-linux (our only supported CI system, asserted in main())
+            // copy the binary somewhere to use it to test built multiversion binaries.
+            if (std.mem.eql(u8, target, "x86_64-linux")) {
+                try shell.exec("cp {exe_name} multiversion-build/tigerbeetle", .{
                     .exe_name = exe_name,
                 });
             }
+
+            // Finally, check the binary produced using both the old and new versions.
+            // TODO(multiversioning): Do the check with the old binary downloaded, if it wasn't
+            // the epoch.
+            try shell.exec("multiversion-build/tigerbeetle multiversion {exe_name}", .{
+                .exe_name = exe_name,
+            });
 
             const zip_name = "tigerbeetle-" ++ target ++ debug_suffix ++ ".zip";
             try shell.exec("zip -9 {zip_path} {exe_name}", .{
@@ -382,9 +380,102 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 shell.project_root,
                 "tigerbeetle-" ++ target,
             );
+            try shell.project_root.deleteFile("tigerbeetle");
         }
 
-        try build_macos_universal_binary(shell, "tigerbeetle", &.{
+        const past_versions_aarch64 = try build_multiversion_body(
+            shell,
+            "aarch64-macos",
+            debug,
+            "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++ ".body",
+        );
+
+        const past_versions_x86_64 = try build_multiversion_body(
+            shell,
+            "x86_64-macos",
+            debug,
+            "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++ ".body",
+        );
+
+        try macos_universal_binary_build(
+            shell,
+            "multiversion-build/tigerbeetle-macos-empty-headers" ++ debug_suffix,
+            &.{
+                .{
+                    .cpu_type = std.macho.CPU_TYPE_ARM64,
+                    .cpu_subtype = std.macho.CPU_SUBTYPE_ARM_ALL,
+                    .path = "tigerbeetle-aarch64-macos",
+                },
+                .{
+                    .cpu_type = std.macho.CPU_TYPE_X86_64,
+                    .cpu_subtype = std.macho.CPU_SUBTYPE_X86_64_ALL,
+                    .path = "tigerbeetle-x86_64-macos",
+                },
+                .{
+                    .cpu_type = 0x00000001, // VAX == .tb_mvb for aarch64
+                    .cpu_subtype = 0x00000000,
+                    .path = "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++
+                        ".body",
+                },
+                .{
+                    .cpu_type = 0x00000002, // ROMP == .tb_mvh for aarch64
+                    .cpu_subtype = 0x00000000,
+                    .path = "multiversion-build/multiversion-empty.header",
+                },
+                .{
+                    .cpu_type = 0x00000004, // NS32032 == .tb_mvb for x86_64
+                    .cpu_subtype = 0x00000000,
+                    .path = "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++
+                        ".body",
+                },
+                .{
+                    .cpu_type = 0x00000005, // NS32332 == .tb_mvh for x86_64
+                    .cpu_subtype = 0x00000000,
+                    .path = "multiversion-build/multiversion-empty.header",
+                },
+            },
+        );
+        const checksum_binary_without_header = try checksum_file(
+            shell,
+            "multiversion-build/tigerbeetle-macos-empty-headers" ++ debug_suffix,
+            multiversion_binary_size_max,
+        );
+
+        inline for (
+            .{ "aarch64-macos", "x86_64-macos" },
+            .{ past_versions_aarch64, past_versions_x86_64 },
+        ) |target, past_versions| {
+            const current_checksum = try checksum_file(
+                shell,
+                "tigerbeetle-" ++ target,
+                multiversion_binary_size_max,
+            );
+
+            const header_name = "multiversion-build/multiversion-" ++ target ++ debug_suffix ++
+                ".header";
+            const header_file = try shell.project_root.createFile(header_name, .{
+                .exclusive = true,
+            });
+
+            header = multiversioning.MultiversionHeader{
+                .current_release = (try multiversioning.Release.parse(
+                    info.release_triple,
+                )).value,
+                .current_checksum = current_checksum,
+                .current_flags = .{
+                    .debug = debug,
+                    .visit = true,
+                },
+                .past = past_versions,
+                .checksum_binary_without_header = checksum_binary_without_header,
+            };
+            header.checksum_header = header.calculate_header_checksum();
+
+            try header_file.writeAll(std.mem.asBytes(&header));
+            header_file.close();
+        }
+
+        try macos_universal_binary_build(shell, "tigerbeetle", &.{
             .{
                 .cpu_type = std.macho.CPU_TYPE_ARM64,
                 .cpu_subtype = std.macho.CPU_SUBTYPE_ARM_ALL,
@@ -395,8 +486,33 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 .cpu_subtype = std.macho.CPU_SUBTYPE_X86_64_ALL,
                 .path = "tigerbeetle-x86_64-macos",
             },
+            .{
+                .cpu_type = 0x00000001, // VAX == .tb_mvb for aarch64
+                .cpu_subtype = 0x00000000,
+                .path = "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++ ".body",
+            },
+            .{
+                .cpu_type = 0x00000002, // ROMP == .tb_mvh for aarch64
+                .cpu_subtype = 0x00000000,
+                .path = "multiversion-build/multiversion-aarch64-macos" ++ debug_suffix ++
+                    ".header",
+            },
+            .{
+                .cpu_type = 0x00000004, // NS32032 == .tb_mvb for x86_64
+                .cpu_subtype = 0x00000000,
+                .path = "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++ ".body",
+            },
+            .{
+                .cpu_type = 0x00000005, // NS32332 == .tb_mvh for x86_64
+                .cpu_subtype = 0x00000000,
+                .path = "multiversion-build/multiversion-x86_64-macos" ++ debug_suffix ++ ".header",
+            },
         });
-        defer shell.project_root.deleteFile("tigerbeetle") catch {};
+
+        // Finally, check the binary produced using both the old and new versions.
+        // TODO(multiversioning): Do the check with the old binary downloaded, if it wasn't
+        // the epoch.
+        try shell.exec("multiversion-build/tigerbeetle multiversion tigerbeetle", .{});
 
         try shell.project_root.deleteFile("tigerbeetle-aarch64-macos");
         try shell.project_root.deleteFile("tigerbeetle-x86_64-macos");
@@ -417,14 +533,20 @@ fn build_tigerbeetle_epoch(shell: *Shell) !void {
     var section = try shell.open_section("build tigerbeetle epoch");
     defer section.close();
 
-    try shell.exec("git clone https://github.com/tigerbeetle/tigerbeetle.git tigerbeetle-epoch", .{});
+    try shell.exec(
+        "git clone https://github.com/tigerbeetle/tigerbeetle.git tigerbeetle-epoch",
+        .{},
+    );
 
     try shell.pushd("./tigerbeetle-epoch");
     defer shell.popd();
 
-    try shell.exec("git checkout {commit}", .{
-        .commit = multiversion_epoch_commit,
+    try shell.exec("git checkout {tag}", .{
+        .tag = multiversion_epoch_tag,
     });
+    const multiversion_epoch_tag_commit = try shell.exec_stdout("git rev-parse HEAD", .{});
+    assert(std.mem.eql(u8, multiversion_epoch_commit, multiversion_epoch_tag_commit));
+
     try shell.exec("scripts/install_zig.sh", .{});
     try shell.exec("zig/zig build scripts -- release --run-number={run_number} --sha={commit} " ++
         "--language=zig --build", .{
@@ -443,23 +565,25 @@ fn build_multiversion_body(
     debug: bool,
     body_path: []const u8,
 ) !multiversioning.MultiversionHeader.PastReleases {
-    assert(std.mem.indexOf(u8, target, "-linux") != null);
-
     var section = try shell.open_section("build multiversion body");
     defer section.close();
+
+    const windows = comptime std.mem.indexOf(u8, target, "windows") != null;
+    const macos = comptime std.mem.indexOf(u8, target, "macos") != null;
+    const exe_name = "tigerbeetle" ++ if (windows) ".exe" else "";
 
     // TODO(multiversioning): Normally this would download and extract the last published release
     // of TigerBeetle. For the 0.15.4 release, it uses the custom build provided in
     // `tigerbeetle-epoch/` by build_tigerbeetle_epoch().
     try shell.exec("unzip -d tigerbeetle-epoch/dist/extracted " ++
         "tigerbeetle-epoch/dist/tigerbeetle/tigerbeetle-{target}{debug}.zip", .{
-        .target = target,
+        .target = if (macos) "universal-macos" else target,
         .debug = if (debug) "-debug" else "",
     });
     defer shell.project_root.deleteTree("tigerbeetle-epoch/dist/extracted") catch {};
 
     const past_binary = try shell.project_root
-        .openFile("./tigerbeetle-epoch/dist/extracted/tigerbeetle", .{ .mode = .read_only });
+        .openFile("./tigerbeetle-epoch/dist/extracted/" ++ exe_name, .{ .mode = .read_only });
     defer past_binary.close();
 
     const past_binary_contents = try past_binary.readToEndAlloc(
@@ -469,7 +593,7 @@ fn build_multiversion_body(
 
     const checksum: u128 = multiversioning.checksum.checksum(past_binary_contents);
 
-    const body_file = try shell.project_root.createFile(body_path, .{ .truncate = true });
+    const body_file = try shell.project_root.createFile(body_path, .{ .exclusive = true });
     defer body_file.close();
 
     try body_file.writeAll(past_binary_contents);
@@ -511,12 +635,15 @@ fn build_multiversion_body(
 /// deprecated architectures hold the multiversion header and body.
 /// It's much easier to embed and read them here, then to do it in the inner MachO binary, like
 /// we do with ELF or PE.
-fn build_macos_universal_binary(
+fn macos_universal_binary_build(
     shell: *Shell,
     output_path: []const u8,
     binaries: []const struct { cpu_type: i32, cpu_subtype: i32, path: []const u8 },
 ) !void {
-    var section = try shell.open_section("build macos universal binary");
+    // Needed to compile, because of the .mode lower down.
+    if (builtin.target.os.tag != .linux) @panic("unsupported platform");
+
+    var section = try shell.open_section("macos universal binary build");
     defer section.close();
 
     // The offset start is relative to the end of the headers, rounded up to the alignment.
@@ -552,7 +679,10 @@ fn build_macos_universal_binary(
         current_offset = std.mem.alignForward(u32, current_offset, alignment);
     }
 
-    var output_file = try shell.project_root.createFile(output_path, .{ .truncate = false });
+    var output_file = try shell.project_root.createFile(output_path, .{
+        .exclusive = true,
+        .mode = 0o777,
+    });
     defer output_file.close();
 
     const fat_header = std.macho.fat_header{
@@ -581,6 +711,70 @@ fn build_macos_universal_binary(
 
         try output_file.writeAll(binary_contents);
     }
+}
+
+/// Does the opposite of macos_universal_binary_build: allows extracting inner binaries from a
+/// universal binary.
+fn macos_universal_binary_extract(
+    shell: *Shell,
+    input_path: []const u8,
+    filter: struct { cpu_type: i32, cpu_subtype: i32 },
+    output_path: []const u8,
+) !void {
+    var section = try shell.open_section("macos universal binary extract");
+    defer section.close();
+
+    const input_file = try shell.project_root.openFile(input_path, .{ .mode = .read_only });
+    defer input_file.close();
+    const binary_contents = try input_file.readToEndAlloc(
+        shell.arena.allocator(),
+        multiversion_binary_size_max,
+    );
+
+    const fat_header = std.mem.bytesAsValue(
+        std.macho.fat_header,
+        binary_contents[0..@sizeOf(std.macho.fat_header)],
+    );
+    assert(fat_header.magic == std.macho.FAT_CIGAM);
+
+    for (0..@byteSwap(fat_header.nfat_arch)) |i| {
+        const header_offset = @sizeOf(std.macho.fat_header) + @sizeOf(std.macho.fat_arch) * i;
+        const fat_arch = std.mem.bytesAsValue(
+            std.macho.fat_arch,
+            binary_contents[header_offset..][0..@sizeOf(std.macho.fat_arch)],
+        );
+        assert(@byteSwap(fat_arch.@"align") == 14);
+
+        if (@byteSwap(fat_arch.cputype) == filter.cpu_type and
+            @byteSwap(fat_arch.cpusubtype) == filter.cpu_subtype)
+        {
+            const offset = @byteSwap(fat_arch.offset);
+            const size = @byteSwap(fat_arch.size);
+
+            const output_file = try shell.project_root.openFile(output_path, .{
+                .mode = .read_only,
+            });
+            defer output_file.close();
+            try output_file.writeAll(binary_contents[offset..][0..size]);
+
+            break;
+        }
+    } else {
+        @panic("no matching inner binary found.");
+    }
+}
+
+fn checksum_file(shell: *Shell, path: []const u8, size_max: u32) !u128 {
+    const file = try shell.project_root.openFile(path, .{
+        .mode = .read_only,
+    });
+    defer file.close();
+
+    const contents = try file.readToEndAlloc(
+        shell.arena.allocator(),
+        size_max,
+    );
+    return multiversioning.checksum.checksum(contents);
 }
 
 fn build_dotnet(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -71,7 +71,9 @@ pub fn main() !void {
         },
         .multiversion => |*args| {
             var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
-            const stdout = stdout_buffer.writer();
+            var stdout_writer = stdout_buffer.writer();
+            const stdout = stdout_writer.any();
+
             try vsr.multiversioning.print_information(allocator, args.path, stdout);
             try stdout_buffer.flush();
         },
@@ -449,7 +451,9 @@ const Command = struct {
 
     pub fn version(allocator: mem.Allocator, verbose: bool) !void {
         var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
-        const stdout = stdout_buffer.writer();
+        var stdout_writer = stdout_buffer.writer();
+        const stdout = stdout_writer.any();
+
         try std.fmt.format(stdout, "TigerBeetle version {}\n", .{constants.semver});
 
         if (verbose) {
@@ -517,7 +521,7 @@ fn replica_release_execute(replica: *Replica, release: vsr.Release) noreturn {
         // the parent process exiting and the new process starting. Work around this by
         // deinit'ing Replica and storage before continuing.
         // We don't need to clean up all resources here, since the process will be terminated
-        // in any case; only the ones that would block a new process from starting up.
+        // in any case; only the resources that would block a new process from starting up.
         const storage = replica.superblock.storage;
         const fd = storage.fd;
         replica.deinit(replica.static_allocator.parent_allocator);


### PR DESCRIPTION
Following on from #2013, this brings multiversion support to Windows and macOS. Multiversion, just like running a replica on these platforms, is considered a development tool and not suitable for production.

In particular, there's no monitoring and automatic restarting if the binary changes, and more of a best effort to not panic in the `parse_{pe,macho}` than an exhaustive attempt like `parse_elf`. These platforms also use physical files on disk, so they might be prone to more strange side-effects than Linux, which uses a memfd. Indeed, they also use sync IO instead of an event loop implementation for `openat` too.

Some known caveats:
* Windows terminal interfacing is strange, the process retains stdout/err when it reexecutes (CreateProcess) but it doesn't seem like it's possible to get it to keep stdin. Spawning a whole new terminal window is another option.

Perhaps one other notable change - in the build process, everything is collected under `multiversion-build/` and that folder is deleted at the end. It makes the cleanup code much easier, as well as making it easier to manually inspect things by disabling the defer.