### PR TITLE
Update REPL

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1681,6 +1681,14 @@ test "repl.zig: Handle parsing errors" {
             .in = "create_transfers id=abcd",
             .err = error.BadKeyValuePair,
         },
+        .{
+            .in = "create_transfers amount=0y1234",
+            .err = error.BadKeyValuePair,
+        },
+        .{
+            .in = "create_transfers amount=--0",
+            .err = error.BadKeyValuePair,
+        },
     };
 
     for (tests) |t| {


### PR DESCRIPTION
- Support representing negative inputs as `maxInt - input`, useful for sentinels such as `AMOUNT_MAX`.
- Allow inputs to specify base prefixes `0x`, `0o`, or `0b`, useful for GUIDs and UUIDs.
- Remove the restriction on handling `timestamp`, allowing the REPL to handle `imported` events.
- Add unit tests.

Related: #2357