### PR TITLE
ci: avoid dependency on gh

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -79,10 +79,6 @@ pub fn main() !void {
 
     const target = try Target.parse(cli_args.target);
 
-    // When we fetch llvm-objcopy in build.zig, there isn't an easy way to mark it as
-    // executable, so do it here.
-    try shell.file_make_executable(cli_args.llvm_objcopy);
-
     switch (target) {
         .windows, .linux => try build_multiversion_single_arch(shell, .{
             .llvm_objcopy = cli_args.llvm_objcopy,


### PR DESCRIPTION
We use `gh` to download releases, but that is suboptimal as:

* this is an extra dependency,
* it requires auth.

But zig is a perfectly fine `curl`, via `zig fetch`, so let's use that.