### PR TITLE
LSM: Optionally index zero values

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1121,7 +1121,7 @@ pub fn GrooveType(
                 const Helper = IndexTreeFieldHelperType(field.name);
 
                 const index = Helper.derive_index(object);
-                if (index != 0 or index_zeroes(field)) {
+                if (index != 0 or comptime index_zeroes(field)) {
                     @field(groove.indexes, field.name).put(&.{
                         .timestamp = object.timestamp,
                         .field = index,
@@ -1178,14 +1178,14 @@ pub fn GrooveType(
 
                 // Only update the indexes that change.
                 if (old_index != new_index) {
-                    if (old_index != 0 or index_zeroes(field)) {
+                    if (old_index != 0 or comptime index_zeroes(field)) {
                         @field(groove.indexes, field.name).remove(&.{
                             .timestamp = old.timestamp,
                             .field = old_index,
                         });
                     }
 
-                    if (new_index != 0 or index_zeroes(field)) {
+                    if (new_index != 0 or comptime index_zeroes(field)) {
                         @field(groove.indexes, field.name).put(&.{
                             .timestamp = new.timestamp,
                             .field = new_index,
@@ -1223,7 +1223,7 @@ pub fn GrooveType(
                 const Helper = IndexTreeFieldHelperType(field.name);
 
                 const index = Helper.derive_index(object);
-                if (index != 0 or index_zeroes(field)) {
+                if (index != 0 or comptime index_zeroes(field)) {
                     @field(groove.indexes, field.name).remove(&.{
                         .timestamp = object.timestamp,
                         .field = index,

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -195,6 +195,7 @@ const ThingsGroove = GrooveType(
             .timestamp = batch_max,
         },
         .ignored = &[_][]const u8{"checksum"},
+        .optional = &[_][]const u8{},
         .derived = .{},
     },
 );

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -200,6 +200,11 @@ pub fn StateMachineType(
                     "flags",
                     "reserved",
                 },
+                .optional = &[_][]const u8{
+                    "user_data_128",
+                    "user_data_64",
+                    "user_data_32",
+                },
                 .derived = .{},
             },
         );
@@ -211,6 +216,13 @@ pub fn StateMachineType(
                 .ids = constants.tree_ids.transfers,
                 .batch_value_count_max = batch_value_count_max.transfers,
                 .ignored = &[_][]const u8{ "timeout", "flags" },
+                .optional = &[_][]const u8{
+                    "pending_id",
+                    "user_data_128",
+                    "user_data_64",
+                    "user_data_32",
+                    "expires_at",
+                },
                 .derived = .{
                     .expires_at = struct {
                         fn expires_at(object: *const Transfer) u64 {
@@ -231,6 +243,7 @@ pub fn StateMachineType(
                 .ids = constants.tree_ids.transfers_pending,
                 .batch_value_count_max = batch_value_count_max.transfers_pending,
                 .ignored = &[_][]const u8{"padding"},
+                .optional = &[_][]const u8{"status"},
                 .derived = .{},
             },
         );
@@ -266,6 +279,7 @@ pub fn StateMachineType(
                     "cr_credits_posted",
                     "reserved",
                 },
+                .optional = &[_][]const u8{},
                 .derived = .{},
             },
         );
@@ -4756,7 +4770,7 @@ test "query_transfers" {
         \\ commit create_accounts
 
         // Creating transfers:
-        \\ transfer T1 A1 A2   10  _ U1000 U10 U1 _ L1 C1 _ _ _ _ _ _ _ _ _ ok
+        \\ transfer T1 A1 A2    0  _ U1000 U10 U1 _ L1 C1 _ _ _ _ _ _ _ _ _ ok
         \\ transfer T2 A3 A4   11  _ U1000 U11 U2 _ L2 C2 _ _ _ _ _ _ _ _ _ ok
         \\ transfer T3 A2 A1   12  _ U1000 U10 U3 _ L1 C3 _ _ _ _ _ _ _ _ _ ok
         \\ transfer T4 A4 A3   13  _ U1000 U11 U4 _ L2 C4 _ _ _ _ _ _ _ _ _ ok

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -88,6 +88,7 @@ pub fn StateMachineType(
                     .value = 1,
                 },
                 .ignored = &[_][]const u8{},
+                .optional = &[_][]const u8{},
                 .derived = .{},
             },
         );


### PR DESCRIPTION
As of https://github.com/tigerbeetle/tigerbeetle/pull/2220, zero-amount transfers are allowed. Since we have an index on `Transfer.amount`, we need to ensure zero-amount transfers are indexed too!

Note that we don't support querying by amount yet, so this isn't actually tested.

This commit should be merged before `0.16.0` is released.