### PR TITLE
vsr: remove -Dconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - run: ./zig/download.sh
       - run: ./zig/zig fmt --check .
       - run: ./zig/zig build check
-      - run: ./zig/zig build check -Dconfig=test_min
       - run: ./.github/ci/docs_check.sh
 
   test_alpine:

--- a/build.zig
+++ b/build.zig
@@ -92,7 +92,6 @@ pub fn build(b: *std.Build) !void {
             "multiversion",
             "Past version to include for upgrades",
         ),
-        .config = b.option(config.ConfigBase, "config", "Base configuration.") orelse .default,
         .config_verify = b.option(bool, "config_verify", "Enable extra assertions.") orelse true,
         .config_aof_recovery = b.option(
             bool,
@@ -153,7 +152,6 @@ pub fn build(b: *std.Build) !void {
         "release_client_min",
         build_options.config_release_client_min,
     );
-    vsr_options.addOption(config.ConfigBase, "config_base", build_options.config);
     vsr_options.addOption(bool, "config_verify", build_options.config_verify);
     vsr_options.addOption(std.log.Level, "config_log_level", build_options.config_log_level);
     vsr_options.addOption(config.TracerBackend, "tracer_backend", build_options.tracer_backend);

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -11,8 +11,8 @@ const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("TigerBeetle.sln"));
 
-    try shell.zig("build clients:dotnet -Drelease -Dconfig=production", .{});
-    try shell.zig("build -Drelease -Dconfig=production", .{});
+    try shell.zig("build clients:dotnet -Drelease", .{});
+    try shell.zig("build -Drelease", .{});
 
     try shell.exec("dotnet restore", .{});
     try shell.exec("dotnet format --no-restore --verify-no-changes", .{});

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -18,8 +18,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     }
 
     // `go build`  won't compile the native library automatically, we need to do that ourselves.
-    try shell.zig("build clients:go -Drelease -Dconfig=production", .{});
-    try shell.zig("build -Drelease -Dconfig=production", .{});
+    try shell.zig("build clients:go -Drelease", .{});
+    try shell.zig("build -Drelease", .{});
 
     // Although we have compiled the TigerBeetle client library, we still need `cgo` to link it with
     // our resulting Go binary. Strictly speaking, `CC` is controlled by the users of TigerBeetle,

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -10,8 +10,8 @@ const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("pom.xml"));
 
-    try shell.zig("build clients:java -Drelease -Dconfig=production", .{});
-    try shell.zig("build -Drelease -Dconfig=production", .{});
+    try shell.zig("build clients:java -Drelease", .{});
+    try shell.zig("build -Drelease", .{});
 
     try shell.zig("build test:jni", .{});
     // Java's maven doesn't support a separate test command, or a way to add dependency on a

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -11,7 +11,7 @@ const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("package.json"));
 
-    try shell.zig("build clients:node -Drelease -Dconfig=production", .{});
+    try shell.zig("build clients:node -Drelease", .{});
 
     // Integration tests.
 

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -67,7 +67,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     // Only build the TigerBeetle binary to test build speed and build size. Throw it away once
     // done, and use a release build from `zig-out/dist/` to run the benchmark.
     var timer = try std.time.Timer.start();
-    try shell.zig("build -Drelease -Dconfig=production install", .{});
+    try shell.zig("build -Drelease install", .{});
     const build_time_ms = timer.lap() / std.time.ns_per_ms;
     const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;
     try shell.project_root.deleteFile("tigerbeetle");

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -269,7 +269,7 @@ fn build_dotnet(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     log.info("dotnet version {s}", .{dotnet_version});
 
     try shell.zig(
-        \\build clients:dotnet -Drelease -Dconfig=production -Dconfig-release={release_triple}
+        \\build clients:dotnet -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
         .release_triple = info.release_triple,
@@ -296,7 +296,7 @@ fn build_go(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     defer shell.popd();
 
     try shell.zig(
-        \\build clients:go -Drelease -Dconfig=production -Dconfig-release={release_triple}
+        \\build clients:go -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
         .release_triple = info.release_triple,
@@ -350,7 +350,7 @@ fn build_java(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     log.info("java version {s}", .{java_version});
 
     try shell.zig(
-        \\build clients:java -Drelease -Dconfig=production -Dconfig-release={release_triple}
+        \\build clients:java -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
         .release_triple = info.release_triple,
@@ -392,7 +392,7 @@ fn build_node(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     log.info("node version {s}", .{node_version});
 
     try shell.zig(
-        \\build clients:node -Drelease -Dconfig=production -Dconfig-release={release_triple}
+        \\build clients:node -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
         .release_triple = info.release_triple,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -41,11 +41,11 @@ pub fn main(
     if (builtin.mode != .ReleaseSafe and builtin.mode != .ReleaseFast) {
         try stderr.print("Benchmark must be built with '-Drelease' for reasonable results.\n", .{});
     }
-    if (!vsr.constants.config.is_production()) {
-        try stderr.print(
-            \\Benchmark must be built with '-Dconfig=production' for reasonable results.
-            \\
-        , .{});
+    if (vsr.constants.config.process.direct_io) {
+        log.warn("direct io is disabled", .{});
+    }
+    if (vsr.constants.config.process.verify) {
+        log.warn("extra assertions are enabled", .{});
     }
 
     if (cli_args.account_count < 2) flags.fatal(

--- a/tools/vscode/format_debug_server.sh
+++ b/tools/vscode/format_debug_server.sh
@@ -11,5 +11,5 @@ if [ -f "$FILE" ]; then
     rm $FILE
 fi
 
-./zig/zig build -Dconfig=production
+./zig/zig build
 ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 $FILE


### PR DESCRIPTION
There's no need to specify config on the CLI --- production config is all you need!

We still need a way to override config for tests and fuzzing, but we do that from-within the source.