### PR TITLE
[PoC] Stack allocation.

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1964,7 +1964,7 @@ pub fn CompactionType(
             // bar to ensure:
             // - manifest log updates are ordered deterministically relative to one another, and
             // - manifest updates are not visible until after the blocks are all on disk.
-            const manifest = &bar.tree.manifest;
+            const manifest = bar.tree.manifest;
             const level_b = compaction.level_b;
             const snapshot_max = snapshot_max_for_table_input(bar.op_min);
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -171,6 +171,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
     };
 
     comptime {
+        @setEvalBranchQuota(10_000);
         assert(std.enums.values(_TreeID).len == _tree_infos.len);
         for (std.enums.values(_TreeID)) |tree_id| {
             const tree_info = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -62,7 +62,7 @@ const FuzzOp = struct {
 
 const GrooveAccounts = type: {
     const forest: Forest = undefined;
-    break :type @TypeOf(forest.grooves.accounts);
+    break :type std.meta.Child(@TypeOf(forest.grooves.accounts));
 };
 
 const ScanParams = struct {
@@ -356,7 +356,7 @@ const Environment = struct {
 
         var context = Context{
             ._id = id,
-            ._groove_accounts = &env.forest.grooves.accounts,
+            ._groove_accounts = env.forest.grooves.accounts,
         };
         context.prefetch_start();
         while (!context.finished) {
@@ -390,7 +390,7 @@ const Environment = struct {
 
         var context = Context{
             ._timestamp = timestamp,
-            ._groove_accounts = &env.forest.grooves.accounts,
+            ._groove_accounts = env.forest.grooves.accounts,
         };
         context.prefetch_start();
         while (!context.finished) {
@@ -417,9 +417,9 @@ const Environment = struct {
     }
 
     fn ScannerIndexType(comptime index: std.meta.FieldEnum(GrooveAccounts.IndexTrees)) type {
-        const Tree = std.meta.fieldInfo(GrooveAccounts.IndexTrees, index).type;
+        const Tree = std.meta.Child(std.meta.FieldType(GrooveAccounts.IndexTrees, index));
         const Value = Tree.Table.Value;
-        const Prefix = std.meta.fieldInfo(Value, .field).type;
+        const Prefix = std.meta.FieldType(Value, .field);
 
         const ScanRange = ScanRangeType(
             Tree,
@@ -459,7 +459,7 @@ const Environment = struct {
                 assert(min <= max);
 
                 const scan_buffer_pool = &env.forest.scan_buffer_pool;
-                const groove_accounts = &env.forest.grooves.accounts;
+                const groove_accounts = env.forest.grooves.accounts;
                 defer scan_buffer_pool.reset();
 
                 // It's not expected to exceed `lsm_scans_max` here.
@@ -467,7 +467,7 @@ const Environment = struct {
 
                 var scan_range = ScanRange.init(
                     {},
-                    &@field(groove_accounts.indexes, @tagName(index)),
+                    @field(groove_accounts.indexes, @tagName(index)),
                     scan_buffer,
                     lsm.snapshot_latest,
                     Value.key_from_value(&.{

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -195,23 +195,31 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         // registered snapshot seen so far.
         snapshot_max: u64 = 1,
 
-        pub fn init(allocator: mem.Allocator, node_pool: *NodePool, config: TreeConfig) !Manifest {
-            var levels: [constants.lsm_levels]Level = undefined;
-            for (&levels, 0..) |*level, i| {
-                errdefer for (levels[0..i]) |*l| l.deinit(allocator, node_pool);
-                level.* = try Level.init(allocator);
-            }
-            errdefer for (&levels) |*level| level.deinit(allocator, node_pool);
-
-            return Manifest{
+        pub fn init(
+            allocator: mem.Allocator,
+            node_pool: *NodePool,
+            config: TreeConfig,
+        ) !*Manifest {
+            const manifest = try allocator.create(Manifest);
+            errdefer allocator.destroy(manifest);
+            manifest.* = .{
                 .node_pool = node_pool,
                 .config = config,
-                .levels = levels,
+                .levels = undefined,
             };
+
+            for (&manifest.levels, 0..) |*level, i| {
+                errdefer for (manifest.levels[0..i]) |*l| l.deinit(allocator, node_pool);
+                level.* = try Level.init(allocator);
+            }
+            errdefer for (&manifest.levels) |*level| level.deinit(allocator, node_pool);
+
+            return manifest;
         }
 
         pub fn deinit(manifest: *Manifest, allocator: mem.Allocator) void {
             for (&manifest.levels) |*level| level.deinit(allocator, manifest.node_pool);
+            allocator.destroy(manifest);
         }
 
         pub fn reset(manifest: *Manifest) void {

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -107,7 +107,7 @@ pub fn ScanBuilderType(
             return self.scan_add(
                 field,
                 ScanImpl.init(
-                    &@field(self.groove().indexes, @tagName(index)),
+                    @field(self.groove().indexes, @tagName(index)),
                     buffer,
                     snapshot,
                     key_from_value(index, prefix, timestamp_range.min),
@@ -157,7 +157,7 @@ pub fn ScanBuilderType(
             return self.scan_add(
                 .timestamp,
                 ScanImpl.init(
-                    &self.groove().objects,
+                    self.groove().objects,
                     buffer,
                     snapshot,
                     timestamp_range.min,
@@ -259,7 +259,7 @@ pub fn ScanBuilderType(
         }
 
         fn CompositeKeyType(comptime index: std.meta.FieldEnum(Groove.IndexTrees)) type {
-            const IndexTree = std.meta.fieldInfo(Groove.IndexTrees, index).type;
+            const IndexTree = std.meta.Child(std.meta.FieldType(Groove.IndexTrees, index));
             return IndexTree.Table.Value;
         }
 
@@ -269,7 +269,7 @@ pub fn ScanBuilderType(
         }
 
         fn ScanImplType(comptime field: std.meta.FieldEnum(Scan.Dispatcher)) type {
-            return std.meta.fieldInfo(Scan.Dispatcher, field).type;
+            return std.meta.FieldType(Scan.Dispatcher, field);
         }
 
         fn key_from_value(
@@ -356,7 +356,7 @@ pub fn ScanType(
 
             // Union fields for each index tree:
             for (std.meta.fields(Groove.IndexTrees)) |field| {
-                const IndexTree = field.type;
+                const IndexTree = std.meta.Child(field.type);
                 const ScanTree = ScanTreeType(*Context, IndexTree, Storage);
                 type_info.Union.fields = type_info.Union.fields ++
                     [_]std.builtin.Type.UnionField{.{

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -873,7 +873,7 @@ const Environment = struct {
             query_spec.reversed,
         );
         env.scan_lookup = ScanLookup.init(
-            &env.forest.grooves.things,
+            env.forest.grooves.things,
             scan,
         );
 
@@ -894,7 +894,7 @@ const Environment = struct {
         reversed: bool,
     ) *Scan {
         const scan_buffer_pool = &env.forest.scan_buffer_pool;
-        const things_groove = &env.forest.grooves.things;
+        const things_groove = env.forest.grooves.things;
         const scan_builder: *ThingsGroove.ScanBuilder = &things_groove.scan_builder;
 
         var stack = stdx.BoundedArray(*Scan, index_max){};

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -175,9 +175,8 @@ pub fn ScanLookupType(
                 worker.index_produced = self.buffer_produced_len.?;
                 self.buffer_produced_len = self.buffer_produced_len.? + 1;
 
-                const objects = &self.groove.objects;
-                if (objects.table_mutable.get(timestamp) orelse
-                    objects.table_immutable.get(timestamp)) |object|
+                if (self.groove.objects.table_mutable.get(timestamp) orelse
+                    self.groove.objects.table_immutable.get(timestamp)) |object|
                 {
                     // TODO(batiati) Handle this properly when we implement snapshot queries.
                     assert(self.scan.snapshot() == snapshot_latest);
@@ -186,7 +185,7 @@ pub fn ScanLookupType(
                     // continue the loop to fetch the next one.
                     self.buffer.?[worker.index_produced.?] = object.*;
                     continue;
-                } else switch (objects.lookup_from_levels_cache(
+                } else switch (self.groove.objects.lookup_from_levels_cache(
                     self.scan.snapshot(),
                     timestamp,
                 )) {
@@ -204,7 +203,7 @@ pub fn ScanLookupType(
                     // The object needs to be loaded from storage, returning now,
                     // the iteration will be resumed when we receive the callback.
                     .possible => |level_min| {
-                        objects.lookup_from_levels_storage(.{
+                        self.groove.objects.lookup_from_levels_storage(.{
                             .callback = lookup_worker_callback,
                             .context = &worker.lookup_context,
                             .snapshot = self.scan.snapshot(),

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -803,8 +803,7 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             assert(self.scan.state == .seeking or
                 self.scan.state == .buffering);
 
-            const manifest: *Manifest = &self.scan.tree.manifest;
-            if (manifest.next_table(.{
+            if (self.scan.tree.manifest.next_table(.{
                 .level = self.level_index,
                 .snapshot = self.scan.snapshot,
                 .key_min = self.scan.key_min,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -150,7 +150,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         grid: Grid,
         manifest_log: ManifestLog,
         node_pool: NodePool,
-        tree: Tree,
+        tree: *Tree,
         scan_tree: ScanTree,
         lookup_context: Tree.LookupContext,
         lookup_value: ?Value,
@@ -323,7 +323,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 if (last_half_beat and compaction.level_b % 2 != 0) continue;
                 if (last_beat and compaction.level_b % 2 == 0) continue;
 
-                const maybe_compaction_work = compaction.bar_setup(&env.tree, op);
+                const maybe_compaction_work = compaction.bar_setup(env.tree, op);
                 if (maybe_compaction_work != null) {
                     compaction_work.append_assume_capacity(compaction);
                 }
@@ -495,7 +495,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
             env.change_state(.fuzzing, .scan_tree);
             env.scan_tree = ScanTree.init(
-                &env.tree,
+                env.tree,
                 &env.scan_buffer,
                 snapshot_latest,
                 key_min,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -110,6 +110,14 @@ pub fn StateMachineType(
                     .code = 17,
                     .timestamp = 18,
                     .expires_at = 19,
+                    .place_holder_1 = 23,
+                    .place_holder_2 = 24,
+                    .place_holder_3 = 25,
+                    .place_holder_4 = 26,
+                    .place_holder_5 = 27,
+                    .place_holder_6 = 28,
+                    .place_holder_7 = 29,
+                    .place_holder_8 = 30,
                 };
 
                 pub const transfers_pending = .{
@@ -232,6 +240,55 @@ pub fn StateMachineType(
                             return 0;
                         }
                     }.expires_at,
+                    // Adding dummy indexes:
+                    .place_holder_1 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_2 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_3 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_4 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_5 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_6 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_7 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_8 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
                 },
             },
         );
@@ -2623,6 +2680,14 @@ pub fn StateMachineType(
                 ledger: u32,
                 code: u32,
                 expires_at: u32,
+                place_holder_1: u32,
+                place_holder_2: u32,
+                place_holder_3: u32,
+                place_holder_4: u32,
+                place_holder_5: u32,
+                place_holder_6: u32,
+                place_holder_7: u32,
+                place_holder_8: u32,
             },
             transfers_pending: struct {
                 timestamp: u32,
@@ -2664,6 +2729,14 @@ pub fn StateMachineType(
                     .ledger = batch_create_transfers,
                     .code = batch_create_transfers,
                     .expires_at = batch_create_transfers,
+                    .place_holder_1 = batch_create_transfers,
+                    .place_holder_2 = batch_create_transfers,
+                    .place_holder_3 = batch_create_transfers,
+                    .place_holder_4 = batch_create_transfers,
+                    .place_holder_5 = batch_create_transfers,
+                    .place_holder_6 = batch_create_transfers,
+                    .place_holder_7 = batch_create_transfers,
+                    .place_holder_8 = batch_create_transfers,
                 },
                 .transfers_pending = .{
                     // Objects are mutated when the pending transfer is posted/voided/expired.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -931,7 +931,7 @@ pub fn StateMachineType(
 
                 var scan_lookup = self.scan_lookup.get(.transfers);
                 scan_lookup.* = TransfersScanLookup.init(
-                    &self.forest.grooves.transfers,
+                    self.forest.grooves.transfers,
                     scan,
                 );
 
@@ -1004,7 +1004,7 @@ pub fn StateMachineType(
 
                         var scan_lookup = self.scan_lookup.get(.account_balances);
                         scan_lookup.* = AccountBalancesScanLookup.init(
-                            &self.forest.grooves.account_balances,
+                            self.forest.grooves.account_balances,
                             scan,
                         );
 
@@ -1077,7 +1077,7 @@ pub fn StateMachineType(
 
             if (!filter_valid) return null;
 
-            const transfers_groove: *TransfersGroove = &self.forest.grooves.transfers;
+            const transfers_groove: *TransfersGroove = self.forest.grooves.transfers;
             const scan_builder: *TransfersGroove.ScanBuilder = &transfers_groove.scan_builder;
 
             const timestamp_range: TimestampRange = .{
@@ -1146,7 +1146,7 @@ pub fn StateMachineType(
 
             if (self.get_scan_from_query_filter(
                 AccountsGroove,
-                &self.forest.grooves.accounts,
+                self.forest.grooves.accounts,
                 filter,
             )) |scan| {
                 assert(self.forest.scan_buffer_pool.scan_buffer_used > 0);
@@ -1160,7 +1160,7 @@ pub fn StateMachineType(
 
                 const scan_lookup = self.scan_lookup.get(.accounts);
                 scan_lookup.* = AccountsScanLookup.init(
-                    &self.forest.grooves.accounts,
+                    self.forest.grooves.accounts,
                     scan,
                 );
 
@@ -1200,7 +1200,7 @@ pub fn StateMachineType(
 
             if (self.get_scan_from_query_filter(
                 TransfersGroove,
-                &self.forest.grooves.transfers,
+                self.forest.grooves.transfers,
                 filter,
             )) |scan| {
                 assert(self.forest.scan_buffer_pool.scan_buffer_used > 0);
@@ -1214,7 +1214,7 @@ pub fn StateMachineType(
 
                 var scan_lookup = self.scan_lookup.get(.transfers);
                 scan_lookup.* = TransfersScanLookup.init(
-                    &self.forest.grooves.transfers,
+                    self.forest.grooves.transfers,
                     scan,
                 );
 
@@ -1337,9 +1337,9 @@ pub fn StateMachineType(
                 self.scan_lookup_buffer[0..scan_buffer_size],
             );
 
-            const transfers_groove: *TransfersGroove = &self.forest.grooves.transfers;
+            const transfers_groove: *TransfersGroove = self.forest.grooves.transfers;
             const scan = self.expire_pending_transfers.scan(
-                &transfers_groove.indexes.expires_at,
+                transfers_groove.indexes.expires_at,
                 self.forest.scan_buffer_pool.acquire_assume_capacity(),
                 .{
                     .snapshot = transfers_groove.prefetch_snapshot.?,
@@ -2812,7 +2812,7 @@ fn ExpirePendingTransfersType(
         const EvaluateNext = @import("lsm/scan_range.zig").EvaluateNext;
         const ScanLookupStatus = @import("lsm/scan_lookup.zig").ScanLookupStatus;
 
-        const Tree = std.meta.FieldType(TransfersGroove.IndexTrees, .expires_at);
+        const Tree = std.meta.Child(std.meta.FieldType(TransfersGroove.IndexTrees, .expires_at));
         const Key = Tree.Table.Key;
         const Value = Tree.Table.Value;
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -347,8 +347,7 @@ const Command = struct {
 
         const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
 
-        const replica: *Replica = try allocator.create(Replica);
-        defer allocator.destroy(replica);
+        var replica: Replica = undefined;
         replica.open(allocator, .{
             .node_count = args.addresses.count_as(u8),
             .release = config.process.release,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -347,7 +347,8 @@ const Command = struct {
 
         const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
 
-        var replica: Replica = undefined;
+        const replica: *Replica = try allocator.create(Replica);
+        defer allocator.destroy(replica);
         replica.open(allocator, .{
             .node_count = args.addresses.count_as(u8),
             .release = config.process.release,

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -186,8 +186,7 @@ pub fn GridScrubberType(comptime Forest: type) type {
                 inline for (Forest.tree_infos) |tree_info| {
                     const tree_id = comptime Forest.tree_id_cast(tree_info.tree_id);
                     const tree = scrubber.forest.tree_for_id_const(tree_id);
-                    const levels = &tree.manifest.levels;
-                    const tree_level_weight = @as(u64, levels[level].tables.len()) *
+                    const tree_level_weight = @as(u64, tree.manifest.levels[level].tables.len()) *
                         tree_info.Tree.Table.index.data_block_count_max;
                     if (tree_level_weight > 0) {
                         weights_sum += tree_level_weight;


### PR DESCRIPTION
PoC: Just for running GHA

- Added 8 dummy indexes to force [stack overflow](https://github.com/tigerbeetle/tigerbeetle/actions/runs/10547365124/job/29219958195) (the `Forest` object is ~608KiB and the `StateMachine` 717KiB).
  At first, I tried to handle the stack allocation directly on the root cause, heap allocating `Replica` on `main.zig`.
  It didn't work. I suspect the problem is due to stack allocations of locals during the various `init` functions.

- The proposed solution moved large declarations that don't need a "relative" pointer for @fieldParentPtr to the heap.
  Objects containing large arrays are now created on the heap and then initialized.

  -  The `Groove`'s trees (particularly the large struct `IndexTrees`) are now pointers to heap-allocated object trees. 
  -  Similarly, `Manifest` and `Compaction` are also heap-allocated.
  
The Forest object is now approximately 1.5KiB in size.
Interestingly, this change reduced the total RSS by 4KiB!