### PR TITLE
multiversioning: don't timeout_start() twice

### DIFF
--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -809,7 +809,6 @@ pub const Multiversion = struct {
     fn binary_statx_callback(self: *Multiversion, _: *IO.Completion, result: anyerror!void) void {
         _ = result catch |e| {
             self.timeout_statx_previous = .err;
-            self.timeout_start();
 
             return self.handle_error(e);
         };


### PR DESCRIPTION
If `statx` returns an error, it would set some state, call `timeout_start()` and then call `handle_error()`. Except, `handle_error()` itself calls `timeout_start()` which leads to an assertion failure.

Practically, this means that upgrading 0.15.4 by deleting the binary and replacing it was broken; overwriting in place for upgrades still works (or anything that wouldn't cause the stat to fail).