### PR TITLE
test: Create more valid transfers in Java workload

### DIFF
--- a/src/testing/systest/workload/src/main/java/Arbitrary.java
+++ b/src/testing/systest/workload/src/main/java/Arbitrary.java
@@ -2,7 +2,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -14,8 +13,9 @@ public class Arbitrary {
   /**
    * Selects a random value in {@code elements}.
    */
-  static <T> T element(Random random, List<T> elements) {
-    return elements.get(random.nextInt(0, elements.size()));
+  static <T> T element(Random random, Collection<T> elements) {
+    var list = new ArrayList<>(elements);
+    return list.get(random.nextInt(0, list.size()));
   }
 
   /**

--- a/src/testing/systest/workload/src/main/java/Model.java
+++ b/src/testing/systest/workload/src/main/java/Model.java
@@ -1,6 +1,7 @@
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 
 /**
  * Tracks information about the accounts created by test (e.g. their ids). The model should only be
@@ -11,6 +12,7 @@ public class Model {
    * Accounts by id.
    */
   HashMap<Long, CreatedAccount> accounts = new HashMap<>();
+  public HashSet<Long> pendingTransfers = new HashSet<>();
   public final int ledger;
 
   public Model(int ledger) {

--- a/src/testing/systest/workload/src/main/java/Workload.java
+++ b/src/testing/systest/workload/src/main/java/Workload.java
@@ -44,11 +44,11 @@ public class Workload implements Callable<Void> {
         result.reconcile(model);
 
         switch (result) {
-          case CreateAccountsResult(var created, var failed) -> {
-            statistics.addRequests(created.size(), failed.size());
+          case CreateAccountsResult(var entries) -> {
+            recordResultEntries(entries);
           }
-          case CreateTransfersResult(var created, var failed) -> {
-            statistics.addRequests(created.size(), failed.size());
+          case CreateTransfersResult(var entries) -> {
+            recordResultEntries(entries);
           }
           default -> {
           }
@@ -64,6 +64,16 @@ public class Workload implements Callable<Void> {
               ledger, 
               command));
         throw e;
+      }
+    }
+  }
+
+  <T> void recordResultEntries(ArrayList<ResultEntry<T>> entries) {
+    for (var entry : entries) {
+      if (entry.successful()) {
+        statistics.addRequests(1, 0);
+      } else {
+        statistics.addRequests(0, 1);
       }
     }
   }


### PR DESCRIPTION
This PR generates more valid transfers by tracking pending IDs, and in general making sure the flags follow the rules. There are still quite a few failed transfers (~25%) with this workload, but that's OK. We want to test failure paths too.

Also, we now check that linked accounts and transfers succeed or fail together.