### PR TITLE
StateMachine: Use `AMOUNT_MAX` as post-pending sentinel

### DIFF
--- a/docs/coding/two-phase-transfers.md
+++ b/docs/coding/two-phase-transfers.md
@@ -31,11 +31,14 @@ A post-pending transfer, denoted by
 pending transfer to "post", transferring some or all of the pending transfer's reserved amount to
 its destination.
 
-- If the posted [`amount`](../reference/transfer.md#amount) is greater than or equal to the pending
-  transfer's amount, the full pending transfer's amount is posted.
-  The transfer's recorded value is set to the pending transfer amount.
 - If the posted [`amount`](../reference/transfer.md#amount) is less than the pending transfer's
   amount, then only this amount is posted, and the remainder is restored to its original accounts.
+- If the posted [`amount`](../reference/transfer.md#amount) is equal to the pending transfer's
+  amount or equal to `AMOUNT_MAX` (`2^128 - 1`), the full pending transfer's amount is posted.
+- If the posted [`amount`](../reference/transfer.md#amount) is greater than the pending transfer's
+  amount (but less than `AMOUNT_MAX`),
+  [`exceeds_pending_transfer_amount`](../reference/requests/create_transfers.md#exceeds_pending_transfer_amount)
+  is returned.
 
 <details>
 <summary>Client &lt; 0.16.0</summary>

--- a/docs/reference/requests/create_transfers.md
+++ b/docs/reference/requests/create_transfers.md
@@ -287,17 +287,8 @@ The post/void transfer's `code` must either be `0` or identical to the pending t
 
 ### `exceeds_pending_transfer_amount`
 
-**Deprecated**: This error code is only returned to clients prior to release `0.16.0`.
-Since `0.16.0`, a posting transfer with an amount that exceeds the pending transfer's amount will
-post the full pending amount.
-
-<details>
-<summary>Client release &lt; 0.16.0</summary>
-
 The transfer was not created. The transfer's [`amount`](../transfer.md#amount) exceeds the `amount`
 of its [pending](../transfer.md#pending_id) transfer.
-
-</details>
 
 ### `pending_transfer_has_different_amount`
 
@@ -354,10 +345,6 @@ A transfer with the same `id` already exists, but with a different
 If the transfer has [`flags.balancing_debit`](../transfer.md#flagsbalancing_debit) or
 [`flags.balancing_credit`](../transfer.md#flagsbalancing_credit) set, then the actual amount
 transferred exceeds this failed transfer's `amount`.
-
-If the transfer has [`flags.post_pending_transfer`](../transfer.md#flagspost_pending_transfer)
-set, then the `amount` is not equal to
-`min(pending_transfer.amount, existing_posting_transfer.amount)`.
 
 ### `exists_with_different_pending_id`
 

--- a/docs/reference/transfer.md
+++ b/docs/reference/transfer.md
@@ -142,8 +142,10 @@ negative balances as well as
   where the actual transfer amount is determined by the debit account's constraints.
 - When `flags.balancing_credit` is set, this is the maximum amount that will be debited/credited,
   where the actual transfer amount is determined by the credit account's constraints.
-- When `flags.post_pending_transfer` is set, the amount posted will be
-  `min(posting_transfer.amount, pending_transfer.amount)`.
+- When `flags.post_pending_transfer` is set, the amount posted will be:
+  - the pending transfer's amount, when the posted transfer's `amount` is `AMOUNT_MAX`
+  - the posting transfer's amount, when the posted transfer's `amount` is less than or equal to the
+    pending transfer's amount.
 
 Constraints:
 
@@ -151,6 +153,11 @@ Constraints:
 - When `flags.void_pending_transfer` is set:
   - If `amount` is zero, it will be automatically be set to the pending transfer's `amount`.
   - If `amount` is nonzero, it must be equal to the pending transfer's `amount`.
+- When `flags.post_pending_transfer` is set:
+  - If `amount` is `AMOUNT_MAX` (`2^128 - 1`), it will automatically be set to the pending
+    transfer's `amount`.
+  - If `amount` is not `AMOUNT_MAX`, it must be less than or equal to the pending transfer's
+    `amount`.
 
 <details>
 <summary>Client release &lt; 0.16.0</summary>


### PR DESCRIPTION
Use `AMOUNT_MAX` as post-pending sentinel.

Unlike `0`, `maxInt(u128)` is hard to collide with accidentally when the amount is set to the result of a calculation.

This commit should be merged before `0.16.0` is released.

Kudos to Phil Davies for suggesting this approach!