### PR TITLE
Update Slack link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here are a few key pages you might be interested in:
 ## Community
 
 * [Projects using TigerBeetle developed by community members.](./docs/COMMUNITY_PROJECTS.md)
-* [Join the TigerBeetle chat on Slack.](https://slack.tigerbeetle.com/invite)
+* [Join the TigerBeetle chat on Slack.](https://join.slack.com/t/tigerbeetle/shared_invite/zt-21xk62q7l-p~~G7~H01zQb88rQn7tWfQ)
 * [Follow us on Twitter](https://twitter.com/TigerBeetleDB), [YouTube](https://www.youtube.com/@tigerbeetledb), and [Twitch](https://www.twitch.tv/tigerbeetle).
 * [Subscribe to our monthly newsletter for the backstory on recent database changes.](https://mailchi.mp/8e9fa0f36056/subscribe-to-tigerbeetle)
 * [Check out past and upcoming talks.](/docs/TALKS.md)


### PR DESCRIPTION
Not sure if there's a cleaner invite URL, I just copied this from the Tigerbeetle's site footer.