### PR TITLE
vsr: prefer wal repair over state sync

### DIFF
--- a/src/testing/marks.zig
+++ b/src/testing/marks.zig
@@ -63,6 +63,17 @@ pub const Mark = struct {
             return error.MarkNotHit;
         }
     }
+
+    pub fn expect_not_hit(mark: Mark) !void {
+        comptime assert(builtin.is_test);
+        assert(global_state.mark_name.?.ptr == mark.name.ptr);
+        defer global_state = .{};
+
+        if (global_state.mark_hit_count != 0) {
+            std.debug.print("mark '{s}' hit", .{mark.name});
+            return error.MarkHit;
+        }
+    }
 };
 
 pub fn check(name: []const u8) Mark {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -471,9 +471,10 @@ test "Cluster: repair: partition 2-1, then backup fast-forward 1 checkpoint" {
     try expectEqual(r_lag.status(), .normal);
     try expectEqual(r_lag.op_checkpoint(), 0);
 
-    // Allow repair, but ensure that state sync doesn't run.
-    r_lag.drop(.__, .bidirectional, .sync_checkpoint);
+    // Allow repair, but check that state sync doesn't run.
+    const mark = marks.check("sync started");
     t.run();
+    try mark.expect_not_hit();
 
     try expectEqual(t.replica(.R_).status(), .normal);
     try expectEqual(t.replica(.R_).op_checkpoint(), checkpoint_1);


### PR DESCRIPTION
New state sync protocol regressed the behavior where the replica would try to repair WAL switching to state sync, and this commit puts the old behavior back in.

Good thing that we have a test here! Sadly, the test was silently regressed as it didn't actually check that the state sync didn't happen. Mark the relevant logs to pin down the behavior!

As for the actual fix, it centers on the `repair_stuck` function. Before, it was a stateless function. My original thinking was that we will only get an SV message in response to our own RSV, and, given that we have a repair_sync_timeout when requesting an SV, there should be natural debouncing here.

What I didn't consider are the two other paths to send an RSV:

* when receiving a message from a newer view
* in `.repair()` when our head is < commit_max

So what actually happens is that a lagging replcia joining the cluster would pretty much spam the primary with RSVs anyway, which in turn, would immediately flip the laggard into the state sync.

So, in this PR `repair_stuck` tracks a bit of state. Namely, once every repair_sync_timeout we note our commit_min, and note whether it is _different_ from the one we had before. commit_min being the same across two timeouts becomes another ingredient to decide if the commit is stuck.

This state is tracked in `sync_wal_repair_progress` which is intentionally never reset and only ever updated by the timeout.