### PR TITLE
 multiversion: streamline handling of universal binaries on macs 

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -407,7 +407,8 @@ fn publish(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
             );
 
             const parsed_offsets = try multiversioning.parse_elf(past_binary_contents);
-            const header_bytes = past_binary_contents[parsed_offsets.header_offset..][0..@sizeOf(
+            const header_bytes =
+                past_binary_contents[parsed_offsets.x86_64.?.header_offset..][0..@sizeOf(
                 multiversioning.MultiversionHeader,
             )];
 


### PR DESCRIPTION
Our parse_macho function is needlessly platfrom specific -- if you
invoce this function on two byte-for-byte indentical binaries, you might
get different result depending your CPU architectere.

This commit:

* Fixes the function to always give the same result, and explicitly set
  the target arch to what it is.
* Moves the code which looks at our builtin.target.cpu to the place
  where we select which sub-binary to load into ram
* I _think_ it also fixes a bug where, if you drop aarch linux binary
  onto an x86 host, the TigerBeetle would wrongly try to execute a
  mismatching architecture