### PR TITLE
release: add back llvm-objcopy, change version number calc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Needed for llvm-objcopy.
       - run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
+
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
 
+      # Needed for llvm-objcopy.
+      - run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
+
       - run: ./scripts/install_zig.sh
       - run: ./zig/zig build scripts -- release --build --publish --run-number=${{ github.run_number }} --sha=${{ github.sha }}
         env:

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -128,11 +128,11 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
     // Enable this once deterministic zip generation has been merged in and released.
     // const raw_run_number = stdx.cut(stdx.cut(tag, ".").?.suffix, ".").?.suffix;
 
-    // // The +185 comes from how release.zig calculates the version number.
+    // // The +186 comes from how release.zig calculates the version number.
     // const run_number = try std.fmt.allocPrint(
     //     shell.arena.allocator(),
     //     "{}",
-    //     .{try std.fmt.parseInt(u32, raw_run_number, 10) + 185},
+    //     .{try std.fmt.parseInt(u32, raw_run_number, 10) + 186},
     // );
 
     // const sha = try shell.exec_stdout("git rev-parse HEAD", .{});

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -81,7 +81,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     const release_triple = .{
         .major = 0,
         .minor = 15,
-        .patch = cli_args.run_number - 185,
+        .patch = cli_args.run_number - 186,
     };
 
     // The minimum client version allowed to connect. This has implications for backwards


### PR DESCRIPTION
Was a bit too eager with wanting to remove LLVM (heh).

Additionally, change the calculation for the version number, so the next release will still be `0.15.4`.