### PR TITLE
Lightweight Tracing

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -123,6 +123,7 @@ const Environment = struct {
 
     state: State,
     storage: *Storage,
+    trace: vsr.trace.Tracer,
     superblock: SuperBlock,
     superblock_context: SuperBlock.Context,
     grid: Grid,
@@ -134,6 +135,8 @@ const Environment = struct {
     fn init(env: *Environment, storage: *Storage) !void {
         env.storage = storage;
 
+        env.trace = try vsr.trace.Tracer.init(allocator, replica, .{});
+
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = env.storage,
             .storage_size_limit = constants.storage_size_limit_max,
@@ -141,6 +144,7 @@ const Environment = struct {
 
         env.grid = try Grid.init(allocator, .{
             .superblock = &env.superblock,
+            .trace = &env.trace,
             .missing_blocks_max = 0,
             .missing_tables_max = 0,
         });
@@ -158,6 +162,7 @@ const Environment = struct {
     fn deinit(env: *Environment) void {
         env.superblock.deinit(allocator);
         env.grid.deinit(allocator);
+        env.trace.deinit(allocator);
         allocator.free(env.scan_lookup_buffer);
     }
 

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -234,6 +234,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(manifest_log.log_block_checksums.count ==
                 manifest_log.log_block_addresses.count);
 
+            manifest_log.grid.trace.reset(.compact_manifest);
+
             manifest_log.log_block_checksums.clear();
             manifest_log.log_block_addresses.clear();
             for (manifest_log.blocks.buffer) |block| @memset(block, 0);
@@ -668,6 +670,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
             // since we now reserve / forfeit per beat.
             assert((op + 1) % @divExact(constants.lsm_compaction_ops, 2) == 0);
 
+            manifest_log.grid.trace.start(.compact_manifest, .{});
+
             if (op < constants.lsm_compaction_ops or
                 manifest_log.superblock.working.vsr_state.op_compacted(op))
             {
@@ -703,6 +707,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(manifest_log.blocks.count == 0);
             assert(manifest_log.entry_count == 0);
             assert(manifest_log.compact_blocks == null);
+
+            manifest_log.grid.trace.stop(.compact_manifest, .{});
 
             const callback = manifest_log.read_callback.?;
             manifest_log.read_callback = null;
@@ -815,6 +821,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(manifest_log.read_callback != null);
             assert(manifest_log.grid_reservation != null);
             assert(manifest_log.compact_blocks.? == 0);
+
+            manifest_log.grid.trace.stop(.compact_manifest, .{});
 
             const callback = manifest_log.read_callback.?;
             manifest_log.read_callback = null;

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -260,6 +260,8 @@ const Environment = struct {
     allocator: std.mem.Allocator,
     storage: Storage,
     storage_verify: Storage,
+    trace: vsr.trace.Tracer,
+    trace_verify: vsr.trace.Tracer,
     superblock: SuperBlock,
     superblock_verify: SuperBlock,
     superblock_context: SuperBlock.Context,
@@ -294,6 +296,14 @@ const Environment = struct {
         errdefer env.storage_verify.deinit(allocator);
 
         fields_initialized += 1;
+        env.trace = try vsr.trace.Tracer.init(allocator, 0, .{});
+        errdefer env.trace.deinit(allocator);
+
+        fields_initialized += 1;
+        env.trace_verify = try vsr.trace.Tracer.init(allocator, 0, .{});
+        errdefer env.trace_verify.deinit(allocator);
+
+        fields_initialized += 1;
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = &env.storage,
             .storage_size_limit = constants.storage_size_limit_max,
@@ -313,6 +323,7 @@ const Environment = struct {
         fields_initialized += 1;
         env.grid = try Grid.init(allocator, .{
             .superblock = &env.superblock,
+            .trace = &env.trace,
             .missing_blocks_max = 0,
             .missing_tables_max = 0,
         });
@@ -321,6 +332,7 @@ const Environment = struct {
         fields_initialized += 1;
         env.grid_verify = try Grid.init(allocator, .{
             .superblock = &env.superblock_verify,
+            .trace = &env.trace_verify,
             .missing_blocks_max = 0,
             .missing_tables_max = 0,
         });
@@ -355,6 +367,8 @@ const Environment = struct {
         env.grid.deinit(env.allocator);
         env.superblock_verify.deinit(env.allocator);
         env.superblock.deinit(env.allocator);
+        env.trace_verify.deinit(env.allocator);
+        env.trace.deinit(env.allocator);
         env.storage_verify.deinit(env.allocator);
         env.storage.deinit(env.allocator);
         env.* = undefined;
@@ -517,6 +531,7 @@ const Environment = struct {
     /// Verify that the state of a ManifestLog restored from checkpoint matches the state
     /// immediately after the checkpoint was created.
     fn verify(env: *Environment) !void {
+        const test_trace = &env.trace;
         const test_superblock = env.manifest_log_verify.superblock;
         const test_storage = test_superblock.storage;
         const test_grid = env.manifest_log_verify.grid;
@@ -525,6 +540,9 @@ const Environment = struct {
         {
             test_storage.copy(env.manifest_log.superblock.storage);
             test_storage.reset();
+
+            test_trace.deinit(env.allocator);
+            test_trace.* = try vsr.trace.Tracer.init(env.allocator, 0, .{});
 
             // Reset the state so that the manifest log (and dependencies) can be reused.
             // Do not "defer deinit()" because these are cleaned up by Env.deinit().
@@ -540,6 +558,7 @@ const Environment = struct {
             test_grid.deinit(env.allocator);
             test_grid.* = try Grid.init(env.allocator, .{
                 .superblock = test_superblock,
+                .trace = test_trace,
                 .missing_blocks_max = 0,
                 .missing_tables_max = 0,
             });

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -520,6 +520,9 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(snapshot_min > 0);
             assert(snapshot_min < snapshot_latest);
 
+            tree.grid.trace.start(.compact_mutable, .{ .tree = tree.config.name });
+            defer tree.grid.trace.stop(.compact_mutable, .{ .tree = tree.config.name });
+
             // TODO
             // assert((tree.compaction_op.? + 1) % constants.lsm_compaction_ops == 0);
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -145,6 +145,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         state: State,
         storage: *Storage,
+        trace: vsr.trace.Tracer,
         superblock: SuperBlock,
         superblock_context: SuperBlock.Context,
         grid: Grid,
@@ -168,6 +169,9 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.state = .init;
             env.storage = storage;
 
+            env.trace = try vsr.trace.Tracer.init(allocator, replica, .{});
+            defer env.trace.deinit(allocator);
+
             env.superblock = try SuperBlock.init(allocator, .{
                 .storage = env.storage,
                 .storage_size_limit = constants.storage_size_limit_max,
@@ -176,6 +180,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
             env.grid = try Grid.init(allocator, .{
                 .superblock = &env.superblock,
+                .trace = &env.trace,
                 .missing_blocks_max = 0,
                 .missing_tables_max = 0,
             });

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -143,6 +143,9 @@ fn tidy_long_line(file: SourceFile) !?u32 {
 
                 // vsr.zig's Checkpoint ops diagram.
                 if (std.mem.startsWith(u8, string_value, "OPS: ")) continue;
+
+                // trace.zig's JSON snapshot test.
+                if (std.mem.startsWith(u8, string_value, "{\"pid\":0,\"tid\":0,\"cat\":")) continue;
             }
 
             return line_index;

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -145,7 +145,7 @@ fn tidy_long_line(file: SourceFile) !?u32 {
                 if (std.mem.startsWith(u8, string_value, "OPS: ")) continue;
 
                 // trace.zig's JSON snapshot test.
-                if (std.mem.startsWith(u8, string_value, "{\"pid\":0,\"tid\":0,\"cat\":")) continue;
+                if (std.mem.startsWith(u8, string_value, "{\"pid\":0,\"tid\":0,\"ph\":")) continue;
             }
 
             return line_index;

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -17,6 +17,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const ChildProcess = std.process.Child;
 
+const vsr = @import("vsr");
 const cli = @import("./cli.zig");
 const benchmark_load = @import("./benchmark_load.zig");
 
@@ -58,6 +59,10 @@ pub fn main(allocator: std.mem.Allocator, args: *const cli.Command.Benchmark) !v
             .data_file = data_file,
             .args = args,
         });
+    } else {
+        if (args.trace) |_| {
+            vsr.flags.fatal("--trace: incompatible with --addresses", .{});
+        }
     }
 
     const addresses = if (args.addresses) |*addresses|
@@ -150,6 +155,7 @@ fn start(allocator: std.mem.Allocator, options: struct {
         .{ options.args.cache_transfers_pending, "cache-transfers-pending" },
         .{ options.args.cache_account_balances, "cache-account-history" },
         .{ options.args.cache_grid, "cache-grid" },
+        .{ options.args.trace, "trace" },
     };
 
     inline for (forward_args) |forward_arg| {
@@ -162,6 +168,10 @@ fn start(allocator: std.mem.Allocator, options: struct {
                 }),
             );
         }
+    }
+
+    if (options.args.trace) |_| {
+        try start_args.append(arena.allocator(), "--experimental");
     }
 
     try start_args.append(arena.allocator(), options.data_file);

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -67,7 +67,7 @@ const CliArgs = union(enum) {
         cache_account_balances: ?flags.ByteSize = null,
         memory_lsm_manifest: ?flags.ByteSize = null,
         memory_lsm_compaction: ?flags.ByteSize = null,
-        trace: bool = false,
+        trace: ?[:0]const u8 = null,
 
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
         /// to the client. The logic behind this code has been kept as simple as possible -
@@ -396,7 +396,7 @@ pub const Command = union(enum) {
         cache_grid_blocks: u32,
         lsm_forest_compaction_block_count: u32,
         lsm_forest_node_count: u32,
-        trace: bool,
+        trace: ?[:0]const u8,
         development: bool,
         experimental: bool,
         aof: bool,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -67,6 +67,7 @@ const CliArgs = union(enum) {
         cache_account_balances: ?flags.ByteSize = null,
         memory_lsm_manifest: ?flags.ByteSize = null,
         memory_lsm_compaction: ?flags.ByteSize = null,
+        trace: bool = false,
 
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
         /// to the client. The logic behind this code has been kept as simple as possible -
@@ -395,6 +396,7 @@ pub const Command = union(enum) {
         cache_grid_blocks: u32,
         lsm_forest_compaction_block_count: u32,
         lsm_forest_node_count: u32,
+        trace: bool,
         development: bool,
         experimental: bool,
         aof: bool,
@@ -767,6 +769,7 @@ fn parse_args_start(start: CliArgs.Start) Command.Start {
         .lsm_forest_node_count = lsm_forest_node_count,
         .development = start.development,
         .experimental = start.experimental,
+        .trace = start.trace,
         .aof = start.aof,
         .path = start.positional.path,
     };

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -117,6 +117,7 @@ const CliArgs = union(enum) {
         print_batch_timings: bool = false,
         id_order: Command.Benchmark.IdOrder = .sequential,
         statsd: bool = false,
+        trace: ?[:0]const u8 = null,
         /// When set, don't delete the data file when the benchmark completes.
         file: ?[]const u8 = null,
         addresses: ?[]const u8 = null,
@@ -441,6 +442,7 @@ pub const Command = union(enum) {
         print_batch_timings: bool,
         id_order: IdOrder,
         statsd: bool,
+        trace: ?[:0]const u8,
         file: ?[]const u8,
         addresses: ?Addresses,
         seed: ?[]const u8,
@@ -824,6 +826,7 @@ fn parse_args_benchmark(benchmark: CliArgs.Benchmark) Command.Benchmark {
         .print_batch_timings = benchmark.print_batch_timings,
         .id_order = benchmark.id_order,
         .statsd = benchmark.statsd,
+        .trace = benchmark.trace,
         .file = benchmark.file,
         .addresses = addresses,
         .seed = benchmark.seed,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -349,6 +349,8 @@ const Command = struct {
 
         const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
 
+        var stdout_writer = std.io.getStdOut().writer();
+
         var replica: Replica = undefined;
         replica.open(allocator, .{
             .node_count = args.addresses.count_as(u8),
@@ -379,9 +381,7 @@ const Command = struct {
                 .clients_limit = clients_limit,
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
-            .tracer_options = .{
-                .writer = if (args.trace) std.io.getStdOut().writer().any() else null,
-            },
+            .tracer_options = .{ .writer = if (args.trace) stdout_writer.any() else null },
         }) catch |err| switch (err) {
             error.NoAddress => fatal("all --addresses must be provided", .{}),
             else => |e| return e,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -379,6 +379,9 @@ const Command = struct {
                 .clients_limit = clients_limit,
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
+            .tracer_options = .{
+                .writer = if (args.trace) std.io.getStdOut().writer().any() else null,
+            },
         }) catch |err| switch (err) {
             error.NoAddress => fatal("all --addresses must be provided", .{}),
             else => |e| return e,

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -1,0 +1,338 @@
+//! Log IO/CPU event spans for analysis/visualization.
+//!
+//! Example:
+//!
+//!     $ ./tigerbeetle start --experimental --trace ... > trace.json
+//!
+//! The trace JSON output is compatible with:
+//! - https://ui.perfetto.dev/
+//! - https://gravitymoth.com/spall/spall.html
+//! - chrome://tracing/
+//!
+//! Example integrations:
+//!
+//!     // Trace a synchronous event.
+//!     // The second argument is a `anytype` struct, corresponding to the struct argument to
+//!     // `log.debug()`.
+//!     tree.grid.trace.start(.compact_mutable, .{ .tree = tree.config.name });
+//!     defer tree.grid.trace.stop(.compact_mutable, .{ .tree = tree.config.name });
+//!
+//! Note that only one of each Event can be running at a time:
+//!
+//!     // good
+//!     tracer.start(.foo, .{});
+//!     tracer.stop(.foo, .{});
+//!     tracer.start(.bar, .{});
+//!     tracer.stop(.bar, .{});
+//!
+//!     // good
+//!     tracer.start(.foo, .{});
+//!     tracer.start(.bar, .{});
+//!     tracer.stop(.foo, .{});
+//!     tracer.stop(.bar, .{});
+//!
+//!     // bad
+//!     tracer.start(.foo, .{});
+//!     tracer.start(.foo, .{});
+//!
+//!     // bad
+//!     tracer.stop(.foo, .{});
+//!     tracer.start(.foo, .{});
+//!
+//! If an event is is cancelled rather than properly stopped, use .reset():
+//! (Reset is safe to call regardless of whether the event is currently started.)
+//!
+//!     // good
+//!     tracer.start(.foo, .{});
+//!     tracer.reset(.foo);
+//!     tracer.start(.foo, .{});
+//!     tracer.stop(.foo, .{});
+//!
+//! Notes:
+//! - When enabled, traces are written to stdout (as opposed to logs, which are written to stderr).
+//! - The JSON output is a "[" followed by a comma-separated list of JSON objects. The JSON array is
+//!   never closed with a "]", but Chrome, Spall, and Perfetto all handle this.
+//! - Event pairing (start/stop) is asserted at runtime.
+//! - `trace.start()/.stop()/.reset()` will `log.debug()` regardless of whether tracing is enabled.
+//!
+//! The JSON output looks like:
+//!
+//!     {
+//!         // Process id:
+//!         // The replica index is encoded as the "process id" of trace events, so events from
+//!         // multiple replicas of a cluster can be unified to visualize them on the same timeline.
+//!         "pid": 0,
+//!
+//!         // Thread id:
+//!         "tid": 0,
+//!
+//!         // Category.
+//!         "cat": "replica_commit",
+//!
+//!         // Phase.
+//!         "ph": "B",
+//!
+//!         // Timestamp:
+//!         // Microseconds since program start.
+//!         "ts": 934327,
+//!
+//!         // Event name:
+//!         // Includes the event name and a *low cardinality subset* of the second argument to
+//!         // `trace.start()`. (Low-cardinality part so that tools like Perfetto can distinguish
+//!         // events usefully.)
+//!         "name": "replica_commit stage='next_pipeline'",
+//!
+//!         // Extra event arguments. (Encoded from the second argument to `trace.start()`).
+//!         "args": {
+//!             "stage": "next_pipeline",
+//!             "op": 1
+//!         },
+//!     },
+//!
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.trace);
+
+// TODO This could be changed to a union(enum) if variable-cardinality events are needed (for
+// example, an event per grid IOP). (`stack()` would need to be updated as well).
+pub const Event = enum {
+    replica_commit,
+
+    compact_blip_read,
+    compact_blip_merge,
+    compact_blip_write,
+    compact_manifest,
+    compact_mutable,
+
+    const stack_count = std.meta.fields(Event).len;
+
+    // Stack is a u32 since it must be losslessly encoded as a JSON integer.
+    fn stack(event: *const Event) u32 {
+        return @intFromEnum(event.*);
+    }
+};
+
+pub const Tracer = struct {
+    replica_index: u8,
+    options: Options,
+
+    events_enabled: [Event.stack_count]bool = [_]bool{false} ** Event.stack_count,
+    time_start: std.time.Instant,
+
+    pub const Options = struct {
+        /// The tracer still validates start/stop state even when writer=null.
+        writer: ?std.io.AnyWriter = null,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, replica_index: u8, options: Options) !Tracer {
+        _ = allocator;
+
+        if (options.writer) |writer| {
+            try writer.writeAll("[\n");
+        }
+
+        return .{
+            .replica_index = replica_index,
+            .options = options,
+            .time_start = std.time.Instant.now() catch @panic("std.time.Instant.now() unsupported"),
+        };
+    }
+
+    pub fn deinit(tracer: *Tracer, allocator: std.mem.Allocator) void {
+        _ = allocator;
+
+        tracer.* = undefined;
+    }
+
+    pub fn start(tracer: *Tracer, event: Event, data: anytype) void {
+        comptime assert(@typeInfo(@TypeOf(data)) == .Struct);
+
+        const stack = event.stack();
+        assert(!tracer.events_enabled[stack]);
+        tracer.events_enabled[stack] = true;
+
+        log.debug("{}: {s}: start:{}", .{
+            tracer.replica_index,
+            @tagName(event),
+            struct_format(data, .dense),
+        });
+
+        const writer = tracer.options.writer orelse return;
+        const time_now = std.time.Instant.now() catch unreachable;
+        const time_elapsed_ns = time_now.since(tracer.time_start);
+        const time_elapsed_us = @divFloor(time_elapsed_ns, std.time.ns_per_us);
+
+        // String tid's would be much more useful.
+        // They are supported by both Chrome and Perfetto, but rejected by Spall.
+        writer.print("{{" ++
+            "\"pid\":{[process_id]}," ++
+            "\"tid\":{[thread_id]}," ++
+            "\"cat\":\"{[category]s}\"," ++
+            "\"ph\":\"{[event]c}\"," ++
+            "\"ts\":{[timestamp]}," ++
+            "\"name\":\"{[name]s}{[data]}\"," ++
+            "\"args\":{[args]}" ++
+            "}},\n", .{
+            .process_id = tracer.replica_index,
+            .thread_id = event.stack(),
+            .category = @tagName(event),
+            .event = 'B',
+            .timestamp = time_elapsed_us,
+            .name = @tagName(event),
+            .data = struct_format(data, .sparse),
+            .args = std.json.Formatter(@TypeOf(data)){ .value = data, .options = .{} },
+        }) catch unreachable;
+    }
+
+    fn start_write_data(writer: std.io.AnyWriter, data: anytype) !void {
+        comptime assert(@typeInfo(@TypeOf(data)) == .Struct);
+
+        inline for (std.meta.fields(@TypeOf(data))) |data_field| {
+            const data_field_value = @field(data, data_field.name);
+            try writer.writeByte(' ');
+            try writer.writeAll(data_field.name);
+            try writer.writeByte('=');
+            if (data_field.type == []const u8) {
+                try writer.print("'{s}'", .{data_field_value});
+            } else if (@typeInfo(data_field.type) == .Enum or
+                @typeInfo(data_field.type) == .Union)
+            {
+                try writer.print("{s}", .{@tagName(data_field_value)});
+            } else {
+                try writer.print("{}", .{data_field_value});
+            }
+        }
+    }
+
+    pub fn stop(tracer: *Tracer, event: Event, data: anytype) void {
+        comptime assert(@typeInfo(@TypeOf(data)) == .Struct);
+
+        log.debug("{}: {s}: stop:{}", .{
+            tracer.replica_index,
+            @tagName(event),
+            struct_format(data, .dense),
+        });
+
+        const stack = event.stack();
+        assert(tracer.events_enabled[stack]);
+        tracer.events_enabled[stack] = false;
+
+        tracer.write_stop(event, data);
+    }
+
+    pub fn reset(tracer: *Tracer, event: Event) void {
+        const stack = event.stack();
+        defer tracer.events_enabled[stack] = false;
+
+        if (tracer.events_enabled[stack]) {
+            log.debug("{}: {s}: reset", .{ tracer.replica_index, @tagName(event) });
+
+            tracer.write_stop(event, .{});
+        }
+    }
+
+    fn write_stop(tracer: *Tracer, event: Event, data: anytype) void {
+        comptime assert(@typeInfo(@TypeOf(data)) == .Struct);
+
+        const writer = tracer.options.writer orelse return;
+        const time_now = std.time.Instant.now() catch unreachable;
+        const time_elapsed_ns = time_now.since(tracer.time_start);
+        const time_elapsed_us = @divFloor(time_elapsed_ns, std.time.ns_per_us);
+
+        writer.print(
+            "{{" ++
+                "\"pid\":{[process_id]}," ++
+                "\"tid\":{[thread_id]}," ++
+                "\"ph\":\"{[event]c}\"," ++
+                "\"ts\":{[timestamp]}" ++
+                "}},\n",
+            .{
+                .process_id = tracer.replica_index,
+                .thread_id = event.stack(),
+                .event = 'E',
+                .timestamp = time_elapsed_us,
+            },
+        ) catch unreachable;
+    }
+};
+
+const DataFormatterCardinality = enum { dense, sparse };
+
+fn StructFormatterType(comptime Data: type, comptime cardinality: DataFormatterCardinality) type {
+    assert(@typeInfo(Data) == .Struct);
+
+    return struct {
+        data: Data,
+
+        pub fn format(
+            formatter: *const @This(),
+            comptime fmt: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = fmt;
+            _ = options;
+
+            inline for (std.meta.fields(Data)) |data_field| {
+                if (cardinality == .sparse) {
+                    if (data_field.type != bool and
+                        data_field.type != u8 and
+                        data_field.type != []const u8 and
+                        data_field.type != [:0]const u8 and
+                        @typeInfo(data_field.type) != .Enum and
+                        @typeInfo(data_field.type) != .Union)
+                    {
+                        break;
+                    }
+                }
+
+                const data_field_value = @field(formatter.data, data_field.name);
+                try writer.writeByte(' ');
+                try writer.writeAll(data_field.name);
+                try writer.writeByte('=');
+
+                if (data_field.type == []const u8 or
+                    data_field.type == [:0]const u8)
+                {
+                    try writer.print("'{s}'", .{data_field_value});
+                } else if (@typeInfo(data_field.type) == .Enum or
+                    @typeInfo(data_field.type) == .Union)
+                {
+                    try writer.print("{s}", .{@tagName(data_field_value)});
+                } else {
+                    try writer.print("{}", .{data_field_value});
+                }
+            }
+        }
+    };
+}
+
+fn struct_format(
+    data: anytype,
+    comptime cardinality: DataFormatterCardinality,
+) StructFormatterType(@TypeOf(data), cardinality) {
+    return StructFormatterType(@TypeOf(data), cardinality){ .data = data };
+}
+
+test "trace json" {
+    const Snap = @import("testing/snaptest.zig").Snap;
+    const snap = Snap.snap;
+
+    var trace_buffer = std.ArrayList(u8).init(std.testing.allocator);
+    defer trace_buffer.deinit();
+
+    var trace = try Tracer.init(std.testing.allocator, 0, .{
+        .writer = trace_buffer.writer().any(),
+    });
+    defer trace.deinit(std.testing.allocator);
+
+    trace.start(.replica_commit, .{ .foo = 123 });
+    trace.stop(.replica_commit, .{ .bar = 456 });
+
+    try snap(@src(),
+        \\[
+        \\{"pid":0,"tid":0,"cat":"replica_commit","ph":"B","ts":<snap:ignore>,"name":"replica_commit","args":{"foo":123}},
+        \\{"pid":0,"tid":0,"ph":"E","ts":<snap:ignore>},
+        \\
+    ).diff(trace_buffer.items);
+}

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -13,6 +13,7 @@ comptime {
     _ = @import("stdx/bounded_array.zig");
     _ = @import("storage.zig");
     _ = @import("tidy.zig");
+    _ = @import("trace.zig");
 
     _ = @import("clients/c/test.zig");
     _ = @import("clients/c/tb_client/echo_client.zig");

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -20,6 +20,7 @@ pub const tb_client = @import("clients/c/tb_client.zig");
 pub const tigerbeetle = @import("tigerbeetle.zig");
 pub const time = @import("time.zig");
 pub const tracer = @import("tracer.zig");
+pub const trace = @import("trace.zig");
 pub const stdx = @import("stdx.zig");
 pub const flags = @import("flags.zig");
 pub const grid = @import("vsr/grid.zig");

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -165,6 +165,7 @@ pub fn GridType(comptime Storage: type) type {
         );
 
         superblock: *SuperBlock,
+        trace: *vsr.trace.Tracer,
         free_set: FreeSet,
         free_set_checkpoint: CheckpointTrailer,
         blocks_missing: GridBlocksMissing,
@@ -206,6 +207,7 @@ pub fn GridType(comptime Storage: type) type {
 
         pub fn init(allocator: mem.Allocator, options: struct {
             superblock: *SuperBlock,
+            trace: *vsr.trace.Tracer,
             cache_blocks_count: u64 = Cache.value_count_max_multiple,
             missing_blocks_max: usize,
             missing_tables_max: usize,
@@ -254,6 +256,7 @@ pub fn GridType(comptime Storage: type) type {
 
             return Grid{
                 .superblock = options.superblock,
+                .trace = options.trace,
                 .free_set = free_set,
                 .free_set_checkpoint = free_set_checkpoint,
                 .blocks_missing = blocks_missing,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3602,6 +3602,16 @@ pub fn ReplicaType(
                 self.commit_min,
             });
 
+            if (stage_old != .idle) {
+                self.trace.stop(.replica_commit, .{ .stage = @tagName(stage_old) });
+            }
+            if (stage_new != .idle) {
+                self.trace.start(.replica_commit, .{
+                    .stage = @tagName(stage_new),
+                    .op = self.commit_min,
+                });
+            }
+
             switch (self.commit_stage) {
                 .next => unreachable,
                 .next_journal => self.commit_journal_next(),
@@ -8801,6 +8811,7 @@ pub fn ReplicaType(
                 assert(self.commit_prepare == null);
             } else {
                 if (self.commit_prepare) |prepare| self.message_bus.unref(prepare);
+                self.trace.reset(.replica_commit);
                 self.commit_prepare = null;
                 self.commit_stage = .idle;
             }


### PR DESCRIPTION
### Overview

Log IO/CPU event spans for analysis/visualization.

Unlike tracy, this approach doesn't require linking libc/libcpp or any third-party libraries.
So we can compile tracing in by default, and optionally enable it at runtime -- even for production release builds.

The trace JSON output is compatible with:

- <https://ui.perfetto.dev/>
- <https://gravitymoth.com/spall/spall.html>
- <chrome://tracing/>

### Usage

```
$ ./tigerbeetle start --experimental --trace=trace.json
```

Then upload the `trace.json` file to one of the trace visualization tools.

### Examples

Here is an [example trace](https://gist.github.com/sentientwaffle/c734797cfa0dbcb0aa6f1c6759699376), captured while running the benchmark:

**Perfetto:**

![perfetto](https://github.com/user-attachments/assets/dbe4a365-eed9-4f8b-a100-dbd226dfa875)

**Spall:**

![spall](https://github.com/user-attachments/assets/58e3afd6-2d94-41ea-9913-dddd8c8789c9)


### Notes

- When enabled, traces are written to the specified file as JSON.
  (In contrast to `log` statements, which are written to stderr).
- Event pairing (`trace.start`/`trace.stop` (or `trace.start`/`trace.reset`)) is asserted at runtime.
- `trace.start()/.stop()/.reset()` will `log.debug()` regardless of whether tracing is enabled.
- Eventually, we could choose parse traces from structured logs and convert them to JSON with a separate tool, but for the time being this is simpler.

<details>
<summary>API Design notes</summary>

One goal was to keep the integration API lightweight.

The original implementation was a global, but I ended up threading a single trace 
- Threading this is necessary since `Trace` tracks the enabled/disabled state of each event. This in turns allows the fuzzers to assert that tracing is used correctly.
- In the future, threading might come in handy for the structured logger, as we could attach fields like `replica_index` and `tree_name` so that every log statement doesn't need to repeat them.

Unlike most tracing APIs, events aren't ever "stacked". (See https://gravitymoth.com/spall/spall.html for an example).
Rather, events are independent -- they can be interleaved.

This keeps the API simple. Stacks are useful when doing fine-grained analysis (like CPU profiling) -- but for that, linux perf would suffice. Tracing is useful for more coarse-grained analysis (async-IO + CPU rather than just CPU).

The first parameter of each trace function is typed (an enum rather than a string) so that we can match start/end events together. I don't think registering events like this is onerous -- I don't expect us to end up with more than a couple dozen unique event types.

</details>

<details>
<summary>Tool overview</summary>

[Spall](https://gravitymoth.com/spall/spall.html) has excellent mouse navigation, but no keybindings.

[Perfetto](https://ui.perfetto.dev/) has keybindings and extensive (albeit opaque) support for querying events. (e.g. "how much cumulative time is spent in event X?").

I didn't check Chrome other than to test that it worked with our format -- I think it is like Perfetto but with fewer features.

Additionally, Perfetto + Chrome support string labels for threads, which would be very nice to use (since thread numbers are meaningless), but Spall errors out on string thread ids.

</details>
