### PR TITLE
ci: build java client before building systest

### DIFF
--- a/src/scripts/antithesis.zig
+++ b/src/scripts/antithesis.zig
@@ -46,6 +46,8 @@ pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
 
     // Build Java client library
     {
+        try shell.exec_zig("build clients:java -Drelease", .{});
+
         try shell.pushd("./src/clients/java");
         defer shell.popd();
 


### PR DESCRIPTION
Had missed adding the clients build step when setting up the systest deploy. Accidentally _worked on my machine_ :tm: because of state.