### PR TITLE
lsm: rename lsm_batch_multiple to lsm_compaction_interval

### DIFF
--- a/docs/about/internals/lsm.md
+++ b/docs/about/internals/lsm.md
@@ -8,8 +8,8 @@ Documentation for (roughly) code in the `src/lsm` directory.
 
 # Glossary
 
-- _bar_: `lsm_batch_multiple` beats; unit of incremental compaction.
-- _beat_: `op % lsm_batch_multiple`; Single step of an incremental compaction.
+- _bar_: `lsm_compaction_ops` beats; unit of incremental compaction.
+- _beat_: `op % lsm_compaction_ops`; Single step of an incremental compaction.
 - _groove_: A collection of LSM trees, storing objects and their indices.
 - _immutable table_: In-memory table; one per tree. Used to periodically flush the mutable table to
   disk.
@@ -46,9 +46,9 @@ Compacting LSM trees involves merging and moving tables into the next levels as 
 To avoid write amplification stalls and bound latency, compaction is done incrementally.
 
 A full compaction phase is denoted as a bar, using terms from music notation.
-Each bar consists of `lsm_batch_multiple` beats or "compaction ticks" of work.
+Each bar consists of `lsm_compaction_ops` beats or "compaction ticks" of work.
 A compaction tick executes asynchronously immediately after every commit, with
-`beat = commit.op % lsm_batch_multiple`.
+`beat = commit.op % lsm_compaction_ops`.
 
 A bar is split in half according to the "first" beat and "middle" beat.
 The first half of the bar compacts even levels while the latter compacts odd levels.
@@ -159,7 +159,7 @@ queries against past states of the tree (unimplemented; future work).
 
 ### Snapshots and Compaction
 
-Consider the half-bar compaction beginning at op=`X` (`12`), with `lsm_batch_multiple=M` (`8`).
+Consider the half-bar compaction beginning at op=`X` (`12`), with `lsm_compaction_ops=M` (`8`).
 Each half-bar contains `N=M/2` (`4`) beats. The next half-bar begins at `Y=X+N` (`16`).
 
 During the half-bar compaction `X`:
@@ -200,7 +200,7 @@ TODO(Persistent Snapshots): Expand this section.
 - The on-disk tables visible to a snapshot `B` do not contain the updates from the commit with op `B`.
 - Rather, snapshot `B` is first visible to a prefetch from the commit with op `B`.
 
-Consider the following diagram (`lsm_batch_multiple=8`):
+Consider the following diagram (`lsm_compaction_ops=8`):
 
 ```
 0   4   8  12  16  20  24  28  (op, snapshot)

--- a/src/config.zig
+++ b/src/config.zig
@@ -164,7 +164,7 @@ const ConfigCluster = struct {
     block_size: comptime_int = 512 * 1024,
     lsm_levels: u6 = 7,
     lsm_growth_factor: u32 = 8,
-    lsm_batch_multiple: comptime_int = 32,
+    lsm_compaction_ops: comptime_int = 32,
     lsm_snapshots_max: usize = 32,
     lsm_manifest_compact_extra_blocks: comptime_int = 1,
     lsm_table_coalescing_threshold_percent: comptime_int = 50,
@@ -288,7 +288,7 @@ pub const configs = struct {
             .message_size_max = Config.Cluster.message_size_max_min(4),
 
             .block_size = sector_size,
-            .lsm_batch_multiple = 4,
+            .lsm_compaction_ops = 4,
             .lsm_growth_factor = 4,
             // (This is higher than the production default value because the block size is smaller.)
             .lsm_manifest_compact_extra_blocks = 5,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -54,8 +54,8 @@ comptime {
 /// The checkpoint interval is chosen to be the highest possible value that satisfies the
 /// constraints described below.
 pub const vsr_checkpoint_interval = journal_slot_count -
-    lsm_batch_multiple -
-    lsm_batch_multiple * stdx.div_ceil(pipeline_prepare_queue_max * 2, lsm_batch_multiple);
+    lsm_compaction_ops -
+    lsm_compaction_ops * stdx.div_ceil(pipeline_prepare_queue_max * 2, lsm_compaction_ops);
 
 comptime {
     // Invariant: to guarantee durability, a log entry from a previous checkpoint can be overwritten
@@ -67,7 +67,7 @@ comptime {
     //
     // More specifically, the checkpoint interval must be less than the WAL length by (at least) the
     // sum of:
-    // - `lsm_batch_multiple`: Ensure that the final batch of entries immediately preceding a
+    // - `lsm_compaction_ops`: Ensure that the final batch of entries immediately preceding a
     //   checkpoint trigger is not overwritten by the following checkpoint's entries. This final
     //   batch's updates were not persisted as part of the former checkpoint – they are only in
     //   memory until they are compacted by the *next* batch of commits (i.e. the first batch of
@@ -82,11 +82,11 @@ comptime {
     //    don't overwrite entries from the previous WAL wrap. By the time we start preparing entries
     //    after the second pipeline_prepare_queue_max, a quorum of replicas is guaranteed to have
     //    already reached the former checkpoint.
-    assert(vsr_checkpoint_interval + lsm_batch_multiple + pipeline_prepare_queue_max * 2 <=
+    assert(vsr_checkpoint_interval + lsm_compaction_ops + pipeline_prepare_queue_max * 2 <=
         journal_slot_count);
     assert(vsr_checkpoint_interval >= pipeline_prepare_queue_max);
-    assert(vsr_checkpoint_interval >= lsm_batch_multiple);
-    assert(vsr_checkpoint_interval % lsm_batch_multiple == 0);
+    assert(vsr_checkpoint_interval >= lsm_compaction_ops);
+    assert(vsr_checkpoint_interval % lsm_compaction_ops == 0);
 }
 
 /// The maximum number of clients allowed per cluster, where each client has a unique 128-bit ID.
@@ -217,7 +217,7 @@ pub const journal_size_headers = journal_slot_count * @sizeOf(vsr.Header);
 pub const journal_size_prepares = journal_slot_count * message_size_max;
 
 comptime {
-    // For the given WAL (lsm_batch_multiple=4):
+    // For the given WAL (lsm_compaction_ops=4):
     //
     //   A    B    C    D    E
     //   |····|····|····|····|
@@ -231,8 +231,8 @@ comptime {
     //
     // The journal must have at least two bars to ensure at least one is checkpointed.
     assert(journal_slot_count >= Config.Cluster.journal_slot_count_min);
-    assert(journal_slot_count >= lsm_batch_multiple * 2);
-    assert(journal_slot_count % lsm_batch_multiple == 0);
+    assert(journal_slot_count >= lsm_compaction_ops * 2);
+    assert(journal_slot_count % lsm_compaction_ops == 0);
     // The journal must have at least two pipelines of messages to ensure that a new, fully-repaired
     // primary has enough headers for a complete SV message, even if the view-change just truncated
     // another pipeline of messages. (See op_repair_min()).
@@ -641,11 +641,11 @@ comptime {
 /// A multiple of batch inserts that a mutable table can definitely accommodate before flushing.
 /// For example, if a message_size_max batch can contain at most 8181 transfers then a multiple of 4
 /// means that the transfer tree's mutable table will be sized to 8190 * 4 = 32760 transfers.
-pub const lsm_batch_multiple = config.cluster.lsm_batch_multiple;
+pub const lsm_compaction_ops = config.cluster.lsm_compaction_ops;
 
 comptime {
     // The LSM tree uses half-measures to balance compaction.
-    assert(lsm_batch_multiple % 2 == 0);
+    assert(lsm_compaction_ops % 2 == 0);
 }
 
 pub const lsm_snapshots_max = config.cluster.lsm_snapshots_max;
@@ -743,13 +743,13 @@ pub const clock_synchronization_window_max_ms = config.process.clock_synchroniza
 
 pub const StateMachineConfig = struct {
     message_body_size_max: comptime_int,
-    lsm_batch_multiple: comptime_int,
+    lsm_compaction_ops: comptime_int,
     vsr_operations_reserved: u8,
 };
 
 pub const state_machine_config = StateMachineConfig{
     .message_body_size_max = message_body_size_max,
-    .lsm_batch_multiple = lsm_batch_multiple,
+    .lsm_compaction_ops = lsm_compaction_ops,
     .vsr_operations_reserved = vsr_operations_reserved,
 };
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -53,7 +53,7 @@ comptime {
 
 /// The checkpoint interval is chosen to be the highest possible value that satisfies the
 /// constraints described below.
-pub const vsr_checkpoint_interval = journal_slot_count -
+pub const vsr_checkpoint_ops = journal_slot_count -
     lsm_compaction_ops -
     lsm_compaction_ops * stdx.div_ceil(pipeline_prepare_queue_max * 2, lsm_compaction_ops);
 
@@ -82,11 +82,11 @@ comptime {
     //    overwrite entries from the previous WAL wrap. By the time we start preparing entries after
     //    the second pipeline_prepare_queue_max, a quorum of replicas is guaranteed to have already
     //    reached the former checkpoint.
-    assert(vsr_checkpoint_interval + lsm_compaction_ops + pipeline_prepare_queue_max * 2 <=
+    assert(vsr_checkpoint_ops + lsm_compaction_ops + pipeline_prepare_queue_max * 2 <=
         journal_slot_count);
-    assert(vsr_checkpoint_interval >= pipeline_prepare_queue_max);
-    assert(vsr_checkpoint_interval >= lsm_compaction_ops);
-    assert(vsr_checkpoint_interval % lsm_compaction_ops == 0);
+    assert(vsr_checkpoint_ops >= pipeline_prepare_queue_max);
+    assert(vsr_checkpoint_ops >= lsm_compaction_ops);
+    assert(vsr_checkpoint_ops % lsm_compaction_ops == 0);
 }
 
 /// The maximum number of clients allowed per cluster, where each client has a unique 128-bit ID.

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -291,15 +291,15 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
 
     const fuzz_op_distribution = fuzz.Distribution(FuzzOpTag){
         // Always do puts, and always more puts than removes.
-        .upsert = constants.lsm_batch_multiple * 2,
+        .upsert = constants.lsm_compaction_ops * 2,
         // Maybe do some removes.
-        .remove = if (random.boolean()) 0 else constants.lsm_batch_multiple,
+        .remove = if (random.boolean()) 0 else constants.lsm_compaction_ops,
         // Maybe do some gets.
-        .get = if (random.boolean()) 0 else constants.lsm_batch_multiple,
+        .get = if (random.boolean()) 0 else constants.lsm_compaction_ops,
         // Maybe do some extra compacts.
         .compact = if (random.boolean()) 0 else 2,
         // Maybe use scopes.
-        .scope = if (random.boolean()) 0 else @divExact(constants.lsm_batch_multiple, 4),
+        .scope = if (random.boolean()) 0 else @divExact(constants.lsm_compaction_ops, 4),
     };
     log.info("fuzz_op_distribution = {:.2}", .{fuzz_op_distribution});
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -63,7 +63,7 @@ pub const compaction_tables_input_max = 1 + constants.lsm_growth_factor;
 /// In the "worst" case, no keys are overwritten/merged, and no tombstones are dropped.
 pub const compaction_tables_output_max = compaction_tables_input_max;
 
-const half_bar_beat_count = @divExact(constants.lsm_batch_multiple, 2);
+const half_bar_beat_count = @divExact(constants.lsm_compaction_ops, 2);
 
 /// Information used when scheduling compactions. Kept unspecialized to make the forest
 /// code easier.
@@ -718,7 +718,7 @@ pub fn CompactionType(
             source_a_immutable_block: *Helpers.CompactionBlock,
         ) void {
             // Limited to half bars for now.
-            assert(beats_max <= @divExact(constants.lsm_batch_multiple, 2));
+            assert(beats_max <= @divExact(constants.lsm_compaction_ops, 2));
             assert(beats_max > 0);
 
             assert(compaction.bar != null);
@@ -2200,8 +2200,8 @@ pub fn snapshot_max_for_table_input(op_min: u64) u64 {
 
 pub fn snapshot_min_for_table_output(op_min: u64) u64 {
     assert(op_min > 0);
-    assert(op_min % @divExact(constants.lsm_batch_multiple, 2) == 0);
-    return op_min + @divExact(constants.lsm_batch_multiple, 2);
+    assert(op_min % @divExact(constants.lsm_compaction_ops, 2) == 0);
+    return op_min + @divExact(constants.lsm_compaction_ops, 2);
 }
 
 /// Returns the first op of the compaction (Compaction.op_min) for a given op/beat.
@@ -2216,7 +2216,7 @@ pub fn snapshot_min_for_table_output(op_min: u64) u64 {
 ///
 ///
 /// These charts depict the commit/compact ops over a series of
-/// commits and compactions (with lsm_batch_multiple=8).
+/// commits and compactions (with lsm_compaction_ops=8).
 ///
 /// Legend:
 ///

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -660,9 +660,9 @@ pub fn ManifestLogType(comptime Storage: type) type {
             // half-bar.
             // This is because otherwise it would mess with our grid reserve / forfeit ordering,
             // since we now reserve / forfeit per beat.
-            assert((op + 1) % @divExact(constants.lsm_batch_multiple, 2) == 0);
+            assert((op + 1) % @divExact(constants.lsm_compaction_ops, 2) == 0);
 
-            if (op < constants.lsm_batch_multiple or
+            if (op < constants.lsm_compaction_ops or
                 manifest_log.superblock.working.vsr_state.op_compacted(op))
             {
                 manifest_log.read_callback = callback;

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -983,8 +983,8 @@ const Environment = struct {
 
         const checkpoint =
             // Can only checkpoint on the last beat of the bar.
-            env.op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1 and
-            env.op > constants.lsm_batch_multiple;
+            env.op % constants.lsm_compaction_ops == constants.lsm_compaction_ops - 1 and
+            env.op > constants.lsm_compaction_ops;
 
         env.change_state(.fuzzing, .forest_compact);
         env.forest.compact(forest_compact_callback, env.op);
@@ -992,7 +992,7 @@ const Environment = struct {
 
         if (checkpoint) {
             assert(env.checkpoint_op == null);
-            env.checkpoint_op = env.op - constants.lsm_batch_multiple;
+            env.checkpoint_op = env.op - constants.lsm_compaction_ops;
 
             env.change_state(.fuzzing, .forest_checkpoint);
             env.forest.checkpoint(forest_checkpoint_callback);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -118,7 +118,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(config.name.len > 0);
 
             const value_count_limit =
-                options.batch_value_count_limit * constants.lsm_batch_multiple;
+                options.batch_value_count_limit * constants.lsm_compaction_ops;
             assert(value_count_limit > 0);
             assert(value_count_limit <= TreeTable.value_count_max);
 
@@ -500,7 +500,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
             tree.manifest.verify(snapshot_latest);
             assert(tree.compaction_op.? == 0 or
-                (tree.compaction_op.? + 1) % constants.lsm_batch_multiple == 0);
+                (tree.compaction_op.? + 1) % constants.lsm_compaction_ops == 0);
             maybe(tree.key_range == null);
         }
 
@@ -513,7 +513,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(snapshot_min < snapshot_latest);
 
             // TODO
-            // assert((tree.compaction_op.? + 1) % constants.lsm_batch_multiple == 0);
+            // assert((tree.compaction_op.? + 1) % constants.lsm_compaction_ops == 0);
 
             // The immutable table must be visible to the next bar.
             // In addition, the immutable table is conceptually an output table of this compaction
@@ -530,8 +530,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
         pub fn assert_between_bars(tree: *const Tree) void {
             // Assert that this is the last beat in the compaction bar.
-            // const compaction_beat = tree.compaction_op.? % constants.lsm_batch_multiple;
-            // const last_beat_in_bar = constants.lsm_batch_multiple - 1;
+            // const compaction_beat = tree.compaction_op.? % constants.lsm_compaction_ops;
+            // const last_beat_in_bar = constants.lsm_compaction_ops - 1;
             // assert(last_beat_in_bar == compaction_beat);
 
             // Assert no outstanding compactions.
@@ -601,7 +601,7 @@ test "TreeType" {
         CompositeKey.sentinel_key,
         CompositeKey.tombstone,
         CompositeKey.tombstone_from_key,
-        constants.state_machine_config.lsm_batch_multiple * 1024,
+        constants.state_machine_config.lsm_compaction_ops * 1024,
         .secondary_index,
     );
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -45,7 +45,7 @@ pub fn StateMachineType(
     comptime config: global_constants.StateMachineConfig,
 ) type {
     assert(config.message_body_size_max > 0);
-    assert(config.lsm_batch_multiple > 0);
+    assert(config.lsm_compaction_ops > 0);
     assert(config.vsr_operations_reserved > 0);
 
     return struct {
@@ -2672,7 +2672,7 @@ const TestContext = struct {
     const StateMachine = StateMachineType(Storage, .{
         // Overestimate the batch size because the test never compacts.
         .message_body_size_max = TestContext.message_body_size_max,
-        .lsm_batch_multiple = global_constants.lsm_batch_multiple,
+        .lsm_compaction_ops = global_constants.lsm_compaction_ops,
         .vsr_operations_reserved = 128,
     });
     const message_body_size_max = 64 * @max(@sizeOf(Account), @sizeOf(Transfer));
@@ -4660,7 +4660,7 @@ test "StateMachine: ref all decls" {
 
     const StateMachine = StateMachineType(Storage, .{
         .message_body_size_max = global_constants.message_body_size_max,
-        .lsm_batch_multiple = 1,
+        .lsm_compaction_ops = 1,
         .vsr_operations_reserved = 128,
     });
 

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -104,11 +104,11 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 // 1. Suppose op X is a checkpoint trigger.
                 // 2. We are committing op X-1 but are stuck due to a block that does not exist in
                 //    the cluster anymore.
-                // 3. When we sync, `commit_min` "backtracks", to `X - lsm_batch_multiple`.
+                // 3. When we sync, `commit_min` "backtracks", to `X - lsm_compaction_ops`.
                 const commit_min_source = state_checker.commit_mins[replica_index];
                 const commit_min_target =
                     replica.syncing.updating_superblock.checkpoint_state.header.op;
-                assert(commit_min_source <= commit_min_target + constants.lsm_batch_multiple);
+                assert(commit_min_source <= commit_min_target + constants.lsm_compaction_ops);
                 state_checker.commit_mins[replica_index] = commit_min_target;
                 return;
             }

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -119,7 +119,7 @@ pub const StorageChecker = struct {
         // If we are syncing, our grid will not be up to date.
         if (superblock.working.vsr_state.sync_op_max > 0) return;
 
-        const bar_beat_count = constants.lsm_batch_multiple;
+        const bar_beat_count = constants.lsm_compaction_ops;
         if ((replica.commit_min + 1) % bar_beat_count != 0) return;
 
         // The ManifestLog acquires a single address (for the "open" block) potentially multiple

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1491,12 +1491,12 @@ pub const Checkpoint = struct {
         const result = op: {
             if (checkpoint == 0) {
                 // First wrap: op_checkpoint_next = 6-1 = 5
-                // -1: vsr_checkpoint_interval is a count, result is an inclusive index.
-                break :op constants.vsr_checkpoint_interval - 1;
+                // -1: vsr_checkpoint_ops is a count, result is an inclusive index.
+                break :op constants.vsr_checkpoint_ops - 1;
             } else {
                 // Second wrap: op_checkpoint_next = 5+6 = 11
                 // Third wrap: op_checkpoint_next = 11+6 = 17
-                break :op checkpoint + constants.vsr_checkpoint_interval;
+                break :op checkpoint + constants.vsr_checkpoint_ops;
             }
         };
 
@@ -1527,7 +1527,7 @@ pub const Checkpoint = struct {
     }
 
     pub fn valid(op: u64) bool {
-        // Divide by `lsm_compaction_ops` instead of `vsr_checkpoint_interval`:
+        // Divide by `lsm_compaction_ops` instead of `vsr_checkpoint_ops`:
         // although today in practice checkpoints are evenly spaced, the LSM layer doesn't assume
         // that. LSM allows any bar boundary to become a checkpoint which happens, e.g., in the tree
         // fuzzer.
@@ -1549,14 +1549,14 @@ test "Checkpoint ops diagram" {
         \\journal_slot_count={[journal_slot_count]}
         \\lsm_compaction_ops={[lsm_compaction_ops]}
         \\pipeline_prepare_queue_max={[pipeline_prepare_queue_max]}
-        \\vsr_checkpoint_interval={[vsr_checkpoint_interval]}
+        \\vsr_checkpoint_ops={[vsr_checkpoint_ops]}
         \\
         \\
     , .{
         .journal_slot_count = constants.journal_slot_count,
         .lsm_compaction_ops = constants.lsm_compaction_ops,
         .pipeline_prepare_queue_max = constants.pipeline_prepare_queue_max,
-        .vsr_checkpoint_interval = constants.vsr_checkpoint_interval,
+        .vsr_checkpoint_ops = constants.vsr_checkpoint_ops,
     });
 
     var checkpoint_prev: u64 = 0;
@@ -1618,7 +1618,7 @@ test "Checkpoint ops diagram" {
         \\journal_slot_count=32
         \\lsm_compaction_ops=4
         \\pipeline_prepare_queue_max=4
-        \\vsr_checkpoint_interval=20
+        \\vsr_checkpoint_ops=20
         \\
         \\OPS: [__0  __1  __2  __3   __4  __5  __6  __7   __8  __9  _10  _11   _12  _13  _14  _15   _16  _17  _18 {_19   _20  _21  _22 <_23>  _24  _25  _26  _27]  _28  _29  _30  _31
         \\OPS:  _32  _33  _34  _35   _36  _37  _38 [_39   _40  _41  _42 <_43>  _44  _45  _46  _47}  _48  _49  _50  _51   _52  _53  _54  _55   _56  _57  _58 {_59   _60  _61  _62 <_63>

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1563,8 +1563,8 @@ test "Checkpoint ops diagram" {
     var checkpoint_next: u64 = 0;
     var checkpoint_count: u32 = 0;
     for (0..constants.journal_slot_count * 10) |op| {
-        const last_beat = op % constants.lsm_batch_multiple == constants.lsm_batch_multiple - 1;
-        const last_slot = (op % constants.journal_slot_count) + 1 == constants.journal_slot_count;
+        const last_beat = (op + 1) % constants.lsm_batch_multiple == 0;
+        const last_slot = (op + 1) % constants.journal_slot_count == 0;
 
         const op_type: enum {
             normal,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1707,7 +1707,7 @@ pub fn ReplicaType(
             // for why op=prepare_max+1 being committed implies that.
             const op_overwritten = (self.op + 1) -| constants.journal_slot_count;
             const op_checkpoint_previous = self.op_checkpoint() -|
-                constants.vsr_checkpoint_interval;
+                constants.vsr_checkpoint_ops;
             if (op_overwritten > op_checkpoint_previous) {
                 assert(self.commit_max >
                     vsr.Checkpoint.prepare_max_for_checkpoint(self.op_checkpoint()).?);
@@ -2190,7 +2190,7 @@ pub fn ReplicaType(
             assert(message.header.replica == self.primary_index(message.header.view));
             assert(message.header.commit >= message.header.checkpoint_op);
             assert(message.header.commit - message.header.checkpoint_op <=
-                constants.vsr_checkpoint_interval + constants.lsm_compaction_ops);
+                constants.vsr_checkpoint_ops + constants.lsm_compaction_ops);
             assert(message.header.op >= message.header.commit);
             assert(message.header.op - message.header.commit <=
                 constants.pipeline_prepare_queue_max);
@@ -2241,7 +2241,7 @@ pub fn ReplicaType(
             //  Cluster is at least two checkpoints ahead. Although SV's checkpoint is not
             //  guaranteed to be durable on a quorum of replicas, it is safe to sync to it, because
             //  prepares in this replica's WAL are no longer needed.
-                message.header.commit > self.op_prepare_max() + constants.vsr_checkpoint_interval or
+                message.header.commit > self.op_prepare_max() + constants.vsr_checkpoint_ops or
                 // Cluster is on the next checkpoint, and that checkpoint is durable and is safe to
                 // sync to. Try to optimistically avoid state sync and prefer WAL repair, unless
                 // there's evidence that the repair can't be completed.
@@ -4751,8 +4751,8 @@ pub fn ReplicaType(
             // The SV includes headers corresponding to the op_prepare_max for preceding
             // checkpoints (as many as we have and can help repair, which is at most 2).
             for ([_]u64{
-                self.op_prepare_max() -| constants.vsr_checkpoint_interval,
-                self.op_prepare_max() -| constants.vsr_checkpoint_interval * 2,
+                self.op_prepare_max() -| constants.vsr_checkpoint_ops,
+                self.op_prepare_max() -| constants.vsr_checkpoint_ops * 2,
             }) |op_hook| {
                 if (op > op_hook and op_hook >= op_min) {
                     op = op_hook;
@@ -5952,7 +5952,7 @@ pub fn ReplicaType(
             const checkpoint_next_1 = vsr.Checkpoint.checkpoint_after(checkpoint_now);
             const checkpoint_next_2 = vsr.Checkpoint.checkpoint_after(checkpoint_next_1);
 
-            if (op + constants.vsr_checkpoint_interval <= checkpoint_now) {
+            if (op + constants.vsr_checkpoint_ops <= checkpoint_now) {
                 // Case 1: op is from a too distant past for us to know its checkpoint id.
                 return null;
             }
@@ -6015,7 +6015,7 @@ pub fn ReplicaType(
                     break :repair_min self.op_checkpoint() + 1;
                 } else {
                     break :repair_min (self.op_checkpoint() + 1) -|
-                        constants.vsr_checkpoint_interval;
+                        constants.vsr_checkpoint_ops;
                 }
             };
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -690,7 +690,7 @@ test "Cluster: repair: primary checkpoint, backup crash before checkpoint, prima
     // 6. A0 prepares a message.
     // 7. B1 restarts. The very first entry in its WAL is corrupt.
     // A0 has *not* already overwritten the corresponding entry in its own WAL, thanks to the
-    // pipeline component of the vsr_checkpoint_interval.
+    // pipeline component of the vsr_checkpoint_ops.
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
 
@@ -989,7 +989,7 @@ test "Cluster: repair: R=2 (primary checkpoints, but backup lags behind)" {
     try expectEqual(b1.op_checkpoint(), 0);
 
     // On B1, corrupt the same slot that A0 is about to overwrite with a new prepare.
-    // (B1 doesn't have any prepare in this slot, thanks to the vsr_checkpoint_interval.)
+    // (B1 doesn't have any prepare in this slot, thanks to the vsr_checkpoint_ops.)
     b1.stop();
     b1.pass(.R_, .incoming, .commit);
     b1.corrupt(.{ .wal_prepare = (checkpoint_1_trigger + 2) % slot_count });
@@ -1282,7 +1282,7 @@ test "Cluster: upgrade: state-sync to new release" {
     try t.replica(.R1).open_upgrade(&[_]u8{ 10, 20 });
     t.run();
     try expectEqual(t.replica(.R0).commit(), checkpoint_1_trigger);
-    try c.request(constants.vsr_checkpoint_interval, constants.vsr_checkpoint_interval);
+    try c.request(constants.vsr_checkpoint_ops, constants.vsr_checkpoint_ops);
     try expectEqual(t.replica(.R0).commit(), checkpoint_2_trigger);
 
     // R2 state-syncs from R0/R1, updating its release from v1 to v2 via CheckpointState...

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -53,7 +53,7 @@ const releases = .{
 comptime {
     // The tests are written for these configuration values in particular.
     assert(constants.journal_slot_count == 32);
-    assert(constants.lsm_batch_multiple == 4);
+    assert(constants.lsm_compaction_ops == 4);
 }
 
 test "Cluster: recovery: WAL prepare corruption (R=3, corrupt right of head)" {
@@ -118,7 +118,7 @@ test "Cluster: recovery: WAL prepare corruption (R=3, corrupt checkpoint…head)
     t.replica(.R0).stop();
 
     // Corrupt op_checkpoint (27) and all ops that follow.
-    var slot: usize = slot_count - constants.lsm_batch_multiple - 1;
+    var slot: usize = slot_count - constants.lsm_compaction_ops - 1;
     while (slot < slot_count) : (slot += 1) {
         t.replica(.R0).corrupt(.{ .wal_prepare = slot });
     }
@@ -1218,13 +1218,13 @@ test "Cluster: upgrade: operation=upgrade near trigger-minus-bar" {
         .{
             // The entire last bar before the operation is free for operation=upgrade's, so when we
             // hit the checkpoint trigger we can immediately upgrade the cluster.
-            .request = checkpoint_1_trigger - constants.lsm_batch_multiple,
+            .request = checkpoint_1_trigger - constants.lsm_compaction_ops,
             .checkpoint = checkpoint_1,
         },
         .{
             // Since there is a non-upgrade request in the last bar, the replica cannot upgrade
             // during checkpoint_1 and must pad ahead to the next checkpoint.
-            .request = checkpoint_1_trigger - constants.lsm_batch_multiple + 1,
+            .request = checkpoint_1_trigger - constants.lsm_compaction_ops + 1,
             .checkpoint = checkpoint_2,
         },
     }) |data| {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -364,7 +364,7 @@ pub const SuperBlockHeader = extern struct {
         /// All prepares between `CheckpointState.commit_min` (i.e. `op_checkpoint`) and
         /// `trigger_for_checkpoint(checkpoint_after(commit_min))` must be executed by this release.
         /// (Prepares with `operation=upgrade` are the exception – upgrades in the last
-        /// `lsm_batch_multiple` before a checkpoint trigger may be replayed by a different release.
+        /// `lsm_compaction_ops` before a checkpoint trigger may be replayed by a different release.
         release: vsr.Release,
 
         reserved: [472]u8 = [_]u8{0} ** 472,


### PR DESCRIPTION
The first commit is a `sed` across the whole repository, the second one is me manually looking at the diff of the first commit and adjusting if necessary. I also grepped for `multiple`, which turned out two comments in constants.zig, also adjusted. 