### PR TITLE
vopr: adjust log_replica hieroglyphs for new state sync

### DIFF
--- a/docs/about/internals/testing.md
+++ b/docs/about/internals/testing.md
@@ -12,12 +12,12 @@ Documentation for (roughly) code in the `src/testing` directory.
 
 1. Replica index.
 2. Event:
-    - `$`: crash
+    - `!`: crash
     - `^`: recover
     - ` `: commit
+    - `$`: sync
     - `[`: checkpoint start
     - `]`: checkpoint done
-    - `>`: sync done
 3. Role (according to the replica itself):
     - `/`: primary
     - `\`: backup

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -797,7 +797,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     };
                 },
                 .sync_stage_changed => switch (replica.syncing) {
-                    .idle => cluster.log_replica(.sync_completed, replica.replica),
+                    .idle => cluster.log_replica(.sync, replica.replica),
                     else => {},
                 },
                 .client_evicted => |client_id| cluster.cluster_on_eviction(client_id),
@@ -821,12 +821,12 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         fn log_replica(
             cluster: *const Self,
             event: enum(u8) {
-                crash = '$',
+                crash = '!',
                 recover = '^',
                 commit = ' ',
+                sync = '$',
                 checkpoint_commenced = '[',
                 checkpoint_completed = ']',
-                sync_completed = '>',
             },
             replica_index: u8,
         ) void {


### PR DESCRIPTION
Sync is now almost instantaneous, so we need to switch from switch_commence/switch_complete to something else. Mnemonics:

- $ S Sync
- ! bang Crash