### PR TITLE
Reduce client libraries verbosity on stderr

### DIFF
--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -27,7 +27,7 @@ else
 pub const std_options = .{
     // Since this is running in application space, log only critical messages to reduce noise.
     .log_level = std.log.Level.err,
-    .logFn = vsr.constants.log,
+    .logFn = vsr.constants.log_nop,
 };
 
 /// Context for a client instance.

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -11,7 +11,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const jni = @import("jni.zig");
-const tb = @import("vsr").tb_client;
+const vsr = @import("vsr");
+const tb = vsr.tb_client;
 
 const log = std.log.scoped(.tb_client_jni);
 const assert = std.debug.assert;
@@ -22,6 +23,12 @@ const global_allocator = if (builtin.link_libc)
     std.heap.c_allocator
 else
     @compileError("tb_client must be built with libc");
+
+pub const std_options = .{
+    // Since this is running in application space, log only critical messages to reduce noise.
+    .log_level = std.log.Level.err,
+    .logFn = vsr.constants.log,
+};
 
 /// Context for a client instance.
 const Context = struct {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -25,6 +25,21 @@ pub const log_level: std.log.Level = config.process.log_level;
 
 pub const log = std.log.defaultLog;
 
+/// A log function that discards all log entries.
+pub fn log_nop(
+    comptime message_level: std.log.Level,
+    comptime scope: @Type(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    _ = .{
+        message_level,
+        scope,
+        format,
+        args,
+    };
+}
+
 // Which mode to use for ./testing/hash_log.zig.
 pub const hash_log_mode = config.process.hash_log_mode;
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -381,7 +381,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             const fd = result catch |err| {
                 bus.process.accept_connection.?.state = .free;
                 // TODO: some errors should probably be fatal
-                log.err("accept failed: {}", .{err});
+                log.warn("accept failed: {}", .{err});
                 return;
             };
             bus.process.accept_connection.?.on_accept(bus, fd);
@@ -587,7 +587,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 connection.state = .connected;
 
                 result catch |err| {
-                    log.err("error connecting to replica {}: {}", .{
+                    log.warn("error connecting to replica {}: {}", .{
                         connection.peer.replica,
                         err,
                     });
@@ -748,13 +748,13 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
                 if (!connection.recv_checked_header) {
                     if (!header.valid_checksum()) {
-                        log.err("invalid header checksum received from {}", .{connection.peer});
+                        log.warn("invalid header checksum received from {}", .{connection.peer});
                         connection.terminate(bus, .shutdown);
                         return null;
                     }
 
                     if (header.size < @sizeOf(Header) or header.size > constants.message_size_max) {
-                        log.err("header with invalid size {d} received from peer {}", .{
+                        log.warn("header with invalid size {d} received from peer {}", .{
                             header.size,
                             connection.peer,
                         });
@@ -763,7 +763,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                     }
 
                     if (header.cluster != bus.cluster) {
-                        log.err("message addressed to the wrong cluster: {}", .{header.cluster});
+                        log.warn("message addressed to the wrong cluster: {}", .{header.cluster});
                         connection.terminate(bus, .shutdown);
                         return null;
                     }
@@ -775,7 +775,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         // bounded by the time it takes to ping, we can hear from a peer before we
                         // can send back to them.
                         .replica => if (!connection.set_and_verify_peer(bus, &header)) {
-                            log.err(
+                            log.warn(
                                 "message from unexpected peer: peer={} header={}",
                                 .{ connection.peer, header },
                             );
@@ -802,7 +802,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
                 const body = data[@sizeOf(Header)..header.size];
                 if (!header.valid_checksum_body(body)) {
-                    log.err("invalid body checksum received from {}", .{connection.peer});
+                    log.warn("invalid body checksum received from {}", .{connection.peer});
                     connection.terminate(bus, .shutdown);
                     return null;
                 }
@@ -973,7 +973,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 assert(connection.state == .connected);
                 const bytes_received = result catch |err| {
                     // TODO: maybe don't need to close on *every* error
-                    log.err("error receiving from {}: {}", .{ connection.peer, err });
+                    log.warn("error receiving from {}: {}", .{ connection.peer, err });
                     connection.terminate(bus, .shutdown);
                     return;
                 };
@@ -1018,7 +1018,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 assert(connection.state == .connected);
                 connection.send_progress += result catch |err| {
                     // TODO: maybe don't need to close on *every* error
-                    log.err("error sending message to replica at {}: {}", .{
+                    log.warn("error sending message to replica at {}: {}", .{
                         connection.peer,
                         err,
                     });
@@ -1098,7 +1098,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 }
 
                 result catch |err| {
-                    log.err("error closing connection to {}: {}", .{ connection.peer, err });
+                    log.warn("error closing connection to {}: {}", .{ connection.peer, err });
                     return;
                 };
             }

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1047,7 +1047,7 @@ pub const Multiversion = struct {
         // While these look like blocking IO operations, on a memfd they're memory manipulation.
         // TODO: Would panic'ing be a better option? On Linux, these should never fail. On other
         // platforms where target_fd might be backed by a file, they could...
-        errdefer log.err("target binary update failed - " ++
+        errdefer log.warn("target binary update failed - " ++
             "this replica might fail to automatically restart!", .{});
 
         const target_file = std.fs.File{ .handle = self.target_fd };
@@ -1063,7 +1063,7 @@ pub const Multiversion = struct {
     fn handle_error(self: *Multiversion, result: anyerror) void {
         assert(self.stage != .init);
 
-        log.err("binary does not contain valid multiversion data: {}", .{result});
+        log.warn("binary does not contain valid multiversion data: {}", .{result});
 
         self.stage = .{ .err = result };
     }

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1063,7 +1063,7 @@ pub const Multiversion = struct {
     fn handle_error(self: *Multiversion, result: anyerror) void {
         assert(self.stage != .init);
 
-        log.warn("binary does not contain valid multiversion data: {}", .{result});
+        log.err("binary does not contain valid multiversion data: {}", .{result});
 
         self.stage = .{ .err = result };
     }

--- a/src/node.zig
+++ b/src/node.zig
@@ -30,7 +30,7 @@ const constants = vsr.constants;
 pub const std_options = .{
     // Since this is running in application space, log only critical messages to reduce noise.
     .log_level = .err,
-    .logFn = vsr.constants.log,
+    .logFn = vsr.constants.log_nop,
 };
 
 // Cached value for JS (null).

--- a/src/node.zig
+++ b/src/node.zig
@@ -30,6 +30,7 @@ const constants = vsr.constants;
 pub const std_options = .{
     // Since this is running in application space, log only critical messages to reduce noise.
     .log_level = .err,
+    .logFn = vsr.constants.log,
 };
 
 // Cached value for JS (null).

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -522,9 +522,9 @@ pub fn exec_stdout_options(
     try child.collectOutput(&stdout, &stderr, options.output_bytes_max);
     const term = try child.wait();
     errdefer {
-        log.warn("command failed", .{});
+        log.err("command failed", .{});
         echo_command(argv.slice());
-        log.warn("stdout:\n{s}\nstderr:\n{s}", .{ stdout.items, stderr.items });
+        log.err("stdout:\n{s}\nstderr:\n{s}", .{ stdout.items, stderr.items });
     }
 
     switch (term) {

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -193,7 +193,7 @@ pub fn env_get_option(shell: *Shell, var_name: []const u8) ?[]const u8 {
 
 pub fn env_get(shell: *Shell, var_name: []const u8) ![]const u8 {
     errdefer {
-        log.err("environment variable '{s}' not defined", .{var_name});
+        log.warn("environment variable '{s}' not defined", .{var_name});
     }
 
     return try std.process.getEnvVarOwned(shell.arena.allocator(), var_name);
@@ -372,7 +372,7 @@ pub fn copy_path(
     dst_path: []const u8,
 ) !void {
     errdefer {
-        log.err("failed to copy {s} to {s}", .{ src_path, dst_path });
+        log.warn("failed to copy {s} to {s}", .{ src_path, dst_path });
     }
     if (std.fs.path.dirname(dst_path)) |dir| {
         try dst_dir.makePath(dir);
@@ -522,9 +522,9 @@ pub fn exec_stdout_options(
     try child.collectOutput(&stdout, &stderr, options.output_bytes_max);
     const term = try child.wait();
     errdefer {
-        log.err("command failed", .{});
+        log.warn("command failed", .{});
         echo_command(argv.slice());
-        log.err("stdout:\n{s}\nstderr:\n{s}", .{ stdout.items, stderr.items });
+        log.warn("stdout:\n{s}\nstderr:\n{s}", .{ stdout.items, stderr.items });
     }
 
     switch (term) {

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -242,7 +242,7 @@ pub fn Storage(comptime IO: type) type {
                     const target = read.target();
                     if (target.len > constants.sector_size) {
                         // We tried to read more than a logical sector and failed.
-                        log.err("latent sector error: offset={}, subdividing read...", .{
+                        log.warn("latent sector error: offset={}, subdividing read...", .{
                             read.offset,
                         });
 
@@ -268,7 +268,7 @@ pub fn Storage(comptime IO: type) type {
                         return;
                     } else {
                         // We tried to read at (or less than) logical sector granularity and failed.
-                        log.err("latent sector error: offset={}, zeroing sector...", .{
+                        log.warn("latent sector error: offset={}, zeroing sector...", .{
                             read.offset,
                         });
 

--- a/src/tb_client_exports.zig
+++ b/src/tb_client_exports.zig
@@ -5,6 +5,12 @@ const builtin = @import("builtin");
 const vsr = @import("vsr.zig");
 const tb = vsr.tb_client;
 
+pub const std_options = .{
+    // Since this is running in application space, log only critical messages to reduce noise.
+    .log_level = std.log.Level.err,
+    .logFn = vsr.constants.log,
+};
+
 comptime {
     if (!builtin.link_libc) {
         @compileError("Must be built with libc to export tb_client symbols");

--- a/src/tb_client_exports.zig
+++ b/src/tb_client_exports.zig
@@ -8,7 +8,7 @@ const tb = vsr.tb_client;
 pub const std_options = .{
     // Since this is running in application space, log only critical messages to reduce noise.
     .log_level = std.log.Level.err,
-    .logFn = vsr.constants.log,
+    .logFn = vsr.constants.log_nop,
 };
 
 comptime {

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -503,10 +503,13 @@ pub fn ClockType(comptime Time: type) type {
                         fmt.fmtDurationSigned(delta),
                     });
                 } else {
-                    log.warn("{}: system time is {} behind, clamping system time to cluster time", .{
-                        self.replica,
-                        fmt.fmtDurationSigned(delta),
-                    });
+                    log.warn(
+                        "{}: system time is {} behind, clamping system time to cluster time",
+                        .{
+                            self.replica,
+                            fmt.fmtDurationSigned(delta),
+                        },
+                    );
                 }
             } else {
                 const delta = system - upper;

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -376,7 +376,7 @@ pub fn ClockType(comptime Time: type) type {
             // Expire the current epoch if successive windows failed to synchronize:
             // Gradual clock drift prevents us from using an epoch for more than a few seconds.
             if (self.epoch.elapsed(self) >= epoch_max) {
-                log.err(
+                log.warn(
                     "{}: no agreement on cluster time (partitioned or too many clock faults)",
                     .{self.replica},
                 );
@@ -424,13 +424,13 @@ pub fn ClockType(comptime Time: type) type {
                 // We took too long to synchronize the window, expire stale samples...
                 const sources_sampled = self.window.sources_sampled();
                 if (sources_sampled <= @divTrunc(self.window.sources.len, 2)) {
-                    log.err("{}: synchronization failed, partitioned (sources={} samples={})", .{
+                    log.warn("{}: synchronization failed, partitioned (sources={} samples={})", .{
                         self.replica,
                         sources_sampled,
                         self.window.samples,
                     });
                 } else {
-                    log.err("{}: synchronization failed, no agreement (sources={} samples={})", .{
+                    log.warn("{}: synchronization failed, no agreement (sources={} samples={})", .{
                         self.replica,
                         sources_sampled,
                         self.window.samples,
@@ -503,7 +503,7 @@ pub fn ClockType(comptime Time: type) type {
                         fmt.fmtDurationSigned(delta),
                     });
                 } else {
-                    log.err("{}: system time is {} behind, clamping system time to cluster time", .{
+                    log.warn("{}: system time is {} behind, clamping system time to cluster time", .{
                         self.replica,
                         fmt.fmtDurationSigned(delta),
                     });
@@ -516,7 +516,7 @@ pub fn ClockType(comptime Time: type) type {
                         fmt.fmtDurationSigned(delta),
                     });
                 } else {
-                    log.err("{}: system time is {} ahead, clamping system time to cluster time", .{
+                    log.warn("{}: system time is {} ahead, clamping system time to cluster time", .{
                         self.replica,
                         fmt.fmtDurationSigned(delta),
                     });

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1024,7 +1024,7 @@ pub fn GridType(comptime Storage: type) type {
             if (result != .valid) {
                 const header =
                     mem.bytesAsValue(vsr.Header.Block, block.*[0..@sizeOf(vsr.Header)]);
-                log.err(
+                log.warn(
                     "{}: {s}: expected address={} checksum={}, found address={} checksum={}",
                     .{
                         grid.superblock.replica_index.?,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5269,7 +5269,10 @@ pub fn ReplicaType(
                 } else if (entry.session < message.header.session) {
                     // This cannot be because of a partition since we check the client's view
                     // number.
-                    log.warn("{}: on_request: ignoring newer session (client bug)", .{self.replica});
+                    log.warn(
+                        "{}: on_request: ignoring newer session (client bug)",
+                        .{self.replica},
+                    );
                     return true;
                 }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5269,7 +5269,7 @@ pub fn ReplicaType(
                 } else if (entry.session < message.header.session) {
                     // This cannot be because of a partition since we check the client's view
                     // number.
-                    log.warn(
+                    log.err(
                         "{}: on_request: ignoring newer session (client bug)",
                         .{self.replica},
                     );
@@ -5278,7 +5278,7 @@ pub fn ReplicaType(
 
                 if (entry.header.release.value != message.header.release.value) {
                     // Clients must not change releases mid-session.
-                    log.warn(
+                    log.err(
                         "{}: on_request: ignoring request from unexpected release" ++
                             " expected={} found={} (client bug)",
                         .{ self.replica, entry.header.release, message.header.release },
@@ -5301,7 +5301,7 @@ pub fn ReplicaType(
                         self.on_request_repeat_reply(message, entry);
                         return true;
                     } else {
-                        log.warn("{}: on_request: request collision (client bug)", .{self.replica});
+                        log.err("{}: on_request: request collision (client bug)", .{self.replica});
                         return true;
                     }
                 } else if (entry.header.request + 1 == message.header.request) {
@@ -5311,7 +5311,7 @@ pub fn ReplicaType(
                         return false;
                     } else {
                         // The client may have only one request inflight at a time.
-                        log.warn("{}: on_request: ignoring new request (client bug)", .{
+                        log.err("{}: on_request: ignoring new request (client bug)", .{
                             self.replica,
                         });
                         return true;
@@ -5320,7 +5320,7 @@ pub fn ReplicaType(
                     // Caused by one of the following:
                     // - client bug, or
                     // - this primary is no longer the actual primary
-                    log.warn("{}: on_request: ignoring newer request (client|network bug)", .{
+                    log.err("{}: on_request: ignoring newer request (client|network bug)", .{
                         self.replica,
                     });
                     return true;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1339,7 +1339,7 @@ pub fn ReplicaType(
             }
 
             if (message.header.invalid()) |reason| {
-                log.err("{}: on_message: invalid (command={}, {s})", .{
+                log.warn("{}: on_message: invalid (command={}, {s})", .{
                     self.replica,
                     message.header.command,
                     reason,
@@ -1393,7 +1393,7 @@ pub fn ReplicaType(
             }
 
             if (self.loopback_queue) |loopback_message| {
-                log.err("{}: on_message: on_{s}() queued a {s} loopback message with no flush", .{
+                log.warn("{}: on_message: on_{s}() queued a {s} loopback message with no flush", .{
                     self.replica,
                     @tagName(message.header.command),
                     @tagName(loopback_message.header.command),
@@ -1525,7 +1525,7 @@ pub fn ReplicaType(
                         assert(!self.solo());
                         self.primary_abdicate_timeout.start();
                     }
-                    log.err("{}: on_request: dropping (clock not synchronized)", .{self.replica});
+                    log.warn("{}: on_request: dropping (clock not synchronized)", .{self.replica});
                     return;
                 };
 
@@ -4675,7 +4675,7 @@ pub fn ReplicaType(
 
                 assert(self.client_sessions.count() == constants.clients_max - 1);
 
-                log.err("{}: client_table_entry_create: clients={}/{} evicting client={}", .{
+                log.warn("{}: client_table_entry_create: clients={}/{} evicting client={}", .{
                     self.replica,
                     clients,
                     constants.clients_max,
@@ -5131,7 +5131,7 @@ pub fn ReplicaType(
             // - client memory corruption
             // - client/replica version mismatch
             if (!message.header.operation.valid(StateMachine)) {
-                log.err("{}: on_request: ignoring invalid operation (client={} operation={})", .{
+                log.warn("{}: on_request: ignoring invalid operation (client={} operation={})", .{
                     self.replica,
                     message.header.client,
                     @intFromEnum(message.header.operation),
@@ -5148,7 +5148,7 @@ pub fn ReplicaType(
                     operation,
                     message.body(),
                 )) {
-                    log.err(
+                    log.warn(
                         "{}: on_request: ignoring invalid body (operation={s}, body.len={})",
                         .{
                             self.replica,
@@ -5269,7 +5269,7 @@ pub fn ReplicaType(
                 } else if (entry.session < message.header.session) {
                     // This cannot be because of a partition since we check the client's view
                     // number.
-                    log.err("{}: on_request: ignoring newer session (client bug)", .{self.replica});
+                    log.warn("{}: on_request: ignoring newer session (client bug)", .{self.replica});
                     return true;
                 }
 
@@ -5298,7 +5298,7 @@ pub fn ReplicaType(
                         self.on_request_repeat_reply(message, entry);
                         return true;
                     } else {
-                        log.err("{}: on_request: request collision (client bug)", .{self.replica});
+                        log.warn("{}: on_request: request collision (client bug)", .{self.replica});
                         return true;
                     }
                 } else if (entry.header.request + 1 == message.header.request) {
@@ -5308,7 +5308,7 @@ pub fn ReplicaType(
                         return false;
                     } else {
                         // The client may have only one request inflight at a time.
-                        log.err("{}: on_request: ignoring new request (client bug)", .{
+                        log.warn("{}: on_request: ignoring new request (client bug)", .{
                             self.replica,
                         });
                         return true;
@@ -5317,7 +5317,7 @@ pub fn ReplicaType(
                     // Caused by one of the following:
                     // - client bug, or
                     // - this primary is no longer the actual primary
-                    log.err("{}: on_request: ignoring newer request (client|network bug)", .{
+                    log.warn("{}: on_request: ignoring newer request (client|network bug)", .{
                         self.replica,
                     });
                     return true;
@@ -5348,7 +5348,7 @@ pub fn ReplicaType(
                     // primary) if we are partitioned and don't yet know about a session. We solve
                     // this by having clients include the view number and rejecting messages from
                     // clients with newer views.
-                    log.err("{}: on_request: no session", .{self.replica});
+                    log.warn("{}: on_request: no session", .{self.replica});
                     self.send_eviction_message_to_client(message.header.client, .no_session);
                     return true;
                 }
@@ -5518,7 +5518,7 @@ pub fn ReplicaType(
                     else => unreachable,
                 }
 
-                log.err("{}: on_request: ignoring (client forked)", .{self.replica});
+                log.warn("{}: on_request: ignoring (client forked)", .{self.replica});
                 return true;
             }
 
@@ -7486,7 +7486,7 @@ pub fn ReplicaType(
             assert(self.status == .normal);
             assert(self.primary());
 
-            log.err("{}: sending eviction message to client={} reason={s}", .{
+            log.warn("{}: sending eviction message to client={} reason={s}", .{
                 self.replica,
                 client,
                 @tagName(reason),
@@ -7630,7 +7630,7 @@ pub fn ReplicaType(
             }
 
             if (message.header.invalid()) |reason| {
-                log.err("{}: send_message_to_replica: invalid ({s})", .{ self.replica, reason });
+                log.warn("{}: send_message_to_replica: invalid ({s})", .{ self.replica, reason });
                 @panic("send_message_to_replica: invalid message");
             }
 


### PR DESCRIPTION
The main goal is to set the client libraries `log_level` as `.err` to reduce noise in user space: only fatal logs should be logged.

To achieve this goal, also we had to change `log.err` to `log.warn` in many places where non-fatal messages were logged (even outside client code, to standardize this pattern).

The behavior running with `log_level = .info` is unchanged.

From std.log docs:
warn:
 "Log a warning message. This log level is intended to be used if it is uncertain whether something has gone wrong or not, but the circumstances would be worth investigating."

 err:
 "Log an error message. This log level is intended to be used when something has gone wrong. This might be recoverable or might be followed by the program exiting."