### PR TITLE
vopr: core_missing_prepare only checks replicas that have attempted to repair

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -681,6 +681,15 @@ pub const Simulator = struct {
         // Don't check for missing uncommitted ops (since the StateChecker does not record them).
         // There may be uncommitted ops due to pulses/upgrades sent during liveness mode.
         const cluster_commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
+        var cluster_op_checkpoint: u64 = 0;
+        for (simulator.cluster.replicas) |*replica| {
+            if (simulator.core.isSet(replica.replica)) {
+                cluster_op_checkpoint = @max(
+                    cluster_op_checkpoint,
+                    replica.superblock.working.vsr_state.checkpoint.header.op,
+                );
+            }
+        }
 
         var missing_header_op: ?u64 = null;
         var missing_prepare_op: ?u64 = null;
@@ -688,6 +697,11 @@ pub const Simulator = struct {
         for (simulator.cluster.replicas) |replica| {
             if (simulator.core.isSet(replica.replica) and !replica.standby()) {
                 assert(simulator.cluster.replica_health[replica.replica] == .up);
+
+                // Lagging replicas do not initiate WAL repair during view change.
+                if (replica.status == .view_change and
+                    replica.op_checkpoint() < cluster_op_checkpoint) continue;
+
                 const commit_max = @min(replica.op, cluster_commit_max);
                 const commit_min = replica.commit_min;
                 if (commit_min < commit_max) {

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -703,26 +703,25 @@ pub const Simulator = struct {
                     replica.op_checkpoint() < cluster_op_checkpoint) continue;
 
                 const commit_max = @min(replica.op, cluster_commit_max);
-                const commit_min = replica.commit_min;
-                if (commit_min < commit_max) {
-                    // Check if replica was stuck while repairing headers. Find largest missing
-                    // header as we repair headers from high -> low ops.
-                    if (replica.journal.find_latest_headers_break_between(
-                        commit_min + 1,
-                        commit_max,
-                    )) |range| {
-                        if (missing_header_op == null or missing_header_op.? < range.op_max) {
-                            missing_header_op = range.op_max;
-                        }
-                    } else {
-                        // Check if replica was stuck while repairing prepares. Find smallest
-                        // missing prepare as we repair prepares from low -> high ops.
-                        for (commit_min + 1..commit_max + 1) |op| {
-                            const header = simulator.cluster.state_checker.header_with_op(op);
-                            if (!replica.journal.has_clean(&header)) {
-                                if (missing_prepare_op == null or missing_prepare_op.? > op) {
-                                    missing_prepare_op = op;
-                                }
+                const op_repair_min = replica.op_repair_min();
+
+                // Check if replica's commit pipeline was stuck due to missing headers.
+                // Find largest missing header as we repair headers from high -> low ops.
+                if (replica.journal.find_latest_headers_break_between(
+                    op_repair_min,
+                    commit_max,
+                )) |range| {
+                    if (missing_header_op == null or missing_header_op.? < range.op_max) {
+                        missing_header_op = range.op_max;
+                    }
+                } else {
+                    // Check if replica's commit pipeline was stuck due to missing prepares.
+                    // Find smallest missing prepare as we repair prepares from low -> high ops.
+                    for (op_repair_min..commit_max + 1) |op| {
+                        const header = simulator.cluster.state_checker.header_with_op(op);
+                        if (!replica.journal.has_clean(&header)) {
+                            if (missing_prepare_op == null or missing_prepare_op.? > op) {
+                                missing_prepare_op = op;
                             }
                         }
                     }

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -706,7 +706,7 @@ pub const Simulator = struct {
                 const op_repair_min = replica.op_repair_min();
 
                 // Check if replica's commit pipeline was stuck due to missing headers.
-                // Find largest missing header as we repair headers from high -> low ops.
+                // Find latest missing header as we repair headers from high -> low ops.
                 if (replica.journal.find_latest_headers_break_between(
                     op_repair_min,
                     commit_max,
@@ -716,7 +716,7 @@ pub const Simulator = struct {
                     }
                 } else {
                     // Check if replica's commit pipeline was stuck due to missing prepares.
-                    // Find smallest missing prepare as we repair prepares from low -> high ops.
+                    // Find earliest missing prepare as we repair prepares from low -> high ops.
                     for (op_repair_min..commit_max + 1) |op| {
                         const header = simulator.cluster.state_checker.header_with_op(op);
                         if (!replica.journal.has_clean(&header)) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6047,7 +6047,7 @@ pub fn ReplicaType(
         ///
         /// When called from status=recovering_head or status=recovering, the caller is responsible
         /// for ensuring that replica.op is valid.
-        fn op_repair_min(self: *const Self) u64 {
+        pub fn op_repair_min(self: *const Self) u64 {
             if (self.status == .recovering) assert(self.solo());
             assert(self.syncing == .updating_checkpoint or self.op >= self.op_checkpoint());
             assert(self.op <= self.op_prepare_max_sync());

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6040,10 +6040,10 @@ pub fn ReplicaType(
         /// Availability condition: each committed op must be present either in a quorum of WALs or
         /// in a quorum of checkpoints.
         ///
-        /// If op=prepare_max+1 is committed, a quorum of replicas have moved to the next
-        /// prepare_max, which in turn signals that the corresponding checkpoint is durably present
-        /// on a quorum of replicas. Repairing all ops since the latest durable checkpoint satisfies
-        /// both conditions.
+        /// If op=prepare_ok_max+1 is committed, a quorum of replicas have moved to the *next*
+        /// prepare_ok_max, which in turn signals that the corresponding checkpoint is durably
+        /// present on a quorum of replicas. Repairing all ops since the latest durable checkpoint
+        /// satisfies both conditions.
         ///
         /// When called from status=recovering_head or status=recovering, the caller is responsible
         /// for ensuring that replica.op is valid.


### PR DESCRIPTION
### Problem

This PR fixes `./zig/zig build -Drelease vopr -- 14126642652659963795` (and also most recently `15696783805748628886`) on main (https://github.com/tigerbeetle/tigerbeetle/commit/dad59e92884fa9d0654c8eb40e3d1314845489a5). This is a false positive in the VOPR, wherein `core_missing_prepare` does not distinguish between:
* a replica that is not able to initiate repair as it cannot step up as potential primary.
* a replica that is able to initiate repair but not able to complete it due to missing prepares/headers. 

A replica can only initiate repair its WAL in certain states - if it is a potential primary in view_change status, or if it is in normal status. Lagging replicas cannot step up as potential primaries and do not initiate repair for their WAL.
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L7070-L7083

The key problem is that `core_missing_prepare` treats all the replicas in the core as the same and assumes that all of them should be able to converge to `commit_min == commit_max`. Specifically, it does not distinguish between a replica that is not able to initiate repair (lagging replicas) from a replica that is able to initiate repair but not able to complete it due to missing prepares/headers. 
https://github.com/tigerbeetle/tigerbeetle/blob/ee59910771501fe1158969c869a23b642af9f2cd/src/vopr.zig#L688-L693


### Solution 

`core_missing_prepare` skips checking lagging replicas in view_change status, since it is correct for them to not initiate repair. For example, in the above VOPR seed, we can see that R2 is lagging (its op_checkpoint is 99 while the maximum op_checkpoint is 139). Consequently, it hasn't been able to step up as a potential primary and hasn't initiated repair.

```C
[debug] (replica): 2: on_do_view_change: view=19526 quorum received
[debug] (replica): 2: on_do_view_change: dvc: replica=1 log_view=19525 op=143 commit_min=143 checkpoint=139
[debug] (replica): 2: on_do_view_change: dvc: header: replica=1 op=143 checksum=166389484745224136312941382982924441585 nack=false present=true type=valid
[debug] (replica): 2: on_do_view_change: dvc: replica=2 log_view=501 op=143 commit_min=106 checkpoint=99
[debug] (replica): 2: on_do_view_change: dvc: header: replica=2 op=143 checksum=166389484745224136312941382982924441585 nack=true present=false type=valid
[debug] (replica): 2: on_do_view_change: lagging primary; forfeiting (view=19526..19528 checkpoint=99..139)
```