### PR TITLE
grid: divide request buffer between the read_global_queue & faulty_blocks queues

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -683,7 +683,7 @@ pub const Simulator = struct {
         const cluster_commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
         var cluster_op_checkpoint: u64 = 0;
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.isSet(replica.replica) and !replica.standby()) {
                 cluster_op_checkpoint = @max(
                     cluster_op_checkpoint,
                     replica.superblock.working.vsr_state.checkpoint.header.op,

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1177,10 +1177,16 @@ pub fn GridType(comptime Storage: type) type {
         pub fn next_batch_of_block_requests(grid: *Grid, requests: []vsr.BlockRequest) usize {
             assert(grid.callback != .cancel);
             assert(requests.len > 0);
+            assert(requests.len == constants.grid_repair_reads_max);
 
             // Prioritize requests for blocks with stalled Grid reads, so that commit/compaction can
-            // continue.
-            const request_faults_count = @min(grid.read_global_queue.count, requests.len);
+            // continue. We now divide the buffer up between `read_global_queue` and
+            // `blocks_missing.faulty_blocks` so that we always request blocks from both queues.
+            const request_faults_count = @min(
+                grid.read_global_queue.count,
+                // Surplus from `blocks_missing.faulty_blocks` may be used by `read_global_queue`.
+                requests.len / 2 + (requests.len / 2 -| grid.blocks_missing.faulty_blocks.count()),
+            );
             // (Note that many – but not all – of these blocks are also in the GridBlocksMissing.
             // The `read_global_queue` is a FIFO, whereas the GridBlocksMissing has a fixed
             // capacity.)

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1180,12 +1180,18 @@ pub fn GridType(comptime Storage: type) type {
             assert(requests.len == constants.grid_repair_reads_max);
 
             // Prioritize requests for blocks with stalled Grid reads, so that commit/compaction can
-            // continue. We now divide the buffer up between `read_global_queue` and
+            // continue. We divide the buffer up between `read_global_queue` and
             // `blocks_missing.faulty_blocks` so that we always request blocks from both queues.
+            // Surplus from `blocks_missing.faulty_blocks` may be used by `read_global_queue`.
+            const request_faults_count_max = requests.len -
+                @min(@divFloor(requests.len, 2), grid.blocks_missing.faulty_blocks.count());
+            assert(request_faults_count_max > 0);
+            assert(request_faults_count_max <= requests.len);
+            assert(request_faults_count_max >= @divFloor(requests.len, 2));
+
             const request_faults_count = @min(
                 grid.read_global_queue.count,
-                // Surplus from `blocks_missing.faulty_blocks` may be used by `read_global_queue`.
-                requests.len / 2 + (requests.len / 2 -| grid.blocks_missing.faulty_blocks.count()),
+                request_faults_count_max,
             );
             // (Note that many – but not all – of these blocks are also in the GridBlocksMissing.
             // The `read_global_queue` is a FIFO, whereas the GridBlocksMissing has a fixed

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -173,8 +173,10 @@ pub const GridBlocksMissing = struct {
             }
         }
 
+        // +1 so we start from the next faulty block in the subsequent function invocation, thereby
+        // cycling through the faulty blocks in the queue.
         queue.faulty_blocks_repair_index =
-            (queue.faulty_blocks_repair_index + fault_offset) % faults_total;
+            (queue.faulty_blocks_repair_index + fault_offset + 1) % faults_total;
 
         assert(requests_count <= requests.len);
         assert(requests_count <= faults_total);


### PR DESCRIPTION
This PR resolves a VOPR false positive on `main` (`./zig/zig build -Drelease vopr -- 435571418441293928`). 

### Problem

After the VOPR liveness mode, if the cluster is found to not have liveness, `core_missing_blocks` checks if all corrupt blocks that can be repaired (are available on the core) should be repaired. However, our grid repair protocol does not guarantee this. Specifically, while choosing what blocks to send in `.request_blocks`, we *first* check `grid.read_global_queue`, and if there is any more capacity in the request buffer, we check `grid.blocks_missing.faulty_blocks`. This could lead to the blocks in `grid.blocks_missing.faulty_blocks` getting starved.

In this VOPR seed, there were 3 faulty blocks in `grid.read_global_queue` (that were not available on the core), leaving space for 1 block from `grid.blocks_missing.faulty_blocks` (`grid_repair_request_max` is 4). That 1 block was not available in the core, so we *never* try to repair any other blocks from `grid.blocks_missing.faulty_blocks`. 

This is because our logic for *cycling* through `grid.blocks_missing.faulty_blocks` is buggy (it requires a + 1 so we start from the *next* faulty block on subsequent invocations).
https://github.com/tigerbeetle/tigerbeetle/blob/5a5b605ebbdfa5e912c25b39e510485d1c8c493a/src/vsr/grid_blocks_missing.zig#L176-L177


### Solution

Now, our grid repair protocol guarantees that all corrupt blocks that can be repaired (are available on the core) should be repaired. To achieve this, we now divide up the buffer for `.request_blocks` between `grid.blocks_missing.faulty_blocks` & `grid.read_global_queue`, such that we always request blocks from both.

Additionally, we fix our buggy logic for cycling through `grid.blocks_missing.faulty_blocks` .