### PR TITLE
ci: fix release validation

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           node-version: 'latest'
 
-      - run: ./zig/download.sh
+      # TODO: Leave only `./zig/download.sh` after the next release is out.
+      - run: ./zig/download.sh | ./scripts/install_zig.sh
 
       - run: ./zig/zig build scripts -- ci --validate-release
         env:


### PR DESCRIPTION
It runs on the release branch and doesn't have zig/download yet