### PR TITLE
Ensure u128 consistency across languages.

### DIFF
--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -85,6 +85,27 @@ const Completion = struct {
     }
 };
 
+// Consistency of U128 across Zig and the language clients.
+// It must be kept in sync with all platforms.
+test "u128 consistency test" {
+    const decimal: u128 = 214850178493633095719753766415838275046;
+    const binary = [16]u8{
+        0xe6, 0xe5, 0xe4, 0xe3, 0xe2, 0xe1,
+        0xd2, 0xd1, 0xc2, 0xc1, 0xb2, 0xb1,
+        0xa4, 0xa3, 0xa2, 0xa1,
+    };
+    const pair: extern struct { lower: u64, upper: u64 } = .{
+        .lower = 15119395263638463974,
+        .upper = 11647051514084770242,
+    };
+
+    try testing.expectEqual(decimal, @as(u128, @bitCast(binary)));
+    try testing.expectEqual(binary, @as([16]u8, @bitCast(decimal)));
+
+    try testing.expectEqual(decimal, @as(u128, @bitCast(pair)));
+    try testing.expectEqual(pair, @as(@TypeOf(pair), @bitCast(decimal)));
+}
+
 // When initialized with tb_client_init_echo, the c_client uses a test context that echoes
 // the data back without creating an actual client or connecting to a cluster.
 //

--- a/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
@@ -11,6 +11,34 @@ namespace TigerBeetle.Tests;
 [TestClass]
 public class UInt128Tests
 {
+    /// <summary>
+    /// Consistency of U128 across Zig and the language clients.
+    /// It must be kept in sync with all platforms.
+    /// </summary>
+    [TestMethod]
+    public void ConsistencyTest() {
+        // Decimal representation:
+        ulong upper = 11647051514084770242;
+        ulong lower = 15119395263638463974;
+        var u128 =  new UInt128(upper, lower);
+        Assert.AreEqual("214850178493633095719753766415838275046", u128.ToString());
+
+        // Binary representation:
+        byte[] binary = new byte[] {
+            0xe6, 0xe5, 0xe4, 0xe3, 0xe2, 0xe1,
+            0xd2, 0xd1,
+            0xc2, 0xc1,
+            0xb2, 0xb1,
+            0xa4, 0xa3, 0xa2, 0xa1,
+        };
+        Assert.IsTrue(binary.SequenceEqual(u128.ToArray()));
+
+        // GUID representation:
+        var guid = Guid.Parse("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6");
+        Assert.AreEqual(guid, u128.ToGuid());
+        Assert.AreEqual(u128, guid.ToUInt128());
+    }
+
     [TestMethod]
     public void GuidConversion()
     {

--- a/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
@@ -16,11 +16,12 @@ public class UInt128Tests
     /// It must be kept in sync with all platforms.
     /// </summary>
     [TestMethod]
-    public void ConsistencyTest() {
+    public void ConsistencyTest()
+    {
         // Decimal representation:
         ulong upper = 11647051514084770242;
         ulong lower = 15119395263638463974;
-        var u128 =  new UInt128(upper, lower);
+        var u128 = new UInt128(upper, lower);
         Assert.AreEqual("214850178493633095719753766415838275046", u128.ToString());
 
         // Binary representation:

--- a/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/UInt128Tests.cs
@@ -138,12 +138,19 @@ public class UInt128Tests
     [TestMethod]
     public void LittleEndian()
     {
-        var expected = new byte[16] { 86, 52, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        byte[] bytes_expected = new byte[16] { 86, 52, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        UInt128 decimal_expected = new UInt128(0, 0x123456);
+        BigInteger bigint_expected = BigInteger.Parse("123456", NumberStyles.HexNumber);
+        Guid guid_expected = Guid.Parse("00000000-0000-0000-0000-000000123456");
 
-        Assert.IsTrue(expected.SequenceEqual(expected.ToUInt128().ToArray()));
-        Assert.IsTrue(expected.SequenceEqual(BigInteger.Parse("123456", NumberStyles.HexNumber).ToUInt128().ToArray()));
-        Assert.IsTrue(expected.SequenceEqual(new Guid(expected).ToUInt128().ToArray()));
-        Assert.IsTrue(expected.SequenceEqual(new UInt128(0, 0x123456).ToArray()));
+        Assert.AreEqual(decimal_expected, bytes_expected.ToUInt128());
+        Assert.AreEqual(decimal_expected, bigint_expected.ToUInt128());
+        Assert.AreEqual(decimal_expected, guid_expected.ToUInt128());
+
+        Assert.IsTrue(bytes_expected.SequenceEqual(decimal_expected.ToArray()));
+        Assert.IsTrue(bytes_expected.SequenceEqual(bytes_expected.ToUInt128().ToArray()));
+        Assert.IsTrue(bytes_expected.SequenceEqual(bigint_expected.ToUInt128().ToArray()));
+        Assert.IsTrue(bytes_expected.SequenceEqual(guid_expected.ToUInt128().ToArray()));
     }
 
     [TestMethod]

--- a/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
@@ -21,7 +21,7 @@ public class UInt128Test {
         // Decimal representation:
         final long upper = Long.parseUnsignedLong("11647051514084770242");
         final long lower = Long.parseUnsignedLong("15119395263638463974");
-        final var u128 = UInt128.asBigInteger(upper, lower);
+        final var u128 = UInt128.asBigInteger(lower, upper);
         assertEquals("214850178493633095719753766415838275046", u128.toString());
 
         // Binary representation:


### PR DESCRIPTION
Ensure u128 consistency across languages.

- Fix Dotnet GUID representation that was not compatible with Java.
- Implement tests to assert that the same binary will be interpreted equally as UInt128, BigInteger, and GUID (when applicable) for all languages (except Node since it's limited to the native big integer type only).

Related: #1977