### PR TITLE
io/storage: add the ability to do per io dsync, and explicit fsync

### DIFF
--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -90,6 +90,7 @@ test "open/write/read/close/statx" {
                 self.fd.?,
                 &self.write_buf,
                 10,
+                .{ .dsync = true },
             );
         }
 

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -925,7 +925,11 @@ pub const IO = struct {
         fd: fd_t,
         buffer: []const u8,
         offset: u64,
+        options: struct { dsync: bool },
     ) void {
+        // Windows will fsync on every write for now.
+        _ = options;
+
         self.submit(
             context,
             callback,

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -207,7 +207,10 @@ pub const IO = struct {
         fd: fd_t,
         buffer: []const u8,
         offset: u64,
+        options: struct { dsync: bool },
     ) void {
+        _ = options;
+
         assert(fd < self.files.len);
 
         self.submit(

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -470,8 +470,8 @@ test "trace json" {
 
     try snap(@src(),
         \\[
-        \\{"pid":0,"tid":208,"ph":"B","ts":0,"cat":"metrics_emit","name":"metrics_emit  ","args":""},
-        \\{"pid":0,"tid":208,"ph":"E","ts":10000},
+        \\{"pid":0,"tid":209,"ph":"B","ts":0,"cat":"metrics_emit","name":"metrics_emit  ","args":""},
+        \\{"pid":0,"tid":209,"ph":"E","ts":10000},
         \\{"pid":1,"tid":0,"ph":"B","ts":10000,"cat":"replica_commit","name":"replica_commit  stage=idle","args":{"stage":"idle","op":123}},
         \\{"pid":1,"tid":8,"ph":"B","ts":20000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
         \\{"pid":1,"tid":8,"ph":"E","ts":40000},

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -92,6 +92,7 @@ pub const Event = union(enum) {
     grid_write: struct { iop: usize },
     storage_read: struct { zone: Zone },
     storage_write: struct { zone: Zone },
+    storage_flush,
 
     metrics_emit: void,
 
@@ -167,6 +168,7 @@ pub const EventTiming = union(Event.Tag) {
     grid_write,
     storage_read: struct { zone: Zone },
     storage_write: struct { zone: Zone },
+    storage_flush,
 
     metrics_emit,
 
@@ -194,6 +196,7 @@ pub const EventTiming = union(Event.Tag) {
         .metrics_emit = 1,
         .storage_read = enum_max(Zone),
         .storage_write = enum_max(Zone),
+        .storage_flush = 1,
         .client_request_round_trip = enum_max(Operation),
     });
 
@@ -327,6 +330,7 @@ pub const EventTracing = union(Event.Tag) {
     grid_write: struct { iop: usize },
     storage_read,
     storage_write,
+    storage_flush,
 
     metrics_emit,
 
@@ -353,6 +357,7 @@ pub const EventTracing = union(Event.Tag) {
         .grid_write = constants.grid_iops_write_max,
         .storage_read = 1,
         .storage_write = 1,
+        .storage_flush = 1,
         .metrics_emit = 1,
         .client_request_round_trip = 1,
     });
@@ -654,6 +659,7 @@ test "EventTiming slot doesn't have collisions" {
             .grid_write => .grid_write,
             .storage_read => .{ .storage_read = .{ .zone = g.enum_value(Zone) } },
             .storage_write => .{ .storage_write = .{ .zone = g.enum_value(Zone) } },
+            .storage_flush => .storage_flush,
             .metrics_emit => .metrics_emit,
             .client_request_round_trip => .{ .client_request_round_trip = .{
                 .operation = g.enum_value(Operation),

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -163,6 +163,22 @@ pub const Zone = enum {
         };
     }
 
+    pub fn dsync(zone: Zone) bool {
+        return switch (zone) {
+            .grid => false,
+            else => true,
+        };
+    }
+
+    // Ensuring only the grid is written without dsync is _critical_ to safety!
+    comptime {
+        for (std.enums.values(Zone)) |zone| {
+            if (!zone.dsync()) {
+                assert(zone == .grid);
+            }
+        }
+    }
+
     /// Ensures that the read or write is aligned correctly for Direct I/O.
     /// If this is not the case, then the underlying syscall will return EINVAL.
     /// We check this only at the start of a read or write because the physical sector size may be

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -52,6 +52,7 @@ pub fn GridType(comptime Storage: type) type {
 
         // Grid just reuses the Storage's NextTick abstraction for simplicity.
         pub const NextTick = Storage.NextTick;
+        pub const Flush = Storage.Flush;
 
         pub const Write = struct {
             callback: *const fn (*Grid.Write) void,


### PR DESCRIPTION
Specifically, we handle all non-grid writes with DSYNC, much in the same way as they were before. Grid writes are flushed after each beat on compaction with an explicit fsync. (technically we request the entire file to be flushed, and Linux will request the entire NVMe namespace to be flushed...)

This supplants #827 with a few differences:
* Due to the new compaction code, there's a natural place to put a call to fsync: after the work for a beat has finished. This fsync is called there as a barrier, so it happens much more frequently than checkpoint, so we won't have a large periodic spike.
* Darwin support. After adding `F_FULLSYNC` after each write, the performance on macOS suffered quite significantly. This brings it back up, with a roughly 4x (!) improvement from 44k TPS to 186k TPS.

In terms of Linux performance, this takes the benchmark from ~308k to ~365k for 10 million transfers. The gap widens with more compactions - at 50 million transfers, it's ~176k vs ~314k.

One source of this performance is that our compaction queue utilization isn't perfect. By allowing the drive's cache to absorb some of the writes, then flush them, we're cheating around this. Additionally, these numbers are from consumer hardware - it's likely enterprise SSDs with battery backed cache won't see much, if any, change.

However, even with perfect queue depth, there's another hidden advantage: when growing the data file, because the inode size metadata has to be updated and journaled, [Linux falls back to using FLUSH as opposed to FUA](https://www.uwsg.indiana.edu/hypermail/linux/kernel/1904.1/03845.html). Now, this happens once per beat, instead of once per compaction write! 

(an alternative solution to the above is preallocating and growing the data file in chunks).

## Tracing NVMe requests
If you're curious, you can directly trace the ops issued to the NVMe drive on Linux with:

```
echo 1 > /sys/kernel/debug/tracing/events/nvme/enable
cat /sys/kernel/debug/tracing/trace_pipe  | grep nvme_setup_cmd | grep 'nvme_cmd_flush'
```

In this case, for the 10 million transfer benchmark, total flushes go from ~3000 to ~2300.