### PR TITLE
io: print less confusing error message if IO_uring is not available

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -40,6 +40,19 @@ pub const IO = struct {
             @panic("Linux kernel 5.5 or greater is required for io_uring OP_ACCEPT");
         }
 
+        errdefer |err| switch (err) {
+            error.SystemOutdated => {
+                log.err("io_uring is not available", .{});
+                log.err("likely cause: the syscall is disabled by seccomp", .{});
+            },
+            error.PermissionDenied => {
+                log.err("io_uring is not available", .{});
+                log.err("likely cause: the syscall is disabled by sysctl, " ++
+                    "try 'sysctl -w kernel.io_uring_disabled=0'", .{});
+            },
+            else => {},
+        };
+
         return IO{ .ring = try IO_Uring.init(entries, flags) };
     }
 


### PR DESCRIPTION
When IO_uring is disabled (eg, by default in docker), kernel returns `ENOSYS`, and Zig converts that to `SystemOutdated`. This is misleading --- the system might be perfectly up-to-date, and the io_uring just disabled by _some_ security policy.

As we have an explicit version check above, it is most likely that `SystemOutdated` means security stuff, so print an appropriate error message.

I wish I could point the user at a _specific_ security policy, but it looks like there are at least two ways to disable io_uring:

* via seccomp
* via systcl https://lwn.net/Articles/937013/

related: #2241