### PR TITLE
vsr: use checkpoint header from superblock on startup if vsr_headers are from future checkpoint

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -711,6 +711,13 @@ pub fn ReplicaType(
                 // that SV to a DVC (dropping the hooks), and never finished the view change.
                 if (op_head == null) {
                     assert(self.view > self.log_view);
+                    if (self.journal.op_maximum() < self.op_checkpoint()) {
+                        const header_checkpoint =
+                            &self.superblock.working.vsr_state.checkpoint.header;
+                        assert(header_checkpoint.op == self.op_checkpoint());
+                        assert(!self.journal.has(header_checkpoint));
+                        self.journal.set_header_as_dirty(header_checkpoint);
+                    }
                     op_head = self.journal.op_maximum();
                 }
             }


### PR DESCRIPTION
This PR fixes the failed seed ./zig/zig build -Drelease vopr -- --lite 2793891317798544292 on main (843ff9a). In this seed, we found a syncing replica that restarts with `self.op < self.op_checkpoint()`, tripping this assert:
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L718-L720

**_Note:_** _This_ particular seed involves a syncing replica, but a non-syncing replica is vulnerable to the same fate as well.

### Solution and backstory

We now use the `superblock.vsr_state.checkpoint.header` from our superblock on startup, _if_ we don't find any headers from `superblock.vsr_headers()` within our `op_prepare_max`. 

We took our first step towards ensuring  _"non-faulty replicas don't restart in .recovering_head state"_ in https://github.com/tigerbeetle/tigerbeetle/pull/2313, wherein we decided to make view, log_view, and view_headers durable as part of `superblock.checkpoint`. We thought that this would suffice and so we added the following assert for this in https://github.com/tigerbeetle/tigerbeetle/pull/2345:
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L718-L720

However, it was just a matter of time before the VOPR would prove us wrong! _This_ solution, however, _should_ be the final nail in the coffin for _"non-faulty replicas restarting in .recovering_head state"_.

### What did we observe in the VOPR bug?

<details>
<summary>Detailed root-cause analysis for 2793891317798544292</summary>
<br>
R2 syncs to op_checkpoint=79 in view=128. It receives a SV belonging to op_checkpoint=79.
<br><br>
<pre>
[debug] (replica): 2: on_start_view: sync started view=128 op_checkpoint=19 op_checkpoint_new=79
[debug] (replica): 2: sync_dispatch: awaiting_checkpoint..updating_checkpoint
[debug] (journal): 2: remove_entries_from: op_min=90
[debug] (replica): 2: on_start_view: view=139 op=39..89 commit=36..85
[debug] (journal): 2: set_header_as_dirty: op=89 checksum=224660968731082331483360323099720333733
[debug] (journal): 2: set_header_as_dirty: op=88 checksum=79542166275339284590358396527562381772
[debug] (journal): 2: set_header_as_dirty: op=87 checksum=296685601794364357684380636429148020511
[debug] (journal): 2: set_header_as_dirty: op=86 checksum=146413527634262165159283002162944793784
[debug] (journal): 2: set_header_as_dirty: op=85 checksum=326327794229916937435010146665442817256
[debug] (journal): 2: set_header_as_dirty: op=71 checksum=326382765393447513253287806246695748310
[debug] (replica): 2: transition_to_normal_from_view_change_status: view=139..139 backup
</pre>
<br>
R2 cycles through view changes up to view=144, some replicas have moved forward to op_checkpoint=99 so the SV headers R2 has received for one of the previous views belongs to op_checkpoint=99. While moving to view=144, SV is converted to DVC and the hook headers for ops 111 & 91 are dropped.
<br><br>
<pre>
[debug] (superblock): 2: view_change: vsr_header: op=116 checksum=241986293699330141264660838796312744086
[debug] (superblock): 2: view_change: vsr_header: op=115 checksum=232655993260648029469703806925004254316
[debug] (superblock): 2: view_change: vsr_header: op=114 checksum=100156909136025166259683376618904595686
[debug] (superblock): 2: view_change: vsr_header: op=113 checksum=11412001273261834769373869866959035128
[debug] (superblock): 2: view_change: vsr_header: op=112 checksum=210151254558897297725920411255228472238
[debug] (superblock): 2: view_change: complete
[debug] (replica): 2: view_durable_update_callback: (view_durable=144 log_view_durable=142)
</pre>

<br>
R2 crashes and restarts, with view=144, log_view=142, op_checkpoint=79. It can't use any of the durable vsr_headers since they're beyond its op_prepare_max (111). R2 tries to find the head op from the journal but it hasn't repaired anything yet. `assert(op_head.? >= self.op_checkpoint())` is triggered.
<br><br>
<pre>
[debug] (journal): 2: recover_slots: dirty=0 faulty=0
thread 32667602 panic: reached unreachable code
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/zig/lib/std/debug.zig:412:14: 0x1049a170f in assert (vopr)
    if (!ok) unreachable; // assertion failure
             ^
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vsr/replica.zig:720:19: 0x1049d405b in open (vopr)
            assert(op_head.? >= self.op_checkpoint());
</pre>
</details>

