### PR TITLE
Multiversion: Simplify upgrade with dev flags

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -287,21 +287,13 @@ const Command = struct {
             if (constants.config.process.release.value ==
                 vsr.multiversioning.Release.minimum.value)
             {
-                log.info("multiversioning: disabled for development ({}) release.", .{
+                log.info("multiversioning: upgrades disabled for development ({}) release.", .{
                     constants.config.process.release,
                 });
                 break :blk null;
             }
-            if (args.development) {
-                log.info("multiversioning: disabled due to --development.", .{});
-                break :blk null;
-            }
-            if (args.experimental) {
-                log.info("multiversioning: disabled due to --experimental.", .{});
-                break :blk null;
-            }
             if (constants.aof_recovery) {
-                log.info("multiversioning: disabled due to aof_recovery.", .{});
+                log.info("multiversioning: upgrades disabled due to aof_recovery.", .{});
                 break :blk null;
             }
 
@@ -380,7 +372,15 @@ const Command = struct {
             else => |e| return e,
         };
 
-        if (multiversion != null) multiversion.?.timeout_start(replica.replica);
+        if (multiversion != null) {
+            if (args.development) {
+                log.info("multiversioning: upgrade polling disabled due to --development.", .{});
+            } else if (args.experimental) {
+                log.info("multiversioning: upgrade polling disabled due to --experimental.", .{});
+            } else {
+                multiversion.?.timeout_start(replica.replica);
+            }
+        }
 
         // Note that this does not account for the fact that any allocations will be rounded up to
         // the nearest page by `std.heap.page_allocator`.


### PR DESCRIPTION
## Overview

When `--development` or `--experimental` is passed to `tigerbeetle start`, upgrading is more complicated than usual:

1. Stop the replica (old binary).
2. Start the replica (new binary) without the offending flag.
3. Wait for the upgrade to complete.
4. Stop the replica (new binary).
5. Start the replica (new binary) with the extra flags.

In this PR, simplify it to:

1. Stop the replica (old binary).
2. Start the replica (new binary) with the extra flags.

... i.e. when `--development`/`--experimental` are set, we still don't monitor the binary for changes, but we _do_ support upgrades.

Also in this commit, clarify some of the `log.info` messages.

## Details

Note that the previous logic:

```zig
if (args.development) {
    log.info("multiversioning: disabled due to --development.", .{});
    break :blk null;
}
if (args.experimental) {
    log.info("multiversioning: disabled due to --experimental.", .{});
    break :blk null;
}
```

... still exists in the bundled versions, so upgrades with `--development`/`--experiment` will only work as those bundled versions get phased out, replaced by binaries with the new logic.

To test this locally, I first built an "old" version with the new logic, then bundled that "old" version with the "new" binary, and tested an upgrade. (See the change in `build.zig`, which simplifies this process by adding a `-Dmultiversion-file` flag).