### PR TITLE
vsr: don't overwrite ops from previous WAL unless they're durable on a commit-quorum of checkpoints

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1695,6 +1695,19 @@ pub fn ReplicaType(
                 self.panic_if_hash_chain_would_break_in_the_same_view(previous, message.header);
             }
 
+            // If we are going to overwrite an op from the previous WAL wrap, assert that it's part
+            // of a checkpoint that is durable on a commit quorum of replicas. See `op_repair_min`
+            // for why op=prepare_max+1 being committed implies that.
+            if ((self.op + 1) > constants.journal_slot_count) {
+                // The first op from the former checkpoint is the first to be overwritten.
+                if ((self.op + 1) - constants.journal_slot_count ==
+                    (self.op_checkpoint() + 1) -| constants.vsr_checkpoint_interval)
+                {
+                    assert(self.commit_max >
+                        vsr.Checkpoint.prepare_max_for_checkpoint(self.op_checkpoint()).?);
+                }
+            }
+
             // We must advance our op and set the header as dirty before replicating and
             // journalling. The primary needs this before its journal is outrun by any
             // prepare_ok quorum:
@@ -5862,8 +5875,9 @@ pub fn ReplicaType(
         /// Availability condition: each committed op must be present either in a quorum of WALs or
         /// in a quorum of checkpoints.
         ///
-        /// If op=trigger+1 is committed, the corresponding checkpoint is durably present on
-        /// a quorum of replicas. Repairing all ops since the latest durable checkpoint satisfies
+        /// If op=prepare_max+1 is committed, a quorum of replicas have moved to the next
+        /// prepare_max, which in turn signals that the corresponding checkpoint is durably present
+        /// on a quorum of replicas. Repairing all ops since the latest durable checkpoint satisfies
         /// both conditions.
         ///
         /// When called from status=recovering_head or status=recovering, the caller is responsible
@@ -5879,13 +5893,15 @@ pub fn ReplicaType(
                     break :repair_min 0;
                 }
 
-                const op_checkpoint_trigger =
-                    vsr.Checkpoint.trigger_for_checkpoint(self.op_checkpoint()).?;
+                const prepare_max_for_current_checkpoint =
+                    vsr.Checkpoint.prepare_max_for_checkpoint(self.op_checkpoint()).?;
                 // After state sync, commit_max might lag behind checkpoint_op.
-                maybe(self.commit_max < op_checkpoint_trigger);
-                if (self.commit_max > op_checkpoint_trigger) {
+                maybe(self.commit_max < prepare_max_for_current_checkpoint);
+                if (self.commit_max > prepare_max_for_current_checkpoint) {
                     if (self.op == self.op_checkpoint()) {
                         // Don't allow "op_repair_min > op_head".
+                        // See https://github.com/tigerbeetle/tigerbeetle/pull/1589 for why
+                        // this is required.
                         break :repair_min self.op_checkpoint();
                     }
                     break :repair_min self.op_checkpoint() + 1;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9493,7 +9493,7 @@ pub fn ReplicaType(
             // could lead to permanent unavailability.
             if (candidate.checkpoint_op == self.op_checkpoint_next()) {
                 if (header.into_const(.commit)) |h| {
-                    if (h.commit <= self.op_checkpoint_next_trigger()) return;
+                    if (h.commit <= self.op_prepare_max()) return;
                 } else {
                     return;
                 }

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1145,12 +1145,12 @@ test "Cluster: sync: slightly lagging replica" {
     // Corrupt all copies of a checkpointed prepare.
     a0.corrupt(.{ .wal_prepare = checkpoint_1 });
     b1.corrupt(.{ .wal_prepare = checkpoint_1 });
-    try c.request(checkpoint_1_trigger + 2, checkpoint_1_trigger + 2);
+    try c.request(checkpoint_1_prepare_max + 1, checkpoint_1_prepare_max + 1);
 
     // At this point, b2 won't be able to repair WAL and must state sync.
     b2.pass_all(.R_, .bidirectional);
-    try c.request(checkpoint_1_trigger + 3, checkpoint_1_trigger + 3);
-    try expectEqual(t.replica(.R_).commit(), checkpoint_1_trigger + 3);
+    try c.request(checkpoint_1_prepare_max + 2, checkpoint_1_prepare_max + 2);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_1_prepare_max + 2);
 }
 
 test "Cluster: sync: checkpoint from a newer view" {


### PR DESCRIPTION
### Goal

Ensuring a prepare in the WAL is only overwritten if it belongs to a commit-quorum of checkpoints. This is essential to the physical durability of each prepare, i.e. each prepare must either exist physically on a commit-quorum of WALs or checkpoints (not a mixture).

### Problem

This is how [op_prepare_max](https://github.com/tigerbeetle/tigerbeetle/blob/5e4a084799b4eda9ca7028756236edcb6b57236a/src/vsr/replica.zig#L5811-L5818) &  [op_repair_min](https://github.com/tigerbeetle/tigerbeetle/blob/5e4a084799b4eda9ca7028756236edcb6b57236a/src/vsr/replica.zig#L5882-L5886) contribute to our goal not being met:

#### 1. [op_prepare_max](https://github.com/tigerbeetle/tigerbeetle/blob/5e4a084799b4eda9ca7028756236edcb6b57236a/src/vsr/replica.zig#L5811-L5818)

Currently, we don't ensure the physical durability of each prepare in either a commit-quorum of WALs or checkpoints (not a mixture). The key problem is that `op_prepare_max` is maintained *independently* on each replica according to their *op_checkpoint*, without any consideration for whether the checkpoint is durable on a commit quorum of replicas or not. However, this can compromise availability in the presence of storage faults. Consider the following scenario in a 3-replica cluster:

A prepare `P` is replicated to R1 & R2, but not to R3. R1 decides to evict and overwrite `P` since it is in R1's checkpoint. However, R2 hasn't reached this checkpoint yet, so it still has `P` in its WAL.  Further, assume a pair of uncorrelated storage faults - a storage corruption of `P` in R2's WAL, combined with a storage corruption in R1's LSM. This can render the cluster unavailable. The core issue here is that even though even have *logical* durability of data across a commit-quorum of replicas (`P` is durable in R1's checkpoint in the LSM tree and in R2's WAL), the *physical* durability of the data is compromised, since the data is present across a commit-quorum of replicas in *different* forms.

#### 2. [op_repair_min](https://github.com/tigerbeetle/tigerbeetle/blob/5e4a084799b4eda9ca7028756236edcb6b57236a/src/vsr/replica.zig#L5882-L5886)

`op_repair_min` uses the cluster committing past the checkpoint trigger of checkpoint C to be a signal that C is durable on a commit quorum of replicas. This is incorrect as the cluster committing past the checkpoint trigger merely signals that a commit quorum of replicas _prepare_ok'd_ an operation past the checkpoint trigger. 


### Solution

#### 1. op_prepare_max

This PR doesn't make changes to the definition `op_prepare_max`. Instead, we ensure by sizing the journal correctly that preparing beyond `op_prepare_max` is safe  and doesn't overwrite entries from the previous checkpoint if they aren't durable on a commit quorum of replicas.

Before this change, `journal_slot_count >= vsr_checkpoint_interval + lsm_batch_multiple + pipeline_prepare_queue_max`. With these configurations, the primary needed an explicit synchronization point wherein before it could prepare past `op_prepare_max`, it would have to wait for a commit quorum of replicas to reach the former checkpoint. We tried to implement this approach in https://github.com/tigerbeetle/tigerbeetle/pull/2104 but we discovered(in [this](https://tigerbeetleinc.slack.com/archives/C03VBG9D2F7/p1721816599554649) Slack discussion) that there was a way to avoid this synchronization point by increasing the size of the journal (while consequently decreasing the checkpoint interval).

Therefore, as part of this change we increase the size of the journal (while consequently decreasing the checkpoint interval), such that `journal_slot_count >= vsr_checkpoint_interval + lsm_batch_multiple + 2 * pipeline_prepare_queue_max`. This margin ensures that the entries prepared immediately following a checkpoint's prepare max never  overwrite an entry from the previous WAL wrap until a quorum of replicas has reached that checkpoint.  By the time we start preparing entries after the second pipeline_prepare_queue_max, a quorum of replicas is guaranteed to have already reached the former checkpoint. 

#### 2. [op_repair_min](https://github.com/tigerbeetle/tigerbeetle/pull/2137/commits/cc0764f9aadff25ad4ae3d39685f678936fbd018#diff-e95e4dc6c1aae349e798cfeed22ad01f830cce0e654e6b4b765b3e7b0c677b6aR5878-R5885)

`op_repair_min` now uses committing atop prepare_max for a checkpoint C as a signal that a commit quorum of replicas of have reached C. This is because op=prepare_max+1 is committed, a quorum of replicas have moved to the next prepare_max, which in turn signals that the corresponding checkpoint is durably present on a quorum of replicas.
