### PR TITLE
Rollback `warn` to `err` and panic.

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1393,15 +1393,14 @@ pub fn ReplicaType(
             }
 
             if (self.loopback_queue) |loopback_message| {
-                log.warn("{}: on_message: on_{s}() queued a {s} loopback message with no flush", .{
+                log.err("{}: on_message: on_{s}() queued a {s} loopback message with no flush", .{
                     self.replica,
                     @tagName(message.header.command),
                     @tagName(loopback_message.header.command),
                 });
+                // Any message handlers that loopback must take responsibility for the flush.
+                @panic("loopback message with no flush");
             }
-
-            // Any message handlers that loopback must take responsibility for the flush.
-            assert(self.loopback_queue == null);
         }
 
         /// Pings are used by replicas to synchronise cluster time and to probe for network


### PR DESCRIPTION
Ref https://github.com/tigerbeetle/tigerbeetle/pull/2314#discussion_r1759556054

We already had an assertion for that, but now it's clearer.