### PR TITLE
[Clients] Don't batch unclosed linked chains

### DIFF
--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -121,3 +121,7 @@ pub fn deinit(
     const context = client_to_context(client);
     (context.deinit_fn)(context);
 }
+
+test {
+    std.testing.refAllDecls(DefaultContext);
+}

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -392,8 +392,8 @@ pub fn ContextType(
                         const Event = StateMachine.Event(tag);
                         // Packet data isn't necessarily aligned.
                         const events: [*]align(@alignOf(u8)) Event = @ptrCast(packet.data.?);
-                        const len: usize = @divExact(packet.data_size, @sizeOf(Event));
-                        break :linked_chain_open events[len - 1].flags.linked;
+                        const events_count: usize = @divExact(packet.data_size, @sizeOf(Event));
+                        break :linked_chain_open events[events_count - 1].flags.linked;
                     },
                     else => false,
                 };

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -12,7 +12,7 @@ pub const Packet = extern struct {
     batch_next: ?*Packet,
     batch_tail: ?*Packet,
     batch_size: u32,
-    reserved: [8]u8,
+    reserved: [8]u8 = [_]u8{0} ** 8,
 
     comptime {
         assert(@sizeOf(Packet) == 64);


### PR DESCRIPTION
### [Clients] Don't batch unclosed linked chains

If the application submits an unclosed linked chain, it can inadvertently make the elements of the next batch part of the same linked chain. To prevent this, do not allow unclosed linked chains to be batched together with other logical batches in the same request. Instead, allow the StateMachine to handle the validation with `.linked_event_chain_open`.

Note: This correction will be unnecessary once [protocol batching](https://github.com/tigerbeetle/tigerbeetle/pull/2230) is implemented.