### PR TITLE
vopr: core_missing_prepare detects replicas stuck repairing headers

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -362,8 +362,6 @@ pub fn main() !void {
             stdx.unimplemented("repair requires reachable primary");
         } else if (simulator.core_missing_quorum()) {
             output.warn("no liveness, core replicas cannot view-change", .{});
-        } else if (simulator.core_missing_header()) |header| {
-            output.warn("no liveness, op={} is not available in core", .{header.op});
         } else if (simulator.core_missing_prepare()) |header| {
             output.warn("no liveness, op={} is not available in core", .{header.op});
         } else if (try simulator.core_missing_blocks(allocator)) |blocks| {
@@ -670,51 +668,10 @@ pub const Simulator = struct {
         return quorums.view_change > core_replicas - core_recovering_head;
     }
 
-    // Returns a header which can't be repaired by the core due to storage faults.
-    //
-    // When generating a FaultAtlas, we don't try to protect core from excessive errors. Instead,
-    // if the core gets stuck, we verify that this is indeed due to storage faults.
-    pub fn core_missing_header(simulator: *const Simulator) ?vsr.Header.Prepare {
-        assert(simulator.core.count() > 0);
-
-        // Don't check for missing uncommitted ops (since the StateChecker does not record them).
-        // There may be uncommitted ops due to pulses/upgrades sent during liveness mode.
-        const commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
-        var missing_op: ?u64 = null;
-        for (simulator.cluster.replicas) |replica| {
-            if (simulator.core.isSet(replica.replica) and !replica.standby()) {
-                assert(simulator.cluster.replica_health[replica.replica] == .up);
-                if (replica.op > replica.commit_min) {
-                    if (replica.journal.find_latest_headers_break_between(
-                        replica.commit_min,
-                        @min(replica.op, commit_max),
-                    )) |range| {
-                        // Find largest missing header as we repair headers from high -> low ops.
-                        if (missing_op == null or missing_op.? < range.op_max) {
-                            missing_op = range.op_max;
-                        }
-                    }
-                }
-            }
-        }
-        if (missing_op == null) return null;
-
-        const missing_header = simulator.cluster.state_checker.header_with_op(missing_op.?);
-
-        for (simulator.cluster.replicas) |replica| {
-            if (simulator.core.isSet(replica.replica) and !replica.standby()) {
-                if (replica.journal.has_clean(&missing_header)) {
-                    // Prepare *was* found on an active core replica, so the header isn't
-                    // actually missing.
-                    return null;
-                }
-            }
-        }
-
-        return missing_header;
-    }
-
     // Returns a header for a prepare which can't be repaired by the core due to storage faults.
+    //
+    // If a replica cannot make progress on committing, then it may be stuck while repairing either
+    // missing headers *or* prepares (see `repair` in replica.zig). This function checks for both.
     //
     // When generating a FaultAtlas, we don't try to protect core from excessive errors. Instead,
     // if the core gets stuck, we verify that this is indeed due to storage faults.
@@ -725,16 +682,31 @@ pub const Simulator = struct {
         // There may be uncommitted ops due to pulses/upgrades sent during liveness mode.
         const commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
 
-        var missing_op: ?u64 = null;
+        var missing_header_op: ?u64 = null;
+        var missing_prepare_op: ?u64 = null;
+
         for (simulator.cluster.replicas) |replica| {
             if (simulator.core.isSet(replica.replica) and !replica.standby()) {
                 assert(simulator.cluster.replica_health[replica.replica] == .up);
                 if (replica.op > replica.commit_min) {
-                    for (replica.commit_min + 1..@min(replica.op, commit_max) + 1) |op| {
-                        const header = simulator.cluster.state_checker.header_with_op(op);
-                        if (!replica.journal.has_clean(&header)) {
-                            if (missing_op == null or missing_op.? > op) {
-                                missing_op = op;
+                    // Check if replica was stuck while repairing headers. Find largest missing
+                    // header as we repair headers from high -> low ops.
+                    if (replica.journal.find_latest_headers_break_between(
+                        replica.commit_min,
+                        @min(replica.op, commit_max),
+                    )) |range| {
+                        if (missing_header_op == null or missing_header_op.? < range.op_max) {
+                            missing_header_op = range.op_max;
+                        }
+                    } else {
+                        // Check if replica was stuck while repairing prepares. Find smallest
+                        // missing prepare as we repair prepares from low -> high ops.
+                        for (replica.commit_min + 1..@min(replica.op, commit_max) + 1) |op| {
+                            const header = simulator.cluster.state_checker.header_with_op(op);
+                            if (!replica.journal.has_clean(&header)) {
+                                if (missing_prepare_op == null or missing_prepare_op.? > op) {
+                                    missing_prepare_op = op;
+                                }
                             }
                         }
                     }
@@ -742,9 +714,10 @@ pub const Simulator = struct {
             }
         }
 
-        if (missing_op == null) return null;
+        if (missing_header_op == null and missing_prepare_op == null) return null;
 
-        const missing_header = simulator.cluster.state_checker.header_with_op(missing_op.?);
+        const missing_op = if (missing_header_op) |op| op else missing_prepare_op.?;
+        const missing_header = simulator.cluster.state_checker.header_with_op(missing_op);
 
         for (simulator.cluster.replicas) |replica| {
             if (simulator.core.isSet(replica.replica) and !replica.standby()) {


### PR DESCRIPTION
Fixes the failed seed `./zig/zig build -Drelease vopr -- 7036583507627146912` on main ([4c4e536](https://github.com/tigerbeetle/tigerbeetle/commit/4c4e53625ae97b0157c7ddd5c57c75bf7afa781f)). This PR adds `core_missing_header`, which finds the _highest header op_ (since headers are repaired from highest → lowest missing op) that is also missing on all replicas in the core.

### Detailed root cause analysis
In this VOPR seed, R0 and R2 are found stuck in view change wherein:
* R2 (self.op=123, op_checkpoint=119) has a corrupt _prepare_ for op=121
* R0 (self.op=122, op_checkpoint=99) is missing _headers_ from 110 → 121 (it performed state sync to reach op_checkpoint=99)
* R0 can't repair headers beyond op=122 since prepare for op=121 is corrupted on R2
* R2 can't commit past op 120 since prepare for op=121 is corrupted
* Neither R0 nor R2 can commit all the ops in their journal to step up as primary

The issue here is that `core_missing_prepare` looks for the smallest missing _prepare_ (likely assuming that the header chain is intact and the commit pipeline is stuck because of a missing prepare), and checks if it is missing on the core. https://github.com/tigerbeetle/tigerbeetle/blob/4a8eb61f8001cc24f89b665c5af17b7011e9eb74/src/vopr.zig#L690-L691

However, a stuck commit pipeline could also be caused by missing _headers_, as we don't start committing till we've repaired all of our headers up till our head op.
https://github.com/tigerbeetle/tigerbeetle/blob/4a8eb61f8001cc24f89b665c5af17b7011e9eb74/src/vsr/replica.zig#L6442-L6448