### PR TITLE
build: further shrink gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 src/clients/c/lib
 dist/
-/main
 /tigerbeetle
 /tigerbeetle.exe
 *_*.tigerbeetle.*
@@ -8,11 +7,5 @@ dist/
 .zig-cache/
 zig-out/
 
-tools/tracy
-# It is occasionally useful to dump LLVM IR to an `.ll` file to investigate perf problems.
-.ll
 # By convention, logs from simulator use .vopr extension.
 *.vopr
-
-# We have a recommended vscode config under tools/vscode, which you can symlink to .vscode.
-/.vscode


### PR DESCRIPTION
- /main, .ll --- I don't think we use this at the moment
- tools/tracy --- obsolete since the last build.zig refactor
- .vscode --- _I_ use it, but, given that its the only editor ignored so far, it doesn't make sense, especially given that I know by heart how to "echo .vscode >> .git/info/exclude"