### PR TITLE
vsr: assert free set consistency

### DIFF
--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -860,8 +860,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 manifest_log.close_block();
                 assert(manifest_log.entry_count == 0);
                 assert(manifest_log.blocks_closed > 0);
-                assert(manifest_log.blocks_closed == manifest_log.blocks.count);
             }
+            assert(manifest_log.blocks_closed == manifest_log.blocks.count);
 
             manifest_log.flush(callback);
         }

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -287,6 +287,11 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             return .negative;
         }
 
+        pub fn block_value_count_max(tree: *Tree) u32 {
+            _ = tree; // autofix
+            return Table.layout.block_value_count_max;
+        }
+
         fn cached_data_block_search(
             tree: *Tree,
             address: u64,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -287,8 +287,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             return .negative;
         }
 
-        pub fn block_value_count_max(tree: *Tree) u32 {
-            _ = tree; // autofix
+        pub fn block_value_count_max(_: *const Tree) u32 {
             return Table.layout.block_value_count_max;
         }
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -790,9 +790,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .checkpoint_completed => {
                     cluster.log_replica(.checkpoint_completed, replica.replica);
                     cluster.manifest_checker.forest_checkpoint(&replica.state_machine.forest);
-                    cluster.storage_checker.replica_checkpoint(
-                        &replica.superblock,
-                    ) catch |err| {
+                    cluster.storage_checker.replica_checkpoint(Replica, replica) catch |err| {
                         fatal(.correctness, "storage checker error: {}", .{err});
                     };
                 },

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -164,12 +164,17 @@ pub const StorageChecker = struct {
         }
     }
 
-    pub fn replica_checkpoint(checker: *StorageChecker, superblock: *const SuperBlock) !void {
-        const syncing = superblock.working.vsr_state.sync_op_max > 0;
+    pub fn replica_checkpoint(
+        checker: *StorageChecker,
+        comptime Replica: type,
+        replica: *const Replica,
+    ) !void {
+        replica.assert_free_set_consistent();
 
+        const syncing = replica.superblock.working.vsr_state.sync_op_max > 0;
         try checker.check(
             "replica_checkpoint",
-            superblock,
+            &replica.superblock,
             std.enums.EnumSet(CheckpointArea).init(.{
                 .superblock_checkpoint = true,
                 .client_replies = !syncing,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9813,12 +9813,13 @@ pub fn ReplicaType(
             assert(!self.state_machine_opened or self.commit_stage == .checkpoint_superblock);
 
             var forest_tables_iterator = ForestTableIterator{};
-            var tables_index_block_count: u32 = 0;
-            var tables_value_block_count: u32 = 0;
-            var forest: *StateMachine.Forest = @constCast(&self.state_machine.forest);
-            while (forest_tables_iterator.next(forest)) |table| {
+            var tables_index_block_count: u64 = 0;
+            var tables_value_block_count: u64 = 0;
+            while (forest_tables_iterator.next(&self.state_machine.forest)) |table| {
                 const block_value_count = switch (StateMachine.Forest.tree_id_cast(table.tree_id)) {
-                    inline else => |tree_id| forest.tree_for_id(tree_id).block_value_count_max(),
+                    inline else => |tree_id| self.state_machine.forest.tree_for_id_const(
+                        tree_id,
+                    ).block_value_count_max(),
                 };
                 tables_index_block_count += 1;
                 tables_value_block_count += stdx.div_ceil(


### PR DESCRIPTION
_On startup and after checkpoint_, we now assert that the free set is consistent. Specifically, we assert that the count of acquired blocks in the free set is the sum of:
1. Index blocks across all tables in the forest
2. Value blocks across all tables in the forest
3. ManifestLog blocks
4. CheckpointTrailer blocks (client sessions & free set)