### PR TITLE
build: verify multiversion header during build

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -104,6 +104,13 @@ pub fn main() !void {
             .output = cli_args.output,
         }),
     }
+
+    const stat = try shell.cwd.statFile(cli_args.output);
+    assert(stat.size <= multiversion_binary_size_max);
+    assert(stat.size <= multiversioning.multiversion_binary_platform_size_max(.{
+        .macos = target == .macos,
+        .debug = cli_args.debug,
+    }));
 }
 
 fn build_multiversion_single_arch(shell: *Shell, options: struct {
@@ -519,9 +526,9 @@ fn build_multiversion_body(shell: *Shell, options: struct {
         (try shell.cwd.statFile(old_current_release_output_name)).size,
     );
 
-    // You can have as many releases as you want, as long as it's 6 or less.
+    // You can have as many releases as you want, as long as it's 5 or less.
     // This is made up of:
-    // * up to 4 releases from the old past pack (extracted from the release downloaded),
+    // * up to 3 releases from the old past pack (extracted from the release downloaded),
     // * 1 old current release (extracted from the release downloaded),
     // * 1 current release (that was just built).
     // This will be improved soon:
@@ -530,7 +537,7 @@ fn build_multiversion_body(shell: *Shell, options: struct {
     // No size limits are explicitly checked here; they're validated later by using the
     // `multiversion` subcommand to test the final built binary against all past binaries that are
     // included.
-    const past_count = @min(4, header.past.count);
+    const past_count: u32 = @min(3, header.past.count);
 
     const past_starting_index = header.past.count - past_count;
 

--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -191,6 +191,7 @@ fn build_multiversion_single_arch(shell: *Shell, options: struct {
         .current_git_commit = try git_sha_to_binary(&vsr_options.git_commit.?),
     };
     header.checksum_header = header.calculate_header_checksum();
+    try header.verify();
 
     try shell.cwd.writeFile(.{
         .sub_path = sections.header,
@@ -343,6 +344,7 @@ fn build_multiversion_universal(shell: *Shell, options: struct {
             .current_git_commit = try git_sha_to_binary(&vsr_options.git_commit.?),
         };
         header.checksum_header = header.calculate_header_checksum();
+        try header.verify();
 
         try shell.cwd.writeFile(.{
             .sub_path = header_name,


### PR DESCRIPTION
Right now, it is possible to build a multiversion binary where last release is not the newest of the pack. Luckily, we validate that when _loading_ the binary, but we definitely should have validated that during the build as well!

What's worse, it seems like we don't have any binary size validation whatsoever, ~~and that, in fact, our latest debug release blew past the limit already!~~ Assert&fix that as well. It seems like we've caught that just in time --- the _next_ release would've blew past the limit!

This does require cutting the number of releases we include from 6 to just 5.