### PR TITLE
VSR: `Header.Reply.peer_type=unknown`; test `peer_type`

### DIFF
--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -230,6 +230,14 @@ pub const Network = struct {
             message.header.command,
         });
 
+        const peer_type = message.header.peer_type();
+        if (peer_type != .unknown) {
+            switch (path.source) {
+                .client => |client_id| assert(std.meta.eql(peer_type, .{ .client = client_id })),
+                .replica => |index| assert(std.meta.eql(peer_type, .{ .replica = index })),
+            }
+        }
+
         const network_message = network.message_pool.get_message(null);
         defer network.message_pool.unref(network_message);
 

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -209,6 +209,7 @@ pub const Header = extern struct {
             },
             .prepare => return .unknown,
             .block => return .unknown,
+            .reply => return .unknown,
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
 
@@ -217,7 +218,6 @@ pub const Header = extern struct {
             .pong,
             .pong_client,
             .prepare_ok,
-            .reply,
             .commit,
             .start_view_change,
             .do_view_change,


### PR DESCRIPTION
Replies are tagged with the `replica` of their corresponding prepare message, which is not necessarily the same replica that transmits the reply to the client. Replicas can also send each other replies (for repair).

Follow-up for https://github.com/tigerbeetle/tigerbeetle/pull/2140.