### PR TITLE
ci: skip merge group checks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   smoke:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +24,7 @@ jobs:
       - run: ./.github/ci/docs_check.sh
 
   test_alpine:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
       image: alpine
@@ -40,6 +42,7 @@ jobs:
       - run: zig/zig build test
 
   test_ubuntu:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +59,7 @@ jobs:
       - run: zig/zig build -Dtracer-backend=tracy
 
   test_aof:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +69,7 @@ jobs:
       - run: ./.github/ci/test_aof.sh
 
   test_windows:
+    if: github.ref != 'refs/heads/main'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +80,7 @@ jobs:
       - run: .\zig\zig build clients:c:sample
 
   test_macos:
+    if: github.ref != 'refs/heads/main'
     strategy:
       matrix:
         include:
@@ -92,6 +98,7 @@ jobs:
 
 
   clients:
+    if: github.ref != 'refs/heads/main'
     strategy:
       matrix:
         include:

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1414,7 +1414,7 @@ fn parse_macho(buffer: []const u8) !HeaderBodyOffsets {
 fn parse_pe(buffer: []const u8) !HeaderBodyOffsets {
     const coff = try std.coff.Coff.init(buffer, false);
 
-    if ((try coff.getStrtab()) == null) return error.InvalidPE;
+    if (!coff.is_image) return error.InvalidPE;
 
     const header_section = coff.getSectionByName(".tb_mvh");
     const body_section = coff.getSectionByName(".tb_mvb");


### PR DESCRIPTION
Jotting this down as an idea:

Maybe we don't want to do this at all, or maybe we want to do it a different way, but I _think_ GitHub guarantees that the commit that passes the `merge_group` is the commit that will be merged onto main. So, we can skip running all our CI on an identical commit.

(If we split the files, so we have a ci.yml that has the merge_group and pull_request triggers, and then a main.yml that has the devhub and kcov job with a push trigger, it'll get rid of the skipped jobs on both the PR check page and the main commit status page)

(Unfortunately the merge_group and the PR have different commit hashes, even though they have the same contents. So to make those conditional if they're identical would be a bit harder)