### PR TITLE
Add missing Query API in docs and C header

### DIFF
--- a/docs/reference/requests/README.md
+++ b/docs/reference/requests/README.md
@@ -23,6 +23,8 @@ event in the request.
   `credit_account_id`
 - [`get_account_balances`](./get_account_balances.md): fetch the historical account balance by the
   `Account`'s `id`.
+- [`query_accounts`](./query_accounts.md): query `Account`s
+- [`query_transfers`](./query_transfers.md): query `Transfer`s
 
 _More request types, including more powerful queries, are coming soon!_
 
@@ -36,8 +38,10 @@ Each request has a corresponding _event_ and _result_ type:
 | `create_transfers`      | [`Transfer`](./create_transfers.md#Event)           | [`CreateTransferResult`](./create_transfers.md#Result)          |
 | `lookup_accounts`       | [`Account.id`](./lookup_accounts.md#Event)          | [`Account`](./lookup_accounts.md#Result) or nothing             |
 | `lookup_transfers`      | [`Transfer.id`](./lookup_transfers.md#Event)        | [`Transfer`](./lookup_transfers.md#Result) or nothing           |
-| `get_account_transfers` | [`AccountFilter`](./get_account_transfers.md#Event) | [`Transfer`](./get_account_transfers.md#Result) or nothing      |
-| `get_account_balances`  | [`AccountFilter`](./get_account_balances.md#Event)  | [`AccountBalance`](./get_account_balances.md#Result) or nothing |
+| `get_account_transfers` | [`AccountFilter`](../account-filter.md)             | [`Transfer`](./get_account_transfers.md#Result) or nothing      |
+| `get_account_balances`  | [`AccountFilter`](../account-filter.md)             | [`AccountBalance`](./get_account_balances.md#Result) or nothing |
+| `query_accounts`        | [`QueryFilter`](../query-filter.md)                 | [`Account`](./lookup_accounts.md#Result) or nothing             |
+| `query_transfers`       | [`QueryFilter`](../query-filter.md)                 | [`Transfer`](./lookup_transfers.md#Result) or nothing           |
 
 ### Idempotency
 
@@ -60,6 +64,8 @@ In the default configuration, the maximum batch sizes for each request type are:
 | `create_transfers`      |                        8190 |                       8190 |
 | `get_account_transfers` |                           1 |                       8190 |
 | `get_account_balances`  |                           1 |                       8190 |
+| `query_accounts`        |                           1 |                       8190 |
+| `query_transfers`       |                           1 |                       8190 |
 
 TigerBeetle clients automatically batch events. Therefore, it is recommended to share the client
 instances between multiple threads or tasks to have events batched transparently.

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -209,6 +209,23 @@ typedef struct tb_account_balance_t {
     uint8_t reserved[56];
 } tb_account_balance_t;
 
+typedef struct tb_query_filter_t {
+    tb_uint128_t user_data_128;
+    uint64_t user_data_64;
+    uint32_t user_data_32;
+    uint32_t ledger;
+    uint16_t code;
+    uint8_t reserved[6];
+    uint64_t timestamp_min;
+    uint64_t timestamp_max;
+    uint32_t limit;
+    uint32_t flags;
+} tb_query_filter_t;
+
+typedef enum TB_QUERY_FILTER_FLAGS {
+    TB_QUERY_FILTER_REVERSED = 1 << 0,
+} TB_QUERY_FILTER_FLAGS;
+
 typedef enum TB_OPERATION {
     TB_OPERATION_PULSE = 128,
     TB_OPERATION_CREATE_ACCOUNTS = 129,
@@ -254,7 +271,7 @@ typedef enum TB_STATUS {
     TB_STATUS_NETWORK_SUBSYSTEM = 6,
 } TB_STATUS;
 
-// Initialize a new TigerBeetle client which connects to the addresses provided and 
+// Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_STATUS tb_client_init(
     tb_client_t* out_client,
@@ -275,7 +292,7 @@ TB_STATUS tb_client_init_echo(
     void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
 );
 
-// Retrieve the callback context initially passed into `tb_client_init` or 
+// Retrieve the callback context initially passed into `tb_client_init` or
 // `tb_client_init_echo`.
 uintptr_t tb_client_completion_context(
     tb_client_t client

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -15,6 +15,8 @@ const type_mappings = .{
     .{ tb.AccountFilter, "tb_account_filter_t" },
     .{ tb.AccountFilterFlags, "TB_ACCOUNT_FILTER_FLAGS" },
     .{ tb.AccountBalance, "tb_account_balance_t" },
+    .{ tb.QueryFilter, "tb_query_filter_t" },
+    .{ tb.QueryFilterFlags, "TB_QUERY_FILTER_FLAGS" },
 
     .{ tb_client.tb_operation_t, "TB_OPERATION" },
     .{ tb_client.tb_packet_status_t, "TB_PACKET_STATUS" },
@@ -197,7 +199,7 @@ pub fn main() !void {
     // TODO: use `std.meta.declaractions` and generate with pub + export functions.
     // Zig 0.9.1 has `decl.data.Fn.arg_names` but it's currently/incorrectly a zero-sized slice.
     try buffer.writer().print(
-        \\// Initialize a new TigerBeetle client which connects to the addresses provided and 
+        \\// Initialize a new TigerBeetle client which connects to the addresses provided and
         \\// completes submitted packets by invoking the callback with the given context.
         \\TB_STATUS tb_client_init(
         \\    tb_client_t* out_client,
@@ -218,7 +220,7 @@ pub fn main() !void {
         \\    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
         \\);
         \\
-        \\// Retrieve the callback context initially passed into `tb_client_init` or 
+        \\// Retrieve the callback context initially passed into `tb_client_init` or
         \\// `tb_client_init_echo`.
         \\uintptr_t tb_client_completion_context(
         \\    tb_client_t client

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -209,6 +209,23 @@ typedef struct tb_account_balance_t {
     uint8_t reserved[56];
 } tb_account_balance_t;
 
+typedef struct tb_query_filter_t {
+    tb_uint128_t user_data_128;
+    uint64_t user_data_64;
+    uint32_t user_data_32;
+    uint32_t ledger;
+    uint16_t code;
+    uint8_t reserved[6];
+    uint64_t timestamp_min;
+    uint64_t timestamp_max;
+    uint32_t limit;
+    uint32_t flags;
+} tb_query_filter_t;
+
+typedef enum TB_QUERY_FILTER_FLAGS {
+    TB_QUERY_FILTER_REVERSED = 1 << 0,
+} TB_QUERY_FILTER_FLAGS;
+
 typedef enum TB_OPERATION {
     TB_OPERATION_PULSE = 128,
     TB_OPERATION_CREATE_ACCOUNTS = 129,
@@ -254,7 +271,7 @@ typedef enum TB_STATUS {
     TB_STATUS_NETWORK_SUBSYSTEM = 6,
 } TB_STATUS;
 
-// Initialize a new TigerBeetle client which connects to the addresses provided and 
+// Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_STATUS tb_client_init(
     tb_client_t* out_client,
@@ -275,7 +292,7 @@ TB_STATUS tb_client_init_echo(
     void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
 );
 
-// Retrieve the callback context initially passed into `tb_client_init` or 
+// Retrieve the callback context initially passed into `tb_client_init` or
 // `tb_client_init_echo`.
 uintptr_t tb_client_completion_context(
     tb_client_t client


### PR DESCRIPTION
- Update "requests" page with `query_*` operations.
- Update C header with query filter/flags