### PR TITLE
Test/VOPR: Test client eviction in the VOPR (2/2)

### DIFF
--- a/src/testing/reply_sequence.zig
+++ b/src/testing/reply_sequence.zig
@@ -2,6 +2,7 @@
 //! correct order (by ascending op number).
 const std = @import("std");
 const assert = std.debug.assert;
+const maybe = stdx.maybe;
 
 const vsr = @import("../vsr.zig");
 const stdx = @import("../stdx.zig");
@@ -16,8 +17,9 @@ const PriorityQueue = std.PriorityQueue;
 
 /// Both messages belong to the ReplySequence's `MessagePool`.
 const PendingReply = struct {
-    client_index: usize,
-    request: *Message.Request,
+    /// `client_index` is null when the prepare does not originate from a client.
+    client_index: ?usize,
+    prepare: *Message.Prepare,
     reply: *Message.Reply,
 
     /// `PendingReply`s are ordered by ascending reply op.
@@ -34,7 +36,7 @@ pub const ReplySequence = struct {
     /// The ReplySequence must reassemble them in the original order (ascending op/commit
     /// number) before handing them off to the Workload for verification.
     ///
-    /// `ReplySequence.stalled_queue` hold replies (and corresponding requests) that are
+    /// `ReplySequence.stalled_queue` hold replies (and corresponding prepares) that are
     /// waiting to be processed.
     pub const stalled_queue_capacity =
         constants.clients_max * constants.client_request_queue_max * 2;
@@ -46,7 +48,7 @@ pub const ReplySequence = struct {
     stalled_queue: PendingReplyQueue,
 
     pub fn init(allocator: std.mem.Allocator) !ReplySequence {
-        // *2 for PendingReply.request and PendingReply.reply.
+        // *2 for PendingReply.prepare and PendingReply.reply.
         var message_pool = try MessagePool.init_capacity(allocator, stalled_queue_capacity * 2);
         errdefer message_pool.deinit(allocator);
 
@@ -62,7 +64,7 @@ pub const ReplySequence = struct {
 
     pub fn deinit(sequence: *ReplySequence, allocator: std.mem.Allocator) void {
         while (sequence.stalled_queue.removeOrNull()) |pending| {
-            sequence.message_pool.unref(pending.request);
+            sequence.message_pool.unref(pending.prepare);
             sequence.message_pool.unref(pending.reply);
         }
         sequence.stalled_queue.deinit();
@@ -79,25 +81,48 @@ pub const ReplySequence = struct {
 
     pub fn insert(
         sequence: *ReplySequence,
-        client_index: usize,
-        request_message: *const Message.Request,
+        client_index: ?usize,
+        prepare_message: *const Message.Prepare,
         reply_message: *const Message.Reply,
     ) void {
-        assert(request_message.header.invalid() == null);
-        assert(request_message.header.client != 0);
-        assert(request_message.header.command == .request);
+        assert(sequence.stalled_queue.count() < stalled_queue_capacity);
 
-        assert(reply_message.header.invalid() == null);
-        assert(reply_message.header.client != 0);
-        assert(reply_message.header.request == request_message.header.request);
+        assert(prepare_message.header.invalid() == null);
+        assert(prepare_message.header.command == .prepare);
+
+        // The ReplySequence includes "replies" that don't actually get sent to a client (e.g.
+        // upgrade/pulse replies).
+        maybe(reply_message.header.invalid() == null);
+        assert((reply_message.header.client == 0) == (client_index == null));
+        assert(reply_message.header.client == prepare_message.header.client);
+        assert(reply_message.header.request == prepare_message.header.request);
         assert(reply_message.header.command == .reply);
-        assert(reply_message.header.operation == request_message.header.operation);
+        assert(reply_message.header.operation == prepare_message.header.operation);
+        assert(reply_message.header.op == prepare_message.header.op);
+
+        var pending_replies = sequence.stalled_queue.iterator();
+        while (pending_replies.next()) |pending| {
+            assert(reply_message.header.op != pending.reply.header.op);
+        }
 
         sequence.stalled_queue.add(.{
             .client_index = client_index,
-            .request = sequence.clone_message(request_message.base_const()).into(.request).?,
+            .prepare = sequence.clone_message(prepare_message.base_const()).into(.prepare).?,
             .reply = sequence.clone_message(reply_message.base_const()).into(.reply).?,
         }) catch unreachable;
+    }
+
+    pub fn contains(sequence: *ReplySequence, reply: *const Message.Reply) bool {
+        assert(reply.header.command == .reply);
+
+        var pending_replies = sequence.stalled_queue.iterator();
+        while (pending_replies.next()) |pending| {
+            if (reply.header.op == pending.reply.header.op) {
+                assert(reply.header.checksum == pending.reply.header.checksum);
+                return true;
+            }
+        }
+        return false;
     }
 
     // TODO(Zig): This type signature could be *const once std.PriorityQueue.peek() is updated.
@@ -116,13 +141,13 @@ pub const ReplySequence = struct {
     pub fn next(sequence: *ReplySequence) void {
         const commit = sequence.stalled_queue.remove();
         sequence.message_pool.unref(commit.reply);
-        sequence.message_pool.unref(commit.request);
+        sequence.message_pool.unref(commit.prepare);
     }
 
     /// Copy the message from a Client's MessagePool to the ReplySequence's MessagePool.
     ///
     /// The client has a finite amount of messages in its pool, and the ReplySequence needs to hold
-    /// onto requests/replies until all preceding requests/replies have arrived.
+    /// onto prepares/replies until all preceding prepares/replies have arrived.
     ///
     /// Returns the ReplySequence's message.
     fn clone_message(sequence: *ReplySequence, message_client: *const Message) *Message {

--- a/src/testing/reply_sequence.zig
+++ b/src/testing/reply_sequence.zig
@@ -80,8 +80,8 @@ pub const ReplySequence = struct {
     pub fn insert(
         sequence: *ReplySequence,
         client_index: usize,
-        request_message: *Message.Request,
-        reply_message: *Message.Reply,
+        request_message: *const Message.Request,
+        reply_message: *const Message.Reply,
     ) void {
         assert(request_message.header.invalid() == null);
         assert(request_message.header.client != 0);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -203,6 +203,7 @@ pub fn main() !void {
                 .cache_entries_account_balances = 256,
             },
         },
+        .on_cluster_reply = Simulator.on_cluster_reply,
     };
 
     const workload_options = StateMachine.Workload.Options.generate(random, .{
@@ -453,7 +454,7 @@ pub const Simulator = struct {
         assert(options.request_idle_off_probability > 0);
         assert(options.request_idle_off_probability <= 100);
 
-        var cluster = try Cluster.init(allocator, on_cluster_reply, options.cluster);
+        var cluster = try Cluster.init(allocator, options.cluster);
         errdefer cluster.deinit();
 
         var workload = try StateMachine.Workload.init(allocator, random, options.workload);
@@ -801,8 +802,8 @@ pub const Simulator = struct {
     fn on_cluster_reply(
         cluster: *Cluster,
         reply_client: usize,
-        request: *Message.Request,
-        reply: *Message.Reply,
+        request: *const Message.Request,
+        reply: *const Message.Reply,
     ) void {
         const simulator: *Simulator = @ptrCast(@alignCast(cluster.context.?));
         simulator.reply_sequence.insert(reply_client, request, reply);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -203,7 +203,7 @@ pub fn main() !void {
                 .cache_entries_account_balances = 256,
             },
         },
-        .on_cluster_reply = Simulator.on_cluster_reply,
+        .on_client_reply = Simulator.on_cluster_reply,
     };
 
     const workload_options = StateMachine.Workload.Options.generate(random, .{

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1571,7 +1571,7 @@ const TestContext = struct {
         var prng = std.rand.DefaultPrng.init(options.seed);
         const random = prng.random();
 
-        const cluster = try Cluster.init(allocator, TestContext.on_client_reply, .{
+        const cluster = try Cluster.init(allocator, .{
             .cluster_id = 0,
             .replica_count = options.replica_count,
             .standby_count = options.standby_count,
@@ -1609,6 +1609,7 @@ const TestContext = struct {
                 .batch_size_limit = constants.message_body_size_max,
                 .lsm_forest_node_count = 4096,
             },
+            .on_cluster_reply = TestContext.on_client_reply,
         });
         errdefer cluster.deinit();
 
@@ -1696,8 +1697,8 @@ const TestContext = struct {
     fn on_client_reply(
         cluster: *Cluster,
         client: usize,
-        request: *Message.Request,
-        reply: *Message.Reply,
+        request: *const Message.Request,
+        reply: *const Message.Reply,
     ) void {
         _ = request;
         _ = reply;

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1609,7 +1609,7 @@ const TestContext = struct {
                 .batch_size_limit = constants.message_body_size_max,
                 .lsm_forest_node_count = 4096,
             },
-            .on_cluster_reply = TestContext.on_client_reply,
+            .on_client_reply = TestContext.on_client_reply,
         });
         errdefer cluster.deinit();
 


### PR DESCRIPTION
Test client eviction in the VOPR.

This requires some shuffling of  `ReplySequence`, `Cluster`,and `Simulator`:
- We need to load replies into `ReplySequence` earlier -- when the reply is generated by the replica, rather than when the reply actually reaches the client (since the client may be evicted before a reply arrives).
- As such, `Cluster` now distinguishes between `on_cluster_reply` and `on_client_reply`.
- As `Simulator` ignores inflight requests by evicted clients for the purposes of `Simulator.done()`.

Note that with this code, the VOPR would be capable of finding the bug fixed by https://github.com/tigerbeetle/tigerbeetle/pull/2153!

Part 1: https://github.com/tigerbeetle/tigerbeetle/pull/2153
Part 1.5: https://github.com/tigerbeetle/tigerbeetle/pull/2170