### PR TITLE
vsr: nack different prepares b/w DVC & journal iff DVC is non-blank

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7488,6 +7488,11 @@ pub fn ReplicaType(
                     maybe(nacks.isSet(i));
                     present.set(i);
                 }
+
+                if (vsr.Headers.dvc_header_type(header) == .blank) {
+                    assert(!present.isSet(i));
+                    if (nacks.isSet(i)) assert(!faulty);
+                }
             }
 
             const message = self.message_bus.get_message(.do_view_change);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7463,7 +7463,9 @@ pub fn ReplicaType(
                 }
 
                 // Case 2: We have a _different_ prepare — safe to nack even if it is faulty.
-                if (journal_header != null and journal_header.?.checksum != header.checksum) {
+                if (journal_header != null and vsr.Headers.dvc_header_type(header) == .valid and
+                    journal_header.?.checksum != header.checksum)
+                {
                     nacks.set(i);
                 }
 


### PR DESCRIPTION
This PR fixes the failed seed `./zig/zig build  vopr -- --lite 364110200398911730` on main (https://github.com/tigerbeetle/tigerbeetle/commit/5159e60472d154dfcf43f44d5bc36d2f8186913f). 

### Problem

In this seed, we observe a replica R whose durable DVC headers contain blanks (as they were first populated using a journal that had corrupt slots). These DVC headers cause R to not contribute to the nack quorum for the blank ops (they are marked as `nack=false present=false`), causing view changes to hit the `quorum received, awaiting repair` case. However, when R crashes and restarts with a clean journal and the same DVC headers with blanks, it nacks the blank ops (they are marked as `nack=true present=false`), triggering the following assertion: https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L10140

The root cause here is that `send_do_view_change` nacks an op if it is non-null in the journal, and its checksum in the journal doesn't match its checksum in the DVC. However, this logic does not correctly honor _blank_ DVCs. In other words, if an op in a DVC is blank, it is *always* nacked, regardless of whether its present in the journal or not.
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L7458-L7461

### Solution

The solution entails comparing the checksum between a header in the journal and the DVC *iff* the header is non-blank in the DVC. This ensures that if the DVC with blanks was populated using a corrupt journal (perhaps due to misdirected reads), and the replica starts up with the *correct* ops in the journal (no misdirected reads), the blank ops aren't nacked while broadcasting the DVC.

### Detailed root-cause analysis

<details>
<summary>Detailed root-cause analysis for 364110200398911730</summary>

<br>
R1 starts up with log_view=view=130 with a certain head op=81, and corruptions in slots 0 → 15. While transitioning to view_change for view=131 on startup, R1 uses a corrupt journal to populate its DVC headers, leading to some blanks in its headers.

```C
[debug] (superblock): 1: view_change: vsr_header: op=81 checksum=46810032428715586571191746510006090604
[debug] (superblock): 1: view_change: vsr_header: op=80 checksum=128466774560797227729232685875003653228
[debug] (superblock): 1: view_change: vsr_header: op=79 checksum=0
[debug] (superblock): 1: view_change: vsr_header: op=78 checksum=0
[debug] (superblock): 1: view_change: vsr_header: op=77 checksum=0
```

The blanks in R1's DVC headers cause R0 and R1 to not be able to complete view change, due to the lack of a nack quorum for ops 77 → 79 (they are marked as `nack=false present=false`).

```C
[warn] (replica): 1: on_do_view_change: view=166 quorum received, awaiting repair
[debug] (replica): 1: on_do_view_change: dvc: replica=0 log_view=127 op=52 commit_min=39 checkpoint=39
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=52 checksum=283635114589337458283008089348885258035 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=51 checksum=51144159442528053499117355531930459159 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: replica=1 log_view=130 op=81 commit_min=59 checkpoint=59
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=81 checksum=46810032428715586571191746510006090604 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=80 checksum=128466774560797227729232685875003653228 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=79 checksum=0 nack=false present=false type=blank
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=78 checksum=0 nack=false present=false type=blank
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=77 checksum=0 nack=false present=false type=blank
```

R1 crashes and restarts in log_view=130, view=283, but *no faults* in its journal. However, this time around, R1 nacks ops 77 → 79, which trips an assertion while R0 is handling DVCQuorum from R0 and R1: 

```C
[debug] (replica): 0: on_do_view_change: dvc: replica=0 log_view=127 op=52 commit_min=39 checkpoint=39
[debug] (replica): 0: on_do_view_change: dvc: header: replica=0 op=52 checksum=283635114589337458283008089348885258035 nack=false present=true type=valid
[debug] (replica): 0: on_do_view_change: dvc: header: replica=0 op=51 checksum=51144159442528053499117355531930459159 nack=false present=true type=valid
[debug] (replica): 0: on_do_view_change: dvc: replica=1 log_view=130 op=81 commit_min=59 checkpoint=59
[debug] (replica): 0: on_do_view_change: dvc: header: replica=1 op=81 checksum=46810032428715586571191746510006090604 nack=false present=true type=valid
[debug] (replica): 0: on_do_view_change: dvc: header: replica=1 op=80 checksum=128466774560797227729232685875003653228 nack=false present=true type=valid
[debug] (replica): 0: on_do_view_change: dvc: header: replica=1 op=79 checksum=0 nack=true present=false type=blank
[debug] (replica): 0: on_do_view_change: dvc: header: replica=1 op=78 checksum=0 nack=true present=false type=blank
[debug] (replica): 0: on_do_view_change: dvc: header: replica=1 op=77 checksum=0 nack=true present=false type=blank
thread 33721713 panic: reached unreachable code
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/zig/lib/std/debug.zig:412:14: 0x1008c570f in assert (vopr)
    if (!ok) unreachable; // assertion failure
             ^
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vsr/replica.zig:10131:23: 0x1009c85fb in quorum_headers (vopr)
                assert(op > op_head_min);
```
</details>
