### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,10 +17,14 @@ TigerBeetle is a single, small, statically-linked binary.
 ```console
 # macOS
 curl -Lo tigerbeetle.zip https://mac.tigerbeetle.com && unzip tigerbeetle.zip && ./tigerbeetle version
+```
 
+```console
 # Linux
 curl -Lo tigerbeetle.zip https://linux.tigerbeetle.com && unzip tigerbeetle.zip && ./tigerbeetle version
+```
 
+```console
 # Windows
 powershell -command "curl.exe -Lo tigerbeetle.zip https://windows.tigerbeetle.com; Expand-Archive tigerbeetle.zip .; .\tigerbeetle version"
 ```


### PR DESCRIPTION
When I click "copy" console command I get 
three commands (macOs, Linux, Windows) 
in my clipboard. This does not make any sense.

I've separated these commands so the  one
can click "copy" on the command they want
to execute. The UIX is better in this case.