### PR TITLE
Multiversioning: Read the entire binary

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -283,8 +283,8 @@ test "help/version smoke" {
 test "in-place upgrade" {
     // Smoke test that in-place upgrades work.
     //
-    // Stats a cluster of three replicas using the previous release of TigerBeetle and then replaces
-    // the binaries on disk with a new version.
+    // Starts a cluster of three replicas using the previous release of TigerBeetle and then
+    // replaces the binaries on disk with a new version.
     //
     // Against this upgrading cluster, we are running a benchmark load and checking that it finishes
     // with a zero status.

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -524,7 +524,7 @@ fn replica_release_execute(replica: *Replica, release: vsr.Release) noreturn {
         if (release_bundled.value == release.value) break;
     } else {
         log.err("{}: release_execute: release {} is not available;" ++
-            "upgrade (or downgrade) the binary", .{
+            " upgrade (or downgrade) the binary", .{
             replica.replica,
             release,
         });


### PR DESCRIPTION
The `"in-place upgrade"` integration test went from passing consistently to failing _most_ (though not all) of the time.

In the upgrade integration test, after we replace the binary, the running replica detects that the binary changed.
Then it reads the new binary.

When the whole binary fits in a single read, the test passes.
When the whole binary doesn't fit in a single read, it fails to parse (`error.InvalidELF`).

(I'm guessing that this started failing as the binary has grown larger (as more versions are bundled each week).)

Fix: ~Use the size from `statx()`, and keep reading from increasing offsets until the entire binary is read.~
Read until one of the reads returns zero bytes. (Since `statx()` is only available on linux).