### PR TITLE
multiversioning/release: bring up build for non-epoch versions

### DIFF
--- a/docs/operating/upgrading.md
+++ b/docs/operating/upgrading.md
@@ -121,7 +121,3 @@ to upgrade, with two options:
   duration of the upgrade and unavailability will be extended.
 * Upgrade the replicas to the latest release that supports the client version in use, then upgrade
   the clients to that version. Repeat this until you're on the latest release.
-
-## Upgrading Windows / macOS
-Upgrading development data files on Windows / macOS is not yet supported. This will be added in the
-next release.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -105,20 +105,24 @@ pub const vsr_releases_max = config.cluster.vsr_releases_max;
 
 /// The maximum cumulative size of a final TigerBeetle output binary - including potential past
 /// releases and metadata.
-pub const multiversion_binary_platform_size_max = blk: {
+pub fn multiversion_binary_platform_size_max(options: struct { macos: bool, debug: bool }) u64 {
     // {Linux, Windows} get the base value. macOS gets 2x since it has universal binaries. All cases
     // get a further 2x in debug.
     var size_max = config.process.multiversion_binary_platform_size_max;
-    if (builtin.target.os.tag == .macos) size_max *= 2;
-    if (builtin.mode != .ReleaseSafe) size_max *= 2;
-    break :blk size_max;
-};
+    if (options.macos) size_max *= 2;
+    if (options.debug) size_max *= 2;
+
+    return size_max;
+}
 
 /// The maximum size, like above, but for any platform.
 pub const multiversion_binary_size_max =
     config.process.multiversion_binary_platform_size_max * 2 * 2;
 comptime {
-    assert(multiversion_binary_platform_size_max <= multiversion_binary_size_max);
+    assert(multiversion_binary_platform_size_max(.{
+        .macos = true,
+        .debug = true,
+    }) <= multiversion_binary_size_max);
 }
 
 pub const multiversion_poll_interval_ms = config.process.multiversion_poll_interval_ms;


### PR DESCRIPTION
The previous code could only handle one case: building the 0.15.4 release. This extends it to be more general going forward - it downloads and bundles past releases from the previous release.