### PR TITLE
ci: fix multiversion build on MacOS

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -264,7 +264,7 @@ fn build_multiversion_universal(shell: *Shell, options: struct {
         .llvm_objcopy = options.llvm_objcopy,
         .tmp_path = options.tmp_path,
         .target = .macos,
-        .arch = .x86_64,
+        .arch = .aarch64,
         .tigerbeetle_past = options.tigerbeetle_past,
         .output = sections.aarch64.body,
     });
@@ -273,7 +273,7 @@ fn build_multiversion_universal(shell: *Shell, options: struct {
         .llvm_objcopy = options.llvm_objcopy,
         .tmp_path = options.tmp_path,
         .target = .macos,
-        .arch = .aarch64,
+        .arch = .x86_64,
         .tigerbeetle_past = options.tigerbeetle_past,
         .output = sections.x86_64.body,
     });


### PR DESCRIPTION
We were confusing x86_64 and aarch64. I think I introduced this bug at https://github.com/tigerbeetle/tigerbeetle/pull/2233