### PR TITLE
Concurrent prefetch

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -377,6 +377,7 @@ const Environment = struct {
             fn prefetch_start(getter: *@This()) void {
                 const groove = getter._groove_accounts;
                 groove.prefetch_setup(null);
+                groove.timestamps.reset();
                 groove.prefetch_exists_enqueue(getter._timestamp);
                 groove.prefetch(@This().prefetch_callback, &getter.prefetch_context);
             }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -472,7 +472,7 @@ pub fn GrooveType(
             self.* = undefined;
         }
 
-        fn reset(self: *TimestampSet) void {
+        pub fn reset(self: *TimestampSet) void {
             self.map.clearRetainingCapacity();
         }
 
@@ -757,8 +757,6 @@ pub fn GrooveType(
 
             groove.prefetch_snapshot = snapshot_target;
             assert(groove.prefetch_keys.count() == 0);
-
-            if (has_id) groove.timestamps.reset();
         }
 
         /// This must be called by the state machine for every key to be prefetched.


### PR DESCRIPTION
Allows multiple grooves to prefetch simultaneously.

While each groove's prefetch already tries to use all available IO (by employing multiple workers), some situations may benefit from more concurrency, especially when creating transfers, where, in most cases, we can prefetch transfers and accounts in one go.

Related https://github.com/tigerbeetle/tigerbeetle/issues/2102