### PR TITLE
node+tidy: tidy up file locations and tidy.zig itself

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1069,10 +1069,12 @@ fn build_node_client(
 
         const lib = b.addSharedLibrary(.{
             .name = "tb_nodeclient",
-            .root_source_file = b.path("src/node.zig"),
+            .root_source_file = b.path("src/clients/node/node.zig"),
             .target = resolved_target,
             .optimize = options.mode,
         });
+        lib.root_module.addImport("vsr", options.vsr_module);
+        lib.root_module.addOptions("vsr_options", options.vsr_options);
         lib.linkLibC();
 
         lib.step.dependOn(&npm_install.step);

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -2,12 +2,10 @@ const std = @import("std");
 const assert = std.debug.assert;
 const allocator = std.heap.c_allocator;
 
-const c = @import("clients/node/src/c.zig");
-const translate = @import("clients/node/src/translate.zig");
-const tb = struct {
-    pub usingnamespace @import("tigerbeetle.zig");
-    pub usingnamespace @import("clients/c/tb_client.zig");
-};
+const c = @import("src/c.zig");
+const translate = @import("src/translate.zig");
+const tb = vsr.tigerbeetle;
+const tb_client = vsr.tb_client;
 
 const Account = tb.Account;
 const AccountFlags = tb.AccountFlags;
@@ -21,7 +19,7 @@ const AccountBalance = tb.AccountBalance;
 const QueryFilter = tb.QueryFilter;
 const QueryFilterFlags = tb.QueryFilterFlags;
 
-const vsr = @import("vsr.zig");
+const vsr = @import("vsr");
 const Storage = vsr.storage.Storage(vsr.io.IO);
 const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
 const Operation = StateMachine.Operation;
@@ -153,7 +151,7 @@ fn create(
         return translate.throw(env, "Failed to acquire reference to thread-safe function.");
     }
 
-    const client = tb.init(
+    const client = tb_client.init(
         allocator,
         cluster_id,
         addresses,
@@ -167,7 +165,7 @@ fn create(
         error.SystemResources => return translate.throw(env, "Failed to reserve system resources."),
         error.NetworkSubsystemFailed => return translate.throw(env, "Network stack failure."),
     };
-    errdefer tb.deinit(client);
+    errdefer tb_client.deinit(client);
 
     return try translate.create_external(env, client);
 }
@@ -179,10 +177,10 @@ fn destroy(env: c.napi_env, context: c.napi_value) !void {
         context,
         "Failed to get client context pointer.",
     );
-    const client: tb.tb_client_t = @ptrCast(@alignCast(client_ptr.?));
-    defer tb.deinit(client);
+    const client: tb_client.tb_client_t = @ptrCast(@alignCast(client_ptr.?));
+    defer tb_client.deinit(client);
 
-    const completion_ctx = tb.completion_context(client);
+    const completion_ctx = tb_client.completion_context(client);
     const completion_tsfn: c.napi_threadsafe_function = @ptrFromInt(completion_ctx);
 
     if (c.napi_release_threadsafe_function(completion_tsfn, c.napi_tsfn_abort) != c.napi_ok) {
@@ -202,7 +200,7 @@ fn request(
         context,
         "Failed to get client context pointer.",
     );
-    const client: tb.tb_client_t = @ptrCast(@alignCast(client_ptr.?));
+    const client: tb_client.tb_client_t = @ptrCast(@alignCast(client_ptr.?));
 
     // Create a reference to the callback so it stay alive until the packet completes.
     var callback_ref: c.napi_ref = undefined;
@@ -248,7 +246,7 @@ fn request(
         .reserved = undefined,
     };
 
-    tb.submit(client, packet);
+    tb_client.submit(client, packet);
 }
 
 // Packet only has one size field which normally tracks `BufferType(op).events().len`.
@@ -262,8 +260,8 @@ const BufferSize = packed struct(u32) {
 
 fn on_completion(
     completion_ctx: usize,
-    client: tb.tb_client_t,
-    packet: *tb.tb_packet_t,
+    client: tb_client.tb_client_t,
+    packet: *tb_client.tb_packet_t,
     result_ptr: ?[*]const u8,
     result_len: u32,
 ) callconv(.C) void {
@@ -320,7 +318,7 @@ fn on_completion_js(
     _ = unused_context;
 
     // Extract the remaining packet information from the packet before it's freed.
-    const packet: *tb.tb_packet_t = @ptrCast(@alignCast(packet_argument.?));
+    const packet: *tb_client.tb_packet_t = @ptrCast(@alignCast(packet_argument.?));
     const callback_ref: c.napi_ref = @ptrCast(@alignCast(packet.user_data.?));
 
     // Decode the packet's Buffer results into an array then free the packet/Buffer.
@@ -490,7 +488,7 @@ fn BufferType(comptime op: Operation) type {
         const Result = StateMachine.Result(op);
 
         const body_align = @max(@alignOf(Event), @alignOf(Result));
-        const body_offset = std.mem.alignForward(usize, @sizeOf(tb.tb_packet_t), body_align);
+        const body_offset = std.mem.alignForward(usize, @sizeOf(tb_client.tb_packet_t), body_align);
 
         ptr: [*]u8,
         count: u32,
@@ -505,7 +503,7 @@ fn BufferType(comptime op: Operation) type {
                 return translate.throw(env, "Batch is larger than the maximum message size.");
             }
 
-            const max_align = @max(body_align, @alignOf(tb.tb_packet_t));
+            const max_align = @max(body_align, @alignOf(tb_client.tb_packet_t));
             const max_bytes = body_offset + body_size;
 
             const bytes = allocator.alignedAlloc(u8, max_align, max_bytes) catch |e| switch (e) {
@@ -528,14 +526,14 @@ fn BufferType(comptime op: Operation) type {
                 @sizeOf(Result) * event_count(op, buffer.count),
             );
 
-            const max_align = @max(body_align, @alignOf(tb.tb_packet_t));
+            const max_align = @max(body_align, @alignOf(tb_client.tb_packet_t));
             const max_bytes = body_offset + body_size;
 
             const bytes: []align(max_align) u8 = @alignCast(buffer.ptr[0..max_bytes]);
             allocator.free(bytes);
         }
 
-        fn packet(buffer: Buffer) *tb.tb_packet_t {
+        fn packet(buffer: Buffer) *tb_client.tb_packet_t {
             return @alignCast(@ptrCast(buffer.ptr));
         }
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -600,17 +600,15 @@ test "tidy extensions" {
     });
 
     const exceptions = std.StaticStringMap(void).initComptime(.{
-        .{".editorconfig"},                       .{".gitignore"},
-        .{".nojekyll"},                           .{"CNAME"},
-        .{"Dockerfile"},                          .{"exclude-pmd.properties"},
-        .{"favicon.ico"},                         .{"favicon.png"},
-        .{"LICENSE"},                             .{"module-info.test"},
-        .{"index.html"},                          .{"logo.svg"},
-        .{"logo-white.svg"},                      .{"logo-with-text-white.svg"},
-        .{"zig/download.sh"},                     .{"src/scripts/cfo_supervisor.sh"},
-        .{"src/docs_website/scripts/build.sh"},   .{".github/ci/docs_check.sh"},
-        .{".github/ci/test_aof.sh"},              .{"tools/systemd/tigerbeetle-pre-start.sh"},
-        .{"tools/vscode/format_debug_server.sh"},
+        .{".editorconfig"},                 .{".gitignore"},
+        .{".nojekyll"},                     .{"CNAME"},
+        .{"exclude-pmd.properties"},        .{"favicon.ico"},
+        .{"favicon.png"},                   .{"LICENSE"},
+        .{"module-info.test"},              .{"index.html"},
+        .{"logo.svg"},                      .{"logo-white.svg"},
+        .{"logo-with-text-white.svg"},      .{"zig/download.sh"},
+        .{"src/scripts/cfo_supervisor.sh"}, .{"src/docs_website/scripts/build.sh"},
+        .{".github/ci/docs_check.sh"},      .{".github/ci/test_aof.sh"},
     });
 
     const allocator = std.testing.allocator;
@@ -618,6 +616,21 @@ test "tidy extensions" {
     defer shell.destroy();
 
     const paths = try list_file_paths(shell);
+
+    for (exceptions.keys()) |exception| {
+        for (paths) |path| {
+            const basename = std.fs.path.basename(path);
+            if (std.mem.eql(u8, exception, basename) or std.mem.eql(u8, exception, path)) {
+                break;
+            }
+        } else {
+            std.debug.panic("exception (or basename) doesn't exist: {s} ({s})", .{
+                exception,
+                std.fs.path.basename(exception),
+            });
+        }
+    }
+
     var bad_extension = false;
     for (paths) |path| {
         if (path.len == 0) continue;


### PR DESCRIPTION
`node.zig` can be moved to `src/clients/node` (but getting `tb_client_exports.zig` out of `src/` is a bit more involved). Additionally, prune the tidy filename exception list, and while we're there, validate all exceptions are actually exceptions.