### PR TITLE
Devhub: Fix invisible text for dark-mode chart labels

### DIFF
--- a/src/devhub/style.css
+++ b/src/devhub/style.css
@@ -127,6 +127,7 @@ td {
     }
 
     #charts {
+        color: black;
         filter: invert(100%);
     }
 }


### PR DESCRIPTION
(Tested in firefox and chromium.)