### PR TITLE
doc: fix broken link in the README.md for Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Check out [docs.tigerbeetle.com](https://docs.tigerbeetle.com/).
 Here are a few key pages you might be interested in:
 
 - Deployment
-  - [Hardware](https://docs.tigerbeetle.com/deploy/hardware/)
+  - [Hardware](https://docs.tigerbeetle.com/operating/hardware/)
 - Usage
   - [Integration](https://docs.tigerbeetle.com/coding/system-architecture)
 - Reference


### PR DESCRIPTION
Corrected the "Hardware" link under the Deployment section in the README.md file. Old one was returning 404 Page Not Found. 


<img width="661" alt="image" src="https://github.com/user-attachments/assets/827c4e2d-ca1b-4f13-a0ef-3fdc94623726">
