### PR TITLE
shell: make exec_ family of APIs more robust

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -786,16 +786,14 @@ fn self_check_enabled(target: Target) bool {
 
 fn self_check(shell: *Shell, multiversion: []const u8, past_releases: []const []const u8) !void {
     assert(past_releases.len > 0);
-    try shell.exec_options(
-        .{ .echo = false },
+    try shell.exec(
         "{multiversion} multiversion {multiversion}",
         .{ .multiversion = multiversion },
     );
     for (past_releases) |past_release| {
         // 0.15.3 didn't have the multiversion subcommand since it was the epoch.
         if (std.mem.indexOf(u8, past_release, "0.15.3") != null) continue;
-        try shell.exec_options(
-            .{ .echo = false },
+        try shell.exec(
             "{past_release} multiversion {multiversion}",
             .{ .multiversion = multiversion, .past_release = past_release },
         );

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -11,8 +11,8 @@ const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("TigerBeetle.sln"));
 
-    try shell.zig("build clients:dotnet -Drelease", .{});
-    try shell.zig("build -Drelease", .{});
+    try shell.exec_zig("build clients:dotnet -Drelease", .{});
+    try shell.exec_zig("build -Drelease", .{});
 
     try shell.exec("dotnet restore", .{});
     try shell.exec("dotnet format --no-restore --verify-no-changes", .{});

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -18,8 +18,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     }
 
     // `go build`  won't compile the native library automatically, we need to do that ourselves.
-    try shell.zig("build clients:go -Drelease", .{});
-    try shell.zig("build -Drelease", .{});
+    try shell.exec_zig("build clients:go -Drelease", .{});
+    try shell.exec_zig("build -Drelease", .{});
 
     // Although we have compiled the TigerBeetle client library, we still need `cgo` to link it with
     // our resulting Go binary. Strictly speaking, `CC` is controlled by the users of TigerBeetle,

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -10,10 +10,10 @@ const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("pom.xml"));
 
-    try shell.zig("build clients:java -Drelease", .{});
-    try shell.zig("build -Drelease", .{});
+    try shell.exec_zig("build clients:java -Drelease", .{});
+    try shell.exec_zig("build -Drelease", .{});
 
-    try shell.zig("build test:jni", .{});
+    try shell.exec_zig("build test:jni", .{});
     // Java's maven doesn't support a separate test command, or a way to add dependency on a
     // project (as opposed to a compiled jar file).
     //

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -11,7 +11,7 @@ const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     assert(shell.file_exists("package.json"));
 
-    try shell.zig("build clients:node -Drelease", .{});
+    try shell.exec_zig("build clients:node -Drelease", .{});
 
     // Integration tests.
 

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -240,12 +240,11 @@ test "benchmark/inspect smoke" {
     const shell = try Shell.create(std.testing.allocator);
     defer shell.destroy();
 
-    const status_ok_benchmark = try shell.exec_status_ok(
+    try shell.exec(
         "{tigerbeetle} benchmark --transfer-count=10_000 --transfer-batch-size=10 --validate " ++
             "--file={file}",
         .{ .tigerbeetle = tigerbeetle, .file = data_file },
     );
-    try std.testing.expect(status_ok_benchmark);
 
     inline for (.{
         "{tigerbeetle} inspect superblock              {path}",
@@ -256,11 +255,10 @@ test "benchmark/inspect smoke" {
         "{tigerbeetle} inspect manifest                {path}",
         "{tigerbeetle} inspect tables --tree=transfers {path}",
     }) |command| {
-        const status_ok_inspect = try shell.exec_status_ok(
+        try shell.exec(
             command,
             .{ .tigerbeetle = tigerbeetle, .path = data_file },
         );
-        try std.testing.expect(status_ok_inspect);
     }
 }
 
@@ -368,7 +366,7 @@ test "in-place upgrade" {
                 try context.install_replica(context.replica_exe[replica_index], .past);
             }
             for (0..replica_count) |replica_index| {
-                try context.shell.exec_options(.{ .echo = false },
+                try context.shell.exec(
                     \\{tigerbeetle} format --cluster=0 --replica={replica} --replica-count=3
                     \\    {datafile}
                 , .{

--- a/src/scripts/antithesis.zig
+++ b/src/scripts/antithesis.zig
@@ -26,12 +26,12 @@ pub const CLIArgs = struct {
 const Image = enum { config, workload, replica };
 
 pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
-    assert(try shell.exec_status_ok("docker --version", .{}));
+    try shell.exec("docker --version", .{});
 
     assert(cli_args.tag.len > 0);
     assert(std.mem.indexOfAny(u8, cli_args.tag, &std.ascii.whitespace) == null);
 
-    try shell.zig("build -Drelease", .{});
+    try shell.exec_zig("build -Drelease", .{});
 
     // Build Java client library
     {
@@ -95,7 +95,7 @@ fn build_image(
                 \\
                 \\    cd {s} && TAG={s} docker compose up
                 \\
-                \\This temporary directory is not automatically deleted. You may do so 
+                \\This temporary directory is not automatically deleted. You may do so
                 \\yourself if you don't need it.
                 \\{ansi-reset}
             , .{ image_dir, tag });
@@ -131,10 +131,9 @@ fn build_image(
 
 fn docker_build_cwd(shell: *Shell, comptime image: Image, tag: []const u8) !void {
     try shell.exec_options(.{
-        .echo = true,
         .stdin_slice = @field(dockerfiles, @tagName(image)),
     },
-        \\docker build 
+        \\docker build
         \\  --platform=linux/amd64
         \\  --file - .
         \\  --build-arg TAG={tag}
@@ -195,7 +194,7 @@ const dockerfiles = .{
 
 const docker_compose_contents =
     \\ version: "3.0"
-    \\ 
+    \\
     \\ services:
     \\   replica0:
     \\     container_name: replica0
@@ -239,7 +238,7 @@ const docker_compose_contents =
     \\     networks:
     \\       antithesis-net:
     \\         ipv4_address: 10.20.20.12
-    \\ 
+    \\
     \\   workload:
     \\     container_name: workload
     \\     hostname: workload
@@ -250,7 +249,7 @@ const docker_compose_contents =
     \\     networks:
     \\       antithesis-net:
     \\         ipv4_address: 10.20.20.100
-    \\ 
+    \\
     \\ # The subnet provided here is an example
     \\ # An alternate /24 can be used
     \\ networks:

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -117,7 +117,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     log.info("start {}", .{stdx.DateTimeUTC.now()});
     defer log.info("end {}", .{stdx.DateTimeUTC.now()});
 
-    assert(try shell.exec_status_ok("git --version", .{}));
+    try shell.exec("git --version", .{});
 
     // Read-write token for <https://github.com/tigerbeetle/devhubdb>.
     const devhub_token_option = shell.env_get_option("DEVHUBDB_PAT");
@@ -130,7 +130,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     if (gh_token_option == null) {
         log.err("'GH_TOKEN' environmental variable is not set, will not fetch pull requests", .{});
     } else {
-        assert(try shell.exec_status_ok("gh --version", .{}));
+        try shell.exec("gh --version", .{});
     }
 
     var seeds = std.ArrayList(SeedRecord).init(shell.arena.allocator());
@@ -217,10 +217,7 @@ fn run_fuzzers(
                         args.clearRetainingCapacity();
                         try args.appendSlice(&.{ "build", "-Drelease" });
                         try fuzzer.fill_args_build(&args);
-                        shell.exec_options(.{ .echo = false }, "{zig} {args}", .{
-                            .zig = shell.zig_exe.?,
-                            .args = args.items,
-                        }) catch {
+                        shell.exec_zig("{args}", .{ .args = args.items }) catch {
                             // Ignore the error, it'll get recorded by the run anyway.
                         };
                     }

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -136,7 +136,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
     // );
 
     // const sha = try shell.exec_stdout("git rev-parse HEAD", .{});
-    // try shell.zig("build scripts -- release --build  --run-number={run_number} " ++
+    // try shell.exec_zig("build scripts -- release --build  --run-number={run_number} " ++
     //     "--sha={sha} --language=zig", .{
     //     .run_number = run_number,
     //     .sha = sha,

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -32,9 +32,9 @@ fn devhub_coverage(shell: *Shell) !void {
     };
     log.info("kcov version {s}", .{kcov_version});
 
-    try shell.zig("build test:unit:build", .{});
-    try shell.zig("build vopr:build", .{});
-    try shell.zig("build fuzz:build", .{});
+    try shell.exec_zig("build test:unit:build", .{});
+    try shell.exec_zig("build vopr:build", .{});
+    try shell.exec_zig("build fuzz:build", .{});
 
     // Put results into src/devhub, as that folder is deployed as GitHub pages.
     try shell.project_root.deleteTree("./src/devhub/coverage");
@@ -66,7 +66,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     // Only build the TigerBeetle binary to test build speed and build size. Throw it away once
     // done, and use a release build from `zig-out/dist/` to run the benchmark.
     var timer = try std.time.Timer.start();
-    try shell.zig("build -Drelease install", .{});
+    try shell.exec_zig("build -Drelease install", .{});
     const build_time_ms = timer.lap() / std.time.ns_per_ms;
     const executable_size_bytes = (try shell.cwd.statFile("tigerbeetle")).size;
     try shell.project_root.deleteFile("tigerbeetle");
@@ -96,12 +96,12 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     };
 
     if (no_changelog_flag) {
-        try shell.zig(
+        try shell.exec_zig(
             \\build scripts -- release --build --no-changelog --sha={sha}
             \\    --language=zig
         , .{ .sha = cli_args.sha });
     } else {
-        try shell.zig(
+        try shell.exec_zig(
             \\build scripts -- release --build --sha={sha}
             \\    --language=zig
         , .{ .sha = cli_args.sha });

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -210,7 +210,7 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
     // `dist`.
     inline for (.{ true, false }) |debug| {
         inline for (targets) |target| {
-            try shell.zig(
+            try shell.exec_zig(
                 \\build
                 \\    -Dtarget={target}
                 \\    -Drelease={release}
@@ -272,7 +272,7 @@ fn build_dotnet(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     };
     log.info("dotnet version {s}", .{dotnet_version});
 
-    try shell.zig(
+    try shell.exec_zig(
         \\build clients:dotnet -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
@@ -299,7 +299,7 @@ fn build_go(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     try shell.pushd("./src/clients/go");
     defer shell.popd();
 
-    try shell.zig(
+    try shell.exec_zig(
         \\build clients:go -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
@@ -353,7 +353,7 @@ fn build_java(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     };
     log.info("java version {s}", .{java_version});
 
-    try shell.zig(
+    try shell.exec_zig(
         \\build clients:java -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
@@ -395,7 +395,7 @@ fn build_node(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     };
     log.info("node version {s}", .{node_version});
 
-    try shell.zig(
+    try shell.exec_zig(
         \\build clients:node -Drelease -Dconfig-release={release_triple}
         \\ -Dconfig-release-client-min={release_triple_client_min}
     , .{
@@ -750,7 +750,6 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
         // PID 1 ensures that signals work as expected, so e.g. "docker stop" will not hang.
         try shell.exec_options(
             .{
-                .echo = true,
                 .stdin_slice =
                 \\FROM alpine:3.19
                 \\RUN apk add --no-cache tini

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -380,7 +380,7 @@ pub fn copy_path(
     try src_dir.copyFile(src_path, dst_dir, dst_path, .{});
 }
 
-/// Runs the given command with inherited stdout and stderr.
+/// Runs the given command for side effects.
 /// Returns an error if exit status is non-zero.
 ///
 /// Supports interpolation using the following syntax:
@@ -392,14 +392,16 @@ pub fn copy_path(
 /// })
 /// ```
 pub fn exec(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
-    return exec_options(shell, .{ .echo = true }, cmd, cmd_args);
+    var argv = try Argv.expand(shell.gpa, cmd, cmd_args);
+    defer argv.deinit();
+
+    return exec_inner(shell, argv.slice(), .{});
 }
 
 pub fn exec_options(
     shell: *Shell,
     options: struct {
         stdin_slice: ?[]const u8 = null,
-        echo: bool,
     },
     comptime cmd: []const u8,
     cmd_args: anytype,
@@ -407,87 +409,28 @@ pub fn exec_options(
     var argv = try Argv.expand(shell.gpa, cmd, cmd_args);
     defer argv.deinit();
 
-    var child = try shell.create_process(argv.slice());
-    var stdin_writer: ?std.Thread = null;
-    defer if (stdin_writer) |thread| thread.join();
-
-    child.stdin_behavior = if (options.stdin_slice != null) .Pipe else .Ignore;
-    if (options.echo) {
-        child.stdout_behavior = .Inherit;
-        child.stderr_behavior = .Inherit;
-        echo_command(argv.slice());
-
-        try child.spawn();
-        if (options.stdin_slice) |bytes| {
-            stdin_writer = try write_stdin(&child, bytes);
-        }
-        const term = try child.wait();
-        switch (term) {
-            .Exited => |code| if (code != 0) return error.NonZeroExitStatus,
-            else => return error.CommandFailed,
-        }
-    } else {
-        var stdout = std.ArrayList(u8).init(shell.gpa);
-        defer stdout.deinit();
-
-        var stderr = std.ArrayList(u8).init(shell.gpa);
-        defer stderr.deinit();
-
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Pipe;
-        errdefer {
-            echo_command(argv.slice());
-            std.debug.print("stdout:{s}\n", .{stdout.items});
-            std.debug.print("stderr:{s}\n", .{stderr.items});
-        }
-
-        try child.spawn();
-        if (options.stdin_slice) |stdin_slice| {
-            stdin_writer = try write_stdin(&child, stdin_slice);
-        }
-        try child.collectOutput(
-            &stdout,
-            &stderr,
-            128 * 1024 * 1024,
-        );
-        const term = try child.wait();
-        switch (term) {
-            .Exited => |code| if (code != 0) return error.NonZeroExitStatus,
-            else => return error.CommandFailed,
-        }
-    }
+    return exec_inner(shell, argv.slice(), .{
+        .stdin_slice = options.stdin_slice,
+    });
 }
 
-/// Returns `true` if the command executed successfully with a zero exit code.
-///
-/// One intended use-case is sanity-checking that an executable is present, by running
-/// `my-tool --version`.
-pub fn exec_status_ok(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) !bool {
+/// Runs the given command and returns its output.
+/// If the output is a single line, the final newline is stripped.
+pub fn exec_stdout(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) ![]const u8 {
     var argv = try Argv.expand(shell.gpa, cmd, cmd_args);
     defer argv.deinit();
 
-    var child = try shell.create_process(argv.slice());
-    const term = try child.spawnAndWait();
-    return switch (term) {
-        .Exited => |code| code == 0,
-        else => false,
-    };
-}
-
-/// Run the command and return its stdout.
-///
-/// Returns an error if the command exists with a non-zero status or a non-empty stderr.
-///
-/// Trims the trailing newline, if any.
-pub fn exec_stdout(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) ![]const u8 {
-    return shell.exec_stdout_options(.{}, cmd, cmd_args);
+    var captured_stdout: []const u8 = &.{};
+    try exec_inner(shell, argv.slice(), .{
+        .capture_stdout = &captured_stdout,
+    });
+    return captured_stdout;
 }
 
 pub fn exec_stdout_options(
     shell: *Shell,
     options: struct {
         stdin_slice: ?[]const u8 = null,
-        output_bytes_max: usize = 1024 * 1024 * 32,
     },
     comptime cmd: []const u8,
     cmd_args: anytype,
@@ -495,49 +438,112 @@ pub fn exec_stdout_options(
     var argv = try Argv.expand(shell.gpa, cmd, cmd_args);
     defer argv.deinit();
 
-    var child = try shell.create_process(argv.slice());
-    child.stdin_behavior = if (options.stdin_slice == null) .Ignore else .Pipe;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    var captured_stdout: []const u8 = &.{};
+    try exec_inner(shell, argv.slice(), .{
+        .stdin_slice = options.stdin_slice,
+        .capture_stdout = &captured_stdout,
+    });
+    return captured_stdout;
+}
 
-    var stdout = std.ArrayList(u8).init(shell.gpa);
-    var stderr = std.ArrayList(u8).init(shell.gpa);
-    defer {
-        stdout.deinit();
-        stderr.deinit();
-    }
+/// Runs the zig compiler.
+pub fn exec_zig(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
+    var argv = Argv.init(shell.gpa);
+    defer argv.deinit();
 
-    try child.spawn();
-    defer {
-        _ = child.kill() catch {};
-    }
+    try argv.append_new_arg("{s}", .{shell.zig_exe.?});
+    try expand_argv(&argv, cmd, cmd_args);
+
+    return shell.exec_inner(argv.slice(), .{});
+}
+
+fn exec_inner(
+    shell: *Shell,
+    argv: []const []const u8,
+    options: struct {
+        stdin_slice: ?[]const u8 = null,
+        capture_stdout: ?*[]const u8 = null, // Optional out parameter.
+        output_limit_bytes: usize = 128 * 1024 * 1024,
+        timeout_ns: u64 = 10 * std.time.ns_per_min,
+    },
+) !void {
+    const argv_formatted = try std.mem.join(shell.gpa, " ", argv);
+    defer shell.gpa.free(argv_formatted);
 
     var stdin_writer: ?std.Thread = null;
     defer if (stdin_writer) |thread| thread.join();
+
+    const Streams = enum { stdout, stderr };
+    var poller: ?std.io.Poller(Streams) = null;
+    defer if (poller) |*p| p.deinit();
+
+    errdefer |err| {
+        log.err("process failed with {s}: {s}", .{ @errorName(err), argv_formatted });
+        if (poller) |*p| {
+            inline for (comptime std.enums.values(Streams)) |stream| {
+                if (p.fifo(stream).count > 0) {
+                    log.err("{s}:\n++++\n{s}++++\n", .{
+                        @tagName(stream),
+                        p.fifo(stream).readableSlice(0),
+                    });
+                }
+            }
+        }
+    }
+
+    var child = std.process.Child.init(argv, shell.gpa);
+    child.cwd = try shell.cwd.realpath(".", &shell.cwd_path_buffer);
+    child.env_map = &shell.env;
+    child.stdin_behavior = if (options.stdin_slice != null) .Pipe else .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    errdefer {
+        _ = child.kill() catch {};
+    }
 
     if (options.stdin_slice) |stdin_slice| {
         stdin_writer = try write_stdin(&child, stdin_slice);
     }
 
-    try child.collectOutput(&stdout, &stderr, options.output_bytes_max);
+    poller = std.io.poll(shell.gpa, Streams, .{
+        .stdout = child.stdout.?,
+        .stderr = child.stderr.?,
+    });
+
+    {
+        defer inline for (comptime std.enums.values(Streams)) |stream| {
+            assert(poller.?.fifo(stream).head == 0);
+        };
+
+        const deadline = std.time.nanoTimestamp() + options.timeout_ns;
+        for (0..1_000_000) |_| {
+            const timeout: u64 = @intCast(deadline -| std.time.nanoTimestamp());
+            if (timeout == 0) return error.ExecTimeout;
+            if (!try poller.?.pollTimeout(timeout)) break;
+            inline for (comptime std.enums.values(Streams)) |stream| {
+                if (poller.?.fifo(stream).count > options.output_limit_bytes) {
+                    return error.StdoutStreamTooLong;
+                }
+            }
+        } else @panic("exec: safety counter exceeded");
+    }
+
     const term = try child.wait();
-    errdefer {
-        log.err("command failed", .{});
-        echo_command(argv.slice());
-        log.err("stdout:\n{s}\nstderr:\n{s}", .{ stdout.items, stderr.items });
-    }
-
     switch (term) {
-        .Exited => |code| if (code != 0) return error.NonZeroExitStatus,
-        else => return error.CommandFailed,
+        .Exited => |code| if (code != 0) return error.ExecNonZeroExitStatus,
+        else => return error.ExecFailed,
     }
 
-    const trailing_newline = if (std.mem.indexOf(u8, stdout.items, "\n")) |first_newline|
-        first_newline == stdout.items.len - 1
-    else
-        false;
-    const len_without_newline = stdout.items.len - if (trailing_newline) @as(usize, 1) else 0;
-    return shell.arena.allocator().dupe(u8, stdout.items[0..len_without_newline]);
+    if (options.capture_stdout) |destination| {
+        const stdout = poller.?.fifo(.stdout).readableSlice(0);
+        const trailing_newline = if (std.mem.indexOf(u8, stdout, "\n")) |first_newline|
+            first_newline == stdout.len - 1
+        else
+            false;
+        const len_without_newline = stdout.len - @intFromBool(trailing_newline);
+        destination.* = try shell.arena.allocator().dupe(u8, stdout[0..len_without_newline]);
+    }
 }
 
 fn write_stdin(child: *std.process.Child, stdin: []const u8) !std.Thread {
@@ -558,8 +564,8 @@ fn write_stdin(child: *std.process.Child, stdin: []const u8) !std.Thread {
     );
 }
 
-/// Run the command and return its status, stderr and stdout. The caller is responsible for checking
-/// the status.
+/// Run the command and return its status, stderr and stdout.
+/// The caller is responsible for checking the status.
 pub fn exec_raw(
     shell: *Shell,
     comptime cmd: []const u8,
@@ -589,56 +595,15 @@ pub fn spawn(
     var argv = try Argv.expand(shell.gpa, cmd, cmd_args);
     defer argv.deinit();
 
-    var child = try shell.create_process(argv.slice());
+    var child = std.process.Child.init(argv.slice(), shell.gpa);
+    child.cwd = try shell.cwd.realpath(".", &shell.cwd_path_buffer);
+    child.env_map = &shell.env;
     child.stdin_behavior = options.stdin_behavior;
     child.stdout_behavior = options.stdout_behavior;
     child.stderr_behavior = options.stderr_behavior;
-
     try child.spawn();
 
     return child;
-}
-
-/// Runs the zig compiler.
-pub fn zig(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
-    var argv = Argv.init(shell.gpa);
-    defer argv.deinit();
-
-    try argv.append_new_arg("{s}", .{shell.zig_exe.?});
-    try expand_argv(&argv, cmd, cmd_args);
-
-    var child = try shell.create_process(argv.slice());
-    child.stdout_behavior = .Inherit;
-    child.stderr_behavior = .Inherit;
-
-    echo_command(argv.slice());
-    const term = try child.spawnAndWait();
-
-    switch (term) {
-        .Exited => |code| if (code != 0) return error.NonZeroExitStatus,
-        else => return error.CommandFailed,
-    }
-}
-
-fn create_process(shell: *Shell, argv: []const []const u8) !std.process.Child {
-    var child = std.process.Child.init(argv, shell.gpa);
-    child.cwd = try shell.cwd.realpath(".", &shell.cwd_path_buffer);
-    child.env_map = &shell.env;
-    child.stdin_behavior = .Ignore;
-    child.stdout_behavior = .Ignore;
-    child.stderr_behavior = .Ignore;
-    return child;
-}
-
-/// If we inherit `stdout` to show the output to the user, it's also helpful to echo the command
-/// itself.
-fn echo_command(argv: []const []const u8) void {
-    std.debug.print("$ ", .{});
-    for (argv, 0..) |arg, i| {
-        if (i != 0) std.debug.print(" ", .{});
-        std.debug.print("{s}", .{arg});
-    }
-    std.debug.print("\n", .{});
 }
 
 /// On GitHub Actions runners, `git commit` fails with an "Author identity unknown" error.

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -48,7 +48,7 @@ pub fn init(
         // rebuilds.
         _ = shell.project_root.statFile(tigerbeetle_exe) catch {
             log.info("building TigerBeetle", .{});
-            try shell.zig("build", .{});
+            try shell.exec_zig("build", .{});
 
             _ = try shell.project_root.statFile(tigerbeetle_exe);
         };
@@ -68,8 +68,7 @@ pub fn init(
     const data_file: []const u8 = try std.fs.path.join(gpa, &.{ tmp_dir_path, "0_0.tigerbeetle" });
     defer gpa.free(data_file);
 
-    try shell.exec_options(
-        .{ .echo = false },
+    try shell.exec(
         "{tigerbeetle} format --cluster=0 --replica=0 --replica-count=1 {data_file}",
         .{ .tigerbeetle = tigerbeetle, .data_file = data_file },
     );

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -467,13 +467,9 @@ test "tidy no large blobs" {
     }
 
     const MiB = 1024 * 1024;
-    const rev_list = try shell.exec_stdout_options(
-        .{ .output_bytes_max = 50 * MiB },
-        "git rev-list --objects HEAD",
-        .{},
-    );
+    const rev_list = try shell.exec_stdout("git rev-list --objects HEAD", .{});
     const objects = try shell.exec_stdout_options(
-        .{ .output_bytes_max = 50 * MiB, .stdin_slice = rev_list },
+        .{ .stdin_slice = rev_list },
         "git cat-file --batch-check={format}",
         .{ .format = "%(objecttype) %(objectsize) %(rest)" },
     );


### PR DESCRIPTION
They now will always reliably print failing command, its stderr and stdout.

The key insight here is that Zig supports pollTimeout, so even if a process hangs, we could still kill it reliably and extract the output so far.

So, there's no reason to inherit the streams.