### PR TITLE
VSR: Header.Block.peer_type=unknown

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -211,8 +211,27 @@ pub const Header = extern struct {
             .block => return .unknown,
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
+
             // All other messages identify the peer as a replica:
-            else => return .{ .replica = self.replica },
+            .ping,
+            .pong,
+            .pong_client,
+            .prepare_ok,
+            .reply,
+            .commit,
+            .start_view_change,
+            .do_view_change,
+            .start_view,
+            .request_start_view,
+            .request_headers,
+            .request_prepare,
+            .request_reply,
+            .headers,
+            .eviction,
+            .request_blocks,
+            .request_sync_checkpoint,
+            .sync_checkpoint,
+            => return .{ .replica = self.replica },
         }
     }
 

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -208,6 +208,7 @@ pub const Header = extern struct {
                 }
             },
             .prepare => return .unknown,
+            .block => return .unknown,
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
             // All other messages identify the peer as a replica:
@@ -348,7 +349,7 @@ pub const Header = extern struct {
         release: vsr.Release,
         protocol: u16 = vsr.Version,
         command: Command,
-        replica: u8 = 0,
+        replica: u8,
         reserved_frame: [12]u8 = [_]u8{0} ** 12,
 
         ping_timestamp_monotonic: u64,


### PR DESCRIPTION
This is a serious bug! `MessageBus` sees `block` messages (due to state sync or repair) and `peer_type` says they are always from replica 0 (since `Header.Block.replica == 0` always). So if they are being sent by a non-R0 replica, message bus drops the messages  with `message from unexpected peer`.

Follow-up PR will actually add `peer_type` coverage to the VOPR, but I wanted to get the fix in soonest.