### PR TITLE
Reformat tidy for fewer merge conflicts

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -607,15 +607,24 @@ test "tidy extensions" {
     });
 
     const exceptions = std.StaticStringMap(void).initComptime(.{
-        .{".editorconfig"},                     .{".gitignore"},
-        .{".nojekyll"},                         .{"CNAME"},
-        .{"exclude-pmd.properties"},            .{"favicon.ico"},
-        .{"favicon.png"},                       .{"LICENSE"},
-        .{"module-info.test"},                  .{"index.html"},
-        .{"style.css"},                         .{"logo.svg"},
-        .{"logo-white.svg"},                    .{"logo-with-text-white.svg"},
-        .{"zig/download.sh"},                   .{"src/scripts/cfo_supervisor.sh"},
-        .{"src/docs_website/scripts/build.sh"}, .{".github/ci/docs_check.sh"},
+        .{".editorconfig"},
+        .{".gitignore"},
+        .{".nojekyll"},
+        .{"CNAME"},
+        .{"exclude-pmd.properties"},
+        .{"favicon.ico"},
+        .{"favicon.png"},
+        .{"LICENSE"},
+        .{"module-info.test"},
+        .{"index.html"},
+        .{"style.css"},
+        .{"logo.svg"},
+        .{"logo-white.svg"},
+        .{"logo-with-text-white.svg"},
+        .{"zig/download.sh"},
+        .{"src/scripts/cfo_supervisor.sh"},
+        .{"src/docs_website/scripts/build.sh"},
+        .{".github/ci/docs_check.sh"},
         .{".github/ci/test_aof.sh"},
     });
 


### PR DESCRIPTION
I find that these lines are prone to merge conflicts, and I hypothesize that formatting these 1-per line will make the diffs simpler to read when fixing (though I have not tested that this is true).