### PR TITLE
ci: try to extract better logging out of upgrade test

### DIFF
--- a/src/shell.zig
+++ b/src/shell.zig
@@ -402,6 +402,7 @@ pub fn exec_options(
     shell: *Shell,
     options: struct {
         stdin_slice: ?[]const u8 = null,
+        timeout_ns: u64 = 10 * std.time.ns_per_min,
     },
     comptime cmd: []const u8,
     cmd_args: anytype,
@@ -411,6 +412,7 @@ pub fn exec_options(
 
     return exec_inner(shell, argv.slice(), .{
         .stdin_slice = options.stdin_slice,
+        .timeout_ns = options.timeout_ns,
     });
 }
 


### PR DESCRIPTION
Before this PR, an upgrade test could succeed, fail immediately, or hang. After this PR, the possible outcomes are a success, or a failure after 10 minutes. That is, we eliminate hangs at the cost of making over failures slower. I think the trade is perhaps worth it!

This is the 100500 instance where we are in need of async process management API, where we want to run a bunch of processes, kill them on timeout, react to processes crashing themselves, and doing general evented IPC.

As usual, we solve this in an ad-hoc way, by combining thread-spawning with hacky APIs and suboptimal behavior.

I am _this_ close to adding process management syscalls to out async IO library and rewriting shell.zig on top of that :-)