### PR TITLE
fix: typos

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -422,7 +422,7 @@ pub fn ContextType(
             assert(packet.next == null); // (previously) inflight packet should not be pending.
 
             // Submit the next pending packet (if any) now that VSR has completed this one.
-            // The submit() call may complete it inline so keep submitting until theres an inflight.
+            // The submit() call may complete it inline so keep submitting until there's an inflight.
             while (self.pending.pop()) |packet_next| {
                 self.submit(packet_next);
                 if (self.client.request_inflight != null) break;
@@ -438,7 +438,7 @@ pub fn ContextType(
 
                     // Demuxer expects []u8 but VSR callback provides []const u8.
                     // The bytes are known to come from a Message body that will be soon discarded
-                    // therefor it's safe to @constCast and potentially modify the data in-place.
+                    // therefore it's safe to @constCast and potentially modify the data in-place.
                     var demuxer = Client.DemuxerType(operation).init(@constCast(reply));
 
                     var it: ?*Packet = packet;

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -422,7 +422,8 @@ pub fn ContextType(
             assert(packet.next == null); // (previously) inflight packet should not be pending.
 
             // Submit the next pending packet (if any) now that VSR has completed this one.
-            // The submit() call may complete it inline so keep submitting until there's an inflight.
+            // The submit() call may complete it inline so keep submitting until there's
+            // an inflight.
             while (self.pending.pop()) |packet_next| {
                 self.submit(packet_next);
                 if (self.client.request_inflight != null) break;

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1851,7 +1851,7 @@ public class IntegrationTests
 
     private static ulong GetTimestampLast()
     {
-        // Inserts a dummy transfer just to retrieve the lastest timestamp
+        // Inserts a dummy transfer just to retrieve the latest timestamp
         // recorded by the cluster.
         // Must be used only in "DoNotParallelize" tests.
         var dummy_account = GenerateAccounts()[0];

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -10,7 +10,7 @@ namespace TigerBeetle;
 
 internal sealed class NativeClient : IDisposable
 {
-    // Once the client handle is set, all interactions with it are sychronized using `lock(this)`
+    // Once the client handle is set, all interactions with it are synchronized using `lock(this)`
     // to prevent threads from accidentally using a deinitialized client handle. It's safe to
     // synchronize on the NativeClient object as it's private to Client and can't be arbitrarily
     // or externally locked by the library user.

--- a/src/clients/go/pkg/types/main.go
+++ b/src/clients/go/pkg/types/main.go
@@ -86,12 +86,12 @@ func BigIntToUint128(value big.Int) Uint128 {
 	// big.Int bytes are big-endian so convert them to little-endian for Uint128 bytes.
 	bytes := value.Bytes()
 	swapEndian(bytes[:])
-	
-	// Only cast slice to bytes when theres enough.
+
+	// Only cast slice to bytes when there's enough.
 	if len(bytes) >= 16 {
 		return BytesToUint128(*(*[16]byte)(bytes))
 	}
-	
+
 	var zeroPadded [16]byte
 	copy(zeroPadded[:], bytes)
 	return BytesToUint128(zeroPadded)
@@ -109,12 +109,12 @@ var idMutex sync.Mutex
 
 // Generates a Universally Unique and Sortable Identifier based on https://github.com/ulid/spec.
 // Uint128 returned are guaranteed to be monotonically increasing when interpreted as little-endian.
-// `ID()` is safe to call from multiple goroutines with monotonicity being sequentially consistent. 
+// `ID()` is safe to call from multiple goroutines with monotonicity being sequentially consistent.
 func ID() Uint128 {
 	timestamp := time.Now().UnixMilli()
 
 	// Lock the mutex for global id variables.
-	// Then ensure lastTimestamp is monotonically increasing & lastRandom changes each millisecond 
+	// Then ensure lastTimestamp is monotonically increasing & lastRandom changes each millisecond
 	idMutex.Lock()
 	if timestamp <= idLastTimestamp {
 		timestamp = idLastTimestamp
@@ -151,7 +151,7 @@ func ID() Uint128 {
 	var id [16]byte
 	binary.LittleEndian.PutUint64(id[:8], randomLo)
 	binary.LittleEndian.PutUint16(id[8:], randomHi)
-	binary.LittleEndian.PutUint16(id[10:], (uint16)(timestamp)) // timestamp lo
-	binary.LittleEndian.PutUint32(id[12:], (uint32)(timestamp >> 16)) // timestamp hi
+	binary.LittleEndian.PutUint16(id[10:], (uint16)(timestamp))     // timestamp lo
+	binary.LittleEndian.PutUint32(id[12:], (uint32)(timestamp>>16)) // timestamp hi
 	return BytesToUint128(id)
 }

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -88,7 +88,7 @@ pub const IO = struct {
                 timeout_ms = if (expires == os.windows.INFINITE) expires - 1 else expires;
             }
 
-            // Poll for IO iff theres IO pending and flush_timeouts() found no ready completions
+            // Poll for IO if theres' IO pending and flush_timeouts() found no ready completions
             if (self.io_pending > 0 and self.completed.empty()) {
                 // In blocking mode, we're always waiting at least until the timeout by run_for_ns.
                 // In non-blocking mode, we shouldn't wait at all.

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -88,7 +88,7 @@ pub const IO = struct {
                 timeout_ms = if (expires == os.windows.INFINITE) expires - 1 else expires;
             }
 
-            // Poll for IO if theres' IO pending and flush_timeouts() found no ready completions
+            // Poll for IO iff there's IO pending and flush_timeouts() found no ready completions
             if (self.io_pending > 0 and self.completed.empty()) {
                 // In blocking mode, we're always waiting at least until the timeout by run_for_ns.
                 // In non-blocking mode, we shouldn't wait at all.

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1315,7 +1315,7 @@ const HeaderBodyOffsets = struct {
 
 /// Parse an untrusted, unverified, and potentially corrupt ELF file. This parsing happens before
 /// any checksums are verified, and so needs to deal with any ELF metadata being corrupt, while
-/// not panicing and returning errors.
+/// not panicking and returning errors.
 ///
 /// Anything that would normally assert should return an error instead - especially implicit things
 /// like bounds checking on slices.

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -696,7 +696,7 @@ fn publish_node(shell: *Shell, info: VersionInfo) !void {
 }
 
 // Docker is not required and not recommended for running TigerBeetle. A container is published
-// just for convenince of consumers expecting one!
+// just for convenience of consumers expecting one!
 fn publish_docker(shell: *Shell, info: VersionInfo) !void {
     var section = try shell.open_section("publish docker");
     defer section.close();

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -1,7 +1,7 @@
 //! Collection of utilities for scripting: an in-process sh+coreutils combo.
 //!
 //! Keep this as a single file, independent from the rest of the codebase, to make it easier to
-//! re-use across different processes (eg build.zig).
+//! reuse across different processes (eg build.zig).
 //!
 //! If possible, avoid shelling out to `sh` or other systems utils --- the whole purpose here is to
 //! avoid any extra dependencies.

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -283,7 +283,7 @@ pub fn Storage(comptime IO: type) type {
                         // We could set `read.target_max` to `vsr.sector_ceil(read.buffer.len)` here
                         // in order to restart our pseudo-binary search on the rest of the sectors
                         // to be read, optimistically assuming that this is the last failing sector.
-                        // However, data corruption that causes EIO errors often has spacial
+                        // However, data corruption that causes EIO errors often has spatial
                         // locality. Therefore, restarting our pseudo-binary search here might give
                         // us abysmal performance in the (not uncommon) case of many successive
                         // failing sectors.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -243,7 +243,7 @@ pub const Command = enum(u8) {
     }
 };
 
-/// This type exists to avoid making the Header type dependant on the state
+/// This type exists to avoid making the Header type dependent on the state
 /// machine used, which would cause awkward circular type dependencies.
 pub const Operation = enum(u8) {
     // Looking to make backwards incompatible changes here? Make sure to check release.zig for


### PR DESCRIPTION
Used `codespell` tool to find typos and corrected them