### PR TITLE
ci: allow git tag and config.process.release to differ

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1515,6 +1515,7 @@ fn fetch(b: *std.Build, options: struct {
     const copy_from_cache = b.addRunArtifact(b.addExecutable(.{
         .name = "copy-from-cache",
         .root_source_file = b.addWriteFiles().add("main.zig",
+            \\const builtin = @import("builtin");
             \\const std = @import("std");
             \\const assert = std.debug.assert;
             \\
@@ -1541,7 +1542,8 @@ fn fetch(b: *std.Build, options: struct {
             \\        source_path,
             \\        std.fs.cwd(),
             \\        args[4],
-            \\        .{},
+            \\        // TODO(Zig): https://github.com/ziglang/zig/pull/21555
+            \\        .{ .override_mode = if (builtin.target.os.tag == .macos) 0o777 else null },
             \\    );
             \\}
         ),


### PR DESCRIPTION
This is useful for rare hot-fix releases, where we need to update the version of the code, but we don't want to run the upgrade through the protocol!

As a bonus, the `--build` part of the release script now works on macOS.