### PR TITLE
tidy: std.fs.MAX_PATH_BYTES -> std.fs.max_path_bytes

### DIFF
--- a/src/flags.zig
+++ b/src/flags.zig
@@ -680,7 +680,7 @@ test "flags" {
         gpa: std.mem.Allocator,
         tmp_dir: std.testing.TmpDir,
         output_buf: std.ArrayList(u8),
-        flags_exe_buf: *[std.fs.MAX_PATH_BYTES]u8,
+        flags_exe_buf: *[std.fs.max_path_bytes]u8,
         flags_exe: []const u8,
 
         fn init(gpa: std.mem.Allocator) !T {
@@ -702,7 +702,7 @@ test "flags" {
             const output_buf = std.ArrayList(u8).init(gpa);
             errdefer output_buf.deinit();
 
-            const flags_exe_buf = try gpa.create([std.fs.MAX_PATH_BYTES]u8);
+            const flags_exe_buf = try gpa.create([std.fs.max_path_bytes]u8);
             errdefer gpa.destroy(flags_exe_buf);
 
             { // Compile this file as an executable!

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1118,7 +1118,7 @@ pub const Multiversion = struct {
             },
             .windows => {
                 // Includes the null byte, that utf8ToUtf16LeWithNull needs.
-                var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+                var buffer: [std.fs.max_path_bytes]u8 = undefined;
                 var fixed_allocator = std.heap.FixedBufferAllocator.init(&buffer);
                 const allocator = fixed_allocator.allocator();
 
@@ -1169,7 +1169,7 @@ pub const Multiversion = struct {
 };
 
 pub fn self_exe_path(allocator: std.mem.Allocator) ![:0]const u8 {
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const native_self_exe_path = try std.fs.selfExePath(&buf);
 
     if (builtin.target.os.tag == .linux and std.mem.eql(

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -50,7 +50,7 @@ cwd_stack_count: usize,
 // ChildProcess's cwd, which is required to be a path, rather than a file descriptor. This buffer
 // is used to materialize the path to cwd when spawning a new process.
 //   <https://github.com/ziglang/zig/issues/5190>
-cwd_path_buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined,
+cwd_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
 
 env: std.process.EnvMap,
 


### PR DESCRIPTION
The former is deprecated in favor of the latter.