### PR TITLE
vopr: heal *both* wal header sectors before replica startup

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1041,8 +1041,8 @@ pub const Simulator = struct {
             // If the entire Zone.wal_headers is corrupted, the replica becomes permanently
             // unavailable (returns `WALInvalid` from `open`). In the simulator, there are only two
             // WAL sectors, which could both get corrupted when a replica crashes while writing them
-            // simultaneously. To keep the replica operational, arbitrarily repair one of the
-            // sectors.
+            // simultaneously. Repair both sectors so that even if one of them becomes corrupted on
+            // startup, the replica still remains operational.
             //
             // In production `journal_iops_write_max < header_sector_count`, which makes is
             // impossible to get torn writes for all journal header sectors at the same time.
@@ -1050,14 +1050,8 @@ pub const Simulator = struct {
                 @divExact(vsr.Zone.wal_headers.start(), constants.sector_size);
             const header_sector_count =
                 @divExact(constants.journal_size_headers, constants.sector_size);
-            var header_sector_count_faulty: u32 = 0;
             for (0..header_sector_count) |header_sector_index| {
-                header_sector_count_faulty += @intFromBool(replica_storage.faults.isSet(
-                    header_sector_offset + header_sector_index,
-                ));
-            }
-            if (header_sector_count_faulty == header_sector_count) {
-                replica_storage.faults.unset(header_sector_offset);
+                replica_storage.faults.unset(header_sector_offset + header_sector_index);
             }
         }
 


### PR DESCRIPTION
Solves failing VOPR seed (`./zig/zig build -Drelease vopr -- 11017357084674077446`) on main (https://github.com/tigerbeetle/tigerbeetle/commit/3792676416b3fb33feadee6720dd795cf181a83d). 

Our [current logic](https://github.com/tigerbeetle/tigerbeetle/blob/56193862533052b686396f521298920812f75d9d/src/vopr.zig#L1049-L1061) arbitrarily repairs one WAL header sectors if _both_ sectors are corrupt. This doesn't account for the following cases that could also lead to `open` returning `WALInvalid`:
* Only one of the WAL header sectors is corrupt and the other one is corrupted on startup (what happened in the current failing seed)
* The sector that is arbitrarily repaired is corrupted again on startup

Instead of arbitrarily repairing one sector, we now repair _both_ sectors so that even if one of them corrupted on startup, the replica still remains operational.
