### PR TITLE
client: print only active addresses

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -172,7 +172,7 @@ pub fn ContextType(
             log.debug("{}: init: initializing client (cluster_id={x:0>32}, addresses={any})", .{
                 context.client_id,
                 cluster_id,
-                context.addresses,
+                context.addresses.const_slice(),
             });
             context.client = try Client.init(
                 allocator,


### PR DESCRIPTION
I was playing around with the client and noticed it hit an `unreachable` while printing the parsed addresses. It seems like `BoundedArray`'s `{any}` format prints the entire inner buffer, even the uninitialized ones. 

I changed the print to use `.const_slice()` which returns the initialized addresses.