### PR TITLE
vsr: DVC header is blank and journal has valid header from old wrap

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7451,7 +7451,7 @@ pub fn ReplicaType(
             var present = BitSet.initEmpty();
             for (self.view_headers.array.const_slice(), 0..) |*header, i| {
                 const slot = self.journal.slot_for_op(header.op);
-                const journal_header = self.journal.header_for_op(header.op);
+                const journal_header = self.journal.header_with_op(header.op);
                 const dirty = self.journal.dirty.bit(slot);
                 const faulty = self.journal.faulty.bit(slot);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7455,41 +7455,44 @@ pub fn ReplicaType(
                 const dirty = self.journal.dirty.bit(slot);
                 const faulty = self.journal.faulty.bit(slot);
 
-                // Case 1: We have this header in memory, but haven't persisted it to disk yet.
-                if (journal_header != null and journal_header.?.checksum == header.checksum and
-                    dirty and !faulty)
-                {
-                    nacks.set(i);
-                }
-
-                // Case 2: We have a _different_ prepare — safe to nack even if it is faulty.
-                if (journal_header != null and vsr.Headers.dvc_header_type(header) == .valid and
-                    journal_header.?.checksum != header.checksum)
-                {
-                    nacks.set(i);
-                }
-
-                // Case 3: We don't have a prepare at all, and that's not due to a fault.
+                // Nack bit case 1: We don't have a prepare at all, and that's not due to a fault.
                 if (journal_header == null and !faulty) {
                     nacks.set(i);
                 }
 
-                // Presence bit: the prepare is on disk, is being written to disk, or is cached
-                // in memory. These conditions mirror logic in `on_request_prepare` and imply
-                // that we can help the new primary to repair this prepare.
-                if ((self.journal.prepare_inhabited[slot.index] and
-                    self.journal.prepare_checksums[slot.index] == header.checksum) or
-                    self.journal.writing(header.op, header.checksum) or
-                    self.pipeline_prepare_by_op_and_checksum(header.op, header.checksum) != null)
-                {
-                    if (journal_header != null) {
-                        assert(journal_header.?.checksum == header.checksum);
+                // We should only access header.checksum if the DVC header is valid.
+                if (vsr.Headers.dvc_header_type(header) == .valid) {
+                    // Nack bit case 2: We have this header in memory, but haven't persisted it to
+                    // disk yet.
+                    if (journal_header != null and journal_header.?.checksum == header.checksum and
+                        dirty and !faulty)
+                    {
+                        nacks.set(i);
                     }
-                    maybe(nacks.isSet(i));
-                    present.set(i);
-                }
+                    // Nack bit case 3: We have a _different_ prepare — safe to nack even if it is
+                    // faulty.
+                    if (journal_header != null and journal_header.?.checksum != header.checksum) {
+                        nacks.set(i);
+                    }
 
-                if (vsr.Headers.dvc_header_type(header) == .blank) {
+                    // Presence bit: the prepare is on disk, is being written to disk, or is cached
+                    // in memory. These conditions mirror logic in `on_request_prepare` and imply
+                    // that we can help the new primary to repair this prepare.
+                    if ((self.journal.prepare_inhabited[slot.index] and
+                        self.journal.prepare_checksums[slot.index] == header.checksum) or
+                        self.journal.writing(header.op, header.checksum) or
+                        self.pipeline_prepare_by_op_and_checksum(
+                        header.op,
+                        header.checksum,
+                    ) != null) {
+                        if (journal_header != null) {
+                            assert(journal_header.?.checksum == header.checksum);
+                        }
+                        maybe(nacks.isSet(i));
+                        present.set(i);
+                    }
+                } else {
+                    assert(vsr.Headers.dvc_header_type(header) == .blank);
                     assert(!present.isSet(i));
                     if (nacks.isSet(i)) assert(!faulty);
                 }


### PR DESCRIPTION
Fixes `./zig/zig build -Drelease -Dvopr-log=full vopr -- --ticks-max-requests=3000000 7746807953021648557` on the matklad/c2 branch (4ee9445f69a4eaf976e795a3d8f4c1214d05fc57). There is no failing seed on main yet but main is vulnerable to this issue as well.

This is a regression due to https://github.com/tigerbeetle/tigerbeetle/pull/2385. While https://github.com/tigerbeetle/tigerbeetle/pull/2385 *correctly* solves a safety issue, it misses out on correctly handling  a *blank DVC header from the current wrap with a valid journal header from an old wrap*. We must nack such headers as the op from the current wrap is *guaranteed* to not exist in the journal.

This is fixed by using `header_for_op` → `header_with_op` while populating the nack & present bitsets in [send_do_view_change](https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L7417). While both these functions fetch a *valid* header from the slot where an op resides, there exists a subtle difference between the two:
* `header_for_op`:  valid header could be from an old wrap
* `header_with_op`: valid header corresponds to the specified op

Using `header_with_op`, nacking a *blank DVC header from the current wrap with a valid journal header from an old wrap* is handled by the following pre-existing condition:
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L7463-L7466