### PR TITLE
vopr: gracefully exit if all clients are evicted

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -945,7 +945,12 @@ pub const Simulator = struct {
                     break :index client_index;
                 }
             } else {
-                unreachable;
+                for (0..client_count) |index| {
+                    assert(simulator.cluster.client_eviction_reasons[index] != null);
+                    assert(simulator.cluster.client_eviction_reasons[index] == .no_session or
+                        simulator.cluster.client_eviction_reasons[index] == .session_too_low);
+                }
+                stdx.unimplemented("client replacement; all clients were evicted");
             }
         };
 


### PR DESCRIPTION
### Problem

This PR fixes `./zig/zig build -Drelease vopr -- 2093263118278902398` on main (ee59910771501fe1158969c869a23b642af9f2cd), which is a crash in the VOPR due to all clients getting evicted (see `unreachable` below): 
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vopr.zig#L940-L947

Given messages can be arbitrarily replayed in the network, we can't guarantee all the clients won't evict each other, we can merely try to reduce the probability of this happening. Specifically, as long as there is even one evicted client, a replayed register message from that client could evict another that is currently in the client table. If this repeats, i.e. if the network keeps replaying register messages from evicted clients, all clients could end up being evicted. 

### Solution
Instead of panicking:
```C
thread 38926335 panic: reached unreachable code
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vopr.zig:0:0: 0x104975daf in tick_requests (vopr)
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vopr.zig:582:32: 0x104966bff in tick (vopr)
        simulator.tick_requests();
```

We now gracefully exit so that this case isn't wrongly categorized as a failed VOPR run:
```C
unimplemented: client replacement; all clients were evicted
not crashing in VOPR
```