### PR TITLE
ci: use changelog as the source of truth for version information

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
 
       - run: ./zig/download.sh
-      - run: ./zig/zig build scripts -- release --build --publish --run-number=${{ github.run_number }} --sha=${{ github.sha }}
+      - run: ./zig/zig build scripts -- release --build --publish --sha=${{ github.sha }}
         env:
           NUGET_KEY: ${{ secrets.NUGET_KEY }}
           TIGERBEETLE_GO_PAT: ${{ secrets.TIGERBEETLE_GO_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 src/clients/c/lib
-dist/
 /tigerbeetle
 /tigerbeetle.exe
 *_*.tigerbeetle.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-# TigerBeetle Changelog
+# Changelog
 
 Subscribe to the [tracking issue #2231](https://github.com/tigerbeetle/tigerbeetle/issues/2231)
 to receive notifications about breaking changes!
 
-## 2024-08-26 (No release: Queued up to improve indexing flags)
+## TigerBeetle (unreleased)
+
+Released: 2024-08-26
 
 ### Safety And Performance
 
@@ -64,7 +66,9 @@ to receive notifications about breaking changes!
 
 - [Used To Love Her](https://www.youtube.com/watch?v=FDIvIb06abI)
 
-## 2024-08-19
+## TigerBeetle 0.15.6
+
+Released: 2024-08-19
 
 ### Safety And Performance
 
@@ -108,7 +112,9 @@ to receive notifications about breaking changes!
 
 - [End of the Line](https://www.youtube.com/watch?v=UMVjToYOjbM)
 
-## 2024-08-12
+## TigerBeetle 0.15.5
+
+Released 2024-08-12
 
 Highlight of this release is fully rolled-out support for multiversion binaries. This means that,
 from now on, the upgrade procedure is going to be as simple as dropping the new version of

--- a/docs/about/internals/releases.md
+++ b/docs/about/internals/releases.md
@@ -4,94 +4,154 @@ sidebar_position: 6
 
 # Releases
 
-How a new TigerBeetle release is made. Note that the process is being established, so this document
-might not perfectly reflect reality just yet.
+How a new TigerBeetle release is made. Note that the process is being
+established, so this document might not perfectly reflect reality just yet.
 
 ## What Is a Release?
 
 TigerBeetle is distributed in binary form. There are two main reasons for this:
 
-- to ensure correctness and rule out large classes of configuration errors, the actual machine code
-  must be tested.
-- Zig is not stable yet. Binary releases insulate the users from this instability and keep the
-  language as an implementation detail.
+- to ensure correctness and rule out large classes of configuration errors, the
+  actual machine code must be tested.
+- Zig is not stable yet. Binary releases insulate the users from this
+  instability and keep the language as an implementation detail.
 
-TigerBeetle binary is released in lockstep with client libraries. At the moment, implementation
-of the client libraries is tightly integrated and shares code with TigerBeetle, requiring matching
-versions.
+TigerBeetle binary is released in lockstep with client libraries. At the moment,
+implementation of the client libraries is tightly integrated and shares code
+with TigerBeetle, requiring matching versions.
 
-Canonical form of the "release" is a `dist/` folder with the following artifacts:
+Canonical form of the "release" is a `dist/` folder with the following
+artifacts:
 
-- `tigerbeetle/` subdirectory with `.zip` archived `tigerbeetle` binaries built for all supported
-  architectures.
+- `tigerbeetle/` subdirectory with `.zip` archived `tigerbeetle` binaries built
+  for all supported architectures.
 - `dotnet/` subdirectory with a Nuget package.
-- `go/` subdirectory with the source code of the go client and precompiled native libraries for
-  all supported platforms.
+- `go/` subdirectory with the source code of the go client and precompiled
+  native libraries for all supported platforms.
 - `java/` subdirectory with a `.jar` file.
 - `node/` subdirectory with a `.tgz` package for npm.
 
 ## Publishing
 
-Release artifacts are uploaded to appropriate package registries. GitHub release is used for
-synchronization:
+Release artifacts are uploaded to appropriate package registries. GitHub release
+is used for synchronization:
 
 - a draft release is created at the start of the publishing process,
-- artifacts are uploaded to GitHub releases, npm, Maven Central, and Nuget. For Go, a new commit
-  is pushed to <https://github.com/tigerbeetle/tigerbeetle-go>
-- if publishing to all registries were successfully, the release is marked as non-draft.
+- artifacts are uploaded to GitHub releases, npm, Maven Central, and Nuget. For
+  Go, a new commit is pushed to <https://github.com/tigerbeetle/tigerbeetle-go>
+- if publishing to all registries were successfully, the release is marked as
+  non-draft.
 
 All publishing keys are stored as GitHub Actions in the `release` environment.
 
 ## Versioning
 
-Because releases are frequent, we avoid specifying the version in the source code. Instead, the
-version is setup automatically by the release process itself, using sequential build numbers as the
-patch version. It might the case that a particular version is skipped (e.g., if a release partially
-failed). It is also a possibility that two releases are functionally identical (this means that no
-pull requests were merged in a week).
+Because releases are frequent, we avoid specifying the version in the source
+code. The source of truth for version is the CHANGELOG.md file. The version at
+the top becomes the version of the new release.
 
-## Release Process
-
-Releases are triggered manually, on Monday. Default release rotation is on the devhub:
-<https://tigerbeetle.github.io/tigerbeetle/>.
-
-The middle name is the default release manager for the _current_ week. After the release, please
-ping the next person to pass the baton.
-
-Before triggering a release, update CHANGELOG.md with the changes since the last release. Run the
-following command to create a release branch and generate changelog skeleton:
-
-```console
-$ ./zig/zig build scripts -- changelog
-```
-
-After the changelog PR is merged, trigger a release  by pushing a commit from `origin/main` to
-`origin/release`:
-
-```console
-$ git fetch origin && git push origin origin/main:release
-```
-
-This triggers the `release.yml` workflow. The workflow doesn't run unit-tests,
-[not rocket science](https://graydon2.dreamwidth.org/1597.html) rule is assumed. The workflow
-requires an approval of at least one other person.
-
-If the release manager isn't available on Monday, a volunteer picks up that release. Releases can be
-skipped if there are not enough people to make a release (at least two are required) or if there
-aren't any changes in a given week.
-
-## Changelog Guidelines
+## Changelog
 
 Purposes of the changelog:
 
 - For everyone: give project a visible "pulse".
-- For TigerBeetle developers: tell fine grained project evolution story, form shared context,
-  provide material for the monthly newsletter.
-- For TigerBeetle users: inform about all visible and potentially relevant changes.
+- For TigerBeetle developers: tell fine grained project evolution story, form
+  shared context, provide material for the monthly newsletter.
+- For TigerBeetle users: inform about all visible and potentially relevant
+  changes.
 
 As such:
 
 - Consider skipping over trivial changes in the changelog.
-- Don't skip over meaningful changes of the internals, even if they are not externally visible.
+- Don't skip over meaningful changes of the internals, even if they are not
+  externally visible.
 - If there is a story behind a series of pull requests, tell it.
 - And don't forget the TigerTrack of the week!
+
+## Release Logistics
+
+Releases are triggered manually, on Monday. Default release rotation is on the
+devhub: <https://tigerbeetle.github.io/tigerbeetle/>.
+
+The middle name is the default release manager for the _current_ week. They should execute [Release
+Manager Algorithm](#release-manager-algorithm) on Monday. If the release manager isn't available on
+Monday, a volunteer picks up that release.
+
+## Skipping Release
+
+Because releases are frequent, it is not a problem to skip a single release. In fact, allowing to
+easily skip a release is one of the explicit purposes of the present process.
+
+If there's any pull request that we feel pressured should land in the next release, the default
+response is to land the PR under its natural pace, and skip the release instead.
+
+Similarly, if there's a question of whether we should do a release or to skip one, the default
+answer is to skip. Skipping is cheap!
+
+If the release is skipped, the changelog is still written and merged on Monday, using the following
+header: `## TigerBeetle (unreleased)`.
+
+When the next real release happens, it should merge all the previously unreleased changes into a
+single versioned changelog entry, to inform users making upgrades.
+
+## Release Manager Algorithm
+
+1. Open [devhub](https://tigerbeetle.github.io/tigerbeetle/) to check that:
+   - you are the release manager for the week
+   - that the vopr results look reasonable (no failures and a bunch of successful runs for recent
+     commits)
+
+2. ```console
+   $ ./zig/zig build scripts -- changelog
+   ```
+   This will update local repository to match remote, create a branch for changelog PR, and add a
+   scaffold of the new changelog to CHANGELOG.md. Importantly, the scaffold will contain a new
+   version number with patch version incremented:
+
+   ```
+   ## TigerBeetle 0.16.3   <- Double check this version.
+
+    Released 2024-08-29
+
+    - [#2256](https://github.com/tigerbeetle/tigerbeetle/pull/2256)
+          Build: Check zig version
+    - [#2248](https://github.com/tigerbeetle/tigerbeetle/pull/2248)
+          vopr: heal *both* wal header sectors before replica startup
+
+    ### Safety And Performance
+
+    -
+
+    ### Features
+
+    -
+
+    ### Internals
+
+    -
+
+    ### TigerTracks 🎧
+
+    - []()
+    ```
+
+    If the current release is being skipped, replace the header with `## TigerBeetle (unreleased)`.
+
+3. Fill in the changelog:
+   - categorize pull requests into three buckets.
+   - drop minor pull requests
+   - group related PRs into a single bullet point
+   - double-check that the version looks right
+   - if there are any big features in the release, write about them in the lead paragraph.
+   - pick the tiger track!
+
+4. Commit the changelog and submit a pull request for review
+
+5. After the PR is merged, push to the `release` branch:
+
+   ```console
+   $ git fetch origin && git push origin origin/main:release
+   ```
+6. Ask someone else to approve the GitHub workflow.
+
+7. Ping release manager for the next week in Slack.

--- a/src/scripts/changelog.zig
+++ b/src/scripts/changelog.zig
@@ -4,6 +4,8 @@ const assert = std.debug.assert;
 const stdx = @import("../stdx.zig");
 const Shell = @import("../shell.zig");
 
+const Release = @import("../multiversioning.zig").Release;
+
 const log = std.log;
 
 pub fn main(shell: *Shell, gpa: std.mem.Allocator) !void {
@@ -53,17 +55,32 @@ fn format_changelog(buffer: std.ArrayList(u8).Writer, options: struct {
         return error.ChangelogAlreadyUpdated;
     }
 
+    var it = ChangelogIterator.init(options.changelog_current);
+    const last_changelog_entry = it.next_changelog().?;
+
     try buffer.print(
-        \\# TigerBeetle Changelog
+        \\# Changelog
         \\
-        \\## {s}
+        \\Subscribe to the [tracking issue #2231](https://github.com/tigerbeetle/tigerbeetle/issues/2231)
+        \\to receive notifications about breaking changes!
         \\
         \\
-    , .{options.today});
+    , .{});
+
+    if (last_changelog_entry.release) |release| {
+        const release_next = Release.from(.{
+            .major = release.triple().major,
+            .minor = release.triple().minor,
+            .patch = release.triple().patch + 1,
+        });
+        try buffer.print("## TigerBeetle {}\n\n", .{release_next});
+    } else {
+        try buffer.print("## TigerBeetle (unreleased)\n\n", .{});
+    }
+    try buffer.print("Released {s}\n\n", .{options.today});
 
     var merges_left = options.merges;
-    // TODO Shrink this down after we release again.
-    for (0..512) |_| {
+    for (0..128) |_| {
         const merge = try format_changelog_cut_single_merge(&merges_left) orelse break;
 
         try buffer.print(
@@ -95,12 +112,7 @@ fn format_changelog(buffer: std.ArrayList(u8).Writer, options: struct {
         \\
     , .{});
 
-    const changelog_rest = stdx.cut(
-        options.changelog_current,
-        "# TigerBeetle Changelog\n\n",
-    ) orelse return error.ParseChangelog;
-
-    try buffer.writeAll(changelog_rest.suffix);
+    try buffer.writeAll(it.all_entries);
 }
 
 fn format_changelog_cut_single_merge(merges_left: *[]const u8) !?struct {
@@ -137,4 +149,139 @@ fn format_changelog_cut_single_merge(merges_left: *[]const u8) !?struct {
     merges_left.* = cut.suffix;
 
     return .{ .pr = pr, .summary = summary };
+}
+
+pub const ChangelogIterator = struct {
+    const Entry = struct {
+        release: ?Release,
+        text_full: []const u8,
+        text_body: []const u8,
+    };
+
+    // Immutable suffix of the changelog, used to prepend a new entry in front.
+    all_entries: []const u8,
+
+    // Mutable suffix of what's yet to be iterated.
+    rest: []const u8,
+
+    release_previous: ?Release = null,
+
+    pub fn init(changelog: []const u8) ChangelogIterator {
+        var rest = stdx.cut_prefix(changelog, "# Changelog\n\n").?;
+        const start_index = std.mem.indexOf(u8, rest, "##").?;
+        assert(rest[start_index - 1] == '\n');
+        rest = rest[start_index..];
+        assert(std.mem.startsWith(u8, rest, "## TigerBeetle"));
+
+        return .{
+            .all_entries = rest,
+            .rest = rest,
+        };
+    }
+
+    pub fn next_changelog(it: *ChangelogIterator) ?Entry {
+        if (it.done()) return null;
+        assert(std.mem.startsWith(u8, it.rest, "## TigerBeetle"));
+        const entry_end_index = std.mem.indexOf(u8, it.rest[2..], "\n\n## ").? + 2;
+        const text_full = it.rest[0 .. entry_end_index + 1];
+        it.rest = it.rest[entry_end_index + 2 ..];
+        const entry = parse_entry(text_full);
+
+        if (it.release_previous != null and entry.release != null) {
+            assert(Release.less_than({}, it.release_previous.?, entry.release.?));
+        }
+        if (entry.release != null) {
+            it.release_previous = entry.release;
+        }
+
+        return entry;
+    }
+
+    fn done(it: *const ChangelogIterator) bool {
+        // First old-style release.
+        return std.mem.startsWith(u8, it.rest, "## 2024-08-05");
+    }
+
+    fn parse_entry(text_full: []const u8) Entry {
+        assert(std.mem.startsWith(u8, text_full, "## TigerBeetle"));
+        assert(std.mem.endsWith(u8, text_full, "\n"));
+        assert(!std.mem.endsWith(u8, text_full, "\n\n"));
+
+        const first_line, var body = stdx.cut(text_full, "\n").?.unpack();
+        const release = if (std.mem.eql(u8, first_line, "## TigerBeetle (unreleased)"))
+            null
+        else
+            Release.parse(stdx.cut_prefix(first_line, "## TigerBeetle ").?) catch
+                @panic("invalid changelog");
+
+        body = stdx.cut_prefix(body, "\nReleased:").?;
+        _, body = stdx.cut(body, "\n").?.unpack();
+        return .{ .release = release, .text_full = text_full, .text_body = body };
+    }
+};
+
+test ChangelogIterator {
+    const changelog =
+        \\# Changelog
+        \\
+        \\Some preamble here
+        \\
+        \\## TigerBeetle 1.2.3
+        \\
+        \\Released 2024-10-23
+        \\
+        \\This is the start of the changelog.
+        \\
+        \\### Features
+        \\
+        \\- a cool PR
+        \\
+        \\## TigerBeetle 1.2.2
+        \\
+        \\Released 2024-10-16
+        \\
+        \\ The beginning.
+        \\
+        \\## 2024-08-05 (prehistory)
+        \\
+        \\
+    ;
+
+    var it = ChangelogIterator.init(changelog);
+
+    var entry = it.next_changelog().?;
+    try std.testing.expectEqual(entry.release.?.triple(), .{
+        .major = 1,
+        .minor = 2,
+        .patch = 3,
+    });
+    try std.testing.expectEqualStrings(entry.text_full,
+        \\## TigerBeetle 1.2.3
+        \\
+        \\Released 2024-10-23
+        \\
+        \\This is the start of the changelog.
+        \\
+        \\### Features
+        \\
+        \\- a cool PR
+        \\
+    );
+    try std.testing.expectEqualStrings(entry.text_body,
+        \\This is the start of the changelog.
+        \\
+        \\### Features
+        \\
+        \\- a cool PR
+        \\
+    );
+
+    entry = it.next_changelog().?;
+    try std.testing.expectEqual(entry.release.?.triple(), .{
+        .major = 1,
+        .minor = 2,
+        .patch = 2,
+    });
+
+    try std.testing.expectEqual(it.next_changelog(), null);
 }

--- a/src/scripts/changelog.zig
+++ b/src/scripts/changelog.zig
@@ -9,7 +9,11 @@ const log = std.log;
 pub fn main(shell: *Shell, gpa: std.mem.Allocator) !void {
     _ = gpa;
 
-    const today = try date_iso(shell);
+    const now_utc = stdx.DateTimeUTC.now();
+    const today = try shell.fmt(
+        "{:0>4}-{:0>2}-{:0>2}",
+        .{ now_utc.year, now_utc.month, now_utc.day },
+    );
 
     try shell.exec("git fetch origin --quiet", .{});
     try shell.exec("git switch --create release-{today} origin/main", .{ .today = today });
@@ -133,8 +137,4 @@ fn format_changelog_cut_single_merge(merges_left: *[]const u8) !?struct {
     merges_left.* = cut.suffix;
 
     return .{ .pr = pr, .summary = summary };
-}
-
-fn date_iso(shell: *Shell) ![]const u8 {
-    return try shell.exec_stdout("date --iso", .{});
 }

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -34,11 +34,8 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
     const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;
     try shell.project_root.deleteFile("tigerbeetle");
 
-    // The build script needs a run number that's newer than the current published release for
-    // multiversion binaries. Pick 255 as the largest supported run number (for now, it's a u8),
-    // that's higher than what the real release run number will be currently (~200).
     try shell.zig(
-        \\build scripts -- release --build --run-number=255 --sha={sha}
+        \\build scripts -- release --build --no-changelog --sha={sha}
         \\    --language=zig
     , .{ .sha = cli_args.sha });
     try shell.project_root.deleteFile("tigerbeetle");

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -161,6 +161,10 @@ pub fn zeroed(bytes: []const u8) bool {
 const Cut = struct {
     prefix: []const u8,
     suffix: []const u8,
+
+    pub fn unpack(self: Cut) struct { []const u8, []const u8 } {
+        return .{ self.prefix, self.suffix };
+    }
 };
 
 /// Splits the `haystack` around the first occurrence of `needle`, returning parts before and after.


### PR DESCRIPTION
As of this PR, we no longer rely on the finnicky `--run-number` set by
GitHub actions to determine the release number, and instead parse out
CHANGELOG.md to learn our version.

The version is updated (by the changelog generating script) when a new
changelog is prepared.

I also refreshed our release instructions!