### PR TITLE
vopr: non faulty replica shouldn't enter recovering_head with op < op_checkpoint

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1099,7 +1099,7 @@ pub const Simulator = struct {
 
         if (replica.status == .recovering_head) {
             // Even with faults disabled, a replica may wind up in status=recovering_head.
-            assert(fault or replica.op < replica.op_checkpoint() or header_prepare_view_mismatch);
+            assert(fault or header_prepare_view_mismatch);
         }
 
         replica_storage.faulty = true;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1279,7 +1279,6 @@ const ViewChangeHeadersSlice = struct {
             .command = command,
             .slice = slice,
         };
-        headers.verify();
         return headers;
     }
 
@@ -1422,6 +1421,7 @@ test "Headers.ViewChangeSlice.view_for_op" {
     headers_array[3].set_checksum();
 
     const headers = Headers.ViewChangeSlice.init(.do_view_change, &headers_array);
+    headers.verify();
     try std.testing.expect(std.meta.eql(headers.view_for_op(11, 12), .{ .min = 12, .max = 12 }));
     try std.testing.expect(std.meta.eql(headers.view_for_op(10, 12), .{ .min = 12, .max = 12 }));
     try std.testing.expect(std.meta.eql(headers.view_for_op(9, 12), .{ .min = 10, .max = 10 }));
@@ -1438,12 +1438,12 @@ const ViewChangeHeadersArray = struct {
     array: Headers.Array,
 
     pub fn root(cluster: u128) ViewChangeHeadersArray {
-        return ViewChangeHeadersArray.init_from_slice(.start_view, &.{
+        return ViewChangeHeadersArray.init(.start_view, &.{
             Header.Prepare.root(cluster),
         });
     }
 
-    pub fn init_from_slice(
+    pub fn init(
         command: ViewChangeCommand,
         slice: []const Header.Prepare,
     ) ViewChangeHeadersArray {
@@ -1451,16 +1451,6 @@ const ViewChangeHeadersArray = struct {
             .command = command,
             .array = Headers.Array.from_slice(slice) catch unreachable,
         };
-        headers.verify();
-        return headers;
-    }
-
-    fn init_from_array(command: ViewChangeCommand, array: Headers.Array) ViewChangeHeadersArray {
-        const headers = ViewChangeHeadersArray{
-            .command = command,
-            .array = array,
-        };
-        headers.verify();
         return headers;
     }
 


### PR DESCRIPTION
Solves a failing seed (`./zig/zig build -Drelease vopr -- --lite 4766636330770358721`) found on this branch (since it involves changing a VOPR condition) wherein a replica enters a recovering_head post startup even if faults are disabled.

#### Problem

Imagine a potential primary handling a do_view_change. Currently, the potential primary replica first updates its in-memory log_view and initiates repair. During repair, the replica could repair some ops around the checkpoint and its trigger and advance its checkpoint. If such a replica crashes before making its log_view durable, it would restart with a regressed log_view and the TruncateViewRange condition would truncate all ops that were repaired (since their view # is greater than the log_view the replica restarts with). This truncation could regress self.op below self.op_checkpoint(), which could lead to a non faulty replica [starting up in the recovering_head state](https://github.com/tigerbeetle/tigerbeetle/blob/bc4a71bc5fa93de1f33403b0ea1d7a1f176e565e/src/vsr/replica.zig#L770-L787).

#### Solution

Potential primaries now initiate making their view_headers durable *before* they start repair. These headers are computed from the journal *after* the potential primary writes the headers from the DVC quorum to its journal using [self.primary_set_log_from_do_view_change_messages()](https://github.com/tigerbeetle/tigerbeetle/blob/bc4a71bc5fa93de1f33403b0ea1d7a1f176e565e/src/vsr/replica.zig#L2153). Therefore, if the potential primary advances its checkpoint during repair, the checkpoint is guaranteed to be written to the superblock *after* the view_headers (since writes to the superblock are serialized). 

After this change, we can never encounter a scenario on startup where `self.log_view < self.view` and `self.op < self.op_checkpoint()`.