### PR TITLE
vopr: pass correct op_min to find_latest_headers_break_between in core_missing_prepare

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -692,7 +692,7 @@ pub const Simulator = struct {
                     // Check if replica was stuck while repairing headers. Find largest missing
                     // header as we repair headers from high -> low ops.
                     if (replica.journal.find_latest_headers_break_between(
-                        replica.commit_min,
+                        replica.commit_min + 1,
                         @min(replica.op, commit_max),
                     )) |range| {
                         if (missing_header_op == null or missing_header_op.? < range.op_max) {

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -680,7 +680,7 @@ pub const Simulator = struct {
 
         // Don't check for missing uncommitted ops (since the StateChecker does not record them).
         // There may be uncommitted ops due to pulses/upgrades sent during liveness mode.
-        const commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
+        const cluster_commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
 
         var missing_header_op: ?u64 = null;
         var missing_prepare_op: ?u64 = null;
@@ -688,12 +688,14 @@ pub const Simulator = struct {
         for (simulator.cluster.replicas) |replica| {
             if (simulator.core.isSet(replica.replica) and !replica.standby()) {
                 assert(simulator.cluster.replica_health[replica.replica] == .up);
-                if (replica.op > replica.commit_min) {
+                const commit_max = @min(replica.op, cluster_commit_max);
+                const commit_min = replica.commit_min;
+                if (commit_min < commit_max) {
                     // Check if replica was stuck while repairing headers. Find largest missing
                     // header as we repair headers from high -> low ops.
                     if (replica.journal.find_latest_headers_break_between(
-                        replica.commit_min + 1,
-                        @min(replica.op, commit_max),
+                        commit_min + 1,
+                        commit_max,
                     )) |range| {
                         if (missing_header_op == null or missing_header_op.? < range.op_max) {
                             missing_header_op = range.op_max;
@@ -701,7 +703,7 @@ pub const Simulator = struct {
                     } else {
                         // Check if replica was stuck while repairing prepares. Find smallest
                         // missing prepare as we repair prepares from low -> high ops.
-                        for (replica.commit_min + 1..@min(replica.op, commit_max) + 1) |op| {
+                        for (commit_min + 1..commit_max + 1) |op| {
                             const header = simulator.cluster.state_checker.header_with_op(op);
                             if (!replica.journal.has_clean(&header)) {
                                 if (missing_prepare_op == null or missing_prepare_op.? > op) {


### PR DESCRIPTION
Fixes failed VOPR seed `./zig/zig build -Drelease vopr -- 6316830026767099413` on main (a8f5b2b4845fdae6e64a2b5b20b6563195c76f66). 

Currently, `core_missing_prepare` can pass incorrect arguments to `find_latest_headers_break_between`: op_min=op_checkpoint, op_max=op_prepare_max, which triggers the below assert. Even though it's perfectly reasonable for a replica to have _self.commit_min=op_checkpoint_, and _self.op=op_prepare_max_, this state indicates that the op_prepare_max has already replaced op_checkpoint in the journal! 
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/journal.zig#L627

As `core_missing_prepare` aims to find out why a replica isn't committing _beyond_ commit_min, _op_min_ passed to `find_latest_headers_break_between`  must be _commit_min + 1_.