### PR TITLE
client: move batching from StateMachine to VSR

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -255,9 +255,10 @@ typedef struct tb_packet_t {
     void* data;
     struct tb_packet_t* batch_next;
     struct tb_packet_t* batch_tail;
-    uint32_t batch_size;
-    uint8_t batch_allowed;
-    uint8_t reserved[7];
+    uint16_t batch_count_packets;
+    uint16_t batch_count_events;
+    uint16_t batch_count_results;
+    uint8_t reserved[6];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -518,6 +518,7 @@ pub fn ContextType(
                     ).init(reply);
 
                     var it: ?*Packet = packet;
+                    var event_count: usize = packet.batch_count_events;
                     while (it) |batched| {
                         assert(batched.batch_next == null or batched.batch_allowed);
                         it = batched.batch_next;
@@ -525,6 +526,9 @@ pub fn ContextType(
                         const results = reader.next() orelse {
                             @panic("client received invalid batched response");
                         };
+
+                        assert(event_count >= results.len);
+                        event_count -= results.len;
 
                         self.on_complete(batched, std.mem.sliceAsBytes(results));
                     }

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -252,7 +252,7 @@ pub fn ContextType(
         pub fn run(self: *Context) void {
             self.batch_size_limit = null;
             self.client.register(client_register_callback, @intFromPtr(self));
-            
+
             while (!self.shutdown.load(.acquire)) {
                 self.tick();
                 self.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms) catch |err| {
@@ -387,7 +387,7 @@ pub fn ContextType(
                 root.batch_count_packets += 1;
                 root.batch_count_events += event_count;
                 root.batch_count_results += packet.batch_count_results;
-                
+
                 root.batch_tail.?.batch_next = packet;
                 root.batch_tail = packet;
                 return;
@@ -475,7 +475,7 @@ pub fn ContextType(
                     message.header.size += writer.wrote;
                 },
             }
-            
+
             self.client.raw_request(
                 Context.on_result,
                 @bitCast(UserData{

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -354,10 +354,7 @@ pub fn ContextType(
                 .pulse => unreachable,
                 inline else => |operation_comptime| StateMachine.operation_result_max(
                     operation_comptime,
-                    @alignCast(std.mem.bytesAsSlice(
-                        StateMachine.Event(operation_comptime),
-                        events,
-                    )),
+                    events,
                 ),
             });
 
@@ -465,10 +462,7 @@ pub fn ContextType(
                     var it: ?*Packet = packet;
                     while (it) |batched| {
                         it = batched.batch_next;
-                        writer.write(@alignCast(std.mem.bytesAsSlice(
-                            StateMachine.Event(operation_comptime),
-                            @as([*]u8, @ptrCast(batched.data.?))[0..batched.data_size],
-                        )));
+                        writer.write(@as([*]u8, @ptrCast(batched.data.?))[0..batched.data_size]);
                     }
 
                     assert(writer.wrote <= constants.message_body_size_max);

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -192,4 +192,3 @@ pub fn EchoClientType(comptime StateMachine_: type, comptime MessageBus: type) t
         }
     };
 }
-

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -20,34 +20,6 @@ pub fn EchoClientType(comptime StateMachine_: type, comptime MessageBus: type) t
         pub const StateMachine = VSRClient.StateMachine;
         pub const Request = VSRClient.Request;
 
-        /// Custom Demuxer which treats EventType(operation)s as results and echoes them back.
-        pub fn DemuxerType(comptime operation: StateMachine.Operation) type {
-            return struct {
-                const Demuxer = @This();
-
-                results: []u8,
-                events_decoded: u32 = 0,
-
-                pub fn init(reply: []u8) Demuxer {
-                    return Demuxer{ .results = reply };
-                }
-
-                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []u8 {
-                    // Double check the event offset/count are contiguously decoded from results.
-                    assert(self.events_decoded == event_offset);
-                    self.events_decoded += event_count;
-
-                    // Double check the results has enough event bytes to echo back.
-                    const byte_count = @sizeOf(StateMachine.EventType(operation)) * event_count;
-                    assert(self.results.len >= byte_count);
-
-                    // Echo back the result bytes and consume the events.
-                    defer self.results = self.results[byte_count..];
-                    return self.results[0..byte_count];
-                }
-            };
-        }
-
         id: u128,
         cluster: u128,
         release: vsr.Release = vsr.Release.minimum,
@@ -221,39 +193,3 @@ pub fn EchoClientType(comptime StateMachine_: type, comptime MessageBus: type) t
     };
 }
 
-test "Echo Demuxer" {
-    const StateMachine = vsr.state_machine.StateMachineType(
-        @import("../../../testing/storage.zig").Storage,
-        constants.state_machine_config,
-    );
-    const MessageBus = vsr.message_bus.MessageBusClient;
-    const Client = EchoClientType(StateMachine, MessageBus);
-
-    var prng = std.rand.DefaultPrng.init(42);
-    inline for ([_]StateMachine.Operation{
-        .create_accounts,
-        .create_transfers,
-    }) |operation| {
-        const Event = StateMachine.EventType(operation);
-        var events: [@divExact(constants.message_body_size_max, @sizeOf(Event))]Event = undefined;
-        prng.fill(std.mem.asBytes(&events));
-
-        for (0..events.len) |i| {
-            const events_total = i + 1;
-            const events_data = std.mem.sliceAsBytes(events[0..events_total]);
-            var demuxer = Client.DemuxerType(operation).init(events_data);
-
-            var events_offset: usize = 0;
-            while (events_offset < events_total) {
-                const events_limit = events_total - events_offset;
-                const events_count = @max(1, prng.random().uintAtMost(usize, events_limit));
-                defer events_offset += events_count;
-
-                const reply_bytes = demuxer.decode(@intCast(events_offset), @intCast(events_count));
-                const reply: []Event = @alignCast(std.mem.bytesAsSlice(Event, reply_bytes));
-                try testing.expectEqual(&reply[0], &events[events_offset]);
-                try testing.expectEqual(reply.len, events[events_offset..][0..events_count].len);
-            }
-        }
-    }
-}

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -11,9 +11,10 @@ pub const Packet = extern struct {
     data: ?*anyopaque,
     batch_next: ?*Packet,
     batch_tail: ?*Packet,
-    batch_size: u32,
-    batch_allowed: bool,
-    reserved: [7]u8 = [_]u8{0} ** 7,
+    batch_count_packets: u16,
+    batch_count_events: u16,
+    batch_count_results: u16,
+    reserved: [6]u8 = [_]u8{0} ** 6,
 
     comptime {
         assert(@sizeOf(Packet) == 64);

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -255,9 +255,10 @@ typedef struct tb_packet_t {
     void* data;
     struct tb_packet_t* batch_next;
     struct tb_packet_t* batch_tail;
-    uint32_t batch_size;
-    uint8_t batch_allowed;
-    uint8_t reserved[7];
+    uint16_t batch_count_packets;
+    uint16_t batch_count_events;
+    uint16_t batch_count_results;
+    uint8_t reserved[6];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -238,12 +238,11 @@ fn request(
         .data = packet_data.ptr,
         .batch_next = undefined,
         .batch_tail = undefined,
-        .batch_size = undefined,
-        .batch_allowed = undefined,
+        .batch_count_packets = undefined,
+        .batch_count_events = undefined,
+        .batch_count_results = undefined,
         .reserved = undefined,
     };
-
-    tb_client.submit(client, packet);
 }
 
 // Packet only has one size field which normally tracks `BufferType(op).events().len`.

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -88,7 +88,7 @@ pub const IO = struct {
                 timeout_ms = if (expires == os.windows.INFINITE) expires - 1 else expires;
             }
 
-            // Poll for IO iff there's IO pending and flush_timeouts() found no ready completions
+            // Poll for IO iff there's IO pending and flush_timeouts() found no ready completions.
             if (self.io_pending > 0 and self.completed.empty()) {
                 // In blocking mode, we're always waiting at least until the timeout by run_for_ns.
                 // In non-blocking mode, we shouldn't wait at all.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -3240,6 +3240,7 @@ const TestContext = struct {
         context.busy = true;
         context.state_machine.prefetch_timestamp = timestamp;
         context.state_machine.prefetch(
+            vsr.Release.minimum,
             TestContext.callback,
             context.client_release,
             op,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -2876,10 +2876,8 @@ pub fn StateMachineType(
             );
         }
 
-        pub fn operation_result_max(
-            comptime operation: Operation,
-            events: []const Event(operation),
-        ) u32 {
+        pub fn operation_result_max(comptime operation: Operation, event_bytes: []const u8) u32 {
+            const events = std.mem.bytesAsSlice(Event(operation), event_bytes);
             switch (operation) {
                 .pulse => {
                     return 0; // pulse has no results;

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -3240,7 +3240,6 @@ const TestContext = struct {
         context.busy = true;
         context.state_machine.prefetch_timestamp = timestamp;
         context.state_machine.prefetch(
-            vsr.Release.minimum,
             TestContext.callback,
             context.client_release,
             op,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -2877,7 +2877,7 @@ pub fn StateMachineType(
         }
 
         pub fn operation_result_max(
-            comptime operation: Operation, 
+            comptime operation: Operation,
             events: []const Event(operation),
         ) u32 {
             switch (operation) {

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -185,6 +185,7 @@ pub fn StateMachineType(
 
         pub fn prefetch(
             state_machine: *StateMachine,
+            client_release: vsr.Release,
             callback: *const fn (*StateMachine) void,
             client_release: vsr.Release,
             op: u64,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -185,7 +185,6 @@ pub fn StateMachineType(
 
         pub fn prefetch(
             state_machine: *StateMachine,
-            client_release: vsr.Release,
             callback: *const fn (*StateMachine) void,
             client_release: vsr.Release,
             op: u64,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -45,32 +45,6 @@ pub fn StateMachineType(
             return u8; // Must be non-zero-sized for sliceAsBytes().
         }
 
-        /// Empty demuxer to be compatible with vsr.Client batching.
-        pub fn DemuxerType(comptime operation: Operation) type {
-            return struct {
-                const Demuxer = @This();
-
-                reply: []ResultType(operation),
-                offset: u32 = 0,
-
-                pub fn init(reply: []u8) Demuxer {
-                    return .{
-                        .reply = @alignCast(std.mem.bytesAsSlice(
-                            ResultType(operation),
-                            reply,
-                        )),
-                    };
-                }
-
-                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []u8 {
-                    assert(self.offset == event_offset);
-                    assert(event_offset + event_count <= self.reply.len);
-                    defer self.offset += event_count;
-                    return std.mem.sliceAsBytes(self.reply[self.offset..][0..event_count]);
-                }
-            };
-        }
-
         pub const Options = struct {
             batch_size_limit: u32,
             lsm_forest_node_count: u32,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -223,7 +223,7 @@ pub fn StateMachineType(
             timestamp: u64,
             operation: Operation,
             input: []align(16) const u8,
-            output: *align(16) [constants.message_body_size_max]u8,
+            output: []align(16) u8,
         ) usize {
             assert(op != 0);
 

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -121,9 +121,6 @@ pub const Event = union(enum) {
     grid_read: struct { iop: usize },
     grid_write: struct { iop: usize },
 
-    grid_read: struct { iop: usize },
-    grid_write: struct { iop: usize },
-
     pub fn format(
         event: *const Event,
         comptime fmt: []const u8,

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -121,6 +121,9 @@ pub const Event = union(enum) {
     grid_read: struct { iop: usize },
     grid_write: struct { iop: usize },
 
+    grid_read: struct { iop: usize },
+    grid_write: struct { iop: usize },
+
     pub fn format(
         event: *const Event,
         comptime fmt: []const u8,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1751,11 +1751,13 @@ pub const RequestBatch = extern struct {
                 assert(self.wrote <= self.body.len);
             }
 
-            pub fn write(self: *Self, values: []const T) void {
+            pub fn write(self: *Self, value_bytes: []const u8) void {
                 if (@sizeOf(T) == 0) {
-                    assert(values.len == 0);
+                    assert(value_bytes.len == 0);
                     return;
                 }
+
+                const values = std.mem.bytesAsSlice(T, value_bytes);
 
                 const value_buffer = self.writable();
                 assert(value_buffer.len >= values.len);
@@ -1763,7 +1765,7 @@ pub const RequestBatch = extern struct {
                 const value_count: u16 = @intCast(values.len);
                 assert(self.wrote + value_count * @sizeOf(T) <= self.body.len);
 
-                stdx.copy_disjoint(.inexact, T, self.writable(), values);
+                stdx.copy_disjoint(.inexact, u8, std.mem.asBytes(value_buffer), value_bytes);
                 self.advance(value_count);
             }
         };

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -20,7 +20,6 @@ pub fn ClientType(comptime StateMachine_: type, comptime MessageBus: type) type 
         const Client = @This();
 
         pub const StateMachine = StateMachine_;
-        pub const DemuxerType = StateMachine.DemuxerType;
         pub const Request = struct {
             pub const Callback = *const fn (
                 user_data: u128,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4137,7 +4137,6 @@ pub fn ReplicaType(
                 self.op_checkpoint(),
                 self.op_checkpoint_next(),
             });
-
             if (self.event_callback) |hook| hook(self, .checkpoint_commenced);
 
             // TODO(Compaction pacing) Move this to before the if guard once there is no IO


### PR DESCRIPTION
Currently, batching of requests with similar operations into the same message only occurs for `create_accounts`/`create_transers`. This is partially due to their returned results containing an `index` field which can be fixed up (through a StateMachine-specific type called `Demuxer`) and used to link each result to its corresponding request. Therefor other operations like `lookup_*` and queries aren't batched.

The goal here is to move the batching logic outside StateMachine and into the messaging/protocol layer so that it works with any operation. This initial version adds a 256-byte header at the start of message body which contains `[128]u16`. The first value contains the number of requests in the message (N). The next N contain the number of items in the message belonging to each request. For example, requests having 2, 7, and 4 items would have a batch header of `[N=3, 2, 7, 4, 0....]`.

A format which keeps the items together in the message body is needed for alignment + processing purposes; All batched items are prefetched by the StateMachine together, but they're committed separately so the response message body can fill in the appropriate item counts.

TODO: support a variable amount of headers. For request item counts of 1 (i.e. `[N, 1, 1, 1...]`) a message is limited to 128 as opposed to the higher `8191` or `batch_limit` as reported by vsr.register.