### PR TITLE
multiversion: fix UAF/double free

### DIFF
--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1220,7 +1220,7 @@ pub fn self_exe_path(allocator: std.mem.Allocator) ![:0]const u8 {
         const path = arg_iterator.next().?;
         assert(std.fs.path.isAbsolute(path));
 
-        return path;
+        return try allocator.dupeZ(u8, path);
     } else {
         // Not running from a memfd or temp path. `native_self_exe_path` is the real path.
         return try allocator.dupeZ(u8, native_self_exe_path);


### PR DESCRIPTION
The `path` here is "owned" by args_iterator:

* on windows, it really is owned, so, after return it points to garbage
* on nix, it actually points to static readonly memory, so we can't free it at the end