### PR TITLE
client: expose reply timestamp

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -416,9 +416,11 @@ pub const AOFReplayClient = struct {
     fn replay_callback(
         user_data: u128,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []u8,
     ) void {
         _ = operation;
+        _ = timestamp;
         _ = result;
 
         const self: *AOFReplayClient = @ptrFromInt(@as(usize, @intCast(user_data)));

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -471,12 +471,14 @@ pub fn ContextType(
         fn on_result(
             raw_user_data: u128,
             op: StateMachine.Operation,
+            timestamp: u64,
             reply: []u8,
         ) void {
             const user_data: UserData = @bitCast(raw_user_data);
             const self = user_data.self;
             const packet = user_data.packet;
             assert(packet.next == null); // (previously) inflight packet should not be pending.
+            assert(timestamp > 0);
 
             // Submit the next pending packet (if any) now that VSR has completed this one.
             // The submit() call may complete it inline so keep submitting until there's

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -846,11 +846,12 @@ pub fn ReplType(comptime MessageBus: type) type {
         fn client_request_callback_error(
             user_data: u128,
             operation: StateMachine.Operation,
+            timestamp: u64,
             result: []const u8,
         ) !void {
             const repl: *Repl = @ptrFromInt(@as(usize, @intCast(user_data)));
             assert(repl.request_done == false);
-            try repl.debug("Operation completed: {}.\n", .{operation});
+            try repl.debug("Operation completed: {} timestamp={}.\n", .{ operation, timestamp });
 
             defer {
                 repl.request_done = true;
@@ -940,11 +941,13 @@ pub fn ReplType(comptime MessageBus: type) type {
         fn client_request_callback(
             user_data: u128,
             operation: StateMachine.Operation,
+            timestamp: u64,
             result: []u8,
         ) void {
             client_request_callback_error(
                 user_data,
                 operation,
+                timestamp,
                 result,
             ) catch |err| {
                 const repl: *Repl = @ptrFromInt(@as(usize, @intCast(user_data)));

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -690,10 +690,12 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         fn request_callback(
             user_data: u128,
             operation: StateMachine.Operation,
+            timestamp: u64,
             result: []u8,
         ) void {
             _ = user_data;
             _ = operation;
+            _ = timestamp;
             _ = result;
         }
 

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -305,7 +305,7 @@ const Benchmark = struct {
     batch_index: usize,
     transfer_index: usize,
     transfer_next_arrival_ns: usize,
-    callback: ?*const fn (*Benchmark, StateMachine.Operation, []const u8) void,
+    callback: ?*const fn (*Benchmark, StateMachine.Operation, u64, []const u8) void,
     done: bool,
     statsd: ?*StatsD,
     print_batch_timings: bool,
@@ -364,9 +364,11 @@ const Benchmark = struct {
     fn create_accounts_finish(
         b: *Benchmark,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []const u8,
     ) void {
         assert(operation == .create_accounts);
+        assert(timestamp > 0);
         const create_accounts_results = std.mem.bytesAsSlice(
             tb.CreateAccountsResult,
             result,
@@ -493,9 +495,11 @@ const Benchmark = struct {
     fn create_transfers_finish(
         b: *Benchmark,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []const u8,
     ) void {
         assert(operation == .create_transfers);
+        assert(timestamp > 0);
         const create_transfers_results = std.mem.bytesAsSlice(
             tb.CreateTransfersResult,
             result,
@@ -600,9 +604,11 @@ const Benchmark = struct {
     fn query_account_transfers_finish(
         b: *Benchmark,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []const u8,
     ) void {
         assert(operation == .get_account_transfers);
+        assert(timestamp > 0);
 
         const batch_end_ns = b.timer.read();
         const transfers = std.mem.bytesAsSlice(tb.Transfer, result);
@@ -662,9 +668,11 @@ const Benchmark = struct {
     fn validate_accounts_finish(
         b: *Benchmark,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []const u8,
     ) void {
         assert(operation == .lookup_accounts);
+        assert(timestamp > 0);
 
         const accounts = std.mem.bytesAsSlice(tb.Account, result);
 
@@ -713,9 +721,11 @@ const Benchmark = struct {
     fn validate_transfers_finish(
         b: *Benchmark,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []const u8,
     ) void {
         assert(operation == .lookup_transfers);
+        assert(timestamp > 0);
 
         const transfers = std.mem.bytesAsSlice(tb.Transfer, result);
 
@@ -750,7 +760,7 @@ const Benchmark = struct {
 
     fn send(
         b: *Benchmark,
-        callback: *const fn (*Benchmark, StateMachine.Operation, []const u8) void,
+        callback: *const fn (*Benchmark, StateMachine.Operation, u64, []const u8) void,
         operation: StateMachine.Operation,
         payload: []u8,
     ) void {
@@ -766,13 +776,14 @@ const Benchmark = struct {
     fn send_complete(
         user_data: u128,
         operation: StateMachine.Operation,
+        timestamp: u64,
         result: []u8,
     ) void {
         const b: *Benchmark = @ptrFromInt(@as(usize, @intCast(user_data)));
         const callback = b.callback.?;
         b.callback = null;
 
-        callback(b, operation, result);
+        callback(b, operation, timestamp, result);
     }
 
     fn register_callback(

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -25,6 +25,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
             pub const Callback = *const fn (
                 user_data: u128,
                 operation: StateMachine.Operation,
+                timestamp: u64,
                 results: []u8,
             ) void;
 
@@ -526,6 +527,7 @@ pub fn Client(comptime StateMachine_: type, comptime MessageBus: type) type {
                 inflight.callback.request(
                     inflight.user_data,
                     inflight_vsr_operation.cast(StateMachine),
+                    reply.header.timestamp,
                     reply.body(),
                 );
             }


### PR DESCRIPTION
Fill-in the API gap, allowing the clients to unambiguously order all replies.

Before this PR, if two different clients issue a `.lookup_accounts` call, it would be impossible, using only the public API, to order them relative to each other.

That is, _one_ of the requests completed first, and it can be determined from the timestamp of the VSR reply message, but that timestamp is not exposed anywhere.

This currently isn't threaded all the way up to language clients, to keep the scope smaller.