### PR TITLE
lsm: refactor compaction

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -660,6 +660,17 @@ comptime {
     assert(lsm_compaction_ops % 2 == 0);
 }
 
+// Limits for the number of value blocks that a single compaction can queue up for IO and for the
+// number of IO operations themselves. The number of index blocks is always one per level.
+// This is a comptime upper bound. The actual number of concurrency is also limited by the
+// runtime-know number of free blocks.
+//
+// For simplicity for now, size IOPS to always be available.
+pub const lsm_compaction_queue_read_max = 8;
+pub const lsm_compaction_queue_write_max = 8;
+pub const lsm_compaction_iops_read_max = lsm_compaction_queue_read_max + 2; // + two index blocks.
+pub const lsm_compaction_iops_write_max = lsm_compaction_queue_write_max + 1; // + one index block.
+
 pub const lsm_snapshots_max = config.cluster.lsm_snapshots_max;
 
 /// The maximum number of blocks that can possibly be referenced by any table index block.

--- a/src/iops.zig
+++ b/src/iops.zig
@@ -35,9 +35,14 @@ pub fn IOPS(comptime T: type, comptime size: u6) type {
             return self.free.count();
         }
 
+        pub fn total(self: *const Self) usize {
+            _ = self;
+            return size;
+        }
+
         /// Returns the count of IOPs in use.
         pub fn executing(self: *const Self) usize {
-            return size - self.available();
+            return self.total() - self.available();
         }
 
         pub const Iterator = struct {

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -2,7 +2,6 @@
 //!
 //! Each Compaction is paced to run in an arbitrary amount of beats, by the forest.
 //!
-//!
 //! Compaction overview:
 //!
 //! 1. Given:
@@ -41,6 +40,7 @@ const log = std.log.scoped(.compaction);
 const constants = @import("../constants.zig");
 
 const stdx = @import("../stdx.zig");
+const maybe = stdx.maybe;
 const trace = @import("../trace.zig");
 const FIFO = @import("../fifo.zig").FIFO;
 const GridType = @import("../vsr/grid.zig").GridType;
@@ -50,6 +50,8 @@ const allocate_block = @import("../vsr/grid.zig").allocate_block;
 const TableInfoType = @import("manifest.zig").TreeTableInfoType;
 const ManifestType = @import("manifest.zig").ManifestType;
 const schema = @import("schema.zig");
+const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
+const IOPS = @import("../iops.zig").IOPS;
 
 /// The upper-bound count of input tables to a single tree's compaction.
 ///
@@ -63,182 +65,202 @@ pub const compaction_tables_input_max = 1 + constants.lsm_growth_factor;
 /// In the "worst" case, no keys are overwritten/merged, and no tombstones are dropped.
 pub const compaction_tables_output_max = compaction_tables_input_max;
 
+/// The maximum number of blocks that a compaction is allowed to carry over between the beats.
+/// This is just a single block --- the index block of the output tables. The input tables will be
+/// re-read in the next beat, and the compaction is paced in such a way as to end the beat only when
+/// an output value block is full.
+pub const compaction_block_count_bar_max: u32 = 1;
+
+// The minimum number of blocks required for a single beat of a single compaction:
+// one index and one value block for two input and one output table.
+pub const compaction_block_count_beat_min: u32 = (1 + 1) * 3;
+
 const half_bar_beat_count = @divExact(constants.lsm_compaction_ops, 2);
 
-/// Information used when scheduling compactions. Kept unspecialized to make the forest
-/// code easier.
-pub const CompactionInfo = struct {
-    /// How many values, across all input tables, need to be processed.
-    /// This is the total – it is fixed for the duration of the compaction.
-    compaction_tables_value_count: usize,
-
-    // Keys are integers in TigerBeetle, with a maximum size of u256. Store these
-    // here, instead of Key, to keep this unspecialized.
-    target_key_min: u256,
-    target_key_max: u256,
-
-    /// Are we doing a move_table? In which case, certain things like grid reservation
-    /// must be skipped by the caller.
-    move_table: bool,
-
-    tree_id: u16,
-    level_b: u8,
-};
-
-/// A bar is exhausted when all input values have been merged.
-/// A beat is exhausted when all of the input values scheduled for this beat (rounded up to the
-/// nearest full data block) have been merged.
+/// Resources shared by all compactions.
 ///
-/// Invariant: If `bar` is exhausted, then `beat` is always exhausted.
-pub const Exhausted = struct { bar: bool, beat: bool };
-const BlipCallback = *const fn (*anyopaque, ?Exhausted) void;
-pub const BlipStage = enum { read, merge, write, drained };
-
-// The following types need to specialize on Grid, but are used both by CompactionType and the
-// forest.
-pub fn CompactionHelperType(comptime Grid: type) type {
+/// ResourcePool is a singleton owned by the Forest, but it doesn't depend on Forest type.
+pub fn ResourcePoolType(comptime Grid: type) type {
     return struct {
-        pub const CompactionBlocks = struct {
-            // Index blocks are global, and shared between blips. The index reads happen
-            // as a mini-stage before reads kick off.
-            source_index_block_a: *CompactionBlock,
-            source_index_block_b: *CompactionBlock,
+        reads: IOPS(BlockRead, constants.lsm_compaction_iops_read_max) = .{},
+        writes: IOPS(BlockWrite, constants.lsm_compaction_iops_write_max) = .{},
+        cpus: IOPS(CPU, 1) = .{},
+        // Use FIFO instead of IOPS here because blocks are allocated at runtime.
+        blocks: FIFO(Block),
+        blocks_backing_storage: []Block,
 
-            /// For each source level, we have a buffer of CompactionBlocks.
-            source_value_blocks: [2]BlockFIFO,
+        const ResourcePool = @This();
 
-            /// We only have one buffer of output CompactionBlocks.
-            target_value_blocks: BlockFIFO,
+        const BlockRead = struct {
+            grid_read: Grid.Read,
+            block: *Block,
+            compaction: *anyopaque,
+
+            fn parent(read: *BlockRead, comptime Compaction: type) *Compaction {
+                return @as(*Compaction, @ptrCast(@alignCast(read.compaction)));
+            }
         };
 
-        pub const CompactionBlock = struct {
-            block: BlockPtr,
+        const BlockWrite = struct {
+            grid_write: Grid.Write,
+            block: *Block,
+            compaction: *anyopaque,
 
-            // CompactionBlocks are stored in buffers where we need a pointer to get back to our
-            // parent.
-            target: ?*anyopaque = null,
-
-            // TODO: This could be a union to save a bit of memory and add a bit of safety.
-            read: Grid.Read = undefined,
-            write: Grid.Write = undefined,
-
-            stage: enum { free, pending, ready, ioing, standalone } = .free,
-            next: ?*CompactionBlock = null,
+            fn parent(write: *BlockWrite, comptime Compaction: type) *Compaction {
+                return @as(*Compaction, @ptrCast(@alignCast(write.compaction)));
+            }
         };
 
-        pub const CompactionBlockFIFO = FIFO(CompactionBlock);
+        /// While we don't currently have a CPU pool, we already treat CPU as a resource, by storing
+        /// it in a ring-buffer of length one.
+        const CPU = struct {
+            next_tick: Grid.NextTick,
+            block: *Block,
+            compaction: *anyopaque,
 
-        pub const BlockFIFO = struct {
-            /// Invariant: a CompactionBlock resides in the FIFO corresponding to its `stage`.
-            free: CompactionBlockFIFO,
-            pending: CompactionBlockFIFO,
-            ready: CompactionBlockFIFO,
-            ioing: CompactionBlockFIFO,
+            fn parent(cpu: *CPU, comptime Compaction: type) *Compaction {
+                return @as(*Compaction, @ptrCast(@alignCast(cpu.compaction)));
+            }
+        };
 
-            /// The (constant) total number of blocks in all four FIFOs.
-            count: usize,
+        const Block = struct {
+            ptr: BlockPtr,
+            stage: enum {
+                // block is in the resource pool.
+                free,
 
-            /// All blocks start in free.
-            pub fn init(block_pool: *CompactionBlockFIFO, count: usize) BlockFIFO {
-                assert(count > 0);
-                assert(count % 2 == 0);
-                assert(block_pool.count >= count);
+                // Block is owned by a table builder.
+                build_index_block,
+                build_value_block,
 
-                var free: CompactionBlockFIFO = .{
-                    .name = "free",
+                // Block is in the read queue
+                read_index_block,
+                read_index_block_done,
+                read_value_block,
+                read_value_block_done,
+
+                // Block is in the read queue and is used by merge.
+                // Next stage is either free or loops back to read_value_block_done.
+                merge,
+
+                // Block is in the write queue. Goes directly to free from here.
+                write_value_block,
+                write_index_block,
+            },
+            // The index block is freed immediately after the read for the last value block is
+            // submitted so, by the time merge consumes a value block, the index block is gone
+            // already. Use this field to mark the spots when the compaciton position should advance
+            // to the next index block.
+            last_block_in_the_table: bool,
+
+            next: ?*Block, // For FIFO.
+        };
+
+        pub fn init(allocator: mem.Allocator, block_count: u32) !ResourcePool {
+            const blocks_backing_storage = try allocator.alloc(Block, block_count);
+            var blocks_allocated: u32 = 0;
+            errdefer {
+                for (blocks_backing_storage[0..blocks_allocated]) |block| {
+                    allocator.free(block.ptr);
+                }
+                allocator.free(blocks_backing_storage);
+            }
+
+            for (blocks_backing_storage) |*block| {
+                block.* = .{
+                    .ptr = try allocate_block(allocator),
+                    .stage = .free,
+                    .last_block_in_the_table = false,
+                    .next = null,
+                };
+                blocks_allocated += 1;
+            }
+            assert(blocks_allocated == block_count);
+
+            var blocks: FIFO(Block) = .{
+                .name = "compaction_blocks",
+                .verify_push = false,
+            };
+            for (blocks_backing_storage) |*block| blocks.push(block);
+
+            return .{
+                .blocks = blocks,
+                .blocks_backing_storage = blocks_backing_storage,
+            };
+        }
+
+        pub fn deinit(pool: *ResourcePool, allocator: Allocator) void {
+            for (pool.blocks_backing_storage) |block| {
+                allocator.free(block.ptr);
+            }
+            allocator.free(pool.blocks_backing_storage);
+        }
+
+        pub fn reset(pool: *ResourcePool) void {
+            pool.* = .{
+                .blocks = .{
+                    .name = "compaction_blocks",
                     .verify_push = false,
+                },
+                .blocks_backing_storage = pool.blocks_backing_storage,
+            };
+            for (pool.blocks_backing_storage) |*block| {
+                block.* = .{
+                    .ptr = block.ptr,
+                    .stage = .free,
+                    .last_block_in_the_table = false,
+                    .next = null,
                 };
-
-                for (0..count) |_| {
-                    const block = block_pool.pop().?;
-                    assert(block.stage == .free);
-                    free.push(block);
-                }
-
-                return .{
-                    .free = free,
-                    .pending = .{ .name = "pending", .verify_push = false },
-                    .ready = .{ .name = "ready", .verify_push = false },
-                    .ioing = .{ .name = "ioing", .verify_push = false },
-                    .count = count,
-                };
+                pool.blocks.push(block);
             }
+        }
 
-            /// Return all the blocks to the pool they came from.
-            pub fn deinit(self: *BlockFIFO, block_pool: *CompactionBlockFIFO) void {
-                assert(self.free.count == self.count);
-                assert(self.pending.count == 0);
-                assert(self.ready.count == 0);
-                assert(self.ioing.count == 0);
+        // NB: idle does not check that no blocks are acquired! Although no IO can happen between
+        // the beats, it is valid to carry over some blocks.
+        pub fn idle(pool: *ResourcePool) bool {
+            return pool.reads.executing() == 0 and
+                pool.writes.executing() == 0 and
+                pool.cpus.executing() == 0;
+        }
 
-                const block_pool_count_start = block_pool.count;
-                defer assert(block_pool.count - block_pool_count_start == self.count);
+        pub fn blocks_acquired(pool: *ResourcePool) u32 {
+            assert(pool.blocks.count <= pool.blocks_backing_storage.len);
+            return @as(u32, @intCast(pool.blocks_backing_storage.len - pool.blocks.count));
+        }
 
-                while (self.free.pop()) |block| {
-                    block_pool.push(block);
-                }
-            }
+        pub fn blocks_free(pool: *ResourcePool) u32 {
+            return @as(u32, @intCast(pool.blocks.count));
+        }
 
-            pub fn ready_peek(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.ready.peek() orelse return null;
-                assert(value.stage == .ready);
-                return value;
-            }
+        fn block_acquire(pool: *@This()) ?*Block {
+            const block = pool.blocks.pop() orelse return null;
+            assert(block.stage == .free);
+            assert(block.next == null);
+            assert(!block.last_block_in_the_table);
+            return block;
+        }
 
-            pub fn free_to_pending(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.free.pop() orelse return null;
-                assert(value.stage == .free);
-                value.stage = .pending;
-                self.pending.push(value);
+        fn block_release(pool: *@This(), block: *Block) void {
+            assert(block.stage == .free);
+            assert(block.next == null);
+            assert(!block.last_block_in_the_table);
+            pool.blocks.push(block);
+        }
 
-                return value;
-            }
-
-            pub fn pending_to_ready(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.pending.pop() orelse return null;
-                assert(value.stage == .pending);
-                value.stage = .ready;
-                self.ready.push(value);
-
-                return value;
-            }
-
-            pub fn pending_to_free(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.pending.pop() orelse return null;
-                assert(value.stage == .pending);
-                value.stage = .free;
-                self.free.push(value);
-
-                return value;
-            }
-
-            pub fn ready_to_ioing(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.ready.pop() orelse return null;
-                assert(value.stage == .ready);
-                value.stage = .ioing;
-                self.ioing.push(value);
-
-                return value;
-            }
-
-            pub fn ready_to_free(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.ready.pop() orelse return null;
-                assert(value.stage == .ready);
-                value.stage = .free;
-                self.free.push(value);
-
-                return value;
-            }
-
-            pub fn ioing_to_free(self: *BlockFIFO) ?*CompactionBlock {
-                const value = self.ioing.pop() orelse return null;
-                assert(value.stage == .ioing);
-                value.stage = .free;
-                self.free.push(value);
-
-                return value;
-            }
-        };
+        pub fn format(
+            self: @This(),
+            comptime _: []const u8,
+            _: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            return writer.print("ResourcePool{{ " ++
+                ".reads = {}/{},  .writes = {}/{}, .cpus = {}/{}, .blocks = {}/{} }}", .{
+                self.reads.available(),  self.reads.total(),
+                self.writes.available(), self.writes.total(),
+                self.cpus.available(),   self.cpus.total(),
+                self.blocks.count,       self.blocks_backing_storage.len,
+            });
+        }
     };
 }
 
@@ -248,11 +270,10 @@ pub fn CompactionType(
     comptime Storage: type,
 ) type {
     return struct {
-        const Helpers = CompactionHelperType(Grid);
         const Compaction = @This();
 
         const Grid = GridType(Storage);
-        pub const Tree_ = Tree;
+        const ResourcePool = ResourcePoolType(Grid);
 
         const Manifest = ManifestType(Table, Storage);
         const TableInfo = TableInfoType(Table);
@@ -270,9 +291,9 @@ pub fn CompactionType(
         };
 
         const Position = struct {
-            index_block: usize = 0,
-            value_block: usize = 0,
-            value_block_index: usize = 0,
+            index_block: u32 = 0,
+            value_block: u32 = 0,
+            value: u32 = 0,
 
             pub fn format(
                 self: @This(),
@@ -281,1647 +302,410 @@ pub fn CompactionType(
                 writer: anytype,
             ) !void {
                 return writer.print("Position{{ .index_block = {}, " ++
-                    ".value_block = {}, .value_block_index = {} }}", .{
+                    ".value_block = {}, .value = {} }}", .{
                     self.index_block,
                     self.value_block,
-                    self.value_block_index,
+                    self.value,
                 });
             }
         };
 
-        const Bar = struct {
-            tree: *Tree,
-
-            /// `op_min` is the first op/beat of this compaction's half-bar.
-            /// `op_min` is used as a snapshot — the compaction's input tables must be visible
-            /// to `op_min`.
-            ///
-            /// After this compaction finishes:
-            /// - `op_min + half_bar_beat_count - 1` will be the input tables' snapshot_max.
-            /// - `op_min + half_bar_beat_count` will be the output tables' snapshot_min.
-            op_min: u64,
-
-            /// Whether this compaction will use the move-table optimization.
-            /// Specifically, this field is set to True if the optimal compaction
-            /// table in level A can simply be moved to level B.
-            move_table: bool,
-
-            table_info_a: TableInfoA,
-            range_b: CompactionRange,
-
-            /// Levels may choose to drop tombstones if keys aren't included in the lower levels.
-            /// This invariant is always true for the last level as it doesn't have any lower ones.
-            drop_tombstones: bool,
-            /// Number of beats we should aim to finish this compaction in. It might be fewer, but
-            /// it'll never be more.
-            beats_max: ?u64,
-            beats_finished: u64 = 0,
-            /// The total number of source values for this compaction.
-            /// This is fixed for the duration of the compaction.
-            compaction_tables_value_count: u64,
-
-            // The total number of source values processed by this compaction across the bar. Must
-            // equal compaction_tables_value_count by bar_apply_to_manifest(). Tracked
-            // independently by both the read and merge stages to ensure no values are dropped.
-            source_values_read_count: u64 = 0,
-            source_values_merge_count: u64 = 0,
-
-            // The total number of target values generated by this compaction across the bar. Must
-            // be equal to one another by bar_apply_to_manifest(), with the same reasoning as the
-            // source_values_* above.
-            target_values_merge_count: u64 = 0,
-            target_values_write_count: u64 = 0,
-
-            /// When level_b == 0, it means level_a is the immutable table, which is special in a
-            /// few ways:
-            /// * It uses an iterator interface, as opposed to raw blocks like the rest.
-            /// * It is responsible for keeping track of its own position, across beats.
-            /// * It encompasses all possible values, so we don't need to worry about reading more.
-            source_a_immutable_values: ?[]const Value = null,
-            source_a_values_consumed_for_fill: usize = 0,
-            source_a_position: Position = .{},
-
-            /// level_b always comes from disk.
-            source_b_position: Position = .{},
-
-            /// At least 2 output index blocks needs to span beat boundaries, otherwise it wouldn't
-            /// be possible to pace at a more granular level than target tables. (That is, each beat
-            /// would need to write at least a full table.)
-            target_index_blocks: ?Helpers.BlockFIFO,
-
-            /// Manifest log appends are queued up until `finish()` is explicitly called to ensure
-            /// they are applied deterministically relative to other concurrent compactions.
-            // Worst-case manifest updates:
-            // See docs/about/internals/lsm.md "Compaction Table Overlap" for more detail.
-            manifest_entries: stdx.BoundedArray(struct {
-                operation: enum {
-                    insert_to_level_b,
-                    move_to_level_b,
-                },
-                table: TableInfo,
-            }, compaction_tables_output_max) = .{},
-
-            table_builder: Table.Builder = .{},
-        };
-
-        const Beat = struct {
-            const Read = struct {
-                callback: BlipCallback,
-                ptr: *anyopaque,
-
-                pending_reads_index: usize = 0,
-                pending_reads_data: usize = 0,
-
-                next_tick: Grid.NextTick = undefined,
-                timer: std.time.Timer,
-                timer_read: usize = 0,
-            };
-            const Merge = struct {
-                callback: BlipCallback,
-                ptr: *anyopaque,
-
-                next_tick: Grid.NextTick = undefined,
-                timer: std.time.Timer,
-            };
-            const Write = struct {
-                callback: BlipCallback,
-                ptr: *anyopaque,
-
-                pending_writes: usize = 0,
-
-                next_tick: Grid.NextTick = undefined,
-                timer: std.time.Timer,
-                timer_write: usize = 0,
-            };
-
-            trace: *trace.Tracer,
-            grid_reservation: Grid.Reservation,
-            value_count_per_beat: u64,
-
-            // TODO: This is now always 0 / 1 so get rid of it and just use index_read_done?
-            index_blocks_read_b: usize = 0,
-            index_read_done: bool = false,
-            blocks: ?Helpers.CompactionBlocks = null,
-            source_a_len_after_set: u64 = 0,
-            source_b_len_after_set: u64 = 0,
-
-            source_values_processed: u64 = 0,
-            source_a_values: ?[]const Value = null,
-            source_b_values: ?[]const Value = null,
-
-            // Unlike other places where we can use a single state enum, a single Compaction
-            // instance is _expected_ to be reading, writing and merging all at once. These
-            // are not disjoint states!
-            //
-            // {read,merge,write} are considered inactive if their context is null.
-            read: ?Read = null,
-            merge: ?Merge = null,
-            write: ?Write = null,
-
-            fn activate_and_assert(
-                self: *Beat,
-                stage: BlipStage,
-                callback: BlipCallback,
-                ptr: *anyopaque,
-            ) void {
-                switch (stage) {
-                    .read => {
-                        assert(self.read == null);
-
-                        self.read = .{
-                            .callback = callback,
-                            .ptr = ptr,
-                            .timer = std.time.Timer.start() catch unreachable,
-                        };
-                        self.read.?.timer.reset();
-                    },
-                    .merge => {
-                        assert(self.merge == null);
-
-                        self.merge = .{
-                            .callback = callback,
-                            .ptr = ptr,
-                            .timer = std.time.Timer.start() catch unreachable,
-                        };
-                        self.merge.?.timer.reset();
-                    },
-                    .write => {
-                        assert(self.write == null);
-
-                        self.write = .{
-                            .callback = callback,
-                            .ptr = ptr,
-                            .timer = std.time.Timer.start() catch unreachable,
-                        };
-                        self.write.?.timer.reset();
-                    },
-                    .drained => unreachable,
-                }
-            }
-
-            fn deactivate_assert_and_callback(
-                self: *Beat,
-                stage: BlipStage,
-                exhausted: ?Exhausted,
-            ) void {
-                switch (stage) {
-                    .read => {
-                        assert(self.read != null);
-                        assert(self.read.?.pending_reads_index == 0);
-                        assert(self.read.?.pending_reads_data == 0);
-
-                        const callback = self.read.?.callback;
-                        const ptr = self.read.?.ptr;
-
-                        self.read = null;
-
-                        callback(ptr, exhausted);
-                    },
-                    .merge => {
-                        assert(self.merge != null);
-
-                        const callback = self.merge.?.callback;
-                        const ptr = self.merge.?.ptr;
-
-                        self.merge = null;
-
-                        callback(ptr, exhausted);
-                    },
-                    .write => {
-                        assert(self.write != null);
-                        assert(self.write.?.pending_writes == 0);
-
-                        const callback = self.write.?.callback;
-                        const ptr = self.write.?.ptr;
-
-                        self.write = null;
-
-                        callback(ptr, exhausted);
-                    },
-                    .drained => unreachable,
-                }
-            }
-
-            fn assert_all_inactive(self: *Beat) void {
-                assert(self.read == null);
-                assert(self.merge == null);
-                assert(self.write == null);
-            }
-        };
-
-        // Passed by `init`.
-        tree_config: Tree.Config,
-        level_b: u8,
+        // Globally scoped fields:
+        // ----------------------
         grid: *Grid,
+        tree: *Tree,
+        level_b: u8,
 
-        // Populated by {bar,beat}_setup.
-        bar: ?Bar,
-        beat: ?Beat,
+        stage: enum {
+            inactive,
+            beat,
+            beat_quota_done,
+            beat_table_done,
+            paused,
+        } = .inactive,
 
-        pub fn init(tree_config: Tree.Config, grid: *Grid, level_b: u8) Compaction {
+        // Bar-scoped fields:
+        // -----------------
+
+        /// `op_min` is the first op/beat of this compaction's half-bar.
+        /// `op_min` is used as a snapshot — the compaction's input tables must be visible
+        /// to `op_min`.
+        ///
+        /// After this compaction finishes:
+        /// - `op_min + half_bar_beat_count - 1` will be the input tables' snapshot_max.
+        /// - `op_min + half_bar_beat_count` will be the output tables' snapshot_min.
+        op_min: u64 = 0,
+
+        table_info_a: ?TableInfoA = null,
+        range_b: ?CompactionRange = null,
+
+        /// Whether this compaction will use the move-table optimization.
+        /// Specifically, this field is set to True if the optimal compaction
+        /// table in level A can simply be moved to level B.
+        move_table: bool = false,
+        /// Levels may choose to drop tombstones if keys aren't included in the lower levels.
+        /// This invariant is always true for the last level as it doesn't have any lower ones.
+        drop_tombstones: bool = false,
+
+        /// Counters track physical IO and are not fully deterministic. In particular, `in` and
+        /// `dropped` values can vary between the replicas.
+        ///
+        /// Counters obey accounting equation of compaction:
+        ///     out = in - (dropped + wasted)
+        counters: struct {
+            in: u64 = 0,
+            dropped: u64 = 0, // Tombstones.
+            // Counts values needlessly read from disk. Wastage can happen both at the end and at
+            // the start of a beat (when part of the value block was already merged previously).
+            wasted: u64 = 0,
+            out: u64 = 0,
+
+            fn consistent(counters: @This()) bool {
+                return counters.out == counters.in - counters.dropped - counters.wasted;
+            }
+        } = .{},
+
+        /// Quotas track logical progress of compaction, determine pacing and must be deterministic.
+        /// Quotas count consumed input values. That is, every time an output block is written,
+        /// the done quota is incremented by the number of input values which contributed to the
+        /// output block.
+        ///
+        /// At the start of the bar, the total number of input values is known. The beat quota is
+        /// then set based on the number of values left and beats left.
+        quotas: struct {
+            done: u64 = 0,
+            beat: u64 = 0,
+            bar: u64 = 0,
+
+            fn beat_done(quotas: @This()) bool {
+                assert(quotas.done <= quotas.bar);
+                return quotas.done >= quotas.beat;
+            }
+
+            fn bar_done(quotas: @This()) bool {
+                assert(quotas.done <= quotas.bar);
+                return quotas.done == quotas.bar;
+            }
+        } = .{},
+
+        // Position points at the next value from the layer that should be feed into the merge
+        // algorithm.
+        level_a_position: Position = .{},
+        level_b_position: Position = .{},
+
+        /// Manifest log appends are queued up until bar_complete is explicitly called to ensure
+        /// they are applied deterministically relative to other concurrent compactions.
+        // Worst-case manifest updates:
+        // See docs/about/internals/lsm.md "Compaction Table Overlap" for more detail.
+        manifest_entries: stdx.BoundedArray(struct {
+            operation: enum {
+                insert_to_level_b,
+                move_to_level_b,
+            },
+            table: TableInfo,
+        }, compaction_tables_output_max) = .{},
+
+        table_builder: Table.Builder = .{},
+        // A beat always ends with writing a value block, but the index block can be carried
+        // over to the next beat.
+        table_builder_index_block: ?*ResourcePool.Block = null,
+
+        // The progress through immutable table is persisted throughout the bar.
+        level_a_immutable_stage: enum { ready, merge, exhausted } = .ready,
+
+        // Beat-scoped fields:
+        // ------------------
+        pool: ?*ResourcePool = null,
+        callback: ?*const fn (*ResourcePool) void = null,
+
+        grid_reservation: ?Grid.Reservation = null,
+        table_builder_value_block: ?*ResourcePool.Block = null,
+
+        // IO queues:
+        //
+        // Compaction structure is such that the data can be read (and written) concurrently, but
+        // the merge must happen sequentially. It is reminiscent of state machine's prefetch/execute
+        // split.
+        //
+        // When a block is read from disk, it is added to the tail of the corresponding queue. When
+        // the head block from both level a and level b queues is in the .read_value_block_done
+        // state, the two blocks are popped off the queues and passed down to the merge. At this
+        // point, any number of the blocks still in the queues can continue their read operations.
+        //
+        // For index blocks, queues of length one are used. Because an index block is freed as soon
+        // as the read for the last value block is scheduled, the pipeline should not dry out even
+        // when switching between the tables.
+        //
+        // Note that level_L_position field tracks the logical, deterministic progression of
+        // compaction. To track which block should be read next, separate `_next` fields are used.
+        //
+        // For output blocks:
+        // - the order of completions doesn't matter,
+        // - the blocks are not used after the completion of the IO. That is, only the number of
+        //   outstanding operations needs to be tracked. Use a RingBuffer with void elements rather
+        //   than an u32 for API uniformity and comptime upper bound. We have
+        //   <https://github.com/ziglang/zig/issues/3806> at home.
+        //
+        // In addition to static max size, the queues are additionally limited at runtime by the
+        // number of available free blocks. The queues are not limited by IOPS --- it is assumed
+        // that there are enough IOPS to fill up all the queues.
+        level_a_index_block: RingBuffer(*ResourcePool.Block, .{
+            .array = 1,
+        }) = .{ .buffer = undefined },
+        level_a_index_block_next: u32 = 0,
+
+        level_a_value_block: RingBuffer(*ResourcePool.Block, .{
+            .array = @divExact(constants.lsm_compaction_queue_read_max, 2),
+        }) = .{ .buffer = undefined },
+        level_a_value_block_next: u32 = 0,
+
+        level_b_index_block: RingBuffer(*ResourcePool.Block, .{
+            .array = 1,
+        }) = .{ .buffer = undefined },
+        level_b_index_block_next: u32 = 0,
+
+        level_b_value_block: RingBuffer(*ResourcePool.Block, .{
+            .array = @divExact(constants.lsm_compaction_queue_read_max, 2),
+        }) = .{ .buffer = undefined },
+        level_b_value_block_next: u32 = 0,
+
+        output_blocks: RingBuffer(void, .{
+            .array = constants.lsm_compaction_queue_write_max,
+        }) = .{ .buffer = undefined },
+
+        pub fn init(tree: *Tree, grid: *Grid, level_b: u8) Compaction {
             assert(level_b < constants.lsm_levels);
 
             return Compaction{
-                .tree_config = tree_config,
                 .grid = grid,
+                .tree = tree,
                 .level_b = level_b,
-
-                .bar = null,
-                .beat = null,
             };
         }
 
-        pub fn deinit(compaction: *Compaction) void {
-            _ = compaction;
-            // TODO: Assert things here - compaction doesn't own anything that needs to be
-            // deallocated.
-        }
-
         pub fn reset(compaction: *Compaction) void {
-            if (compaction.beat) |beat| {
-                beat.trace.reset(.compact_blip_read);
-                beat.trace.reset(.compact_blip_merge);
-                beat.trace.reset(.compact_blip_write);
-            }
-
+            compaction.grid.trace.reset(.compact_beat);
+            compaction.grid.trace.reset(.compact_beat_merge);
             compaction.* = .{
-                .tree_config = compaction.tree_config,
                 .grid = compaction.grid,
+                .tree = compaction.tree,
                 .level_b = compaction.level_b,
-
-                .bar = null,
-                .beat = null,
             };
         }
 
         pub fn assert_between_bars(compaction: *const Compaction) void {
-            assert(compaction.bar == null);
-            assert(compaction.beat == null);
+            assert(compaction.stage == .inactive);
+            assert(compaction.idle());
+            assert(compaction.table_builder_index_block == null);
+            assert(compaction.manifest_entries.empty());
         }
 
-        /// Perform the bar-wise setup, and returns the compaction work that needs to be done for
-        /// scheduling decisions. Returns null if there's no compaction work, or if move_table
-        /// is happening (since it only touches the manifest).
-        pub fn bar_setup(compaction: *Compaction, tree: *Tree, op: u64) ?CompactionInfo {
-            assert(compaction.bar == null);
-            assert(compaction.beat == null);
+        pub fn idle(compaction: *const Compaction) bool {
+            return compaction.pool == null and compaction.callback == null and
+                // level_a
+                compaction.level_a_index_block.count == 0 and
+                compaction.level_a_index_block_next == 0 and
+                compaction.level_a_value_block.count == 0 and
+                compaction.level_a_value_block_next == 0 and
+                // level_b
+                compaction.level_b_index_block.count == 0 and
+                compaction.level_b_index_block_next == 0 and
+                compaction.level_b_value_block.count == 0 and
+                compaction.level_b_value_block_next == 0 and
+                // output
+                compaction.table_builder_value_block == null and
+                compaction.output_blocks.count == 0;
+        }
+
+        /// Plan the work for the bar:
+        /// - check if compaction is needed at all (if the level_a is full),
+        /// - find a table on level_a and the corresponding range on level_b that should be
+        ///   compacted,
+        /// - compute the bar quota (just the total number of values in all input tables),
+        /// - execute move table optimization if range_b turns out to be empty.
+        pub fn bar_commence(compaction: *Compaction, op: u64) void {
+            assert(compaction.idle());
+            assert(compaction.stage == .inactive);
+            compaction.stage = .paused;
+            compaction.op_min = compaction_op_min(op);
 
             // level_b 0 is special; unlike all the others which have level_a on disk, level 0's
             // level_a comes from the immutable table. This means that blip_read will be a partial,
             // no-op, and that the minimum input blocks are lowered by one.
             if (compaction.level_b == 0) {
                 // Do not start compaction if the immutable table does not require compaction.
-                if (tree.table_immutable.mutability.immutable.flushed) {
-                    return null;
+                if (compaction.tree.table_immutable.mutability.immutable.flushed) {
+                    assert(compaction.quotas.bar == 0);
+                    assert(compaction.quotas.bar_done());
+                    log.debug("{s}:{}: bar_commence: immutable table flushed", .{
+                        compaction.tree.config.name,
+                        compaction.level_b,
+                    });
+                    return;
                 }
 
-                const table_immutable_values_count = tree.table_immutable.count();
-                assert(table_immutable_values_count > 0);
-                assert(table_immutable_values_count <= Table.value_count_max);
+                assert(compaction.tree.table_immutable.count() > 0);
+                assert(compaction.tree.table_immutable.count() <= Table.value_count_max);
+                compaction.table_info_a = .{
+                    .immutable = compaction.tree.table_immutable.values_used(),
+                };
 
-                const range_b = tree.manifest.immutable_table_compaction_range(
-                    tree.table_immutable.key_min(),
-                    tree.table_immutable.key_max(),
-                    .{ .value_count = tree.table_immutable.count() },
+                compaction.range_b = compaction.tree.manifest.immutable_table_compaction_range(
+                    compaction.tree.table_immutable.key_min(),
+                    compaction.tree.table_immutable.key_max(),
+                    .{ .value_count = compaction.tree.table_immutable.count() },
                 );
 
                 // +1 to count the immutable table (level A).
-                assert(range_b.tables.count() + 1 <= compaction_tables_input_max);
-                assert(range_b.key_min <= tree.table_immutable.key_min());
-                assert(tree.table_immutable.key_max() <= range_b.key_max);
-
-                log.debug("{s}: compacting immutable table to level 0 " ++
-                    "(snapshot_min={d} compaction.op_min={d} table_count={d} values={d})", .{
-                    tree.config.name,
-                    tree.table_immutable.mutability.immutable.snapshot_min,
-                    op,
-                    range_b.tables.count() + 1,
-                    table_immutable_values_count,
-                });
-
-                var compaction_tables_value_count: usize = table_immutable_values_count;
-                for (range_b.tables.const_slice()) |*table| {
-                    compaction_tables_value_count += table.table_info.value_count;
-                }
-
-                compaction.bar = .{
-                    .tree = tree,
-                    .op_min = compaction_op_min(op),
-
-                    .move_table = false,
-                    .table_info_a = .{ .immutable = tree.table_immutable.values_used() },
-                    .range_b = range_b,
-                    .drop_tombstones = tree.manifest.compaction_must_drop_tombstones(
-                        compaction.level_b,
-                        range_b,
-                    ),
-
-                    .compaction_tables_value_count = compaction_tables_value_count,
-
-                    .target_index_blocks = null,
-                    .beats_max = null,
-                };
+                assert(compaction.range_b.?.tables.count() + 1 <= compaction_tables_input_max);
+                assert(compaction.range_b.?.key_min <= compaction.tree.table_immutable.key_min());
+                assert(compaction.tree.table_immutable.key_max() <= compaction.range_b.?.key_max);
             } else {
                 const level_a = compaction.level_b - 1;
 
                 // Do not start compaction if level A does not require compaction.
-                const table_range = tree.manifest.compaction_table(level_a) orelse return null;
-
-                const table_a = table_range.table_a.table_info;
-                const range_b = table_range.range_b;
-
-                assert(range_b.tables.count() + 1 <= compaction_tables_input_max);
-                assert(table_a.key_min <= table_a.key_max);
-                assert(range_b.key_min <= table_a.key_min);
-                assert(table_a.key_max <= range_b.key_max);
-
-                log.debug("{s}: compacting {d} tables from level {d} to level {d}", .{
-                    tree.config.name,
-                    range_b.tables.count() + 1,
-                    level_a,
-                    compaction.level_b,
-                });
-
-                var compaction_tables_value_count: usize = table_a.value_count;
-                for (range_b.tables.const_slice()) |*table| {
-                    compaction_tables_value_count += table.table_info.value_count;
-                }
-
-                compaction.bar = .{
-                    .tree = tree,
-                    .op_min = compaction_op_min(op),
-
-                    .move_table = range_b.tables.empty(),
-                    .table_info_a = .{ .disk = table_range.table_a },
-                    .range_b = range_b,
-                    .drop_tombstones = tree.manifest.compaction_must_drop_tombstones(
+                const table_range = compaction.tree.manifest.compaction_table(level_a) orelse {
+                    assert(compaction.quotas.bar == 0);
+                    assert(compaction.quotas.bar_done());
+                    log.debug("{s}:{}: bar_commence: nothing to compact", .{
+                        compaction.tree.config.name,
                         compaction.level_b,
-                        range_b,
-                    ),
-
-                    .compaction_tables_value_count = compaction_tables_value_count,
-
-                    .target_index_blocks = null,
-                    .beats_max = null,
+                    });
+                    return;
                 };
 
-                // Append the entries to the manifest update queue here and now if we're doing
-                // move table. They'll be applied later by bar_apply_to_manifest.
-                if (compaction.bar.?.move_table) {
-                    log.debug(
-                        "{s}: Moving table: level_b={}",
-                        .{ compaction.tree_config.name, compaction.level_b },
-                    );
+                compaction.table_info_a = .{ .disk = table_range.table_a };
+                compaction.range_b = table_range.range_b;
 
-                    const snapshot_max = snapshot_max_for_table_input(compaction.bar.?.op_min);
-                    assert(table_a.snapshot_max >= snapshot_max);
-
-                    compaction.bar.?.manifest_entries.append_assume_capacity(.{
-                        .operation = .move_to_level_b,
-                        .table = table_a.*,
-                    });
-
-                    // If we move the table, we've processed all the values in it.
-                    compaction.bar.?.source_values_read_count =
-                        compaction.bar.?.compaction_tables_value_count;
-                    compaction.bar.?.source_values_merge_count =
-                        compaction.bar.?.compaction_tables_value_count;
-                    compaction.bar.?.target_values_merge_count =
-                        compaction.bar.?.compaction_tables_value_count;
-                    compaction.bar.?.target_values_write_count =
-                        compaction.bar.?.compaction_tables_value_count;
-                }
+                assert(compaction.range_b.?.tables.count() + 1 <= compaction_tables_input_max);
+                assert(compaction.table_info_a.?.disk.table_info.key_min <=
+                    compaction.table_info_a.?.disk.table_info.key_max);
+                assert(compaction.range_b.?.key_min <=
+                    compaction.table_info_a.?.disk.table_info.key_min);
+                assert(compaction.table_info_a.?.disk.table_info.key_max <=
+                    compaction.range_b.?.key_max);
             }
+
+            var quota_bar = switch (compaction.table_info_a.?) {
+                .immutable => compaction.tree.table_immutable.count(),
+                .disk => |table| table.table_info.value_count,
+            };
+            for (compaction.range_b.?.tables.const_slice()) |*table| {
+                quota_bar += table.table_info.value_count;
+            }
+            compaction.quotas = .{
+                .done = 0,
+                .beat = 0,
+                .bar = quota_bar,
+            };
+            compaction.move_table = compaction.table_info_a.? == .disk and
+                compaction.range_b.?.tables.empty();
+            compaction.drop_tombstones = compaction.tree.manifest
+                .compaction_must_drop_tombstones(compaction.level_b, &compaction.range_b.?);
 
             // The last level must always drop tombstones.
-            assert(compaction.bar.?.drop_tombstones or
-                compaction.level_b < constants.lsm_levels - 1);
+            if (compaction.level_b == constants.lsm_levels - 1) assert(compaction.drop_tombstones);
 
-            return .{
-                .compaction_tables_value_count = compaction.bar.?.compaction_tables_value_count,
-                .target_key_min = compaction.bar.?.range_b.key_min,
-                .target_key_max = compaction.bar.?.range_b.key_max,
-                .move_table = compaction.bar.?.move_table,
-                .tree_id = tree.config.id,
-                .level_b = compaction.level_b,
-            };
-        }
-
-        /// Setup the per beat budget, as well as the output index blocks. Done in a separate step
-        /// to bar_setup() since the forest requires information from that step to calculate how it
-        /// should split the work, and if there's move table, target_index_blocks must be len 0.
-        /// beats_max is the number of beats that this compaction will have available to do its
-        /// work.
-        /// A compaction may be done before beats_max, if eg tables are mostly empty.
-        /// Output index blocks are special, and are allocated at a bar level unlike all the
-        /// other blocks which are done at a beat level. This is because while we can ensure we
-        /// fill a value block, index blocks are too infrequent (one per table) to divide
-        /// compaction by.
-        pub fn bar_setup_budget(
-            compaction: *Compaction,
-            beats_max: u64,
-            target_index_blocks: Helpers.BlockFIFO,
-        ) void {
-            // Limited to half bars for now.
-            assert(beats_max <= @divExact(constants.lsm_compaction_ops, 2));
-            assert(beats_max > 0);
-
-            assert(compaction.bar != null);
-            assert(compaction.beat == null);
-
-            const bar = &compaction.bar.?;
-            assert(!bar.move_table);
-
-            assert(bar.beats_max == null);
-
-            bar.beats_max = beats_max;
-            bar.target_index_blocks = target_index_blocks;
-            assert(target_index_blocks.count > 0);
-
-            log.debug("bar_setup_budget({s}): bar.compaction_tables_value_count={}", .{
-                compaction.tree_config.name,
-                bar.compaction_tables_value_count,
-            });
-        }
-
-        /// Reserve blocks from the grid for this beat's worth of work, in the semi-worst case:
-        /// - no tombstones are dropped,
-        /// - no values are overwritten,
-        /// - but, we know exact input value counts, so table fullness *is* accounted for.
-        ///
-        /// We must reserve before doing any async work so that the block acquisition order
-        /// is deterministic (relative to other concurrent compactions).
-        pub fn beat_grid_reserve(
-            compaction: *Compaction,
-        ) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat == null);
-
-            const bar = &compaction.bar.?;
-
-            // If we're move_table, only the manifest is being updated, *not* the grid.
-            assert(!bar.move_table);
-
-            assert(bar.beats_max != null);
-
-            // Calculate how many values we have to compact each beat, to self-correct our pacing.
-            // Pacing will have imperfections due to rounding up to fill target value blocks and
-            // immutable table filtering duplicate values.
-            const beats_remaining = bar.beats_max.? - bar.beats_finished;
-            const value_count_per_beat = stdx.div_ceil(
-                bar.compaction_tables_value_count - bar.source_values_merge_count,
-                beats_remaining,
-            );
-            assert(bar.compaction_tables_value_count > bar.source_values_merge_count);
-            assert(beats_remaining > 0);
-            assert(bar.source_values_merge_count + value_count_per_beat * beats_remaining >=
-                bar.compaction_tables_value_count);
-
-            // The +1 is for imperfections in pacing our immutable table, which might cause us
-            // to overshoot by a single block (limited to 1 due to how the immutable table values
-            // are consumed.)
-            const value_blocks_per_beat = stdx.div_ceil(
-                value_count_per_beat,
-                Table.layout.block_value_count_max,
-            ) + 1;
-
-            // The +1 is in case we had a partially finished index block from a previous beat.
-            const index_blocks_per_beat = stdx.div_ceil(
-                value_blocks_per_beat,
-                Table.data_block_count_max,
-            ) + 1;
-            const total_blocks_per_beat = index_blocks_per_beat + value_blocks_per_beat;
-
-            // TODO The replica must stop accepting requests if it runs out of blocks/capacity,
-            // rather than panicking here.
-            // (actually, we want to still panic but with something nicer like vsr.fail)
-            const grid_reservation = compaction.grid.reserve(total_blocks_per_beat).?;
-            log.debug("beat_grid_reserve({s}): total_blocks_per_beat={} " ++
-                "index_blocks_per_beat={} value_blocks_per_beat={} " ++
-                "beat.value_count_per_beat={} ", .{
-                compaction.tree_config.name,
-                total_blocks_per_beat,
-                index_blocks_per_beat,
-                value_blocks_per_beat,
-                value_count_per_beat,
-            });
-
-            compaction.beat = .{
-                .trace = compaction.grid.trace,
-                .grid_reservation = grid_reservation,
-                .value_count_per_beat = value_count_per_beat,
-            };
-        }
-
-        pub fn beat_blocks_assign(compaction: *Compaction, blocks: Helpers.CompactionBlocks) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.beat.?.blocks == null);
-            assert(!compaction.bar.?.move_table);
-            assert(compaction.bar.?.table_builder.data_block_empty());
-
-            assert(blocks.source_value_blocks[0].count > 0);
-            assert(blocks.source_value_blocks[1].count > 0);
-            assert(blocks.target_value_blocks.count > 0);
-
-            assert(blocks.source_index_block_a.stage == .free);
-            assert(blocks.source_index_block_b.stage == .free);
-
-            blocks.source_index_block_a.stage = .standalone;
-            blocks.source_index_block_b.stage = .standalone;
-
-            compaction.beat.?.blocks = blocks;
-        }
-
-        // Our blip pipeline is 3 stages long, and split into read, merge and write stages. The
-        // merge stage has a data dependency on both the read (source) and write (target) stages.
-        //
-        // Within a single compaction, the pipeline looks something like:
-        // --------------------------------------------------
-        // | R     | M       | W      | R      |           |
-        // --------------------------------------------------
-        // |       | R       | M      | W      |           |
-        // --------------------------------------------------
-        // |       |         | W      | C → E  | W         |
-        // --------------------------------------------------
-        //
-        // Where → E means that the merge step indicated our work was complete for either this beat
-        // or bar.
-        //
-        // At the moment, the forest won't pipeline different compactions from other tree-levels
-        // together. It _can_ do this, but it requires a bit more thought in how memory is managed.
-        //
-        // IO work is always submitted to the kernel _before_ entering blip_merge().
-        //
-        // TODO: even without a threadpool, we can likely drive better performance by doubling up
-        // the stages. The reason for this is that we expect blip_merge() to be quite a bit quicker
-        // than blip_write().
-
-        /// Perform read IO to fill our source_index_block_{a,b} and source_value_blocks with as
-        /// many blocks as we can, given their sizes, and where we are in the amount of work we
-        /// need to do this beat.
-        pub fn blip_read(compaction: *Compaction, callback: BlipCallback, ptr: *anyopaque) void {
-            log.debug("blip_read({s}): scheduling read IO", .{compaction.tree_config.name});
-
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.bar.?.move_table == false);
-
-            const beat = &compaction.beat.?;
-
-            beat.activate_and_assert(.read, callback, ptr);
-
-            beat.trace.start(.compact_blip_read, .{
-                .tree = compaction.tree_config.name,
-                .level_b = compaction.level_b,
-            });
-
-            if (!beat.index_read_done) {
-                compaction.blip_read_index();
-            } else {
-                compaction.blip_read_data();
-            }
-        }
-
-        fn blip_read_index(compaction: *Compaction) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-            const blocks = &beat.blocks.?;
-
-            assert(!beat.index_read_done);
-            assert(beat.index_blocks_read_b == 0);
-
-            assert(beat.read != null);
-            const read = &beat.read.?;
-
-            // TODO: We only support 2 index blocks (1 for table a, 1 for table b) and don't
-            // support spanning value reads across them for now.
-            // TODO: index_block_a will always point to source_index_block_a (even though if our
-            // source is immutable this isn't needed! Future optimization)...
-            // index_block_b will be the index block of the table we're currently merging with.
-            switch (bar.table_info_a) {
-                .disk => |table_ref| {
-                    blocks.source_index_block_a.target = compaction;
-                    compaction.grid.read_block(
-                        .{ .from_local_or_global_storage = blip_read_index_callback },
-                        &blocks.source_index_block_a.read,
-                        table_ref.table_info.address,
-                        table_ref.table_info.checksum,
-                        .{ .cache_read = true, .cache_write = true },
-                    );
-                    read.pending_reads_index += 1;
-                },
-                .immutable => {
-                    // Immutable values come from the in memory immutable table - no need to read.
-                },
+            assert(std.meta.eql(compaction.counters, .{}));
+            inline for (.{ compaction.level_a_position, compaction.level_b_position }) |position| {
+                assert(std.meta.eql(position, .{}));
             }
 
-            if (bar.range_b.tables.count() == 0) assert(compaction.level_b == 0);
-            assert(bar.source_b_position.index_block <= bar.range_b.tables.count());
-
-            if (bar.range_b.tables.count() > 0 and
-                bar.source_b_position.index_block < bar.range_b.tables.count())
-            {
-                const table_ref = bar.range_b.tables.get(bar.source_b_position.index_block);
-                blocks.source_index_block_b.target = compaction;
-                compaction.grid.read_block(
-                    .{ .from_local_or_global_storage = blip_read_index_callback },
-                    &blocks.source_index_block_b.read,
-                    table_ref.table_info.address,
-                    table_ref.table_info.checksum,
-                    .{ .cache_read = true, .cache_write = true },
-                );
-                read.pending_reads_index += 1;
-                beat.index_blocks_read_b += 1;
-            }
-
-            log.debug("blip_read({s}): scheduled {} index reads", .{
-                compaction.tree_config.name,
-                read.pending_reads_index,
-            });
-
-            // Either we have pending index reads, in which case blip_read_data gets called by
-            // blip_read_index_callback once all reads are done, or we don't, in which case call it
-            // here.
-            // TODO: Should we switch this at the read_block() level?
-            if (read.pending_reads_index == 0) {
-                beat.index_read_done = true;
-
-                compaction.blip_read_data();
-            }
-        }
-
-        fn blip_read_index_callback(grid_read: *Grid.Read, index_block: BlockPtrConst) void {
-            const parent: *Helpers.CompactionBlock = @fieldParentPtr("read", grid_read);
-            const compaction: *Compaction = @alignCast(@ptrCast(parent.target));
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.tree_config.id == Table.index.block_metadata(index_block).tree_id);
-
-            const beat = &compaction.beat.?;
-
-            assert(beat.read != null);
-            const read = &beat.read.?;
-
-            read.pending_reads_index -= 1;
-            read.timer_read += 1;
-
-            stdx.copy_disjoint(.exact, u8, parent.block, index_block);
-
-            if (read.pending_reads_index != 0) return;
-
-            beat.index_read_done = true;
-
-            compaction.blip_read_data();
-        }
-
-        fn blip_read_data(compaction: *Compaction) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-
-            assert(beat.index_read_done);
-            assert(beat.read != null);
-            const read = &beat.read.?;
-
-            assert(read.pending_reads_index == 0);
-            assert(read.pending_reads_data == 0);
-
-            // TODO: The code for reading table_a and table_b are almost identical,
-            // only differing in _a vs _b and [0] vs [1]...
-
-            // Read data for table a - which we'll only have if compaction.level_b > 0.
-            assert(bar.source_a_position.index_block <= 1);
-            if (bar.table_info_a == .disk and bar.source_a_position.index_block == 0) {
-                assert(beat.blocks.?.source_value_blocks[0].pending.empty());
-
-                var i: usize = bar.source_a_position.value_block +
-                    beat.blocks.?.source_value_blocks[0].ready.count;
-
-                const index_block = beat.blocks.?.source_index_block_a.block;
-                const index_schema = schema.TableIndex.from(index_block);
-
-                const value_blocks_used = index_schema.data_blocks_used(index_block);
-                const value_block_addresses = index_schema.data_addresses_used(index_block);
-                const value_block_checksums = index_schema.data_checksums_used(index_block);
-
-                var free_blocks_used: usize = 0;
-                // Read at most half of the blocks, to smooth out reading over multiple steps.
-                const half_blocks_count = stdx.div_ceil(
-                    beat.blocks.?.source_value_blocks[0].count,
-                    2,
-                );
-                // Once our read buffer is full, end the loop.
-                while (i < value_blocks_used and free_blocks_used < half_blocks_count) {
-                    const source_value_block =
-                        beat.blocks.?.source_value_blocks[0].free_to_pending() orelse break;
-
-                    source_value_block.target = compaction;
-                    compaction.grid.read_block(
-                        .{ .from_local_or_global_storage = blip_read_data_callback },
-                        &source_value_block.read,
-                        value_block_addresses[i],
-                        value_block_checksums[i].value,
-                        .{ .cache_read = true, .cache_write = true },
-                    );
-
-                    read.pending_reads_data += 1;
-                    free_blocks_used += 1;
-                    i += 1;
-                }
-            }
-
-            // Read data for our tables in range b, which will always come from disk.
-            const table_b_count = bar.range_b.tables.count();
-            assert(table_b_count == 0 or
-                bar.source_b_position.index_block == table_b_count or
-                beat.index_blocks_read_b == 1);
-            assert(bar.source_b_position.index_block <= table_b_count);
-
-            if (table_b_count > 0 and bar.source_b_position.index_block < table_b_count) {
-                assert(beat.blocks.?.source_value_blocks[1].pending.empty());
-
-                var i: usize = bar.source_b_position.value_block +
-                    beat.blocks.?.source_value_blocks[1].ready.count;
-
-                // TODO: Getting this right, while spanning multiple tables, turned out to be
-                // tricky. Now, we're required to blip again when a table is finished.
-                const index_block = beat.blocks.?.source_index_block_b.block;
-                const index_schema = schema.TableIndex.from(index_block);
-
-                const value_blocks_used = index_schema.data_blocks_used(index_block);
-                const value_block_addresses = index_schema.data_addresses_used(index_block);
-                const value_block_checksums = index_schema.data_checksums_used(index_block);
-
-                var free_blocks_used: usize = 0;
-                const half_blocks_count = stdx.div_ceil(
-                    beat.blocks.?.source_value_blocks[1].count,
-                    2,
-                );
-                while (i < value_blocks_used and free_blocks_used < half_blocks_count) {
-                    const maybe_source_value_block =
-                        beat.blocks.?.source_value_blocks[1].free_to_pending();
-                    free_blocks_used += 1;
-
-                    // Once our read buffer is full, break out of the outer loop.
-                    if (maybe_source_value_block == null) break;
-
-                    const source_value_block = maybe_source_value_block.?;
-
-                    source_value_block.target = compaction;
-                    compaction.grid.read_block(
-                        .{ .from_local_or_global_storage = blip_read_data_callback },
-                        &source_value_block.read,
-                        value_block_addresses[i],
-                        value_block_checksums[i].value,
-                        .{ .cache_read = true, .cache_write = true },
-                    );
-
-                    read.pending_reads_data += 1;
-                    i += 1;
-                }
-            }
-
-            log.debug("blip_read({s}): scheduled {} data reads.", .{
-                compaction.tree_config.name,
-                read.pending_reads_data,
-            });
-
-            // Either we have pending data reads, in which case blip_read_next_tick gets called by
-            // blip_read_data_callback once all reads are done, or we don't, in which case call it
-            // here via next_tick.
-            if (read.pending_reads_data == 0) {
-                compaction.grid.on_next_tick(blip_read_next_tick, &read.next_tick);
-            }
-        }
-
-        fn blip_read_data_callback(grid_read: *Grid.Read, value_block: BlockPtrConst) void {
-            const parent: *Helpers.CompactionBlock = @fieldParentPtr("read", grid_read);
-            const compaction: *Compaction = @alignCast(@ptrCast(parent.target));
-            assert(compaction.tree_config.id == Table.data.block_metadata(value_block).tree_id);
-
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-
-            const beat = &compaction.beat.?;
-
-            assert(beat.read != null);
-            const read = &beat.read.?;
-
-            read.pending_reads_data -= 1;
-            read.timer_read += 1;
-
-            // TODO: This copies the block, we should try instead to steal it for the duration of
-            // the compaction...
-            stdx.copy_disjoint(.exact, u8, parent.block, value_block);
-
-            // Join on all outstanding reads before continuing.
-            if (read.pending_reads_data != 0) return;
-
-            // Unlike the blip_write which has to make use of an io'ing stage, the only thing
-            // that transitions read blocks to pending is blip_read_data, so it's safe here.
-            while (beat.blocks.?.source_value_blocks[0].pending_to_ready() != null) {}
-            while (beat.blocks.?.source_value_blocks[1].pending_to_ready() != null) {}
-
-            // Call the next tick handler directly. This callback is invoked async, so it's safe
-            // from stack overflows.
-            blip_read_next_tick(&read.next_tick);
-        }
-
-        fn blip_read_next_tick(next_tick: *Grid.NextTick) void {
-            // TODO(zig): Address usage of @fieldParentPtr to optional fields.
-            const beat_read: *Beat.Read = @fieldParentPtr("next_tick", next_tick);
-            const read: *?Beat.Read = @ptrCast(beat_read);
-            const beat: *Beat = @fieldParentPtr("read", read);
-
-            const duration = read.*.?.timer.read();
-            log.debug("blip_read(): took {} to read {} blocks", .{
-                std.fmt.fmtDuration(duration),
-                read.*.?.timer_read,
-            });
-            beat.trace.stop(.compact_blip_read, .{});
-
-            beat.deactivate_assert_and_callback(.read, null);
-        }
-
-        /// Perform CPU merge work, to transform our source tables to our target tables.
-        ///
-        /// blip_merge is also responsible for signalling when to stop blipping entirely. A
-        /// sequence of blips is over when one of the following condition are met, considering we
-        /// don't want to output partial value blocks unless we have to:
-        ///
-        /// * We have reached our value_count_per_beat. Finish up the next value block, and we're
-        ///   done.
-        /// * We have no more source values remaining, at all - the bar is done. This will likely
-        ///   result in a partially full value block, but that's OK (end of a table).
-        /// * We have no more output value blocks remaining in our buffer - we might need more
-        ///   blips, but that's up to the forest to orchestrate.
-        /// * We have no more output index blocks remaining in our buffer - we might have a partial
-        ///   value block here, but that's OK (end of a table).
-        ///
-        /// This is not to be confused with blip_merge itself finishing; this can happen at any time
-        /// because we need more input values, and that's OK. We hold on to our buffers for a beat.
-        pub fn blip_merge(compaction: *Compaction, callback: BlipCallback, ptr: *anyopaque) void {
-            log.debug("blip_merge({s}) starting", .{compaction.tree_config.name});
-
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.bar.?.move_table == false);
-
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-
-            beat.trace.start(.compact_blip_merge, .{
-                .tree = compaction.tree_config.name,
-                .level_b = compaction.level_b,
-            });
-            defer beat.trace.stop(.compact_blip_merge, .{});
-
-            beat.activate_and_assert(.merge, callback, ptr);
-            const merge = &beat.merge.?;
-
-            var source_exhausted_bar = false;
-            var source_exhausted_beat = false;
-
-            assert(bar.table_builder.value_count < Table.layout.block_value_count_max);
-
-            const blocks = &beat.blocks.?;
-
-            var target_value_blocks = &blocks.target_value_blocks;
-            var target_index_blocks = &bar.target_index_blocks.?;
-
-            // Loop through the CPU work until we have nothing left.
-            // TODO: Put better bounds on this, to get rid of while(true).
-            while (true) {
-                // Set the index block if needed.
-                if (bar.table_builder.state == .no_blocks) {
-                    if (target_index_blocks.ready.count ==
-                        @divExact(target_index_blocks.count, 2))
-                    {
-                        break;
-                    }
-
-                    const index_block = target_index_blocks.free_to_pending().?.block;
-                    // TODO: We don't need to zero the whole block; just the part of the padding
-                    // that's not covered by alignment.
-                    @memset(index_block, 0);
-                    bar.table_builder.set_index_block(index_block);
-                }
-
-                // Set the value block if needed.
-                if (bar.table_builder.state == .index_block) {
-                    if (target_value_blocks.ready.count ==
-                        @divExact(target_value_blocks.count, 2))
-                    {
-                        break;
-                    }
-
-                    const value_block = target_value_blocks.free_to_pending().?.block;
-                    // TODO: We don't need to zero the whole block; just the part of the padding
-                    // that's not covered by alignment.
-                    @memset(value_block, 0);
-                    bar.table_builder.set_data_block(value_block);
-                }
-
-                // Try to refill our sources.
-                const source_a_filled = compaction.set_source_a();
-                const source_b_filled = compaction.set_source_b();
-
-                if (source_a_filled == .need_read or source_b_filled == .need_read) {
-                    log.debug("blip_merge({s}): need to read more blocks.", .{
-                        compaction.tree_config.name,
-                    });
-
-                    // This will get set again on the next iteration of the loop.
-                    source_exhausted_beat = false;
-
-                    break;
-                }
-
-                const source_a_exhausted = source_a_filled == .exhausted;
-                const source_b_exhausted = source_b_filled == .exhausted;
-
-                log.debug("blip_merge({s}): source_a_exhausted={} source_b_exhausted={} " ++
-                    "bar.source_values_merge_count={} bar.compaction_tables_value_count={}", .{
-                    compaction.tree_config.name,
-                    source_a_exhausted,
-                    source_b_exhausted,
-                    bar.source_values_merge_count,
-                    bar.compaction_tables_value_count,
+            // Append the entries to the manifest update queue here and now if we're doing
+            // move table. They'll be applied later by bar_apply_to_manifest.
+            if (compaction.move_table) {
+                const snapshot_max = snapshot_max_for_table_input(compaction.op_min);
+                assert(compaction.table_info_a.?.disk.table_info.snapshot_max >= snapshot_max);
+
+                compaction.manifest_entries.append_assume_capacity(.{
+                    .operation = .move_to_level_b,
+                    .table = compaction.table_info_a.?.disk.table_info.*,
                 });
-
-                // It's important here to take note of what these checks mean: they apply when a
-                // source is _completely_ exhausted; ie, there's no more data on disk so the mode
-                // is switched.
-                // TODO: Assert the state transitions - if source_a_exhausted, it can never be
-                // unexhausted for that bar. (etc)
-                const table_builder_count = bar.table_builder.value_count;
-                if (source_a_exhausted and !source_b_exhausted) {
-                    compaction.copy(.b);
-                } else if (source_b_exhausted and !source_a_exhausted) {
-                    if (bar.drop_tombstones) {
-                        compaction.copy_drop_tombstones();
-                    } else {
-                        compaction.copy(.a);
-                    }
-                } else if (!source_a_exhausted and !source_b_exhausted) {
-                    compaction.merge_values();
-                }
-                bar.target_values_merge_count += bar.table_builder.value_count -
-                    table_builder_count;
-
-                const source_values_merge_count_a = compaction.update_position_a();
-                const source_values_merge_count_b = compaction.update_position_b();
-                const source_values_merge_count = source_values_merge_count_a +
-                    source_values_merge_count_b;
-                log.debug("blip_merge({s}): source_values_merge_count_a={} " ++
-                    "source_values_merge_count_b={}", .{
-                    compaction.tree_config.name,
-                    source_values_merge_count_a,
-                    source_values_merge_count_b,
-                });
-
-                beat.source_values_processed += source_values_merge_count;
-                bar.source_values_merge_count += source_values_merge_count;
-
-                // Sanity check. If our sources are exhausted but our values processed sum doesn't
-                // match the total values we had to process we have a bug somewhere.
-                if (source_a_exhausted and source_b_exhausted) {
-                    assert(bar.source_values_merge_count == bar.compaction_tables_value_count);
-                }
-
-                // beat.source_values_processed can overrun, but we can never do more work for a
-                // bar than what we know we have.
-                assert(bar.source_values_merge_count <= bar.compaction_tables_value_count);
-
-                // When checking if we're done, there are two things we need to consider:
-                // 1. Have we finished our input entirely? If so, we flush what we have - it's
-                //    likely to be a partial block but that's OK.
-                // 2. Have we reached our value_count_per_beat? If so, we'll flush at the next
-                //    complete value block.
-                //
-                // This means that we'll potentially overrun our value_count_per_beat by up to
-                // a full value block.
-                source_exhausted_bar = bar.source_values_merge_count ==
-                    bar.compaction_tables_value_count;
-                source_exhausted_beat = beat.source_values_processed >= beat.value_count_per_beat;
-
-                log.debug("blip_merge({s}): beat.source_values_processed={} " ++
-                    "beat.value_count_per_beat={} (source_exhausted_bar={}, " ++
-                    "source_exhausted_beat={})", .{
-                    compaction.tree_config.name,
-                    beat.source_values_processed,
-                    beat.value_count_per_beat,
-                    source_exhausted_bar,
-                    source_exhausted_beat,
-                });
-
-                switch (compaction.check_and_finish_blocks(source_exhausted_bar)) {
-                    .unfinished_value_block => {},
-                    .finished_value_block => if (source_exhausted_beat) break,
-                }
-            }
-
-            const d = merge.timer.read();
-            log.debug("blip_merge(): took {} to merge blocks", .{std.fmt.fmtDuration(d)});
-
-            if (source_exhausted_bar) {
-                assert(compaction.set_source_a() == .exhausted);
-                assert(compaction.set_source_b() == .exhausted);
-                assert(bar.source_values_read_count == bar.source_values_merge_count);
-
-                // Sanity check our primary condition.
-                assert(bar.source_values_merge_count == bar.compaction_tables_value_count);
-
-                if (bar.table_info_a == .immutable) {
-                    assert(bar.table_info_a.immutable.len == 0);
-                } else {
-                    assert(blocks.source_value_blocks[0].ready.count == 0);
-                    compaction.release_table_blocks(blocks.source_index_block_a.block);
-                }
-
-                assert(blocks.source_value_blocks[1].ready.count == 0);
-                // table_b's release_table_blocks gets called in update_position_b.
-                // TODO: Maybe we should move table_a's there too...?
-            }
-
-            beat.deactivate_assert_and_callback(.merge, .{
-                .bar = source_exhausted_bar,
-                .beat = source_exhausted_bar or source_exhausted_beat,
-            });
-        }
-
-        fn set_source_a(compaction: *Compaction) enum { filled, need_read, exhausted } {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-
-            if (bar.table_info_a == .immutable) {
-                // Immutable table can never .need_read, since all its values come from memory.
-                stdx.maybe(bar.source_a_immutable_values == null);
-                assert(compaction.level_b == 0);
-
-                // If our immutable values 'block' is empty, refill it from its iterator.
-                // TODO: Cleanup the logic here!
-                var updated_fill_count = false;
-                if (bar.source_a_immutable_values == null or
-                    bar.source_a_immutable_values.?.len == 0)
-                {
-                    if (bar.table_info_a.immutable.len > 0) {
-                        // Only consume one block at a time so that `blip_merge` never goes over its
-                        // target by more than 1 value block.
-                        const filled = @min(
-                            Table.data.value_count_max,
-                            bar.table_info_a.immutable.len,
-                        );
-
-                        bar.source_a_values_consumed_for_fill = filled;
-                        bar.source_a_immutable_values = bar.table_info_a.immutable[0..filled];
-                        bar.table_info_a.immutable = bar.table_info_a.immutable[filled..];
-
-                        updated_fill_count = true;
-                        log.debug("set_source_a({s}): refilled immutable values (filled={})", .{
-                            compaction.tree_config.name,
-                            filled,
-                        });
-                    }
-                }
-
-                beat.source_a_values = bar.source_a_immutable_values.?;
-                if (bar.source_a_immutable_values.?.len == 0) {
-                    if (!updated_fill_count) {
-                        bar.source_a_values_consumed_for_fill = 0;
-                    }
-                    return .exhausted;
-                } else {
-                    return .filled;
-                }
-            } else {
-                const blocks = &beat.blocks.?;
-                defer beat.source_a_len_after_set = beat.source_a_values.?.len;
-
-                log.debug("set_source_a({s}): bar.source_a_position = {}", .{
-                    compaction.tree_config.name,
-                    bar.source_a_position,
-                });
-
-                // Unlike with range_b, where we can have an empty index block, with table_a if
-                // we're not coming from the immutable table we have an index block by definition.
-                if (bar.source_a_position.index_block == 1) {
-                    beat.source_a_values = &.{};
-                    return .exhausted;
-                }
-
-                if (beat.source_a_values != null and beat.source_a_values.?.len > 0) return .filled;
-                if (blocks.source_value_blocks[0].ready.empty()) return .need_read;
-
-                const current_value_block = blocks.source_value_blocks[0].ready_peek().?.block;
-
-                // Verify this block is indeed the correct one.
-                const index_block = blocks.source_index_block_a.block;
-                const index_schema = schema.TableIndex.from(index_block);
-                const value_block_checksums = index_schema.data_checksums_used(index_block);
-                const current_value_block_header = schema.header_from_block(current_value_block);
-                assert(value_block_checksums[bar.source_a_position.value_block].value ==
-                    current_value_block_header.checksum);
-
-                beat.source_a_values = Table.data_block_values_used(
-                    current_value_block,
-                )[bar.source_a_position.value_block_index..];
-
-                return .filled;
+                compaction.quotas.done = compaction.table_info_a.?.disk.table_info.value_count;
+                compaction.quotas.beat = compaction.table_info_a.?.disk.table_info.value_count;
+                assert(compaction.quotas.beat_done());
+                assert(compaction.quotas.bar_done());
             }
         }
 
-        fn set_source_b(compaction: *Compaction) enum { filled, need_read, exhausted } {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-            const blocks = &beat.blocks.?;
-
-            log.debug("set_source_b({s}): bar.source_b_position={} " ++
-                "bar.range_b.tables.count()={}", .{
-                compaction.tree_config.name,
-                bar.source_b_position,
-                bar.range_b.tables.count(),
-            });
-
-            defer beat.source_b_len_after_set = beat.source_b_values.?.len;
-
-            if (bar.range_b.tables.empty()) {
-                beat.source_b_values = &.{};
-                return .exhausted;
-            }
-            if (bar.source_b_position.index_block == bar.range_b.tables.count()) {
-                beat.source_b_values = &.{};
-                return .exhausted;
-            }
-            if (beat.source_b_values != null and beat.source_b_values.?.len > 0) return .filled;
-            if (blocks.source_value_blocks[1].ready.empty()) return .need_read;
-
-            const current_value_block = blocks.source_value_blocks[1].ready_peek().?.block;
-
-            // Verify this block is indeed the correct one.
-            const index_block = blocks.source_index_block_b.block;
-            const index_schema = schema.TableIndex.from(index_block);
-            const value_block_checksums = index_schema.data_checksums_used(index_block);
-            const current_value_block_header = schema.header_from_block(current_value_block);
-            assert(value_block_checksums[bar.source_b_position.value_block].value ==
-                current_value_block_header.checksum);
-
-            beat.source_b_values = Table.data_block_values_used(
-                current_value_block,
-            )[bar.source_b_position.value_block_index..];
-
-            return .filled;
-        }
-
-        fn update_position_a(compaction: *Compaction) usize {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-            const blocks = &beat.blocks.?;
-
-            if (bar.table_info_a == .immutable) {
-                bar.source_a_immutable_values = beat.source_a_values;
-
-                if (beat.source_a_values != null and beat.source_a_values.?.len == 0) {
-                    bar.source_values_read_count +=
-                        bar.source_a_values_consumed_for_fill;
-                    return bar.source_a_values_consumed_for_fill;
-                }
-            } else {
-                if (beat.source_a_values != null and beat.source_a_values.?.len > 0) {
-                    const values_consumed = beat.source_a_len_after_set -
-                        beat.source_a_values.?.len;
-                    bar.source_a_position.value_block_index += values_consumed;
-
-                    return values_consumed;
-                }
-
-                if (bar.source_a_position.index_block == 1) {
-                    return 0;
-                }
-
-                bar.source_a_position.value_block_index = 0;
-                bar.source_a_position.value_block += 1;
-
-                const old_block = blocks.source_value_blocks[0].ready_to_free().?;
-                bar.source_values_read_count += Table.data_block_values_used(old_block.block).len;
-
-                const index_block = blocks.source_index_block_a.block;
-                const index_schema = schema.TableIndex.from(index_block);
-                const value_blocks_used = index_schema.data_blocks_used(index_block);
-
-                if (bar.source_a_position.value_block == value_blocks_used) {
-                    bar.source_a_position.value_block = 0;
-                    bar.source_a_position.index_block += 1;
-                }
-
-                return beat.source_a_len_after_set;
-            }
-
-            return 0;
-        }
-
-        fn update_position_b(compaction: *Compaction) usize {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-            const blocks = &beat.blocks.?;
-
-            if (beat.source_b_values != null and beat.source_b_values.?.len > 0) {
-                const values_consumed = beat.source_b_len_after_set - beat.source_b_values.?.len;
-                bar.source_b_position.value_block_index += values_consumed;
-
-                return values_consumed;
-            }
-            if (bar.range_b.tables.empty()) return 0;
-            if (bar.source_b_position.index_block == bar.range_b.tables.count()) return 0;
-
-            bar.source_b_position.value_block_index = 0;
-            bar.source_b_position.value_block += 1;
-            const old_block = blocks.source_value_blocks[1].ready_to_free().?;
-            bar.source_values_read_count += Table.data_block_values_used(old_block.block).len;
-
-            const index_block = blocks.source_index_block_b.block;
-            const index_schema = schema.TableIndex.from(index_block);
-            const value_blocks_used = index_schema.data_blocks_used(index_block);
-
-            if (bar.source_b_position.value_block == value_blocks_used) {
-                bar.source_b_position.value_block = 0;
-                bar.source_b_position.index_block += 1;
-
-                // Release the index block and any value blocks it referenced.
-                compaction.release_table_blocks(blocks.source_index_block_b.block);
-
-                // TODO: Perhaps this logic should be in read rather?
-                if (bar.source_b_position.index_block < bar.range_b.tables.count()) {
-                    beat.index_read_done = false;
-                    beat.index_blocks_read_b = 0;
-                }
-            }
-            return beat.source_b_len_after_set;
-        }
-
-        fn check_and_finish_blocks(compaction: *Compaction, force_flush: bool) enum {
-            unfinished_value_block,
-            finished_value_block,
-        } {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-
-            const target_value_blocks = &beat.blocks.?.target_value_blocks;
-            const target_index_blocks = &bar.target_index_blocks.?;
-
-            assert(beat.merge != null);
-
-            const table_builder = &bar.table_builder;
-
-            var finished_value_block = false;
-            assert(bar.table_builder.state == .index_and_data_block);
-
-            const release =
-                compaction.grid.superblock.working.vsr_state.checkpoint.release;
-
-            // Flush the value block if needed.
-            if (table_builder.data_block_full() or
-                table_builder.index_block_full() or
-                (force_flush and !table_builder.data_block_empty()))
-            {
-                log.debug("blip_merge({s}): finished target value block", .{
-                    compaction.tree_config.name,
-                });
-                table_builder.data_block_finish(.{
-                    .cluster = compaction.grid.superblock.working.cluster,
-                    .release = release,
-                    .address = compaction.grid.acquire(compaction.beat.?.grid_reservation),
-                    .snapshot_min = snapshot_min_for_table_output(bar.op_min),
-                    .tree_id = compaction.tree_config.id,
-                });
-
-                assert(target_value_blocks.pending.count == 1);
-                _ = target_value_blocks.pending_to_ready().?;
-                finished_value_block = true;
-            } else if (force_flush and table_builder.data_block_empty()) {
-                assert(target_value_blocks.pending.count == 1);
-
-                _ = target_value_blocks.pending_to_free().?;
-                table_builder.state = .index_block;
-                finished_value_block = true;
-            }
-
-            // Flush the index block if needed.
-            if (table_builder.index_block_full() or
-                // If the input is exhausted then we need to flush all blocks before finishing.
-                (force_flush and !table_builder.index_block_empty()))
-            {
-                log.debug("blip_merge({s}): finished target index block", .{
-                    compaction.tree_config.name,
-                });
-                const table = table_builder.index_block_finish(.{
-                    .cluster = compaction.grid.superblock.working.cluster,
-                    .release = release,
-                    .address = compaction.grid.acquire(compaction.beat.?.grid_reservation),
-                    .snapshot_min = snapshot_min_for_table_output(bar.op_min),
-                    .tree_id = compaction.tree_config.id,
-                });
-
-                assert(target_index_blocks.pending.count == 1);
-                _ = target_index_blocks.pending_to_ready().?;
-
-                // Make this table visible at the end of this bar.
-                bar.manifest_entries.append_assume_capacity(.{
-                    .operation = .insert_to_level_b,
-                    .table = table,
-                });
-            } else if (force_flush and table_builder.index_block_empty()) {
-                assert(target_index_blocks.pending.count == 1);
-
-                _ = target_index_blocks.pending_to_free().?;
-                table_builder.state = .no_blocks;
-            }
-
-            if (finished_value_block) return .finished_value_block;
-            return .unfinished_value_block;
-        }
-
-        // TODO: Support for LSM snapshots would require us to only remove blocks
-        // that are invisible.
-        fn release_table_blocks(compaction: *Compaction, index_block: BlockPtrConst) void {
-            // Release the table's block addresses in the Grid as it will be made invisible.
-            // This is safe; compaction.index_block_b holds a copy of the index block for a
-            // table in Level B. Additionally, compaction.index_block_a holds
-            // a copy of the index block for the Level A table being compacted.
-            log.debug("release_table_blocks({s})", .{compaction.tree_config.name});
-
-            const grid = compaction.grid;
-            const index_schema = schema.TableIndex.from(index_block);
-            for (index_schema.data_addresses_used(index_block)) |address| grid.release(address);
-            grid.release(Table.block_address(index_block));
-        }
-
-        /// Perform write IO to write our target_index_blocks and target_value_blocks to disk.
-        pub fn blip_write(compaction: *Compaction, callback: BlipCallback, ptr: *anyopaque) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.bar.?.move_table == false);
-
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-
-            beat.activate_and_assert(.write, callback, ptr);
-
-            assert(beat.write != null);
-            const write = &beat.write.?;
-
-            log.debug("blip_write({s}): scheduling IO", .{compaction.tree_config.name});
-
-            beat.trace.start(.compact_blip_write, .{
-                .tree = compaction.tree_config.name,
-                .level_b = compaction.level_b,
-            });
-
-            assert(write.pending_writes == 0);
-
-            // Write any complete index blocks.
-            while (bar.target_index_blocks.?.ready_to_ioing()) |target_index_block| {
-                target_index_block.target = compaction;
-                compaction.grid.create_block(
-                    blip_write_callback,
-                    &target_index_block.write,
-                    &target_index_block.block,
-                );
-                write.pending_writes += 1;
-            }
-
-            // Write any complete value blocks.
-            while (beat.blocks.?.target_value_blocks.ready_to_ioing()) |target_value_block| {
-                target_value_block.target = compaction;
-
-                // It would be nice to set this in the callback, but create_block consumes our
-                // block...
-                bar.target_values_write_count +=
-                    Table.data_block_values_used(target_value_block.block).len;
-
-                compaction.grid.create_block(
-                    blip_write_callback,
-                    &target_value_block.write,
-                    &target_value_block.block,
-                );
-                write.pending_writes += 1;
-            }
-
-            const d = write.timer.read();
-            log.debug("blip_write({s}): took {} to schedule {} blocks", .{
-                compaction.tree_config.name,
-                std.fmt.fmtDuration(d),
-                write.pending_writes,
-            });
-            write.timer.reset();
-
-            // TODO: The big idea is to make compaction pacing explicit and asserted behaviour
-            // rather than just an implicit property of the code. We should add asserts around how
-            // much work we do per beat.
-
-            if (write.pending_writes == 0) {
-                compaction.grid.on_next_tick(blip_write_next_tick, &write.next_tick);
-            }
-        }
-
-        fn blip_write_callback(grid_write: *Grid.Write) void {
-            const parent: *Helpers.CompactionBlock = @fieldParentPtr("write", grid_write);
-            const compaction: *Compaction = @alignCast(@ptrCast(parent.target));
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-
-            const beat = &compaction.beat.?;
-
-            assert(beat.write != null);
-            const write = &beat.write.?;
-            write.pending_writes -= 1;
-            write.timer_write += 1;
-
-            // Join on all outstanding writes before continuing.
-            if (write.pending_writes != 0) return;
-
-            var freed: usize = 0;
-            while (beat.blocks.?.target_value_blocks.ioing_to_free() != null) freed += 1;
-            while (compaction.bar.?.target_index_blocks.?.ioing_to_free() != null) freed += 1;
-            assert(freed > 0);
-
-            // Call the next tick handler directly. This callback is invoked async, so it's safe
-            // from stack overflows.
-            blip_write_next_tick(&write.next_tick);
-        }
-
-        fn blip_write_next_tick(next_tick: *Grid.NextTick) void {
-            // TODO(zig): Address usage of @fieldParentPtr to optional fields.
-            const write: *?Beat.Write = @ptrCast(
-                @as(*Beat.Write, @fieldParentPtr("next_tick", next_tick)),
-            );
-            const beat: *Beat = @fieldParentPtr("write", write);
-
-            const duration = write.*.?.timer.read();
-            log.debug("blip_write(): took {} to write {} blocks", .{
-                std.fmt.fmtDuration(duration),
-                write.*.?.timer_write,
-            });
-            beat.trace.stop(.compact_blip_write, .{});
-
-            beat.deactivate_assert_and_callback(.write, null);
-        }
-
-        /// Return our blocks to the block pool.
-        pub fn beat_blocks_unassign(
-            compaction: *Compaction,
-            block_pool: *Helpers.CompactionBlockFIFO,
-        ) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.beat.?.blocks != null);
-            assert(!compaction.bar.?.move_table);
-
-            const blocks = &compaction.beat.?.blocks.?;
-
-            assert(blocks.source_index_block_a.stage == .standalone);
-            assert(blocks.source_index_block_b.stage == .standalone);
-
-            blocks.source_index_block_a.stage = .free;
-            blocks.source_index_block_b.stage = .free;
-
-            block_pool.push(blocks.source_index_block_a);
-            block_pool.push(blocks.source_index_block_b);
-
-            // source_value_blocks[*] can finish with blocks in the ready state. This is because
-            // these are reads that we're throwing away as we didn't need them.
-            // TODO(metric): Track this.
-            while (blocks.source_value_blocks[0].ready_to_free() != null) {}
-            while (blocks.source_value_blocks[1].ready_to_free() != null) {}
-
-            blocks.source_value_blocks[0].deinit(block_pool);
-            blocks.source_value_blocks[1].deinit(block_pool);
-            blocks.target_value_blocks.deinit(block_pool);
-
-            compaction.beat.?.blocks = null;
-        }
-
-        pub fn beat_grid_forfeit(compaction: *Compaction) void {
-            assert(compaction.bar != null);
-            assert(compaction.beat != null);
-            assert(compaction.bar.?.move_table == false);
-
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-
-            assert(beat.blocks == null);
-
-            beat.assert_all_inactive();
-            assert(bar.table_builder.data_block_empty());
-
-            log.debug("beat_grid_forfeit({s}): forfeiting {}", .{
-                compaction.tree_config.name,
-                beat.grid_reservation,
-            });
-            compaction.grid.forfeit(beat.grid_reservation);
-
-            // Our beat is done!
-            bar.beats_finished += 1;
-            compaction.beat = null;
-        }
-
-        pub fn bar_blocks_unassign(
-            compaction: *Compaction,
-            block_pool: *Helpers.CompactionBlockFIFO,
-        ) void {
-            assert(compaction.beat == null);
-            assert(compaction.bar != null);
-
-            const bar = &compaction.bar.?;
-
-            if (bar.move_table) {
-                assert(bar.target_index_blocks == null);
-            } else {
-                bar.target_index_blocks.?.deinit(block_pool);
-                bar.target_index_blocks = null;
-            }
-        }
-
-        /// Apply the changes that have been accumulated in memory to the manifest, remove any
-        /// tables that are now invisible, and set compaction.bar to null to indicate that it's
-        /// finished.
-        pub fn bar_apply_to_manifest(compaction: *Compaction) void {
-            assert(compaction.beat == null);
-            assert(compaction.bar != null);
-
-            const bar = &compaction.bar.?;
-
-            log.debug("bar_apply_to_manifest({s}): level_b={} source_values_merge_count={} " ++
-                "compaction_tables_value_count={} move_table={}", .{
-                compaction.tree_config.name,
-                compaction.level_b,
-                bar.source_values_merge_count,
-                bar.compaction_tables_value_count,
-                bar.move_table,
-            });
-
+        /// Apply the changes that have been accumulated in memory to the manifest and remove any
+        /// tables that are now invisible.
+        pub fn bar_complete(compaction: *Compaction) void {
+            assert(compaction.idle());
+            assert(compaction.stage == .paused);
+            assert(compaction.counters.consistent());
+            assert(compaction.quotas.bar_done());
             // Assert blocks have been released back to the pipeline.
-            assert(bar.target_index_blocks == null);
+            assert(compaction.table_builder.state == .no_blocks);
+            assert(compaction.table_builder_index_block == null);
+            assert(compaction.table_builder_value_block == null);
 
-            // Assert our input has been fully exhausted.
-            assert(bar.source_values_read_count > 0);
-            assert(bar.source_values_merge_count == bar.compaction_tables_value_count);
-            assert(bar.source_values_read_count == bar.source_values_merge_count);
+            defer {
+                compaction.* = .{
+                    .grid = compaction.grid,
+                    .tree = compaction.tree,
+                    .level_b = compaction.level_b,
+                };
+                assert(compaction.stage == .inactive);
+            }
 
-            // Assert we've written all the values we've merged.
-            // TODO: Can we assert target_values_merge_count > 0 here?
-            assert(bar.target_values_merge_count == bar.target_values_write_count);
+            if (compaction.table_info_a == null) {
+                assert(compaction.range_b == null);
+                if (compaction.level_b == 0) {
+                    assert(compaction.tree.table_immutable.mutability.immutable.flushed);
+                }
+                return;
+            }
+            assert(compaction.table_info_a != null);
+            assert(compaction.range_b != null);
 
-            // Assert we've finished within the number of beats we were allocated.
-            // TODO(metric): Track the delta between target and actual.
-            if (!bar.move_table)
-                assert(bar.beats_finished <= bar.beats_max.?);
+            log.debug("{s}:{}: bar_complete: " ++
+                "values_in={} values_out={} values_dropped={} values_wasted={}", .{
+                compaction.tree.config.name,
+                compaction.level_b,
+                compaction.counters.in,
+                compaction.counters.out,
+                compaction.counters.dropped,
+                compaction.counters.wasted,
+            });
 
             // Mark the immutable table as flushed, if we were compacting into level 0.
-            if (compaction.level_b == 0 and bar.table_info_a.immutable.len == 0) {
-                bar.tree.table_immutable.mutability.immutable.flushed = true;
+            if (compaction.level_b == 0) {
+                compaction.tree.table_immutable.mutability.immutable.flushed = true;
             }
 
             // Each compaction's manifest updates are deferred to the end of the last
             // bar to ensure:
             // - manifest log updates are ordered deterministically relative to one another, and
             // - manifest updates are not visible until after the blocks are all on disk.
-            const manifest = &bar.tree.manifest;
+            const manifest = &compaction.tree.manifest;
             const level_b = compaction.level_b;
-            const snapshot_max = snapshot_max_for_table_input(bar.op_min);
+            const snapshot_max = snapshot_max_for_table_input(compaction.op_min);
 
             var manifest_removed_value_count: u64 = 0;
             var manifest_added_value_count: u64 = 0;
 
-            if (bar.move_table) {
+            if (compaction.move_table) {
                 // If no compaction is required, don't update snapshot_max.
             } else {
                 // These updates MUST precede insert_table() and move_table() since they use
                 // references to modify the ManifestLevel in-place.
-                switch (bar.table_info_a) {
+                switch (compaction.table_info_a.?) {
                     .immutable => {
-                        if (bar.table_info_a.immutable.len == 0) {
-                            manifest_removed_value_count = bar.tree.table_immutable.count();
-                        }
+                        manifest_removed_value_count = compaction.tree.table_immutable.count();
                     },
                     .disk => |table_info| {
                         manifest_removed_value_count += table_info.table_info.value_count;
                         manifest.update_table(level_b - 1, snapshot_max, table_info);
                     },
                 }
-                for (bar.range_b.tables.const_slice()) |table| {
+                for (compaction.range_b.?.tables.const_slice()) |table| {
                     manifest_removed_value_count += table.table_info.value_count;
                     manifest.update_table(level_b, snapshot_max, table);
                 }
             }
 
-            for (bar.manifest_entries.slice()) |*entry| {
+            for (compaction.manifest_entries.slice()) |*entry| {
                 switch (entry.operation) {
                     .insert_to_level_b => {
                         manifest.insert_table(level_b, &entry.table);
@@ -1934,190 +718,1201 @@ pub fn CompactionType(
                     },
                 }
             }
-            log.debug("bar_apply_to_manifest({s}): manifest_removed_value_count={} " ++
-                "manifest_added_value_count={} source_values_read_count={} " ++
-                "target_values_merge_count={}", .{
-                compaction.tree_config.name,
-                manifest_removed_value_count,
-                manifest_added_value_count,
-                bar.source_values_read_count,
-                bar.target_values_merge_count,
-            });
-            assert(bar.source_values_read_count == manifest_removed_value_count);
-            assert(bar.target_values_merge_count == manifest_added_value_count);
+            if (compaction.move_table) {
+                assert(std.meta.eql(compaction.counters, .{}));
+                assert(manifest_added_value_count == manifest_removed_value_count);
+                assert(manifest_added_value_count > 0);
+            } else {
+                assert(manifest_added_value_count == compaction.counters.out);
+                assert(manifest_removed_value_count ==
+                    compaction.counters.in - compaction.counters.wasted);
+                assert(manifest_removed_value_count - manifest_added_value_count ==
+                    compaction.counters.dropped);
+            }
 
             // Hide any tables that are now invisible.
             manifest.remove_invisible_tables(
                 level_b,
                 &.{},
-                bar.range_b.key_min,
-                bar.range_b.key_max,
+                compaction.range_b.?.key_min,
+                compaction.range_b.?.key_max,
             );
             if (level_b > 0) {
                 manifest.remove_invisible_tables(
                     level_b - 1,
                     &.{},
-                    bar.range_b.key_min,
-                    bar.range_b.key_max,
+                    compaction.range_b.?.key_min,
+                    compaction.range_b.?.key_max,
                 );
             }
-
-            // Our bar is done!
-            compaction.bar = null;
         }
 
-        // TODO: Add benchmarks for these CPU merge methods.
-        fn copy(compaction: *Compaction, source: enum { a, b }) void {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-            if (source == .a) assert(!bar.drop_tombstones);
+        /// Plan the work for the beat:
+        /// - determine our quota in terms of minimum number of input values to process,
+        /// - reserve grid blocks for the output.
+        pub fn beat_commence(
+            compaction: *Compaction,
+            beats_remaining: u64,
+        ) void {
+            assert(compaction.idle());
+            assert(compaction.stage == .paused);
+            if (compaction.move_table) assert(compaction.quotas.bar_done());
+            assert(compaction.quotas.done >= compaction.quotas.beat);
+            defer assert(compaction.quotas.done <= compaction.quotas.beat);
 
-            assert(bar.table_builder.value_count < Table.layout.block_value_count_max);
+            assert(beats_remaining > 0);
+            assert(beats_remaining <= half_bar_beat_count);
 
-            log.debug("blip_merge({s}): merging via copy({s})", .{
-                compaction.tree_config.name,
-                @tagName(source),
+            // Calculate how many values we have to compact each beat, to self-correct our pacing.
+            // Pacing will have imperfections due to rounding up to fill target value blocks and
+            // immutable table filtering duplicate values.
+            const values_remaining = compaction.quotas.bar - compaction.quotas.done;
+            const beat_values_quota = stdx.div_ceil(values_remaining, beats_remaining);
+            compaction.quotas.beat = compaction.quotas.done + beat_values_quota;
+            assert(compaction.quotas.done <= compaction.quotas.beat);
+            assert(compaction.quotas.beat <= compaction.quotas.bar);
+            if (beats_remaining == 1) {
+                assert(compaction.quotas.beat == compaction.quotas.bar);
+            }
+
+            if (compaction.quotas.beat_done()) {
+                assert(compaction.stage == .paused);
+                log.debug("{s}:{}: beat_commence: quota fulfilled", .{
+                    compaction.tree.config.name,
+                    compaction.level_b,
+                });
+                return;
+            }
+            compaction.stage = .beat;
+
+            // The +1 is for imperfections in pacing our immutable table, which might cause us
+            // to overshoot by a single block (limited to 1 due to how the immutable table values
+            // are consumed.)
+            const beat_value_blocks_max = stdx.div_ceil(
+                beat_values_quota,
+                Table.layout.block_value_count_max,
+            ) + 1;
+
+            // The +1 is in case we had a partially finished index block from a previous beat.
+            const beat_index_blocks_max = stdx.div_ceil(
+                beat_value_blocks_max,
+                Table.data_block_count_max,
+            ) + 1;
+            const beat_blocks_max = beat_value_blocks_max + beat_index_blocks_max;
+
+            assert(compaction.grid_reservation == null);
+            compaction.grid_reservation = compaction.grid.reserve(beat_blocks_max).?;
+
+            // These values were already processed during the previous beat and add to wastage.
+            if (compaction.table_info_a.? == .disk) {
+                compaction.counters.wasted += compaction.level_a_position.value;
+            }
+            compaction.counters.wasted += compaction.level_b_position.value;
+
+            log.debug("{s}:{}: beat_commence: quota_done={} quota_beat={} quota_bar={} " ++
+                "blocks_reserved={} values_wasted={}", .{
+                compaction.tree.config.name,
+                compaction.level_b,
+                compaction.quotas.done,
+                compaction.quotas.beat,
+                compaction.quotas.bar,
+                beat_blocks_max,
+                compaction.counters.wasted,
+            });
+        }
+
+        // While beat_commence is called by the forest sequentially for each compaction, to get
+        // deterministic grid reservations, each compaction completes its own beat's work
+        // asynchronously
+        fn beat_complete(compaction: *Compaction) void {
+            assert(compaction.stage == .beat_table_done);
+            switch (compaction.table_builder.state) {
+                .no_blocks => {},
+                .index_block => assert(!compaction.table_builder.index_block_full()),
+                .index_and_data_block => unreachable,
+            }
+            if (compaction.table_info_a.? == .immutable) {
+                switch (compaction.level_a_immutable_stage) {
+                    .ready, .exhausted => {},
+                    .merge => unreachable,
+                }
+            }
+            assert(compaction.level_a_index_block.empty());
+            assert(compaction.level_a_value_block.empty());
+            assert(compaction.level_b_index_block.empty());
+            assert(compaction.level_b_value_block.empty());
+            assert(compaction.output_blocks.empty());
+
+            assert(compaction.pool.?.idle());
+            maybe(compaction.pool.?.blocks_acquired() > 0);
+            assert(compaction.grid_reservation != null);
+            compaction.grid.forfeit(compaction.grid_reservation.?);
+            compaction.grid_reservation = null;
+
+            assert(compaction.counters.consistent());
+
+            assert(compaction.quotas.beat_done());
+            assert(compaction.table_builder.data_block_empty());
+            assert(compaction.table_builder_value_block == null);
+            assert(compaction.table_builder.state == .no_blocks or
+                !compaction.table_builder.index_block_full());
+
+            if (compaction.quotas.bar_done()) {
+                assert(compaction.table_builder.state == .no_blocks);
+                assert(compaction.table_builder_index_block == null);
+            }
+
+            compaction.stage = .paused;
+            const pool = compaction.pool.?;
+            const callback = compaction.callback.?;
+            compaction.pool = null;
+            compaction.callback = null;
+            assert(compaction.idle());
+            assert(pool.idle());
+            log.debug("{s}:{}: beat_complete: quota_done={} quota_beat={} quota_bar={} " ++
+                "values_wasted={}", .{
+                compaction.tree.config.name,
+                compaction.level_b,
+                compaction.quotas.done,
+                compaction.quotas.beat,
+                compaction.quotas.bar,
+                compaction.counters.wasted,
+            });
+            callback(pool);
+        }
+
+        /// The entry point to the actual compaction work for the beat. Called by the forest.
+        pub fn compaction_dispatch_enter(
+            compaction: *Compaction,
+            pool: *ResourcePool,
+            callback: *const fn (*ResourcePool) void,
+        ) enum { active, beat_finished } {
+            assert(compaction.idle());
+            switch (compaction.stage) {
+                .inactive => unreachable,
+                .paused => {
+                    assert(compaction.quotas.beat_done());
+                    return .beat_finished;
+                },
+                .beat => {},
+                .beat_quota_done, .beat_table_done => unreachable,
+            }
+            assert(pool.idle());
+            compaction.pool = pool;
+            compaction.callback = callback;
+            assert(
+                pool.blocks_free() >= compaction_block_count_beat_min -
+                    @intFromBool(compaction.table_builder_index_block != null),
+            );
+            compaction.grid.trace.start(.compact_beat, .{
+                .tree = compaction.tree.config.name,
+                .level_b = compaction.level_b,
+            });
+            compaction.level_a_index_block_next = compaction.level_a_position.index_block;
+            compaction.level_a_value_block_next = compaction.level_a_position.value_block;
+            compaction.level_b_index_block_next = compaction.level_b_position.index_block;
+            compaction.level_b_value_block_next = compaction.level_b_position.value_block;
+            compaction.compaction_dispatch();
+            return .active;
+        }
+
+        // Compaction is a lot of work: read input tables from both levels, merge their value
+        // blocks, write the results to disk. Many of these jobs can proceed in parallel. For
+        // example, only a single value block from each level is needed to start a merge.
+        //
+        // The job of compaction_dispatch is to kick off all the jobs. There are several additional
+        // concerns:
+        // - All jobs use the same common pool of resources (ResourcePool). The jobs are started
+        //   in the order that splits resources fairly (e.g., reads from level a and level b
+        //   alternate). Fairness also ensures that the process does not deadlock.
+        // - Jobs have dependencies --- merging needs value blocks, reading a value block needs the
+        //   corresponding index blocks.
+        // - A single bar of compaction should process only a fraction of the input, so the
+        //   processes can be suspended in the middle.
+        //
+        // A beat of compaction ends when both:
+        //   - at least quota.bar of input values is consumed,
+        //   - there's no incomplete output value blocks.
+        //
+        // In other words, the only compaction state that gets carried over to the next beat is a
+        // partially full index block. The current beat must end with writing a data block, and the
+        // next beat must start with re-reading level_a and level_b index and value blocks.
+        fn compaction_dispatch(compaction: *Compaction) void {
+            switch (compaction.stage) {
+                .beat,
+                .beat_quota_done,
+                .beat_table_done,
+                => {},
+                .inactive,
+                .paused,
+                => unreachable,
+            }
+
+            // The loop below runs while (!progressed) and, every time progressed is set to true,
+            // one of the safety_counter resources is acquired.
+            var progressed = true;
+            const safety_counter =
+                compaction.pool.?.reads.total() +
+                compaction.pool.?.writes.total() +
+                compaction.pool.?.cpus.total() + 1;
+            for (0..safety_counter) |_| {
+                if (!progressed) break;
+                progressed = false;
+
+                if (compaction.stage == .beat_table_done) {
+                    // Just wait for all in-flight jobs to complete.
+                    return compaction.compaction_dispatch_beat_table_done();
+                }
+
+                // To avoid deadlocks, allocate blocks for the table builder first.
+                if (compaction.table_builder.state == .no_blocks) {
+                    assert(compaction.table_builder_index_block == null);
+                    if (compaction.pool.?.block_acquire()) |block| {
+                        assert(block.stage == .free);
+                        block.stage = .build_index_block;
+                        compaction.table_builder.set_index_block(block.ptr);
+                        compaction.table_builder_index_block = block;
+                    } else {
+                        assert(compaction.output_blocks.count > 0);
+                    }
+                }
+
+                if (compaction.table_builder.state == .index_block) {
+                    assert(compaction.table_builder_value_block == null);
+                    if (compaction.pool.?.block_acquire()) |block| {
+                        assert(block.stage == .free);
+                        block.stage = .build_value_block;
+                        compaction.table_builder.set_data_block(block.ptr);
+                        compaction.table_builder_value_block = block;
+                    } else {
+                        assert(compaction.output_blocks.count > 0);
+                    }
+                }
+
+                // Read level A index block (for level_b > 0).
+                if (compaction.table_info_a.? == .disk) {
+                    assert(compaction.level_b > 0);
+                    if (!compaction.level_a_index_block.full() and
+                        compaction.level_a_index_block_next < 1)
+                    {
+                        if (compaction.pool.?.block_acquire()) |block| {
+                            const read = compaction.pool.?.reads.acquire().?;
+
+                            assert(block.stage == .free);
+                            block.stage = .read_index_block;
+                            compaction.level_a_index_block.push_assume_capacity(block);
+
+                            compaction.read_index_block(.level_a, read, block);
+                            progressed = true;
+                        } else {
+                            assert(compaction.level_a_index_block.count > 0 or
+                                compaction.output_blocks.count > 0);
+                        }
+                    }
+                }
+
+                // Read level B index block.
+                if (!compaction.level_b_index_block.full() and
+                    compaction.level_b_index_block_next < compaction.range_b.?.tables.count())
+                {
+                    if (compaction.pool.?.block_acquire()) |block| {
+                        const read = compaction.pool.?.reads.acquire().?;
+
+                        assert(block.stage == .free);
+                        block.stage = .read_index_block;
+                        compaction.level_b_index_block.push_assume_capacity(block);
+
+                        compaction.read_index_block(.level_b, read, block);
+                        progressed = true;
+                    } else {
+                        assert(compaction.level_b_index_block.count > 0 or
+                            compaction.output_blocks.count > 0);
+                    }
+                }
+
+                // Read level A value block.
+                if (compaction.table_info_a.? == .immutable) {
+                    // The whole table is in memory, no need to read anything.
+                } else {
+                    if (compaction.level_a_index_block.head()) |index_block| {
+                        assert(index_block.stage == .read_index_block or
+                            index_block.stage == .read_index_block_done);
+
+                        const level_a_priority = compaction.level_b_index_block.count == 0 or
+                            compaction.level_a_value_block.count <
+                            compaction.level_b_value_block.count;
+                        if (index_block.stage == .read_index_block_done and
+                            !compaction.level_a_value_block.full() and
+                            level_a_priority)
+                        {
+                            if (compaction.stage == .beat_quota_done and
+                                compaction.level_a_value_block.count >= 2)
+                            {
+                                // Avoid over-read at the end of the beat.
+                            } else {
+                                if (compaction.pool.?.block_acquire()) |block| {
+                                    const read = compaction.pool.?.reads.acquire().?;
+
+                                    assert(block.stage == .free);
+                                    block.stage = .read_value_block;
+                                    compaction.level_a_value_block.push_assume_capacity(block);
+
+                                    compaction.read_value_block(.level_a, read, block);
+                                    progressed = true;
+                                } else {
+                                    assert(compaction.level_a_value_block.count > 0 or
+                                        compaction.output_blocks.count > 0);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Read level B value block.
+                if (compaction.level_b_index_block.head()) |index_block| {
+                    assert(index_block.stage == .read_index_block or
+                        index_block.stage == .read_index_block_done);
+                    const level_b_priority = compaction.level_a_index_block.count == 0 or
+                        compaction.level_b_value_block.count <=
+                        compaction.level_a_value_block.count;
+                    if (index_block.stage == .read_index_block_done and
+                        !compaction.level_b_value_block.full() and
+                        level_b_priority)
+                    {
+                        if (compaction.stage == .beat_quota_done and
+                            compaction.level_b_value_block.count >= 2)
+                        {
+                            // Avoid over-read at the end of the beat.
+                        } else {
+                            if (compaction.pool.?.block_acquire()) |block| {
+                                const read = compaction.pool.?.reads.acquire().?;
+
+                                assert(block.stage == .free);
+                                block.stage = .read_value_block;
+                                compaction.level_b_value_block.push_assume_capacity(block);
+
+                                compaction.read_value_block(.level_b, read, block);
+                                progressed = true;
+                            } else {
+                                assert(compaction.level_b_value_block.count > 0 or
+                                    compaction.output_blocks.count > 0);
+                            }
+                        }
+                    }
+                }
+
+                const level_a_ready_immutable = compaction.table_info_a.? == .immutable and
+                    compaction.level_a_immutable_stage == .ready;
+                const level_a_ready_disk = compaction.table_info_a.? == .disk and
+                    compaction.level_a_value_block.head() != null and
+                    compaction.level_a_value_block.head().?.stage == .read_value_block_done;
+                const level_a_ready = level_a_ready_immutable or level_a_ready_disk;
+
+                const level_a_exhausted_immutable = compaction.table_info_a.? == .immutable and
+                    compaction.level_a_immutable_stage == .exhausted;
+                const level_a_exhausted_disk = compaction.table_info_a.? == .disk and
+                    compaction.level_a_index_block.count == 0 and
+                    compaction.level_a_value_block.count == 0;
+                const level_a_exhausted = level_a_exhausted_immutable or level_a_exhausted_disk;
+
+                const level_b_ready = compaction.level_b_value_block.head() != null and
+                    compaction.level_b_value_block.head().?.stage == .read_value_block_done;
+
+                const level_b_exhausted =
+                    compaction.level_b_index_block.count == 0 and
+                    compaction.level_b_value_block.count == 0;
+                assert((level_a_exhausted and level_b_exhausted) == (compaction.quotas.bar_done()));
+
+                if (compaction.table_builder.state == .index_and_data_block) {
+                    if (level_a_exhausted and level_b_exhausted) {
+                        assert(compaction.stage == .beat_quota_done);
+                    } else if ((level_a_exhausted or level_a_ready) and
+                        (level_b_exhausted or level_b_ready) and
+                        !compaction.table_builder.data_block_full())
+                    {
+                        const cpu = compaction.pool.?.cpus.acquire().?;
+                        compaction.merge(cpu);
+                        progressed = true;
+                    }
+
+                    if (compaction.table_builder.data_block_full() and
+                        // Ensure that it is possible to immediately write the index block.
+                        compaction.output_blocks.spare_capacity() >= 2)
+                    {
+                        const write = compaction.pool.?.writes.acquire().?;
+                        compaction.write_value_block(write, .{
+                            .address = compaction.grid.acquire(compaction.grid_reservation.?),
+                        });
+                        progressed = true;
+                    }
+
+                    if (compaction.table_builder.index_block_full()) {
+                        assert(!compaction.output_blocks.full());
+                        const write = compaction.pool.?.writes.acquire().?;
+                        compaction.write_index_block(write, .{
+                            .address = compaction.grid.acquire(compaction.grid_reservation.?),
+                        });
+                        progressed = true;
+                    }
+                }
+            }
+            assert(!progressed);
+            assert(!compaction.pool.?.idle());
+        }
+
+        fn compaction_dispatch_beat_table_done(compaction: *Compaction) void {
+            assert(compaction.stage == .beat_table_done);
+
+            if (compaction.table_builder.state == .index_and_data_block) {
+                if (!compaction.table_builder.data_block_full()) {
+                    assert(compaction.quotas.bar_done());
+                }
+                if (compaction.table_builder.data_block_empty()) {
+                    const value_block = compaction.table_builder_value_block.?;
+                    compaction.table_builder_value_block = null;
+                    compaction.table_builder.state = .index_block;
+
+                    assert(value_block.stage == .build_value_block);
+                    value_block.stage = .free;
+                    compaction.pool.?.block_release(value_block);
+                } else {
+                    if (!compaction.output_blocks.full()) {
+                        const write = compaction.pool.?.writes.acquire().?;
+                        compaction.write_value_block(write, .{
+                            .address = compaction.grid.acquire(compaction.grid_reservation.?),
+                        });
+                        assert(compaction.table_builder.state == .index_block);
+                        assert(compaction.table_builder_value_block == null);
+                    }
+                }
+            }
+
+            if (compaction.table_builder.state == .index_block and
+                (compaction.table_builder.index_block_full() or compaction.quotas.bar_done()))
+            {
+                if (compaction.table_builder.index_block_empty()) {
+                    assert(compaction.quotas.bar_done());
+                    const index_block = compaction.table_builder_index_block.?;
+                    compaction.table_builder_index_block = null;
+                    compaction.table_builder.state = .no_blocks;
+
+                    assert(index_block.stage == .build_index_block);
+                    index_block.stage = .free;
+                    compaction.pool.?.block_release(index_block);
+                } else {
+                    if (!compaction.output_blocks.full()) {
+                        const write = compaction.pool.?.writes.acquire().?;
+                        compaction.write_index_block(write, .{
+                            .address = compaction.grid.acquire(compaction.grid_reservation.?),
+                        });
+                    }
+                }
+            }
+
+            if (compaction.output_blocks.count > 0) {
+                return;
+            }
+            switch (compaction.table_builder.state) {
+                .no_blocks => {},
+                .index_block => {
+                    assert(!compaction.table_builder.index_block_full());
+                    assert(!compaction.quotas.bar_done());
+                },
+                .index_and_data_block => unreachable,
+            }
+
+            while (compaction.level_a_value_block.head()) |block| {
+                if (block.stage == .read_value_block) {
+                    return;
+                }
+                assert(block.stage == .read_value_block_done);
+                compaction.counters.wasted +=
+                    Table.data_block_values_used(block.ptr).len;
+
+                _ = compaction.level_a_value_block.pop();
+                block.stage = .free;
+                block.last_block_in_the_table = false;
+                compaction.pool.?.block_release(block);
+            }
+            assert(compaction.level_a_value_block.count == 0);
+            compaction.level_a_value_block_next = 0;
+
+            while (compaction.level_a_index_block.head()) |block| {
+                if (block.stage == .read_index_block) {
+                    return;
+                }
+                assert(block.stage == .read_index_block_done);
+                _ = compaction.level_a_index_block.pop();
+                block.stage = .free;
+                compaction.pool.?.block_release(block);
+            }
+            assert(compaction.level_a_index_block.count == 0);
+            compaction.level_a_index_block_next = 0;
+
+            while (compaction.level_b_value_block.head()) |block| {
+                if (block.stage == .read_value_block) {
+                    return;
+                }
+                assert(block.stage == .read_value_block_done);
+                compaction.counters.wasted +=
+                    Table.data_block_values_used(block.ptr).len;
+
+                _ = compaction.level_b_value_block.pop();
+                block.stage = .free;
+                block.last_block_in_the_table = false;
+                compaction.pool.?.block_release(block);
+            }
+            assert(compaction.level_b_value_block.count == 0);
+            compaction.level_b_value_block_next = 0;
+
+            while (compaction.level_b_index_block.head()) |block| {
+                if (block.stage == .read_index_block) {
+                    return;
+                }
+                assert(block.stage == .read_index_block_done);
+                _ = compaction.level_b_index_block.pop();
+                block.stage = .free;
+                compaction.pool.?.block_release(block);
+            }
+            assert(compaction.level_b_index_block.count == 0);
+            compaction.level_b_index_block_next = 0;
+
+            // When computing wastage from over-read blocks, we don't bother accounting for
+            // partially consumed blocks and instead compensate here.
+            if (compaction.table_info_a.? == .disk) {
+                compaction.counters.wasted -= compaction.level_a_position.value;
+            }
+            compaction.counters.wasted -= compaction.level_b_position.value;
+            compaction.grid.trace.stop(.compact_beat, .{
+                .tree = compaction.tree.config.name,
+                .level_b = compaction.level_b,
+            });
+            compaction.beat_complete();
+        }
+
+        fn read_index_block(
+            compaction: *Compaction,
+            level: enum { level_a, level_b },
+            read: *ResourcePool.BlockRead,
+            index_block: *ResourcePool.Block,
+        ) void {
+            assert(compaction.stage == .beat or compaction.stage == .beat_quota_done);
+            assert(index_block.stage == .read_index_block);
+            switch (level) {
+                .level_a => assert(compaction.level_a_position.index_block == 0),
+                .level_b => assert(
+                    compaction.level_b_index_block_next < compaction.range_b.?.tables.count(),
+                ),
+            }
+
+            const table_ref = switch (level) {
+                .level_a => compaction.table_info_a.?.disk,
+                .level_b => compaction.range_b.?.tables.get(compaction.level_b_index_block_next),
+            };
+            read.block = index_block;
+            read.compaction = compaction;
+            compaction.grid.read_block(
+                .{ .from_local_or_global_storage = read_index_block_callback },
+                &read.grid_read,
+                table_ref.table_info.address,
+                table_ref.table_info.checksum,
+                .{ .cache_read = true, .cache_write = true },
+            );
+            switch (level) {
+                .level_a => compaction.level_a_index_block_next += 1,
+                .level_b => compaction.level_b_index_block_next += 1,
+            }
+        }
+
+        fn read_index_block_callback(grid_read: *Grid.Read, index_block: BlockPtrConst) void {
+            const read: *ResourcePool.BlockRead = @fieldParentPtr("grid_read", grid_read);
+            const compaction: *Compaction = read.parent(Compaction);
+            const block = read.block;
+            compaction.pool.?.reads.release(read);
+
+            assert(block.stage == .read_index_block);
+            stdx.copy_disjoint(.exact, u8, block.ptr, index_block);
+            block.stage = .read_index_block_done;
+            compaction.compaction_dispatch();
+        }
+
+        fn read_value_block(
+            compaction: *Compaction,
+            level: enum { level_a, level_b },
+            read: *ResourcePool.BlockRead,
+            value_block: *ResourcePool.Block,
+        ) void {
+            assert(compaction.stage == .beat or compaction.stage == .beat_quota_done);
+            assert(value_block.stage == .read_value_block);
+            if (level == .level_a) assert(compaction.table_info_a.? == .disk);
+
+            const index_block = switch (level) {
+                .level_a => compaction.level_a_index_block.head().?,
+                .level_b => compaction.level_b_index_block.head().?,
+            };
+            const value_block_index = switch (level) {
+                .level_a => compaction.level_a_value_block_next,
+                .level_b => compaction.level_b_value_block_next,
+            };
+
+            const index_schema = schema.TableIndex.from(index_block.ptr);
+
+            const value_block_address =
+                index_schema.data_addresses_used(index_block.ptr)[value_block_index];
+            const value_block_checksum =
+                index_schema.data_checksums_used(index_block.ptr)[value_block_index];
+
+            read.block = value_block;
+            read.compaction = compaction;
+            compaction.grid.read_block(
+                .{ .from_local_or_global_storage = read_value_block_callback },
+                &read.grid_read,
+                value_block_address,
+                value_block_checksum.value,
+                .{ .cache_read = true, .cache_write = true },
+            );
+
+            switch (level) {
+                .level_a => {
+                    compaction.level_a_value_block_next += 1;
+                    if (compaction.level_a_value_block_next ==
+                        index_schema.data_blocks_used(index_block.ptr))
+                    {
+                        value_block.last_block_in_the_table = true;
+                        const pop = compaction.level_a_index_block.pop().?;
+                        assert(pop.ptr == index_block.ptr);
+                        assert(index_block.stage == .read_index_block_done);
+
+                        compaction.read_value_block_release_table(index_block.ptr);
+                        index_block.stage = .free;
+                        compaction.pool.?.block_release(index_block);
+                        compaction.level_a_value_block_next = 0;
+                    }
+                },
+                .level_b => {
+                    compaction.level_b_value_block_next += 1;
+                    if (compaction.level_b_value_block_next ==
+                        index_schema.data_blocks_used(index_block.ptr))
+                    {
+                        value_block.last_block_in_the_table = true;
+                        const pop = compaction.level_b_index_block.pop().?;
+                        assert(pop.ptr == index_block.ptr);
+                        assert(index_block.stage == .read_index_block_done);
+
+                        compaction.read_value_block_release_table(index_block.ptr);
+                        index_block.stage = .free;
+                        compaction.pool.?.block_release(index_block);
+                        compaction.level_b_value_block_next = 0;
+                    }
+                },
+            }
+        }
+
+        // TODO: Support for LSM snapshots would require us to only remove blocks
+        // that are invisible.
+        fn read_value_block_release_table(
+            compaction: *Compaction,
+            index_block: BlockPtrConst,
+        ) void {
+            const index_schema = schema.TableIndex.from(index_block);
+            const index_block_address = Table.block_address(index_block);
+            const data_block_addresses = index_schema.data_addresses_used(index_block);
+            // Tables are release when the index block is no longer needed. Given that the same
+            // index block can get re-read across the bar, the same table can be released twice.
+            if (compaction.grid.free_set.is_released(index_block_address)) {
+                for (data_block_addresses) |address| {
+                    assert(compaction.grid.free_set.is_released(address));
+                }
+            } else {
+                for (data_block_addresses) |address| {
+                    compaction.grid.free_set.release(address);
+                }
+                compaction.grid.free_set.release(index_block_address);
+            }
+        }
+
+        fn read_value_block_callback(grid_read: *Grid.Read, value_block: BlockPtrConst) void {
+            const read: *ResourcePool.BlockRead = @fieldParentPtr("grid_read", grid_read);
+            const compaction: *Compaction = read.parent(Compaction);
+            const block = read.block;
+            compaction.pool.?.reads.release(read);
+
+            assert(block.stage == .read_value_block);
+            stdx.copy_disjoint(.exact, u8, block.ptr, value_block);
+            block.stage = .read_value_block_done;
+            compaction.counters.in += Table.data_block_values_used(block.ptr).len;
+            compaction.compaction_dispatch();
+        }
+
+        fn merge(compaction: *Compaction, cpu: *ResourcePool.CPU) void {
+            assert(!compaction.quotas.bar_done());
+
+            if (compaction.table_info_a.? == .immutable) {
+                if (compaction.level_a_immutable_stage == .ready) {
+                    compaction.level_a_immutable_stage = .merge;
+                } else assert(compaction.level_a_immutable_stage == .exhausted);
+            } else {
+                if (compaction.level_a_value_block.head()) |block| {
+                    assert(block.stage == .read_value_block_done);
+                    block.stage = .merge;
+                } else assert(compaction.level_b_value_block.head() != null);
+            }
+
+            if (compaction.level_b_value_block.head()) |block| {
+                assert(block.stage == .read_value_block_done);
+                block.stage = .merge;
+            }
+
+            assert(compaction.table_builder.state == .index_and_data_block);
+
+            cpu.compaction = compaction;
+            compaction.grid.on_next_tick(merge_callback, &cpu.next_tick);
+        }
+
+        fn merge_callback(next_tick: *Grid.NextTick) void {
+            const cpu: *ResourcePool.CPU = @fieldParentPtr("next_tick", next_tick);
+            const compaction: *Compaction = cpu.parent(Compaction);
+            compaction.pool.?.cpus.release(cpu);
+            assert(compaction.table_builder.state == .index_and_data_block);
+
+            compaction.grid.trace.start(.compact_beat_merge, .{
+                .tree = compaction.tree.config.name,
+                .level_b = compaction.level_b,
             });
 
-            // Copy variables locally to ensure a tight loop - TODO: Actually benchmark this.
-            const source_local = if (source == .a)
-                beat.source_a_values.?
+            const values_in_a, const values_in_b = compaction.merge_inputs();
+            assert(values_in_a != null or values_in_b != null);
+            inline for (.{ values_in_a, values_in_b }) |values_in| {
+                if (values_in) |values| {
+                    assert(values.len > 0);
+                    assert(values.len <= Table.data.value_count_max);
+                }
+            }
+
+            const values_out = compaction.table_builder
+                .data_block_values()[compaction.table_builder.value_count..];
+
+            // Do the actual merge from inputs to the output (table builder).
+            const merge_result: MergeResult = if (values_in_a == null) blk: {
+                const consumed = values_copy(values_out, values_in_b.?);
+                break :blk .{
+                    .consumed_a = 0,
+                    .consumed_b = consumed,
+                    .dropped = 0,
+                    .produced = consumed,
+                };
+            } else if (values_in_b == null) blk: {
+                if (compaction.drop_tombstones) {
+                    const copy_result = values_copy_drop_tombstones(values_out, values_in_a.?);
+                    break :blk .{
+                        .consumed_a = copy_result.consumed,
+                        .consumed_b = 0,
+                        .dropped = copy_result.dropped,
+                        .produced = copy_result.produced,
+                    };
+                } else {
+                    const consumed = values_copy(values_out, values_in_a.?);
+                    break :blk .{
+                        .consumed_a = consumed,
+                        .consumed_b = 0,
+                        .dropped = 0,
+                        .produced = consumed,
+                    };
+                }
+            } else values_merge(
+                values_out,
+                values_in_a.?,
+                values_in_b.?,
+                compaction.drop_tombstones,
+            );
+
+            compaction.level_a_position.value += merge_result.consumed_a;
+            compaction.level_b_position.value += merge_result.consumed_b;
+            compaction.table_builder.value_count += merge_result.produced;
+
+            if (compaction.table_info_a.? == .immutable) {
+                compaction.counters.in += merge_result.consumed_a;
+            }
+            compaction.counters.dropped += merge_result.dropped;
+
+            compaction.quotas.done += merge_result.consumed_a + merge_result.consumed_b;
+            assert(compaction.table_builder.value_count <= Table.data.value_count_max);
+
+            compaction.merge_advance_position();
+
+            // NB: although all the work here is synchronous, we don't defer trace.stop precisely
+            // to exclude compaction.dispatch call below.
+            compaction.grid.trace.stop(.compact_beat_merge, .{
+                .tree = compaction.tree.config.name,
+                .level_b = compaction.level_b,
+            });
+            compaction.compaction_dispatch();
+        }
+
+        fn merge_inputs(compaction: *Compaction) struct { ?[]const Value, ?[]const Value } {
+            const level_a_values_used: ?[]const Value = values: {
+                switch (compaction.table_info_a.?) {
+                    .immutable => {
+                        if (compaction.level_a_immutable_stage == .merge) {
+                            break :values compaction.table_info_a.?.immutable;
+                        } else {
+                            assert(compaction.level_a_immutable_stage == .exhausted);
+                            break :values null;
+                        }
+                    },
+                    .disk => {
+                        if (compaction.level_a_value_block.head()) |block| {
+                            assert(block.stage == .merge);
+                            break :values Table.data_block_values_used(block.ptr);
+                        } else {
+                            break :values null;
+                        }
+                    },
+                }
+            };
+
+            const level_b_values_used: ?[]const Value = values: {
+                if (compaction.level_b_value_block.head()) |block| {
+                    assert(block.stage == .merge);
+                    break :values Table.data_block_values_used(block.ptr);
+                } else {
+                    break :values null;
+                }
+            };
+            assert(!(level_a_values_used == null and level_b_values_used == null));
+
+            const level_a_values = if (level_a_values_used) |values_used| values: {
+                const values_remaining = values_used[compaction.level_a_position.value..];
+                // Only consume one block at a time so that `blip_merge` never goes over its
+                // target by more than 1 value block.
+                const limit = @min(
+                    Table.data.value_count_max,
+                    values_remaining.len,
+                );
+                break :values values_remaining[0..limit];
+            } else null;
+
+            const level_b_values = if (level_b_values_used) |values_used|
+                values_used[compaction.level_b_position.value..]
             else
-                beat.source_b_values.?;
-            const values_out = bar.table_builder.data_block_values();
-            const values_out_index = bar.table_builder.value_count;
+                null;
 
-            assert(source_local.len > 0);
+            return .{ level_a_values, level_b_values };
+        }
 
-            const len = @min(source_local.len, values_out.len - values_out_index);
-            assert(len > 0);
+        // merge_callback advances just position.values. Here, we implement the carry-flag logic,
+        // advancing value_block and index_block. This is also the place where determine that the
+        // beat's quota of work is done and begin to wind down the dispatch loop.
+        fn merge_advance_position(compaction: *Compaction) void {
+            if (compaction.table_info_a.? == .immutable) {
+                if (compaction.level_a_immutable_stage == .merge) {
+                    if (compaction.level_a_position.value ==
+                        compaction.table_info_a.?.immutable.len)
+                    {
+                        compaction.level_a_position.value_block += 1;
+                        assert(compaction.level_a_position.value_block == 1);
+                        compaction.level_a_position.value = 0;
+                        compaction.level_a_immutable_stage = .exhausted;
+                    } else {
+                        compaction.level_a_immutable_stage = .ready;
+                    }
+                } else {
+                    assert(compaction.level_a_immutable_stage == .exhausted);
+                }
+            } else {
+                if (compaction.level_a_value_block.head()) |value_block| {
+                    assert(value_block.stage == .merge);
+                    if (compaction.level_a_position.value ==
+                        Table.data_block_values_used(value_block.ptr).len)
+                    {
+                        _ = compaction.level_a_value_block.pop();
+                        compaction.level_a_position.value_block += 1;
+                        compaction.level_a_position.value = 0;
+
+                        if (value_block.last_block_in_the_table) {
+                            compaction.level_a_position.index_block += 1;
+                            assert(compaction.level_a_position.index_block == 1);
+                            compaction.level_a_position.value_block = 0;
+                        }
+
+                        value_block.stage = .free;
+                        value_block.last_block_in_the_table = false;
+                        compaction.pool.?.block_release(value_block);
+                    } else {
+                        value_block.stage = .read_value_block_done;
+                    }
+                } else {
+                    assert(compaction.level_a_position.value == 0); // Level A exhausted.
+                }
+            }
+
+            if (compaction.level_b_value_block.head()) |value_block| {
+                assert(value_block.stage == .merge);
+                if (compaction.level_b_position.value ==
+                    Table.data_block_values_used(value_block.ptr).len)
+                {
+                    _ = compaction.level_b_value_block.pop().?;
+                    compaction.level_b_position.value_block += 1;
+                    compaction.level_b_position.value = 0;
+
+                    if (value_block.last_block_in_the_table) {
+                        compaction.level_b_position.index_block += 1;
+                        compaction.level_b_position.value_block = 0;
+                    }
+
+                    value_block.stage = .free;
+                    value_block.last_block_in_the_table = false;
+                    compaction.pool.?.block_release(value_block);
+                } else {
+                    value_block.stage = .read_value_block_done;
+                }
+            } else {
+                assert(compaction.level_b_position.value == 0); // Level B exhausted.
+            }
+
+            if (compaction.quotas.beat_done()) {
+                assert(
+                    compaction.stage == .beat or
+                        compaction.stage == .beat_quota_done,
+                );
+                compaction.stage = .beat_quota_done;
+
+                if (compaction.table_builder.data_block_full() or compaction.quotas.bar_done()) {
+                    compaction.stage = .beat_table_done;
+                }
+            }
+        }
+
+        fn write_value_block(
+            compaction: *Compaction,
+            write: *ResourcePool.BlockWrite,
+            options: struct { address: u64 },
+        ) void {
+            const block = compaction.table_builder_value_block.?;
+            assert(block.stage == .build_value_block);
+            assert(compaction.table_builder.data_block == block.ptr);
+            assert(!compaction.output_blocks.full());
+
+            compaction.counters.out += compaction.table_builder.value_count;
+            compaction.table_builder.data_block_finish(.{
+                .cluster = compaction.grid.superblock.working.cluster,
+                .release = compaction.grid.superblock.working.vsr_state.checkpoint.release,
+                .address = options.address,
+                .snapshot_min = snapshot_min_for_table_output(compaction.op_min),
+                .tree_id = compaction.tree.config.id,
+            });
+            assert(compaction.table_builder.state == .index_block);
+            compaction.table_builder_value_block = null;
+
+            compaction.output_blocks.push_assume_capacity({});
+            block.stage = .write_value_block;
+
+            write.block = block;
+            write.compaction = compaction;
+            compaction.grid.create_block(
+                write_block_callback,
+                &write.grid_write,
+                &write.block.ptr,
+            );
+        }
+
+        fn write_index_block(
+            compaction: *Compaction,
+            write: *ResourcePool.BlockWrite,
+            options: struct { address: u64 },
+        ) void {
+            const block = compaction.table_builder_index_block.?;
+            assert(block.stage == .build_index_block);
+            assert(compaction.table_builder.index_block == block.ptr);
+            assert(!compaction.output_blocks.full());
+
+            const table = compaction.table_builder.index_block_finish(.{
+                .cluster = compaction.grid.superblock.working.cluster,
+                .release = compaction.grid.superblock.working.vsr_state.checkpoint.release,
+                .address = options.address,
+                .snapshot_min = snapshot_min_for_table_output(compaction.op_min),
+                .tree_id = compaction.tree.config.id,
+            });
+            assert(compaction.table_builder.state == .no_blocks);
+            compaction.table_builder_index_block = null;
+
+            compaction.manifest_entries.append_assume_capacity(.{
+                .operation = .insert_to_level_b,
+                .table = table,
+            });
+
+            compaction.output_blocks.push_assume_capacity({});
+            block.stage = .write_index_block;
+
+            write.block = block;
+            write.compaction = compaction;
+            compaction.grid.create_block(
+                write_block_callback,
+                &write.grid_write,
+                &write.block.ptr,
+            );
+        }
+
+        fn write_block_callback(grid_write: *Grid.Write) void {
+            const write: *ResourcePool.BlockWrite = @fieldParentPtr("grid_write", grid_write);
+            const compaction: *Compaction = write.parent(Compaction);
+            const block = write.block;
+            compaction.pool.?.writes.release(write);
+
+            assert(block.stage == .write_value_block or block.stage == .write_index_block);
+            block.stage = .free;
+            compaction.pool.?.block_release(block);
+
+            const popped = compaction.output_blocks.pop();
+            assert(popped != null);
+
+            compaction.compaction_dispatch();
+        }
+
+        // The three functions below are hot CPU loops doing the actual merging, TigerBeetle's data
+        // plane. To reduce the probability of the optimizer getting confused over pointers, don't
+        // use 'self' and instead specify all inputs and outputs explicitly. Its the caller's job to
+        // apply control plane changes to the compaction state.
+        //
+        // TODO: Add micro benchmarks.
+
+        fn values_copy(values_out: []Value, values_in: []const Value) u32 {
+            assert(values_in.len > 0);
+            assert(values_in.len <= Table.data.value_count_max);
+            assert(values_out.len > 0);
+            assert(values_out.len <= Table.data.value_count_max);
+
+            const len: u32 = @intCast(@min(values_in.len, values_out.len));
             stdx.copy_disjoint(
                 .exact,
                 Value,
-                values_out[values_out_index..][0..len],
-                source_local[0..len],
+                values_out[0..len],
+                values_in[0..len],
             );
 
-            if (source == .a) {
-                beat.source_a_values = source_local[len..];
-            } else {
-                beat.source_b_values = source_local[len..];
-            }
-            bar.table_builder.value_count += @as(u32, @intCast(len));
+            return len;
         }
 
-        /// Copy values from table_a to table_b, dropping tombstones as we go.
-        fn copy_drop_tombstones(compaction: *Compaction) void {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
-            assert(bar.drop_tombstones);
+        const CopyDropTombstonesResult = struct {
+            consumed: u32,
+            dropped: u32,
+            produced: u32,
+        };
+        /// Copy values from values_in to values_out, dropping tombstones as we go.
+        fn values_copy_drop_tombstones(
+            values_out: []Value,
+            values_in: []const Value,
+        ) CopyDropTombstonesResult {
+            assert(values_in.len > 0);
+            assert(values_in.len <= Table.data.value_count_max);
+            assert(values_out.len > 0);
+            assert(values_out.len <= Table.data.value_count_max);
 
-            log.debug("blip_merge({s}: merging via copy_drop_tombstones()", .{
-                compaction.tree_config.name,
-            });
-
-            // Copy variables locally to ensure a tight loop - TODO: Actually benchmark this.
-            const source_a_local = beat.source_a_values.?;
-            const values_out = bar.table_builder.data_block_values();
-            var values_in_a_index: usize = 0;
-
-            assert(source_a_local.len > 0);
-            assert(beat.source_b_values.?.len == 0);
-            assert(bar.table_builder.value_count < Table.layout.block_value_count_max);
-
-            var values_out_index = bar.table_builder.value_count;
-
+            var index_in: usize = 0;
+            var index_out: usize = 0;
             // Merge as many values as possible.
-            while (values_in_a_index < source_a_local.len and
-                values_out_index < values_out.len)
+            while (index_in < values_in.len and
+                index_out < values_out.len)
             {
-                const value_a = &source_a_local[values_in_a_index];
-
-                values_in_a_index += 1;
-                // TODO: What's the impact of this check? We could invert it since Table.usage
-                // is comptime known.
-                if (tombstone(value_a)) {
+                const value_in = &values_in[index_in];
+                index_in += 1;
+                if (tombstone(value_in)) {
                     assert(Table.usage != .secondary_index);
                     continue;
                 }
-                values_out[values_out_index] = value_a.*;
-                values_out_index += 1;
+                values_out[index_out] = value_in.*;
+                index_out += 1;
             }
-
-            // Copy variables back out.
-            beat.source_a_values = source_a_local[values_in_a_index..];
-            bar.table_builder.value_count = values_out_index;
+            const copy_result: CopyDropTombstonesResult = .{
+                .consumed = @intCast(index_in),
+                .dropped = @intCast(index_in - index_out),
+                .produced = @intCast(index_out),
+            };
+            assert(copy_result.consumed > 0);
+            assert(copy_result.consumed <= values_in.len);
+            assert(copy_result.dropped <= copy_result.consumed);
+            assert(copy_result.produced <= values_out.len);
+            assert(copy_result.produced == copy_result.consumed - copy_result.dropped);
+            return copy_result;
         }
+
+        const MergeResult = struct {
+            consumed_a: u32,
+            consumed_b: u32,
+            dropped: u32,
+            produced: u32,
+        };
 
         /// Merge values from table_a and table_b, with table_a taking precedence. Tombstones may
         /// or may not be dropped depending on bar.drop_tombstones.
-        fn merge_values(compaction: *Compaction) void {
-            const bar = &compaction.bar.?;
-            const beat = &compaction.beat.?;
+        fn values_merge(
+            values_out: []Value,
+            values_in_a: []const Value,
+            values_in_b: []const Value,
+            drop_tombstones: bool,
+        ) MergeResult {
+            assert(values_in_a.len > 0);
+            assert(values_in_a.len <= Table.data.value_count_max);
+            assert(values_in_b.len > 0);
+            assert(values_in_b.len <= Table.data.value_count_max);
+            assert(values_out.len > 0);
+            assert(values_out.len <= Table.data.value_count_max);
 
-            log.debug("blip_merge({s}: merging via merge_values()", .{compaction.tree_config.name});
+            var index_in_a: usize = 0;
+            var index_in_b: usize = 0;
+            var index_out: usize = 0;
 
-            // Copy variables locally to ensure a tight loop - TODO: Actually benchmark this.
-            const source_a_local = beat.source_a_values.?;
-            const source_b_local = beat.source_b_values.?;
-
-            const values_out = bar.table_builder.data_block_values();
-            var source_a_index: usize = 0;
-            var source_b_index: usize = 0;
-            var values_out_index = bar.table_builder.value_count;
-
-            assert(source_a_local.len > 0);
-            assert(source_b_local.len > 0);
-            assert(bar.table_builder.value_count < Table.layout.block_value_count_max);
-
-            // Merge as many values as possible.
-            while (source_a_index < source_a_local.len and
-                source_b_index < source_b_local.len and
-                values_out_index < values_out.len)
+            while (index_in_a < values_in_a.len and
+                index_in_b < values_in_b.len and
+                index_out < values_out.len)
             {
-                const value_a = &source_a_local[source_a_index];
-                const value_b = &source_b_local[source_b_index];
+                const value_a = &values_in_a[index_in_a];
+                const value_b = &values_in_b[index_in_b];
                 switch (std.math.order(key_from_value(value_a), key_from_value(value_b))) {
                     .lt => {
-                        source_a_index += 1;
-                        if (bar.drop_tombstones and
-                            tombstone(value_a))
-                        {
+                        index_in_a += 1;
+                        if (drop_tombstones and tombstone(value_a)) {
                             assert(Table.usage != .secondary_index);
                             continue;
                         }
-                        values_out[values_out_index] = value_a.*;
-                        values_out_index += 1;
+                        values_out[index_out] = value_a.*;
+                        index_out += 1;
                     },
                     .gt => {
-                        source_b_index += 1;
-                        values_out[values_out_index] = value_b.*;
-                        values_out_index += 1;
+                        index_in_b += 1;
+                        values_out[index_out] = value_b.*;
+                        index_out += 1;
                     },
                     .eq => {
-                        source_a_index += 1;
-                        source_b_index += 1;
+                        index_in_a += 1;
+                        index_in_b += 1;
 
-                        if (Table.usage == .secondary_index) {
+                        if (comptime Table.usage == .secondary_index) {
                             // Secondary index optimization --- cancel out put and remove.
                             assert(tombstone(value_a) != tombstone(value_b));
-                            continue;
-                        } else if (bar.drop_tombstones) {
-                            if (tombstone(value_a)) {
-                                continue;
-                            }
+                        } else {
+                            if (drop_tombstones and tombstone(value_a)) continue;
+                            values_out[index_out] = value_a.*;
+                            index_out += 1;
                         }
-
-                        values_out[values_out_index] = value_a.*;
-                        values_out_index += 1;
                     },
                 }
             }
 
-            // Copy variables back out.
-            beat.source_a_values = source_a_local[source_a_index..];
-            beat.source_b_values = source_b_local[source_b_index..];
-            bar.table_builder.value_count = values_out_index;
+            const merge_result: MergeResult = .{
+                .consumed_a = @intCast(index_in_a),
+                .consumed_b = @intCast(index_in_b),
+                .dropped = @intCast(index_in_a + index_in_b - index_out),
+                .produced = @intCast(index_out),
+            };
+            assert(merge_result.consumed_a > 0 or merge_result.consumed_b > 0);
+            assert(merge_result.consumed_a <= values_in_a.len);
+            assert(merge_result.consumed_b <= values_in_b.len);
+            assert(merge_result.dropped <= merge_result.consumed_a + merge_result.consumed_b);
+            assert(merge_result.produced <= values_out.len);
+            assert(merge_result.produced ==
+                merge_result.consumed_a + merge_result.consumed_b - merge_result.dropped);
+            return merge_result;
         }
     };
 }

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -647,7 +647,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         pub fn compaction_must_drop_tombstones(
             manifest: *const Manifest,
             level_b: u8,
-            range: CompactionRange,
+            range: *const CompactionRange,
         ) bool {
             assert(level_b < constants.lsm_levels);
             assert(range.key_min <= range.key_max);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -147,14 +147,12 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
             for (0..tree.compactions.len) |i| {
                 errdefer for (tree.compactions[0..i]) |*c| c.deinit();
-                tree.compactions[i] = Compaction.init(config, grid, @intCast(i));
+                tree.compactions[i] = Compaction.init(tree, grid, @intCast(i));
             }
             errdefer for (tree.compactions) |*c| c.deinit();
         }
 
         pub fn deinit(tree: *Tree, allocator: mem.Allocator) void {
-            for (&tree.compactions) |*compaction| compaction.deinit();
-
             tree.manifest.deinit(allocator);
             tree.table_immutable.deinit(allocator);
             tree.table_mutable.deinit(allocator);

--- a/src/ring_buffer.zig
+++ b/src/ring_buffer.zig
@@ -159,6 +159,10 @@ pub fn RingBuffer(
             return self.count == self.buffer.len;
         }
 
+        pub inline fn spare_capacity(self: Self) usize {
+            return self.buffer.len - self.count;
+        }
+
         /// Returns whether the ring buffer is completely empty.
         pub inline fn empty(self: Self) bool {
             return self.count == 0;

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -106,9 +106,8 @@ const trace_span_size_max = 1024;
 pub const Event = union(enum) {
     replica_commit,
 
-    compact_blip_read,
-    compact_blip_merge,
-    compact_blip_write,
+    compact_beat,
+    compact_beat_merge,
     compact_manifest,
     compact_mutable,
     compact_mutable_suffix,
@@ -145,9 +144,8 @@ pub const Event = union(enum) {
 
     const event_stack_cardinality = std.enums.EnumArray(EventTag, u32).init(.{
         .replica_commit = 1,
-        .compact_blip_read = 1,
-        .compact_blip_merge = 1,
-        .compact_blip_write = 1,
+        .compact_beat = 1,
+        .compact_beat_merge = 1,
         .compact_manifest = 1,
         .compact_mutable = 1,
         .compact_mutable_suffix = 1,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -59,6 +59,15 @@ comptime {
     assert(constants.lsm_compaction_ops == 4);
 }
 
+test "Cluster: smoke" {
+    const t = try TestContext.init(.{ .replica_count = 1 });
+    defer t.deinit();
+
+    var c = t.clients(0, t.cluster.clients.len);
+    try c.request(checkpoint_2_trigger, checkpoint_2_trigger);
+    try expectEqual(t.replica(.R_).commit(), checkpoint_2_trigger);
+}
+
 test "Cluster: recovery: WAL prepare corruption (R=3, corrupt right of head)" {
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();


### PR DESCRIPTION
Preface: 

I've been hacking on this code for a past couple of days, and, while I am not yet bold enough to hit `./zig/zig build check` button, I am at the point where I desperately need feedback!

I _think_ the overall shape of code should be somewhat clear at this point, even if it is missing a detail or two (I see that I've removed `release_table_blocks`, I probably should be calling that _somewhere_).

Right now, I am at the stage where I am pretty convinced in this new approach, but that's probably simply because I've been staring at this code for quite some time and it makes _too_ much sense to me. So curious WDYT here!

---

Refactor compaction to:
- make the code easier to follow,
- make it less unobvious how the compactions are actually schedules (that is, what work can be in-flight at any given point in time),
- make scheduling a bit more aggressive inside a single compaction (e.g. start merge when the first two value blocks are in, separate IO and block resources),
- make it easier to run several compactions at the same time.

Code Changes
============

* Fewer types
* All tricky logic is centralized in `compaction_dispatch`
* Many FIFOs are replaced with fewer RingBuffers
* Flatten Beat and Bar into compaction

CompactionPipeline no longer implements pipelining. Now, it only deals with scheduling compactions themselves. Pipelining is the job of each individual compaction. That is, CompactonPipeline kicks off a particualar compaciton, and recieves the control back only when that compaciton's beat is done.

CompactionPipeline should be rename to CompactionSchedule, or maybe just merged with a forest.

A new type, CompactionPool, is introduced. This is a bag of all resources shared by compactions. Previously, blocks, reads and writes were lumped together. Now, CompactionPool holds separate IOPS for reads, writes, blocks, and CPUS.

CompactionPool is a forest-level object, but it _doesn't_ depend on the type of the forest. So, all compactions share the same CompactionPool _type_, which allows them to share the actual object.

The actual pipelining logic is moved to `Compaction.compaction_dispatch` function. This function no longer tries to _explicitly_ encode a pipeline. Rather, it is just a loop that spawns a bunch of jobs, and the pipelining happens as a side-effect of that. The pseudo-code for compaction_dispatch is:

    for each job:
        if have resources for the job AND
           job's dependencies are fulfilled AND
           it makes sense to start the job:

           start the job

Here, the jobs are reading the index blocks, reading the value blocks, merging/copying, writing the data blocks, writing the index blocks. Resources are blocks (memory) and grid reads&writes. Dependencies are blocks read previously by other jobs (reading a value block needs an index block). The "makes sense" part coves:
- spreading resources across jobs to avoid deadlocks,
- avoiding overreads when finishing a beat-worth of work.

There _isn't_ some kind of comptime meta programming framework for defining jobs, it's just a good old pile of ifs (pushed up to the `compaction_dispatch` cental location).

Dependency tracking is done via RingBuffers. For example, there's a RingBuffer of level_b value blocks. Blocks are added to this queue in order when we _start_ the corrsponding read. When we finish the read, we flip the status of block (which is in the queue at this point) to `read_done`.

So, when we think about launching a merge, we check that:

- there's a head value block in the queue
- the status of this block is `read_done`

If the merge ends up fully consuming the block, it pops it off the queue and adds back to the shared pool.

This setup is similar to a bunch of fifos we used before, but:

* With ring-buffers, so that it's statically obvious what's the upper bound for the size of the queue.
* Queues are matched to block kind (value block/index block/output block) rather than to it's lifetime stage (pending/reading etc).
* There are just fewer queues (I think, didn't actually count).

Behavior Changes
================

* Separate limits for memory, CPU, and IO resources.
* Aggressive scheduling -- start merge as soon as the first two blocks are in
* Running two compactions just work, given enough resources.
* A different "winding down" approach.

Previously, allocating a block for compaction also allocated a grid read and a grid write. In the new approach, those are allocated separately. Additionally, besides available resources there are static limits on the amount of outstanding work. That is, RingBuffers for blocks are statically sized, so you can't read more than X blocks at the same time even if you have spare blocks.

For simplicity, it is assumed that there's actually enough reads and writes to fill the queues fully, but the approach should work even if you restrict _all_ compactions to just a single read and a single write.

The blocks are distributed in a priority round-robin fashion. That is, we first give block to the table builder, and then alternate between level b and level a. This way:

* We avoid deadlocks: if the number of blocks is larger than a minimum, than the jobs will be scheduled in the right order to avoid running out of blocks completely
* We give equal resources to level a and level b (the approach should be extensible to fair allocation, proportional to level "size")
* The schedule ends up being maximally pipelined (the first four reads are: level_a index, level_b index, level_b value, level_a value, which allows starting the merge ASAP).

I _think_ this schedule allows even for a simplistic strategy for running several compactions: if you have N*min blocks, it would be correct to start N compactions at the same time. At least one of them will be guaranteed to be able to proceed. This scheme is simplistic, because:
- a single compaction can monopolize an unfair share of resources. Compactions are greedy.
- there's no code path for "if compaction A frees resource X, wake up compaction B waiting on X".

Both points should be fixable I think though!

Another difference (I think) happens in the "winding down" phase. That is, in what happens when the compaction consumed the required quota of inputs, but haven't yet produced a full value table of output. This is a tricky situation, because, depending on the tombstones, you might have to read quite a bit more tables still. The worst case here is that you have a full table on level A, a full table on level B, but their merge is an empty set.

In the previous approach, due to explicit pipelining, we'll just loop over:

    loop {
        read fixed number of blocks from level
        run merge
    }

In the new approach, this is handled by `AND it makes sense to start the job` part of the pseudocode --- if we _are_ in the winding-down phase, we just artificially limit the depth of our RingBuffers.

Such overreads are tracked via `values_wasted_count`.