### PR TITLE
docs: used # for document titles and ## for section headings

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -28,10 +28,10 @@ Moved to [about/safety](./about/safety.md#fault-models).
 
 Moved to [about/architecture](./about/architecture.md#protocol).
 
-# Why C/Zig?
+## Why C/Zig?
 
 Moved to [about/zig](./about/zig.md).
 
-# References
+## References
 
 Moved to [about](./about/README.md#references).

--- a/docs/about/internals/lsm.md
+++ b/docs/about/internals/lsm.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Documentation for (roughly) code in the `src/lsm` directory.
 
-# Glossary
+## Glossary
 
 - _bar_: `lsm_compaction_ops` beats; unit of incremental compaction.
 - _beat_: `op % lsm_compaction_ops`; Single step of an incremental compaction.
@@ -19,8 +19,8 @@ Documentation for (roughly) code in the `src/lsm` directory.
 - _mutable table_: In-memory table; one per tree. All tree updates (e.g. `Tree.put`) directly modify just this table.
 - _snapshot_: Sequence number which selects the queryable partition of on-disk tables.
 
-# Tree
-## Tables
+## Tree
+### Tables
 
 A tree is a hierarchy of in-memory and on-disk tables. There are three categories of tables:
 
@@ -38,7 +38,7 @@ A tree is a hierarchy of in-memory and on-disk tables. There are three categorie
     (`config.lsm_growth_factor` is typically 8).
   - Within a given level and snapshot, the tables' key ranges are [disjoint](https://github.com/tigerbeetle/tigerbeetle/blob/main/src/lsm/manifest_level.zig).
 
-## Compaction
+### Compaction
 
 Tree compaction runs to the sound of music!
 
@@ -94,7 +94,7 @@ Invariants:
     * Remove input tables that are invisible to all current and persisted snapshots.
     * Release reservations from the Free Set.
 
-### Compaction Selection Policy
+#### Compaction Selection Policy
 
 Compaction selects the table from level `A` which overlaps the fewest visible tables of level `B`.
 
@@ -112,7 +112,7 @@ Links:
 - [Constructing and Analyzing the LSM Compaction Design Space](http://vldb.org/pvldb/vol14/p2216-sarkar.pdf) describes the tradeoffs of various data movement policies. TigerBeetle implements the "least overlapping with parent" policy.
 - [Option of Compaction Priority](https://rocksdb.org/blog/2016/01/29/compaction_pri.html)
 
-#### Compaction Move Table
+##### Compaction Move Table
 
 When the [selected input table](#compaction-selection-policy) from level `A` does not overlap _any_
 input tables in level `B`, the input table can be "moved" to level `B`.
@@ -123,7 +123,7 @@ This is referred to as the _move table_ optimization.
 Where a tree performs inserts mostly in sort order, with a minimum of updates, this _move table_
 optimization should enable the tree's performance to approach that of an append-only log.
 
-#### Compaction Table Overlap
+##### Compaction Table Overlap
 
 Applying [this](#compaction-selection-policy) selection policy while compacting a table
 from level A to level B, what is the maximum number of level-B tables that may overlap with the
@@ -141,7 +141,7 @@ Perhaps surprisingly, this is `lsm_growth_factor`:
   that implies the existence of a table in level `A` with _less than_ `lsm_growth_factor` overlap.
   The latter table would be selected over the former.
 
-## Snapshots
+### Snapshots
 
 Each table has a minimum and maximum integer snapshot (`snapshot_min` and `snapshot_max`).
 
@@ -157,7 +157,7 @@ Compaction does not modify tables in place — it copies data. Snapshots control
 which copies are useful, and which can be deleted. Snapshots can also be persisted, enabling
 queries against past states of the tree (unimplemented; future work).
 
-### Snapshots and Compaction
+#### Snapshots and Compaction
 
 Consider the half-bar compaction beginning at op=`X` (`12`), with `lsm_compaction_ops=M` (`8`).
 Each half-bar contains `N=M/2` (`4`) beats. The next half-bar begins at `Y=X+N` (`16`).
@@ -185,17 +185,17 @@ Beginning from the next op after the compaction (`Y`; `16`):
 
 At this point the input tables can be removed if they are invisible to all persistent snapshots.
 
-### Snapshot Queries
+#### Snapshot Queries
 
 Each query targets a particular snapshot, either:
 - the current snapshot (`snapshot_latest`), or
 - a [persisted snapshot](#persistent-snapshots).
 
-#### Persistent Snapshots
+##### Persistent Snapshots
 
 TODO(Persistent Snapshots): Expand this section.
 
-### Snapshot Values
+#### Snapshot Values
 
 - The on-disk tables visible to a snapshot `B` do not contain the updates from the commit with op `B`.
 - Rather, snapshot `B` is first visible to a prefetch from the commit with op `B`.
@@ -225,7 +225,7 @@ At the end of the last beat of the compaction bar (`23`):
 - `tree.lookup_snapshot_max` is `x` when committing op `x` (for `x ∈ {24,25,…}`).
 
 
-## Manifest
+### Manifest
 
 The manifest is a tree's index of table locations and metadata.
 
@@ -233,7 +233,7 @@ Each manifest has two components:
 - a single [`ManifestLog`](#manifest-log) shared by all trees and levels, and
 - one [`ManifestLevel`](#manifest-level) for each on-disk level.
 
-### Manifest Log
+#### Manifest Log
 
 The manifest log is an on-disk log of all updates to the trees' table indexes.
 
@@ -257,7 +257,7 @@ Each manifest block has a reference to the (chronologically) previous manifest b
 The superblock stores the head and tail address/checksum of this linked list.
 The reference on the header of the head manifest block "dangles" – the block it references has already been compacted.
 
-### Manifest Level
+#### Manifest Level
 
 A `ManifestLevel` is an in-memory collection of the table metadata for a single level of a tree.
 
@@ -266,7 +266,7 @@ but the key ranges are disjoint.
 
 Manifest levels are queried for tables at a target snapshot and within a key range.
 
-#### Example
+##### Example
 
 Given the `ManifestLevel` tables (with values chosen for visualization, not realism):
 


### PR DESCRIPTION
There are two schools of thought regarding largest (`# War and Peace`) headings in markdown. One school says that they are _section_ titles, so you could have multiple #'s in the document. But another option is to say that a single # signifies document _title_, and there should be only one in a document.

We use markdown to create HTML, so # turns into h1. MDN recommends that there's only a single h1 in a page:

<https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#avoid_using_multiple_h1_elements_on_one_page>

For this reason,  we follow the second convention.