### PR TITLE
StateMachine: Add test/example for per-transfer balance invariant

### DIFF
--- a/docs/coding/recipes/balance-invariant-transfers.md
+++ b/docs/coding/recipes/balance-invariant-transfers.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 8
+---
+
+# Balance-invariant Transfers
+
+For some accounts, it may be useful to enforce
+[`flags.debits_must_not_exceed_credits`](../../reference/account.md#flagsdebits_must_not_exceed_credits)
+or
+[`flags.credits_must_not_exceed_debits`](../../reference/account.md#flagscredits_must_not_exceed_debits).
+balance invariants for only a subset of all transfers, rather than all transfers.
+
+## Per-transfer `credits_must_not_exceed_debits`
+
+This recipe requires three accounts:
+1. The **source** account, to debit.
+2. The **destination** account, to credit. (With _neither_
+  [`flags.credits_must_not_exceed_debits`](../../reference/account.md#flagscredits_must_not_exceed_debits) nor
+  [`flags.debits_must_not_exceed_credits`](../../reference/account.md#flagsdebits_must_not_exceed_credits) set,
+  since in this recipe we are only enforcing the invariant on a per-transfer basis.
+3. The **control** account, to test the balance invariant. The control account should have
+  [`flags.credits_must_not_exceed_debits`](../../reference/account.md#flagscredits_must_not_exceed_debits)
+  set.
+
+| Id | Debit Account | Credit Account | Amount | Pending Id |                                               Flags |
+| -: | ------------: | -------------: | -----: | ---------: | --------------------------------------------------: |
+|  1 |        Source |    Destination |    123 |          - | [`linked`](../../reference/transfer.md#flagslinked) |
+|  2 |   Destination |        Control |      1 |          - | [`linked`](../../reference/transfer.md#flagslinked), [`pending`](../../reference/transfer.md#flagspending), [`balancing_debit`](../../reference/transfer.md#flagsbalancing_debit) |
+|  3 |             - |              - |      0 |          2 | [`void_pending_transfer`](../../reference/transfer.md#flagsvoid_pending_transfer) |
+
+When the destination account's final credits do not exceed its debits, the chain will succeed.
+When the destination account's final credits exceeds its debits, transfer `2` will fail with `exceeds_debits`.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -4520,6 +4520,33 @@ test "create_transfers: multiple debits, single credit, balancing debits" {
     );
 }
 
+test "create_transfers: per-transfer balance invariant" {
+    // Temporarily enforce `credits_must_not_exceed_debits` on account `A2`.
+    try check(
+        \\ account A1  0  0  0  0  _  _  _ _ L1 C1   _   _   _ _ _ _ _ _ ok
+        \\ account A2  0  0  0  0  _  _  _ _ L1 C1   _   _   _ _ _ _ _ _ ok
+        \\ account A3  0  0  0  0  _  _  _ _ L1 C1   _   _ C<D _ _ _ _ _ ok
+        \\ commit create_accounts
+        \\
+        \\ setup A2 0 40 0 0
+        \\
+        \\ transfer T1 A1 A2 41   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ linked_event_failed
+        \\ transfer T2 A2 A3 41   _  _  _  _    0 L1 C1 LNK PEN _   _ BDR   _ _ _ _ _ _ exceeds_debits
+        \\ transfer T3 A2 A3  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ linked_event_failed
+        \\ commit create_transfers
+        \\
+        \\ transfer T1 A1 A2 40   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ ok
+        \\ transfer T2 A2 A3 40   _  _  _  _    0 L1 C1 LNK PEN _   _ BDR   _ _ _ _ _ _ ok
+        \\ transfer T3 A2 A3  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ ok
+        \\ commit create_transfers
+        \\
+        \\ lookup_account A1 0 40 0  0 _
+        \\ lookup_account A2 0 40 0 40 _
+        \\ lookup_account A3 0  0 0  0 _
+        \\ commit lookup_accounts
+    );
+}
+
 test "imported events: imported batch" {
     try check(
         \\ tick 10 nanoseconds

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -4531,12 +4531,12 @@ test "create_transfers: per-transfer balance invariant" {
         \\ setup A2 0 40 0 0
         \\
         \\ transfer T1 A1 A2 41   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ linked_event_failed
-        \\ transfer T2 A2 A3 41   _  _  _  _    0 L1 C1 LNK PEN _   _ BDR   _ _ _ _ _ _ exceeds_debits
+        \\ transfer T2 A2 A3  1   _  _  _  _    0 L1 C1 LNK PEN _   _ BDR   _ _ _ _ _ _ exceeds_debits
         \\ transfer T3 A2 A3  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ linked_event_failed
         \\ commit create_transfers
         \\
         \\ transfer T1 A1 A2 40   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ ok
-        \\ transfer T2 A2 A3 40   _  _  _  _    0 L1 C1 LNK PEN _   _ BDR   _ _ _ _ _ _ ok
+        \\ transfer T2 A2 A3  1   _  _  _  _    0 L1 C1 LNK PEN _   _ BDR   _ _ _ _ _ _ ok
         \\ transfer T3 A2 A3  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ ok
         \\ commit create_transfers
         \\
@@ -4556,12 +4556,12 @@ test "create_transfers: per-transfer balance invariant" {
         \\ setup A1 0 0 0 40
         \\
         \\ transfer T1 A1 A2 41   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ linked_event_failed
-        \\ transfer T2 A3 A1 41   _  _  _  _    0 L1 C1 LNK PEN _   _   _ BCR _ _ _ _ _ exceeds_credits
+        \\ transfer T2 A3 A1  1   _  _  _  _    0 L1 C1 LNK PEN _   _   _ BCR _ _ _ _ _ exceeds_credits
         \\ transfer T3 A3 A1  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ linked_event_failed
         \\ commit create_transfers
         \\
         \\ transfer T1 A1 A2 40   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ ok
-        \\ transfer T2 A3 A1 40   _  _  _  _    0 L1 C1 LNK PEN _   _   _ BCR _ _ _ _ _ ok
+        \\ transfer T2 A3 A1  1   _  _  _  _    0 L1 C1 LNK PEN _   _   _ BCR _ _ _ _ _ ok
         \\ transfer T3 A3 A1  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ ok
         \\ commit create_transfers
         \\

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -4545,6 +4545,31 @@ test "create_transfers: per-transfer balance invariant" {
         \\ lookup_account A3 0  0 0  0 _
         \\ commit lookup_accounts
     );
+
+    // Temporarily enforce `debits_must_not_exceed_credits` on account `A1`.
+    try check(
+        \\ account A1  0  0  0  0  _  _  _ _ L1 C1   _   _   _ _ _ _ _ _ ok
+        \\ account A2  0  0  0  0  _  _  _ _ L1 C1   _   _   _ _ _ _ _ _ ok
+        \\ account A3  0  0  0  0  _  _  _ _ L1 C1   _   D<C _ _ _ _ _ _ ok
+        \\ commit create_accounts
+        \\
+        \\ setup A1 0 0 0 40
+        \\
+        \\ transfer T1 A1 A2 41   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ linked_event_failed
+        \\ transfer T2 A3 A1 41   _  _  _  _    0 L1 C1 LNK PEN _   _   _ BCR _ _ _ _ _ exceeds_credits
+        \\ transfer T3 A3 A1  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ linked_event_failed
+        \\ commit create_transfers
+        \\
+        \\ transfer T1 A1 A2 40   _  _  _  _    0 L1 C1 LNK   _ _   _   _   _ _ _ _ _ _ ok
+        \\ transfer T2 A3 A1 40   _  _  _  _    0 L1 C1 LNK PEN _   _   _ BCR _ _ _ _ _ ok
+        \\ transfer T3 A3 A1  0  T2  _  _  _    0 L1 C1   _   _ _ VOI   _   _ _ _ _ _ _ ok
+        \\ commit create_transfers
+        \\
+        \\ lookup_account A1 0 40 0 40 _
+        \\ lookup_account A2 0  0 0 40 _
+        \\ lookup_account A3 0  0 0  0 _
+        \\ commit lookup_accounts
+    );
 }
 
 test "imported events: imported batch" {


### PR DESCRIPTION
Add a test which applies a balance invariant for a single transfer -- that is, temporarily apply a balance invariant to an account that doesn't have a balance invariant.