### PR TITLE
vsr: non faulty replica shouldn't enter recovering_head with op < op_checkpoint

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -298,6 +298,7 @@ const Environment = struct {
                 header.set_checksum();
                 break :header header;
             },
+            .view_attributes = null,
             .manifest_references = env.forest.manifest_log.checkpoint_references(),
             .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
             .client_sessions_reference = .{

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -490,7 +490,7 @@ const Environment = struct {
                     header.set_checksum();
                     break :header header;
                 },
-
+                .view_attributes = null,
                 .manifest_references = env.manifest_log.checkpoint_references(),
                 .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
                 .client_sessions_reference = .{

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -1016,6 +1016,7 @@ const Environment = struct {
                     header.set_checksum();
                     break :header header;
                 },
+                .view_attributes = null,
                 .manifest_references = env.forest.manifest_log.checkpoint_references(),
                 .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
                 .client_sessions_reference = .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -436,6 +436,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     header.set_checksum();
                     break :header header;
                 },
+                .view_attributes = null,
                 .manifest_references = std.mem.zeroes(vsr.SuperBlockManifestReferences),
                 .free_set_reference = env.grid.free_set_checkpoint.checkpoint_reference(),
                 .client_sessions_reference = .{

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1099,7 +1099,7 @@ pub const Simulator = struct {
 
         if (replica.status == .recovering_head) {
             // Even with faults disabled, a replica may wind up in status=recovering_head.
-            assert(fault or replica.op < replica.op_checkpoint() or header_prepare_view_mismatch);
+            assert(fault or header_prepare_view_mismatch);
         }
 
         replica_storage.faulty = true;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1317,7 +1317,6 @@ const ViewChangeHeadersSlice = struct {
 
             switch (Headers.dvc_header_type(header)) {
                 .blank => {
-                    assert(headers.command == .do_view_change);
                     continue; // Don't update "child".
                 },
                 .valid => {
@@ -1480,7 +1479,6 @@ const ViewChangeHeadersArray = struct {
     }
 
     pub fn append_blank(headers: *ViewChangeHeadersArray, op: u64) void {
-        assert(headers.command == .do_view_change);
         assert(headers.array.count() > 0);
         headers.array.append_assume_capacity(Headers.dvc_blank(op));
     }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1438,27 +1438,18 @@ const ViewChangeHeadersArray = struct {
     array: Headers.Array,
 
     pub fn root(cluster: u128) ViewChangeHeadersArray {
-        return ViewChangeHeadersArray.init_from_slice(.start_view, &.{
+        return ViewChangeHeadersArray.init(.start_view, &.{
             Header.Prepare.root(cluster),
         });
     }
 
-    pub fn init_from_slice(
+    pub fn init(
         command: ViewChangeCommand,
         slice: []const Header.Prepare,
     ) ViewChangeHeadersArray {
         const headers = ViewChangeHeadersArray{
             .command = command,
             .array = Headers.Array.from_slice(slice) catch unreachable,
-        };
-        headers.verify();
-        return headers;
-    }
-
-    fn init_from_array(command: ViewChangeCommand, array: Headers.Array) ViewChangeHeadersArray {
-        const headers = ViewChangeHeadersArray{
-            .command = command,
-            .array = array,
         };
         headers.verify();
         return headers;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1317,6 +1317,7 @@ const ViewChangeHeadersSlice = struct {
 
             switch (Headers.dvc_header_type(header)) {
                 .blank => {
+                    assert(headers.command == .do_view_change);
                     continue; // Don't update "child".
                 },
                 .valid => {
@@ -1479,6 +1480,7 @@ const ViewChangeHeadersArray = struct {
     }
 
     pub fn append_blank(headers: *ViewChangeHeadersArray, op: u64) void {
+        assert(headers.command == .do_view_change);
         assert(headers.array.count() > 0);
         headers.array.append_assume_capacity(Headers.dvc_blank(op));
     }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4849,7 +4849,10 @@ pub fn ReplicaType(
             // Determine the consecutive extent of the log that we can help recover.
             // This may precede op_repair_min if we haven't had a view-change recently.
             const range_min = (op_hash_chain_verified + 1) -| constants.journal_slot_count;
-            const range = self.journal.find_latest_headers_break_between(range_min, op_hash_chain_verified);
+            const range = self.journal.find_latest_headers_break_between(
+                range_min,
+                op_hash_chain_verified,
+            );
             const op_min = if (range) |r| r.op_max + 1 else range_min;
             assert(op_min <= op);
             assert(op_min <= self.op_repair_min());

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -706,6 +706,13 @@ pub fn ReplicaType(
                     }
                     break;
                 }
+            } else {
+                // This case can occur if we loaded an SV for its hook header but never finished
+                // that SV to a DVC (dropping the hooks), but never finished the view change.
+                if (op_head == null) {
+                    assert(self.view > self.log_view);
+                    op_head = self.journal.op_maximum();
+                }
             }
             assert(op_head.? <= self.op_prepare_max());
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4849,9 +4849,14 @@ pub fn ReplicaType(
 
             self.view_headers.array.clear();
 
-            // Primaries/potential primaries are guaranteed to have no gaps between commit_min and
-            // self.op in their journal, while backups are not (they may have not received some
-            // prepares yet).
+            // All replicas are guaranteed to have no gaps in their headers between op_checkpoint
+            // and commit_min. Between commit_min and self.op:
+            // * The primary is guaranteed to have no gaps.
+            // * A potential primary in .view_change status is guaranteed to have no gaps, since we
+            //   only start committing *after* we have the hash chain intact up to self.op
+            //   (see `repair`).
+            // * Backups are not guaranteed to have no gaps, they may have not received some
+            //   prepares yet.
             const op_head_no_gaps = if (self.primary_index(self.view) == self.replica)
                 self.op
             else

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4751,7 +4751,6 @@ pub fn ReplicaType(
             self.primary_update_view_headers();
             assert(self.view_headers.command == .start_view);
             assert(self.view_headers.array.get(0).op == self.op);
-            self.view_headers.verify();
 
             const message = self.message_bus.get_message(.start_view);
             defer self.message_bus.unref(message);
@@ -4825,6 +4824,7 @@ pub fn ReplicaType(
                     self.view_headers.append(self.journal.header_with_op(op).?);
                 }
             }
+            self.view_headers.verify();
         }
 
         /// The caller owns the returned message, if any, which has exactly 1 reference.
@@ -8311,7 +8311,6 @@ pub fn ReplicaType(
 
             self.view_headers.command = .start_view;
             self.primary_update_view_headers();
-            self.view_headers.verify();
 
             self.transition_to_normal_from_view_change_status(self.view);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10267,7 +10267,10 @@ fn start_view_message_headers(message: *const Message.StartView) []const Header.
     assert(headers.len > 0);
     vsr.Headers.ViewChangeSlice.verify(.{ .command = .start_view, .slice = headers });
     if (constants.verify) {
-        for (headers) |header| assert(header.valid_checksum());
+        for (headers) |*header| {
+            assert(header.valid_checksum());
+            assert(vsr.Headers.dvc_header_type(header) == .valid);
+        }
     }
     return headers;
 }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -706,14 +706,6 @@ pub fn ReplicaType(
                     }
                     break;
                 }
-            } else {
-                // This case can only occur if we loaded an SV for its hook header, then converted
-                // that SV to a DVC (dropping the hooks; see start_view_into_do_view_change()),
-                // but never finished the view change.
-                if (op_head == null) {
-                    assert(self.view > self.log_view);
-                    op_head = self.journal.op_maximum();
-                }
             }
             assert(op_head.? <= self.op_prepare_max());
 

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -881,6 +881,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
             vsr_state.sync_op_max = update.sync_op_max;
             vsr_state.sync_view = 0;
             if (update.view_attributes) |*view_attributes| {
+                assert(view_attributes.log_view <= view_attributes.view);
+                view_attributes.headers.verify();
                 vsr_state.log_view = view_attributes.log_view;
                 vsr_state.view = view_attributes.view;
             }

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -584,7 +584,7 @@ pub const data_file_size_min =
 ///               a        (a)      a         Repair any broken copies of `a`.
 ///
 /// checkpoint    seq      seq      seq
-/// (or sync)     a        a        a
+///               a        a        a
 ///               a        a+1
 ///               a        a+1      a+1
 ///               a+1      a+1      a+1       Read quorum; verify 3/4 are valid.
@@ -609,7 +609,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
             read: Storage.Read = undefined,
             read_threshold: ?Quorums.Threshold = null,
             copy: ?u8 = null,
-            /// Used by format(), checkpoint(), view_change(), sync().
+            /// Used by format(), checkpoint(), view_change().
             vsr_state: ?SuperBlockHeader.VSRState = null,
             /// Used by format() and view_change().
             vsr_headers: ?vsr.Headers.ViewChangeArray = null,
@@ -812,6 +812,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
         const UpdateCheckpoint = struct {
             header: vsr.Header.Prepare,
+            log_view: u32,
+            view: u32,
+            view_change_headers: *const vsr.Headers.ViewChangeArray,
             commit_max: u64,
             sync_op_min: u64,
             sync_op_max: u64,
@@ -875,6 +878,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
             vsr_state.sync_op_min = update.sync_op_min;
             vsr_state.sync_op_max = update.sync_op_max;
             vsr_state.sync_view = 0;
+            vsr_state.log_view = update.log_view;
+            vsr_state.view = update.view;
             assert(superblock.staging.vsr_state.would_be_updated_by(vsr_state));
 
             context.* = .{
@@ -882,6 +887,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .callback = callback,
                 .caller = .checkpoint,
                 .vsr_state = vsr_state,
+                .vsr_headers = update.view_change_headers.*,
             };
             superblock.log_context(context);
             superblock.acquire(context);
@@ -1356,7 +1362,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 },
                 .checkpoint,
                 .view_change,
-                .sync,
                 => {
                     assert(stdx.equal_bytes(
                         SuperBlockHeader.VSRState,
@@ -1397,7 +1402,6 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 .format,
                 .checkpoint,
                 .view_change,
-                .sync,
                 => switch (constants.superblock_copies) {
                     4 => 3,
                     6 => 4,
@@ -1456,7 +1460,6 @@ pub const Caller = enum {
     open,
     checkpoint,
     view_change,
-    sync,
 
     /// Beyond formatting and opening of the superblock, which are mutually exclusive of all
     /// other operations, only the following queue combinations are allowed:
@@ -1468,11 +1471,7 @@ pub const Caller = enum {
             .format = Set.init(.{}),
             .open = Set.init(.{}),
             .checkpoint = Set.init(.{ .view_change = true }),
-            .view_change = Set.init(.{
-                .checkpoint = true,
-                .sync = true,
-            }),
-            .sync = Set.init(.{ .view_change = true }),
+            .view_change = Set.init(.{ .checkpoint = true }),
         });
     };
 
@@ -1480,9 +1479,8 @@ pub const Caller = enum {
         return switch (caller) {
             .format => true,
             .open => unreachable,
-            .checkpoint => false,
+            .checkpoint => true,
             .view_change => true,
-            .sync => false,
         };
     }
 };

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -440,6 +440,7 @@ const Environment = struct {
                 .newest_address = 0,
                 .block_count = 0,
             },
+            .view_attributes = null,
             .free_set_reference = .{
                 .last_block_checksum = 0,
                 .last_block_address = 0,


### PR DESCRIPTION
### Problem

See https://github.com/tigerbeetle/tigerbeetle/pull/2295 for broader context.

Imagine a potential primary handling a do_view_change. Currently, the potential primary replica first updates its in-memory log_view and initiates repair. During repair, the replica could repair some ops around the checkpoint and its trigger and advance its checkpoint. If such a replica crashes before making its log_view durable, it would restart with a regressed log_view and the TruncateViewRange condition would truncate all ops that were repaired (since their view # is greater than the log_view the replica restarts with). This truncation could regress self.op below self.op_checkpoint().

Backups may be vulnerable to the same state as well. Specifically, imagine a case where a backup in view V is handling a start_view message for view V+1. In this case, the backup first transitions to view_change, invokes view_durable_update to make view=V +1 durable. Then, the backup transitions to normal, invokes view_durable_update to make log_view=V+1 and start_view headers durable. However, this invocation of view_durable_update ends up being a no-op if the earlier view_durable_update is still underway. Finally, if the backup initiates repair and advances to the next checkpoint _before_ log_view=V+1 is made durable, it could restart into a state wherein self.op regresses below self.op_checkpoint(). 

These cases where self.op regresses below self.op_checkpoint() could lead to a non faulty replica [starting up in the recovering_head state](https://github.com/tigerbeetle/tigerbeetle/blob/bc4a71bc5fa93de1f33403b0ea1d7a1f176e565e/src/vsr/replica.zig#L770-L787). 

### Solution

We solve this problem by making view_headers, view & log_view durable during `superblock.checkpoint`. Before this PR, they were only made durable during `superblock.view_change`. This entails regenerating start_view headers _before_ `superblock.checkpoint` is invoked, to ensure that durable view_headers *always* contain on op from the checkpoint that a replica starts with. 