### PR TITLE
[PoC] Stack allocation (PlanB)

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -171,6 +171,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
     };
 
     comptime {
+        @setEvalBranchQuota(10_000);
         assert(std.enums.values(_TreeID).len == _tree_infos.len);
         for (std.enums.values(_TreeID)) |tree_id| {
             const tree_info = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -205,7 +205,7 @@ const Environment = struct {
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
 
-        env.forest = try Forest.init(allocator, &env.grid, .{
+        try env.forest.init(allocator, &env.grid, .{
             // TODO Test that the same sequence of events applied to forests with different
             // compaction_blocks result in identical grids.
             .compaction_block_count = Forest.Options.compaction_block_count_min,

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -547,15 +547,30 @@ pub fn GrooveType(
         };
 
         pub fn init(
+            groove: *Groove,
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
             options: Options,
-        ) !Groove {
+        ) !void {
             assert(options.tree_options_object.batch_value_count_limit *
                 constants.lsm_compaction_ops <= ObjectTree.Table.value_count_max);
 
-            var objects_cache = try ObjectsCache.init(allocator, .{
+            groove.* = Groove{
+                .grid = grid,
+                .objects = undefined,
+                .ids = undefined,
+                .indexes = undefined,
+
+                .prefetch_keys = undefined,
+                .prefetch_snapshot = null,
+                .objects_cache = undefined,
+                .timestamps = undefined,
+
+                .scan_builder = undefined,
+            };
+
+            groove.objects_cache = try ObjectsCache.init(allocator, .{
                 .cache_value_count_max = options.cache_entries_max,
 
                 // In the worst case, each Map must be able to store batch_value_count_limit per
@@ -572,10 +587,10 @@ pub fn GrooveType(
 
                 .name = @typeName(Object),
             });
-            errdefer objects_cache.deinit(allocator);
+            errdefer groove.objects_cache.deinit(allocator);
 
             // Initialize the object LSM tree.
-            var object_tree = try ObjectTree.init(
+            try groove.objects.init(
                 allocator,
                 node_pool,
                 grid,
@@ -585,9 +600,9 @@ pub fn GrooveType(
                 },
                 options.tree_options_object,
             );
-            errdefer object_tree.deinit(allocator);
+            errdefer groove.objects.deinit(allocator);
 
-            var id_tree = if (!has_id) {} else (try IdTree.init(
+            if (has_id) try groove.ids.init(
                 allocator,
                 node_pool,
                 grid,
@@ -596,22 +611,20 @@ pub fn GrooveType(
                     .name = @typeName(Object) ++ ".id",
                 },
                 options.tree_options_id,
-            ));
-            errdefer if (has_id) id_tree.deinit(allocator);
+            );
+            errdefer if (has_id) groove.ids.deinit(allocator);
 
             var index_trees_initialized: usize = 0;
-            var index_trees: IndexTrees = undefined;
-
             // Make sure to deinit initialized index LSM trees on error.
             errdefer inline for (std.meta.fields(IndexTrees), 0..) |field, field_index| {
                 if (index_trees_initialized >= field_index + 1) {
-                    @field(index_trees, field.name).deinit(allocator);
+                    @field(groove.indexes, field.name).deinit(allocator);
                 }
             };
 
             // Initialize index LSM trees.
             inline for (std.meta.fields(IndexTrees)) |field| {
-                @field(index_trees, field.name) = try field.type.init(
+                try @field(groove.indexes, field.name).init(
                     allocator,
                     node_pool,
                     grid,
@@ -624,35 +637,21 @@ pub fn GrooveType(
                 index_trees_initialized += 1;
             }
 
-            var prefetch_keys: PrefetchKeys = .{};
-            try prefetch_keys.ensureTotalCapacity(
+            groove.prefetch_keys = .{};
+            try groove.prefetch_keys.ensureTotalCapacity(
                 allocator,
                 options.prefetch_entries_for_read_max + options.prefetch_entries_for_update_max,
             );
-            errdefer prefetch_keys.deinit(allocator);
+            errdefer groove.prefetch_keys.deinit(allocator);
 
-            var timestamps = if (has_id) try TimestampSet.init(
+            groove.timestamps = if (has_id) try TimestampSet.init(
                 allocator,
                 options.prefetch_entries_for_read_max,
             ) else {};
-            errdefer if (has_id) timestamps.deinit(allocator);
+            errdefer if (has_id) groove.timestamps.deinit(allocator);
 
-            var scan_builder = if (has_scan) try ScanBuilder.init(allocator) else {};
-            errdefer if (has_scan) scan_builder.deinit(allocator);
-
-            return Groove{
-                .grid = grid,
-                .objects = object_tree,
-                .ids = id_tree,
-                .indexes = index_trees,
-
-                .prefetch_keys = prefetch_keys,
-                .prefetch_snapshot = null,
-                .objects_cache = objects_cache,
-                .timestamps = timestamps,
-
-                .scan_builder = scan_builder,
-            };
+            groove.scan_builder = if (has_scan) try ScanBuilder.init(allocator) else {};
+            errdefer if (has_scan) groove.scan_builder.deinit(allocator);
         }
 
         pub fn deinit(groove: *Groove, allocator: mem.Allocator) void {

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -195,19 +195,22 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         // registered snapshot seen so far.
         snapshot_max: u64 = 1,
 
-        pub fn init(allocator: mem.Allocator, node_pool: *NodePool, config: TreeConfig) !Manifest {
-            var levels: [constants.lsm_levels]Level = undefined;
-            for (&levels, 0..) |*level, i| {
-                errdefer for (levels[0..i]) |*l| l.deinit(allocator, node_pool);
-                level.* = try Level.init(allocator);
-            }
-            errdefer for (&levels) |*level| level.deinit(allocator, node_pool);
-
-            return Manifest{
+        pub fn init(
+            manifest: *Manifest,
+            allocator: mem.Allocator,
+            node_pool: *NodePool,
+            config: TreeConfig,
+        ) !void {
+            manifest.* = .{
                 .node_pool = node_pool,
                 .config = config,
-                .levels = levels,
+                .levels = undefined,
             };
+            for (&manifest.levels, 0..) |*level, i| {
+                errdefer for (manifest.levels[0..i]) |*l| l.deinit(allocator, node_pool);
+                level.* = try Level.init(allocator);
+            }
+            errdefer for (&manifest.levels) |*level| level.deinit(allocator, node_pool);
         }
 
         pub fn deinit(manifest: *Manifest, allocator: mem.Allocator) void {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -965,7 +965,7 @@ const Environment = struct {
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
 
-        env.forest = try Forest.init(allocator, &env.grid, .{
+        try env.forest.init(allocator, &env.grid, .{
             .compaction_block_count = Forest.Options.compaction_block_count_min,
             .node_count = node_count,
         }, forest_options);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -110,12 +110,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         };
 
         pub fn init(
+            tree: *Tree,
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
             config: Config,
             options: Options,
-        ) !Tree {
+        ) !void {
             assert(grid.superblock.opened);
             assert(config.id != 0); // id=0 is reserved.
             assert(config.name.len > 0);
@@ -125,39 +126,37 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(value_count_limit > 0);
             assert(value_count_limit <= TreeTable.value_count_max);
 
-            var table_mutable = try TableMemory.init(allocator, .mutable, config.name, .{
+            tree.* = .{
+                .grid = grid,
+                .config = config,
+                .options = options,
+                .table_mutable = undefined,
+                .table_immutable = undefined,
+                .manifest = undefined,
+                .compactions = undefined,
+            };
+
+            tree.table_mutable = try TableMemory.init(allocator, .mutable, config.name, .{
                 .value_count_limit = value_count_limit,
             });
-            errdefer table_mutable.deinit(allocator);
+            errdefer tree.table_mutable.deinit(allocator);
 
-            var table_immutable = try TableMemory.init(
+            tree.table_immutable = try TableMemory.init(
                 allocator,
                 .{ .immutable = .{} },
                 config.name,
                 .{ .value_count_limit = value_count_limit },
             );
-            errdefer table_immutable.deinit(allocator);
+            errdefer tree.table_immutable.deinit(allocator);
 
-            var manifest = try Manifest.init(allocator, node_pool, config);
-            errdefer manifest.deinit(allocator);
+            try tree.manifest.init(allocator, node_pool, config);
+            errdefer tree.manifest.deinit(allocator);
 
-            var compactions: [constants.lsm_levels]Compaction = undefined;
-
-            for (0..compactions.len) |i| {
-                errdefer for (compactions[0..i]) |*c| c.deinit();
-                compactions[i] = try Compaction.init(config, grid, @intCast(i));
+            for (0..tree.compactions.len) |i| {
+                errdefer for (tree.compactions[0..i]) |*c| c.deinit();
+                tree.compactions[i] = try Compaction.init(config, grid, @intCast(i));
             }
-            errdefer for (compactions) |*c| c.deinit();
-
-            return Tree{
-                .grid = grid,
-                .config = config,
-                .options = options,
-                .table_mutable = table_mutable,
-                .table_immutable = table_immutable,
-                .manifest = manifest,
-                .compactions = compactions,
-            };
+            errdefer for (tree.compactions) |*c| c.deinit();
         }
 
         pub fn deinit(tree: *Tree, allocator: mem.Allocator) void {

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -259,7 +259,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.grid.open(grid_open_callback);
 
             env.tick_until_state_change(.free_set_open, .tree_init);
-            env.tree = try Tree.init(allocator, &env.node_pool, &env.grid, .{
+            try env.tree.init(allocator, &env.node_pool, &env.grid, .{
                 .id = 1,
                 .name = "Key.Value",
             }, .{

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -110,6 +110,14 @@ pub fn StateMachineType(
                     .code = 17,
                     .timestamp = 18,
                     .expires_at = 19,
+                    .place_holder_1 = 23,
+                    .place_holder_2 = 24,
+                    .place_holder_3 = 25,
+                    .place_holder_4 = 26,
+                    .place_holder_5 = 27,
+                    .place_holder_6 = 28,
+                    .place_holder_7 = 29,
+                    .place_holder_8 = 30,
                 };
 
                 pub const transfers_pending = .{
@@ -232,6 +240,55 @@ pub fn StateMachineType(
                             return 0;
                         }
                     }.expires_at,
+                    // Adding dummy indexes:
+                    .place_holder_1 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_2 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_3 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_4 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_5 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_6 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_7 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
+                    .place_holder_8 = struct {
+                        fn action(object: *const Transfer) u64 {
+                            _ = object;
+                            return 1;
+                        }
+                    }.action,
                 },
             },
         );
@@ -2623,6 +2680,14 @@ pub fn StateMachineType(
                 ledger: u32,
                 code: u32,
                 expires_at: u32,
+                place_holder_1: u32,
+                place_holder_2: u32,
+                place_holder_3: u32,
+                place_holder_4: u32,
+                place_holder_5: u32,
+                place_holder_6: u32,
+                place_holder_7: u32,
+                place_holder_8: u32,
             },
             transfers_pending: struct {
                 timestamp: u32,
@@ -2664,6 +2729,14 @@ pub fn StateMachineType(
                     .ledger = batch_create_transfers,
                     .code = batch_create_transfers,
                     .expires_at = batch_create_transfers,
+                    .place_holder_1 = batch_create_transfers,
+                    .place_holder_2 = batch_create_transfers,
+                    .place_holder_3 = batch_create_transfers,
+                    .place_holder_4 = batch_create_transfers,
+                    .place_holder_5 = batch_create_transfers,
+                    .place_holder_6 = batch_create_transfers,
+                    .place_holder_7 = batch_create_transfers,
+                    .place_holder_8 = batch_create_transfers,
                 },
                 .transfers_pending = .{
                     // Objects are mutated when the pending transfer is posted/voided/expired.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -512,13 +512,27 @@ pub fn StateMachineType(
 
         tracer_slot: ?tracer.SpanStart = null,
 
-        pub fn init(allocator: mem.Allocator, grid: *Grid, options: Options) !StateMachine {
+        pub fn init(
+            self: *StateMachine,
+            allocator: mem.Allocator,
+            grid: *Grid,
+            options: Options,
+        ) !void {
             assert(options.batch_size_limit <= config.message_body_size_max);
             inline for (comptime std.enums.values(Operation)) |operation| {
                 assert(options.batch_size_limit >= @sizeOf(Event(operation)));
             }
 
-            var forest = try Forest.init(
+            self.* = .{
+                .batch_size_limit = options.batch_size_limit,
+                .prefetch_timestamp = 0,
+                .prepare_timestamp = 0,
+                .commit_timestamp = 0,
+                .forest = undefined,
+                .scan_lookup_buffer = undefined,
+            };
+
+            try self.forest.init(
                 allocator,
                 grid,
                 .{
@@ -527,21 +541,12 @@ pub fn StateMachineType(
                 },
                 forest_options(options),
             );
-            errdefer forest.deinit(allocator);
+            errdefer self.forest.deinit(allocator);
 
-            const scan_lookup_buffer = try allocator.alignedAlloc(u8, 16, @max(
+            self.scan_lookup_buffer = try allocator.alignedAlloc(u8, 16, @max(
                 constants.batch_max.get_account_transfers * @sizeOf(Transfer),
                 constants.batch_max.get_account_balances * @sizeOf(AccountBalancesGrooveValue),
             ));
-
-            return StateMachine{
-                .batch_size_limit = options.batch_size_limit,
-                .prefetch_timestamp = 0,
-                .prepare_timestamp = 0,
-                .commit_timestamp = 0,
-                .forest = forest,
-                .scan_lookup_buffer = scan_lookup_buffer,
-            };
         }
 
         pub fn deinit(self: *StateMachine, allocator: mem.Allocator) void {
@@ -3029,7 +3034,7 @@ const TestContext = struct {
         });
         errdefer ctx.grid.deinit(allocator);
 
-        ctx.state_machine = try StateMachine.init(allocator, &ctx.grid, .{
+        try ctx.state_machine.init(allocator, &ctx.grid, .{
             .batch_size_limit = message_body_size_max,
             .lsm_forest_compaction_block_count = StateMachine.Forest.Options
                 .compaction_block_count_min,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -109,10 +109,21 @@ pub fn StateMachineType(
         prefetch_context: ThingGroove.PrefetchContext = undefined,
         callback: ?*const fn (state_machine: *StateMachine) void = null,
 
-        pub fn init(allocator: std.mem.Allocator, grid: *Grid, options: Options) !StateMachine {
+        pub fn init(
+            self: *StateMachine,
+            allocator: std.mem.Allocator,
+            grid: *Grid,
+            options: Options,
+        ) !void {
+            self.* = StateMachine{
+                .options = options,
+                .forest = undefined,
+            };
+
             const things_cache_entries_max =
                 ThingGroove.ObjectsCache.Cache.value_count_max_multiple;
-            var forest = try Forest.init(
+
+            try self.forest.init(
                 allocator,
                 grid,
                 .{
@@ -130,12 +141,7 @@ pub fn StateMachineType(
                     },
                 },
             );
-            errdefer forest.deinit(allocator);
-
-            return StateMachine{
-                .options = options,
-                .forest = forest,
-            };
+            errdefer self.forest.deinit(allocator);
         }
 
         pub fn deinit(state_machine: *StateMachine, allocator: std.mem.Allocator) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1078,7 +1078,7 @@ pub fn ReplicaType(
             }
             errdefer for (self.grid_repair_write_blocks) |b| allocator.free(b);
 
-            self.state_machine = try StateMachine.init(
+            try self.state_machine.init(
                 allocator,
                 &self.grid,
                 options.state_machine_options,


### PR DESCRIPTION
PoC: Just for running GHA

Added 8 dummy indexes to force [stack overflow](https://github.com/tigerbeetle/tigerbeetle/actions/runs/10547365124/job/29219958195) (the Forest object is ~608KiB and the StateMachine 717KiB).

This is an alternative to #2242. However, this is a different (and simpler) approach, avoiding copying and preventing stack allocation of local objects by changing the init signature to take the object's pointer.

While the overall object size remains the same (e.g., Forest is still ~608KiB), this solution is even more flexible, allowing the caller to choose whether to allocate it on the stack or the heap. The initialization is guaranteed to preserve stack size, avoiding both copying and moving data around.