### PR TITLE
test: add "starting workload" log to be matched on

### DIFF
--- a/src/testing/systest/workload/src/main/java/Main.java
+++ b/src/testing/systest/workload/src/main/java/Main.java
@@ -21,6 +21,7 @@ public final class Main {
     byte[] clusterID = UInt128.asBytes(Long.parseLong(env.getOrDefault("CLUSTER", "1")));
 
     try (var client = new Client(clusterID, replicaAddresses)) {
+      System.err.println("starting workload");
       new Workload(random, client).run();
     }
   }

--- a/src/testing/systest/workload/src/main/java/Workload.java
+++ b/src/testing/systest/workload/src/main/java/Workload.java
@@ -53,7 +53,7 @@ public class Workload {
         }
 
         if (n % 1000 == 0) {
-          System.out.println(
+          System.err.println(
               "%d succeeded, %d failed".formatted(commandsSucceededCount, commandsFailedCount));
         }
 


### PR DESCRIPTION
The antithesis tests time out unless we print something in the workload that matches a configured pattern. This adds a suitable log message to match on.