### PR TITLE
Add zipfian-distributed random numbers to benchmark

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -5,6 +5,8 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 pub const BoundedArray = @import("./stdx/bounded_array.zig").BoundedArray;
+pub const ZipfianGenerator = @import("./stdx/zipfian.zig").ZipfianGenerator;
+pub const ShuffledZipfian = @import("./stdx/zipfian.zig").ShuffledZipfian;
 
 pub inline fn div_ceil(numerator: anytype, denominator: anytype) @TypeOf(numerator, denominator) {
     comptime {

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -6,7 +6,7 @@ const assert = std.debug.assert;
 
 pub const BoundedArray = @import("./stdx/bounded_array.zig").BoundedArray;
 pub const ZipfianGenerator = @import("./stdx/zipfian.zig").ZipfianGenerator;
-pub const ShuffledZipfian = @import("./stdx/zipfian.zig").ShuffledZipfian;
+pub const ZipfianShuffled = @import("./stdx/zipfian.zig").ZipfianShuffled;
 
 pub inline fn div_ceil(numerator: anytype, denominator: anytype) @TypeOf(numerator, denominator) {
     comptime {

--- a/src/stdx/zipfian.zig
+++ b/src/stdx/zipfian.zig
@@ -105,11 +105,13 @@ pub const ZipfianGenerator = struct {
         // Math voodoo, copied from the paper,
         // which doesn't explain it, but claims it is from Knuth volume 3.
 
-        const nf: f64 = @floatFromInt(self.n);
-
         // NB: These depend only on zetan and could be cached for a minor speedup.
         const alpha = 1.0 / (1.0 - self.theta);
-        const eta = (1.0 - math.pow(f64, 2.0 / nf, 1.0 - self.theta)) /
+        const eta = (1.0 - math.pow(
+            f64,
+            2.0 / @as(f64, @floatFromInt(self.n)),
+            1.0 - self.theta,
+        )) /
             (1.0 - zeta(2.0, self.theta) / self.zetan);
 
         const u = rng.float(f64);
@@ -123,7 +125,10 @@ pub const ZipfianGenerator = struct {
             return 1;
         }
 
-        return @as(u64, @intFromFloat(nf * math.pow(f64, (eta * u) - eta + 1.0, alpha)));
+        return @as(u64, @intFromFloat(
+            @as(f64, @floatFromInt(self.n)) *
+                math.pow(f64, (eta * u) - eta + 1.0, alpha),
+        ));
     }
 
     /// Grow the size of the random set.
@@ -140,7 +145,6 @@ pub const ZipfianGenerator = struct {
     /// The probability that an index will be chosen.
     fn probability(self: *const ZipfianGenerator, item: u64) f64 {
         assert(item < self.n);
-        const itemf: f64 = @floatFromInt(item);
 
         // Reference: https://en.wikipedia.org/wiki/Zipf's_law#Formal_definition
         //
@@ -150,7 +154,11 @@ pub const ZipfianGenerator = struct {
         //
         // zetan is the generalized harmonic number of order "s" (theta) for `n`.
         // We add 1 to `k` because our items are 0-based but the math is 1-based.
-        return (1.0 / self.zetan) * (1.0 / math.pow(f64, itemf + 1, self.theta));
+        return (1.0 / self.zetan) * (1.0 / math.pow(
+            f64,
+            @as(f64, @floatFromInt(item)) + 1,
+            self.theta,
+        ));
     }
 
     /// Returns the numbef of items at which the cumulative distribution function (CDF - the
@@ -180,8 +188,7 @@ fn zeta(n: u64, theta: f64) f64 {
     var i: u64 = 1;
     var zeta_sum: f64 = 0.0;
     while (i <= n) : (i += 1) {
-        const ifl: f64 = @floatFromInt(i);
-        zeta_sum += math.pow(f64, 1.0 / ifl, theta);
+        zeta_sum += math.pow(f64, 1.0 / @as(f64, @floatFromInt(i)), theta);
     }
     return zeta_sum;
 }
@@ -197,8 +204,7 @@ fn zeta_incremental(
     var i = n_previous + 1;
     var zeta_sum = zetan_previous;
     while (i <= n_new) : (i += 1) {
-        const ifl: f64 = @floatFromInt(i);
-        zeta_sum += math.pow(f64, 1.0 / ifl, theta);
+        zeta_sum += math.pow(f64, 1.0 / @as(f64, @floatFromInt(i)), theta);
     }
     return zeta_sum;
 }

--- a/src/stdx/zipfian.zig
+++ b/src/stdx/zipfian.zig
@@ -86,7 +86,7 @@ pub const ZipfianGenerator = struct {
     ///
     /// `theta` is the "skew" and is usually specified to be greater than 0 and less than 1,
     /// with YCSB using 0.99, though values greater than 1 also seem to generate reasonable
-    /// distributions.
+    /// distributions. `theta = 1` isn't allowed since it does not behave reasonably. 
     pub fn init_theta(items: u64, theta: f64) ZipfianGenerator {
         assert(theta > 0.0);
         assert(theta != 1.0); // 1.0 does not behave reasonably.

--- a/src/stdx/zipfian.zig
+++ b/src/stdx/zipfian.zig
@@ -38,11 +38,11 @@
 //! both of which generate random keys from 0 to a specified maximum.
 //! In the basic `ZipfianGenerator`, key 0 has the highest probability,
 //! 1 the next highest, etc.
-//! The `ShuffledZipfian` generator instead spreads the distribution out
+//! The `ZipfianShuffled` generator instead spreads the distribution out
 //! across the key space as if it were a shuffled deck.
 //!
 //! Both generators allow for the key space to grow (but not shrink),
-//! dynamically recomputing the distribution. When the `ShuffledZipfian`
+//! dynamically recomputing the distribution. When the `ZipfianShuffled`
 //! generator grows it acts as if each new key was inserted into the shuffled
 //! deck randomly, preserving the relative probability of existing keys.
 //!
@@ -50,21 +50,21 @@
 //! the shuffled generator does not because the tail distribution is fudged.
 
 const std = @import("std");
-const assert = @import("std").debug.assert;
-const Random = @import("std").Random;
-const math = @import("std").math;
-const BoundedArray = @import("./bounded_array.zig").BoundedArray;
+const stdx = @import("../stdx.zig");
+const assert = std.debug.assert;
+const Random = std.Random;
+const math = std.math;
+const BoundedArray = stdx.BoundedArray;
 
 /// The default "skew" of the distribution.
 const theta_default = 0.99; // per YCSB
 
 /// Generates Zipfian-distributed numbers from 0 to a specified maximum.
 ///
-/// The internal variables here are the same is in the paper;
-/// the external intended to be more understandable to the user.
+/// Many internal variables here are the same is in the paper, which I think
+/// should reduce confusion if this subject needs to be revisited; the external
+/// intended to be more understandable to the user and follow TigerStyle.
 pub const ZipfianGenerator = struct {
-    const Self = @This();
-
     theta: f64,
 
     /// The number of items in the set.
@@ -86,10 +86,10 @@ pub const ZipfianGenerator = struct {
     ///
     /// `theta` is the "skew" and is usually specified to be greater than 0 and less than 1,
     /// with YCSB using 0.99, though values greater than 1 also seem to generate reasonable
-    /// distributions. `theta = 1` isn't allowed since it does not behave reasonably. 
+    /// distributions. `theta = 1` isn't allowed since it does not behave reasonably.
     pub fn init_theta(items: u64, theta: f64) ZipfianGenerator {
         assert(theta > 0.0);
-        assert(theta != 1.0); // 1.0 does not behave reasonably.
+        assert(theta != 1.0);
         return ZipfianGenerator{
             .theta = theta,
             .n = items,
@@ -97,7 +97,9 @@ pub const ZipfianGenerator = struct {
         };
     }
 
-    pub fn next(self: *const Self, rng: Random) u64 {
+    /// Note that the variables in this function are mostly named
+    /// as in the reference paper and do not follow TigerStyle.
+    pub fn next(self: *const ZipfianGenerator, rng: Random) u64 {
         assert(self.n > 0);
 
         // Math voodoo, copied from the paper,
@@ -125,9 +127,9 @@ pub const ZipfianGenerator = struct {
     }
 
     /// Grow the size of the random set.
-    pub fn grow(self: *Self, new_items: u64) void {
+    pub fn grow(self: *ZipfianGenerator, new_items: u64) void {
         const items = self.n + new_items;
-        const zetan_new = zeta_incr(self.n, new_items, self.zetan, self.theta);
+        const zetan_new = zeta_incremental(self.n, new_items, self.zetan, self.theta);
         self.* = .{
             .theta = self.theta,
             .n = items,
@@ -136,7 +138,7 @@ pub const ZipfianGenerator = struct {
     }
 
     /// The probability that an index will be chosen.
-    fn probability(self: *const Self, item: u64) f64 {
+    fn probability(self: *const ZipfianGenerator, item: u64) f64 {
         assert(item < self.n);
         const itemf: f64 = @floatFromInt(item);
 
@@ -152,18 +154,19 @@ pub const ZipfianGenerator = struct {
     }
 
     /// Returns the numbef of items at which the cumulative distribution function (CDF - the
-    /// probability of some value less than x being generated) is greater or equal to `prob`.
+    /// probability of some value less than x being generated) is greater or equal to
+    /// `cdf_probability`.
     ///
     /// If there is no such value, returns the total number of items.
-    fn cumulative_distribution_items(self: *const Self, prob: f64) u64 {
-        assert(prob >= 0.0 and prob <= 1.0);
+    fn cumulative_distribution_items(self: *const ZipfianGenerator, cdf_probability: f64) u64 {
+        assert(cdf_probability >= 0.0 and cdf_probability <= 1.0);
 
-        var idx: u64 = 0;
-        var prob_sum: f64 = 0.0;
-        while (idx < self.n) : (idx += 1) {
-            prob_sum += self.probability(idx);
-            if (prob_sum >= prob) {
-                return idx + 1;
+        var index: u64 = 0;
+        var probability_sum: f64 = 0.0;
+        while (index < self.n) : (index += 1) {
+            probability_sum += self.probability(index);
+            if (probability_sum >= cdf_probability) {
+                return index + 1;
             }
         }
 
@@ -175,24 +178,29 @@ pub const ZipfianGenerator = struct {
 /// aka the "generalized harmonic number" of order 'theta' for `n`.
 fn zeta(n: u64, theta: f64) f64 {
     var i: u64 = 1;
-    var ans: f64 = 0.0;
+    var zeta_sum: f64 = 0.0;
     while (i <= n) : (i += 1) {
         const ifl: f64 = @floatFromInt(i);
-        ans += math.pow(f64, 1.0 / ifl, theta);
+        zeta_sum += math.pow(f64, 1.0 / ifl, theta);
     }
-    return ans;
+    return zeta_sum;
 }
 
 /// Incremental calculation of zeta.
-fn zeta_incr(prev_n: u64, addtl_n: u64, prev_zetan: f64, theta: f64) f64 {
-    const new_n = prev_n + addtl_n;
-    var i = prev_n + 1;
-    var ans = prev_zetan;
-    while (i <= new_n) : (i += 1) {
+fn zeta_incremental(
+    n_previous: u64,
+    n_additional: u64,
+    zetan_previous: f64,
+    theta: f64,
+) f64 {
+    const n_new = n_previous + n_additional;
+    var i = n_previous + 1;
+    var zeta_sum = zetan_previous;
+    while (i <= n_new) : (i += 1) {
         const ifl: f64 = @floatFromInt(i);
-        ans += math.pow(f64, 1.0 / ifl, theta);
+        zeta_sum += math.pow(f64, 1.0 / ifl, theta);
     }
-    return ans;
+    return zeta_sum;
 }
 
 /// Generates Zipfian-distributed numbers from 0 to maximum,
@@ -213,9 +221,7 @@ fn zeta_incr(prev_n: u64, addtl_n: u64, prev_zetan: f64, theta: f64) f64 {
 /// This technique is described offhandedly in the paper in
 /// a single sentence, and YCSB does not use it, so we are
 /// inventing the details here in a way that seems efficient.
-pub const ShuffledZipfian = struct {
-    const Self = @This();
-
+pub const ZipfianShuffled = struct {
     const HotArray = BoundedArray(u64, hot_items_limit);
 
     /// We prefer to store enough hot items to fill the cumulative probablity here.
@@ -233,12 +239,12 @@ pub const ShuffledZipfian = struct {
     gen: ZipfianGenerator,
     hot_items: HotArray,
 
-    pub fn init(items: u64, rng: Random) ShuffledZipfian {
-        return ShuffledZipfian.init_theta(items, theta_default, rng);
+    pub fn init(items: u64, rng: Random) ZipfianShuffled {
+        return ZipfianShuffled.init_theta(items, theta_default, rng);
     }
 
-    pub fn init_theta(items: u64, theta: f64, rng: Random) ShuffledZipfian {
-        var zipf = ShuffledZipfian{
+    pub fn init_theta(items: u64, theta: f64, rng: Random) ZipfianShuffled {
+        var zipf = ZipfianShuffled{
             .gen = ZipfianGenerator.init_theta(0, theta),
             .hot_items = HotArray{},
         };
@@ -248,23 +254,23 @@ pub const ShuffledZipfian = struct {
         return zipf;
     }
 
-    pub fn next(self: *const Self, rng: Random) u64 {
+    pub fn next(self: *const ZipfianShuffled, rng: Random) u64 {
         // First try to pick from a zipfian distribution
         // of hot items.
-        const zipf_idx = self.gen.next(rng);
-        if (zipf_idx < self.hot_items.count()) {
-            const item = self.hot_items.get(zipf_idx);
+        const zipf_index = self.gen.next(rng);
+        if (zipf_index < self.hot_items.count()) {
+            const item = self.hot_items.get(zipf_index);
             assert(item < self.gen.n);
             return item;
         }
 
         // Next pick from uniform distribution of all items.
-        const uni_idx = rng.intRangeLessThan(u64, 0, self.gen.n);
-        return uni_idx;
+        const uni_index = rng.intRangeLessThan(u64, 0, self.gen.n);
+        return uni_index;
     }
 
     /// Grow the size of the random set.
-    pub fn grow(self: *Self, new_items: u64, rng: Random) void {
+    pub fn grow(self: *ZipfianShuffled, new_items: u64, rng: Random) void {
         if (new_items == 0) {
             return;
         }
@@ -283,13 +289,13 @@ pub const ShuffledZipfian = struct {
 
         // Shuffle each new item into deck of items.
         // If it's a hot item we'll track it, if not discard it.
-        const start_idx = old_n;
-        const end_idx = new_n;
-        var idx = start_idx;
-        while (idx < end_idx) : (idx += 1) {
+        const start_index = old_n;
+        const end_index = new_n;
+        var index = start_index;
+        while (index < end_index) : (index += 1) {
             if (self.hot_items.count() < hot_items_count_max) {
                 const pos_actual = rng.intRangeAtMost(u64, 0, self.hot_items.count());
-                self.hot_items.insert_assume_capacity(pos_actual, idx);
+                self.hot_items.insert_assume_capacity(pos_actual, index);
             } else {
                 // NB: I believe this is biased as to which new items become hot items,
                 // but it probably doesn't matter for our purposes.
@@ -297,7 +303,7 @@ pub const ShuffledZipfian = struct {
                 if (pos_init < hot_items_count_max) {
                     self.hot_items.truncate(hot_items_count_max - 1);
                     const pos_actual = rng.intRangeAtMost(u64, 0, self.hot_items.count());
-                    self.hot_items.insert_assume_capacity(pos_actual, idx);
+                    self.hot_items.insert_assume_capacity(pos_actual, index);
                 }
             }
         }
@@ -305,7 +311,7 @@ pub const ShuffledZipfian = struct {
         assert(self.hot_items.count() == hot_items_count_max);
     }
 
-    fn hot_items_max(self: *Self) u64 {
+    fn hot_items_max(self: *ZipfianShuffled) u64 {
         // If the probability of selecting any individual item greater than hot_items.count is low,
         // then we don't need any more hot_items. This short-circuits calculating the
         // expensive cumulative distribution function.
@@ -323,12 +329,12 @@ pub const ShuffledZipfian = struct {
         assert(cdf_items_max >= self.hot_items.count());
 
         var max = cdf_items_max;
-        var hot_idx = self.hot_items.count();
-        while (hot_idx < cdf_items_max) : (hot_idx += 1) {
-            const prob = self.gen.probability(hot_idx);
-            if (prob < hot_items_min_probability_limit) {
-                assert(hot_idx > 0);
-                max = hot_idx;
+        var hot_index = self.hot_items.count();
+        while (hot_index < cdf_items_max) : (hot_index += 1) {
+            const probability = self.gen.probability(hot_index);
+            if (probability < hot_items_min_probability_limit) {
+                assert(hot_index > 0);
+                max = hot_index;
                 break;
             }
         }
@@ -340,37 +346,37 @@ pub const ShuffledZipfian = struct {
     }
 };
 
-test "zeta_incr" {
+test "zeta_incremental" {
     const Case = struct {
         n_start: u64,
-        n_incr: u64,
+        n_incremental: u64,
         theta: f64,
     };
     const cases = [_]Case{
         .{
             .n_start = 0,
-            .n_incr = 10,
+            .n_incremental = 10,
             .theta = 0.99,
         },
         .{
             .n_start = 0,
-            .n_incr = 10,
+            .n_incremental = 10,
             .theta = 1.01,
         },
         .{
             .n_start = 100,
-            .n_incr = 100,
+            .n_incremental = 100,
             .theta = 0.99,
         },
     };
 
     for (cases) |case| {
-        const n = case.n_start + case.n_incr;
+        const n = case.n_start + case.n_incremental;
         const zeta_expected = zeta(n, case.theta);
         const zeta_actual_start = zeta(case.n_start, case.theta);
-        const zeta_actual = zeta_incr(
+        const zeta_actual = zeta_incremental(
             case.n_start,
-            case.n_incr,
+            case.n_incremental,
             zeta_actual_start,
             case.theta,
         );
@@ -410,8 +416,8 @@ test "zipfian-ctors" {
         {
             const zipf1 = ZipfianGenerator.init(i);
             const zipf2 = ZipfianGenerator.init_theta(i, theta_default);
-            const szipf1 = ShuffledZipfian.init(i, rand);
-            const szipf2 = ShuffledZipfian.init_theta(i, theta_default, rand);
+            const szipf1 = ZipfianShuffled.init(i, rand);
+            const szipf2 = ZipfianShuffled.init_theta(i, theta_default, rand);
 
             assert(zipf1.n == zipf2.n);
             assert(zipf1.n == szipf1.gen.n);
@@ -424,7 +430,7 @@ test "zipfian-ctors" {
 
         {
             const zipf1 = ZipfianGenerator.init_theta(i, 0.89);
-            const szipf1 = ShuffledZipfian.init_theta(i, 0.89, rand);
+            const szipf1 = ZipfianShuffled.init_theta(i, 0.89, rand);
 
             assert(zipf1.n == szipf1.gen.n);
             assert(zipf1.zetan == szipf1.gen.zetan);
@@ -439,22 +445,22 @@ test "zipfian-hot-items" {
     const rand = rng.random();
 
     {
-        const szipf = ShuffledZipfian.init(0, rand);
+        const szipf = ZipfianShuffled.init(0, rand);
         assert(szipf.hot_items.count() == 0);
     }
 
     {
-        const szipf = ShuffledZipfian.init(1, rand);
+        const szipf = ZipfianShuffled.init(1, rand);
         assert(szipf.hot_items.count() == 1);
     }
 
     {
-        const szipf = ShuffledZipfian.init(2, rand);
+        const szipf = ZipfianShuffled.init(2, rand);
         assert(szipf.hot_items.count() == 2);
     }
 
     for ([_]u64{ 3, 10, 999, 1_000_000 }) |i| {
-        const szipf = ShuffledZipfian.init(i, rand);
+        const szipf = ZipfianShuffled.init(i, rand);
         assert(szipf.hot_items.count() >= 1);
         assert(szipf.hot_items.count() < i);
 

--- a/src/stdx/zipfian.zig
+++ b/src/stdx/zipfian.zig
@@ -121,7 +121,7 @@ pub const ZipfianGenerator = struct {
             return 1;
         }
 
-        return @as(u64, @intFromFloat(nf * math.pow(f64, eta * u - eta + 1.0, alpha)));
+        return @as(u64, @intFromFloat(nf * math.pow(f64, (eta * u) - eta + 1.0, alpha)));
     }
 
     /// Grow the size of the random set.

--- a/src/stdx/zipfian.zig
+++ b/src/stdx/zipfian.zig
@@ -1,0 +1,490 @@
+//! Zipfian-distributed random number generation.
+//!
+//! In the Zipfian distribution a small percentage of candidate
+//! items have a high probability of being selected, while most items
+//! have very low probability of being selected.
+//! It is commonly understood to model the "80-20" Pareto principle,
+//! and to be a discreet version of the Pareto distribution,
+//! and terminology related to both are often used interchangably.
+//!
+//! Zipfian numbers follow an inverse power law, where the 1st item
+//! is selected with high probability, and subsequent items
+//! quickly fall off in probability. The rate of the fall off
+//! is tunable by the _skew_, also called `s`, or `theta`,
+//! depending on the source.
+//!
+//! Reference:
+//!
+//! - https://en.wikipedia.org/wiki/Zipf's_law#Formal_definition
+//!
+//! Note that it is not actually possible to select a value for
+//! theta that literally follows the "80-20" rule for arbitrary set sizes;
+//! the proportion of items that cumulatively make up 80% probability will
+//! change as the set grows.
+//! A zipfian generator that can adaptively follow the 80-20 rule is left for future work.
+//!
+//! In practice these probabilities often need to be spread across e.g. a
+//! table's keyspace, which involves some kind of mapping step from index to index.
+//! Because that mapping is non-trivial to optimize, it is also provided here.
+//!
+//! The algorithm here is based on
+//! "Quickly Generating Billion-Record Synthetic Databases", Jim Gray et al, SIGMOD 1994.
+//! Per the paper it is adapted from Knuth vol 3.
+//! This is also the algorithm used by YCSB's ZipfianGenerator.java.
+//! Note that the code listing in the paper contains obvious errors,
+//! corrected here and in YCSB.
+//!
+//! There are two generators here,
+//! both of which generate random keys from 0 to a specified maximum.
+//! In the basic `ZipfianGenerator`, key 0 has the highest probability,
+//! 1 the next highest, etc.
+//! The `ShuffledZipfian` generator instead spreads the distribution out
+//! across the key space as if it were a shuffled deck.
+//!
+//! Both generators allow for the key space to grow (but not shrink),
+//! dynamically recomputing the distribution. When the `ShuffledZipfian`
+//! generator grows it acts as if each new key was inserted into the shuffled
+//! deck randomly, preserving the relative probability of existing keys.
+//!
+//! The non-shuffled generator should pass a 2-sample Kolmogorov–Smirnov test;
+//! the shuffled generator does not because the tail distribution is fudged.
+
+const std = @import("std");
+const assert = @import("std").debug.assert;
+const Random = @import("std").Random;
+const math = @import("std").math;
+const BoundedArray = @import("./bounded_array.zig").BoundedArray;
+
+/// The default "skew" of the distribution.
+const theta_default = 0.99; // per YCSB
+
+/// Generates Zipfian-distributed numbers from 0 to a specified maximum.
+///
+/// The internal variables here are the same is in the paper;
+/// the external intended to be more understandable to the user.
+pub const ZipfianGenerator = struct {
+    const Self = @This();
+
+    theta: f64,
+
+    /// The number of items in the set.
+    n: u64,
+    /// The Riemann zeta function calculated up to `n`,
+    /// aka the "generalized harmonic number" of order `theta` for `n`.
+    /// This is a pre-calculated factor in the probability of any particular item
+    /// being selected.
+    /// It is expensive to calculate for large but useful values of `n`,
+    /// but can be calculated incrementally as `n` grows.
+    zetan: f64,
+
+    /// Create a generator from `[0, items)` with `theta` equal to 0.99.
+    pub fn init(items: u64) ZipfianGenerator {
+        return ZipfianGenerator.init_theta(items, theta_default);
+    }
+
+    /// Create a generator from `[0, items)` with given `theta`.
+    ///
+    /// `theta` is the "skew" and is usually specified to be greater than 0 and less than 1,
+    /// with YCSB using 0.99, though values greater than 1 also seem to generate reasonable
+    /// distributions.
+    pub fn init_theta(items: u64, theta: f64) ZipfianGenerator {
+        assert(theta > 0.0);
+        assert(theta != 1.0); // 1.0 does not behave reasonably.
+        return ZipfianGenerator{
+            .theta = theta,
+            .n = items,
+            .zetan = zeta(items, theta),
+        };
+    }
+
+    pub fn next(self: *const Self, rng: Random) u64 {
+        assert(self.n > 0);
+
+        // Math voodoo, copied from the paper,
+        // which doesn't explain it, but claims it is from Knuth volume 3.
+
+        const nf: f64 = @floatFromInt(self.n);
+
+        // NB: These depend only on zetan and could be cached for a minor speedup.
+        const alpha = 1.0 / (1.0 - self.theta);
+        const eta = (1.0 - math.pow(f64, 2.0 / nf, 1.0 - self.theta)) /
+            (1.0 - zeta(2.0, self.theta) / self.zetan);
+
+        const u = rng.float(f64);
+        const uz = u * self.zetan;
+
+        if (uz < 1.0) {
+            return 0;
+        }
+
+        if (uz < 1.0 + math.pow(f64, 0.5, self.theta)) {
+            return 1;
+        }
+
+        return @as(u64, @intFromFloat(nf * math.pow(f64, eta * u - eta + 1.0, alpha)));
+    }
+
+    /// Grow the size of the random set.
+    pub fn grow(self: *Self, new_items: u64) void {
+        const items = self.n + new_items;
+        const zetan_new = zeta_incr(self.n, new_items, self.zetan, self.theta);
+        self.* = .{
+            .theta = self.theta,
+            .n = items,
+            .zetan = zetan_new,
+        };
+    }
+
+    /// The probability that an index will be chosen.
+    fn probability(self: *const Self, item: u64) f64 {
+        assert(item < self.n);
+        const itemf: f64 = @floatFromInt(item);
+
+        // Reference: https://en.wikipedia.org/wiki/Zipf's_law#Formal_definition
+        //
+        //   1      1
+        // ----- * ---
+        // zetan   k^s
+        //
+        // zetan is the generalized harmonic number of order "s" (theta) for `n`.
+        // We add 1 to `k` because our items are 0-based but the math is 1-based.
+        return (1.0 / self.zetan) * (1.0 / math.pow(f64, itemf + 1, self.theta));
+    }
+
+    /// Returns the numbef of items at which the cumulative distribution function (CDF - the
+    /// probability of some value less than x being generated) is greater or equal to `prob`.
+    ///
+    /// If there is no such value, returns the total number of items.
+    fn cumulative_distribution_items(self: *const Self, prob: f64) u64 {
+        assert(prob >= 0.0 and prob <= 1.0);
+
+        var idx: u64 = 0;
+        var prob_sum: f64 = 0.0;
+        while (idx < self.n) : (idx += 1) {
+            prob_sum += self.probability(idx);
+            if (prob_sum >= prob) {
+                return idx + 1;
+            }
+        }
+
+        return self.n;
+    }
+};
+
+/// The Riemann zeta function up to `n`,
+/// aka the "generalized harmonic number" of order 'theta' for `n`.
+fn zeta(n: u64, theta: f64) f64 {
+    var i: u64 = 1;
+    var ans: f64 = 0.0;
+    while (i <= n) : (i += 1) {
+        const ifl: f64 = @floatFromInt(i);
+        ans += math.pow(f64, 1.0 / ifl, theta);
+    }
+    return ans;
+}
+
+/// Incremental calculation of zeta.
+fn zeta_incr(prev_n: u64, addtl_n: u64, prev_zetan: f64, theta: f64) f64 {
+    const new_n = prev_n + addtl_n;
+    var i = prev_n + 1;
+    var ans = prev_zetan;
+    while (i <= new_n) : (i += 1) {
+        const ifl: f64 = @floatFromInt(i);
+        ans += math.pow(f64, 1.0 / ifl, theta);
+    }
+    return ans;
+}
+
+/// Generates Zipfian-distributed numbers from 0 to maximum,
+/// but the probabilities of each number are "shuffled",
+/// not clustered around 0.
+///
+/// This is used to simulate typical data access patterns in
+/// some keyspace, where a few keys are hot and most are cold.
+///
+/// This behaves as if it maintains a shuffled mapping
+/// from every index to a different index. It is implemented
+/// as suggested in the Jim Gray paper: we observe that
+/// most items have very low probability of being selected;
+/// we don't maintain a mapping for this set and instead treat
+/// them as uniformly distributed; we keep only a small
+/// mapping of the most probably selected items.
+///
+/// This technique is described offhandedly in the paper in
+/// a single sentence, and YCSB does not use it, so we are
+/// inventing the details here in a way that seems efficient.
+pub const ShuffledZipfian = struct {
+    const Self = @This();
+
+    const HotArray = BoundedArray(u64, hot_items_limit);
+
+    /// We prefer to store enough hot items to fill the cumulative probablity here.
+    /// Other items have uniform probability. In practice though most uses of this
+    /// type first hit the `hot_items_min_probability_limit` below.
+    const hot_items_cumulative_distribution_function = 0.8;
+    /// The cutoff probability for hot items.
+    /// Any index with a probability less than this has uniform probability.
+    /// This is used to short circuit the CDF above for data sets / thetas with a particularly
+    /// large hot item set.
+    const hot_items_min_probability_limit = 0.0001;
+    /// The maximum hot items we're willing to track.
+    const hot_items_limit = 1024 * 4;
+
+    gen: ZipfianGenerator,
+    hot_items: HotArray,
+
+    pub fn init(items: u64, rng: Random) ShuffledZipfian {
+        return ShuffledZipfian.init_theta(items, theta_default, rng);
+    }
+
+    pub fn init_theta(items: u64, theta: f64, rng: Random) ShuffledZipfian {
+        var zipf = ShuffledZipfian{
+            .gen = ZipfianGenerator.init_theta(0, theta),
+            .hot_items = HotArray{},
+        };
+
+        zipf.grow(items, rng);
+
+        return zipf;
+    }
+
+    pub fn next(self: *const Self, rng: Random) u64 {
+        // First try to pick from a zipfian distribution
+        // of hot items.
+        const zipf_idx = self.gen.next(rng);
+        if (zipf_idx < self.hot_items.count()) {
+            const item = self.hot_items.get(zipf_idx);
+            assert(item < self.gen.n);
+            return item;
+        }
+
+        // Next pick from uniform distribution of all items.
+        const uni_idx = rng.intRangeLessThan(u64, 0, self.gen.n);
+        return uni_idx;
+    }
+
+    /// Grow the size of the random set.
+    pub fn grow(self: *Self, new_items: u64, rng: Random) void {
+        if (new_items == 0) {
+            return;
+        }
+
+        const old_n = self.gen.n;
+        const new_n = old_n + new_items;
+
+        self.gen.grow(new_items);
+
+        assert(self.gen.n == new_n);
+
+        const hot_items_count_max = self.hot_items_max();
+
+        assert(hot_items_count_max > 0);
+        assert(hot_items_count_max <= new_n);
+
+        // Shuffle each new item into deck of items.
+        // If it's a hot item we'll track it, if not discard it.
+        const start_idx = old_n;
+        const end_idx = new_n;
+        var idx = start_idx;
+        while (idx < end_idx) : (idx += 1) {
+            if (self.hot_items.count() < hot_items_count_max) {
+                const pos_actual = rng.intRangeAtMost(u64, 0, self.hot_items.count());
+                self.hot_items.insert_assume_capacity(pos_actual, idx);
+            } else {
+                // NB: I believe this is biased as to which new items become hot items,
+                // but it probably doesn't matter for our purposes.
+                const pos_init = rng.intRangeLessThan(u64, 0, new_n);
+                if (pos_init < hot_items_count_max) {
+                    self.hot_items.truncate(hot_items_count_max - 1);
+                    const pos_actual = rng.intRangeAtMost(u64, 0, self.hot_items.count());
+                    self.hot_items.insert_assume_capacity(pos_actual, idx);
+                }
+            }
+        }
+
+        assert(self.hot_items.count() == hot_items_count_max);
+    }
+
+    fn hot_items_max(self: *Self) u64 {
+        // If the probability of selecting any individual item greater than hot_items.count is low,
+        // then we don't need any more hot_items. This short-circuits calculating the
+        // expensive cumulative distribution function.
+        if (self.hot_items.count() > 0) {
+            const cur_hot_min_probability = self.gen.probability(self.hot_items.count() - 1);
+            if (cur_hot_min_probability < hot_items_min_probability_limit) {
+                return self.hot_items.count();
+            }
+        }
+
+        const cdf_items_max = self.gen.cumulative_distribution_items(
+            hot_items_cumulative_distribution_function,
+        );
+
+        assert(cdf_items_max >= self.hot_items.count());
+
+        var max = cdf_items_max;
+        var hot_idx = self.hot_items.count();
+        while (hot_idx < cdf_items_max) : (hot_idx += 1) {
+            const prob = self.gen.probability(hot_idx);
+            if (prob < hot_items_min_probability_limit) {
+                assert(hot_idx > 0);
+                max = hot_idx;
+                break;
+            }
+        }
+
+        // Hopefully hot items fit our array.
+        assert(max <= hot_items_limit);
+
+        return max;
+    }
+};
+
+test "zeta_incr" {
+    const Case = struct {
+        n_start: u64,
+        n_incr: u64,
+        theta: f64,
+    };
+    const cases = [_]Case{
+        .{
+            .n_start = 0,
+            .n_incr = 10,
+            .theta = 0.99,
+        },
+        .{
+            .n_start = 0,
+            .n_incr = 10,
+            .theta = 1.01,
+        },
+        .{
+            .n_start = 100,
+            .n_incr = 100,
+            .theta = 0.99,
+        },
+    };
+
+    for (cases) |case| {
+        const n = case.n_start + case.n_incr;
+        const zeta_expected = zeta(n, case.theta);
+        const zeta_actual_start = zeta(case.n_start, case.theta);
+        const zeta_actual = zeta_incr(
+            case.n_start,
+            case.n_incr,
+            zeta_actual_start,
+            case.theta,
+        );
+        assert(zeta_expected == zeta_actual);
+    }
+}
+
+// Testing that the grow function correctly calculates zeta incrementally.
+test "zipfian-grow" {
+    // Need to try multiple times to ensure they don't both coincidentally
+    // pick the likely 0 value.
+    var i: u64 = 10;
+    while (i < 100) : (i += 1) {
+        const expected = brk: {
+            var rng = std.Random.Pcg.init(0);
+            const rand = rng.random();
+            var zipf = ZipfianGenerator.init_theta(i, 0.9);
+            break :brk zipf.next(rand);
+        };
+        const actual = brk: {
+            var rng = std.Random.Pcg.init(0);
+            const rand = rng.random();
+            var zipf = ZipfianGenerator.init_theta(1, 0.9);
+            zipf.grow(i - 1);
+            break :brk zipf.next(rand);
+        };
+        assert(expected == actual);
+    }
+}
+
+// Test that ctors are all doing the same thing.
+test "zipfian-ctors" {
+    var rng = std.Random.Pcg.init(0);
+    const rand = rng.random();
+
+    for ([_]u64{ 0, 1, 10, 999 }) |i| {
+        {
+            const zipf1 = ZipfianGenerator.init(i);
+            const zipf2 = ZipfianGenerator.init_theta(i, theta_default);
+            const szipf1 = ShuffledZipfian.init(i, rand);
+            const szipf2 = ShuffledZipfian.init_theta(i, theta_default, rand);
+
+            assert(zipf1.n == zipf2.n);
+            assert(zipf1.n == szipf1.gen.n);
+            assert(zipf1.n == szipf2.gen.n);
+
+            assert(zipf1.zetan == zipf2.zetan);
+            assert(zipf1.zetan == szipf1.gen.zetan);
+            assert(zipf1.zetan == szipf2.gen.zetan);
+        }
+
+        {
+            const zipf1 = ZipfianGenerator.init_theta(i, 0.89);
+            const szipf1 = ShuffledZipfian.init_theta(i, 0.89, rand);
+
+            assert(zipf1.n == szipf1.gen.n);
+            assert(zipf1.zetan == szipf1.gen.zetan);
+        }
+    }
+}
+
+// Non-statistical smoke tests related to the shuffled hot items optimization.
+// These could fail if that optimization is tweaked or if the prng changes.
+test "zipfian-hot-items" {
+    var rng = std.Random.Pcg.init(0);
+    const rand = rng.random();
+
+    {
+        const szipf = ShuffledZipfian.init(0, rand);
+        assert(szipf.hot_items.count() == 0);
+    }
+
+    {
+        const szipf = ShuffledZipfian.init(1, rand);
+        assert(szipf.hot_items.count() == 1);
+    }
+
+    {
+        const szipf = ShuffledZipfian.init(2, rand);
+        assert(szipf.hot_items.count() == 2);
+    }
+
+    for ([_]u64{ 3, 10, 999, 1_000_000 }) |i| {
+        const szipf = ShuffledZipfian.init(i, rand);
+        assert(szipf.hot_items.count() >= 1);
+        assert(szipf.hot_items.count() < i);
+
+        // Hot items should be unique
+        for (szipf.hot_items.const_slice()) |h1| {
+            var dupes: u64 = 0;
+            for (szipf.hot_items.const_slice()) |h2| {
+                if (h1 == h2) {
+                    dupes += 1;
+                }
+            }
+            assert(dupes == 1);
+        }
+
+        // Test that mostly hot items are selected, sometimes non-hot items.
+        var j: u64 = 0;
+        var hot: u64 = 0;
+        while (j < 100) : (j += 1) {
+            const n = szipf.next(rand);
+            for (szipf.hot_items.const_slice()) |hot_item| {
+                if (n == hot_item) {
+                    hot += 1;
+                }
+            }
+        }
+        if (i < 1000) {
+            assert(hot > 80);
+        } else {
+            assert(hot > 30);
+        }
+        assert(hot < 100);
+    }
+}

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -29,7 +29,7 @@ const tb = vsr.tigerbeetle;
 const StatsD = vsr.statsd.StatsD;
 const IdPermutation = vsr.testing.IdPermutation;
 const ZipfianGenerator = stdx.ZipfianGenerator;
-const ShuffledZipfian = stdx.ShuffledZipfian;
+const ZipfianShuffled = stdx.ZipfianShuffled;
 
 const cli = @import("./cli.zig");
 
@@ -136,7 +136,7 @@ pub fn main(
 
     const account_generator: Generator = switch (cli_args.account_distribution) {
         .zipfian => .{
-            .zipfian = ShuffledZipfian.init(cli_args.account_count, random),
+            .zipfian = ZipfianShuffled.init(cli_args.account_count, random),
         },
         .latest => .{
             .latest = ZipfianGenerator.init(cli_args.account_count),
@@ -232,7 +232,7 @@ pub fn main(
 }
 
 const Generator = union(enum) {
-    zipfian: ShuffledZipfian,
+    zipfian: ZipfianShuffled,
     latest: ZipfianGenerator,
     uniform,
 };

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -98,7 +98,7 @@ const CLIArgs = union(enum) {
         account_count: usize = 10_000,
         /// The probability distribution used to select accounts when making
         /// transfers or queries.
-        account_distribution: Command.Benchmark.Distribution = .zipfian,
+        account_distribution: Command.Benchmark.Distribution = .uniform,
         account_distribution_debit: Command.Benchmark.DistributionInherited = .inherit,
         account_distribution_credit: Command.Benchmark.DistributionInherited = .inherit,
         account_distribution_query: Command.Benchmark.DistributionInherited = .inherit,

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -11,6 +11,7 @@ comptime {
     _ = @import("shell.zig");
     _ = @import("stdx.zig");
     _ = @import("stdx/bounded_array.zig");
+    _ = @import("stdx/zipfian.zig");
     _ = @import("storage.zig");
     _ = @import("tidy.zig");
     _ = @import("trace.zig");


### PR DESCRIPTION
This adds two generators of Zipfian random numbers, and modifies the benchmark to use them to select accounts for transfers and querying.

This immediately allows the benchmark to produce more realistic workloads than at present. The ultimate goal though is to approximate the five YCSB core workloads within our benchmark, which this PR does not do.

The comments in zipfian.zig are thorough and mostly not repeated in this PR description.

Some sources that may help understand this PR:

- https://en.wikipedia.org/wiki/Zipf's_law
- ["Quickly Generating Billion Record Synthetic Databases"](https://www.microsoft.com/en-us/research/publication/quickly-generating-billion-record-synthetic-databases/) - the basis for this technique, page 30. Note the code listing contains errors.
- [YCSB's ZipfianGenerator](https://github.com/brianfrankcooper/YCSB/blob/master/core/src/main/java/site/ycsb/generator/ZipfianGenerator.java) - for comparison, also derived from the paper, but I did not use it directly
- [YCSB paper](https://courses.cs.duke.edu/fall13/cps296.4/838-CloudPapers/ycsb.pdf) - core workloads described on page 6

There is an obvious unit test missing here: a 2-sample kolmogorov-smirnov test that the generated numbers are statistically likely to follow the zipfian distribution. I have done this test in python, which has the required statistical methods built-in, but not in zig. I am happy to write this test in zig if asked.

I have not paid close attention to overflow, nan, or type narrowing issues as this is test code and we always compile in ReleaseSafe mode, though I'm happy to address such issues if requested.

---

This modifies the benchmark in incompatible ways. It removes the `--account-count-hot` and `--transfer-hot-percent` flags, and adds the `--account-distribution` flag, with the possible values "zipfian", "latest", and "uniform".

"zipfian" is the default as it is probably most representative of real workloads, with hot accounts being shuffled randomly across the keyspace. Passing "--account-distribution=uniform" results in the same workloads as today, but without the concept of "hot accounts". "latest" is a zipfian distribution where the most recent accounts are the most accessed; used in the YCSB core workloads.

It is no longer possible to represent the previous `--account-count-hot` and `--transfer-hot-percent` behavior. These previously allowed for a rough approximation of the "80-20 rule" and similar distributions of work, where e.g. 80 percent of transfers would use 20 percent of accounts.

That type of behavior is the purpose of the Zipfian distribution, though at least in this PR it is not tunable the way the previous flags are. It would be desirable and feasible to have similar flags like `--account-hot-percent=20` and `--account-hot-probability=80`. As mentioned in the comments of zipfian.zig, I don't presently know how to tune the distribution to say "20 percent of items have 80 percent probability" when also the number of items selected from is growable. Tuning the distribution like this involves selecting the correct `theta` for the set size, and maintaining the same 80-20 ratio seemingly requires changing theta with the set size; and there is an expensive calculation involved in changing theta. I have not yet seen any literature about this topic and have not attempted to implement it. An important caveat here though is that __at present__ the benchmark _does not_ grow the set of accounts during the benchmark, which moots the issue. I do expect to modify the benchmark in the future though to insert new accounts over time, as needed by the YCSB core workloads.

Another change: where previously the "hot" accounts would be selected for only the debit side of a transfer, and credit accounts would be selected uniformly, now both sides of the transfer follow the selected distribution.

---

Perhaps surprisingly, tigerbeetle appears to perform worse with zipfian access patterns than uniform, and so after this PR that switches to zipfian by default benchmark results in the default configuration will appear to regress.

Here are three representative runs, using uniform, zipfian, and latest distributions on my laptop:

```
$ zig/zig build run -- benchmark --transfer-count=1000000 --account-distribution=uniform
info(io): opening "0_0-3e8c5e56.tigerbeetle.benchmark"...
info(main): multiversioning: disabled for development (0.0.1) release.
info(main): release=0.0.1
info(main): release_client_min=0.0.1
info(main): releases_bundled={ 0.0.1 }
info(main): git_commit=df661c9c8e46a6b1b7dccdd2affa31628f9fd529
info(replica): superblock release=0.0.1
info(main): 0: Allocated 3070MiB during replica init
info(main): 0: Grid cache: 1024MiB, LSM-tree manifests: 128MiB
info(main): 0: cluster=0: listening on 127.0.0.1:45325
warning(main): 0: started with constants.verify - expect reduced performance. Recompile with -Dconfig=production if unexpected.
Benchmark must be built with '-Drelease' for reasonable results.
Benchmark must be built with '-Dconfig=production' for reasonable results.
info: Benchmark running against { 127.0.0.1:45325 }
info: Benchmark seed = 42
info: Account distribution = uniform
info(message_bus): connected to replica 0
info(message_bus): connection from client 126812723862003569197151784371068247806
123 batches in 27.36 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 36548 tx/s
batch latency p1 = 79 ms
batch latency p10 = 83 ms
batch latency p20 = 84 ms
batch latency p30 = 85 ms
batch latency p40 = 87 ms
batch latency p50 = 89 ms
batch latency p60 = 94 ms
batch latency p70 = 189 ms
batch latency p80 = 231 ms
batch latency p90 = 293 ms
batch latency p95 = 326 ms
batch latency p99 = 2876 ms
batch latency p100 = 3616 ms

100 queries in 8.80 s
query latency p1 = 6 ms
query latency p10 = 6 ms
query latency p20 = 7 ms
query latency p30 = 7 ms
query latency p40 = 7 ms
query latency p50 = 8 ms
query latency p60 = 8 ms
query latency p70 = 9 ms
query latency p80 = 10 ms
query latency p90 = 285 ms
query latency p95 = 316 ms
query latency p99 = 394 ms
query latency p100 = 3465 ms
info(main): stdin closed, exiting

rss = 3234099200 bytes

datafile empty = 1141374976 bytes
datafile = 1823477760 bytes
```

```
$ zig/zig build run -- benchmark --transfer-count=1000000 --account-distribution=zipfian
info(io): opening "0_0-f156d697.tigerbeetle.benchmark"...
info(main): multiversioning: disabled for development (0.0.1) release.
info(main): release=0.0.1
info(main): release_client_min=0.0.1
info(main): releases_bundled={ 0.0.1 }
info(main): git_commit=df661c9c8e46a6b1b7dccdd2affa31628f9fd529
info(replica): superblock release=0.0.1
info(main): 0: Allocated 3070MiB during replica init
info(main): 0: Grid cache: 1024MiB, LSM-tree manifests: 128MiB
info(main): 0: cluster=0: listening on 127.0.0.1:35147
warning(main): 0: started with constants.verify - expect reduced performance. Recompile with -Dconfig=production if unexpected.
Benchmark must be built with '-Drelease' for reasonable results.
Benchmark must be built with '-Dconfig=production' for reasonable results.
info: Benchmark running against { 127.0.0.1:35147 }
info: Benchmark seed = 42
info: Account distribution = zipfian
info(message_bus): connected to replica 0
info(message_bus): connection from client 180844811304677403733424898741826464730
info(message_bus): message queue for peer message_bus.MessageBusType(.replica).Connection.Peer{ .replica = 0 } full, dropping request message
info(message_bus): message queue for peer message_bus.MessageBusType(.replica).Connection.Peer{ .replica = 0 } full, dropping request message
123 batches in 43.87 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 22794 tx/s
batch latency p1 = 125 ms
batch latency p10 = 141 ms
batch latency p20 = 146 ms
batch latency p30 = 175 ms
batch latency p40 = 182 ms
batch latency p50 = 190 ms
batch latency p60 = 207 ms
batch latency p70 = 242 ms
batch latency p80 = 276 ms
batch latency p90 = 360 ms
batch latency p95 = 397 ms
batch latency p99 = 4553 ms
batch latency p100 = 6304 ms

100 queries in 11.50 s
query latency p1 = 4 ms
query latency p10 = 12 ms
query latency p20 = 16 ms
query latency p30 = 21 ms
query latency p40 = 33 ms
query latency p50 = 61 ms
query latency p60 = 67 ms
query latency p70 = 73 ms
query latency p80 = 81 ms
query latency p90 = 294 ms
query latency p95 = 332 ms
query latency p99 = 494 ms
query latency p100 = 3144 ms
info(main): stdin closed, exiting

rss = 3234918400 bytes

datafile empty = 1141374976 bytes
datafile = 1823477760 bytes
```

```
$ zig/zig build run -- benchmark --transfer-count=1000000 --account-distribution=latest
info(io): opening "0_0-b7af7882.tigerbeetle.benchmark"...
info(main): multiversioning: disabled for development (0.0.1) release.
info(main): release=0.0.1
info(main): release_client_min=0.0.1
info(main): releases_bundled={ 0.0.1 }
info(main): git_commit=df661c9c8e46a6b1b7dccdd2affa31628f9fd529
info(replica): superblock release=0.0.1
info(main): 0: Allocated 3070MiB during replica init
info(main): 0: Grid cache: 1024MiB, LSM-tree manifests: 128MiB
info(main): 0: cluster=0: listening on 127.0.0.1:43467
warning(main): 0: started with constants.verify - expect reduced performance. Recompile with -Dconfig=production if unexpected.
Benchmark must be built with '-Drelease' for reasonable results.
Benchmark must be built with '-Dconfig=production' for reasonable results.
info: Benchmark running against { 127.0.0.1:43467 }
info: Benchmark seed = 42
info: Account distribution = latest
info(message_bus): connected to replica 0
info(message_bus): connection from client 193447347888948890384498736063778658676
123 batches in 31.64 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 31602 tx/s
batch latency p1 = 92 ms
batch latency p10 = 98 ms
batch latency p20 = 103 ms
batch latency p30 = 112 ms
batch latency p40 = 119 ms
batch latency p50 = 128 ms
batch latency p60 = 142 ms
batch latency p70 = 203 ms
batch latency p80 = 284 ms
batch latency p90 = 308 ms
batch latency p95 = 352 ms
batch latency p99 = 3423 ms
batch latency p100 = 3738 ms

100 queries in 11.78 s
query latency p1 = 5 ms
query latency p10 = 6 ms
query latency p20 = 7 ms
query latency p30 = 10 ms
query latency p40 = 25 ms
query latency p50 = 50 ms
query latency p60 = 68 ms
query latency p70 = 72 ms
query latency p80 = 88 ms
query latency p90 = 282 ms
query latency p95 = 365 ms
query latency p99 = 457 ms
query latency p100 = 3541 ms
info(main): stdin closed, exiting

rss = 3232616448 bytes

datafile empty = 1141374976 bytes
datafile = 1823477760 bytes
```