### PR TITLE
Devhub: Run fuzzers with `--events-max`

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -41,10 +41,11 @@ fn devhub_coverage(shell: *Shell) !void {
     try shell.project_root.makePath("./src/devhub/coverage");
 
     const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./src/devhub/coverage" };
-    try shell.exec("{kcov} ./zig-out/bin/test", .{ .kcov = kcov });
-    try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_tree 92", .{ .kcov = kcov });
-    try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_forest 92", .{ .kcov = kcov });
-    try shell.exec("{kcov} ./zig-out/bin/vopr 92", .{ .kcov = kcov });
+    const kcov_args = .{ .kcov = kcov };
+    try shell.exec("{kcov} ./zig-out/bin/test", kcov_args);
+    try shell.exec("{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92", kcov_args);
+    try shell.exec("{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92", kcov_args);
+    try shell.exec("{kcov} ./zig-out/bin/vopr 92", kcov_args);
 
     var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
     defer coverage_dir.close();

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -41,11 +41,14 @@ fn devhub_coverage(shell: *Shell) !void {
     try shell.project_root.makePath("./src/devhub/coverage");
 
     const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./src/devhub/coverage" };
-    const kcov_args = .{ .kcov = kcov };
-    try shell.exec("{kcov} ./zig-out/bin/test", kcov_args);
-    try shell.exec("{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92", kcov_args);
-    try shell.exec("{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92", kcov_args);
-    try shell.exec("{kcov} ./zig-out/bin/vopr 92", kcov_args);
+    inline for (.{
+        "{kcov} ./zig-out/bin/test",
+        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92",
+        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92",
+        "{kcov} ./zig-out/bin/vopr 92",
+    }) |command| {
+        try shell.exec(command, .{ .kcov = kcov });
+    }
 
     var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
     defer coverage_dir.close();


### PR DESCRIPTION
Right now devhub uploads are failing with:

```
error: process failed with ExecTimeout: kcov --include-path=./src ./src/devhub/coverage ./zig-out/bin/fuzz lsm_tree 92
error: stderr:
++++
info(fuzz): Fuzz seed = 92
info(lsm_tree_fuzz): table_usage=lsm.table.TableUsage.general
info(lsm_tree_fuzz): fuzz_op_count = 1560620
info(lsm_tree_fuzz): fuzz_op_distribution = enums.EnumFieldStruct(@typeInfo(lsm.tree_fuzz.FuzzOp).Union.tag_type.?,f64,null){ .compact = 0.00e0, .put = 8.00e0, .remove = 4.00e0, .get = 0.00e0, .scan = 4.00e0 }
info(lsm_tree_fuzz): puts_since_compact_max = 120
info(lsm_tree_fuzz): compacts_per_checkpoint = 8
++++

error: ExecTimeout
/home/runner/work/tigerbeetle/tigerbeetle/src/shell.zig:524:31: 0x11b4684 in exec_inner (scripts)
            if (timeout <= 0) return error.ExecTimeout;
                              ^
/home/runner/work/tigerbeetle/tigerbeetle/src/shell.zig:398:5: 0x12762a4 in exec__anon_9931 (scripts)
    return exec_inner(shell, argv.slice(), .{});
    ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts/devhub.zig:45:5: 0x1277d58 in devhub_coverage (scripts)
    try shell.exec("{kcov} ./zig-out/bin/fuzz lsm_tree 92", .{ .kcov = kcov });
    ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts/devhub.zig:26:5: 0x1278098 in main (scripts)
    try devhub_coverage(shell);
    ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts.zig:90:34: 0x12973bf in main (scripts)
        .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
```

The `./zig-out/bin/fuzz lsm_tree 91` takes ~9 minutes to run on my laptop. Since this is for code coverage purposes, that is probably more than is needed anyhow. With `--events-max=50000` it takes >2 minutes.