### PR TITLE
dotnet: fix type error in sample

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -351,7 +351,7 @@ appropriate accounts and **not** apply them to the `debits_posted` and
 transfers = new Transfer[] { new Transfer {
     Id = 2,
     PendingId = 1,
-    Flags = TransferFlags.PostPendingTransfer,
+    Flags = TransferFlags.VoidPendingTransfer,
 }};
 
 createTransfersError = client.CreateTransfers(transfers);

--- a/src/clients/dotnet/samples/walkthrough/Program.cs
+++ b/src/clients/dotnet/samples/walkthrough/Program.cs
@@ -138,7 +138,7 @@ using (var client = new Client(clusterID, addresses))
     transfers = new Transfer[] { new Transfer {
         Id = 2,
         PendingId = 1,
-        Flags = TransferFlags.PostPendingTransfer,
+        Flags = TransferFlags.VoidPendingTransfer,
     }};
 
     createTransfersError = client.CreateTransfers(transfers);


### PR DESCRIPTION
Fix little type error in the walkthrough sample for the .NET client