### PR TITLE
test: Java workload sleep

### DIFF
--- a/src/testing/systest/workload/src/main/java/Main.java
+++ b/src/testing/systest/workload/src/main/java/Main.java
@@ -35,7 +35,7 @@ public final class Main {
 
       var executor = Executors.newFixedThreadPool(workloadCount);
       var completionService = new ExecutorCompletionService<Void>(executor);
-      var statistics = new Statistics(System.currentTimeMillis());
+      var statistics = new Statistics();
       var logger = new Thread(() -> logStatistics(statistics));
       logger.setDaemon(true);
       logger.start();
@@ -62,19 +62,17 @@ public final class Main {
       try {
         Thread.sleep(Duration.ofSeconds(10));
 
-        var requestsSuccessful = statistics.successful();
-        var requestsFailed = statistics.failed();
-        var requestsTotal = requestsSuccessful + requestsFailed;
-        var requestsPerSecond = statistics.requestsPerSecond();
-        var requestSuccessRate = requestsTotal > 0 
-          ? ((double) requestsSuccessful / requestsTotal) 
+        var eventsSuccessful = statistics.successful();
+        var eventsFailed = statistics.failed();
+        var eventsTotal = eventsSuccessful + eventsFailed;
+        var eventSuccessRate = eventsTotal > 0 
+          ? ((double) eventsSuccessful / eventsTotal) 
           : 0.0;
 
         System.err.println(
-            "%d requests in total, %s successful, throughput of %d req/s".formatted(
-              requestsTotal,
-              NumberFormat.getPercentInstance().format(requestSuccessRate),
-              requestsPerSecond));
+            "%d events in total, %s successful".formatted(
+              eventsTotal,
+              NumberFormat.getPercentInstance().format(eventSuccessRate)));
       } catch (InterruptedException e) {
         break;
       }

--- a/src/testing/systest/workload/src/main/java/Statistics.java
+++ b/src/testing/systest/workload/src/main/java/Statistics.java
@@ -3,20 +3,12 @@
  * This class is thread-safe.
  */
 class Statistics {
-  private long startTimeMs;
   private long successful;
   private long failed;
 
-  public Statistics(long startTimeMs) {
-    this.startTimeMs = startTimeMs;
+  public Statistics() {
     this.successful = 0;
     this.failed = 0;
-  }
-
-  public synchronized long requestsPerSecond() {
-    long nowMs = System.currentTimeMillis();
-    long elapsedSeconds = (nowMs - startTimeMs) / 1000;
-    return (successful / elapsedSeconds) + (failed / elapsedSeconds);
   }
 
   public synchronized long successful() {
@@ -27,7 +19,7 @@ class Statistics {
       return this.failed;
   }
 
-  public void addRequests(long successful, long failed) {
+  public void addEvents(long successful, long failed) {
     synchronized (this) {
       this.successful += successful;
       this.failed += failed;


### PR DESCRIPTION
This is to increase chance of cluster healing, and to not overwhelm the Antithesis environment with disk space usage.