### PR TITLE
vsr: decoupling replication and appending to WAL

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7624,9 +7624,11 @@ pub fn ReplicaType(
                     assert(message.header.replica != replica);
                 },
             }
-            if (replica != self.replica) {
-                // Critical: Do not advertise a view/log_view before it is durable.
-                // See view_durable()/log_view_durable().
+            // Critical:
+            // Do not advertise a view/log_view before it is durable. We only need perform these
+            // checks if we authored the message, not if we're simply forwarding a message along.
+            // See view_durable()/log_view_durable().
+            if (replica != self.replica and message.header.replica == self.replica) {
                 if (message.header.view > self.view_durable() and
                     message.header.command != .request_start_view and
                     !(message.header.command == .ping and

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1600,11 +1600,6 @@ pub fn ReplicaType(
                 return;
             }
 
-            if (message.header.view < self.view) {
-                log.debug("{}: on_prepare: ignoring (older view)", .{self.replica});
-                return;
-            }
-
             self.replicate(message);
 
             if (self.status != .normal) {
@@ -5624,12 +5619,10 @@ pub fn ReplicaType(
         fn is_repair(self: *const Self, message: *const Message.Prepare) bool {
             assert(message.header.command == .prepare);
 
+            if (message.header.view < self.view) return true;
+
             if (self.status == .normal) {
-                if (message.header.view < self.view) return true;
                 if (message.header.view == self.view and message.header.op <= self.op) return true;
-            } else if (self.status == .view_change) {
-                if (message.header.view < self.view) return true;
-                // The view has already started or is newer.
             }
 
             return false;


### PR DESCRIPTION
Currently, while handling a prepare message in [on_prepare](https://github.com/tigerbeetle/tigerbeetle/blob/9a2c665bdbfa81b060c31a4be9cdd1c5f37b9819/src/vsr/replica.zig#L1592), [replication](https://github.com/tigerbeetle/tigerbeetle/blob/9a2c665bdbfa81b060c31a4be9cdd1c5f37b9819/src/vsr/replica.zig#L6949) of the prepare to the next replica in the configuration chain is subject to the same restrictions as [appending](https://github.com/tigerbeetle/tigerbeetle/blob/9a2c665bdbfa81b060c31a4be9cdd1c5f37b9819/src/vsr/replica.zig#L1726) the prepare to the replica's WAL. While these [asserts](https://github.com/tigerbeetle/tigerbeetle/blob/9a2c665bdbfa81b060c31a4be9cdd1c5f37b9819/src/vsr/replica.zig#L1597-L1696) (whether there is space in the WAL, whether the prepare is from a future view, whether the replica is in normal status) are critical invariants for appending the prepare to the replica's WAL, forwarding it to another replica even if the sending replica doesn't satisfy these invariants should be a safe operation.

This change decouples replication and appending to the WAL on backups, such that a replica _always_ forwards a prepare to the next replica, even if it can't process that prepare locally.