### PR TITLE
client: halt VM on completion exception

### DIFF
--- a/src/clients/java/src/main/java/com/tigerbeetle/AsyncRequest.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AsyncRequest.java
@@ -91,12 +91,16 @@ final class AsyncRequest<TResponse extends Batch> extends Request<TResponse> {
     @Override
     protected void setResult(final TResponse result) {
         final var completed = future.complete(result);
-        AssertionError.assertTrue(completed, "CompletableFuture already completed");
+        if (!completed) {
+            throw new IllegalStateException("CompletableFuture already completed");
+        }
     }
 
     @Override
     protected void setException(final Throwable exception) {
         final var completed = future.completeExceptionally(exception);
-        AssertionError.assertTrue(completed, "CompletableFuture already completed");
+        if (!completed) {
+            throw new IllegalStateException("CompletableFuture already completed");
+        }
     }
 }

--- a/src/clients/java/src/main/java/com/tigerbeetle/AsyncRequest.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AsyncRequest.java
@@ -92,7 +92,7 @@ final class AsyncRequest<TResponse extends Batch> extends Request<TResponse> {
     protected void setResult(final TResponse result) {
         final var completed = future.complete(result);
         if (!completed) {
-            throw new IllegalStateException("CompletableFuture already completed");
+            throw new IllegalStateException("Request has already been completed");
         }
     }
 
@@ -100,7 +100,7 @@ final class AsyncRequest<TResponse extends Batch> extends Request<TResponse> {
     protected void setException(final Throwable exception) {
         final var completed = future.completeExceptionally(exception);
         if (!completed) {
-            throw new IllegalStateException("CompletableFuture already completed");
+            throw new IllegalStateException("Request has already been completed");
         }
     }
 }

--- a/src/clients/java/src/main/java/com/tigerbeetle/BlockingRequest.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/BlockingRequest.java
@@ -115,7 +115,7 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
         synchronized (this) {
 
             if (isDone()) {
-                throw new IllegalStateException("This request has already been completed");
+                throw new IllegalStateException("Request has already been completed");
             } else {
                 this.result = result;
                 this.exception = null;
@@ -132,7 +132,7 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
         synchronized (this) {
 
             if (isDone()) {
-                throw new IllegalStateException("This request has already been completed");
+                throw new IllegalStateException("Request has already been completed");
             } else {
                 this.result = null;
                 this.exception = exception;

--- a/src/clients/java/src/main/java/com/tigerbeetle/BlockingRequest.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/BlockingRequest.java
@@ -115,13 +115,8 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
         synchronized (this) {
 
             if (isDone()) {
-
-                this.result = null;
-                this.exception = new AssertionError(this.exception,
-                        "This request has already been completed");
-
+                throw new IllegalStateException("This request has already been completed");
             } else {
-
                 this.result = result;
                 this.exception = null;
             }
@@ -135,8 +130,14 @@ final class BlockingRequest<TResponse extends Batch> extends Request<TResponse> 
     protected void setException(final Throwable exception) {
 
         synchronized (this) {
-            this.result = null;
-            this.exception = exception;
+
+            if (isDone()) {
+                throw new IllegalStateException("This request has already been completed");
+            } else {
+                this.result = null;
+                this.exception = exception;
+            }
+
             notify();
         }
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -177,10 +177,17 @@ abstract class Request<TResponse extends Batch> {
             exception = any;
         }
 
-        if (exception == null) {
-            setResult((TResponse) result);
-        } else {
-            setException(exception);
+        try {
+            if (exception == null) {
+                setResult((TResponse) result);
+            } else {
+                setException(exception);
+            }
+        } catch (Throwable any) {
+            System.err.println("Completion of request failed!\n"
+                    + "This is a bug in TigerBeetle. Please report it at https://github.com/tigerbeetle/tigerbeetle.\n"
+                    + "Cause: " + any.toString());
+            Runtime.getRuntime().halt(1);
         }
     }
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -187,6 +187,7 @@ abstract class Request<TResponse extends Batch> {
             System.err.println("Completion of request failed!\n"
                     + "This is a bug in TigerBeetle. Please report it at https://github.com/tigerbeetle/tigerbeetle.\n"
                     + "Cause: " + any.toString());
+            any.printStackTrace();
             Runtime.getRuntime().halt(1);
         }
     }

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -536,11 +536,11 @@ public class AsyncRequestTest {
         var status = PacketStatus.TooMuchData.value;
 
         try {
-          // First completion is OK, registering the exception in the CompletableFuture.
-          request.setException(new RequestException(status));
+            // First completion is OK, registering the exception in the CompletableFuture.
+            request.setException(new RequestException(status));
         } catch (Throwable any) {
-          // No exception is expected in the first call.
-          assert false;
+            // No exception is expected in the first call.
+            assert false;
         }
         // Second time throws an exception, because it can only be completed once.
         request.setException(new RequestException(status));

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -535,8 +535,13 @@ public class AsyncRequestTest {
         var request = AsyncRequest.lookupTransfers(client, batch);
         var status = PacketStatus.TooMuchData.value;
 
-        // First completion is OK, registering the exception in the CompletableFuture.
-        request.setException(new RequestException(status));
+        try {
+          // First completion is OK, registering the exception in the CompletableFuture.
+          request.setException(new RequestException(status));
+        } catch (Throwable any) {
+          // No exception is expected in the first call.
+          assert false;
+        }
         // Second time throws an exception, because it can only be completed once.
         request.setException(new RequestException(status));
 

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -526,6 +526,22 @@ public class AsyncRequestTest {
         }
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testFailedFutureCompletedTwice() {
+        var client = getDummyClient();
+        var batch = new IdBatch(1);
+        batch.add();
+
+        var request = AsyncRequest.lookupTransfers(client, batch);
+        var status = PacketStatus.TooMuchData.value;
+
+        // First completion is OK, registering the exception in the CompletableFuture.
+        request.setException(new RequestException(status));
+        // Second time throws an exception, because it can only be completed once.
+        request.setException(new RequestException(status));
+
+    }
+
     private static NativeClient getDummyClient() {
         return NativeClient.initEcho(UInt128.asBytes(0), "3000");
     }

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -221,7 +221,7 @@ public class BlockingRequestTest {
         request.waitForResult();
     }
 
-    @Test(expected = AssertionError.class)
+    @Test(expected = IllegalStateException.class)
     public void testEndRequestTwice() {
         var client = getDummyClient();
 
@@ -243,13 +243,11 @@ public class BlockingRequestTest {
         var result = request.waitForResult();
         assertEquals(1, result.getLength());
 
-        request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
-
-        assertTrue(request.isDone());
-
-        request.waitForResult();
-        assert false;
+        // Can't end the request twice.
+        // NOTE: Normally this is caught by `Request.endRequest`, halting the VM immediately.
+        // But we can't test that in a good way, so we use `setException` here and catch the
+        // IllegalStateException.
+        request.setException(new RequestException(PacketStatus.TooMuchData.value));
     }
 
     @Test

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -237,7 +237,14 @@ public class BlockingRequestTest {
         assertFalse(request.isDone());
 
         request.setReplyBuffer(dummyReplyBuffer.position(0).array());
-        request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+
+        // First completion is OK, registering the exception.
+        try {
+          request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+        } catch (Throwable any) {
+          // No exception is expected in the first call.
+          assert false;
+        }
 
         assertTrue(request.isDone());
         var result = request.waitForResult();

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -240,10 +240,10 @@ public class BlockingRequestTest {
 
         // First completion is OK, registering the exception.
         try {
-          request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
+            request.endRequest(Request.Operations.CREATE_ACCOUNTS.value, PacketStatus.Ok.value);
         } catch (Throwable any) {
-          // No exception is expected in the first call.
-          assert false;
+            // No exception is expected in the first call.
+            assert false;
         }
 
         assertTrue(request.isDone());


### PR DESCRIPTION
* Any double-completion results in Runtime.halt
* Same behavior for async and blocking requests
* Use internal sync/async-specific methods for testing