### PR TITLE
Vortex Zig driver: write results from main thread

### DIFF
--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -71,7 +71,15 @@ pub fn main(_: std.mem.Allocator, args: CLIArgs) !void {
             }
         }
 
-        try write_results(stdout, operation, context.result[0..context.result_size]);
+        write_results(stdout, operation, context.result[0..context.result_size]) catch |err| {
+            switch (err) {
+                error.BrokenPipe => {
+                    log.info("stdout is closed, exiting", .{});
+                    break;
+                },
+                else => return err,
+            }
+        };
     }
 }
 

--- a/src/vortex.zig
+++ b/src/vortex.zig
@@ -56,7 +56,9 @@ pub fn main() !void {
         .workload => |driver_args| {
             var driver = try start_driver(allocator, driver_args);
             defer {
-                _ = driver.kill() catch {};
+                _ = driver.kill() catch {
+                    log.err("failed to kill driver", .{});
+                };
             }
 
             try Workload.main(allocator, &.{


### PR DESCRIPTION
Instead of writing to stdout from the tb_client callback directly, we use a mutex and a condition to await the results in the main thread, through a shared context.

One reason for doing this is that we can reinitialize the client in a controlled way. Previously, a callback might happen after reinitializing the client.

This is based on the same mechanism as used in
`src/clients/c/samples/main.zig`.