### PR TITLE
ci: fix md grep

### DIFF
--- a/.github/ci/docs_check.sh
+++ b/.github/ci/docs_check.sh
@@ -27,6 +27,6 @@ chmod +x /tmp/jq
 cat docs/.cspell.json | /tmp/jq empty
 
 # Spellcheck
-files="$(git ls-files -s | grep -v ^16 | cut -f2- | grep \.md)"
+files="$(git ls-files -s | grep -v ^16 | cut -f2- | grep \\.md)"
 npx cspell --config ./docs/.cspell.json $files
 '


### PR DESCRIPTION
A single backslash is munched by the shell, so grep matches anything ending in `md`.