### PR TITLE
vsr: sync cleanups

### DIFF
--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -97,7 +97,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
         /// Returns whether the replica's state changed since the last check_state().
         pub fn check_state(state_checker: *Self, replica_index: u8) !void {
             const replica = &state_checker.replicas[replica_index];
-            if (replica.syncing == .updating_superblock) {
+            if (replica.syncing == .updating_checkpoint) {
                 // Allow a syncing replica to fast-forward its commit.
                 //
                 // But "fast-forwarding" may actually move commit_min slightly backwards:
@@ -107,7 +107,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 // 3. When we sync, `commit_min` "backtracks", to `X - lsm_compaction_ops`.
                 const commit_min_source = state_checker.commit_mins[replica_index];
                 const commit_min_target =
-                    replica.syncing.updating_superblock.checkpoint_state.header.op;
+                    replica.syncing.updating_checkpoint.header.op;
                 assert(commit_min_source <= commit_min_target + constants.lsm_compaction_ops);
                 state_checker.commit_mins[replica_index] = commit_min_target;
                 return;

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -370,9 +370,7 @@ const Environment = struct {
                 .command = .do_view_change,
                 .array = vsr_headers,
             },
-            .checkpoint = &vsr_state.checkpoint,
-            .sync_op_min = vsr_state.sync_op_min,
-            .sync_op_max = vsr_state.sync_op_max,
+            .sync_checkpoint = null,
         });
     }
 

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -28,11 +28,7 @@ pub const Stage = union(enum) {
     awaiting_checkpoint,
 
     /// We received a new checkpoint and a log suffix are in process of writing them to disk.
-    updating_superblock: UpdatingSuperBlock,
-
-    pub const UpdatingSuperBlock = struct {
-        checkpoint_state: vsr.CheckpointState,
-    };
+    updating_checkpoint: vsr.CheckpointState,
 
     pub fn valid_transition(from: std.meta.Tag(Stage), to: std.meta.Tag(Stage)) bool {
         return switch (from) {
@@ -41,8 +37,8 @@ pub const Stage = union(enum) {
                 to == .awaiting_checkpoint,
             .canceling_commit => to == .canceling_grid,
             .canceling_grid => to == .awaiting_checkpoint,
-            .awaiting_checkpoint => to == .awaiting_checkpoint or to == .updating_superblock,
-            .updating_superblock => to == .idle,
+            .awaiting_checkpoint => to == .awaiting_checkpoint or to == .updating_checkpoint,
+            .updating_checkpoint => to == .idle,
         };
     }
 };


### PR DESCRIPTION
The goal of that PR was to unify `superblock.checkpoint` and `superblock.view_change` functions into a single

```
update(options: struct {
    view: ?ViewUpdate,
    checkpoint: ?Checkpoint,
})
```

That goal was not achieved! I did make a couple of refactors that make the code clearer along the way though.

The reason why I wasn't able unify the two functions is that they actually update checkpoint differently. `fn checkpoint` advances the checkpoint logically -- it materializes `CheckpointState` out of passed arguments. In contrast, `view_change` jumps the checkpoint physically --- it gets the _bytes_ of `CheckpointState` as an argument.

So instead:

* group checkpoint-related fields of `view_change` into an optional struct, to make it clear that the checkpoint is optionally updated
* add assertions that that checkpoint is connected to ours via parent_id/grandparent_id
* rename and peel a layer of `syncing.updating_superblock`.

I am still looking for a better name for `superblock.view_change` / `replica.view_durable_update`.