### PR TITLE
AOF: make aof record a flag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,11 +74,6 @@ pub fn build(b: *std.Build) !void {
     const build_options = .{
         .target = b.option([]const u8, "target", "The CPU architecture and OS to build for"),
         .config = b.option(config.ConfigBase, "config", "Base configuration.") orelse .default,
-        .config_aof_record = b.option(
-            bool,
-            "config-aof-record",
-            "Enable AOF Recording.",
-        ) orelse false,
         .config_aof_recovery = b.option(
             bool,
             "config-aof-recovery",
@@ -136,7 +131,6 @@ pub fn build(b: *std.Build) !void {
     vsr_options.addOption(config.ConfigBase, "config_base", build_options.config);
     vsr_options.addOption(std.log.Level, "config_log_level", build_options.config_log_level);
     vsr_options.addOption(config.TracerBackend, "tracer_backend", build_options.tracer_backend);
-    vsr_options.addOption(bool, "config_aof_record", build_options.config_aof_record);
     vsr_options.addOption(bool, "config_aof_recovery", build_options.config_aof_recovery);
     vsr_options.addOption(config.HashLogMode, "hash_log_mode", build_options.hash_log_mode);
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -21,7 +21,6 @@ const BuildOptions = struct {
     git_commit: ?[40]u8,
     release: ?[]const u8,
     release_client_min: ?[]const u8,
-    config_aof_record: bool,
     config_aof_recovery: bool,
 };
 
@@ -135,7 +134,6 @@ const ConfigProcess = struct {
     grid_repair_reads_max: usize = 4,
     grid_missing_blocks_max: usize = 30,
     grid_missing_tables_max: usize = 6,
-    aof_record: bool = false,
     grid_scrubber_reads_max: usize = 1,
     grid_scrubber_cycle_ms: usize = std.time.ms_per_day * 180,
     grid_scrubber_interval_ms_min: usize = std.time.ms_per_s / 20,
@@ -341,7 +339,6 @@ pub const configs = struct {
         base.process.release = release;
         base.process.release_client_min = release_client_min;
         base.process.git_commit = build_options.git_commit;
-        base.process.aof_record = build_options.config_aof_record;
         base.process.aof_recovery = build_options.config_aof_recovery;
 
         assert(base.process.release.value >= base.process.release_client_min.value);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -774,13 +774,6 @@ pub const state_machine_config = StateMachineConfig{
 /// only during unit tests of the data structure.
 pub const verify = config.process.verify;
 
-/// AOF (Append Only File) logs all transactions synchronously to disk before replying
-/// to the client. The logic behind this code has been kept as simple as possible -
-/// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple log
-/// consisting of logged requests. Much like a redis AOF with fsync=on.
-/// Enabling this will have performance implications.
-pub const aof_record = config.process.aof_record;
-
 /// Place us in a special recovery state, where we accept timestamps passed in to us. Used to
 /// replay our AOF.
 pub const aof_recovery = config.process.aof_recovery;

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -55,7 +55,7 @@ const CliArgs = union(enum) {
         // Everything below here is considered experimental, and requires `--experimental` to be
         // set. Experimental flags disable automatic upgrades with multiversion binaries; each
         // replica has to be manually restarted.
-        // Experimental flags must default to null.
+        // Experimental flags must default to null, except for bools which must be false.
         experimental: bool = false,
 
         limit_storage: ?flags.ByteSize = null,
@@ -67,6 +67,13 @@ const CliArgs = union(enum) {
         cache_account_balances: ?flags.ByteSize = null,
         memory_lsm_manifest: ?flags.ByteSize = null,
         memory_lsm_compaction: ?flags.ByteSize = null,
+
+        /// AOF (Append Only File) logs all transactions synchronously to disk before replying
+        /// to the client. The logic behind this code has been kept as simple as possible -
+        /// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple
+        /// log consisting of logged requests. Much like a redis AOF with fsync=on.
+        /// Enabling this will have performance implications.
+        aof: bool = false,
     };
 
     const Version = struct {
@@ -389,6 +396,7 @@ pub const Command = union(enum) {
         lsm_forest_node_count: u32,
         development: bool,
         experimental: bool,
+        aof: bool,
         path: [:0]const u8,
     };
 
@@ -565,9 +573,10 @@ fn parse_args_start(start: CliArgs.Start) Command.Start {
 
         // If you've added a flag and get a comptime error here, it's likely because
         // we require experimental flags to default to null.
-        assert(flags.default_value(field).? == null);
+        const required_default = if (field.type == bool) false else null;
+        assert(flags.default_value(field).? == required_default);
 
-        if (@field(start, field.name) != null and !start.experimental) {
+        if (@field(start, field.name) != required_default and !start.experimental) {
             flags.fatal(
                 "{s} is marked experimental, add `--experimental` to continue.",
                 .{flag_name},
@@ -756,6 +765,7 @@ fn parse_args_start(start: CliArgs.Start) Command.Start {
         .lsm_forest_node_count = lsm_forest_node_count,
         .development = start.development,
         .experimental = start.experimental,
+        .aof = start.aof,
         .path = start.positional.path,
     };
 }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -26,8 +26,7 @@ const MessagePool = vsr.message_pool.MessagePool;
 const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
 const Grid = vsr.GridType(Storage);
 
-const AOFType = if (constants.aof_record) AOF else void;
-const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time, AOFType);
+const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time, AOF);
 const SuperBlock = vsr.SuperBlockType(Storage);
 const superblock_zone_size = vsr.superblock.superblock_zone_size;
 const data_file_size_min = vsr.superblock.data_file_size_min;
@@ -260,13 +259,13 @@ const Command = struct {
         } });
         defer message_pool.deinit(allocator);
 
-        var aof: AOFType = undefined;
-        if (constants.aof_record) {
+        var aof: ?AOF = if (args.aof) blk: {
             const aof_path = try std.fmt.allocPrint(allocator, "{s}.aof", .{args.path});
             defer allocator.free(aof_path);
 
-            aof = try AOF.from_absolute_path(aof_path);
-        }
+            break :blk try AOF.from_absolute_path(aof_path);
+        } else null;
+        defer if (aof != null) aof.?.close();
 
         const grid_cache_size = @as(u64, args.cache_grid_blocks) * constants.block_size;
         const grid_cache_size_min = constants.block_size * Grid.Cache.value_count_max_multiple;
@@ -354,7 +353,7 @@ const Command = struct {
             .pipeline_requests_limit = args.pipeline_requests_limit,
             .storage_size_limit = args.storage_size_limit,
             .storage = &command.storage,
-            .aof = &aof,
+            .aof = if (aof != null) &aof.? else null,
             .message_pool = &message_pool,
             .nonce = nonce,
             .time = .{},
@@ -413,6 +412,13 @@ const Command = struct {
         if (constants.verify) {
             log.warn("{}: started with constants.verify - expect reduced performance. " ++
                 "Recompile with -Dconfig=production if unexpected.", .{replica.replica});
+        }
+
+        if (replica.aof != null) {
+            log.warn(
+                "{}: started with --aof - expect much reduced performance.",
+                .{replica.replica},
+            );
         }
 
         // It is possible to start tigerbeetle passing `0` as an address:

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -542,7 +542,7 @@ pub fn ReplicaType(
         tracer_slot_commit: ?tracer.SpanStart = null,
         tracer_slot_checkpoint: ?tracer.SpanStart = null,
 
-        aof: *AOF,
+        aof: ?*AOF,
 
         const OpenOptions = struct {
             node_count: u8,
@@ -552,7 +552,7 @@ pub fn ReplicaType(
             message_pool: *MessagePool,
             nonce: Nonce,
             time: Time,
-            aof: *AOF,
+            aof: ?*AOF,
             state_machine_options: StateMachine.Options,
             message_bus_options: MessageBus.Options,
             grid_cache_blocks_count: u32 = Grid.Cache.value_count_max_multiple,
@@ -952,7 +952,7 @@ pub fn ReplicaType(
             nonce: Nonce,
             time: Time,
             storage: *Storage,
-            aof: *AOF,
+            aof: ?*AOF,
             message_pool: *MessagePool,
             message_bus_options: MessageBus.Options,
             state_machine_options: StateMachine.Options,
@@ -4278,8 +4278,8 @@ pub fn ReplicaType(
             //
             // It should be impossible for a client to receive a response without the request
             // being logged by at least one replica.
-            if (AOF != void) {
-                self.aof.write(prepare, .{
+            if (self.aof) |aof| {
+                aof.write(prepare, .{
                     .replica = self.replica,
                     .primary = self.primary_index(self.view),
                 }) catch @panic("aof failure");


### PR DESCRIPTION
Partly supersedes #2167.

Removes the AOF record code from the build system, and makes it a runtime option instead: `--experimental --aof`.

Additionally, only replay certain state machine operations. These are controlled by `AOF.replay_message`, and are needed in the case of replaying an AOF that has a large number of lookups that otherwise significantly slow down importing.

~Proper support for expiring pending transfers is still TBC and TODO.~