### PR TITLE
vsr: crash cleanly if the data file is too large

### DIFF
--- a/src/lsm/node_pool.zig
+++ b/src/lsm/node_pool.zig
@@ -65,7 +65,7 @@ pub fn NodePoolType(comptime _node_size: u32, comptime _node_alignment: u13) typ
             const node_index = pool.free.findFirstSet() orelse vsr.fatal(
                 .manifest_node_pool_exhausted,
                 "out of memory for manifest, " ++
-                    "restart the replica with larger '--memory-lsm-manifest' argument",
+                    "restart the replica increasing '--memory-lsm-manifest'",
                 .{},
             );
             assert(pool.free.isSet(node_index));

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -643,6 +643,7 @@ const FatalReason = enum(u8) {
     cli = 1,
     no_space_left = 2,
     manifest_node_pool_exhausted = 3,
+    storage_size_exceeds_limit = 4,
 
     fn exit_status(reason: FatalReason) u8 {
         return @intFromEnum(reason);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1270,6 +1270,20 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     });
                 }
 
+                if (superblock.working.vsr_state.checkpoint.storage_size >
+                    superblock.storage_size_limit)
+                {
+                    vsr.fatal(
+                        .storage_size_exceeds_limit,
+                        "data file too large size={} > limit={}, " ++
+                            "restart the replica increasing '--storage_size_limit'",
+                        .{
+                            superblock.working.vsr_state.checkpoint.storage_size,
+                            superblock.storage_size_limit,
+                        },
+                    );
+                }
+
                 if (context.caller == .open) {
                     if (context.repairs) |_| {
                         // We just verified that the repair completed.


### PR DESCRIPTION
If, at startup, data file size is larger than what our CLI prepared us for, fatal-error cleanly.

Note that this _doesn't_ correctly handle the case where the data file grows when the replica is already up. That'll assert on `free_set.reserve().?` currently which is not ideal.

Closes: https://github.com/tigerbeetle/tigerbeetle/issues/340