### PR TITLE
vsr: potential primaries updating their SV may have gaps in journal

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1293,13 +1293,6 @@ const ViewChangeHeadersSlice = struct {
         // A SV never includes gaps or faulty headers.
         assert(Headers.dvc_header_type(head) == .valid);
 
-        if (headers.command == .start_view) {
-            assert(headers.slice.len >= @min(
-                constants.view_change_headers_suffix_max,
-                head.op + 1, // +1 to include the head itself.
-            ));
-        }
-
         var child = head;
         for (headers.slice[1..], 0..) |*header, i| {
             const index = i + 1;
@@ -1318,7 +1311,14 @@ const ViewChangeHeadersSlice = struct {
 
             switch (Headers.dvc_header_type(header)) {
                 .blank => {
-                    assert(headers.command == .do_view_change);
+                    // We can't verify that SV headers contain no gaps headers here:
+                    // superblock.checkpoint could make .do_view_change headers durable instead of
+                    // .start_view headers when view == log_view (see `commit_checkpoint_superblock`
+                    // in `replica.zig`). When these headers are loaded from the superblock on
+                    // startup, they are considered to be .start_view headers (see `vsr_headers` in
+                    // `superblock.zig`).
+                    maybe(headers.command == .do_view_change);
+                    maybe(headers.command == .start_view);
                     continue; // Don't update "child".
                 },
                 .valid => {


### PR DESCRIPTION
This PR fixes the failed seed `./zig/zig build vopr -- --lite 17467401530694012113` on main ([4c4e536](https://github.com/tigerbeetle/tigerbeetle/commit/4c4e53625ae97b0157c7ddd5c57c75bf7afa781f)). In this seed, a potential primary attempted to update its start_view headers (assuming it had no gaps from commit_min →  self.op) _before_ it finished repair (before invoking `superblock.checkpoint`).

### Solution

We now make do_view_change headers durable for potential primaries, instead of start_view headers. This is because a potential primary performing `superblock.checkpoint` is not guaranteed to have no gaps from commit_min →  self.op.
 
However, to achieve this, we now have to loosen verification while loading view_headers stored in the superblock. This is because we may end up finding _either_ do_view_change/start_view headers in our superblock even when `log_view == view`. 
https://github.com/tigerbeetle/tigerbeetle/blob/4a8eb61f8001cc24f89b665c5af17b7011e9eb74/src/vsr/superblock.zig#L454-L462

### Detailed Backstory

When we introduced the change (https://github.com/tigerbeetle/tigerbeetle/pull/2313) for making view_headers durable during `superblock.checkpoint`, we were under the impression that a potential primary (replica in .view_change that is repairing to become primary) is guaranteed to have no gaps from _commit_min →  self.op_ while creating its start_view headers. 
https://github.com/tigerbeetle/tigerbeetle/blob/4a8eb61f8001cc24f89b665c5af17b7011e9eb74/src/vsr/replica.zig#L4855-L4857

This understanding hinges on the assumption that a potential primary only starts committing (and therefore checkpointing) _after_ repairing its header hash chain up till self.op.
https://github.com/tigerbeetle/tigerbeetle/blob/4a8eb61f8001cc24f89b665c5af17b7011e9eb74/src/vsr/replica.zig#L6442-L6448

While this understanding is _correct_, it is *imprecise*. It does not cater to the case where a replica starts committing the checkpoint_trigger op in a *previous log_view*, but reaches the `checkpoint_superblock` state in a log_view in which it is a potential primary. 
https://github.com/tigerbeetle/tigerbeetle/blob/4a8eb61f8001cc24f89b665c5af17b7011e9eb74/src/vsr/replica.zig#L3628-L3629

