### PR TITLE
vsr: send start_view message as soon as you can construct start_view headers

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1026,8 +1026,9 @@ pub const Header = extern struct {
         /// Set to zero for a new view, and to a nonce from an RSV when responding to the RSV.
         nonce: u128,
         op: u64,
-        /// Set to `commit_min`/`commit_max` (they are the same).
-        commit: u64,
+        /// Equal to `commit_min` if the SV message is being sent by a .normal primary, but may not
+        /// be equal if the SV message is being sent by potential primary in .view_change status.
+        commit_max: u64,
         /// The replica's `op_checkpoint`.
         checkpoint_op: u64,
         reserved: [88]u8 = [_]u8{0} ** 88,
@@ -1035,8 +1036,8 @@ pub const Header = extern struct {
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .start_view);
             if (self.release.value != 0) return "release != 0";
-            if (self.op < self.commit) return "op < commit_min";
-            if (self.commit < self.checkpoint_op) return "commit_min < checkpoint_op";
+            if (self.op < self.commit_max) return "op < commit_max";
+            if (self.commit_max < self.checkpoint_op) return "commit_max < checkpoint_op";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
             return null;
         }

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1680,6 +1680,108 @@ test "Cluster: view_change: DVC header doesn't match current header in journal" 
     try expectEqual(t.replica(.R0).commit_max(), checkpoint_2_prepare_max);
 }
 
+test "Cluster: view_change: lagging replica repairs WAL using start_view from potential primary" {
+    // It could be the case that the replica with the most advanced checkpoint has a corruption in
+    // its grid. In this case, a replica on an older checkpoint can use a start_view message from
+    // the most up-to-date replica to repair its WAL, advance its checkpoint, and become primary.
+
+    const t = try TestContext.init(.{ .replica_count = 3 });
+    defer t.deinit();
+    var c = t.clients(0, t.cluster.clients.len);
+    var a0 = t.replica(.A0);
+    var b1 = t.replica(.B1);
+    var b2 = t.replica(.B2);
+
+    b2.stop();
+
+    // Ensure b1 only commits up till checkpoint_2_trigger - 1, so it stays at checkpoint_1 while
+    // a0 moves to checkpoint_2.
+    b1.drop(.R_, .incoming, .commit);
+
+    try c.request(checkpoint_2_trigger, checkpoint_2_trigger);
+
+    try expectEqual(a0.commit(), checkpoint_2_trigger);
+    try expectEqual(a0.op_checkpoint(), checkpoint_2);
+    try expectEqual(b1.commit(), checkpoint_2_trigger - 1);
+    try expectEqual(b1.op_checkpoint(), checkpoint_1);
+
+    // Start b2 so that the a0 & b2 can make progress to checkpoint_3; b1 is stopped so it remains
+    // lagging at checkpoint_1.
+    try b2.open();
+    b1.stop();
+
+    t.run();
+
+    try expectEqual(b2.op_checkpoint(), checkpoint_2);
+    try expectEqual(b2.commit_max(), checkpoint_2_trigger);
+    try expectEqual(b2.status(), .normal);
+    try b2.expect_sync_done();
+
+    try c.request(
+        checkpoint_3_trigger,
+        checkpoint_3_trigger,
+    );
+
+    try expectEqual(a0.op_head(), checkpoint_3_trigger);
+    try expectEqual(a0.op_checkpoint(), checkpoint_3);
+    try expectEqual(b2.op_head(), checkpoint_3_trigger);
+    try expectEqual(b2.op_checkpoint(), checkpoint_3);
+
+    // Simulate compaction getting stuck on a0 due to a grid corruption. Corrupting the grid doesn't
+    // work here since compaction in replica tests is always able to apply the move table
+    // optimization. This is because all requests in replica tests are `echo` operations, which are
+    // inserted into the LSM with monotonically increasing id.
+    const a0_replica = &t.cluster.replicas[a0.replicas.get(0)];
+    a0_replica.commit_stage = .compact;
+
+    try c.request(
+        checkpoint_3_trigger + 1,
+        checkpoint_3_trigger,
+    );
+
+    try expectEqual(a0.op_head(), checkpoint_3_trigger + 1);
+    try expectEqual(a0.commit(), checkpoint_3_trigger);
+
+    try expectEqual(b2.op_head(), checkpoint_3_trigger + 1);
+    try expectEqual(b2.commit(), checkpoint_3_trigger);
+
+    const committing_prepare = a0_replica.pipeline.queue.prepare_queue.head_ptr_const().?;
+    a0_replica.commit_prepare = committing_prepare.message.ref();
+
+    // Partition a0, force b1 & b2 into view_change by blocking outgoing .do_view_change messages.
+    a0.drop_all(.R_, .bidirectional);
+
+    try b1.open();
+    b1.drop(.R_, .outgoing, .do_view_change);
+    b2.drop(.R_, .outgoing, .do_view_change);
+
+    t.run();
+
+    try expectEqual(b1.status(), .view_change);
+    try expectEqual(b2.status(), .view_change);
+
+    // Stop b2, allow a0 and b1 to view change. a0 can't step up as primary since it has a
+    // corruption in its grid, due to which it can't make progress on its commit pipeline. However,
+    // since it has an intact WAL, it is able to send a .start_view message to b1. With the help
+    // of the .start_view message, b1 can repair, commit, advance from checkpoint_1 -> checkpoint_3,
+    // and step up as primary.
+    b2.stop();
+    a0.pass_all(.R_, .bidirectional);
+    b1.pass(.R_, .outgoing, .do_view_change);
+
+    t.run();
+
+    try expectEqual(b1.status(), .normal);
+    try expectEqual(b1.role(), .primary);
+    try expectEqual(b1.op_checkpoint(), checkpoint_3);
+    try expectEqual(b1.commit(), checkpoint_3_trigger + 1);
+
+    try expectEqual(a0.status(), .normal);
+    try expectEqual(a0.role(), .backup);
+    try expectEqual(a0.op_checkpoint(), checkpoint_3);
+    try expectEqual(b1.commit(), checkpoint_3_trigger + 1);
+}
+
 const ProcessSelector = enum {
     __, // all replicas, standbys, and clients
     R_, // all (non-standby) replicas


### PR DESCRIPTION
Currently, a primary only sends a start_view message to the backups after it has done the following:
* Repaired header hash chain _and_ prepares between op_repair_min → head op
* Committed up to commit_max

This is overly restrictive. A replica should be able to send a start_view message to the backups _as soon as_ it has repaired the header hash chain between op_repair_min → head op. In other words, once a replica has repaired headers and prepares, it can concurrently send start_view message to the backups and attempt to commit up to commit_max.

This is good for both _performance_ and _availability_:
* Performance: During view change, as backups can now repair concurrently while a potential primary attempts to commit up to commit_max
* Availability: This allows lagging replicas to repair, commit, advance their checkpoint *and* step up as primary, in case the most up-to-date replica isn't able to commit up to commit_max (due to a corruption in its grid, for instance)