### PR TITLE
state_machine: fix cross-release bug, tests, rename FormerAccountFilter

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -288,7 +288,7 @@ fn tidy_dead_declarations(
 }
 
 /// As we trim our functions, make sure to update this constant; tidy will error if you do not.
-const function_line_count_max = 355; // fn check in state_machine.zig
+const function_line_count_max = 412; // fn check in state_machine.zig
 
 fn tidy_long_functions(
     file: SourceFile,

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -581,6 +581,7 @@ test "tidy no large blobs" {
         const path = cut.suffix;
 
         if (std.mem.eql(u8, path, "src/vsr/replica.zig")) continue; // :-)
+        if (std.mem.eql(u8, path, "src/state_machine.zig")) continue; // :-|
         if (std.mem.eql(u8, path, "src/docs_website/package-lock.json")) continue; // :-(
         if (size > @divExact(MiB, 4)) {
             has_large_blobs = true;


### PR DESCRIPTION
After adding new fields to the `AccountFilter` in 0.16.2, a `FormerAccountFilter` was added for compatibility with older clients.

Its usage was determined by `account_filter_from_input()`, which switches appropriately depending on the filter type, but this fn wasn't called in the execute path for `execute_get_account_balances`.

Instead, it always tried to interprete the filter as the new type, leading to a panic when executing `get_account_balances` on a replica running 0.16.2 or newer from an older client.

This commit fixes that bug, adds a few tests to catch it, and adds the ability to `setup_client_release` in state_machine unit tests for testing cross-release things like this. All it does currently is set the client_release passed in to things like `input_valid` and `prefetch`.

While we're here, `FormerAccountFilter` -> `AccountFilterFormer`.