### PR TITLE
cli: don't allocate when parsing CLI arguments 

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -292,8 +292,9 @@ pub const AOFReplayClient = struct {
     message_pool: *MessagePool,
     inflight_message: ?*Message.Request = null,
 
-    pub fn init(allocator: std.mem.Allocator, raw_addresses: []const u8) !Self {
-        const addresses = try vsr.parse_addresses(allocator, raw_addresses, constants.replicas_max);
+    pub fn init(allocator: std.mem.Allocator, addresses: []std.net.Address) !Self {
+        assert(addresses.len > 0);
+        assert(addresses.len <= constants.replicas_max);
 
         var io = try allocator.create(IO);
         errdefer allocator.destroy(io);
@@ -752,7 +753,9 @@ pub fn main() !void {
         var it = try AOF.iterator(paths[0]);
         defer it.close();
 
-        var replay = try AOFReplayClient.init(allocator, addresses.?);
+        var addresses_buffer: [constants.replicas_max]std.net.Address = undefined;
+        const addresses_parsed = try vsr.parse_addresses(addresses.?, &addresses_buffer);
+        var replay = try AOFReplayClient.init(allocator, addresses_parsed);
         defer replay.deinit(allocator);
 
         try replay.replay(&it);

--- a/src/stdx/bounded_array.zig
+++ b/src/stdx/bounded_array.zig
@@ -49,6 +49,14 @@ pub fn BoundedArray(comptime T: type, comptime capacity: usize) type {
             return array.inner.constSlice();
         }
 
+        pub inline fn unused_capacity_slice(array: *Self) []T {
+            return array.inner.unusedCapacitySlice();
+        }
+
+        pub fn resize(array: *Self, len: usize) error{Overflow}!void {
+            try array.inner.resize(len);
+        }
+
         pub inline fn add_one_assume_capacity(array: *Self) *T {
             return array.inner.addOneAssumeCapacity();
         }

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -60,7 +60,10 @@ pub fn main(allocator: std.mem.Allocator, args: *const cli.Command.Benchmark) !v
         });
     }
 
-    const addresses = args.addresses orelse &.{tigerbeetle_process.?.address};
+    const addresses = if (args.addresses) |*addresses|
+        addresses.const_slice()
+    else
+        &.{tigerbeetle_process.?.address};
     try benchmark_load.main(allocator, addresses, args);
 
     if (tigerbeetle_process) |*p| {


### PR DESCRIPTION
No _strong_ reason to do this, but the fact that we have to deal with
allocating and defalcating twelve medium-sized integers irked me
incessantly for many years!