### PR TITLE
IO/Linux: Cancel IO before freeing memory

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -227,7 +227,7 @@ pub fn ContextType(
             self.signal.notify();
             self.thread.join();
 
-            try self.io.cancel();
+            self.io.cancel_all();
 
             self.signal.deinit();
             self.client.deinit(self.allocator);

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -217,7 +217,7 @@ pub fn ContextType(
             return context;
         }
 
-        pub fn deinit(self: *Context) void {
+        pub fn deinit(self: *Context) !void {
             // Only one thread calls deinit() and it's UB for any further Context interaction.
             const already_shutdown = self.shutdown.swap(true, .release);
             assert(!already_shutdown);
@@ -226,6 +226,8 @@ pub fn ContextType(
             // packets, and finish running.
             self.signal.notify();
             self.thread.join();
+
+            try self.io.cancel();
 
             self.signal.deinit();
             self.client.deinit(self.allocator);
@@ -569,7 +571,9 @@ pub fn ContextType(
 
         fn on_deinit(implementation: *ContextImplementation) void {
             const self = get_context(implementation);
-            self.deinit();
+            self.deinit() catch |err| {
+                std.debug.panic("deinit error: {}", .{err});
+            };
         }
 
         test "client_batch_linked_chain" {

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -288,6 +288,11 @@ pub const IO = struct {
         }
     }
 
+    pub fn cancel(self: *IO) !void {
+        _ = self;
+        // TODO Cancel in-flight async IO and wait for all completions.
+    }
+
     pub const AcceptError = posix.AcceptError || posix.SetSockOptError;
 
     pub fn accept(

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -288,8 +288,7 @@ pub const IO = struct {
         }
     }
 
-    pub fn cancel(self: *IO) !void {
-        _ = self;
+    pub fn cancel_all(_: *IO) void {
         // TODO Cancel in-flight async IO and wait for all completions.
     }
 

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -739,3 +739,105 @@ test "pipe data over socket" {
         }
     }.run();
 }
+
+test "cancel" {
+    const checksum = @import("../vsr/checksum.zig").checksum;
+    const allocator = std.testing.allocator;
+    const file_path = "test_cancel";
+    const read_count = 8;
+    const read_size = 1024 * 16;
+
+    // For this test to be useful, we rely on open(DIRECT).
+    // (See below).
+    if (builtin.target.os.tag != .linux) return;
+
+    try struct {
+        const Context = @This();
+
+        io: IO,
+        canceled: bool = false,
+
+        fn run_test() !void {
+            defer std.fs.cwd().deleteFile(file_path) catch {};
+
+            var context: Context = .{ .io = try IO.init(32, 0) };
+            defer context.io.deinit();
+
+            {
+                // Initialize the file and fill it with test data.
+                const file = try std.fs.cwd().createFile(file_path, .{
+                    .read = true,
+                    .truncate = true,
+                });
+                defer file.close();
+
+                const file_buffer = try allocator.alloc(u8, read_size);
+                defer allocator.free(file_buffer);
+                for (file_buffer, 0..) |*b, i| b.* = @intCast(i % 256);
+
+                try file.writeAll(file_buffer);
+            }
+
+            var read_completions: [read_count]IO.Completion = undefined;
+            var read_buffers: [read_count][]u8 = undefined;
+            var read_buffer_checksums: [read_count]u128 = undefined;
+            var read_buffers_allocated: u32 = 0;
+            defer for (read_buffers[0..read_buffers_allocated]) |b| allocator.free(b);
+
+            for (&read_buffers) |*read_buffer| {
+                read_buffer.* = try allocator.alloc(u8, read_size);
+                read_buffers_allocated += 1;
+            }
+
+            // Test cancellation:
+            // 1. Re-open the file.
+            // 2. Kick off multiple (async) reads.
+            // 3. Abort the reads (ideally before they can complete, since that is more interesting
+            //    to test).
+            //
+            // The reason to re-open the file with DIRECT is that it slows down the reads enough to
+            // actually test the interesting case -- cancelling an in-flight read and verifying that
+            // the buffer is not written to after `cancel()` completes.
+            //
+            // (Without DIRECT the reads all finish their callbacks even before io.tick() returns.)
+            const file = try std.posix.open(file_path, .{ .DIRECT = true }, 0);
+            defer std.posix.close(file);
+
+            for (&read_completions, read_buffers) |*completion, buffer| {
+                context.io.read(*Context, &context, read_callback, completion, file, buffer, 0);
+            }
+            try context.io.tick();
+
+            // Set to true *before* calling cancel() to ensure that any farther callbacks from IO
+            // completion will panic.
+            context.canceled = true;
+
+            try context.io.cancel();
+
+            // All of the in-flight reads are canceled at this point.
+            // To verify, checksum all of the read buffer memory, then wait and make sure that there
+            // are no farther modifications to the buffers.
+            for (read_buffers, &read_buffer_checksums) |buffer, *buffer_checksum| {
+                buffer_checksum.* = checksum(buffer);
+            }
+
+            const sleep_ms = 50;
+            std.time.sleep(sleep_ms * std.time.ns_per_ms);
+
+            for (read_buffers, read_buffer_checksums) |buffer, buffer_checksum| {
+                try testing.expectEqual(checksum(buffer), buffer_checksum);
+            }
+        }
+
+        fn read_callback(
+            context: *Context,
+            completion: *IO.Completion,
+            result: IO.ReadError!usize,
+        ) void {
+            _ = completion;
+            _ = result catch @panic("read error");
+
+            assert(!context.canceled);
+        }
+    }.run_test();
+}

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -283,6 +283,11 @@ pub const IO = struct {
         }
     }
 
+    pub fn cancel(self: *IO) !void {
+        _ = self;
+        // TODO Cancel in-flight async IO and wait for all completions.
+    }
+
     pub const AcceptError = std.posix.AcceptError || std.posix.SetSockOptError;
 
     pub fn accept(

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -283,8 +283,7 @@ pub const IO = struct {
         }
     }
 
-    pub fn cancel(self: *IO) !void {
-        _ = self;
+    pub fn cancel_all(_: *IO) void {
         // TODO Cancel in-flight async IO and wait for all completions.
     }
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -179,7 +179,10 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             }
 
             for (bus.connections) |*connection| {
-                connection.terminate(bus, .shutdown);
+                if (connection.fd != IO.INVALID_SOCKET) {
+                    bus.io.close_socket(connection.fd);
+                }
+
                 if (connection.recv_message) |message| bus.unref(message);
                 while (connection.send_queue.pop()) |message| bus.unref(message);
             }


### PR DESCRIPTION
### IO

Cancel in-flight IO before freeing memory.

More specifically: If IO has been submitted to io_uring, we must be careful not to free any buffers referenced by that IO until it is complete. Otherwise we might write to that memory after it has been freed.

`IO` implements this by maintaining a new doubly-linked list of in-flight IO. When deinitializing IO, we cancel those IO's one at a time, and wait for each to complete (where "complete" might mean failing with a `ECANCELED` result).

```
// Before freeing any memory, wait for in-flight IO to finish:
try io.cancel();

// Now that there is no running IO, and no more IO is allowed to start running, we can safely free
// all of our buffers:
message_bus.deinit();
io.deinit();
```

If in the future we bump our minimum supported Linux kernel version to at least 5.19, then this logic can be massively simplified by taking advantage of the `IORING_ASYNC_CANCEL_ALL` and `IORING_ASYNC_CANCEL_ANY` flags to cancel all IO with a single operation. And if we bump to 6.0, we can additionally use `io_uring`, simplifying our `IO.cancel()` implementation even farther.

<details>
<summary>Other approaches</summary>

Another approach I tried was adding a `io.cancel(completion)` function which consumers of IO were expected to call during their own `deinit()`.

But this had several drawbacks:

- `io.cancel` has to wait for IO to finish, which means it needs to `io.tick`. And `io.tick()` can fail, which means many `deinit()` functions can return an error.
- We need to increase the surface area of `Storage` since consumers of `Storage` don't know about `IO`, e.g. `storage.cancel_read()`, `storage.cancel_write()`.
- While canceling an operation, we tick IO, which can make progress on other IO, calling their callbacks, which is hard to reason about. In the implemented version, cancellation is all-or-nothing -- once we start cancellation, we can just not ever invoke a completion callback again.

</details>

---

### MessageBus

Fix `MessageBus.deinit()` assertion failure caused by invoking `connection.terminate()` twice (for the same connection).

Stack trace of assert (via Vortex!):

```

thread 17 panic: reached unreachable code
/home/owi/projects/tigerbeetle/tigerbeetle/src/message_bus.zig:0:0: 0x10796a0 in terminate (vortex)
/home/owi/projects/tigerbeetle/tigerbeetle/src/message_bus.zig:182:37: 0x106bed5 in deinit (vortex)
                connection.terminate(bus, .shutdown);
                                    ^
/home/owi/projects/tigerbeetle/tigerbeetle/src/clients/c/tb_client/context.zig:231:31: 0x106b920 in on_deinit (vortex)
            self.client.deinit(self.allocator);
                              ^
```