### PR TITLE
test: use git timestamps for Docker image builds

### DIFF
--- a/src/scripts/antithesis.zig
+++ b/src/scripts/antithesis.zig
@@ -130,6 +130,13 @@ fn build_image(
 }
 
 fn docker_build_cwd(shell: *Shell, comptime image: Image, tag: []const u8) !void {
+    // We use the current commit's timestamp rather than the default (Unix epoch),
+    // which gives us a meaningful timestamp while still being determinstic in CI.
+    // This prevents the false positive in Antithesis saying that versions are too old.
+    const timestamp = try shell.exec_stdout("git log -1 --pretty=%ct", .{});
+    // See: https://docs.docker.com/build/ci/github-actions/reproducible-builds/
+    try shell.env.put("SOURCE_DATE_EPOCH", timestamp);
+
     try shell.exec_options(.{
         .echo = true,
         .stdin_slice = @field(dockerfiles, @tagName(image)),


### PR DESCRIPTION
Here we use the current commit's timestamp rather than the default (Unix epoch) for Docker images, which gives us a meaningful timestamp while still being determinstic in CI (not yet set up). This prevents the false positive in Antithesis saying that versions are too old.