### PR TITLE
VSR: Evict clients that try to change releases mid-session

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1262,6 +1262,7 @@ pub const Header = extern struct {
             invalid_request_body = 5,
             invalid_request_body_size = 6,
             session_too_low = 7,
+            session_release_mismatch = 8,
 
             comptime {
                 for (std.enums.values(Reason), 0..) |reason, index| {


### PR DESCRIPTION
Evict clients that try to change releases mid-session. (This would indicate a client bug.)