### PR TITLE
changelog: reference test and make `Released:` formatting consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ to receive notifications about breaking changes!
 
 ## TigerBeetle 0.16.0
 
-Released 2024-09-02
+Released: 2024-09-02
 
 This release is 0.16.0 as it includes a new breaking API change around zero amount transfers, as
 well as the behavior around posting a full pending transfer amount or balancing as much as possible.

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -65,5 +65,6 @@ comptime {
     _ = @import("vsr/sync.zig");
 
     _ = @import("scripts/release.zig");
+    _ = @import("scripts/changelog.zig");
     _ = @import("scripts/cfo.zig");
 }


### PR DESCRIPTION
Also, fixes the case where during the release process itself, `--no-changelog` shouldn't be passed in.