### PR TITLE
vsr: correct assert

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2336,7 +2336,7 @@ pub fn ReplicaType(
                 // State sync can "truncate" the first batch of committed ops!
                 maybe(self.commit_min >
                     self.syncing.updating_superblock.checkpoint_state.header.op);
-                assert(self.commit_min < constants.lsm_compaction_ops +
+                assert(self.commit_min <= constants.lsm_compaction_ops +
                     self.syncing.updating_superblock.checkpoint_state.header.op);
 
                 self.commit_min = self.syncing.updating_superblock.checkpoint_state.header.op;


### PR DESCRIPTION
It can be the case that:

* commit_min = checkpoint_trigger
* op_checkpoint = _pervious_ checkpoint
* commit_stage = .idle

This happens if we executed checkpoint trigger, advanced our commit_min, but then got stuck in the subsequent compaction.

Seed: ./zig/zig build  vopr -- --lite 2464843278033237343