### PR TITLE
test: smoke test for upgrades

### DIFF
--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -23,6 +23,7 @@ const release = @import("./scripts/release.zig");
 const devhub = @import("./scripts/devhub.zig");
 const kcov = @import("./scripts/kcov.zig");
 const changelog = @import("./scripts/changelog.zig");
+const upgrader = @import("./scripts/upgrader.zig");
 
 const CliArgs = union(enum) {
     cfo: cfo.CliArgs,
@@ -31,6 +32,7 @@ const CliArgs = union(enum) {
     devhub: devhub.CliArgs,
     kcov: kcov.CliArgs,
     changelog: void,
+    upgrader: upgrader.CliArgs,
 
     pub const help =
         \\Usage:
@@ -91,5 +93,6 @@ pub fn main() !void {
         .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
         .kcov => |args_kcov| try kcov.main(shell, gpa, args_kcov),
         .changelog => try changelog.main(shell, gpa),
+        .upgrader => |args_upgrader| try upgrader.main(shell, gpa, args_upgrader),
     }
 }

--- a/src/scripts/upgrader.zig
+++ b/src/scripts/upgrader.zig
@@ -1,0 +1,141 @@
+/// Smoke test for upgrade procedure:
+/// - given two multiversion tigerbeetle binaries, old and new
+/// - format three data files using old
+/// - spawn a benchmark load using old against a local cluster
+/// - spawn three replicas at old
+/// - for some time in a loop, crash, restart, or upgrade a random replica; then
+/// - crash all replicas and restart them at the new version
+/// - join the benchmark load, to make sure it exits with zero.
+const std = @import("std");
+const builtin = @import("builtin");
+const log = std.log;
+const assert = std.debug.assert;
+
+const stdx = @import("../stdx.zig");
+const flags = @import("../flags.zig");
+const fatal = flags.fatal;
+const Shell = @import("../shell.zig");
+
+pub const CliArgs = struct {
+    old: []const u8,
+    new: []const u8,
+};
+
+const replica_count = 3;
+
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+    _ = gpa;
+
+    const seed = std.crypto.random.int(u64);
+    log.info("seed = {}", .{seed});
+    var rng = std.rand.DefaultPrng.init(seed);
+    const random = rng.random();
+
+    try shell.exec("{tigerbeetle} version", .{ .tigerbeetle = cli_args.old });
+    try shell.exec("{tigerbeetle} version", .{ .tigerbeetle = cli_args.new });
+
+    shell.project_root.deleteTree(".zig-cache/upgrader") catch {};
+    try shell.project_root.makePath(".zig-cache/upgrader");
+
+    for (0..replica_count) |replica_index| {
+        try shell.exec(
+            \\{tigerbeetle} format --cluster=0 --replica={replica} --replica-count=3
+            \\    .zig-cache/upgrader/0_{replica}.tigerbeetle
+        , .{
+            .tigerbeetle = cli_args.old,
+            .replica = replica_index,
+        });
+    }
+
+    log.info("cluster at --addresses=127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003", .{});
+
+    var load = try shell.spawn(.{ .stderr_behavior = .Inherit },
+        \\{tigerbeetle} benchmark
+        \\    --print-batch-timings
+        \\    --transfer-count=2_000_000
+        \\    --addresses=127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003
+    , .{
+        .tigerbeetle = cli_args.old,
+    });
+
+    var replicas: [replica_count]?std.process.Child = .{null} ** replica_count;
+    var replicas_upgraded: [replica_count]bool = .{false} ** replica_count;
+    defer {
+        for (&replicas) |*replica_maybe| {
+            if (replica_maybe.*) |*replica| {
+                _ = replica.kill() catch {};
+            }
+        }
+    }
+
+    for (&replicas, 0..replica_count) |*replica, replica_index| {
+        replica.* = try spawn(shell, .{
+            .tigerbeetle = cli_args.old,
+            .replica = replica_index,
+        });
+    }
+
+    for (0..50) |_| {
+        std.time.sleep(2 * std.time.ns_per_s);
+        const replica_index = random.uintLessThan(u8, replica_count);
+        const crash = random.uintLessThan(u8, 4) == 0;
+        const restart = random.uintLessThan(u8, 2) == 0;
+        const upgrade = random.uintLessThan(u8, 2) == 0;
+        if (replicas[replica_index] == null) {
+            if (restart) {
+                replicas[replica_index] = try spawn(shell, .{
+                    .tigerbeetle = if (replicas_upgraded[replica_index])
+                        cli_args.new
+                    else
+                        cli_args.old,
+                    .replica = replica_index,
+                });
+            }
+        } else {
+            if (crash) {
+                _ = replicas[replica_index].?.kill() catch {};
+                replicas[replica_index] = null;
+            } else if (upgrade and !replicas_upgraded[replica_index]) {
+                replicas_upgraded[replica_index] = true;
+                _ = replicas[replica_index].?.kill() catch {};
+                replicas[replica_index] = try spawn(shell, .{
+                    .tigerbeetle = cli_args.new,
+                    .replica = replica_index,
+                });
+            }
+        }
+    }
+    for (0..replica_count) |replica_index| {
+        if (replicas[replica_index]) |*replica| {
+            _ = replica.kill() catch {};
+            replicas[replica_index] = null;
+        }
+    }
+    for (0..replica_count) |replica_index| {
+        replicas[replica_index] = try spawn(shell, .{
+            .tigerbeetle = cli_args.new,
+            .replica = replica_index,
+        });
+    }
+
+    log.info("all upgraded", .{});
+    const term = try load.wait();
+    assert(term.Exited == 0);
+    log.info("success, cluster is functional after upgrade", .{});
+}
+
+fn spawn(shell: *Shell, options: struct {
+    tigerbeetle: []const u8,
+    replica: usize,
+}) !std.process.Child {
+    return try shell.spawn(.{
+        .stderr_behavior = .Inherit,
+    },
+        \\{tigerbeetle} start
+        \\    --addresses=127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003
+        \\    .zig-cache/upgrader/0_{replica}.tigerbeetle
+    , .{
+        .tigerbeetle = options.tigerbeetle,
+        .replica = options.replica,
+    });
+}

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -423,7 +423,7 @@ const Benchmark = struct {
         const ms_time = @divTrunc(batch_end_ns - b.batch_start_ns, std.time.ns_per_ms);
 
         if (b.print_batch_timings) {
-            log.info("batch {}: {} tx in {} ms\n", .{
+            log.info("batch {}: {} tx in {} ms", .{
                 b.batch_index,
                 b.batch_transfers.items.len,
                 ms_time,


### PR DESCRIPTION
This is in no way integrated with our CI story, but, having seen the upgrade procedure with my own eyes when running manually against 0.15.3 and 0.15.4, I am so much confident now!

```
$ gh release download 0.15.3 --pattern tigerbeetle-x86_64-linux.zip
$ unzip tigerbeetle-x86_64-linux.zip && mv tigerbeetle tigerbeetle-0.15.3

$ gh release download 0.15.4 --pattern tigerbeetle-x86_64-linux.zip --clobber
$ unzip tigerbeetle-x86_64-linux.zip && mv tigerbeetle tigerbeetle-0.15.4

$ ./zig/zig build scripts -- upgrader --old=./tigerbeetle-0.15.3 --new=./tigerbeetle-0.15.4
```