### PR TITLE
devhub: allow filtering by either commit or fuzzer

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -97,9 +97,9 @@ async function mainSeeds() {
     let include = undefined;
     if (query_all) {
       include = true;
-    } else if (query_fuzzer) {
-      include = record.fuzzer == query_fuzzer &&
-        record.commit_sha == query_commit;
+    } else if (query_fuzzer || query_commit) {
+      include = (!query_fuzzer || record.fuzzer == query_fuzzer) &&
+        (!query_commit || record.commit_sha == query_commit);
     } else if (
       pullRequestNumber(record) &&
       !openPullRequests.has(pullRequestNumber(record))


### PR DESCRIPTION
I regularly patch query string only to realize that this doesn't actually work as I expect it to work, so let's fix this