### PR TITLE
ci: remove workaround for zig/download.sh transition

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -38,8 +38,7 @@ jobs:
         with:
           node-version: 'latest'
 
-      # TODO: Leave only `./zig/download.sh` after the next release is out.
-      - run: ./zig/download.sh | ./scripts/install_zig.sh
+      - run: ./zig/download.sh
 
       - run: ./zig/zig build scripts -- ci --validate-release
         env:


### PR DESCRIPTION
It wasn't working anyway, because `|` is not `||`