### PR TITLE
LSM: Secondary indexes on flags.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -381,6 +381,8 @@ fn build_tigerbeetle(
             "tigerbeetle.ll",
         ).step);
     }
+    // TODO: investigate why do we need to grow the stack when adding new indexes.
+    tigerbeetle.stack_size = 18 * 1024 * 1024;
 
     // "zig build install" moves the server executable to the root folder:
     steps.install.dependOn(&b.addInstallArtifact(tigerbeetle, .{}).step);

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -5,11 +5,17 @@ const math = std.math;
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 
+/// Combines a field (the key prefix) with a timestamp (the primary key).
+/// To keep alignment, it supports either `u64` or `u128` prefixes (which can be truncated
+/// to smaller types to fit the correct field data type).
+/// It also supports composite keys without a prefix (`Field == void`), which is useful for
+/// indexing flags that are only checked with "exists".
 pub fn CompositeKeyType(comptime Field: type) type {
     // The type if zeroed padding is needed.
     const Pad = switch (Field) {
-        u128 => u64,
+        void => u0,
         u64 => u0,
+        u128 => u64,
         else => @compileError("invalid Field for CompositeKey: " ++ @typeName(Field)),
     };
 
@@ -17,14 +23,17 @@ pub fn CompositeKeyType(comptime Field: type) type {
         const CompositeKey = @This();
 
         pub const sentinel_key: Key = key_from_value(&.{
-            .field = math.maxInt(Field),
+            .field = if (Field == void) {} else math.maxInt(Field),
             .timestamp = math.maxInt(u64),
         });
 
         const tombstone_bit: u64 = 1 << (64 - 1);
 
         // u128 may be aligned to 8 instead of the expected 16.
-        const field_bitsize_alignment = @divExact(@bitSizeOf(Field), 8);
+        const field_bitsize_alignment = @max(
+            @divExact(@bitSizeOf(Field), 8),
+            @divExact(@bitSizeOf(u64), 8),
+        );
 
         pub const Key = std.meta.Int(
             .unsigned,
@@ -37,8 +46,13 @@ pub fn CompositeKeyType(comptime Field: type) type {
         padding: Pad = 0,
 
         comptime {
-            assert(@sizeOf(CompositeKey) == @sizeOf(Field) * 2);
             assert(@sizeOf(CompositeKey) == @sizeOf(Key));
+            assert(@sizeOf(CompositeKey) == switch (Field) {
+                void => @sizeOf(u64),
+                u64 => @sizeOf(u128),
+                u128 => @sizeOf(u256),
+                else => unreachable,
+            });
             assert(@alignOf(CompositeKey) >= @alignOf(Field));
             assert(@alignOf(CompositeKey) == field_bitsize_alignment);
             assert(stdx.no_padding(CompositeKey));
@@ -46,11 +60,17 @@ pub fn CompositeKeyType(comptime Field: type) type {
 
         pub inline fn key_from_value(value: *const CompositeKey) Key {
             if (constants.verify) assert(value.padding == 0);
-            return @as(Key, value.timestamp & ~tombstone_bit) | (@as(Key, value.field) << 64);
+            if (Field == void) {
+                comptime assert(Key == u64);
+                return value.timestamp & ~tombstone_bit;
+            } else {
+                comptime assert(@sizeOf(Key) == @sizeOf(Field) * 2);
+                return @as(Key, value.timestamp & ~tombstone_bit) | (@as(Key, value.field) << 64);
+            }
         }
 
         pub inline fn key_prefix(key: Key) Field {
-            return @truncate(key >> 64);
+            return if (Field == void) {} else @truncate(key >> 64);
         }
 
         pub inline fn tombstone(value: *const CompositeKey) bool {
@@ -60,11 +80,10 @@ pub fn CompositeKeyType(comptime Field: type) type {
 
         pub inline fn tombstone_from_key(key: Key) CompositeKey {
             const timestamp: u64 = @truncate(key);
-            const field: Field = @truncate(key >> 64);
             assert(timestamp & tombstone_bit == 0);
 
             return .{
-                .field = field,
+                .field = key_prefix(key),
                 .timestamp = timestamp | tombstone_bit,
             };
         }
@@ -78,7 +97,7 @@ pub fn is_composite_key(comptime Value: type) bool {
     {
         const Field = std.meta.FieldType(Value, .field);
         return switch (Field) {
-            u64, u128 => Value == CompositeKeyType(Field),
+            void, u64, u128 => Value == CompositeKeyType(Field),
             else => false,
         };
     }
@@ -86,40 +105,68 @@ pub fn is_composite_key(comptime Value: type) bool {
     return false;
 }
 
-fn composite_key_test(comptime CompositeKey: type) !void {
-    {
-        const a = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 100 });
-        const b = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 101 });
-        try std.testing.expect(a < b);
+test "composite_key - u64 and u128" {
+    inline for (.{ u128, u64 }) |Prefix| {
+        const CompositeKey = CompositeKeyType(Prefix);
+
+        {
+            const a = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 100 });
+            const b = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 101 });
+            try std.testing.expect(a < b);
+        }
+
+        {
+            const a = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 100 });
+            const b = CompositeKey.key_from_value(&.{ .field = 2, .timestamp = 99 });
+            try std.testing.expect(a < b);
+        }
+
+        {
+            const a = CompositeKey.key_from_value(&.{
+                .field = 1,
+                .timestamp = @as(u64, 100) | CompositeKey.tombstone_bit,
+            });
+            const b = CompositeKey.key_from_value(&.{
+                .field = 1,
+                .timestamp = 100,
+            });
+            try std.testing.expect(a == b);
+        }
+
+        {
+            const key = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 100 });
+            const value = CompositeKey.tombstone_from_key(key);
+            try std.testing.expect(CompositeKey.tombstone(&value));
+            try std.testing.expect(value.timestamp == @as(u64, 100) | CompositeKey.tombstone_bit);
+        }
     }
+}
+
+test "composite_key - void" {
+    const CompositeKey = CompositeKeyType(void);
 
     {
-        const a = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 100 });
-        const b = CompositeKey.key_from_value(&.{ .field = 2, .timestamp = 99 });
+        const a = CompositeKey.key_from_value(&.{ .field = {}, .timestamp = 100 });
+        const b = CompositeKey.key_from_value(&.{ .field = {}, .timestamp = 101 });
         try std.testing.expect(a < b);
     }
 
     {
         const a = CompositeKey.key_from_value(&.{
-            .field = 1,
+            .field = {},
             .timestamp = @as(u64, 100) | CompositeKey.tombstone_bit,
         });
         const b = CompositeKey.key_from_value(&.{
-            .field = 1,
+            .field = {},
             .timestamp = 100,
         });
         try std.testing.expect(a == b);
     }
 
     {
-        const key = CompositeKey.key_from_value(&.{ .field = 1, .timestamp = 100 });
+        const key = CompositeKey.key_from_value(&.{ .field = {}, .timestamp = 100 });
         const value = CompositeKey.tombstone_from_key(key);
         try std.testing.expect(CompositeKey.tombstone(&value));
         try std.testing.expect(value.timestamp == @as(u64, 100) | CompositeKey.tombstone_bit);
     }
-}
-
-test "composite_key" {
-    try composite_key_test(CompositeKeyType(u64));
-    try composite_key_test(CompositeKeyType(u128));
 }

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -761,15 +761,17 @@ const Environment = struct {
                 for (accounts) |*account| {
                     const prefix_current: u128 = switch (params.index) {
                         .imported => index: {
-                            assert(params.min == 0 and params.max == 0);
+                            assert(params.min == 0);
+                            assert(params.max == 0);
+                            assert(prefix_last == null);
                             assert(account.flags.imported);
-                            break :index 0;
+                            break :index undefined;
                         },
                         inline else => |field| index: {
                             const Helper = GrooveAccounts.IndexTreeFieldHelperType(@tagName(field));
                             comptime assert(Helper.Index != void);
 
-                            const value = Helper.derive_index(account).?;
+                            const value = Helper.index_from_object(account).?;
                             assert(value >= params.min and value <= params.max);
                             break :index value;
                         },
@@ -799,6 +801,8 @@ const Environment = struct {
                         }
                         timestamp_last = account.timestamp;
                     } else {
+                        assert(params.index != .imported);
+
                         // If not exact, it's expected to be sorted by prefix and then timestamp.
                         if (prefix_last) |prefix| {
                             // If range (between min .. max), it's expected to be sorted by prefix.

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -336,8 +336,7 @@ pub fn GrooveType(
     assert(indexes_count_actual == indexes_count_expect);
     assert(indexes_count_actual == std.meta.fields(_IndexTreeOptions).len);
 
-    // Generate a helper function for interacting with an Index field type.
-    const IndexTreeFieldHelperType = struct {
+    const _IndexTreeFieldHelperType = struct {
         /// Returns true if the field is a derived field.
         fn is_derived(comptime field_name: []const u8) bool {
             comptime var derived = false;
@@ -364,8 +363,8 @@ pub fn GrooveType(
 
         fn HelperType(comptime field_name: []const u8) type {
             return struct {
-                const Index = IndexType(field_name);
-                const IndexPrefix = switch (@typeInfo(Index)) {
+                pub const Index = IndexType(field_name);
+                pub const IndexPrefix = switch (@typeInfo(Index)) {
                     .Void => void,
                     .Int => Index,
                     .Enum => |info| info.tag_type,
@@ -490,6 +489,9 @@ pub fn GrooveType(
         pub const IndexTrees = _IndexTrees;
         pub const ObjectsCache = _ObjectsCache;
         pub const config = groove_options;
+
+        /// Helper function for interacting with an Index field type.
+        pub const IndexTreeFieldHelperType = _IndexTreeFieldHelperType;
 
         const Grid = GridType(Storage);
         const ManifestLog = ManifestLogType(Storage);

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -300,6 +300,7 @@ fn has_pointers(comptime T: type) bool {
 /// Checks that a type does not have implicit padding.
 pub fn no_padding(comptime T: type) bool {
     comptime switch (@typeInfo(T)) {
+        .Void => return true,
         .Int => return @bitSizeOf(T) == 8 * @sizeOf(T),
         .Array => |info| return no_padding(info.child),
         .Struct => |info| {

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -1170,8 +1170,8 @@ fn print_table_info(
         const Field = @TypeOf(f.field);
         const key_min_timestamp: u64 = @truncate(key_min & std.math.maxInt(u64));
         const key_max_timestamp: u64 = @truncate(key_max & std.math.maxInt(u64));
-        const key_min_field: Field = @intCast(key_min >> 64);
-        const key_max_field: Field = @intCast(key_max >> 64);
+        const key_min_field: Field = Value.key_prefix(key_min);
+        const key_max_field: Field = Value.key_prefix(key_max);
 
         try output.print(" K={:_>6}:{}..{:_>6}:{}", .{
             key_min_field,


### PR DESCRIPTION
### LSM: Secondary indexes on flags.

- Allow secondary indexes to be a `CompositeKey(void)` for minimal overhead when indexing flags (see commit messages).
- StateMachine: Index `Accounts.flags.imported` and `Transfer.flags.imported`.
- Fuzz: scan indexed flags.

Note: Since this PR adds a new index over a flag introduced by #2171, it should be merged preferentially before releasing `0.16.0`.


EDIT:
The two new indexes add ~24MiB of RSS.
Running the benchmark with `--flag-imported` increases the data file only by ~90MiB, with no performance impact.

