### PR TITLE
VSR: Fix stuck-client bug; Add eviction replica_tests (part 1/2)

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -312,13 +312,15 @@ pub const AOFReplayClient = struct {
 
         client.* = try Client.init(
             allocator,
-            std.crypto.random.int(u128),
-            0,
-            @intCast(addresses.len),
-            message_pool,
             .{
-                .configuration = addresses,
-                .io = io,
+                .id = std.crypto.random.int(u128),
+                .cluster = 0,
+                .replica_count = @intCast(addresses.len),
+                .message_pool = message_pool,
+                .message_bus_options = .{
+                    .configuration = addresses,
+                    .io = io,
+                },
             },
         );
         errdefer client.deinit(allocator);

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -169,13 +169,15 @@ pub fn ContextType(
             });
             context.client = try Client.init(
                 allocator,
-                context.client_id,
-                cluster_id,
-                @intCast(context.addresses.len),
-                &context.message_pool,
                 .{
-                    .configuration = context.addresses,
-                    .io = &context.io,
+                    .id = context.client_id,
+                    .cluster = cluster_id,
+                    .replica_count = @intCast(context.addresses.len),
+                    .message_pool = &context.message_pool,
+                    .message_bus_options = .{
+                        .configuration = context.addresses,
+                        .io = &context.io,
+                    },
                 },
             );
             errdefer context.client.deinit(context.allocator);

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -57,20 +57,22 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
 
         pub fn init(
             allocator: mem.Allocator,
-            id: u128,
-            cluster: u128,
-            replica_count: u8,
-            message_pool: *MessagePool,
-            message_bus_options: MessageBus.Options,
+            options: struct {
+                id: u128,
+                cluster: u128,
+                replica_count: u8,
+                message_pool: *MessagePool,
+                message_bus_options: MessageBus.Options,
+            },
         ) !Self {
             _ = allocator;
-            _ = replica_count;
-            _ = message_bus_options;
+            _ = options.replica_count;
+            _ = options.message_bus_options;
 
             return Self{
-                .id = id,
-                .cluster = cluster,
-                .message_pool = message_pool,
+                .id = options.id,
+                .cluster = options.cluster,
+                .message_pool = options.message_pool,
             };
         }
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -633,13 +633,15 @@ pub fn ReplType(comptime MessageBus: type) type {
 
             var client = try Client.init(
                 allocator,
-                client_id,
-                cluster_id,
-                @intCast(addresses.len),
-                &message_pool,
                 .{
-                    .configuration = addresses,
-                    .io = &io,
+                    .id = client_id,
+                    .cluster = cluster_id,
+                    .replica_count = @intCast(addresses.len),
+                    .message_pool = &message_pool,
+                    .message_bus_options = .{
+                        .configuration = addresses,
+                        .io = &io,
+                    },
                 },
             );
             repl.client = &client;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -267,11 +267,13 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 errdefer for (clients[0..i]) |*c| c.deinit(allocator);
                 client.* = try Client.init(
                     allocator,
-                    client_id_permutation.encode(i + client_id_permutation_shift),
-                    options.cluster_id,
-                    options.replica_count,
-                    &client_pools[i],
-                    .{ .network = network },
+                    .{
+                        .id = client_id_permutation.encode(i + client_id_permutation_shift),
+                        .cluster = options.cluster_id,
+                        .replica_count = options.replica_count,
+                        .message_pool = &client_pools[i],
+                        .message_bus_options = .{ .network = network },
+                    },
                 );
                 client.release = options.releases[0].release;
             }

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -222,6 +222,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             var replica_pools = try allocator.alloc(MessagePool, node_count);
             errdefer allocator.free(replica_pools);
 
+            // There may be more clients than `clients_max` (to test session eviction).
             const pipeline_requests_limit =
                 @min(options.client_count, constants.clients_max) -|
                 constants.pipeline_prepare_queue_max;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -689,9 +689,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             assert(reply_message.header.command == .reply);
             assert(reply_message.header.operation == request_message.header.operation);
 
-            const client_index = for (cluster.clients, 0..) |*c, i| {
-                if (client == c) break i;
-            } else unreachable;
+            const client_index =
+                cluster.client_id_permutation.decode(client.id) - client_id_permutation_shift;
+            assert(&cluster.clients[client_index] == client);
 
             cluster.on_cluster_reply(cluster, client_index, request_message, reply_message);
         }

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -198,8 +198,10 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                     // `checksum_body` will not match; the leader's StateMachine updated the
                     // timestamps in the prepare body's accounts/transfers.
                 } else {
-                    // The cluster is running with one or more raw MessageBus "clients", so there
-                    // may be requests not found in `Cluster.clients`.
+                    // Either:
+                    // - The cluster is running with one or more raw MessageBus "clients", so there
+                    //   may be requests not found in `Cluster.clients`.
+                    // - The test includes one or more client evictions.
                 }
             }
 

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -76,13 +76,15 @@ pub fn main(
 
     var client = try Client.init(
         allocator,
-        client_id,
-        cluster_id,
-        @intCast(addresses.len),
-        &message_pool,
         .{
-            .configuration = addresses,
-            .io = &io,
+            .id = client_id,
+            .cluster = cluster_id,
+            .replica_count = @intCast(addresses.len),
+            .message_pool = &message_pool,
+            .message_bus_options = .{
+                .configuration = addresses,
+                .io = &io,
+            },
         },
     );
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -123,6 +123,10 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 replica_count: u8,
                 message_pool: *MessagePool,
                 message_bus_options: MessageBus.Options,
+                /// When eviction_callback is null, the client will panic on eviction.
+                ///
+                /// When eviction_callback is non-null, it must `deinit()` the Client.
+                /// After eviction, the client must not send or process any additional messages.
                 eviction_callback: ?*const fn (
                     client: *Self,
                     eviction: *const Message.Eviction,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -13,7 +13,7 @@ const Message = @import("../message_pool.zig").MessagePool.Message;
 const IOPS = @import("../iops.zig").IOPS;
 const FIFO = @import("../fifo.zig").FIFO;
 
-const log = std.log.scoped(.client);
+const log = stdx.log.scoped(.client);
 
 pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
     return struct {

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1261,6 +1261,7 @@ pub const Header = extern struct {
             invalid_request_operation = 4,
             invalid_request_body = 5,
             invalid_request_body_size = 6,
+            session_too_low = 7,
 
             comptime {
                 for (std.enums.values(Reason), 0..) |reason, index| {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -92,6 +92,7 @@ pub const ReplicaEvent = union(enum) {
     /// 4. Recover in the new checkpoint (but op_checkpoint wasn't called).
     checkpoint_completed,
     sync_stage_changed,
+    client_evicted: u128,
 };
 
 const Nonce = u128;
@@ -4534,6 +4535,10 @@ pub fn ReplicaType(
                     constants.clients_max,
                     evictee,
                 });
+
+                if (self.event_callback) |hook| {
+                    hook(self, .{ .client_evicted = evictee });
+                }
             }
 
             log.debug("{}: client_table_entry_create: write (client={} session={} request={})", .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5123,7 +5123,19 @@ pub fn ReplicaType(
                 } else if (entry.session > message.header.session) {
                     // The client must not reuse the ephemeral client ID when registering a new
                     // session.
+                    //
+                    // Alternatively, this could be caused by the following scenario:
+                    // 1. Client `A` sends an `operation=register` to a fresh cluster. (`A₁`)
+                    // 2. Cluster prepares + commits `A₁`, and sends the reply to `A`.
+                    // 4. `A` receives the reply to `A₁`, and issues a second request (`A₂`).
+                    // 5. `clients_max` other clients register, evicting `A`'s session.
+                    // 6. An old retry (or replay) of `A₁` arrives at the cluster.
+                    // 7. `A₁` is committed (for a second time, as a different op, evicting one of
+                    //    the other clients).
+                    // 8. `A` sends a second request (`A₂`), but `A` has the session number from the
+                    //    first time `A₁` was committed.
                     log.err("{}: on_request: ignoring older session (client bug)", .{self.replica});
+                    self.send_eviction_message_to_client(message.header.client, .session_too_low);
                     return true;
                 } else if (entry.session < message.header.session) {
                     // This cannot be because of a partition since we check the client's view

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5134,7 +5134,7 @@ pub fn ReplicaType(
                     //    the other clients).
                     // 8. `A` sends a second request (`A₂`), but `A` has the session number from the
                     //    first time `A₁` was committed.
-                    log.err("{}: on_request: ignoring older session (client bug)", .{self.replica});
+                    log.mark.err("{}: on_request: ignoring older session", .{self.replica});
                     self.send_eviction_message_to_client(message.header.client, .session_too_low);
                     return true;
                 } else if (entry.session < message.header.session) {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2137,6 +2137,20 @@ const TestClients = struct {
         for (t.clients.const_slice()) |c| replies_total += t.context.client_replies[c];
         return replies_total;
     }
+
+    pub fn eviction_reason(t: *const TestClients) ?vsr.Header.Eviction.Reason {
+        var evicted_all: ?vsr.Header.Eviction.Reason = null;
+        for (t.clients.const_slice(), 0..) |r, i| {
+            const client_eviction_reason = t.cluster.client_eviction_reasons[r];
+            if (i == 0) {
+                assert(evicted_all == null);
+            } else {
+                assert(evicted_all == client_eviction_reason);
+            }
+            evicted_all = client_eviction_reason;
+        }
+        return evicted_all;
+    }
 };
 
 /// TestClientBus supports tests which require fine-grained control of the client protocol.

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1495,8 +1495,11 @@ test "Cluster: eviction: session_too_low" {
     t.replica(.R_).replay_recorded();
     t.run();
 
+    const mark = marks.check("on_request: ignoring older session");
+
     // C0 now has a session again, but the client only knows the old (evicted) session number.
     try c0.request(2, 1);
+    try mark.expect_hit();
     try expectEqual(c0.eviction_reason(), .session_too_low);
 }
 


### PR DESCRIPTION
## Summary

Fix a bug in which a client could get stuck -- indefinitely unable to make requests, despite having a session.
(Thankfully it isn't an easy bug to hit -- triggering the bug requires more than `clients_max` clients.)

Additionally:

- Add replica tests for client eviction and the aforementioned bug.
    - Add an optional `eviction_callback` hook to `vsr.Client.Options`. When set, don't panic on eviction. (Language clients don't pass this flag -- they still panic, like before.)
- The follow-up PR will add eviction to the VOPR as well. (It involves some refactoring that isn't needed for this PR.)

## Stuck-Client Bug
### Scenario

1. Client `A` sends an `operation=register` to a fresh cluster. (request `A₁`)
2. The cluster prepares and commits `A₁`, and sends the reply to `A`.
3. (The reply doesn't arrive immediately. Client `A` keeps re-sending `A₁`.)
4. Client `A` receives the reply to `A₁`, and issues a second request. (request `A₂`)
5. `clients_max` other clients register, evicting `A`'s session.
6. An old retry (or replay) of `A₁` arrives at the cluster.
7. Request `A₁` is committed (for a second time, as a different op -- and thus a different session number -- evicting one of the other clients).
8. Client `A` is stuck. It keeps retrying its second request (`A₂`), but `A` has the session number from the first time `A₁` was committed.

(To be clear, enrolling so many clients is an operator error. But we should handle it more gracefully nonetheless!)

In this case, (prior to this PR,) the client `A` would be stuck forever (or at least until it is evicted for unrelated reasons, due to more new clients registering).

### Fix

When the cluster observes a client sending requests with an old session number, send an eviction message (`reason=session_too_low`), so that the error can be bubbled up to the operator.