### PR TITLE
vsr: handle multiple torn writes at the end of the WAL

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5845,8 +5845,7 @@ pub fn ReplicaType(
         fn op_head_certain(self: *const Self) bool {
             assert(self.status == .recovering);
 
-            // "op-head < op-checkpoint" is possible if op_checkpoint…head (inclusive) is corrupt or
-            // if the replica restarts after state sync updates superblock.
+            // "op-head < op-checkpoint" is possible if op_checkpoint…head (inclusive) is corrupt.
             if (self.op < self.op_checkpoint()) {
                 log.warn("{}: op_head_certain: op < op_checkpoint op={} op_checkpoint={}", .{
                     self.replica,
@@ -5936,7 +5935,7 @@ pub fn ReplicaType(
         /// Receiving and storing an op higher than `op_prepare_max()` is forbidden;
         /// doing so would overwrite a message (or the slot of a message) that has not yet been
         /// committed and checkpointed.
-        fn op_prepare_max(self: *const Self) u64 {
+        pub fn op_prepare_max(self: *const Self) u64 {
             return vsr.Checkpoint.prepare_max_for_checkpoint(self.op_checkpoint_next()).?;
         }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -759,7 +759,8 @@ pub fn ReplicaType(
                         self.transition_to_recovering_head_from_recovering_status();
                     }
                 } else {
-                    // Even if op_head_certain() returns false, a DVC always has a certain head op.
+                    // Don't call op_head_certain() here, as we didn't use the journal to infer our
+                    // head op. We used only vsr_headers, and a DVC always has a certain head op.
                     assert(self.view > self.log_view);
                     self.transition_to_view_change_status(self.view);
                 }
@@ -5871,7 +5872,7 @@ pub fn ReplicaType(
             // - op=op_checkpoint, or
             // - op=op_prepare_max
             if (self.journal.faulty.bit(slot_prepare_max)) {
-                log.warn("{}: op_head_certain: faulty checkpoint slot={}", .{
+                log.warn("{}: op_head_certain: faulty prepare_max slot={}", .{
                     self.replica,
                     slot_prepare_max,
                 });


### PR DESCRIPTION
Currently, our logic for handling torn prepares (prepares that were being made durable before a replica crash, but weren't written out completely) only handles _one_ torn prepare: https://github.com/tigerbeetle/tigerbeetle/blob/577b638e52725f5ff128822e4c75ccc4fb2ca5f2/src/vsr/journal.zig#L1369

This is incorrect because there could be _multiple_ prepares concurrently being written before a replica crash:
https://github.com/tigerbeetle/tigerbeetle/blob/577b638e52725f5ff128822e4c75ccc4fb2ca5f2/src/config.zig#L114

This PR correctly detects and truncates multiple torn writes in the WAL, improving _availability_! Before this change, a replica with multiple torn writes at the end of the WAL would transition into .recovering_head status on startup as those writes would be conservatively treated as corruptions.