### PR TITLE
vsr: refine heuristic for lagging potential primary forfeiting view change

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2110,10 +2110,17 @@ pub fn ReplicaType(
                 DVCQuorum.commit_max(self.do_view_change_from_all_replicas),
             );
 
-            // We are lagging from the cluster by at least a checkpoint, and that checkpoint is
-            // durable on a commit quorum of replicas. Forfeit the view change and prefer the
-            // replica with the durable checkpoint for primary.
-            if (vsr.Checkpoint.durable(self.op_checkpoint_next(), commit_max)) {
+            // A lagging potential primary may forfeit the view change to allow a more up-to-date
+            // replica to step up as primary:
+            // * Unconditionally, when it is lagging by least a checkpoint and that checkpoint is
+            //   durable.
+            // * Heurisitically, when the maximum checkpoint in the cluster is not durable. The
+            //   heuristic is simple - a lagging replica gives a more-up-date replica *one* chance
+            //   to step up as primary before it attempts to step up as primary.
+            if (vsr.Checkpoint.durable(self.op_checkpoint_next(), commit_max) or
+                (op_checkpoint_max > self.op_checkpoint() and
+                (self.view - self.log_view < self.replica_count)))
+            {
                 // This serves a few purposes:
                 // 1. Availability: We pick a primary to minimize the number of WAL repairs, to
                 //    minimize the likelihood of a repair-deadlock.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2114,7 +2114,7 @@ pub fn ReplicaType(
             // replica to step up as primary:
             // * Unconditionally, when it is lagging by least a checkpoint and that checkpoint is
             //   durable.
-            // * Heurisitically, when the maximum checkpoint in the cluster is not durable. The
+            // * Heuristically, when the maximum checkpoint in the cluster is not durable. The
             //   heuristic is simple - a lagging replica gives a more-up-date replica *one* chance
             //   to step up as primary before it attempts to step up as primary.
             if (vsr.Checkpoint.durable(self.op_checkpoint_next(), commit_max) or


### PR DESCRIPTION
Currently, a lagging potential primary *never* forfeits a view change if the maximum checkpoint in the cluster is not durable on a commit quorum of replicas. However, this may not always be the most efficient way to complete view change! This PR introduces a heuristic wherein a lagging replica first gives the more up-to-date replica a chance to become potential primary.  If the more up-to-date replica isn't able to step up as primary (due to a storage fault, for example) and the view change circles back around to the lagging replica, the lagging replica tries to step up as primary. 

The heuristic is simple, lagging replicas compare their `view` with `log_view`. If `view - log_view >= replica_count`, we view change has circled around and come back to the lagging replica without electing a primary. In this case, the lagging replica *does not forfeit* and tries to step up as primary (thereby incrementing its log_view and *resetting* the heuristic).

Thanks to @matklad for suggesting this heuristic! 🚀 