### PR TITLE
ci: fix coverage upload to GitHub pages

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -46,6 +46,17 @@ fn devhub_coverage(shell: *Shell) !void {
     try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_tree 92", .{ .kcov = kcov });
     try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_forest 92", .{ .kcov = kcov });
     try shell.exec("{kcov} ./zig-out/bin/vopr 92", .{ .kcov = kcov });
+
+    var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
+    defer coverage_dir.close();
+
+    // kcov adds some symlinks to the output, which prevents upload to GitHub actions from working.
+    var it = coverage_dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind == .sym_link) {
+            try coverage_dir.deleteFile(entry.name);
+        }
+    }
 }
 
 fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {


### PR DESCRIPTION
Symlinks confuse tar:

    2024-09-05T21:01:41.1681971Z tar: ./coverage/vopr: File removed before we read it

    <https://productionresultssa1.blob.core.windows.net/actions-results/7d2fc998-7c82-4357-a9a1-6c5b206c0fbc/workflow-job-run-a55491d9-0675-57de-7e23-915287532f8d/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-09-06T08%3A46%3A12Z&sig=Fa7GGm%2BQ8Z%2BEsukXjLBE4Ryy9RmN%2BrW6r7pzwgXLzKk%3D&ske=2024-09-06T17%3A21%3A32Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-09-06T05%3A21%3A32Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-05-04&sp=r&spr=https&sr=b&st=2024-09-06T08%3A36%3A07Z&sv=2024-05-04>