### PR TITLE
vsr: replica needn't repair its *entire* journal to become primary

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8401,7 +8401,6 @@ pub fn ReplicaType(
 
             assert(self.commit_min == self.commit_max);
             assert(self.commit_max <= self.op);
-            assert(self.valid_hash_chain_between(self.op_repair_min(), self.op));
 
             {
                 const pipeline_queue = self.primary_repair_pipeline_done();


### PR DESCRIPTION
Currently, a replica only steps up as primary once it has no header breaks from *op_repair_min → head op*, as well as no corrupt/faulty prepares *in the entirety of its journal*. 
https://github.com/tigerbeetle/tigerbeetle/blob/ed0a1c73a24b2caa9fbcecf54b52dfbb27ded83d/src/vsr/replica.zig#L6473

This is overly restrictive; a replica needn't have a _completely_ pristine log to step up as primary. It can transition to .normal status as primary once:
* **commit_min == commit_max**: Requires non faulty headers and prepares between op_checkpoint → commit_max
* **Prepares loaded into its in-memory pipeline**: Requires non faulty headers and prepares for all uncommitted ops, between commit_max → head op
* **No broken headers & faulty prepares between op_repair_min → op_checkpoint**

In other words, a replica should always be able to recover back till op_repair_min, but faults *before* op_repair_min should not cause a replica to not step up as primary. 
