### PR TITLE
[Clients] Avoid Mixing Batchable and Non-Batchable Packets

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -256,7 +256,8 @@ typedef struct tb_packet_t {
     struct tb_packet_t* batch_next;
     struct tb_packet_t* batch_tail;
     uint32_t batch_size;
-    uint8_t reserved[8];
+    uint8_t batch_allowed;
+    uint8_t reserved[7];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -296,7 +296,7 @@ pub fn ContextType(
         }
 
         fn request(self: *Context, packet: *Packet) void {
-            const operation = operation_from_int(packet.operation) orelse {
+            const operation: StateMachine.Operation = operation_from_int(packet.operation) orelse {
                 return self.on_complete(packet, error.InvalidOperation);
             };
 
@@ -339,6 +339,11 @@ pub fn ContextType(
             packet.batch_next = null;
             packet.batch_tail = packet;
             packet.batch_size = packet.data_size;
+            packet.batch_allowed = batch_logical_allowed(
+                operation,
+                packet.data,
+                packet.data_size,
+            );
 
             // Avoid making a packet inflight by cancelling it if the client was shutdown.
             if (self.shutdown.load(.acquire)) {
@@ -350,14 +355,15 @@ pub fn ContextType(
                 return self.submit(packet);
             }
 
-            // Otherwise, try to batch the packet with another already in self.pending.
-            if (batch_logical_allowed(packet)) {
+            // If allowed, try to batch the packet with another already in self.pending.
+            if (packet.batch_allowed) {
                 var it = self.pending.peek();
                 while (it) |root| {
                     it = root.next;
 
                     // Check for pending packets of the same operation which can be batched.
                     if (root.operation != packet.operation) continue;
+                    if (!root.batch_allowed) continue;
 
                     const merged_events = @divExact(root.batch_size + packet.data_size, event_size);
                     if (merged_events > events_batch_max) continue;
@@ -374,8 +380,11 @@ pub fn ContextType(
             self.pending.push(packet);
         }
 
-        fn batch_logical_allowed(packet: *const Packet) bool {
-            const operation: StateMachine.Operation = @enumFromInt(packet.operation);
+        fn batch_logical_allowed(
+            operation: StateMachine.Operation,
+            data: ?*const anyopaque,
+            data_size: u32,
+        ) bool {
             if (!StateMachine.batch_logical_allowed.get(operation)) return false;
 
             // TODO(king): Remove this code once protocol batching is implemented.
@@ -383,16 +392,16 @@ pub fn ContextType(
             // If the application submits an unclosed linked chain, it can inadvertently make
             // the elements of the next batch part of it.
             // To work around this issue, we don't allow unclosed linked chains to be batched.
-            if (packet.data_size > 0) {
-                assert(packet.data != null);
+            if (data_size > 0) {
+                assert(data != null);
                 const linked_chain_open: bool = switch (operation) {
                     inline .create_accounts,
                     .create_transfers,
                     => |tag| linked_chain_open: {
                         const Event = StateMachine.Event(tag);
                         // Packet data isn't necessarily aligned.
-                        const events: [*]align(@alignOf(u8)) Event = @ptrCast(packet.data.?);
-                        const events_count: usize = @divExact(packet.data_size, @sizeOf(Event));
+                        const events: [*]align(@alignOf(u8)) const Event = @ptrCast(data.?);
+                        const events_count: usize = @divExact(data_size, @sizeOf(Event));
                         break :linked_chain_open events[events_count - 1].flags.linked;
                     },
                     else => false,
@@ -431,6 +440,7 @@ pub fn ContextType(
             var offset: u32 = 0;
             var it: ?*Packet = packet;
             while (it) |batched| {
+                assert(batched.batch_next == null or batched.batch_allowed);
                 it = batched.batch_next;
 
                 const event_data: []const u8 = if (batched.data_size > 0)
@@ -490,6 +500,7 @@ pub fn ContextType(
                     var it: ?*Packet = packet;
                     var event_offset: u32 = 0;
                     while (it) |batched| {
+                        assert(batched.batch_next == null or batched.batch_allowed);
                         it = batched.batch_next;
 
                         const event_count = @divExact(
@@ -513,6 +524,7 @@ pub fn ContextType(
         fn cancel(self: *Context, packet: *Packet) void {
             var it: ?*Packet = packet;
             while (it) |batched| {
+                assert(batched.batch_next == null or batched.batch_allowed);
                 it = batched.batch_next;
                 self.on_complete(batched, error.ClientShutdown);
             }
@@ -567,35 +579,36 @@ pub fn ContextType(
             }) |operation| {
                 const Event = StateMachine.Event(operation);
                 var data = [_]Event{std.mem.zeroInit(Event, .{})} ** 3;
-                var packet = Packet{
-                    .next = null,
-                    .user_data = null,
-                    .operation = @intFromEnum(operation),
-                    .status = .ok,
-                    .data_size = data.len * @sizeOf(Event),
-                    .data = &data,
-                    .batch_next = null,
-                    .batch_tail = null,
-                    .batch_size = 0,
-                };
 
                 // Broken linked chain cannot be batched.
                 for (&data) |*item| item.flags.linked = true;
-                try std.testing.expect(!batch_logical_allowed(&packet));
+                try std.testing.expect(!batch_logical_allowed(
+                    operation,
+                    data[0..],
+                    data.len * @sizeOf(Event),
+                ));
 
                 // Valid linked chain.
                 data[data.len - 1].flags.linked = false;
-                try std.testing.expect(batch_logical_allowed(&packet));
+                try std.testing.expect(batch_logical_allowed(
+                    operation,
+                    data[0..],
+                    data.len * @sizeOf(Event),
+                ));
 
                 // Single element.
-                packet.data_size = 1 * @sizeOf(Event);
-                packet.data = &data[data.len - 1];
-                try std.testing.expect(batch_logical_allowed(&packet));
+                try std.testing.expect(batch_logical_allowed(
+                    operation,
+                    &data[data.len - 1],
+                    1 * @sizeOf(Event),
+                ));
 
                 // No elements.
-                packet.data_size = 0;
-                packet.data = null;
-                try std.testing.expect(batch_logical_allowed(&packet));
+                try std.testing.expect(batch_logical_allowed(
+                    operation,
+                    null,
+                    0,
+                ));
             }
         }
     };

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -12,7 +12,8 @@ pub const Packet = extern struct {
     batch_next: ?*Packet,
     batch_tail: ?*Packet,
     batch_size: u32,
-    reserved: [8]u8 = [_]u8{0} ** 8,
+    batch_allowed: bool,
+    reserved: [7]u8 = [_]u8{0} ** 7,
 
     comptime {
         assert(@sizeOf(Packet) == 64);

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -30,6 +30,7 @@ fn resolve_c_type(comptime Type: type) []const u8 {
         .Array => |info| return resolve_c_type(info.child),
         .Enum => |info| return resolve_c_type(info.tag_type),
         .Struct => return resolve_c_type(std.meta.Int(.unsigned, @bitSizeOf(Type))),
+        .Bool => return "uint8_t",
         .Int => |info| {
             std.debug.assert(info.signedness == .unsigned);
             return switch (info.bits) {

--- a/src/clients/c/tb_client_header_test.zig
+++ b/src/clients/c/tb_client_header_test.zig
@@ -110,6 +110,7 @@ test "valid tb_client.h" {
                                 field_type = std.meta.Int(.unsigned, @bitSizeOf(field_type));
                             },
                             .Enum => |info| field_type = info.tag_type,
+                            .Bool => field_type = u8,
                             else => {},
                         }
 

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1209,7 +1209,7 @@ internal unsafe struct TBPacket
     [StructLayout(LayoutKind.Sequential, Size = SIZE)]
     private unsafe struct ReservedData
     {
-        public const int SIZE = 8;
+        public const int SIZE = 7;
 
         private fixed byte raw[SIZE];
 
@@ -1253,6 +1253,8 @@ internal unsafe struct TBPacket
     public TBPacket* batchTail;
 
     public uint batchSize;
+
+    public byte batchAllowed;
 
     private ReservedData reserved;
 

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -141,6 +141,7 @@ fn dotnet_type(comptime Type: type) []const u8 {
     switch (@typeInfo(Type)) {
         .Enum, .Struct => return comptime get_mapped_type_name(Type) orelse
             @compileError("Type " ++ @typeName(Type) ++ " not mapped."),
+        .Bool => return "byte",
         .Int => |info| {
             std.debug.assert(info.signedness == .unsigned);
             return switch (info.bits) {

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -256,7 +256,8 @@ typedef struct tb_packet_t {
     struct tb_packet_t* batch_next;
     struct tb_packet_t* batch_tail;
     uint32_t batch_size;
-    uint8_t reserved[8];
+    uint8_t batch_allowed;
+    uint8_t reserved[7];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -442,6 +442,54 @@ func doTestClient(t *testing.T, client Client) {
 		assert.Equal(t, TRANSFERS_MAX, big.NewInt(0).Sub(&accountBDebitsAfter, &accountBDebits).Int64())
 	})
 
+	t.Run("can create concurrent linked chains", func(t *testing.T) {
+		accountA, accountB := createTwoAccounts(t)
+
+		// NB: this test is _not_ parallel, so can use up all the concurrency.
+		const TRANSFERS_MAX = 10_000
+
+		accounts, err := client.LookupAccounts([]types.Uint128{accountA.ID, accountB.ID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, accounts, 2)
+
+		var waitGroup sync.WaitGroup
+		for i := 0; i < TRANSFERS_MAX; i++ {
+			waitGroup.Add(1)
+			go func(i int) {
+				defer waitGroup.Done()
+
+				// The Linked flag will cause the
+				// batch to fail due to LinkedEventChainOpen.
+				flags := types.TransferFlags{Linked: i%10 == 0}.ToUint16()
+				results, err := client.CreateTransfers([]types.Transfer{
+					{
+						ID:              types.ID(),
+						CreditAccountID: accountA.ID,
+						DebitAccountID:  accountB.ID,
+						Amount:          types.ToUint128(1),
+						Ledger:          1,
+						Code:            1,
+						Flags:           flags,
+					},
+				})
+
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if i%10 == 0 {
+					assert.Len(t, results, 1)
+					assert.Equal(t, results[0].Result, types.TransferLinkedEventChainOpen)
+				} else {
+					assert.Empty(t, results)
+				}
+			}(i)
+		}
+		waitGroup.Wait()
+	})
+
 	t.Run("can query transfers for an account", func(t *testing.T) {
 		t.Parallel()
 		accountA, accountB := createTwoAccounts(t)

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -239,6 +239,7 @@ fn request(
         .batch_next = undefined,
         .batch_tail = undefined,
         .batch_size = undefined,
+        .batch_allowed = undefined,
         .reserved = undefined,
     };
 


### PR DESCRIPTION
As per #2394, packets containing an unclosed linked chain will not be batched. **However**, it's still possible for other batchable packets to be inserted into a request that contains an unclosed linked chain!

This PR fixes the issue by introducing the `Packet.batch_allowed` flag, which prevents non-batchable requests from sharing multiple packets.