### PR TITLE
vsr: rollout new sync protocol, stage 0 

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -219,6 +219,11 @@ pub const Command = enum(u8) {
     request_sync_checkpoint = 21,
     sync_checkpoint = 22,
 
+    // A reserved command for the new state sync protocol. At the moment, replica ignores this
+    // command (as opposed to panicking on an unknown command), to allow the next release to send
+    // both versions of StartView.
+    start_view2 = 23,
+
     comptime {
         for (std.enums.values(Command), 0..) |result, index| {
             assert(@intFromEnum(result) == index);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -89,6 +89,7 @@ pub const Header = extern struct {
             .start_view_change => StartViewChange,
             .do_view_change => DoViewChange,
             .start_view => StartView,
+            .start_view2 => StartView2,
             .request_start_view => RequestStartView,
             .request_headers => RequestHeaders,
             .request_prepare => RequestPrepare,
@@ -212,6 +213,8 @@ pub const Header = extern struct {
             .reply => return .unknown,
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
+
+            .start_view2 => return .unknown, // At the current version, SV2 is completely ignored.
 
             // All other messages identify the peer as a replica:
             .ping,
@@ -1042,6 +1045,32 @@ pub const Header = extern struct {
             if (self.op < self.commit) return "op < commit_min";
             if (self.commit < self.checkpoint_op) return "commit_min < checkpoint_op";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
+            return null;
+        }
+    };
+
+    pub const StartView2 = extern struct {
+        pub usingnamespace HeaderFunctions(@This());
+
+        checksum: u128,
+        checksum_padding: u128,
+        checksum_body: u128,
+        checksum_body_padding: u128,
+        nonce_reserved: u128,
+        cluster: u128,
+        size: u32,
+        epoch: u32,
+        view: u32,
+        release: vsr.Release = vsr.Release.zero,
+        protocol: u16 = vsr.Version,
+        command: Command,
+        replica: u8,
+        reserved_frame: [12]u8 = [_]u8{0} ** 12,
+
+        reserved: [128]u8 = .{0} ** 128,
+
+        fn invalid_header(self: *const @This()) ?[]const u8 {
+            assert(self.command == .start_view2);
             return null;
         }
     };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1379,6 +1379,14 @@ pub fn ReplicaType(
                 return;
             }
 
+            if (message.header.command == .start_view2) {
+                log.err("{}: on_message: ignoring (command={})", .{
+                    self.replica,
+                    message.header.command,
+                });
+                return;
+            }
+
             // No client or replica should ever send a .reserved message.
             assert(message.header.command != .reserved);
 
@@ -1407,6 +1415,7 @@ pub fn ReplicaType(
                 .start_view_change => |m| self.on_start_view_change(m),
                 .do_view_change => |m| self.on_do_view_change(m),
                 .start_view => |m| self.on_start_view(m),
+                .start_view2 => unreachable,
                 .request_start_view => |m| self.on_request_start_view(m),
                 .request_prepare => |m| self.on_request_prepare(m),
                 .request_headers => |m| self.on_request_headers(m),
@@ -7576,6 +7585,7 @@ pub fn ReplicaType(
                     assert(header.commit == self.commit_max);
                     assert(header.checkpoint_op == self.op_checkpoint());
                 },
+                .start_view2 => unreachable, // Only a future version of a replica can send this.
                 .headers => {
                     assert(!self.standby());
                     assert(message.header.view == self.view);


### PR DESCRIPTION
This is a pre-requisite for
https://github.com/tigerbeetle/tigerbeetle/pull/1951

To avoid needlessly disturbing the clients and to simplify upgrade rollout procedure, we want to avoid bumping VSR Protocol version and instead introduce a new command for the new SV.

Then, for rollout, replicas will be sending _both_ versions of SV. To make this work though, it is important that a replica on the old version ignores SV from the new version. Right now replicas are super-strict around receiving unknown message commands, and intentionally panic.

This commit implements the opt-in ignoring for new SVs.

I choose the somewhat awkward StartView2 name:

- while we perhaps can invent a new name here, I don't want to rename (or add a separate command for) `request_start_view`
- once the upgrade completes, StartView2 will get renamed back to StartView