### PR TITLE
LSM: Incrementally sort mutable table

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1384,11 +1384,9 @@ pub fn CompactionType(
                         bar.table_info_a.immutable = bar.table_info_a.immutable[filled..];
 
                         updated_fill_count = true;
-                        log.debug("set_source_a({s}): refilled immutable block. {} values out, " ++
-                            "{} values consumed", .{
+                        log.debug("set_source_a({s}): refilled immutable values (filled={})", .{
                             compaction.tree_config.name,
                             filled,
-                            bar.source_a_values_consumed_for_fill,
                         });
                     }
                 }

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1287,7 +1287,7 @@ pub fn CompactionType(
                 const source_values_merge_count_b = compaction.update_position_b();
                 const source_values_merge_count = source_values_merge_count_a +
                     source_values_merge_count_b;
-                std.log.debug("blip_merge({s}): source_values_merge_count_a={} " ++
+                log.debug("blip_merge({s}): source_values_merge_count_a={} " ++
                     "source_values_merge_count_b={}", .{
                     compaction.tree_config.name,
                     source_values_merge_count_a,
@@ -1979,7 +1979,7 @@ pub fn CompactionType(
                     },
                 }
             }
-            std.log.debug("bar_apply_to_manifest({s}): manifest_removed_value_count={} " ++
+            log.debug("bar_apply_to_manifest({s}): manifest_removed_value_count={} " ++
                 "manifest_added_value_count={} source_values_read_count={} " ++
                 "target_values_merge_count={}", .{
                 compaction.tree_config.name,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1399,9 +1399,9 @@ pub fn CompactionType(
                         bar.source_a_values_consumed_for_fill = 0;
                     }
                     return .exhausted;
+                } else {
+                    return .filled;
                 }
-
-                return .filled;
             } else {
                 const blocks = &beat.blocks.?;
                 defer beat.source_a_len_after_set = beat.source_a_values.?.len;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1581,18 +1581,14 @@ pub fn CompactionType(
 
             var source = bar.table_info_a.immutable;
             assert(source.len > 0);
+            assert(target.len > 0);
 
             // TODO Don't copy this, just use directly.
             const count = @min(target.len, source.len);
+            assert(count > 0);
+
             stdx.copy_disjoint(.exact, Value, target[0..count], source[0..count]);
-
-            bar.table_info_a.immutable =
-                bar.table_info_a.immutable[count..];
-
-            if (count == 0) {
-                assert(Table.usage == .secondary_index);
-                return 0;
-            }
+            bar.table_info_a.immutable = bar.table_info_a.immutable[count..];
 
             if (constants.verify) {
                 // The immutable table's keys must be strictly increasing.
@@ -1604,8 +1600,6 @@ pub fn CompactionType(
                     assert(key_from_value(value_next) > key_from_value(value));
                 }
             }
-
-            assert(count > 0);
             return count;
         }
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -516,6 +516,11 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     forest.compaction_pipeline.block_pool_raw.len);
             }
 
+            // Groove sync compaction - must be done after all async work for the beat completes???
+            inline for (std.meta.fields(Grooves)) |field| {
+                @field(forest.grooves, field.name).compact(op);
+            }
+
             // Swap the mutable and immutable tables; this must happen on the last beat, regardless
             // of pacing.
             if (last_beat) {
@@ -535,11 +540,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 // reset our pipeline state.
                 assert(forest.compaction_pipeline.bar_active.count() == 0);
                 forest.compaction_pipeline.compactions.clear();
-            }
-
-            // Groove sync compaction - must be done after all async work for the beat completes???
-            inline for (std.meta.fields(Grooves)) |field| {
-                @field(forest.grooves, field.name).compact(op);
             }
 
             // On the last beat of the bar, make sure that manifest log compaction is finished.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -516,7 +516,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     forest.compaction_pipeline.block_pool_raw.len);
             }
 
-            // Groove sync compaction - must be done after all async work for the beat completes???
+            // Groove sync compaction - must be done after all async work for the beat completes.
             inline for (std.meta.fields(Grooves)) |field| {
                 @field(forest.grooves, field.name).compact(op);
             }

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -767,7 +767,7 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
         /// be shared between compactions, so these are all multiplied by the number
         /// of concurrent compactions.
         /// TODO: This is currently the case for fixed half-bar scheduling.
-        const block_count_bar_single: u64 = 3;
+        const block_count_bar_single: u64 = 2;
 
         const block_count_bar_concurrent: u64 = blk: {
             var block_count: u64 = 0;
@@ -1040,11 +1040,8 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
                         block_pool_count_start - self.block_pool.count == block_count_bar_single,
                     );
 
-                    const immutable_table_a_block = self.block_pool.pop().?;
-                    const target_index_blocks = CompactionHelper.BlockFIFO.init(
-                        &self.block_pool,
-                        2,
-                    );
+                    const target_index_blocks =
+                        CompactionHelper.BlockFIFO.init(&self.block_pool, 2);
 
                     // A compaction is marked as live at the start of a bar, unless it's
                     // move_table...
@@ -1062,7 +1059,6 @@ fn CompactionPipelineType(comptime Forest: type, comptime Grid: type) type {
                             self.tree_compaction(tree_id, compaction.level_b).bar_setup_budget(
                                 @divExact(constants.lsm_compaction_ops, 2),
                                 target_index_blocks,
-                                immutable_table_a_block,
                             );
                         },
                     }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1403,6 +1403,13 @@ pub fn GrooveType(
         }
 
         pub fn compact(groove: *Groove, op: u64) void {
+            if (has_id) groove.ids.compact();
+            groove.objects.compact();
+
+            inline for (std.meta.fields(IndexTrees)) |field| {
+                @field(groove.indexes, field.name).compact();
+            }
+
             // Compact the objects_cache on the last beat of the bar, just like the trees do to
             // their mutable tables.
             const compaction_beat = op % constants.lsm_compaction_ops;

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -35,7 +35,7 @@ pub fn TableMemoryType(comptime Table: type) type {
         pub fn init(
             table: *TableMemory,
             allocator: mem.Allocator,
-            mutability: Mutability,
+            mutability: std.meta.Tag(Mutability),
             name: []const u8,
             options: struct {
                 value_count_limit: u32,
@@ -45,7 +45,10 @@ pub fn TableMemoryType(comptime Table: type) type {
 
             table.* = .{
                 .value_context = .{},
-                .mutability = mutability,
+                .mutability = switch (mutability) {
+                    .mutable => .mutable,
+                    .immutable => .{ .immutable = .{} },
+                },
                 .name = name,
 
                 .values = undefined,

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -128,8 +128,6 @@ pub fn TableMemoryType(comptime Table: type) type {
             assert(table.value_context.count <= table.values.len);
             defer assert(table.value_context.sorted);
 
-            // Sort all the values. In future, this will be done incrementally, and use
-            // k_way_merge, but for now the performance regression was too bad.
             table.sort();
 
             // If we have no values, then we can consider ourselves flushed right away.
@@ -189,7 +187,8 @@ pub fn TableMemoryType(comptime Table: type) type {
             var source_index: u32 = offset;
             var target_index: u32 = offset;
             while (source_index < source_count) {
-                table.values[target_index] = table.values[source_index];
+                const value = table.values[source_index];
+                table.values[target_index] = value;
 
                 // If we're at the end of the source, there is no next value, so the next value
                 // can't be equal.

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -502,6 +502,14 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             maybe(tree.key_range == null);
         }
 
+        pub fn compact(tree: *Tree) void {
+            assert(tree.table_mutable.mutability == .mutable);
+
+            // Spreads sort+deduplication work between beats, to avoid a latency spike at the end of
+            // each bar (or immediately prior to scans).
+            tree.table_mutable.sort_suffix();
+        }
+
         /// Called after the last beat of a full compaction bar, by the compaction instance.
         pub fn swap_mutable_and_immutable(tree: *Tree, snapshot_min: u64) void {
             assert(tree.table_mutable.mutability == .mutable);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -505,6 +505,9 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         pub fn compact(tree: *Tree) void {
             assert(tree.table_mutable.mutability == .mutable);
 
+            tree.grid.trace.start(.compact_mutable_suffix, .{ .tree = tree.config.name });
+            defer tree.grid.trace.stop(.compact_mutable_suffix, .{ .tree = tree.config.name });
+
             // Spreads sort+deduplication work between beats, to avoid a latency spike at the end of
             // each bar (or immediately prior to scans).
             tree.table_mutable.sort_suffix();

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -137,12 +137,9 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             });
             errdefer tree.table_mutable.deinit(allocator);
 
-            try tree.table_immutable.init(
-                allocator,
-                .{ .immutable = .{} },
-                config.name,
-                .{ .value_count_limit = value_count_limit },
-            );
+            try tree.table_immutable.init(allocator, .immutable, config.name, .{
+                .value_count_limit = value_count_limit,
+            });
             errdefer tree.table_immutable.deinit(allocator);
 
             try tree.manifest.init(allocator, node_pool, config);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -335,7 +335,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 if (compaction.bar != null and compaction.bar.?.move_table) {
                     continue;
                 }
-                const source_a_immutable_block = env.block_pool.pop().?;
                 const target_index_blocks = CompactionHelper.BlockFIFO.init(&env.block_pool, 2);
 
                 const beat_blocks = .{
@@ -348,7 +347,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     .target_value_blocks = CompactionHelper.BlockFIFO.init(&env.block_pool, 2),
                 };
 
-                compaction.bar_setup_budget(1, target_index_blocks, source_a_immutable_block);
+                compaction.bar_setup_budget(1, target_index_blocks);
                 compaction.beat_grid_reserve();
                 compaction.beat_blocks_assign(beat_blocks);
 

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -111,6 +111,7 @@ pub const Event = union(enum) {
     compact_blip_write,
     compact_manifest,
     compact_mutable,
+    compact_mutable_suffix,
 
     lookup,
     lookup_worker: struct { index: u8 },
@@ -149,6 +150,7 @@ pub const Event = union(enum) {
         .compact_blip_write = 1,
         .compact_manifest = 1,
         .compact_mutable = 1,
+        .compact_mutable_suffix = 1,
         .lookup = 1,
         .lookup_worker = constants.grid_iops_read_max,
         .scan_tree = constants.lsm_scans_max,


### PR DESCRIPTION
### Overview

Previously, we sorted the mutable table updates at the end of each bar, immediately prior to converting into the immutable table. This causes a large latency spike every 64 ops (>250ms).

Instead, spread the sort work across the whole bar. At the end of each beat, sort the suffix of value updates that were just appended during that beat. This spreads out the last beat's work across the bar. The final sort at the end of the last beat merges the sorted runs together -- but many sort algorithms (including zig's "block" sort `std.mem.sort`) optimize the case where the data being sorted is a sequence of sorted sub-arrays, so the final sort is now more efficient.

Also included:
- Move the mutable table sort/deduplication logic from `compaction.zig` to `table_memory.zig`.
- Remove an extra copy of the mutable table data that was happening in `compaction.zig`, and acquire one fewer block per compaction.

### Benchmark

This change doesn't appear to impact overall TPS, but it does cut the transaction p100 by more than half.

<details>
<summary>Before</summary>

```
1222 batches in 29.69 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 336842 tx/s
batch latency p1 = 5 ms
batch latency p10 = 5 ms
batch latency p20 = 6 ms
batch latency p30 = 10 ms
batch latency p40 = 13 ms
batch latency p50 = 15 ms
batch latency p60 = 20 ms
batch latency p70 = 23 ms
batch latency p80 = 25 ms
batch latency p90 = 27 ms
batch latency p95 = 29 ms
batch latency p99 = 278 ms
batch latency p100 = 282 ms

100 queries in 4.28 s
query latency p1 = 26 ms
query latency p10 = 29 ms
query latency p20 = 30 ms
query latency p30 = 31 ms
query latency p40 = 35 ms
query latency p50 = 38 ms
query latency p60 = 45 ms
query latency p70 = 48 ms
query latency p80 = 53 ms
query latency p90 = 57 ms
query latency p95 = 60 ms
query latency p99 = 105 ms
query latency p100 = 125 ms
info(main): stdin closed, exiting

rss = 3231879168 bytes

datafile empty = 1141374976 bytes
datafile = 14825820160 bytes
```
</details>

<details>
<summary>After</summary>

```
1222 batches in 29.53 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 338663 tx/s
batch latency p1 = 7 ms
batch latency p10 = 11 ms
batch latency p20 = 12 ms
batch latency p30 = 15 ms
batch latency p40 = 18 ms
batch latency p50 = 21 ms
batch latency p60 = 25 ms
batch latency p70 = 28 ms
batch latency p80 = 30 ms
batch latency p90 = 32 ms
batch latency p95 = 34 ms
batch latency p99 = 108 ms
batch latency p100 = 113 ms

100 queries in 4.21 s
query latency p1 = 26 ms
query latency p10 = 29 ms
query latency p20 = 30 ms
query latency p30 = 31 ms
query latency p40 = 35 ms
query latency p50 = 40 ms
query latency p60 = 46 ms
query latency p70 = 48 ms
query latency p80 = 51 ms
query latency p90 = 56 ms
query latency p95 = 58 ms
query latency p99 = 61 ms
query latency p100 = 116 ms
info(main): stdin closed, exiting

rss = 3177619456 bytes

datafile empty = 1141374976 bytes
datafile = 14825820160 bytes
```
</details>