### PR TITLE
Add Scan and Lookup Traces.

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -317,6 +317,11 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 @field(forest.grooves, field.name).reset();
             }
 
+            forest.grid.trace.reset(.lookup);
+            forest.grid.trace.reset(.lookup_worker);
+            forest.grid.trace.reset(.scan_tree);
+            forest.grid.trace.reset(.scan_tree_level);
+
             forest.manifest_log.reset();
             forest.node_pool.reset();
             forest.scan_buffer_pool.reset();

--- a/src/lsm/scan_buffer.zig
+++ b/src/lsm/scan_buffer.zig
@@ -39,10 +39,18 @@ pub const ScanBuffer = struct {
         }
     };
 
+    index: u8,
     levels: [constants.lsm_levels]LevelBuffer,
 
-    pub fn init(self: *ScanBuffer, allocator: Allocator) !void {
+    pub fn init(
+        self: *ScanBuffer,
+        allocator: Allocator,
+        options: struct {
+            index: u8,
+        },
+    ) !void {
         self.* = .{
+            .index = options.index,
             .levels = undefined,
         };
         for (&self.levels, 0..) |*level, i| {
@@ -73,9 +81,12 @@ pub const ScanBufferPool = struct {
             .scan_buffer_used = 0,
         };
 
-        for (&self.scan_buffers, 0..) |*scan_buffer, i| {
-            errdefer for (self.scan_buffers[0..i]) |*buffer| buffer.deinit(allocator);
-            try scan_buffer.init(allocator);
+        for (&self.scan_buffers, 0..) |*scan_buffer, index| {
+            errdefer for (self.scan_buffers[0..index]) |*buffer| buffer.deinit(allocator);
+            try scan_buffer.init(
+                allocator,
+                .{ .index = @intCast(index) },
+            );
         }
         errdefer for (&self.scan_buffers) |*buffer| buffer.deinit(allocator);
     }

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -233,6 +233,11 @@ pub fn ScanTreeType(
         pub fn read(self: *ScanTree, context: Context, callback: Callback) void {
             assert(self.state == .idle or self.state == .needs_data);
 
+            self.tree.grid.trace.start(
+                .{ .scan_tree = .{ .index = self.buffer.index } },
+                .{ .tree = self.tree.config.name },
+            );
+
             const state_before = self.state;
             self.state = .{
                 .buffering = .{
@@ -401,6 +406,11 @@ pub fn ScanTreeType(
                     self.direction,
                 );
             }
+
+            self.tree.grid.trace.stop(
+                .{ .scan_tree = .{ .index = self.buffer.index } },
+                .{ .tree = self.tree.config.name },
+            );
 
             callback(context, self);
         }
@@ -607,6 +617,14 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
 
         pub fn fetch(self: *ScanTreeLevel) void {
             assert(self.scan.state == .buffering);
+
+            self.scan.tree.grid.trace.start(
+                .{ .scan_tree_level = .{
+                    .index = self.scan.buffer.index,
+                    .level = self.level_index,
+                } },
+                .{ .tree = self.scan.tree.config.name },
+            );
 
             switch (self.state) {
                 .loading_manifest => unreachable,
@@ -970,6 +988,14 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 self.move_next();
             }
 
+            self.scan.tree.grid.trace.stop(
+                .{ .scan_tree_level = .{
+                    .index = self.scan.buffer.index,
+                    .level = self.level_index,
+                } },
+                .{ .tree = self.scan.tree.config.name },
+            );
+
             switch (self.values) {
                 .fetching => self.fetch(),
                 .buffered, .finished => self.scan.levels_read_complete(),
@@ -987,6 +1013,14 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             assert(self.values == .finished);
             assert(self.scan.state == .buffering);
             assert(self.scan.state.buffering.pending_count > 0);
+
+            self.scan.tree.grid.trace.stop(
+                .{ .scan_tree_level = .{
+                    .index = self.scan.buffer.index,
+                    .level = self.level_index,
+                } },
+                .{ .tree = self.scan.tree.config.name },
+            );
 
             self.scan.levels_read_complete();
         }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -198,7 +198,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.tree = undefined;
             env.lookup_value = null;
 
-            try env.scan_buffer.init(allocator);
+            try env.scan_buffer.init(allocator, .{ .index = 0 });
             defer env.scan_buffer.deinit(allocator);
 
             env.scan_results = try allocator.alloc(Value, scan_results_max);

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -110,6 +110,12 @@ pub const Event = union(enum) {
     compact_manifest,
     compact_mutable,
 
+    lookup,
+    lookup_worker: struct { index: u8 },
+
+    scan_tree: struct { index: u8 },
+    scan_tree_level: struct { index: u8, level: u8 },
+
     grid_read: struct { iop: usize },
     grid_write: struct { iop: usize },
 
@@ -141,6 +147,10 @@ pub const Event = union(enum) {
         .compact_blip_write = 1,
         .compact_manifest = 1,
         .compact_mutable = 1,
+        .lookup = 1,
+        .lookup_worker = constants.grid_iops_read_max,
+        .scan_tree = constants.lsm_scans_max,
+        .scan_tree_level = constants.lsm_scans_max * @as(u32, constants.lsm_levels),
         .grid_read = constants.grid_iops_read_max,
         .grid_write = constants.grid_iops_write_max,
     });
@@ -165,14 +175,41 @@ pub const Event = union(enum) {
 
     // Stack is a u32 since it must be losslessly encoded as a JSON integer.
     fn stack(event: *const Event) u32 {
-        const stack_base = event_stack_base.get(event.*);
-        const stack_offset: u32 = switch (event.*) {
-            .grid_read => |data| @intCast(data.iop),
-            .grid_write => |data| @intCast(data.iop),
-            else => 0,
-        };
-        assert(stack_offset < event_stack_cardinality.get(event.*));
-        return stack_base + stack_offset;
+        switch (event.*) {
+            .lookup_worker => |data| {
+                assert(data.index < event_stack_cardinality.get(event.*));
+                const stack_base = event_stack_base.get(event.*);
+                return stack_base + data.index;
+            },
+            .scan_tree => |data| {
+                assert(data.index < constants.lsm_scans_max);
+                // This event has "nested" sub-events, so its offset is calculated
+                // with padding to accommodate `scan_tree_level` events in between.
+                const stack_base = event_stack_base.get(event.*);
+                const scan_tree_offset = (constants.lsm_levels + 1) * data.index;
+                return stack_base + scan_tree_offset;
+            },
+            .scan_tree_level => |data| {
+                assert(data.index < constants.lsm_scans_max);
+                assert(data.level < constants.lsm_levels);
+                // This is a "nested" event, so its offset is calculated
+                // relative to the parent `scan_tree`'s offset.
+                const stack_base = event_stack_base.get(.scan_tree);
+                const scan_tree_offset = (constants.lsm_levels + 1) * data.index;
+                const scan_tree_level_offset = data.level + 1;
+                return stack_base + scan_tree_offset + scan_tree_level_offset;
+            },
+            inline .grid_read, .grid_write => |data| {
+                assert(data.iop < event_stack_cardinality.get(event.*));
+                const stack_base = event_stack_base.get(event.*);
+                return stack_base + @as(u32, @intCast(data.iop));
+            },
+            inline else => |data, event_tag| {
+                comptime assert(@TypeOf(data) == void);
+                comptime assert(event_stack_cardinality.get(event_tag) == 1);
+                return comptime event_stack_base.get(event_tag);
+            },
+        }
     }
 };
 


### PR DESCRIPTION
Add new Traces:

- Lookup/LookupWorker (covers both prefetching and scan lookups)
- ScanTree/ScanTreeLevel

Note 1: [Spall](https://gravitymoth.com/spall/spall.html) sorts the "Thread ID" alphabetically, so it fails to render a usable visualization of this trace, as `ScanTree` and `ScanTreeLevel` are nested events (e.g., each `ScanTree` has up to `lsm_levels` `ScanTreeLevel`) and stack number (displayed as "Thread ID: ##") is the only thing that groups them together.

Note 2: For a more "illustrated" trace sample, try running the benchmark with the flags `--id-order=random` to skip the negative lookup optimization and `--transfer-pending` to scan by expired transfers.

```bash
./tigerbeetle benchmark --trace=trace.json --id-order=random --transfer-pending  
```

![image](https://github.com/user-attachments/assets/3e426795-9d02-4c95-ade3-f032b689f768)
