### PR TITLE
build: shorten one giant function

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -178,7 +178,7 @@ fn tidy_control_characters(file: SourceFile) ?u8 {
 }
 
 /// As we trim our functions, make sure to update this constant; tidy will error if you do not.
-const function_line_count_max = 441; // build in build.zig
+const function_line_count_max = 377; // release.zig
 
 fn tidy_long_functions(
     file: SourceFile,


### PR DESCRIPTION
Our build.zig is mostly just one giant function that does everything. This is hard to read. In particular, it is somewhat hard to navigate to any particular place inside this function.

To make it easier to navigate, split it into a bunch of functions, where each funciton is responsible for a small number of steps. Pass in all the dependencies and parametres explicitly: while verbose, and labor-prone to write the frist time, it seems like this should be easier to maintain long term.