### PR TITLE
MessageBus: Terminate connections on deinit()

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -179,6 +179,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             }
 
             for (bus.connections) |*connection| {
+                connection.terminate(bus, .shutdown);
                 if (connection.recv_message) |message| bus.unref(message);
                 while (connection.send_queue.pop()) |message| bus.unref(message);
             }


### PR DESCRIPTION
Bug:

Start a single-replica cluster with `--development`.

Then, with the node client, run:

```javascript
import { createClient } from 'tigerbeetle-node';
import timersPromises from 'node:timers/promises';

async function rejectAfter(timeout) {
    await timersPromises.setTimeout(timeout);
    throw "timed out";
}

function withTimeout(promise, timeout) {
    return Promise.race([promise, rejectAfter(timeout)]);
}

for (let index = 0; index < 10; index++) {
    const tb = createClient({ cluster_id: 0n, replica_addresses: ["3000"] });
    console.log(`${index}: connecting to tigerbeetle cluster`);
    await withTimeout(tb.lookupAccounts([0n]), 30_000);
    console.log(`${index}: disconnecting`);
    tb.destroy();
}
```

The 9th client/request hangs.
Looking at the replica (debug) logs, the request never even arrives. But the client (debug) logs show it being retried. (If the client script is killed (control+c) the final request immediately arrives at the cluster.)

The issue is that the deinitialized clients didn't actually close their connection(s).

(I'm not sure where the connection limit on the client side originates, since the `ulimit` should be much higher than that.)

---

Thanks Phil Davies for reporting this issue and providing the client script!