### PR TITLE
CI: Don't cancel in-progress actions on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 concurrency:
   group: core-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   merge_group:


### PR DESCRIPTION
Don't cancel in-progress GitHub actions on the `main` branch.

In particular, this ensures that `zig build scripts -- devhub` records the benchmark measurements for every merge to `main`, even if those merges occur in quick succession. (Previous, if 2 PRs were merged within a few minutes of each other, the former would get interrupted, so it wouldn't show up on https://tigerbeetle.github.io/tigerbeetle/).