### PR TITLE
Devhub: Pass higher s/max_output_bytes/output_bytes_max

### DIFF
--- a/src/shell.zig
+++ b/src/shell.zig
@@ -445,7 +445,7 @@ pub fn exec_stdout_options(
     shell: *Shell,
     options: struct {
         stdin_slice: ?[]const u8 = null,
-        output_bytes_max: usize = 1024 * 1024,
+        output_bytes_max: usize = 1024 * 1024 * 32,
     },
     comptime cmd: []const u8,
     cmd_args: anytype,

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -445,7 +445,7 @@ pub fn exec_stdout_options(
     shell: *Shell,
     options: struct {
         stdin_slice: ?[]const u8 = null,
-        max_output_bytes: usize = 1024 * 1024,
+        output_bytes_max: usize = 1024 * 1024,
     },
     comptime cmd: []const u8,
     cmd_args: anytype,
@@ -490,7 +490,7 @@ pub fn exec_stdout_options(
         child.stdin = null;
     }
 
-    try child.collectOutput(&stdout, &stderr, options.max_output_bytes);
+    try child.collectOutput(&stdout, &stderr, options.output_bytes_max);
     const term = try child.wait();
     errdefer {
         log.err("command failed", .{});

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -423,12 +423,12 @@ test "tidy no large blobs" {
 
     const MiB = 1024 * 1024;
     const rev_list = try shell.exec_stdout_options(
-        .{ .max_output_bytes = 50 * MiB },
+        .{ .output_bytes_max = 50 * MiB },
         "git rev-list --objects HEAD",
         .{},
     );
     const objects = try shell.exec_stdout_options(
-        .{ .max_output_bytes = 50 * MiB, .stdin_slice = rev_list },
+        .{ .output_bytes_max = 50 * MiB, .stdin_slice = rev_list },
         "git cat-file --batch-check={format}",
         .{ .format = "%(objecttype) %(objectsize) %(rest)" },
     );


### PR DESCRIPTION
See: https://github.com/tigerbeetle/tigerbeetle/actions/runs/10499672062/job/29086857746 (devhub build error on main)

```
(snip...)
$ unzip dist/tigerbeetle/tigerbeetle-x86_64-linux.zip
Archive:  dist/tigerbeetle/tigerbeetle-x86_64-linux.zip
  inflating: tigerbeetle
error: StderrStreamTooLong
/home/runner/work/tigerbeetle/tigerbeetle/zig/lib/std/process/Child.zig:357:13: 0x10e91ac in collectOutput (scripts)
            return error.StderrStreamTooLong;
            ^
/home/runner/work/tigerbeetle/tigerbeetle/src/shell.zig:493:5: 0x1222be9 in exec_stdout_options__anon_10962 (scripts)
    try child.collectOutput(&stdout, &stderr, options.max_output_bytes);
    ^
/home/runner/work/tigerbeetle/tigerbeetle/src/shell.zig:441:5: 0x1223617 in exec_stdout__anon_10961 (scripts)
    return shell.exec_stdout_options(.{}, cmd, cmd_args);
    ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts/devhub.zig:46:30: 0x122b2bd in main (scripts)
    const benchmark_result = try shell.exec_stdout(
                             ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts.zig:93:34: 0x124377e in main (scripts)
        .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
                                 ^
scripts
+- run scripts failure
error: the following command exited with error code 1:
/home/runner/work/tigerbeetle/tigerbeetle/.zig-cache/o/f43ab7906754f3f902da9c3750a8de05/scripts devhub --sha=7f9a39ad00437b2fabdac30c14d48d6e7410547b
(snip...)
```