### PR TITLE
test: run concurrent workloads with separate ledgers

### DIFF
--- a/src/testing/systest/workload/src/main/java/Main.java
+++ b/src/testing/systest/workload/src/main/java/Main.java
@@ -2,6 +2,8 @@ import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
 import com.tigerbeetle.Client;
 import com.tigerbeetle.UInt128;
 
@@ -17,12 +19,34 @@ public final class Main {
           "REPLICAS must list at least one address (comma-separated)");
     }
 
+    int workloadCount = Integer.parseUnsignedInt(env.getOrDefault("WORKLOAD_COUNT", "5"));
+    if (replicaAddresses.length == 0) {
+      throw new IllegalArgumentException(
+          "REPLICAS must list at least one address (comma-separated)");
+    }
+
     Random random = new SecureRandom();
     byte[] clusterID = UInt128.asBytes(Long.parseLong(env.getOrDefault("CLUSTER", "1")));
 
     try (var client = new Client(clusterID, replicaAddresses)) {
-      System.err.println("starting workload");
-      new Workload(random, client).run();
+      System.err.println("starting %d workload(s)".formatted(workloadCount));
+
+      var executor = Executors.newFixedThreadPool(workloadCount);
+      var completionService = new ExecutorCompletionService<Void>(executor);
+
+      for (int i = 0; i < workloadCount; i++) {
+        final var ledger = i + 1;
+        completionService.submit(new Workload(random, client, ledger));
+      }
+
+      try {
+        for (int i = 0; i < workloadCount; i++) {
+          var result = completionService.take();
+          result.get();
+        }
+      } finally {
+        executor.shutdownNow();
+      }
     }
   }
 }

--- a/src/testing/systest/workload/src/main/java/Model.java
+++ b/src/testing/systest/workload/src/main/java/Model.java
@@ -1,46 +1,27 @@
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
- * Tracks information about the accounts created by test, i.e. their ids and which ledgers they
- * belong to.
+ * Tracks information about the accounts created by test (e.g. their ids). The model should only be
+ * used for a single ledger.
  */
 public class Model {
   /**
    * Accounts by id.
    */
   HashMap<Long, CreatedAccount> accounts = new HashMap<>();
+  public final int ledger;
+
+  public Model(int ledger) {
+    this.ledger = ledger;
+  }
 
   ArrayList<CreatedAccount> allAccounts() {
     // We use a sorted collection of accounts for stable index-based lookups.
     var allAccounts =
         accounts.values().stream().sorted(Comparator.comparing(account -> account.id())).toList();
     return new ArrayList<CreatedAccount>(allAccounts);
-  }
-
-  ArrayList<CreatedAccount> ledgerAccounts(int ledger) {
-    // We use a sorted collection of accounts for stable index-based lookups.
-    var ledgerAccounts = accounts.values().stream().filter(account -> account.ledger() == ledger)
-        .sorted(Comparator.comparing(account -> account.id())).toList();
-
-    return new ArrayList<CreatedAccount>(ledgerAccounts);
-  }
-
-  Map<Integer, ArrayList<CreatedAccount>> accountsPerLedger() {
-    var ledgerAccounts =
-        accounts.values().stream().collect(Collectors.groupingBy(account -> account.ledger()));
-
-    var results = new HashMap<Integer, ArrayList<CreatedAccount>>();
-
-    for (var entry : ledgerAccounts.entrySet()) {
-      var values = new ArrayList<CreatedAccount>(entry.getValue());
-      results.put(entry.getKey(), values);
-    }
-
-    return results;
   }
 }
 

--- a/src/testing/systest/workload/src/main/java/Statistics.java
+++ b/src/testing/systest/workload/src/main/java/Statistics.java
@@ -1,0 +1,37 @@
+/**
+ * Collects basic statistics about requests completed by the workload.
+ * This class is thread-safe.
+ */
+class Statistics {
+  private long startTimeMs;
+  private long successful;
+  private long failed;
+
+  public Statistics(long startTimeMs) {
+    this.startTimeMs = startTimeMs;
+    this.successful = 0;
+    this.failed = 0;
+  }
+
+  public synchronized long requestsPerSecond() {
+    long nowMs = System.currentTimeMillis();
+    long elapsedSeconds = (nowMs - startTimeMs) / 1000;
+    return (successful / elapsedSeconds) + (failed / elapsedSeconds);
+  }
+
+  public synchronized long successful() {
+      return this.successful;
+  }
+
+  public synchronized long failed() {
+      return this.failed;
+  }
+
+  public void addRequests(long successful, long failed) {
+    synchronized (this) {
+      this.successful += successful;
+      this.failed += failed;
+    }
+  }
+
+}

--- a/src/testing/systest/workload/src/main/java/Workload.java
+++ b/src/testing/systest/workload/src/main/java/Workload.java
@@ -3,6 +3,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import com.tigerbeetle.AccountFlags;
 import com.tigerbeetle.Client;
@@ -16,20 +17,24 @@ import com.tigerbeetle.TransferFlags;
  *
  * After every operation, all accounts are queried, and basic invariants are checked.
  */
-public class Workload {
+public class Workload implements Callable<Void> {
   static int ACCOUNTS_COUNT_MAX = 100;
   static int BATCH_SIZE_MAX = 100;
 
-  Model model = new Model();
-  Random random;
-  Client client;
+  final Model model;
+  final Random random;
+  final Client client;
+  final int ledger;
 
-  public Workload(Random random, Client client) {
+  public Workload(Random random, Client client, int ledger) {
     this.random = random;
     this.client = client;
+    this.model = new Model(ledger);
+    this.ledger = ledger;
   }
 
-  void run() {
+  @Override
+  public Void call() {
     long commandsFailedCount = 0;
     long commandsSucceededCount = 0;
 
@@ -54,7 +59,10 @@ public class Workload {
 
         if (n % 1000 == 0) {
           System.err.println(
-              "%d succeeded, %d failed".formatted(commandsSucceededCount, commandsFailedCount));
+              "ledger %d: %d succeeded, %d failed".formatted(
+                ledger, 
+                commandsSucceededCount, 
+                commandsFailedCount));
         }
 
         lookupAllAccounts().ifPresent(query -> {
@@ -62,7 +70,9 @@ public class Workload {
           response.reconcile(model);
         });
       } catch (AssertionError e) {
-        System.err.print("Assertion failed after executing command: %s".formatted(command));
+        System.err.println("ledger %d: Assertion failed after executing command: %s".formatted(
+              ledger, 
+              command));
         throw e;
       }
     }
@@ -100,7 +110,6 @@ public class Workload {
 
         for (int i = 0; i < newAccountsCount; i++) {
           var id = random.nextLong(0, Long.MAX_VALUE);
-          var ledger = random.nextInt(1, 10);
           var code = random.nextInt(1, 100);
           var flags = Arbitrary.element(random,
               List.of(AccountFlags.NONE, AccountFlags.LINKED,
@@ -119,11 +128,10 @@ public class Workload {
   }
 
   Optional<Supplier<? extends Command<?>>> createTransfers() {
-    // We can only try to transfer within ledgers with at least two accounts.
-    var enabledLedgers = model.accountsPerLedger().entrySet().stream()
-        .filter(accounts -> accounts.getValue().size() > 2).toList();
+    var accounts = model.allAccounts();
 
-    if (enabledLedgers.isEmpty()) {
+    // We can only transfer when there are at least two accounts.
+    if (accounts.size() < 2) {
       return Optional.empty();
     }
 
@@ -132,13 +140,7 @@ public class Workload {
       var newTransfers = new ArrayList<NewTransfer>(transfersCount);
 
       for (int i = 0; i < transfersCount; i++) {
-        // For every transfer we pick a random (enabled) ledger.
-        var ledger = Arbitrary.element(random, enabledLedgers);
-        var accounts = ledger.getValue();
-
-
         var id = random.nextLong(0, Long.MAX_VALUE);
-        var ledger2 = ledger.getKey();
         var code = random.nextInt(1, 100);
         var amount = BigInteger.valueOf(random.nextLong(0, Long.MAX_VALUE));
         var flags = Arbitrary.element(random,
@@ -147,14 +149,14 @@ public class Workload {
                 TransferFlags.BALANCING_DEBIT, TransferFlags.BALANCING_CREDIT,
                 TransferFlags.CLOSING_DEBIT, TransferFlags.CLOSING_CREDIT));
 
-        int debitAccountIndex = random.nextInt(0, ledger.getValue().size());
+        int debitAccountIndex = random.nextInt(0, accounts.size());
         int creditAccountIndex = random.ints(0, accounts.size())
             .filter((index) -> index != debitAccountIndex).findFirst().orElseThrow();
         var debitAccountId = accounts.get(debitAccountIndex).id();
         var creditAccountId = accounts.get(creditAccountIndex).id();
 
         newTransfers.add(
-            new NewTransfer(id, debitAccountId, creditAccountId, ledger2, code, amount, flags));
+            new NewTransfer(id, debitAccountId, creditAccountId, ledger, code, amount, flags));
       }
 
       return new CreateTransfers(newTransfers);


### PR DESCRIPTION
Restructures the systest workload (in Java) to run multiple workloads in separate threads, isolated by using unique ledgers. This let's us verify the thread safety claim of the Java client, which is shared across the threads.

The verified properties after querying known accounts are similar to before, because we already grouped accounts by ledger and checked consistency for each group.