### PR TITLE
multiversioning: fix parse_pe

### DIFF
--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1414,7 +1414,7 @@ fn parse_macho(buffer: []const u8) !HeaderBodyOffsets {
 fn parse_pe(buffer: []const u8) !HeaderBodyOffsets {
     const coff = try std.coff.Coff.init(buffer, false);
 
-    if ((try coff.getStrtab()) == null) return error.InvalidPE;
+    if (!coff.is_image) return error.InvalidPE;
 
     const header_section = coff.getSectionByName(".tb_mvh");
     const body_section = coff.getSectionByName(".tb_mvb");


### PR DESCRIPTION
Turns out, it won't error out if there's no header, but instead set is_image to false. Check that, rather than looking at the string table which didn't work.