### PR TITLE
fix: correct AMOUNT_MAX value

### DIFF
--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -106,8 +106,7 @@ const type_mappings = .{
             .readonly_fields = &.{},
             .docs_link = "reference/transfer#",
             .constants =
-            \\    public static final BigInteger AMOUNT_MAX =
-            \\        UInt128.asBigInteger(Long.MIN_VALUE, Long.MIN_VALUE);
+            \\    public static final BigInteger AMOUNT_MAX = UInt128.asBigInteger(-1L, -1L);
             \\
             ,
         },

--- a/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
@@ -10,8 +10,7 @@ import java.math.BigInteger;
 
 public final class TransferBatch extends Batch {
 
-    public static final BigInteger AMOUNT_MAX =
-        UInt128.asBigInteger(Long.MIN_VALUE, Long.MIN_VALUE);
+    public static final BigInteger AMOUNT_MAX = UInt128.asBigInteger(-1L, -1L);
 
     interface Struct {
         int SIZE = 128;

--- a/src/clients/java/src/test/java/com/tigerbeetle/TransferTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/TransferTest.java
@@ -209,6 +209,11 @@ public class TransferTest {
     }
 
     @Test
+    public void testAmountMax() {
+        assertEquals(BigInteger.TWO.pow(128).subtract(BigInteger.ONE), TransferBatch.AMOUNT_MAX);
+    }
+
+    @Test
     public void testPendingId() {
         var transfers = new TransferBatch(1);
         transfers.add();


### PR DESCRIPTION
Correct value for the AMOUNT_MAX sentinel value definition in the java client.

fixes #2396 