### PR TITLE
vsr: syncing replicas shouldn't falsely contribute to checkpoint durability

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9097,6 +9097,14 @@ pub fn ReplicaType(
             if (self.superblock.staging.vsr_state.sync_op_max == 0) {
                 return true;
             } else {
+                // Trailers/manifest haven't yet been synced.
+                if (self.client_sessions_checkpoint.size_transferred <
+                    self.superblock.working.client_sessions_reference().trailer_size or
+                    !self.grid.free_set.opened or !self.state_machine_opened)
+                {
+                    return false;
+                }
+
                 for (0..constants.clients_max) |entry_slot| {
                     if (self.client_sessions.entries_free.isSet(entry_slot)) continue;
 


### PR DESCRIPTION
### Problem

Currently, replicas that have freshly synced to a new checkpoint but not finished syncing the tables for that checkpoint freely send prepare_ok for all new prepares that they append to their WAL (up to op_prepare_max). However, in doing so, they may  be falsely and prematurely contributing to the durability of that checkpoint, since they haven't yet finished making all the grid changes from that checkpoint durable. This could lead to liveness issues in the presence of storage faults.

For instance, consider this series of steps in a 3-replica cluster:

* R0, R1, R2 are at op_checkpoint=0
* R1 and R2 move to op_checkpoint=19
* R2 moves to op_checkpoint=39. R1 necessarily appends all prepares up to that as well, but doesn't actually commit anything (perhaps its disk is very slow) and crashes
* One block of op_checkpoint=39 gets corrupted on R2 (the single corruption)
* R0 syncs to op_checkpoint=39
* R0 together with R2 move all the way up to op_checkpoint=59. They are able to do so because the corrupted block isn't actually necessary for that strings of prepares. 
* R1 restarts, and notices that the cluster is at op_checkpoint=59 and syncs to that
* But now that corrupted block becomes permanently lost, as R1 no longer has a chance to repair it.


### Solution

To avoid falsely contributing to the durability of the current checkpoint, replicas syncing table blocks should not send prepare_oks for prepares past the current checkpoint's prepare_max. However, ops past prepare_max + pipeline_prepare_queue_max can be safely prepare_ok'd. This is because if the primary prepared these ops, prepare_max + 1 is committed and the checkpoint is durable on a commit quorum! Concretely, if a replica syncs to checkpoint Cn, it withholds prepares between ops `[Cn + trigger + pipeline, Cn + trigger + 2 * pipeline]`.

Withholding prepares between [Cn + trigger + pipeline, Cn + trigger + 2 * pipeline]) fixes the aforementioned scenario by ensuring R1 and R2 get to op_checkpoint=39 but not beyond. As a result, when R0 restarts, it *won't* state sync; instead, it would do WAL repair and just re-create the corrupted block.