### PR TITLE
Restructure benchmark around generalized workloads

### DIFF
--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -30,6 +30,7 @@ const StatsD = vsr.statsd.StatsD;
 const IdPermutation = vsr.testing.IdPermutation;
 const ZipfianGenerator = stdx.ZipfianGenerator;
 const ZipfianShuffled = stdx.ZipfianShuffled;
+const Distribution = cli.Command.Benchmark.Distribution;
 
 const cli = @import("./cli.zig");
 
@@ -211,45 +212,161 @@ pub fn main(
     }
     benchmark.done = false;
 
-    benchmark.create_accounts();
+    // benchmark.create_accounts();
 
-    while (!benchmark.done) {
-        benchmark.client.tick();
-        try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
-    }
-    benchmark.done = false;
+    // while (!benchmark.done) {
+    //     benchmark.client.tick();
+    //     try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+    // }
+    // benchmark.done = false;
 
-    if (cli_args.checksum_performance) {
-        const stdout = std.io.getStdOut().writer();
-        stdout.print("\nmessage size max = {} bytes\n", .{
-            constants.message_size_max,
-        }) catch unreachable;
+    // if (cli_args.checksum_performance) {
+    //     const stdout = std.io.getStdOut().writer();
+    //     stdout.print("\nmessage size max = {} bytes\n", .{
+    //         constants.message_size_max,
+    //     }) catch unreachable;
 
-        const buffer = try allocator.alloc(u8, constants.message_size_max);
-        defer allocator.free(buffer);
-        benchmark.rng.fill(buffer);
+    //     const buffer = try allocator.alloc(u8, constants.message_size_max);
+    //     defer allocator.free(buffer);
+    //     benchmark.rng.fill(buffer);
 
-        benchmark.timer.reset();
-        _ = vsr.checksum(buffer);
-        const checksum_duration_ns = benchmark.timer.read();
+    //     benchmark.timer.reset();
+    //     _ = vsr.checksum(buffer);
+    //     const checksum_duration_ns = benchmark.timer.read();
 
-        stdout.print("checksum message size max = {} us\n", .{
-            @divTrunc(checksum_duration_ns, std.time.ns_per_us),
-        }) catch unreachable;
-    }
+    //     stdout.print("checksum message size max = {} us\n", .{
+    //         @divTrunc(checksum_duration_ns, std.time.ns_per_us),
+    //     }) catch unreachable;
+    // }
 
-    if (!benchmark.validate) return;
+    // if (!benchmark.validate) return;
 
-    // Reset our state so we can check our work.
-    benchmark.rng = rng;
-    benchmark.account_index = 0;
-    benchmark.transfer_index = 0;
-    benchmark.validate_accounts();
+    // // Reset our state so we can check our work.
+    // benchmark.rng = rng;
+    // benchmark.account_index = 0;
+    // benchmark.transfer_index = 0;
+    // benchmark.validate_accounts();
 
-    while (!benchmark.done) {
-        benchmark.client.tick();
-        try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
-    }
+    // while (!benchmark.done) {
+    //     benchmark.client.tick();
+    //     try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+    // }
+
+    var workloads =
+        try std.ArrayListUnmanaged(Workload).initCapacity(allocator, 0);
+    defer workloads.deinit(allocator);
+
+    try workloads.appendSlice(allocator, &[_]Workload{
+        // The "setup" workload that generates the starting state of the database,
+        // currently just `account_count` accounts.
+        Workload {
+            .operation_count = cli_args.account_count,
+
+            .create_accounts_weight = 100,
+            .create_transfers_weight = 0,
+            .get_account_balances_weight = 0,
+            .get_account_transfers_weight = 0,
+            .lookup_accounts_weight = 0,
+            .lookup_transfers_weight = 0,
+            .query_accounts_weight = 0,
+            .query_transfers_weight = 0,
+
+            .create_accounts_batch_size = cli_args.account_batch_size,
+            .create_transfers_batch_size = cli_args.transfer_batch_size,
+
+            .account_distribution_debit = Distribution.uniform,
+            .account_distribution_credit = Distribution.uniform,
+            .account_distribution_query = Distribution.uniform,
+
+            .flag_history = cli_args.flag_history,
+            .flag_imported = cli_args.flag_imported,
+            .transfer_pending = cli_args.transfer_pending,
+        },
+        // The main workload, currently just generating `transfer_count` transfers.
+        Workload {
+            .operation_count = cli_args.transfer_count,
+
+            .create_accounts_weight = 0,
+            .create_transfers_weight = 100,
+            .get_account_balances_weight = 0,
+            .get_account_transfers_weight = 0,
+            .lookup_accounts_weight = 0,
+            .lookup_transfers_weight = 0,
+            .query_accounts_weight = 0,
+            .query_transfers_weight = 0,
+
+            .create_accounts_batch_size = cli_args.account_batch_size,
+            .create_transfers_batch_size = cli_args.transfer_batch_size,
+
+            .account_distribution_debit = cli_args.account_distribution,
+            .account_distribution_credit = cli_args.account_distribution,
+            .account_distribution_query = cli_args.account_distribution,
+
+            .flag_history = cli_args.flag_history,
+            .flag_imported = cli_args.flag_imported,
+            .transfer_pending = cli_args.transfer_pending,
+        },
+        // The default query workload.
+        Workload {
+            .operation_count = cli_args.query_count,
+
+            .create_accounts_weight = 0,
+            .create_transfers_weight = 0,
+            .get_account_balances_weight = 0,
+            .get_account_transfers_weight = 100,
+            .lookup_accounts_weight = 0,
+            .lookup_transfers_weight = 0,
+            .query_accounts_weight = 0,
+            .query_transfers_weight = 0,
+
+            .create_accounts_batch_size = cli_args.account_batch_size,
+            .create_transfers_batch_size = cli_args.transfer_batch_size,
+
+            .account_distribution_debit = cli_args.account_distribution,
+            .account_distribution_credit = cli_args.account_distribution,
+            .account_distribution_query = cli_args.account_distribution,
+
+            .flag_history = cli_args.flag_history,
+            .flag_imported = cli_args.flag_imported,
+            .transfer_pending = cli_args.transfer_pending,
+        },
+        // An example workload of multiple interleaved operations.
+        Workload {
+            .operation_count = cli_args.account_count + cli_args.transfer_count + cli_args.query_count,
+
+            .create_accounts_weight = 33,
+            .create_transfers_weight = 33,
+            .get_account_balances_weight = 0,
+            .get_account_transfers_weight = 33,
+            .lookup_accounts_weight = 0,
+            .lookup_transfers_weight = 0,
+            .query_accounts_weight = 0,
+            .query_transfers_weight = 0,
+
+            .create_accounts_batch_size = cli_args.account_batch_size,
+            .create_transfers_batch_size = cli_args.transfer_batch_size,
+
+            .account_distribution_debit = cli_args.account_distribution,
+            .account_distribution_credit = cli_args.account_distribution,
+            .account_distribution_query = cli_args.account_distribution,
+
+            .flag_history = cli_args.flag_history,
+            .flag_imported = cli_args.flag_imported,
+            .transfer_pending = cli_args.transfer_pending,
+        }
+    });
+
+    try run_workloads(
+        allocator,
+        benchmark.io,
+        benchmark.client,
+        workloads.items,
+        account_id_permutation,
+        .{
+            .rng_seed = seed,
+            .validate = cli_args.validate,
+        },
+    );
 }
 
 const Generator = union(enum) {
@@ -258,7 +375,7 @@ const Generator = union(enum) {
     uniform,
 
     fn from_distribution(
-        distribution: cli.Command.Benchmark.Distribution,
+        distribution: Distribution,
         count: u64,
         random: std.Random,
     ) Generator {
@@ -271,6 +388,14 @@ const Generator = union(enum) {
             },
             .uniform => .uniform,
         };
+    }
+
+    fn grow(self: *Generator, count: u64, random: std.Random) void {
+        switch (self.*) {
+            .zipfian => |*d| d.grow(count, random),
+            .latest => |*d| d.grow(count),
+            .uniform => {},
+        }
     }
 };
 
@@ -809,3 +934,1569 @@ fn print_percentiles_histogram(
         }) catch unreachable;
     }
 }
+
+/// Run a series of deterministic workloads against the database.
+///
+/// After each workload print a summary.
+/// Optionally run a second validation pass that checks the state
+/// of the database against the transactions generated by each workload.
+fn run_workloads(
+    allocator: std.mem.Allocator,
+    io: *IO,
+    client: *Client,
+    workloads: []const Workload,
+    id_permutation: IdPermutation,
+    options: struct {
+        rng_seed: u64,
+        validate: bool,
+    },
+) !void {
+    const stdout = std.io.getStdOut().writer().any();
+
+    const modes = if (!options.validate)
+        &[_]WorkloadRunMode{.transact}
+    else
+        &[_]WorkloadRunMode{.transact, .validate}
+    ;
+
+    for (modes) |mode| {
+        var account_index: u64 = 0;
+        var transfer_index: u64 = 0;
+
+        for (workloads, 0..) |*workload, i| {
+
+            switch (mode) {
+                .transact => {
+                    try stdout.print("Running transactional workload {}\n", .{i});
+                },
+                .validate => {
+                    try stdout.print("Running validation workload {}\n", .{i});
+                },
+            }
+
+            var workload_runner = try WorkloadRunner.init(.{
+                .allocator = allocator,
+                .workload = workload,
+                .workload_index = i,
+                .mode = mode,
+                .client = client,
+                .rng_seed = options.rng_seed,
+                .id_permutation = id_permutation,
+                .account_index_committed = account_index,
+                .transfer_index_committed = transfer_index,
+            });
+            defer workload_runner.deinit();
+
+            workload_runner.run();
+
+            while (!workload_runner.done) {
+                client.tick();
+                try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+            }
+
+            try workload_runner.print_summary(stdout);
+
+            const next_world_state = workload_runner.world_state();
+            account_index = next_world_state.account_index;
+            transfer_index = next_world_state.transfer_index;
+        }
+    }
+
+}
+
+/// A description of a workload.
+///
+/// Each workload is defined by a total number of operations to perform,
+/// and a probabilistic combination of all types of operation
+/// supported by TigerBeetle, as defined by the various `weight` fields.
+/// If e.g. only one `weight` field is non-zero, then the workload will consist
+/// of a single type of operation.
+///
+/// Operations that can be batched have a defined batch size, and will only
+/// submit batches of exactly that size, except for the final batch,
+/// which will be whatever size is necessary to fulfill the required number
+/// of operations.
+///
+/// In various transactions and queries, ids are selected by a specific
+/// random distribution, as defined by the `Distribution` type.
+const Workload = struct {
+    operation_count: usize,
+
+    create_accounts_weight: u64,
+    create_transfers_weight: u64,
+    get_account_balances_weight: u64,
+    get_account_transfers_weight: u64,
+    lookup_accounts_weight: u64,
+    lookup_transfers_weight: u64,
+    query_accounts_weight: u64,
+    query_transfers_weight: u64,
+
+    create_accounts_batch_size: u64,
+    create_transfers_batch_size: u64,
+
+    account_distribution_debit: Distribution,
+    account_distribution_credit: Distribution,
+    account_distribution_query: Distribution,
+
+    flag_history: bool,
+    flag_imported: bool,
+    transfer_pending: bool,
+
+    fn total_operation_weight(self: *const Workload) u64 {
+        return self.create_accounts_weight +
+            self.create_transfers_weight +
+            self.get_account_balances_weight +
+            self.get_account_transfers_weight +
+            self.lookup_accounts_weight +
+            self.lookup_transfers_weight +
+            self.query_accounts_weight +
+            self.query_transfers_weight;
+    }
+
+    fn next_operation_type(
+        self: *const Workload,
+        random: std.Random,
+    ) StateMachine.Operation {
+        const OptionTuple = struct { u64, StateMachine.Operation };
+        const options = [_]OptionTuple{
+            .{ self.create_accounts_weight, StateMachine.Operation.create_accounts },
+            .{ self.create_transfers_weight, StateMachine.Operation.create_transfers },
+            .{ self.get_account_balances_weight, StateMachine.Operation.get_account_balances },
+            .{ self.get_account_transfers_weight, StateMachine.Operation.get_account_transfers },
+            .{ self.lookup_accounts_weight, StateMachine.Operation.lookup_accounts },
+            .{ self.lookup_transfers_weight, StateMachine.Operation.lookup_transfers },
+            .{ self.query_accounts_weight, StateMachine.Operation.query_accounts },
+            .{ self.query_transfers_weight, StateMachine.Operation.query_transfers },
+        };
+
+        const rand_max = self.total_operation_weight();
+        assert(rand_max > 0);
+        var num = random.uintLessThan(u64, rand_max);
+
+        for (options) |option| {
+            const weight = option[0];
+            const operation = option[1];
+            if (num < weight) {
+                return operation;
+            } else {
+                num -= weight;
+            }
+        }
+
+        unreachable;
+    }
+};
+
+const WorkloadRunMode = enum { transact, validate };
+
+/// Runs a single `Workload`.
+///
+/// The workload runs is one of two modes: `transact` or `validate`.
+/// Validation mode regenerates the same random operations, but does not submit
+/// transactions, instead just querying the database and checking that the state
+/// is as expected after a previously run transactional workload.
+///
+/// Execution is initiated by the `run` method, and driven by an external
+/// `IO` event loop, which should check the `done` variable to determine
+/// when the workload is complete. A summary can the be printed with `print_summary`.
+///
+/// The random generation of requests is delegated to `WorkloadOperations`.
+const WorkloadRunner = struct {
+    workload: *const Workload,
+    workload_index: u64,
+    mode: WorkloadRunMode,
+
+    allocator: std.mem.Allocator,
+    client: *Client,
+    rng: std.rand.DefaultPrng,
+    timer: std.time.Timer,
+
+    callback: ?*const fn (*WorkloadRunner, StateMachine.Operation, []const u8) void,
+
+    /// Generates pending operations and requests to send to the database.
+    operations: WorkloadOperations,
+    inflight_request_info: ?struct {
+        request: WorkloadInflightRequest,
+        start_ns: u64,
+    },
+
+    done: bool,
+
+    metrics: WorkloadMetrics,
+
+    /// Buffers for storing the validation payloads.
+    validate_buffers: struct {
+        create_accounts: std.ArrayListUnmanaged(u128),
+        create_transfers: std.ArrayListUnmanaged(u128),
+    },
+
+    fn init(options: struct {
+        allocator: std.mem.Allocator,
+        workload: *const Workload,
+        workload_index: u64,
+        mode: WorkloadRunMode,
+        client: *Client,
+        rng_seed: u64,
+        id_permutation: IdPermutation,
+        account_index_committed: u64,
+        transfer_index_committed: u64,
+    }) !WorkloadRunner {
+        var rng = std.rand.DefaultPrng.init(options.rng_seed +% options.workload_index);
+        const random = rng.random();
+
+        const generator = WorkloadGenerator.init(.{
+            .workload = options.workload,
+            .id_permutation = options.id_permutation,
+            .account_index_committed = options.account_index_committed,
+            .transfer_index_committed = options.transfer_index_committed,
+            .random = random,
+        });
+
+        var operations = try WorkloadOperations.init(options.allocator, options.workload, generator);
+        errdefer operations.deinit(options.allocator);
+
+        var metrics = try WorkloadMetrics.init(options.allocator);
+        errdefer metrics.deinit(options.allocator);
+
+        var validate_buffer_create_accounts = try std.ArrayListUnmanaged(u128).initCapacity(
+            options.allocator, options.workload.create_accounts_batch_size,
+        );
+        errdefer validate_buffer_create_accounts.deinit(options.allocator);
+        var validate_buffer_create_transfers = try std.ArrayListUnmanaged(u128).initCapacity(
+            options.allocator, options.workload.create_transfers_batch_size,
+        );
+        errdefer validate_buffer_create_transfers.deinit(options.allocator);
+
+        return WorkloadRunner {
+            .workload = options.workload,
+            .workload_index = options.workload_index,
+            .mode = options.mode,
+
+            .allocator = options.allocator,
+            .client = options.client,
+            .rng = rng,
+            .timer = try std.time.Timer.start(),
+
+            .callback = null,
+
+            .operations = operations,
+            .inflight_request_info = null,
+
+            .done = false,
+
+            .metrics = metrics,
+
+            .validate_buffers = .{
+                .create_accounts = validate_buffer_create_accounts,
+                .create_transfers = validate_buffer_create_transfers,
+            },
+        };
+    }
+
+    fn deinit(self: *WorkloadRunner) void {
+        self.operations.deinit(self.allocator);
+        self.metrics.deinit(self.allocator);
+        self.validate_buffers.create_accounts.deinit(self.allocator);
+        self.validate_buffers.create_transfers.deinit(self.allocator);
+    }
+
+    fn run(self: *WorkloadRunner) void {
+        assert(!self.done);
+        self.metrics.workload_start_ns = self.timer.read();
+        self.exec_step();
+    }
+
+    fn stop(self: *WorkloadRunner) void {
+        assert(!self.done);
+        self.metrics.workload_end_ns = self.timer.read();
+        self.done = true;
+    }
+
+    /// Execute a single request and wait for completion.
+    ///
+    /// It generates a new random request from the `WorkloadOperations` then:
+    ///
+    /// - In `transact` mode sends that request to the server.
+    /// - In `validate` mode, if the generated request is a transaction
+    ///   instead sends a query to the server asking about the ids in that transaction.
+    fn exec_step(self: *WorkloadRunner) void {
+        assert(self.operations.operations_completed < self.workload.operation_count);
+        assert(!self.done);
+
+        const random = self.rng.random();
+        const request = self.operations.next_request(random);
+        const request_start_ns = self.timer.read();
+
+        switch (self.mode) {
+            .transact => {
+                self.send_request_for_transact_mode(&request);
+            },
+            .validate => {
+                self.send_request_for_validate_mode(&request);
+            },
+        }
+
+        assert(self.inflight_request_info == null);
+        self.inflight_request_info = .{
+            .request = request,
+            .start_ns = request_start_ns,
+        };
+
+        // NB: could do async preparation of next request
+        // here for a minor (1%?) throughput improvement.
+    }
+
+    /// Completion callback for the request sent by `exec_step`.
+    ///
+    /// Validates the response, records metrics about the request,
+    /// and returns allocated resources to the `WorkloadOperations`.
+    fn exec_step_finish(
+        self: *WorkloadRunner,
+        operation: StateMachine.Operation,
+        result: []const u8,
+    ) void {
+        const request_start_ns = self.inflight_request_info.?.start_ns;
+        const request_end_ns = self.timer.read();
+        const request_time_ns = request_end_ns - request_start_ns;
+        const request_time_ms = @divTrunc(request_time_ns, std.time.ns_per_ms);
+
+        self.metrics.request_total_ns += request_time_ns;
+        add_time_ms_to_histogram(self.metrics.all_requests_latency_histogram, request_time_ms);
+
+        switch (self.mode) {
+            .transact => {
+                handle_response_for_transact_mode(
+                    operation,
+                    result,
+                    &self.inflight_request_info.?.request,
+                    request_time_ns,
+                    request_time_ms,
+                    &self.metrics,
+                );
+            },
+            .validate => {
+                handle_response_for_validate_mode(
+                    operation,
+                    result,
+                    &self.inflight_request_info.?.request,
+                    request_time_ns,
+                    request_time_ms,
+                    &self.metrics,
+                );
+            },
+        }
+
+        const random = self.rng.random();
+        self.operations.complete_request(
+            random,
+            self.inflight_request_info.?.request,
+        );
+        self.inflight_request_info = null;
+
+        assert(self.operations.operations_completed <= self.workload.operation_count);
+
+        if (self.operations.operations_completed == self.workload.operation_count) {
+            self.stop();
+            return;
+        }
+
+        self.exec_step();
+    }
+
+    fn send_request_for_transact_mode(
+        self: *WorkloadRunner,
+        request: *const WorkloadInflightRequest,
+    ) void {
+        self.send(
+            exec_step_finish,
+            request.operation,
+            request.payload,
+        );
+    }
+
+    fn handle_response_for_transact_mode(
+        operation: StateMachine.Operation,
+        result: []const u8,
+        inflight_request: *const WorkloadInflightRequest,
+        request_time_ns: u64,
+        request_time_ms: u64,
+        metrics: *WorkloadMetrics,
+    ) void {
+        switch (inflight_request.data) {
+            .create_accounts => |request| {
+                assert(operation == StateMachine.Operation.create_accounts);
+
+                const results = std.mem.bytesAsSlice(
+                    tb.CreateAccountsResult,
+                    result,
+                );
+                if (results.len > 0) {
+                    panic("CreateAccountsResults: {any}", .{results});
+                }
+
+                metrics.create_accounts_operations += request.count;
+                metrics.create_accounts_requests += 1;
+                metrics.create_accounts_total_ns += request_time_ns;
+                add_time_ms_to_histogram(metrics.create_accounts_latency_histogram, request_time_ms);
+
+            },
+            .create_transfers => |request| {
+                assert(operation == StateMachine.Operation.create_transfers);
+
+                const results = std.mem.bytesAsSlice(
+                    tb.CreateTransfersResult,
+                    result,
+                );
+                if (results.len > 0) {
+                    panic("CreateTransfersResults: {any}", .{results});
+                }
+
+                metrics.create_transfers_operations += request.count;
+                metrics.create_transfers_requests += 1;
+                metrics.create_transfers_total_ns += request_time_ns;
+                add_time_ms_to_histogram(metrics.create_transfers_latency_histogram, request_time_ms);
+
+            },
+            .get_account_transfers => |request| {
+                assert(operation == StateMachine.Operation.get_account_transfers);
+
+                const transfers = std.mem.bytesAsSlice(tb.Transfer, result);
+                for (transfers) |*transfer| {
+                    assert(transfer.debit_account_id == request.account_id or
+                               transfer.credit_account_id == request.account_id);
+                }
+
+                metrics.get_account_transfers_operations += 1;
+                metrics.get_account_transfers_total_ns += request_time_ns;
+                add_time_ms_to_histogram(metrics.get_account_transfers_latency_histogram, request_time_ms);
+            }
+        }
+    }
+
+    fn send_request_for_validate_mode(
+        self: *WorkloadRunner,
+        inflight_request: *const WorkloadInflightRequest,
+    ) void {
+        const send_noop_request = struct {
+            fn send_noop_request(
+                self_: *WorkloadRunner,
+            ) void {
+                self_.send(
+                    exec_step_finish,
+                    StateMachine.Operation.lookup_accounts,
+                    &[_]u8{},
+                );
+            }
+        }.send_noop_request;
+
+        switch (inflight_request.data) {
+            .create_accounts => |request| {
+                assert(self.validate_buffers.create_accounts.items.len == 0);
+                assert(self.validate_buffers.create_accounts.capacity ==
+                           request.accounts.capacity);
+                for (request.accounts.items) |*account| {
+                    self.validate_buffers.create_accounts.appendAssumeCapacity(account.*.id);
+                }
+                self.send(
+                    exec_step_finish,
+                    StateMachine.Operation.lookup_accounts,
+                    std.mem.sliceAsBytes(self.validate_buffers.create_accounts.items),
+                );
+                self.validate_buffers.create_accounts.clearRetainingCapacity();
+            },
+            .create_transfers => |request| {
+                assert(self.validate_buffers.create_transfers.items.len == 0);
+                assert(self.validate_buffers.create_transfers.capacity ==
+                           request.transfers.capacity);
+                for (request.transfers.items) |*transfer| {
+                    self.validate_buffers.create_transfers.appendAssumeCapacity(transfer.*.id);
+                }
+                self.send(
+                    exec_step_finish,
+                    StateMachine.Operation.lookup_transfers,
+                    std.mem.sliceAsBytes(self.validate_buffers.create_transfers.items),
+                );
+                self.validate_buffers.create_transfers.clearRetainingCapacity();
+            },
+            .get_account_transfers => |request| {
+                _ = request;
+                send_noop_request(self);
+            },
+        }
+    }
+
+    fn handle_response_for_validate_mode(
+        operation: StateMachine.Operation,
+        result: []const u8,
+        inflight_request: *const WorkloadInflightRequest,
+        request_time_ns: u64,
+        request_time_ms: u64,
+        metrics: *WorkloadMetrics,
+    ) void {
+        const handle_noop_request = struct {
+            fn handle_noop_request(
+                operation_: StateMachine.Operation,
+                result_: []const u8,
+                request_time_ns_: u64,
+                request_time_ms_: u64,
+                metrics_: *WorkloadMetrics,
+            ) void {
+                assert(operation_ == StateMachine.Operation.lookup_accounts);
+                assert(result_.len == 0);
+
+                metrics_.validate_noop_operations += 1;
+                metrics_.validate_noop_total_ns += request_time_ns_;
+                add_time_ms_to_histogram(metrics_.validate_noop_latency_histogram, request_time_ms_);
+            }
+        }.handle_noop_request;
+
+        switch (inflight_request.data) {
+            .create_accounts => |request| {
+                assert(operation == StateMachine.Operation.lookup_accounts);
+
+                const accounts = std.mem.bytesAsSlice(tb.Account, result);
+
+                for (request.accounts.items, accounts) |expected, actual| {
+                    assert(expected.id == actual.id);
+                    assert(expected.user_data_128 == actual.user_data_128);
+                    assert(expected.user_data_64 == actual.user_data_64);
+                    assert(expected.user_data_32 == actual.user_data_32);
+                    assert(expected.code == actual.code);
+                    assert(@as(u16, @bitCast(expected.flags)) == @as(u16, @bitCast(actual.flags)));
+                }
+
+                metrics.validate_lookup_accounts_operations += request.count;
+                metrics.validate_lookup_accounts_requests += 1;
+                metrics.validate_lookup_accounts_total_ns += request_time_ns;
+                add_time_ms_to_histogram(metrics.validate_lookup_accounts_latency_histogram, request_time_ms);
+            },
+            .create_transfers => |request| {
+                assert(operation == StateMachine.Operation.lookup_transfers);
+
+                const transfers = std.mem.bytesAsSlice(tb.Transfer, result);
+
+                for (request.transfers.items, transfers) |expected, actual| {
+                    assert(expected.id == actual.id);
+                    assert(expected.debit_account_id == actual.debit_account_id);
+                    assert(expected.credit_account_id == actual.credit_account_id);
+                    assert(expected.amount == actual.amount);
+                    assert(expected.pending_id == actual.pending_id);
+                    assert(expected.user_data_128 == actual.user_data_128);
+                    assert(expected.user_data_64 == actual.user_data_64);
+                    assert(expected.user_data_32 == actual.user_data_32);
+                    assert(expected.timeout == actual.timeout);
+                    assert(expected.ledger == actual.ledger);
+                    assert(expected.code == actual.code);
+                    assert(@as(u16, @bitCast(expected.flags)) == @as(u16, @bitCast(actual.flags)));
+                }
+
+                metrics.validate_lookup_transfers_operations += request.count;
+                metrics.validate_lookup_transfers_requests += 1;
+                metrics.validate_lookup_transfers_total_ns += request_time_ns;
+                add_time_ms_to_histogram(metrics.validate_lookup_transfers_latency_histogram, request_time_ms);
+            },
+            .get_account_transfers => |request| {
+                _ = request;
+                handle_noop_request(
+                    operation,
+                    result,
+                    request_time_ns,
+                    request_time_ms,
+                    metrics,
+                );
+            }
+        }
+    }
+
+    fn send(
+        self: *WorkloadRunner,
+        callback: *const fn (*WorkloadRunner, StateMachine.Operation, []const u8) void,
+        operation: StateMachine.Operation,
+        payload: []const u8,
+    ) void {
+        self.callback = callback;
+        self.client.request(
+            send_complete,
+            @intCast(@intFromPtr(self)),
+            operation,
+            payload,
+        );
+    }
+
+    fn send_complete(
+        user_data: u128,
+        operation: StateMachine.Operation,
+        result: []u8,
+    ) void {
+        const self: *WorkloadRunner = @ptrFromInt(@as(usize, @intCast(user_data)));
+        const callback = self.callback.?;
+        self.callback = null;
+
+        callback(self, operation, result);
+    }
+
+    fn add_time_ms_to_histogram(histogram: []u64, time_ms: u64) void {
+        histogram[@min(time_ms, histogram.len - 1)] += 1;
+    }
+
+    fn print_summary(
+        self: *const WorkloadRunner,
+        stdout: std.io.AnyWriter,
+    ) !void {
+        const summary = WorkloadSummary.init(self);
+        try summary.print(stdout);
+    }
+
+    fn world_state(self: *const WorkloadRunner) struct {
+        account_index: u64,
+        transfer_index: u64,
+    } {
+        return .{
+            .account_index = self.operations.generator.account_index_committed,
+            .transfer_index = self.operations.generator.transfer_index_committed,
+        };
+    }
+};
+
+/// Generates new data for transactions according to specified distributions,
+/// transforms raw generated id indexes into database ids per `IdPermutation`,
+/// and maintains information about generated ids.
+const WorkloadGenerator = struct {
+    workload: *const Workload,
+
+    id_permutation: IdPermutation,
+
+    account_index_uncommitted: usize,
+    account_index_committed: usize,
+    transfer_index_uncommitted: usize,
+    transfer_index_committed: usize,
+
+    account_generator_debit: Generator,
+    account_generator_credit: Generator,
+    account_generator_query: Generator,
+
+    fn init(options: struct {
+        workload: *const Workload,
+        id_permutation: IdPermutation,
+        account_index_committed: u64,
+        transfer_index_committed: u64,
+        random: std.Random,
+    }) WorkloadGenerator {
+        const account_generator_debit = Generator.from_distribution(
+            options.workload.account_distribution_debit,
+            options.account_index_committed,
+            options.random,
+        );
+        const account_generator_credit = Generator.from_distribution(
+            options.workload.account_distribution_credit,
+            options.account_index_committed,
+            options.random,
+        );
+        const account_generator_query = Generator.from_distribution(
+            options.workload.account_distribution_query,
+            options.account_index_committed,
+            options.random,
+        );
+
+        return WorkloadGenerator {
+            .workload = options.workload,
+
+            .id_permutation = options.id_permutation,
+
+            .account_index_uncommitted = options.account_index_committed,
+            .account_index_committed = options.account_index_committed,
+            .transfer_index_uncommitted = options.transfer_index_committed,
+            .transfer_index_committed = options.transfer_index_committed,
+
+            .account_generator_debit = account_generator_debit,
+            .account_generator_credit = account_generator_credit,
+            .account_generator_query = account_generator_query,
+        };
+    }
+
+    fn gen_account_index(
+        self: *WorkloadGenerator,
+        generator: *Generator,
+        random: std.Random,
+    ) u64 {
+        switch (generator.*) {
+            .zipfian => |gen| {
+                // zipfian set size must be same as account set size
+                assert(self.account_index_committed == gen.gen.n);
+                const index = gen.next(random);
+                assert(index < self.account_index_committed);
+                return index;
+            },
+            .latest => |gen| {
+                assert(self.account_index_committed == gen.n);
+                const index_rev = gen.next(random);
+                assert(index_rev < self.account_index_committed);
+                return self.account_index_committed - index_rev - 1;
+            },
+            .uniform => {
+                return random.uintLessThan(u64, self.account_index_committed);
+            },
+        }
+    }
+
+    fn gen_account(self: *WorkloadGenerator, random: std.Random) tb.Account {
+        const account = tb.Account {
+            .id = self.id_permutation.encode(self.account_index_uncommitted + 1),
+            .user_data_128 = random.int(u128),
+            .user_data_64 = random.int(u64),
+            .user_data_32 = random.int(u32),
+            .reserved = 0,
+            .ledger = 2,
+            .code = 1,
+            .flags = .{
+                .history = self.workload.flag_history,
+                .imported = self.workload.flag_imported,
+            },
+            .debits_pending = 0,
+            .debits_posted = 0,
+            .credits_pending = 0,
+            .credits_posted = 0,
+            .timestamp = if (self.workload.flag_imported) self.account_index_uncommitted + 1 else 0,
+        };
+        self.account_index_uncommitted += 1;
+        return account;
+    }
+
+    fn gen_transfer(self: *WorkloadGenerator, random: std.Random) ?tb.Transfer {
+        if (self.account_index_committed < 2) {
+            assert(self.workload.create_accounts_weight > 0);
+            return null;
+        }
+
+        var debit_account_index: u64 = 0;
+        var credit_account_index: u64 = 0;
+        while (debit_account_index == credit_account_index) {
+            debit_account_index = self.gen_account_index(&self.account_generator_debit, random);
+            credit_account_index = self.gen_account_index(&self.account_generator_credit, random);
+        }
+
+        const debit_account_id = self.id_permutation.encode(debit_account_index + 1);
+        const credit_account_id = self.id_permutation.encode(credit_account_index + 1);
+        assert(debit_account_id != credit_account_id);
+
+        // 30% of pending transfers.
+        const pending = self.workload.transfer_pending and random.intRangeAtMost(u8, 0, 9) < 3;
+
+        const transfer = tb.Transfer {
+            .id = self.id_permutation.encode(self.transfer_index_uncommitted + 1),
+            .debit_account_id = debit_account_id,
+            .credit_account_id = credit_account_id,
+            .user_data_128 = random.int(u128),
+            .user_data_64 = random.int(u64),
+            .user_data_32 = random.int(u32),
+            // TODO Benchmark posting/voiding pending transfers.
+            .pending_id = 0,
+            .ledger = 2,
+            .code = random.int(u16) +| 1,
+            .flags = .{
+                .pending = pending,
+                .imported = self.workload.flag_imported,
+            },
+            .timeout = if (pending) random.intRangeAtMost(u32, 1, 60) else 0,
+            .amount = random_int_exponential(random, u64, 10_000) +| 1,
+            // FIXME will this clash with account timestamps?
+            .timestamp = if (self.workload.flag_imported) self.account_index_uncommitted + self.transfer_index_uncommitted + 1 else 0,
+        };
+        self.transfer_index_uncommitted += 1;
+        return transfer;
+    }
+
+    fn gen_account_filter(self: *WorkloadGenerator, random: std.Random) ?tb.AccountFilter {
+        if (self.account_index_committed < 1) {
+            assert(self.workload.create_accounts_weight > 0);
+            return null;
+        }
+
+        const account_index = self.gen_account_index(&self.account_generator_query, random);
+        const filter = tb.AccountFilter{
+            .account_id = self.id_permutation.encode(account_index + 1),
+            .user_data_128 = 0,
+            .user_data_64 = 0,
+            .user_data_32 = 0,
+            .code = 0,
+            .timestamp_min = 0,
+            .timestamp_max = 0,
+            .limit = @divExact(
+                constants.message_size_max - @sizeOf(vsr.Header),
+                @sizeOf(tb.Transfer),
+            ),
+            .flags = .{
+                .credits = true,
+                .debits = true,
+                .reversed = false,
+            },
+        };
+        return filter;
+    }
+};
+
+/// Maintains pending database operations and turns them into requests as needed.
+const WorkloadOperations = struct {
+    workload: *const Workload,
+    generator: WorkloadGenerator,
+
+    create_accounts_operations: ?std.ArrayListUnmanaged(tb.Account),
+    create_transfers_operations: ?std.ArrayListUnmanaged(tb.Transfer),
+    unbatched_operation: ?UnbatchedOperation,
+
+    unbatched_buffers: struct {
+        account_filter: ?*?tb.AccountFilter,
+    },
+
+    request_in_flight: bool,
+    operations_completed: u64,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        workload: *const Workload,
+        generator: WorkloadGenerator,
+    ) !WorkloadOperations {
+        var create_accounts_operations =
+            try std.ArrayListUnmanaged(tb.Account).initCapacity(
+                allocator,
+                workload.create_accounts_batch_size,
+        );
+        errdefer create_accounts_operations.deinit(allocator);
+
+        var create_transfers_operations =
+            try std.ArrayListUnmanaged(tb.Transfer).initCapacity(
+                allocator,
+                workload.create_transfers_batch_size,
+        );
+        errdefer create_transfers_operations.deinit(allocator);
+
+        const buffer_account_filter = try allocator.create(?tb.AccountFilter);
+        errdefer allocator.destroy(buffer_account_filter);
+        buffer_account_filter.* = null;
+
+        return WorkloadOperations {
+            .workload = workload,
+            .generator = generator,
+
+            .create_accounts_operations = create_accounts_operations,
+            .create_transfers_operations = create_transfers_operations,
+            .unbatched_operation = null,
+
+            .unbatched_buffers = .{
+                .account_filter = buffer_account_filter,
+            },
+
+            .request_in_flight = false,
+            .operations_completed = 0,
+        };
+    }
+
+    fn deinit(self: *WorkloadOperations, allocator: std.mem.Allocator) void {
+        assert(!self.request_in_flight);
+        self.create_accounts_operations.?.deinit(allocator);
+        self.create_transfers_operations.?.deinit(allocator);
+        allocator.destroy(self.unbatched_buffers.account_filter.?);
+    }
+
+    fn count(self: *const WorkloadOperations) u64 {
+        assert(!self.request_in_flight);
+        return self.create_accounts_operations.?.items.len
+            + self.create_transfers_operations.?.items.len
+            + if (self.unbatched_operation == null) @as(u64, 0) else @as(u64, 1);
+    }
+
+    fn all_operations_generated(self: *const WorkloadOperations) bool {
+        return self.operations_completed + self.count() == self.workload.operation_count;
+    }
+
+    fn next_request(
+        self: *WorkloadOperations,
+        random: std.Random,
+    ) WorkloadInflightRequest {
+        assert(self.operations_completed + self.count() <= self.workload.operation_count);
+
+        assert(!self.request_in_flight);
+        defer self.request_in_flight = true;
+
+        assert(self.create_accounts_operations != null);
+        assert(self.create_transfers_operations != null);
+        assert(self.unbatched_buffers.account_filter != null);
+        assert(self.unbatched_buffers.account_filter.?.* == null);
+
+        while(true) {
+            assert(self.create_accounts_operations.?.items.len <= self.workload.create_accounts_batch_size);
+            assert(self.create_transfers_operations.?.items.len <= self.workload.create_transfers_batch_size);
+
+            const have_full_account_batch = self.create_accounts_operations.?.items.len == self.workload.create_accounts_batch_size;
+            const have_partial_account_batch = self.create_accounts_operations.?.items.len > 0 and !have_full_account_batch;
+            const have_full_transfer_batch = self.create_transfers_operations.?.items.len == self.workload.create_transfers_batch_size;
+            const have_partial_transfer_batch = self.create_transfers_operations.?.items.len > 0 and !have_full_transfer_batch;
+
+            if (have_full_account_batch) {
+                const new_account_count = self.workload.create_accounts_batch_size;
+                const accounts = self.create_accounts_operations.?;
+                self.create_accounts_operations = null;
+                return WorkloadInflightRequest {
+                    .operation = StateMachine.Operation.create_accounts,
+                    .payload = std.mem.sliceAsBytes(
+                        accounts.items[0..new_account_count],
+                    ),
+                    .data = WorkloadInflightRequestData {
+                        .create_accounts = .{
+                            .count = new_account_count,
+                            .accounts = accounts,
+                        },
+                    },
+                };
+            }
+            if (have_partial_account_batch and self.all_operations_generated()) {
+                const new_account_count = self.create_accounts_operations.?.items.len;
+                const accounts = self.create_accounts_operations.?;
+                self.create_accounts_operations = null;
+                return WorkloadInflightRequest {
+                    .operation = StateMachine.Operation.create_accounts,
+                    .payload = std.mem.sliceAsBytes(
+                        accounts.items[0..new_account_count],
+                    ),
+                    .data = WorkloadInflightRequestData {
+                        .create_accounts = .{
+                            .count = new_account_count,
+                            .accounts = accounts,
+                        },
+                    },
+                };
+            }
+            if (have_full_transfer_batch) {
+                const new_transfer_count = self.workload.create_transfers_batch_size;
+                const transfers = self.create_transfers_operations.?;
+                self.create_transfers_operations = null;
+                return WorkloadInflightRequest {
+                    .operation = StateMachine.Operation.create_transfers,
+                    .payload = std.mem.sliceAsBytes(
+                        transfers.items[0..new_transfer_count],
+                    ),
+                    .data = WorkloadInflightRequestData {
+                        .create_transfers = .{
+                            .count = new_transfer_count,
+                            .transfers = transfers,
+                        },
+                    },
+                };
+            }
+            if (have_partial_transfer_batch and self.all_operations_generated()) {
+                const new_transfer_count = self.create_transfers_operations.?.items.len;
+                const transfers = self.create_transfers_operations.?;
+                self.create_transfers_operations = null;
+                return WorkloadInflightRequest {
+                    .operation = StateMachine.Operation.create_transfers,
+                    .payload = std.mem.sliceAsBytes(
+                        transfers.items[0..new_transfer_count],
+                    ),
+                    .data = WorkloadInflightRequestData {
+                        .create_transfers = .{
+                            .count = new_transfer_count,
+                            .transfers = transfers,
+                        },
+                    },
+                };
+            }
+            if (self.unbatched_operation) |*op| {
+                defer self.unbatched_operation = null;
+                switch (op.*) {
+                    .get_account_transfers => |*filter| {
+                        const filter_buffer = self.unbatched_buffers.account_filter.?;
+                        self.unbatched_buffers.account_filter = null;
+                        filter_buffer.* = filter.*;
+                        return WorkloadInflightRequest {
+                            .operation = StateMachine.Operation.get_account_transfers,
+                            .payload = std.mem.asBytes(&(filter_buffer.*.?)),
+                            .data = WorkloadInflightRequestData {
+                                .get_account_transfers = .{
+                                    .account_id = filter.account_id,
+                                    .filter = filter_buffer,
+                                },
+                            },
+                        };
+                    },
+                }
+            }
+
+            assert(!self.all_operations_generated());
+
+            // fixme it may improve throughput to short circuit the above checks when generating large batches
+            self.prepare_one_operation(random);
+        }
+    }
+
+    fn complete_request(
+        self: *WorkloadOperations,
+        random: std.Random,
+        completed_request: WorkloadInflightRequest,
+    ) void {
+        assert(self.request_in_flight);
+        defer self.request_in_flight = false;
+
+        switch (completed_request.data) {
+            .create_accounts => |request| {
+                assert(self.create_accounts_operations == null);
+                self.create_accounts_operations = request.accounts;
+                self.create_accounts_operations.?.clearRetainingCapacity();
+                
+                self.operations_completed += request.count;
+
+                self.generator.account_index_committed += request.count;
+
+                self.generator.account_generator_debit.grow(request.count, random);
+                self.generator.account_generator_credit.grow(request.count, random);
+                self.generator.account_generator_query.grow(request.count, random);
+            },
+            .create_transfers => |request| {
+                assert(self.create_transfers_operations == null);
+                self.create_transfers_operations = request.transfers;
+                self.create_transfers_operations.?.clearRetainingCapacity();
+
+                self.operations_completed += request.count;
+
+                self.generator.transfer_index_committed += request.count;
+            },
+            .get_account_transfers => |request| {
+                assert(self.unbatched_buffers.account_filter == null);
+                self.unbatched_buffers.account_filter = request.filter;
+                self.unbatched_buffers.account_filter.?.* = null;
+
+                self.operations_completed += 1;
+            },
+        }
+    }
+
+    fn prepare_one_operation(
+        self: *WorkloadOperations,
+        random: std.Random,
+    ) void {
+        assert(!self.request_in_flight);
+        assert(!self.all_operations_generated());
+        assert(self.create_accounts_operations.?.items.len < self.create_accounts_operations.?.capacity);
+        assert(self.create_transfers_operations.?.items.len < self.create_transfers_operations.?.capacity);
+        assert(self.unbatched_operation == null);
+
+        switch (self.workload.next_operation_type(random)) {
+            StateMachine.Operation.create_accounts => {
+                const account = self.generator.gen_account(random);
+                self.create_accounts_operations.?.appendAssumeCapacity(account);
+            },
+            StateMachine.Operation.create_transfers => {
+                if (self.generator.gen_transfer(random)) |transfer| {
+                    self.create_transfers_operations.?.appendAssumeCapacity(transfer);
+                }
+            },
+            StateMachine.Operation.get_account_transfers => {
+                if (self.generator.gen_account_filter(random)) |filter| {
+                    self.unbatched_operation = UnbatchedOperation {
+                        .get_account_transfers = filter,
+                    };
+                }
+            },
+            else => @panic("todo"),
+        }
+    }
+};
+
+const UnbatchedOperation = union(enum) {
+    get_account_transfers: tb.AccountFilter,
+};
+
+const WorkloadInflightRequest = struct {
+    operation: StateMachine.Operation,
+    payload: []const u8,
+    data: WorkloadInflightRequestData,
+};
+
+const WorkloadInflightRequestData = union(enum) {
+    create_accounts: struct {
+        count: u64,
+        accounts: std.ArrayListUnmanaged(tb.Account),
+    },
+    create_transfers: struct {
+        count: u64,
+        transfers: std.ArrayListUnmanaged(tb.Transfer),
+    },
+    get_account_transfers: struct {
+        account_id: u128,
+        filter: *?tb.AccountFilter,
+    },
+};
+
+const WorkloadMetrics = struct {
+    workload_start_ns: u64 = 0,
+    workload_end_ns: u64 = 0,
+    request_total_ns: u64 = 0,
+
+    all_requests_latency_histogram: []u64,
+
+    create_accounts_operations: u64 = 0,
+    create_accounts_requests: u64 = 0,
+    create_accounts_total_ns: u64 = 0,
+    create_accounts_latency_histogram: []u64,
+
+    create_transfers_operations: u64 = 0,
+    create_transfers_requests: u64 = 0,
+    create_transfers_total_ns: u64 = 0,
+    create_transfers_latency_histogram: []u64,
+
+    get_account_transfers_operations: u64 = 0,
+    get_account_transfers_total_ns: u64 = 0,
+    get_account_transfers_latency_histogram: []u64,
+
+    validate_lookup_accounts_operations: u64 = 0,
+    validate_lookup_accounts_requests: u64 = 0,
+    validate_lookup_accounts_total_ns: u64 = 0,
+    validate_lookup_accounts_latency_histogram: []u64,
+
+    validate_lookup_transfers_operations: u64 = 0,
+    validate_lookup_transfers_requests: u64 = 0,
+    validate_lookup_transfers_total_ns: u64 = 0,
+    validate_lookup_transfers_latency_histogram: []u64,
+
+    validate_noop_operations: u64 = 0,
+    validate_noop_total_ns: u64 = 0,
+    validate_noop_latency_histogram: []u64,
+
+    fn init(allocator: std.mem.Allocator) !WorkloadMetrics {
+        const all_requests_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(all_requests_latency_histogram, 0);
+        errdefer allocator.free(all_requests_latency_histogram);
+        const create_accounts_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(create_accounts_latency_histogram, 0);
+        errdefer allocator.free(create_accounts_latency_histogram);
+        const create_transfers_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(create_transfers_latency_histogram, 0);
+        errdefer allocator.free(create_transfers_latency_histogram);
+        const get_account_transfers_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(get_account_transfers_latency_histogram, 0);
+        errdefer allocator.free(get_account_transfers_latency_histogram);
+        const validate_lookup_accounts_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(validate_lookup_accounts_latency_histogram, 0);
+        errdefer allocator.free(validate_lookup_accounts_latency_histogram);
+        const validate_lookup_transfers_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(validate_lookup_transfers_latency_histogram, 0);
+        errdefer allocator.free(validate_lookup_transfers_latency_histogram);
+        const validate_noop_latency_histogram =
+            try allocator.alloc(u64, 10_001);
+        @memset(validate_noop_latency_histogram, 0);
+        errdefer allocator.free(validate_noop_latency_histogram);
+
+        return WorkloadMetrics {
+            .all_requests_latency_histogram = all_requests_latency_histogram,
+            .create_accounts_latency_histogram = create_accounts_latency_histogram,
+            .create_transfers_latency_histogram = create_transfers_latency_histogram,
+            .get_account_transfers_latency_histogram = get_account_transfers_latency_histogram,
+            .validate_lookup_accounts_latency_histogram = validate_lookup_accounts_latency_histogram,
+            .validate_lookup_transfers_latency_histogram = validate_lookup_transfers_latency_histogram,
+            .validate_noop_latency_histogram = validate_noop_latency_histogram,
+        };
+    }
+
+    fn deinit(self: *WorkloadMetrics, allocator: std.mem.Allocator) void {
+        allocator.free(self.all_requests_latency_histogram);
+        allocator.free(self.create_accounts_latency_histogram);
+        allocator.free(self.create_transfers_latency_histogram);
+        allocator.free(self.get_account_transfers_latency_histogram);
+        allocator.free(self.validate_lookup_accounts_latency_histogram);
+        allocator.free(self.validate_lookup_transfers_latency_histogram);
+        allocator.free(self.validate_noop_latency_histogram);
+    }
+};
+
+const WorkloadSummary = struct {
+    workload_index: u64,
+
+    total_workload_time_s: f64,
+    total_request_time_s: f64,
+    total_non_request_time_s: f64,
+    total_operations: u64,
+    total_requests: u64,
+    total_request_latencies: LatencyPercentiles,
+
+    create_accounts_request_time_s: f64,
+    create_accounts_operations: u64,
+    create_accounts_requests: u64,
+    create_accounts_batch_size: u64,
+    create_accounts_batch_size_rem: u64,
+    create_accounts_latencies: LatencyPercentiles,
+
+    create_transfers_request_time_s: f64,
+    create_transfers_operations: u64,
+    create_transfers_requests: u64,
+    create_transfers_batch_size: u64,
+    create_transfers_batch_size_rem: u64,
+    create_transfers_latencies: LatencyPercentiles,
+
+    get_account_transfers_request_time_s: f64,
+    get_account_transfers_operations: u64,
+    get_account_transfers_latencies: LatencyPercentiles,
+
+    validate_lookup_accounts_request_time_s: f64,
+    validate_lookup_accounts_operations: u64,
+    validate_lookup_accounts_requests: u64,
+    validate_lookup_accounts_batch_size: u64,
+    validate_lookup_accounts_batch_size_rem: u64,
+    validate_lookup_accounts_latencies: LatencyPercentiles,
+
+    validate_lookup_transfers_request_time_s: f64,
+    validate_lookup_transfers_operations: u64,
+    validate_lookup_transfers_requests: u64,
+    validate_lookup_transfers_batch_size: u64,
+    validate_lookup_transfers_batch_size_rem: u64,
+    validate_lookup_transfers_latencies: LatencyPercentiles,
+
+    validate_noop_request_time_s: f64,
+    validate_noop_operations: u64,
+    validate_noop_latencies: LatencyPercentiles,
+
+    fn init(runner: *const WorkloadRunner) WorkloadSummary {
+        const total_workload_time_ns = runner.metrics.workload_end_ns - runner.metrics.workload_start_ns;
+        const total_workload_time_s = @as(f64, @floatFromInt(total_workload_time_ns)) / std.time.ns_per_s;
+        const total_request_time_s = @as(f64, @floatFromInt(runner.metrics.request_total_ns)) / std.time.ns_per_s;
+        const total_non_request_time_s = total_workload_time_s - total_request_time_s;
+
+        const create_accounts_request_time_s = @as(f64, @floatFromInt(runner.metrics.create_accounts_total_ns)) / std.time.ns_per_s;
+        const create_transfers_request_time_s = @as(f64, @floatFromInt(runner.metrics.create_transfers_total_ns)) / std.time.ns_per_s;
+        const get_account_transfers_request_time_s = @as(f64, @floatFromInt(runner.metrics.get_account_transfers_total_ns)) / std.time.ns_per_s;
+        const validate_lookup_accounts_request_time_s = @as(f64, @floatFromInt(runner.metrics.validate_lookup_accounts_total_ns)) / std.time.ns_per_s;
+        const validate_lookup_transfers_request_time_s = @as(f64, @floatFromInt(runner.metrics.validate_lookup_transfers_total_ns)) / std.time.ns_per_s;
+        const validate_noop_request_time_s = @as(f64, @floatFromInt(runner.metrics.validate_noop_total_ns)) / std.time.ns_per_s;
+
+        const total_operations = runner.metrics.create_accounts_operations +
+            runner.metrics.create_transfers_operations +
+            runner.metrics.get_account_transfers_operations +
+            runner.metrics.validate_lookup_accounts_operations +
+            runner.metrics.validate_lookup_transfers_operations +
+            runner.metrics.validate_noop_operations;
+        const total_requests = runner.metrics.create_accounts_requests +
+            runner.metrics.create_transfers_requests +
+            runner.metrics.get_account_transfers_operations +
+            runner.metrics.validate_lookup_accounts_requests +
+            runner.metrics.validate_lookup_transfers_requests +
+            runner.metrics.validate_noop_operations;
+
+        const create_accounts_batch_size_rem =
+            std.math.rem(
+                u64,
+                runner.metrics.create_accounts_operations,
+                runner.workload.create_accounts_batch_size,
+        ) catch 0;
+        const create_transfers_batch_size_rem =
+            std.math.rem(
+                u64,
+                runner.metrics.create_transfers_operations,
+                runner.workload.create_transfers_batch_size,
+        ) catch 0;
+        const validate_lookup_accounts_batch_size_rem =
+            std.math.rem(
+                u64,
+                runner.metrics.validate_lookup_accounts_operations,
+                // nb - same batch size as create_accounts
+                runner.workload.create_accounts_batch_size,
+        ) catch 0;
+        const validate_lookup_transfers_batch_size_rem =
+            std.math.rem(
+                u64,
+                runner.metrics.validate_lookup_transfers_operations,
+                // nb - same batch size as create_transfers
+                runner.workload.create_transfers_batch_size,
+        ) catch 0;
+
+        return WorkloadSummary {
+            .workload_index = runner.workload_index,
+
+            .total_workload_time_s = total_workload_time_s,
+            .total_request_time_s = total_request_time_s,
+            .total_non_request_time_s = total_non_request_time_s,
+            .total_operations = total_operations,
+            .total_requests = total_requests,
+            .total_request_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.all_requests_latency_histogram,
+            ),
+
+            .create_accounts_request_time_s = create_accounts_request_time_s,
+            .create_accounts_operations = runner.metrics.create_accounts_operations,
+            .create_accounts_requests = runner.metrics.create_accounts_requests,
+            .create_accounts_batch_size = runner.workload.create_accounts_batch_size,
+            .create_accounts_batch_size_rem = create_accounts_batch_size_rem,
+            .create_accounts_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.create_accounts_latency_histogram,
+            ),
+
+            .create_transfers_request_time_s = create_transfers_request_time_s,
+            .create_transfers_operations = runner.metrics.create_transfers_operations,
+            .create_transfers_requests = runner.metrics.create_transfers_requests,
+            .create_transfers_batch_size = runner.workload.create_transfers_batch_size,
+            .create_transfers_batch_size_rem = create_transfers_batch_size_rem,
+            .create_transfers_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.create_transfers_latency_histogram,
+            ),
+
+            .get_account_transfers_request_time_s = get_account_transfers_request_time_s,
+            .get_account_transfers_operations = runner.metrics.get_account_transfers_operations,
+            .get_account_transfers_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.get_account_transfers_latency_histogram,
+            ),
+
+            .validate_lookup_accounts_request_time_s = validate_lookup_accounts_request_time_s,
+            .validate_lookup_accounts_operations = runner.metrics.validate_lookup_accounts_operations,
+            .validate_lookup_accounts_requests = runner.metrics.validate_lookup_accounts_requests,
+            // nb - same batch size as create_accounts
+            .validate_lookup_accounts_batch_size = runner.workload.create_accounts_batch_size,
+            .validate_lookup_accounts_batch_size_rem = validate_lookup_accounts_batch_size_rem,
+            .validate_lookup_accounts_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.validate_lookup_accounts_latency_histogram,
+            ),
+
+            .validate_lookup_transfers_request_time_s = validate_lookup_transfers_request_time_s,
+            .validate_lookup_transfers_operations = runner.metrics.validate_lookup_transfers_operations,
+            .validate_lookup_transfers_requests = runner.metrics.validate_lookup_transfers_requests,
+            // nb - same batch size as create_transfers
+            .validate_lookup_transfers_batch_size = runner.workload.create_transfers_batch_size,
+            .validate_lookup_transfers_batch_size_rem = validate_lookup_transfers_batch_size_rem,
+            .validate_lookup_transfers_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.validate_lookup_transfers_latency_histogram,
+            ),
+
+            .validate_noop_request_time_s = validate_noop_request_time_s,
+            .validate_noop_operations = runner.metrics.validate_noop_operations,
+            .validate_noop_latencies = LatencyPercentiles.from_histogram(
+                runner.metrics.validate_noop_latency_histogram,
+            ),
+        };
+    }
+
+    fn print(
+        self: *const WorkloadSummary,
+        stdout: std.io.AnyWriter,
+    ) !void {
+        try stdout.print(
+            "-----\n", .{},
+        );
+        try stdout.print(
+            "# Workload {}\n",
+            .{self.workload_index},
+        );
+        try stdout.print(
+            "total time: {d:.2}\n",
+            .{self.total_workload_time_s},
+        );
+        try stdout.print(
+            "total request time: {d:.2}s\n",
+            .{self.total_request_time_s},
+        );
+        try stdout.print(
+            "total non-request time: {d:.2}s\n",
+            .{self.total_non_request_time_s},
+        );
+        try stdout.print(
+            "total operations: {}\n",
+            .{self.total_operations},
+        );
+        try stdout.print(
+            "total requests: {}\n",
+            .{self.total_requests},
+        );
+        try self.total_request_latencies.print(stdout, "total");
+        if (self.create_accounts_operations > 0) {
+            try stdout.print(
+                "create_accounts request time: {d:.2}s\n",
+                .{self.create_accounts_request_time_s},
+            );
+            try stdout.print(
+                "create_accounts operations: {}\n",
+                .{self.create_accounts_operations},
+            );
+            try stdout.print(
+                "create_accounts requests: {}\n",
+                .{self.create_accounts_requests},
+            );
+            try stdout.print(
+                "create_accounts batch size: {}\n",
+                .{self.create_accounts_batch_size},
+            );
+            try stdout.print(
+                "create_accounts final batch size: {}\n",
+                .{self.create_accounts_batch_size_rem},
+            );
+            try self.create_accounts_latencies.print(stdout, "create_accounts");
+        }
+        if (self.create_transfers_operations > 0) {
+            try stdout.print(
+                "create_transfers request time: {d:.2}s\n",
+                .{self.create_transfers_request_time_s},
+            );
+            try stdout.print(
+                "create_transfers operations: {}\n",
+                .{self.create_transfers_operations},
+            );
+            try stdout.print(
+                "create_transfers requests: {}\n",
+                .{self.create_transfers_requests},
+            );
+            try stdout.print(
+                "create_transfers batch size: {}\n",
+                .{self.create_transfers_batch_size},
+            );
+            try stdout.print(
+                "create_transfers final batch size: {}\n",
+                .{self.create_transfers_batch_size_rem},
+            );
+            try self.create_transfers_latencies.print(stdout, "create_transfers");
+        }
+        if (self.get_account_transfers_operations > 0) {
+            try stdout.print(
+                "get_account_transfers request time: {d:.2}s\n",
+                .{self.get_account_transfers_request_time_s},
+            );
+            try stdout.print(
+                "get_account_transfers operations: {}\n",
+                .{self.get_account_transfers_operations},
+            );
+            try self.get_account_transfers_latencies.print(stdout, "get_account_transfers");
+        }
+        if (self.validate_lookup_accounts_operations > 0) {
+            try stdout.print(
+                "validate_lookup_accounts request time: {d:.2}s\n",
+                .{self.validate_lookup_accounts_request_time_s},
+            );
+            try stdout.print(
+                "validate_lookup_accounts operations: {}\n",
+                .{self.validate_lookup_accounts_operations},
+            );
+            try stdout.print(
+                "validate_lookup_accounts requests: {}\n",
+                .{self.validate_lookup_accounts_requests},
+            );
+            try stdout.print(
+                "validate_lookup_accounts batch size: {}\n",
+                .{self.validate_lookup_accounts_batch_size},
+            );
+            try stdout.print(
+                "validate_lookup_accounts final batch size: {}\n",
+                .{self.validate_lookup_accounts_batch_size_rem},
+            );
+            try self.validate_lookup_accounts_latencies.print(stdout, "validate_lookup_accounts");
+        }
+        if (self.validate_lookup_transfers_operations > 0) {
+            try stdout.print(
+                "validate_lookup_transfers request time: {d:.2}s\n",
+                .{self.validate_lookup_transfers_request_time_s},
+            );
+            try stdout.print(
+                "validate_lookup_transfers operations: {}\n",
+                .{self.validate_lookup_transfers_operations},
+            );
+            try stdout.print(
+                "validate_lookup_transfers requests: {}\n",
+                .{self.validate_lookup_transfers_requests},
+            );
+            try stdout.print(
+                "validate_lookup_transfers batch size: {}\n",
+                .{self.validate_lookup_transfers_batch_size},
+            );
+            try stdout.print(
+                "validate_lookup_transfers final batch size: {}\n",
+                .{self.validate_lookup_transfers_batch_size_rem},
+            );
+            try self.validate_lookup_transfers_latencies.print(stdout, "validate_lookup_transfers");
+        }
+        if (self.validate_noop_operations > 0) {
+            try stdout.print(
+                "validate_noop request time: {d:.2}s\n",
+                .{self.validate_noop_request_time_s},
+            );
+            try stdout.print(
+                "validate_noop operations: {}\n",
+                .{self.validate_noop_operations},
+            );
+            try self.validate_noop_latencies.print(stdout, "validate_noop");
+        }
+        try stdout.print(
+            "-----\n", .{},
+        );
+    }
+};
+
+const LatencyPercentiles = struct {
+    percentiles: [7]u64,
+    latencies: [7]u64,
+    exceptions: [7]bool,
+
+    fn from_histogram(histogram_buckets: []const u64) LatencyPercentiles {
+        var histogram_total: u64 = 0;
+        for (histogram_buckets) |bucket| histogram_total += bucket;
+
+        const percentiles = [_]u64{ 1, 10, 50, 90, 95, 99, 100 };
+        var latencies = [_]u64{ 0 } ** percentiles.len;
+        var exceptions = [_]bool{ false } ** percentiles.len;
+        for (percentiles, 0..) |percentile, percentile_index| {
+            const histogram_percentile: usize = @divTrunc(histogram_total * percentile, 100);
+
+            // Since each bucket in our histogram represents 1ms, the bucket we're in is the ms value.
+            var sum: usize = 0;
+            const latency = for (histogram_buckets, 0..) |bucket, bucket_index| {
+                sum += bucket;
+                if (sum >= histogram_percentile) break bucket_index;
+            } else histogram_buckets.len;
+            latencies[percentile_index] = latency;
+
+            if (latency == histogram_buckets.len) {
+                exceptions[percentile_index] = true;
+            }
+        }
+
+        return LatencyPercentiles {
+            .percentiles = percentiles,
+            .latencies = latencies,
+            .exceptions = exceptions,
+        };
+    }
+
+    fn print(
+        self: *const LatencyPercentiles,
+        stdout: std.io.AnyWriter,
+        label: []const u8,
+    ) !void {
+        var have_exception = false;
+        var exception_chars = [_]u8{ ' ' } ** 7;
+        assert(self.exceptions.len == exception_chars.len);
+        for (self.exceptions, 0..) |exception, i| {
+            if (exception) {
+                have_exception = true;
+                exception_chars[i] = '*';
+            }
+        }
+
+        try stdout.print("{s} latency histogram:\n", .{label});
+        try stdout.print("|p |p{: <3}  |p{: <3}  |p{: <3}  |p{: <3}  |p{: <3}  |p{: <3}  |p{: <3}\n", .{
+            self.percentiles[0], self.percentiles[1],
+            self.percentiles[2], self.percentiles[3],
+            self.percentiles[4], self.percentiles[5],
+            self.percentiles[6],
+        });
+        try stdout.print("|ms|{: >5}{c}|{: >5}{c}|{: >5}{c}|{: >5}{c}|{: >5}{c}|{: >5}{c}|{: >5}{c}\n", .{
+            self.latencies[0], exception_chars[0],
+            self.latencies[1], exception_chars[1],
+            self.latencies[2], exception_chars[2],
+            self.latencies[3], exception_chars[3],
+            self.latencies[4], exception_chars[4],
+            self.latencies[5], exception_chars[5],
+            self.latencies[6], exception_chars[6],
+        });
+
+        if (have_exception) {
+            try stdout.print(" *: exceeds histogram resolution", .{});
+        }
+    }
+};


### PR DESCRIPTION
*This is just an incomplete draft so that people can see the big changes I am making to the benchmark. Review is not necessary yet, though it is welcome.*

This PR restructures the benchmark around execution of generalized workloads, each of which is composed of a probabilistic combination of all possible requests. This PR preserves the existing behavior of the benchmark (essentially, if not strictly) and does not change the CLI, but the intent is that the internal structure will support a future PR that does provide a more generalized and flexible interface. My personal goal is to support workloads similar to the 5 YCSB core workloads described in their [paper](https://courses.cs.duke.edu/fall13/cps296.4/838-CloudPapers/ycsb.pdf).

This PR is based on the introduction of the zipfian distribution in https://github.com/tigerbeetle/tigerbeetle/pull/2274, and most of the commits are from that PR. **Only the final commit ("wip-workload") is unique to this PR, so I recommend only reviewing that commit here**. This PR is not presently up to date with the zipfian PR it is based on, but will be later.

The changes are extensive, with much of the code moved from methods of `Benchmark` to methods of `WorkloadRunner`, `WorkloadOperations`, `WorkloadGenerator`, etc. I intend the structure to be clear, maintainable, and extensible to future request types and benchmark features. At present it _mostly_ reproduces all the behavior from `Benchmark`, but a few minor features are missing; this is at present a proof of concept that the existing behavior can be restructured in a way that is extensible to more generalized and complex workloads, preserving the "validation" feature, metrics, summary, etc. The methods on `Benchmark` still exist in this PR as I am working on it, but most are not called.

Missing features presently include `--checksum-performance`, `--print-batch-timings`, `--transfer-batch-delay`, some of the printed metrics.

Prior to this PR, the benchmark is organized as so:

- a number of accounts are generated as a non-measured setup step
- a number of transfers are sent and measured
- a number of queries are sent and measured
- optionally, the state of accounts and transactions are "validated" by re-running the random value generation and querying the database instead of sending transactions

After this PR, each of these is a separate "workload", with the validation step being executed by re-running the workload in a validation mode.

The collection of metrics and output summary is generalized around these workloads, so the exact format of the output needs to change. At present not all the same metrics are reported, but those details are easy to add. An example of the current output looks like:

```
$ zig/zig build run -- benchmark --account-count=1001 --account-batch-size=10 --transfer-count=1002 --transfer-batch-size=10 --query-count=1003 --account-distribution=zipfian --validate
info(io): opening "0_0-a016be46.tigerbeetle.benchmark"...
info(main): multiversioning: disabled for development (0.0.1) release.
info(main): release=0.0.1
info(main): release_client_min=0.0.1
info(main): releases_bundled={ 0.0.1 }
info(main): git_commit=22c9a7a1f919d50e1d28b3bb5f3c76e323578953
info(replica): superblock release=0.0.1
info(main): 0: Allocated 3077MiB during replica init
info(main): 0: Grid cache: 1024MiB, LSM-tree manifests: 128MiB
info(main): 0: cluster=0: listening on 127.0.0.1:38811
info(main): 0: started with extra verification checks
Benchmark must be built with '-Drelease' for reasonable results.
warning: extra assertions are enabled
info: Benchmark running against { 127.0.0.1:38811 }
info: Benchmark seed = 42
info: Account distributions = debit: zipfian; credit: zipfian; query: zipfian
info(message_bus): connected to replica 0
info(message_bus): connection from client 81211741692805082726730562303693272335
Running transactional workload 0
-----
# Workload 0
total time: 0.20
total request time: 0.19s
total non-request time: 0.00s
total operations: 1001
total requests: 101
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   33
create_accounts request time: 0.19s
create_accounts operations: 1001
create_accounts requests: 101
create_accounts batch size: 10
create_accounts final batch size: 1
create_accounts latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   33
-----
Running transactional workload 1
-----
# Workload 1
total time: 0.25
total request time: 0.25s
total non-request time: 0.00s
total operations: 1002
total requests: 101
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |   21 |   58
create_transfers request time: 0.25s
create_transfers operations: 1002
create_transfers requests: 101
create_transfers batch size: 10
create_transfers final batch size: 2
create_transfers latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |   21 |   58
-----
Running transactional workload 2
-----
# Workload 2
total time: 1.71
total request time: 1.70s
total non-request time: 0.01s
total operations: 1003
total requests: 1003
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   37
get_account_transfers request time: 1.70s
get_account_transfers operations: 1003
get_account_transfers latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   37
-----
Running transactional workload 3
-----
# Workload 3
total time: 3.43
total request time: 3.41s
total non-request time: 0.02s
total operations: 3006
total requests: 1206
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    2 |   51 |   57
create_accounts request time: 0.21s
create_accounts operations: 1030
create_accounts requests: 103
create_accounts batch size: 10
create_accounts final batch size: 0
create_accounts latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   51
create_transfers request time: 0.41s
create_transfers operations: 971
create_transfers requests: 98
create_transfers batch size: 10
create_transfers final batch size: 1
create_transfers latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    0 |    1 |    1 |    1 |   30 |   51 |   53
get_account_transfers request time: 2.79s
get_account_transfers operations: 1005
get_account_transfers latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    2 |   50 |   57
-----
Running validation workload 0
-----
# Workload 0
total time: 0.23
total request time: 0.23s
total non-request time: 0.00s
total operations: 1001
total requests: 101
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   30
validate_lookup_accounts request time: 0.23s
validate_lookup_accounts operations: 1001
validate_lookup_accounts requests: 101
validate_lookup_accounts batch size: 10
validate_lookup_accounts final batch size: 1
validate_lookup_accounts latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    2 |   30
-----
Running validation workload 1
-----
# Workload 1
total time: 0.18
total request time: 0.17s
total non-request time: 0.00s
total operations: 1002
total requests: 101
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |    2
validate_lookup_transfers request time: 0.17s
validate_lookup_transfers operations: 1002
validate_lookup_transfers requests: 101
validate_lookup_transfers batch size: 10
validate_lookup_transfers final batch size: 2
validate_lookup_transfers latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |    2
-----
Running validation workload 2
-----
# Workload 2
total time: 1.39
total request time: 1.38s
total non-request time: 0.01s
total operations: 1003
total requests: 1003
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |   13
validate_noop request time: 1.38s
validate_noop operations: 1003
validate_noop latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |   13
-----
Running validation workload 3
-----
# Workload 3
total time: 1.72
total request time: 1.70s
total non-request time: 0.02s
total operations: 3006
total requests: 1206
total latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |   11
validate_lookup_accounts request time: 0.14s
validate_lookup_accounts operations: 1030
validate_lookup_accounts requests: 103
validate_lookup_accounts batch size: 10
validate_lookup_accounts final batch size: 0
validate_lookup_accounts latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |    1
validate_lookup_transfers request time: 0.14s
validate_lookup_transfers operations: 971
validate_lookup_transfers requests: 98
validate_lookup_transfers batch size: 10
validate_lookup_transfers final batch size: 1
validate_lookup_transfers latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    0 |    1 |    1 |    1 |    1 |    1 |    1
validate_noop request time: 1.41s
validate_noop operations: 1005
validate_noop latency histogram:
|p |p1    |p10   |p50   |p90   |p95   |p99   |p100
|ms|    1 |    1 |    1 |    1 |    1 |    1 |   11
-----
info(main): stdin closed, exiting

rss = 3237859328 bytes

datafile empty = 1141374976 bytes
datafile = 1577062400 bytes
```

Note the change in how percentiles are printed. This is to be more compact, but in doing so I printed fewer buckets, assuming some of them were less interesting than others.


 