### PR TITLE
[FIX] Client compatibility if a transient error is solved and retried.

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1214,8 +1214,12 @@ pub fn GrooveType(
         pub fn insert(groove: *Groove, object: *const Object) void {
             assert(object.timestamp >= TimestampRange.timestamp_min);
             assert(object.timestamp <= TimestampRange.timestamp_max);
-            if (constants.verify) {
-                assert(!groove.objects_cache.has(@field(object, primary_field)));
+
+            // Old clients may retry the same transient error many times.
+            // TODO: When client_release_min is bumped, replace this code with
+            // `assert(!groove.objects_cache.has(@field(object, primary_field)));`
+            if (groove.objects_cache.get(@field(object, primary_field))) |existing| {
+                assert(existing.timestamp == 0);
             }
 
             groove.objects_cache.upsert(object);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -4140,8 +4140,16 @@ test "create_transfers/lookup_transfers" {
         \\ transfer   T8 A1 A3    0   _  _  _  _    _ L1 C2   _   _   _   _   _   _ _  _ _ _ _ ok
         \\ commit create_transfers
         \\
-        \\ lookup_account A1 223 203   0   7  _
-        \\ lookup_account A3   0   7 233 213  _
+        // Ensure compatibility with clients < 0.16.4
+        \\ setup_client_release 0 16 3
+        \\ transfer   T9 A4 A5  199   _  _  _  _    _ L1 C1   _   _   _   _   _   _ _  _   _   _ _ exceeds_credits
+        \\ transfer   T9 A4 A5  199   _  _  _  _    _ L1 C1   _   _   _   _   _   _ _  _   _   _ _ exceeds_credits
+        \\ transfer   T9 A1 A3    1   _  _  _  _    _ L1 C1   _ _     _   _   _   _ _  _   _   _ _ ok
+        \\ transfer   T9 A1 A3    1   _  _  _  _    _ L2 C1   _ _     _   _   _   _ _  _   _   _ _ transfer_must_have_the_same_ledger_as_accounts
+        \\ commit create_transfers
+        \\
+        \\ lookup_account A1 223 204   0   7  _
+        \\ lookup_account A3   0   7 233 214  _
         \\ commit lookup_accounts
         \\
         \\ lookup_transfer T5 exists true


### PR DESCRIPTION
Assert clients < 0.16.4 are compatible with scenarios where the new results `id_already_failed` and `exists_with_different_ledger` would be returned.

Fix an overtight assertion that would cause the **replica to crash** if a transient error is solved.