### PR TITLE
build: refactor client bindings generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: ["main"]
 
+env:
+  CI: 1 # build.zig enables extra sanity checks if CI is set.
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
-const assert = std.debug.assert;
+const vsr = @import("vsr");
 
-// TODO: Move this back to src/clients/dotnet when there's a better solution for main_pkg_path=src/
-const vsr = @import("vsr.zig");
+const assert = std.debug.assert;
 const stdx = vsr.stdx;
 const tb = vsr.tigerbeetle;
 const tb_client = vsr.tb_client;
-
-const output_file = "src/clients/dotnet/TigerBeetle/Bindings.cs";
 
 const TypeMapping = struct {
     name: []const u8,
@@ -515,23 +512,5 @@ pub fn main() !void {
     var buffer = std.ArrayList(u8).init(allocator);
     try generate_bindings(&buffer);
 
-    try std.fs.cwd().writeFile(.{ .sub_path = output_file, .data = buffer.items });
-}
-
-const testing = std.testing;
-
-test "bindings dotnet" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
-    defer buffer.deinit();
-
-    try generate_bindings(&buffer);
-
-    const current = try std.fs.cwd().readFileAlloc(
-        testing.allocator,
-        output_file,
-        std.math.maxInt(usize),
-    );
-    defer testing.allocator.free(current);
-
-    try testing.expectEqualStrings(current, buffer.items);
+    try std.io.getStdOut().writeAll(buffer.items);
 }

--- a/src/clients/go/go_bindings.zig
+++ b/src/clients/go/go_bindings.zig
@@ -1,12 +1,9 @@
 const std = @import("std");
+const vsr = @import("vsr");
 
-// TODO: Move this back to src/clients/go when there's a better solution for main_pkg_path=src/
-const vsr = @import("vsr.zig");
 const stdx = vsr.stdx;
 const tb = vsr.tigerbeetle;
 const tb_client = vsr.tb_client;
-
-const output_file = "src/clients/go/pkg/types/bindings.go";
 
 const type_mappings = .{
     .{ tb.AccountFlags, "AccountFlags" },
@@ -362,23 +359,5 @@ pub fn main() !void {
 
     var buffer = std.ArrayList(u8).init(allocator);
     try generate_bindings(&buffer);
-    try std.fs.cwd().writeFile(.{ .sub_path = output_file, .data = buffer.items });
-}
-
-const testing = std.testing;
-
-test "bindings go" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
-    defer buffer.deinit();
-
-    try generate_bindings(&buffer);
-
-    const current = try std.fs.cwd().readFileAlloc(
-        testing.allocator,
-        output_file,
-        std.math.maxInt(usize),
-    );
-    defer testing.allocator.free(current);
-
-    try testing.expectEqualStrings(current, buffer.items);
+    try std.io.getStdOut().writeAll(buffer.items);
 }

--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
 
-// TODO: Move this back to src/clients/java when there's a better solution for main_pkg_path=src/
-const vsr = @import("vsr.zig");
+const vsr = @import("vsr");
 const stdx = vsr.stdx;
 const tb = vsr.tigerbeetle;
 const tb_client = vsr.tb_client;
 const assert = std.debug.assert;
-
-const output_path = "src/clients/java/src/main/java/com/tigerbeetle/";
 
 const TypeMapping = struct {
     name: []const u8,
@@ -917,45 +914,31 @@ pub fn generate_bindings(
 }
 
 pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    const allocator = arena.allocator();
+
+    var args = try std.process.argsWithAllocator(allocator);
+    defer args.deinit();
+    assert(args.skip());
+    const target_dir_path = args.next().?;
+    assert(args.next() == null);
+
+    var target_dir = try std.fs.cwd().openDir(target_dir_path, .{});
+    defer target_dir.close();
+
     // Emit Java declarations.
     inline for (type_mappings) |type_mapping| {
         const ZigType = type_mapping[0];
         const mapping = type_mapping[1];
 
-        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-        defer arena.deinit();
-        const allocator = arena.allocator();
-
         var buffer = std.ArrayList(u8).init(allocator);
         try generate_bindings(ZigType, mapping, &buffer);
 
-        try std.fs.cwd().writeFile(.{
-            .sub_path = output_path ++ mapping.name ++ ".java",
+        try target_dir.writeFile(.{
+            .sub_path = mapping.name ++ ".java",
             .data = buffer.items,
         });
-    }
-}
-
-const testing = std.testing;
-
-test "bindings java" {
-    // Test Java declarations.
-    inline for (type_mappings) |type_mapping| {
-        const ZigType = type_mapping[0];
-        const mapping = type_mapping[1];
-
-        var buffer = std.ArrayList(u8).init(testing.allocator);
-        defer buffer.deinit();
-
-        try generate_bindings(ZigType, mapping, &buffer);
-
-        const current = try std.fs.cwd().readFileAlloc(
-            testing.allocator,
-            output_path ++ mapping.name ++ ".java",
-            std.math.maxInt(usize),
-        );
-        defer testing.allocator.free(current);
-
-        try testing.expectEqualStrings(buffer.items, current);
     }
 }

--- a/src/clients/node/node_bindings.zig
+++ b/src/clients/node/node_bindings.zig
@@ -1,12 +1,9 @@
 const std = @import("std");
-const assert = std.debug.assert;
+const vsr = @import("vsr");
 
-// TODO: Move this back to src/clients/node when there's a better solution for main_pkg_path=src/
-const vsr = @import("vsr.zig");
+const assert = std.debug.assert;
 const tb = vsr.tigerbeetle;
 const tb_client = vsr.tb_client;
-
-const output_file = "src/clients/node/src/bindings.ts";
 
 const TypeMapping = struct {
     name: []const u8,
@@ -265,23 +262,5 @@ pub fn main() !void {
 
     var buffer = std.ArrayList(u8).init(allocator);
     try generate_bindings(&buffer);
-    try std.fs.cwd().writeFile(.{ .sub_path = output_file, .data = buffer.items });
-}
-
-const testing = std.testing;
-
-test "bindings node" {
-    var buffer = std.ArrayList(u8).init(testing.allocator);
-    defer buffer.deinit();
-
-    try generate_bindings(&buffer);
-
-    const current = try std.fs.cwd().readFileAlloc(
-        testing.allocator,
-        output_file,
-        std.math.maxInt(usize),
-    );
-    defer testing.allocator.free(current);
-
-    try testing.expectEqualStrings(current, buffer.items);
+    try std.io.getStdOut().writeAll(buffer.items);
 }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -17,10 +17,6 @@ comptime {
     _ = @import("clients/c/test.zig");
     _ = @import("clients/c/tb_client/echo_client.zig");
     _ = @import("clients/c/tb_client_header_test.zig");
-    _ = @import("dotnet_bindings.zig");
-    _ = @import("go_bindings.zig");
-    _ = @import("java_bindings.zig");
-    _ = @import("node_bindings.zig");
 
     _ = @import("io/test.zig");
 


### PR DESCRIPTION
Our binding generated code survived a number of code motions, and
accumulated a bunch of accidental complexity. This new implementation
aims at simplifying the things overall.

Bindings are source files in target language (.java, .go, etc), which
are generated from our tigerbeetle.zig code. We want the generated files
to change automatically when the sources change. At the same time, we
want to commit the generated files to our repository. We expect this
files to be human readable. Users our our libraries should read
generated bindings in their language, rather then the generating code in
Zig.

This is achieved by generating the bindings in build.zig, with a twist:
if a CI env variable is set, instead of overwriting the files, they are
checked for freshness.

If the generator generates a single file, it should write it to stdout.

If it generates multiple files, it should generate them to the output
directory, which is specified as the sole CLI argument.

Implementation-wise, `Generated` struct handles all the details.