### PR TITLE
vsr: primary rejects prepares if log_view is not durable

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3901,7 +3901,9 @@ pub fn ReplicaType(
             assert(self.commit_min == self.commit_prepare.?.header.op);
             assert(self.commit_min <= self.commit_max);
 
-            if (self.status == .normal and self.primary() and !self.view_durable_updating()) {
+            if (self.status == .normal and self.primary()) {
+                assert(!self.view_durable_updating());
+
                 if (self.pipeline.queue.pop_request()) |request| {
                     // Start preparing the next request in the queue (if any).
                     self.primary_pipeline_prepare(request);


### PR DESCRIPTION
### Problem
Solves a failed VOPR seed (./zig/zig build -Drelease -Dvopr-log=full vopr -- --lite 9087327468587795673) on main(140c7a03d9b6e6ad0a85c46f0b93c597e98f3a95) wherein a primary accepting prepares before making its log_view durable exposes a break in its hash chain.

 A _failing_ replica test that reproduces this issue on a more recent commit on main (aea9cbf1391768c78f35fe31988187119383903e) is in the following GitHub gist: https://gist.github.com/chaitanyabhandari/4a64e74cd90d778d1560d3d327ac4f64

### Solution

The solution entails rejecting prepares on the primary if its view isn't durable. Turns out this piece of code already exists for solo clusters, this PR enables it for primaries in all cases. 
 

### Triggering conditions

1. R1 becomes primary in view=1, initiates writing log_view=1 to the superblock
2. R1 prepares op=1,2,3, and 4.
3. R1 crashes before log_view becomes durable.
4. R1 restarts with self.log_view=0 and truncates op=1,2,3 and 4 as per [case_cut_view_range](https://github.com/tigerbeetle/tigerbeetle/blob/main/src/vsr/journal.zig#L1335-L1345) in journal recovery. R1 sets self.op=0.
5. R1 becomes primary for view=1, successfully writes log_view=1 to the superblock.
6. R1 prepares op=1, replacing the old op=1 in its journal.
7. R1 crashes and restarts with self.log_view=1 and treats op=2,3, and 4 as case [@G ](https://github.com/tigerbeetle/tigerbeetle/blob/main/src/vsr/journal.zig#L2192-L2197)in journal recovery.
8. R1 loads ops=1,2,3, and 4 from the journal into its view headers in [view_change_update_view_headers](https://github.com/tigerbeetle/tigerbeetle/blob/main/src/vsr/replica.zig#L8503)

This exposes a break in the hash chain, since op=2 points to the older op=1 that is prepared, while the journal contains a new op=1 with a different checksum.