### PR TITLE
Switch AOF to being a runtime option

### DIFF
--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -6,12 +6,7 @@ if [ ! -d "zig" ]; then
     ./scripts/install_zig.sh
 fi
 
-# TODO: remove -Drelease once we no longer use a lot of stack in Groove.zig
-./zig/zig build -Drelease -Dconfig-aof-record=true
-mv zig-out/bin/tigerbeetle tigerbeetle-aof
-
-./zig/zig build -Drelease -Dconfig-aof-record=true -Dconfig-aof-recovery=true
-mv zig-out/bin/tigerbeetle tigerbeetle-aof-recovery
+./zig/zig build install
 
 rm -f aof.log
 
@@ -35,14 +30,14 @@ trap onerror EXIT
 rm -f aof-test.tigerbeetle
 rm -f aof-test.tigerbeetle.aof
 
-./tigerbeetle-aof format --cluster=0 --replica=0 --replica-count=1 aof-test.tigerbeetle > aof.log 2>&1
-./tigerbeetle-aof start --cache-grid=256MiB --addresses=3001 aof-test.tigerbeetle >> aof.log 2>&1 &
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 aof-test.tigerbeetle > aof.log 2>&1
+./tigerbeetle start --cache-grid=256MiB --addresses=3001 --aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
 
 # Wait for replicas to start, listen and connect:
 sleep 1
 
-echo "Running 'zig build benchmark' to populate AOF..."
-./zig/zig build -Drelease -Dconfig=production run -- benchmark --addresses=3001 --transfer-count=400000 >> aof.log 2>&1
+echo "Running benchmark to populate AOF..."
+./tigerbeetle benchmark --addresses=3001 --transfer-count=4000 --transfer-batch-size=20 >> aof.log 2>&1
 
 echo ""
 echo "Running 'zig build aof -- debug aof-test.tigerbeetle.aof' to check AOF..."
@@ -57,13 +52,13 @@ sleep 1
 rm -rf 1 2
 
 mkdir 1 && cd 1
-../tigerbeetle-aof-recovery format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 aof-test.tigerbeetle >> aof.log 2>&1 &
+../tigerbeetle format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> aof.log 2>&1
+../tigerbeetle start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
 cd ..
 
 mkdir 2 && cd 2
-../tigerbeetle-aof-recovery format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 aof-test.tigerbeetle >> aof.log 2>&1 &
+../tigerbeetle format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> aof.log 2>&1
+../tigerbeetle start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
 cd ..
 
 # mkdir 3 && cd 3
@@ -73,7 +68,7 @@ cd ..
 
 sleep 1
 
-./zig/zig build aof -- recover 127.0.0.1:3001,127.0.0.1:3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
+./zig/zig build aof -- import 127.0.0.1:3001,127.0.0.1:3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
 
 # Give replicas time to settle.
 sleep 10

--- a/build.zig
+++ b/build.zig
@@ -76,11 +76,6 @@ pub fn build(b: *std.Build) !void {
             "config-aof-record",
             "Enable AOF Recording.",
         ) orelse false,
-        .config_aof_recovery = b.option(
-            bool,
-            "config-aof-recovery",
-            "Enable AOF Recovery mode.",
-        ) orelse false,
         .config_log_level = b.option(std.log.Level, "config-log-level", "Log level.") orelse .info,
         .config_release = b.option([]const u8, "config-release", "Release triple."),
         .config_release_client_min = b.option(
@@ -134,7 +129,6 @@ pub fn build(b: *std.Build) !void {
     vsr_options.addOption(std.log.Level, "config_log_level", build_options.config_log_level);
     vsr_options.addOption(config.TracerBackend, "tracer_backend", build_options.tracer_backend);
     vsr_options.addOption(bool, "config_aof_record", build_options.config_aof_record);
-    vsr_options.addOption(bool, "config_aof_recovery", build_options.config_aof_recovery);
     vsr_options.addOption(config.HashLogMode, "hash_log_mode", build_options.hash_log_mode);
 
     const vsr_module: *std.Build.Module = vsr: {

--- a/build.zig
+++ b/build.zig
@@ -71,11 +71,6 @@ pub fn build(b: *std.Build) !void {
     const build_options = .{
         .target = b.option([]const u8, "target", "The CPU architecture and OS to build for"),
         .config = b.option(config.ConfigBase, "config", "Base configuration.") orelse .default,
-        .config_aof_record = b.option(
-            bool,
-            "config-aof-record",
-            "Enable AOF Recording.",
-        ) orelse false,
         .config_log_level = b.option(std.log.Level, "config-log-level", "Log level.") orelse .info,
         .config_release = b.option([]const u8, "config-release", "Release triple."),
         .config_release_client_min = b.option(
@@ -128,7 +123,6 @@ pub fn build(b: *std.Build) !void {
     vsr_options.addOption(config.ConfigBase, "config_base", build_options.config);
     vsr_options.addOption(std.log.Level, "config_log_level", build_options.config_log_level);
     vsr_options.addOption(config.TracerBackend, "tracer_backend", build_options.tracer_backend);
-    vsr_options.addOption(bool, "config_aof_record", build_options.config_aof_record);
     vsr_options.addOption(config.HashLogMode, "hash_log_mode", build_options.hash_log_mode);
 
     const vsr_module: *std.Build.Module = vsr: {

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -684,8 +684,8 @@ const usage =
     \\
     \\Commands:
     \\
-    \\  recover  Recover a recorded AOF file at <path> to a TigerBeetle cluster running
-    \\           at <addresses>. Said cluster must be running with aof_recovery = true
+    \\  import   Recover a recorded AOF file at <path> to a TigerBeetle cluster running
+    \\           at <addresses>. Said cluster must have support for `import_*` operations
     \\           and have the same cluster ID as the source. The AOF must have a consistent
     \\           hash chain, which can be ensured using the `merge` subcommand.
     \\

--- a/src/config.zig
+++ b/src/config.zig
@@ -21,7 +21,6 @@ const BuildOptions = struct {
     git_commit: ?[40]u8,
     release: ?[]const u8,
     release_client_min: ?[]const u8,
-    config_aof_record: bool,
 };
 
 // Allow setting build-time config either via `build.zig` `Options`, or via a struct in the root
@@ -134,7 +133,6 @@ const ConfigProcess = struct {
     grid_repair_reads_max: usize = 8,
     grid_missing_blocks_max: usize = 30,
     grid_missing_tables_max: usize = 3,
-    aof_record: bool = false,
     grid_scrubber_reads_max: usize = 1,
     grid_scrubber_cycle_ms: usize = std.time.ms_per_day * 180,
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
@@ -339,7 +337,6 @@ pub const configs = struct {
         base.process.release = release;
         base.process.release_client_min = release_client_min;
         base.process.git_commit = build_options.git_commit;
-        base.process.aof_record = build_options.config_aof_record;
 
         assert(base.process.release.value >= base.process.release_client_min.value);
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -22,7 +22,6 @@ const BuildOptions = struct {
     release: ?[]const u8,
     release_client_min: ?[]const u8,
     config_aof_record: bool,
-    config_aof_recovery: bool,
 };
 
 // Allow setting build-time config either via `build.zig` `Options`, or via a struct in the root
@@ -140,7 +139,6 @@ const ConfigProcess = struct {
     grid_scrubber_cycle_ms: usize = std.time.ms_per_day * 180,
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
     grid_scrubber_interval_ms_max: usize = std.time.ms_per_s * 10,
-    aof_recovery: bool = false,
     multiversion_binary_platform_size_max: u64 = 64 * 1024 * 1024,
     multiversion_poll_interval_ms: u64 = 1000,
 };
@@ -342,7 +340,6 @@ pub const configs = struct {
         base.process.release_client_min = release_client_min;
         base.process.git_commit = build_options.git_commit;
         base.process.aof_record = build_options.config_aof_record;
-        base.process.aof_recovery = build_options.config_aof_recovery;
 
         assert(base.process.release.value >= base.process.release_client_min.value);
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -767,13 +767,6 @@ pub const state_machine_config = StateMachineConfig{
 /// only during unit tests of the data structure.
 pub const verify = config.process.verify;
 
-/// AOF (Append Only File) logs all transactions synchronously to disk before replying
-/// to the client. The logic behind this code has been kept as simple as possible -
-/// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple log
-/// consisting of logged requests. Much like a redis AOF with fsync=on.
-/// Enabling this will have performance implications.
-pub const aof_record = config.process.aof_record;
-
 /// The maximum number of bytes to use for compaction blocks.
 pub const compaction_block_memory_size_max = std.math.maxInt(u32) * block_size;
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -774,10 +774,6 @@ pub const verify = config.process.verify;
 /// Enabling this will have performance implications.
 pub const aof_record = config.process.aof_record;
 
-/// Place us in a special recovery state, where we accept timestamps passed in to us. Used to
-/// replay our AOF.
-pub const aof_recovery = config.process.aof_recovery;
-
 /// The maximum number of bytes to use for compaction blocks.
 pub const compaction_block_memory_size_max = std.math.maxInt(u32) * block_size;
 

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -282,7 +282,7 @@ test "help/version smoke" {
         .{ .command = "{tigerbeetle} --help", .substring = "tigerbeetle repl" },
         .{ .command = "{tigerbeetle} inspect --help", .substring = "tables --tree" },
         .{ .command = "{tigerbeetle} version", .substring = "TigerBeetle version" },
-        .{ .command = "{tigerbeetle} version --verbose", .substring = "process.aof_recovery=" },
+        .{ .command = "{tigerbeetle} version --verbose", .substring = "process.grid_scrubber_interval_ms_max=" },
     }) |check| {
         const output = try shell.exec_stdout(check.command, .{ .tigerbeetle = tigerbeetle });
         try std.testing.expect(output.len > 0);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -605,7 +605,6 @@ pub fn StateMachineType(
         }
 
         pub fn pulse_needed(self: *const StateMachine, timestamp: u64) bool {
-            assert(!global_constants.aof_recovery);
             assert(self.expire_pending_transfers.pulse_next_timestamp >=
                 TimestampRange.timestamp_min);
 
@@ -1326,7 +1325,7 @@ pub fn StateMachineType(
             _ = client;
             assert(op != 0);
             assert(self.input_valid(operation, input));
-            assert(timestamp > self.commit_timestamp or global_constants.aof_recovery);
+            assert(timestamp > self.commit_timestamp);
             assert(input.len <= self.batch_size_limit);
 
             maybe(self.scan_lookup_result_count != null);
@@ -1690,7 +1689,7 @@ pub fn StateMachineType(
         }
 
         fn create_account(self: *StateMachine, a: *const Account) CreateAccountResult {
-            assert(a.timestamp > self.commit_timestamp or global_constants.aof_recovery);
+            assert(a.timestamp > self.commit_timestamp);
 
             if (a.reserved != 0) return .reserved_field;
             if (a.flags.padding != 0) return .reserved_flag;
@@ -1733,7 +1732,7 @@ pub fn StateMachineType(
         }
 
         fn create_transfer(self: *StateMachine, t: *const Transfer) CreateTransferResult {
-            assert(t.timestamp > self.commit_timestamp or global_constants.aof_recovery);
+            assert(t.timestamp > self.commit_timestamp);
 
             if (t.flags.padding != 0) return .reserved_flag;
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -54,7 +54,7 @@ const CliArgs = union(enum) {
         // Everything below here is considered experimental, and requires `--experimental` to be
         // set. Experimental flags disable automatic upgrades with multiversion binaries; each
         // replica has to be manually restarted.
-        // Experimental flags must default to null.
+        // Experimental flags must default to null, except for bools which must be false.
         experimental: bool = false,
 
         limit_storage: ?flags.ByteSize = null,
@@ -66,6 +66,13 @@ const CliArgs = union(enum) {
         cache_account_balances: ?flags.ByteSize = null,
         memory_lsm_manifest: ?flags.ByteSize = null,
         memory_lsm_compaction: ?flags.ByteSize = null,
+
+        /// AOF (Append Only File) logs all transactions synchronously to disk before replying
+        /// to the client. The logic behind this code has been kept as simple as possible -
+        /// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple
+        /// log consisting of logged requests. Much like a redis AOF with fsync=on.
+        /// Enabling this will have performance implications.
+        aof: bool = false,
     };
 
     const Version = struct {
@@ -386,6 +393,7 @@ pub const Command = union(enum) {
         lsm_forest_node_count: u32,
         development: bool,
         experimental: bool,
+        aof: bool,
         path: [:0]const u8,
     };
 
@@ -573,9 +581,10 @@ fn parse_args_start(allocator: std.mem.Allocator, start: CliArgs.Start) Command.
 
         // If you've added a flag and get a comptime error here, it's likely because
         // we require experimental flags to default to null.
-        assert(flags.default_value(field).? == null);
+        const required_default = if (field.type == bool) false else null;
+        assert(flags.default_value(field).? == required_default);
 
-        if (@field(start, field.name) != null and !start.experimental) {
+        if (@field(start, field.name) != required_default and !start.experimental) {
             flags.fatal(
                 "{s} is marked experimental, add `--experimental` to continue.",
                 .{flag_name},
@@ -764,6 +773,7 @@ fn parse_args_start(allocator: std.mem.Allocator, start: CliArgs.Start) Command.
         .lsm_forest_node_count = lsm_forest_node_count,
         .development = start.development,
         .experimental = start.experimental,
+        .aof = start.aof,
         .path = start.positional.path,
     };
 }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -26,8 +26,7 @@ const MessagePool = vsr.message_pool.MessagePool;
 const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
 const Grid = vsr.GridType(Storage);
 
-const AOFType = if (constants.aof_record) AOF else void;
-const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time, AOFType);
+const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time, AOF);
 const SuperBlock = vsr.SuperBlockType(Storage);
 const superblock_zone_size = vsr.superblock.superblock_zone_size;
 const data_file_size_min = vsr.superblock.data_file_size_min;
@@ -261,8 +260,8 @@ const Command = struct {
         } });
         defer message_pool.deinit(allocator);
 
-        var aof: AOFType = undefined;
-        if (constants.aof_record) {
+        var aof: ?AOF = null;
+        if (args.aof) {
             const aof_path = try std.fmt.allocPrint(allocator, "{s}.aof", .{args.path});
             defer allocator.free(aof_path);
 
@@ -352,7 +351,7 @@ const Command = struct {
             .pipeline_requests_limit = args.pipeline_requests_limit,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
-            .aof = &aof,
+            .aof = if (aof != null) &aof.? else null,
             .message_pool = &message_pool,
             .nonce = nonce,
             .time = .{},
@@ -403,6 +402,10 @@ const Command = struct {
         if (constants.verify) {
             log.warn("{}: started with constants.verify - expect reduced performance. " ++
                 "Recompile with -Dconfig=production if unexpected.", .{replica.replica});
+        }
+
+        if (replica.aof != null) {
+            log.warn("{}: started with --aof - expect much reduced performance.", .{replica.replica});
         }
 
         // It is possible to start tigerbeetle passing `0` as an address:

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -313,9 +313,6 @@ const Command = struct {
         } else if (args.experimental) blk: {
             log.info("multiversioning: disabled due to --experimental.", .{});
             break :blk null;
-        } else if (constants.aof_recovery) blk: {
-            log.info("multiversioning: disabled due to aof_recovery.", .{});
-            break :blk null;
         } else try vsr.multiversioning.Multiversion.init(
             allocator,
             &command.io,
@@ -402,14 +399,6 @@ const Command = struct {
             replica.cluster,
             replica.message_bus.process.accept_address,
         });
-
-        if (constants.aof_recovery) {
-            log.warn(
-                "{}: started in AOF recovery mode. This is potentially dangerous - if it's" ++
-                    " unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.",
-                .{replica.replica},
-            );
-        }
 
         if (constants.verify) {
             log.warn("{}: started with constants.verify - expect reduced performance. " ++

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -299,10 +299,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             assert(message.header.parent == 0);
             assert(message.header.session == 0);
             assert(message.header.request == 0);
-
-            if (!constants.aof_recovery) {
-                assert(!message.header.operation.vsr_reserved());
-            }
+            assert(!message.header.operation.vsr_reserved());
 
             // TODO: Re-investigate this state for AOF as it currently traps.
             // assert(message.header.timestamp == 0 or constants.aof_recovery);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -510,7 +510,7 @@ pub const Header = extern struct {
             assert(self.command == .request);
             if (self.release.value == 0) return "release == 0";
             if (self.parent_padding != 0) return "parent_padding != 0";
-            if (self.timestamp != 0 and !constants.aof_recovery) return "timestamp != 0";
+            if (self.timestamp != 0) return "timestamp != 0";
             switch (self.operation) {
                 .reserved => return "operation == .reserved",
                 .root => return "operation == .root",

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -544,7 +544,7 @@ pub fn ReplicaType(
         tracer_slot_commit: ?tracer.SpanStart = null,
         tracer_slot_checkpoint: ?tracer.SpanStart = null,
 
-        aof: *AOF,
+        aof: ?*AOF,
 
         const OpenOptions = struct {
             node_count: u8,
@@ -554,7 +554,7 @@ pub fn ReplicaType(
             message_pool: *MessagePool,
             nonce: Nonce,
             time: Time,
-            aof: *AOF,
+            aof: ?*AOF,
             state_machine_options: StateMachine.Options,
             message_bus_options: MessageBus.Options,
             grid_cache_blocks_count: u32 = Grid.Cache.value_count_max_multiple,
@@ -958,7 +958,7 @@ pub fn ReplicaType(
             nonce: Nonce,
             time: Time,
             storage: *Storage,
-            aof: *AOF,
+            aof: ?*AOF,
             message_pool: *MessagePool,
             message_bus_options: MessageBus.Options,
             state_machine_options: StateMachine.Options,
@@ -4244,8 +4244,8 @@ pub fn ReplicaType(
             //
             // It should be impossible for a client to receive a response without the request
             // being logged by at least one replica.
-            if (AOF != void) {
-                self.aof.write(prepare, .{
+            if (self.aof) |aof| {
+                aof.write(prepare, .{
                     .replica = self.replica,
                     .primary = self.primary_index(self.view),
                 }) catch @panic("aof failure");


### PR DESCRIPTION
Depends on #1989 

Removes the AOF code from the build system, and makes it a runtime option instead. Importing an AOF is also now handled with the `import_` operations instead of a custom build time flag.

Additionally, only log certain state machine operations. These are controlled by the `aof_record` EnumArray inside the state machine. This is useful to avoid logging of read only operations.

(still WIP: doesn't yet do the imports, and hash chaining is broken with only recording certain operations.)