### PR TITLE
tidy: follow style guide for CLIArgs name

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -35,7 +35,7 @@ const Target = union(enum) {
     }
 };
 
-const CliArgs = struct {
+const CLIArgs = struct {
     target: []const u8,
     debug: bool = false,
     tigerbeetle_current: ?[]const u8 = null,
@@ -65,7 +65,7 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(gpa);
     defer args.deinit();
 
-    const cli_args = flags.parse(&args, CliArgs);
+    const cli_args = flags.parse(&args, CLIArgs);
 
     const tmp_dir_path = try shell.fmt("{s}/{d}", .{
         cli_args.tmp,

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -39,7 +39,7 @@ pub const std_options = .{
     .log_level = .info,
 };
 
-const CliArgs = union(enum) {
+const CLIArgs = union(enum) {
     memcpy: struct { bytes: u32 },
     funcsize,
 };
@@ -53,7 +53,7 @@ pub fn main() !void {
 
     var args = try std.process.argsWithAllocator(allocator);
 
-    const cli_args = flags.parse(&args, CliArgs);
+    const cli_args = flags.parse(&args, CLIArgs);
 
     const line_buffer = try allocator.alloc(u8, 1024 * 1024);
     const func_buf = try allocator.alloc(u8, 4096);

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -51,7 +51,7 @@ pub fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
 /// Parse CLI arguments for subcommands specified as Zig `struct` or `union(enum)`:
 ///
 /// ```
-/// const CliArgs = union(enum) {
+/// const CLIArgs = union(enum) {
 ///    start: struct { addresses: []const u8, replica: u32 },
 ///    format: struct {
 ///        verbose: bool = false,
@@ -65,16 +65,16 @@ pub fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
 ///        \\ tigerbeetle format [--verbose] <path>
 /// }
 ///
-/// const cli_args = parse_commands(&args, CliArgs);
+/// const cli_args = parse_commands(&args, CLIArgs);
 /// ```
 ///
 /// `positional` field is treated specially, it designates positional arguments.
 ///
 /// If `pub const help` declaration is present, it is used to implement `-h/--help` argument.
-pub fn parse(args: *std.process.ArgIterator, comptime CliArgs: type) CliArgs {
-    comptime assert(CliArgs != void);
+pub fn parse(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
+    comptime assert(CLIArgs != void);
     assert(args.skip()); // Discard executable name.
-    return parse_flags(args, CliArgs);
+    return parse_flags(args, CLIArgs);
 }
 
 fn parse_commands(args: *std.process.ArgIterator, comptime Commands: type) Commands {
@@ -580,7 +580,7 @@ pub usingnamespace if (@import("root") != @This()) struct {
     // For production builds, don't include the main function.
     // This is `if __name__ == "__main__":` at comptime!
 } else struct {
-    const CliArgs = union(enum) {
+    const CLIArgs = union(enum) {
         empty,
         prefix: struct {
             foo: u8 = 0,
@@ -629,7 +629,7 @@ pub usingnamespace if (@import("root") != @This()) struct {
         var args = try std.process.argsWithAllocator(gpa);
         defer args.deinit();
 
-        const cli_args = parse(&args, CliArgs);
+        const cli_args = parse(&args, CLIArgs);
 
         const stdout = std.io.getStdOut();
         const out_stream = stdout.writer();

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -44,7 +44,7 @@ const Fuzzers = .{
 
 const FuzzersEnum = std.meta.FieldEnum(@TypeOf(Fuzzers));
 
-const CliArgs = struct {
+const CLIArgs = struct {
     events_max: ?usize = null,
     positional: struct {
         fuzzer: FuzzersEnum,
@@ -56,7 +56,7 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(fuzz.allocator);
     defer args.deinit();
 
-    const cli_args = flags.parse(&args, CliArgs);
+    const cli_args = flags.parse(&args, CLIArgs);
 
     switch (cli_args.positional.fuzzer) {
         .smoke => {
@@ -105,7 +105,7 @@ fn main_smoke() !void {
     log.info("done in {}", .{std.fmt.fmtDuration(timer_all.lap())});
 }
 
-fn main_single(cli_args: CliArgs) !void {
+fn main_single(cli_args: CLIArgs) !void {
     assert(cli_args.positional.fuzzer != .smoke);
 
     const seed = cli_args.positional.seed orelse std.crypto.random.int(u64);

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -25,14 +25,14 @@ const kcov = @import("./scripts/kcov.zig");
 const changelog = @import("./scripts/changelog.zig");
 const upgrader = @import("./scripts/upgrader.zig");
 
-const CliArgs = union(enum) {
-    cfo: cfo.CliArgs,
-    ci: ci.CliArgs,
-    release: release.CliArgs,
-    devhub: devhub.CliArgs,
-    kcov: kcov.CliArgs,
+const CLIArgs = union(enum) {
+    cfo: cfo.CLIArgs,
+    ci: ci.CLIArgs,
+    release: release.CLIArgs,
+    devhub: devhub.CLIArgs,
+    kcov: kcov.CLIArgs,
     changelog: void,
-    upgrader: upgrader.CliArgs,
+    upgrader: upgrader.CLIArgs,
 
     pub const help =
         \\Usage:
@@ -84,7 +84,7 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(gpa);
     defer args.deinit();
 
-    const cli_args = flags.parse(&args, CliArgs);
+    const cli_args = flags.parse(&args, CLIArgs);
 
     switch (cli_args) {
         .cfo => |args_cfo| try cfo.main(shell, gpa, args_cfo),

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -55,7 +55,7 @@ const flags = @import("../flags.zig");
 const fatal = flags.fatal;
 const Shell = @import("../shell.zig");
 
-pub const CliArgs = struct {
+pub const CLIArgs = struct {
     budget_minutes: u64 = 10,
     hang_minutes: u64 = 30,
     concurrency: ?u32 = null,
@@ -109,7 +109,7 @@ const Fuzzer = enum {
     }
 };
 
-pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     if (builtin.os.tag == .windows) {
         return error.NotSupported;
     }

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -24,12 +24,12 @@ const LanguageCI = .{
     .node = @import("../clients/node/ci.zig"),
 };
 
-pub const CliArgs = struct {
+pub const CLIArgs = struct {
     language: ?Language = null,
     validate_release: bool = false,
 };
 
-pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     if (cli_args.validate_release) {
         try validate_release(shell, gpa, cli_args.language);
     } else {

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -15,11 +15,11 @@ const Shell = @import("../shell.zig");
 
 const log = std.log;
 
-pub const CliArgs = struct {
+pub const CLIArgs = struct {
     sha: []const u8,
 };
 
-pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     _ = gpa;
 
     const commit_timestamp_str =

--- a/src/scripts/kcov.zig
+++ b/src/scripts/kcov.zig
@@ -13,9 +13,9 @@ const Shell = @import("../shell.zig");
 
 const log = std.log;
 
-pub const CliArgs = struct {};
+pub const CLIArgs = struct {};
 
-pub fn main(shell: *Shell, _: std.mem.Allocator, _: CliArgs) !void {
+pub fn main(shell: *Shell, _: std.mem.Allocator, _: CLIArgs) !void {
     const kcov_version = shell.exec_stdout("kcov --version", .{}) catch {
         log.err("can't find kcov", .{});
         std.process.exit(1);

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -33,7 +33,7 @@ const section_to_macho_cpu = multiversioning.section_to_macho_cpu;
 
 const Language = enum { dotnet, go, java, node, zig, docker };
 const LanguageSet = std.enums.EnumSet(Language);
-pub const CliArgs = struct {
+pub const CLIArgs = struct {
     sha: []const u8,
     language: ?Language = null,
     build: bool = false,
@@ -52,7 +52,7 @@ const VersionInfo = struct {
     sha: []const u8,
 };
 
-pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     assert(builtin.target.os.tag == .linux);
     assert(builtin.target.cpu.arch == .x86_64);
     _ = gpa;

--- a/src/scripts/upgrader.zig
+++ b/src/scripts/upgrader.zig
@@ -16,14 +16,14 @@ const flags = @import("../flags.zig");
 const fatal = flags.fatal;
 const Shell = @import("../shell.zig");
 
-pub const CliArgs = struct {
+pub const CLIArgs = struct {
     old: []const u8,
     new: []const u8,
 };
 
 const replica_count = 3;
 
-pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CliArgs) !void {
+pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     _ = gpa;
 
     const seed = std.crypto.random.int(u64);

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -29,7 +29,7 @@ const StateMachine = vsr.state_machine.StateMachineType(
     constants.state_machine_config,
 );
 
-const CliArgs = union(enum) {
+const CLIArgs = union(enum) {
     const Format = struct {
         cluster: u128,
         replica: ?u8 = null,
@@ -365,7 +365,7 @@ const start_defaults_development = StartDefaults{
 const lsm_compaction_block_count_min = StateMachine.Forest.Options.compaction_block_count_min;
 const lsm_compaction_block_memory_min = lsm_compaction_block_count_min * constants.block_size;
 
-/// While CliArgs store raw arguments as passed on the command line, Command ensures that
+/// While CLIArgs store raw arguments as passed on the command line, Command ensures that
 /// arguments are properly validated and desugared (e.g, sizes converted to counts where
 ///  appropriate).
 pub const Command = union(enum) {
@@ -486,7 +486,7 @@ pub const Command = union(enum) {
 /// Parse the command line arguments passed to the `tigerbeetle` binary.
 /// Exits the program with a non-zero exit code if an error is found.
 pub fn parse_args(args_iterator: *std.process.ArgIterator) Command {
-    const cli_args = flags.parse(args_iterator, CliArgs);
+    const cli_args = flags.parse(args_iterator, CLIArgs);
 
     return switch (cli_args) {
         .format => |format| .{ .format = parse_args_format(format) },
@@ -499,7 +499,7 @@ pub fn parse_args(args_iterator: *std.process.ArgIterator) Command {
     };
 }
 
-fn parse_args_format(format: CliArgs.Format) Command.Format {
+fn parse_args_format(format: CLIArgs.Format) Command.Format {
     if (format.replica_count == 0) {
         flags.fatal("--replica-count: value needs to be greater than zero", .{});
     }
@@ -555,7 +555,7 @@ fn parse_args_format(format: CliArgs.Format) Command.Format {
     };
 }
 
-fn parse_args_start(start: CliArgs.Start) Command.Start {
+fn parse_args_start(start: CLIArgs.Start) Command.Start {
     // Allowlist of stable flags. --development will disable automatic multiversion
     // upgrades too, but the flag itself is stable.
     const stable_args = .{
@@ -772,13 +772,13 @@ fn parse_args_start(start: CliArgs.Start) Command.Start {
     };
 }
 
-fn parse_args_version(version: CliArgs.Version) Command.Version {
+fn parse_args_version(version: CLIArgs.Version) Command.Version {
     return .{
         .verbose = version.verbose,
     };
 }
 
-fn parse_args_repl(repl: CliArgs.Repl) Command.Repl {
+fn parse_args_repl(repl: CLIArgs.Repl) Command.Repl {
     const addresses = parse_addresses(repl.addresses);
 
     return .{
@@ -789,7 +789,7 @@ fn parse_args_repl(repl: CliArgs.Repl) Command.Repl {
     };
 }
 
-fn parse_args_benchmark(benchmark: CliArgs.Benchmark) Command.Benchmark {
+fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
     const addresses = if (benchmark.addresses) |addresses|
         parse_addresses(addresses)
     else
@@ -827,7 +827,7 @@ fn parse_args_benchmark(benchmark: CliArgs.Benchmark) Command.Benchmark {
     };
 }
 
-fn parse_args_inspect(inspect: CliArgs.Inspect) Command.Inspect {
+fn parse_args_inspect(inspect: CLIArgs.Inspect) Command.Inspect {
     const path = switch (inspect) {
         inline else => |args| args.positional.path,
     };
@@ -857,7 +857,7 @@ fn parse_args_inspect(inspect: CliArgs.Inspect) Command.Inspect {
     };
 }
 
-fn parse_args_multiversion(multiversion: CliArgs.Multiversion) Command.Multiversion {
+fn parse_args_multiversion(multiversion: CLIArgs.Multiversion) Command.Multiversion {
     return .{
         .path = multiversion.positional.path,
     };

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -67,7 +67,7 @@ pub const tigerbeetle_config = @import("config.zig").configs.test_min;
 
 const cluster_id = 0;
 
-const CliArgs = struct {
+const CLIArgs = struct {
     // "lite" mode runs a small cluster and only looks for crashes.
     lite: bool = false,
     ticks_max_requests: u32 = 40_000_000,
@@ -87,7 +87,7 @@ pub fn main() !void {
     var args = try std.process.argsWithAllocator(allocator);
     defer args.deinit();
 
-    const cli_args = flags.parse(&args, CliArgs);
+    const cli_args = flags.parse(&args, CLIArgs);
 
     const seed_random = std.crypto.random.int(u64);
     const seed = seed_from_arg: {


### PR DESCRIPTION
As per Tiger Style:

>  Do not abbreviate variable names, unless the variable is a primitive
>  integer type used as an argument to a sort function or matrix
>  calculation. Use proper capitalization for acronyms (`VSRState`, not
>  `VsrState`).