### PR TITLE
vopr: disable new storage faults before transitioning to liveness mode

### DIFF
--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -715,6 +715,12 @@ pub const Storage = struct {
             assert(data_block_header.block_type == .data);
         }
     }
+
+    pub fn transition_to_liveness_mode(storage: *Storage) void {
+        storage.options.read_fault_probability = 0;
+        storage.options.write_fault_probability = 0;
+        storage.options.crash_fault_probability = 0;
+    }
 };
 
 pub const Area = union(enum) {

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -583,6 +583,15 @@ pub const Simulator = struct {
         simulator.tick_crash();
     }
 
+    /// Executes the following:
+    /// * Pick a quorum of replicas to be fully available (the core)
+    /// * Restart any core replicas that are down at the moment
+    /// * Heal all network partitions between core replicas
+    /// * Disable storage faults on the core replicas
+    /// * For all failures involving non-core replicas, make those failures permanent.
+    ///
+    /// See https://tigerbeetle.com/blog/2023-07-06-simulation-testing-for-liveness for broader
+    /// context.
     pub fn transition_to_liveness_mode(simulator: *Simulator) void {
         simulator.core = random_core(
             simulator.random,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -597,6 +597,7 @@ pub const Simulator = struct {
             if (simulator.cluster.replica_health[replica_index] == .down) {
                 simulator.restart_replica(@intCast(replica_index), fault);
             }
+            simulator.cluster.storages[replica_index].transition_to_liveness_mode();
         }
 
         simulator.cluster.network.transition_to_liveness_mode(simulator.core);


### PR DESCRIPTION
Resolves the failed VOPR seed (./zig/zig build -Drelease -Dvopr-state-machine=testing vopr -- 12865272390949771184) on main (5378e181bcd5030ceac012ae6cecd428c6b0d3d2). The seed is a false positive, VOPR panics with `@panic("block found in core");` since we disable network & process crash faults while transitioning to liveness mode in the VOPR, but _storage faults are kept enabled_. This PR disables storage faults as well.

This is solved by zeroing storage fault probabilities before transitioning to liveness mode (similar to what we do for network & process faults: https://github.com/tigerbeetle/tigerbeetle/blob/34e85703da17cb9b890c43855453580dfcd74c06/src/vopr.zig#L602-L606)