### PR TITLE
ci: set release binary date to be the date of the commit its building

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -54,7 +54,7 @@ pub fn main() !void {
     var allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer {
         if (allocator.deinit() != .ok) {
-            @panic("memory leaked", .{});
+            @panic("memory leaked");
         }
     }
     const gpa = allocator.allocator();

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -202,6 +202,10 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
         "aarch64-macos", // Will build a universal binary.
     };
 
+    const sha_date = try shell.exec_stdout("git show --no-patch --no-notes --pretty=%cI {sha}", .{
+        .sha = info.sha,
+    });
+
     // Build tigerbeetle binary for all OS/CPU combinations we support and copy the result to
     // `dist`.
     inline for (.{ true, false }) |debug| {
@@ -244,7 +248,8 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
                 assert(std.mem.indexOf(u8, output, build_mode) != null);
             }
 
-            try shell.exec("touch -d 1970-01-01T00:00:00Z {exe_name}", .{
+            try shell.exec("touch -d {sha_date} {exe_name}", .{
+                .sha_date = sha_date,
                 .exe_name = exe_name,
             });
             try shell.exec("zip -9 {zip_path} {exe_name}", .{


### PR DESCRIPTION
Previously, it was set to the epoch, but this leads to "Jan 1 1970" if you run `ls`.

(also, fix broken multiversion builds!)