### PR TITLE
[Clients] Allow Empty Batches

### DIFF
--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -337,14 +337,8 @@ test "c_client tb_packet_status" {
         c.TB_PACKET_INVALID_OPERATION,
     );
 
-    // Messages length 0 or not a multiple of the event size
+    // Messages not a multiple of the event size
     // should return "invalid_data_size":
-    try assert_result(
-        tb_client,
-        c.TB_OPERATION_CREATE_ACCOUNTS,
-        0,
-        c.TB_PACKET_INVALID_DATA_SIZE,
-    );
     try assert_result(
         tb_client,
         c.TB_OPERATION_CREATE_TRANSFERS,
@@ -362,5 +356,25 @@ test "c_client tb_packet_status" {
         c.TB_OPERATION_LOOKUP_ACCOUNTS,
         @sizeOf(u128) * 2.5,
         c.TB_PACKET_INVALID_DATA_SIZE,
+    );
+
+    // Messages with zero length or multiple of the event size are valid.
+    try assert_result(
+        tb_client,
+        c.TB_OPERATION_CREATE_ACCOUNTS,
+        0,
+        c.TB_PACKET_OK,
+    );
+    try assert_result(
+        tb_client,
+        c.TB_OPERATION_CREATE_ACCOUNTS,
+        @sizeOf(c.tb_account_t),
+        c.TB_PACKET_OK,
+    );
+    try assert_result(
+        tb_client,
+        c.TB_OPERATION_CREATE_ACCOUNTS,
+        @sizeOf(c.tb_account_t) * 2,
+        c.TB_PACKET_OK,
     );
 }

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -964,6 +964,69 @@ public class IntegrationTests
         }
     }
 
+    [TestMethod]
+    public void CreateZeroLengthAccounts()
+    {
+        var accounts = Array.Empty<Account>();
+        var results = client.CreateAccounts(accounts);
+        Assert.IsTrue(results.Length == 0);
+    }
+
+    [TestMethod]
+    public async Task CreateZeroLengthAccountsAsync()
+    {
+        var accounts = Array.Empty<Account>();
+        var results = await client.CreateAccountsAsync(accounts);
+        Assert.IsTrue(results.Length == 0);
+    }
+
+    [TestMethod]
+    public void CreateZeroLengthTransfers()
+    {
+        var transfers = Array.Empty<Transfer>();
+        var results = client.CreateTransfers(transfers);
+        Assert.IsTrue(results.Length == 0);
+    }
+
+    [TestMethod]
+    public async Task CreateZeroLengthTransfersAsync()
+    {
+        var transfers = Array.Empty<Transfer>();
+        var results = await client.CreateTransfersAsync(transfers);
+        Assert.IsTrue(results.Length == 0);
+    }
+
+    [TestMethod]
+    public void LookupZeroLengthAccounts()
+    {
+        var ids = Array.Empty<UInt128>();
+        var accounts = client.LookupAccounts(ids);
+        Assert.IsTrue(accounts.Length == 0);
+    }
+
+    [TestMethod]
+    public async Task LookupZeroLengthAccountsAsync()
+    {
+        var ids = Array.Empty<UInt128>();
+        var accounts = await client.LookupAccountsAsync(ids);
+        Assert.IsTrue(accounts.Length == 0);
+    }
+
+    [TestMethod]
+    public void LookupZeroLengthTransfers()
+    {
+        var ids = Array.Empty<UInt128>();
+        var transfers = client.LookupTransfers(ids);
+        Assert.IsTrue(transfers.Length == 0);
+    }
+
+    [TestMethod]
+    public async Task LookupZeroLengthTransfersAsync()
+    {
+        var ids = Array.Empty<UInt128>();
+        var transfers = await client.LookupTransfersAsync(ids);
+        Assert.IsTrue(transfers.Length == 0);
+    }
 
     [TestMethod]
     public void TestGetAccountTransfers()

--- a/src/clients/dotnet/TigerBeetle/Client.cs
+++ b/src/clients/dotnet/TigerBeetle/Client.cs
@@ -37,7 +37,6 @@ public sealed class Client : IDisposable
 
     public CreateAccountsResult[] CreateAccounts(ReadOnlySpan<Account> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequest<CreateAccountsResult, Account>(TBOperation.CreateAccounts, batch);
     }
 
@@ -49,7 +48,6 @@ public sealed class Client : IDisposable
 
     public Task<CreateAccountsResult[]> CreateAccountsAsync(ReadOnlyMemory<Account> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequestAsync<CreateAccountsResult, Account>(TBOperation.CreateAccounts, batch);
     }
 
@@ -61,7 +59,6 @@ public sealed class Client : IDisposable
 
     public CreateTransfersResult[] CreateTransfers(ReadOnlySpan<Transfer> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequest<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, batch);
     }
 
@@ -73,7 +70,6 @@ public sealed class Client : IDisposable
 
     public Task<CreateTransfersResult[]> CreateTransfersAsync(ReadOnlyMemory<Transfer> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequestAsync<CreateTransfersResult, Transfer>(TBOperation.CreateTransfers, batch);
     }
 
@@ -85,7 +81,6 @@ public sealed class Client : IDisposable
 
     public Account[] LookupAccounts(ReadOnlySpan<UInt128> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequest<Account, UInt128>(TBOperation.LookupAccounts, batch);
     }
 
@@ -97,7 +92,6 @@ public sealed class Client : IDisposable
 
     public Task<Account[]> LookupAccountsAsync(ReadOnlyMemory<UInt128> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequestAsync<Account, UInt128>(TBOperation.LookupAccounts, batch);
     }
 
@@ -109,7 +103,6 @@ public sealed class Client : IDisposable
 
     public Transfer[] LookupTransfers(ReadOnlySpan<UInt128> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequest<Transfer, UInt128>(TBOperation.LookupTransfers, batch);
     }
 
@@ -121,7 +114,6 @@ public sealed class Client : IDisposable
 
     public Task<Transfer[]> LookupTransfersAsync(ReadOnlyMemory<UInt128> batch)
     {
-        if (batch.Length == 0) throw new ArgumentException("The batch cannot be empty", nameof(batch));
         return nativeClient.CallRequestAsync<Transfer, UInt128>(TBOperation.LookupTransfers, batch);
     }
 

--- a/src/clients/go/pkg/errors/main.go
+++ b/src/clients/go/pkg/errors/main.go
@@ -38,10 +38,6 @@ type ErrInvalidOperation struct{}
 
 func (s ErrInvalidOperation) Error() string { return "internal operation provided was invalid." }
 
-type ErrEmptyBatch struct{}
-
-func (s ErrEmptyBatch) Error() string { return "Empty batch." }
-
 type ErrMaximumBatchSizeExceeded struct{}
 
 func (s ErrMaximumBatchSizeExceeded) Error() string { return "Maximum batch size exceeded." }

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -347,6 +347,46 @@ func doTestClient(t *testing.T, client Client) {
 		assert.True(t, !accounts[1].AccountFlags().Closed)
 	})
 
+	t.Run("accept zero-length create_accounts", func(t *testing.T) {
+		t.Parallel()
+		results, err := client.CreateAccounts([]types.Account{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("accept zero-length create_transfers", func(t *testing.T) {
+		t.Parallel()
+		results, err := client.CreateTransfers([]types.Transfer{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("accept zero-length lookup_accounts", func(t *testing.T) {
+		t.Parallel()
+		results, err := client.LookupAccounts([]types.Uint128{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("accept zero-length lookup_transfers", func(t *testing.T) {
+		t.Parallel()
+		results, err := client.LookupTransfers([]types.Uint128{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Empty(t, results)
+	})
+
 	t.Run("can create concurrent transfers", func(t *testing.T) {
 		accountA, accountB := createTwoAccounts(t)
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -73,9 +73,6 @@ abstract class Request<TResponse extends Batch> {
         this.sendBuffer = batch.getBuffer();
         this.sendBufferLen = batch.getBufferLen();
         this.replyBuffer = null;
-
-        if (this.sendBufferLen == 0 || this.requestLen == 0)
-            throw new IllegalArgumentException("Empty batch");
     }
 
     public void beginRequest() {

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -74,22 +74,16 @@ public class AsyncRequestTest {
         assert false;
     }
 
-    @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroCapacityBatch() {
         var client = getDummyClient();
         var batch = new AccountBatch(0);
-
         AsyncRequest.createAccounts(client, batch);
-        assert false;
     }
 
-    @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroItemsBatch() {
         var client = getDummyClient();
         var batch = new AccountBatch(1);
-
         AsyncRequest.createAccounts(client, batch);
-        assert false;
     }
 
     @Test(expected = AssertionError.class)

--- a/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BlockingRequestTest.java
@@ -66,7 +66,6 @@ public class BlockingRequestTest {
         assert false;
     }
 
-    @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroCapacityBatch() {
         var client = getDummyClient();
         var batch = new AccountBatch(0);
@@ -75,7 +74,6 @@ public class BlockingRequestTest {
         assert false;
     }
 
-    @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithZeroItemsBatch() {
         var client = getDummyClient();
         var batch = new AccountBatch(1);

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -939,6 +939,66 @@ public class IntegrationTest {
         }
     }
 
+    @Test
+    public void testZeroLengthCreateAccounts() throws Throwable {
+        final var accounts = new AccountBatch(1); // Capacity 1 but zero items.
+        final var createAccountErrors = client.createAccounts(accounts);
+        assertTrue(createAccountErrors.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthCreateAccountsAsync() throws Throwable {
+        final var accounts = new AccountBatch(1); // Capacity 1 but zero items.
+        final var createAccountErrorsFuture = client.createAccountsAsync(accounts);
+        final var createAccountErrors = createAccountErrorsFuture.get();
+        assertTrue(createAccountErrors.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthCreateTransfers() throws Throwable {
+        final var transfers = new TransferBatch(0);
+        final var createTransfersErrors = client.createTransfers(transfers);
+        assertTrue(createTransfersErrors.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthCreateTransfersAsync() throws Throwable {
+        final var transfers = new TransferBatch(0);
+        final var createTransfersErrorsFuture = client.createTransfersAsync(transfers);
+        final var createTransfersErrors = createTransfersErrorsFuture.get();
+        assertTrue(createTransfersErrors.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthLookupAccounts() throws Throwable {
+        final var ids = new IdBatch(0);
+        final var accounts = client.lookupAccounts(ids);
+        assertTrue(accounts.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthLookupAccountsAsync() throws Throwable {
+        final var ids = new IdBatch(0);
+        final var accountsFuture = client.lookupAccountsAsync(ids);
+        final var accounts = accountsFuture.get();
+        assertTrue(accounts.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthLookupTransfers() throws Throwable {
+        final var ids = new IdBatch(0);
+        final var transfers = client.lookupTransfers(ids);
+        assertTrue(transfers.getLength() == 0);
+    }
+
+    @Test
+    public void testZeroLengthLookupTransfersAsync() throws Throwable {
+        final var ids = new IdBatch(0);
+        final var transfersFuture = client.lookupTransfersAsync(ids);
+        final var transfers = transfersFuture.get();
+        assertTrue(transfers.getLength() == 0);
+    }
+
     /**
      * This test asserts that the client can handle parallel threads up to concurrencyMax.
      */

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -211,11 +211,7 @@ fn request(
         std.log.warn("Failed to delete reference to callback on error.", .{});
     };
 
-    const array_length = try translate.array_length(env, array);
-    if (array_length < 1) {
-        return translate.throw(env, "Batch must contain at least one event.");
-    }
-
+    const array_length: u32 = try translate.array_length(env, array);
     const packet, const packet_data = switch (operation) {
         inline else => |op| blk: {
             const buffer = try BufferType(op).alloc(

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -1318,7 +1318,6 @@ test('query with invalid filter', async (): Promise<void> => {
   assert.deepStrictEqual((await client.queryTransfers(filter)), [])
 })
 
-
 test('can import accounts and transfers', async (): Promise<void> => {
   const accountTmp: Account = {
     id: id(),
@@ -1406,6 +1405,26 @@ test('can import accounts and transfers', async (): Promise<void> => {
   const transfers = await client.lookupTransfers([transfer.id])
   assert.strictEqual(transfers.length, 1)
   assert.strictEqual(transfers[0].timestamp, timestampMax + 3n)
+})
+
+test('accept zero-length create_accounts', async (): Promise<void> => {
+  const errors = await client.createAccounts([])
+  assert.deepStrictEqual(errors, [])
+})
+
+test('accept zero-length create_transfers', async (): Promise<void> => {
+  const errors = await client.createTransfers([])
+  assert.deepStrictEqual(errors, [])
+})
+
+test('accept zero-length lookup_accounts', async (): Promise<void> => {
+  const accounts = await client.lookupAccounts([])
+  assert.deepStrictEqual(accounts, [])
+})
+
+test('accept zero-length lookup_transfers', async (): Promise<void> => {
+  const transfers = await client.lookupTransfers([])
+  assert.deepStrictEqual(transfers, [])
 })
 
 async function main () {


### PR DESCRIPTION
### [Clients] Allow Empty Batches

**Motivation:**
The Go client panicked when calling any operation with an empty slice (accessing `&batch[0]`), and other clients threw exceptions like "batch cannot be empty." In fact, even the Go client declared `error.ErrEmptyBatch` despite the bug.

Instead of handling `ErrEmptyBatch` in the Go client, remove this artificial limitation from `tb_client` and language clients, allowing empty batches to be sent, since this is a valid protocol message (currently not used by TigerBeetle's state machine).