### PR TITLE
grid: make reserve() panic rather than returning null

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -92,7 +92,8 @@ const ConfigProcess = struct {
     git_commit: ?[40]u8 = null,
     port: u16 = 3001,
     address: []const u8 = "127.0.0.1",
-    storage_size_limit_max: u64 = 16 * 1024 * 1024 * 1024 * 1024,
+    storage_size_limit_default: u64 = 16 * 1024 * 1024 * 1024 * 1024,
+    storage_size_limit_max: u64 = 64 * 1024 * 1024 * 1024 * 1024,
     memory_size_max_default: u64 = 1024 * 1024 * 1024,
     cache_accounts_size_default: usize,
     cache_transfers_size_default: usize,
@@ -238,6 +239,7 @@ pub const configs = struct {
     /// reach.
     pub const test_min = Config{
         .process = .{
+            .storage_size_limit_default = 1 * 1024 * 1024 * 1024,
             .storage_size_limit_max = 1 * 1024 * 1024 * 1024,
             .direct_io = false,
             .cache_accounts_size_default = @sizeOf(vsr.tigerbeetle.Account) * 256,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -407,9 +407,9 @@ pub const grid_scrubber_reads_max = config.process.grid_scrubber_reads_max;
 /// Napkin math for the "worst case" scrubber read overhead as a function of cycle duration
 /// (assuming a fully-loaded data file – maximum size and 100% acquired):
 ///
-///   storage_size_limit_max      = 16TiB
+///   storage_size_limit          = 64TiB
 ///   grid_scrubber_cycle_seconds = 180 days * 24 hr/day * 60 min/hr * 60 s/min (2 cycle/year)
-///   read_bytes_per_second       = storage_size_max / grid_scrubber_cycle_seconds ≈ 1.08 MiB/s
+///   read_bytes_per_second       = storage_size_limit / grid_scrubber_cycle_seconds ≈ 4.32 MiB/s
 ///
 pub const grid_scrubber_cycle_ticks = config.process.grid_scrubber_cycle_ms / tick_ms;
 
@@ -575,6 +575,10 @@ comptime {
     assert(superblock_copies <= 8);
 }
 
+/// The default maximum size of a local data file. This can be override, up to
+/// storage_size_limit_max, by a CLI flag.
+pub const storage_size_limit_default = config.process.storage_size_limit_default;
+
 /// The maximum size of a local data file.
 /// This should not be much larger than several TiB to limit:
 /// * blast radius and recovery time when a whole replica is lost,
@@ -584,6 +588,10 @@ comptime {
 /// This is a "firm" limit --- while it is a compile-time constant, it does not affect data file
 /// layout and can be safely changed for an existing cluster.
 pub const storage_size_limit_max = config.process.storage_size_limit_max;
+
+comptime {
+    assert(storage_size_limit_max >= storage_size_limit_default);
+}
 
 /// The unit of read/write access to LSM manifest and LSM table blocks in the block storage zone.
 ///

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -831,7 +831,7 @@ pub fn CompactionType(
             const beat_blocks_max = beat_value_blocks_max + beat_index_blocks_max;
 
             assert(compaction.grid_reservation == null);
-            compaction.grid_reservation = compaction.grid.reserve(beat_blocks_max).?;
+            compaction.grid_reservation = compaction.grid.reserve(beat_blocks_max);
 
             // These values were already processed during the previous beat and add to wastage.
             if (compaction.table_info_a.? == .disk) {

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -137,7 +137,7 @@ const Environment = struct {
 
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = env.storage,
-            .storage_size_limit = constants.storage_size_limit_max,
+            .storage_size_limit = constants.storage_size_limit_default,
         });
 
         env.grid = try Grid.init(allocator, .{
@@ -847,7 +847,11 @@ const Environment = struct {
 
 pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) !void {
     // Init mocked storage.
-    var storage = try Storage.init(allocator, constants.storage_size_limit_max, storage_options);
+    var storage = try Storage.init(
+        allocator,
+        constants.storage_size_limit_default,
+        storage_options,
+    );
     defer storage.deinit(allocator);
 
     try Environment.run(&storage, fuzz_ops);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -234,7 +234,7 @@ const Environment = struct {
 
         var reservations: [free_set_fragments_max]Reservation = undefined;
         for (&reservations) |*reservation| {
-            reservation.* = env.grid.reserve(free_set_fragment_size).?;
+            reservation.* = env.grid.reserve(free_set_fragment_size);
         }
         for (reservations) |reservation| {
             _ = env.grid.free_set.acquire(reservation).?;

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -693,7 +693,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             manifest_log.grid_reservation = manifest_log.grid.reserve(
                 manifest_log.compact_blocks.? +
                     manifest_log.pace.half_bar_append_blocks_max,
-            ).?;
+            );
 
             manifest_log.read_callback = callback;
             manifest_log.flush(compact_next_block);

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -280,12 +280,12 @@ const Environment = struct {
 
         fields_initialized += 1;
         env.storage =
-            try Storage.init(allocator, constants.storage_size_limit_max, storage_options);
+            try Storage.init(allocator, constants.storage_size_limit_default, storage_options);
         errdefer env.storage.deinit(allocator);
 
         fields_initialized += 1;
         env.storage_verify =
-            try Storage.init(allocator, constants.storage_size_limit_max, storage_options);
+            try Storage.init(allocator, constants.storage_size_limit_default, storage_options);
         errdefer env.storage_verify.deinit(allocator);
 
         fields_initialized += 1;
@@ -299,14 +299,14 @@ const Environment = struct {
         fields_initialized += 1;
         env.superblock = try SuperBlock.init(allocator, .{
             .storage = &env.storage,
-            .storage_size_limit = constants.storage_size_limit_max,
+            .storage_size_limit = constants.storage_size_limit_default,
         });
         errdefer env.superblock.deinit(allocator);
 
         fields_initialized += 1;
         env.superblock_verify = try SuperBlock.init(allocator, .{
             .storage = &env.storage_verify,
-            .storage_size_limit = constants.storage_size_limit_max,
+            .storage_size_limit = constants.storage_size_limit_default,
         });
         errdefer env.superblock_verify.deinit(allocator);
 
@@ -543,7 +543,7 @@ const Environment = struct {
                 env.allocator,
                 .{
                     .storage = test_storage,
-                    .storage_size_limit = constants.storage_size_limit_max,
+                    .storage_size_limit = constants.storage_size_limit_default,
                 },
             );
 

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -634,7 +634,7 @@ const Environment = struct {
 
             .superblock = try SuperBlock.init(allocator, .{
                 .storage = env.storage,
-                .storage_size_limit = constants.storage_size_limit_max,
+                .storage_size_limit = constants.storage_size_limit_default,
             }),
 
             .grid = try Grid.init(allocator, .{
@@ -1096,7 +1096,7 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     // Init mocked storage.
     var storage = try Storage.init(
         allocator,
-        constants.storage_size_limit_max,
+        constants.storage_size_limit_default,
         Storage.Options{
             .seed = random.int(u64),
             .read_latency_min = 0,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -166,7 +166,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
             env.superblock = try SuperBlock.init(allocator, .{
                 .storage = env.storage,
-                .storage_size_limit = constants.storage_size_limit_max,
+                .storage_size_limit = constants.storage_size_limit_default,
             });
             defer env.superblock.deinit(allocator);
 
@@ -891,7 +891,11 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     defer allocator.free(fuzz_ops);
 
     // Init mocked storage.
-    var storage = try Storage.init(allocator, constants.storage_size_limit_max, storage_options);
+    var storage = try Storage.init(
+        allocator,
+        constants.storage_size_limit_default,
+        storage_options,
+    );
     defer storage.deinit(allocator);
 
     switch (table_usage) {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -615,7 +615,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         if (start.development) start_defaults_development else start_defaults_production;
 
     const start_limit_storage: flags.ByteSize = start.limit_storage orelse
-        .{ .value = constants.storage_size_limit_max };
+        .{ .value = constants.storage_size_limit_default };
     const start_memory_lsm_manifest: flags.ByteSize = start.memory_lsm_manifest orelse
         .{ .value = constants.lsm_manifest_memory_size_default };
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -645,6 +645,7 @@ const FatalReason = enum(u8) {
     no_space_left = 2,
     manifest_node_pool_exhausted = 3,
     storage_size_exceeds_limit = 4,
+    storage_size_would_exceed_limit = 5,
 
     fn exit_status(reason: FatalReason) u8 {
         return @intFromEnum(reason);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1276,7 +1276,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     vsr.fatal(
                         .storage_size_exceeds_limit,
                         "data file too large size={} > limit={}, " ++
-                            "restart the replica increasing '--storage_size_limit'",
+                            "restart the replica increasing '--storage-size-limit'",
                         .{
                             superblock.working.vsr_state.checkpoint.storage_size,
                             superblock.storage_size_limit,

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -76,13 +76,13 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
 
     var superblock = try SuperBlock.init(allocator, .{
         .storage = &storage,
-        .storage_size_limit = constants.storage_size_limit_max,
+        .storage_size_limit = constants.storage_size_limit_default,
     });
     defer superblock.deinit(allocator);
 
     var superblock_verify = try SuperBlock.init(allocator, .{
         .storage = &storage_verify,
-        .storage_size_limit = constants.storage_size_limit_max,
+        .storage_size_limit = constants.storage_size_limit_default,
     });
     defer superblock_verify.deinit(allocator);
 


### PR DESCRIPTION
Currently all uses of `grid.reserve()` unwrap the result. Cut out the middleman, and panic directly in `reserve()` with a nice error message.