### PR TITLE
multiversioning: relax assert in exec_latest

### DIFF
--- a/docs/about/internals/upgrades.md
+++ b/docs/about/internals/upgrades.md
@@ -85,7 +85,7 @@ version is what will checkpoint to the new version, at which point the exec happ
 
 ## Executing
 The final step is executing into the new version of TigerBeetle. On Linux, this is handled by
-`execveat` which allows executing from a `memfd`. If executing the latest release, `exec_latest`
+`execveat` which allows executing from a `memfd`. If executing the latest release, `exec_current`
 re-execs the `memfd` as-is. If executing an older release, `exec_release` copies it out of the
 pack, verifies its checksum, and then executes it.
 

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1054,7 +1054,13 @@ pub const Multiversion = struct {
     }
 
     pub fn exec_latest(self: *Multiversion) !noreturn {
-        assert(self.stage == .ready);
+        // target_fd is only modified in target_update() which happens synchronously.
+        assert(self.stage != .target_update);
+
+        // Ensure that target_update() has been called at least once, and thus target_fd is
+        // populated by checking that target_header has been set.
+        assert(self.target_header != null);
+
         log.info("re-executing {s}...\n", .{self.exe_path});
         try self.exec_target_fd();
     }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -552,7 +552,7 @@ fn replica_release_execute(replica: *Replica, release: vsr.Release) noreturn {
         // For the upgrade case, re-run the latest binary in place. If we need something older
         // than the latest, that'll be handled when the case above is hit when re-execing:
         // (current version v1) -> (latest version v4) -> (desired version v2)
-        multiversion.exec_latest() catch |err| {
+        multiversion.exec_current(release) catch |err| {
             std.debug.panic("failed to execute latest release: {}", .{err});
         };
     }


### PR DESCRIPTION
Fixes an overly strict assertion in `exec_latest`. `target_fd` is double buffered, and only ever updated in `target_update`, so it's safe to call `exec_latest` as long as:
* `stage` is not `.target_update` (should never happen, as it's a sync fn),
* `target_fd` has been populated (checked through `self.target_header`).

~Marked as draft because:~
~* I haven't tested this yet,~
~* Not yet sure if we'll backport etc.~