### PR TITLE
IO: stdx.unexpectedErrno 

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -5,6 +5,7 @@ const mem = std.mem;
 const assert = std.debug.assert;
 const log = std.log.scoped(.io);
 
+const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const FIFO = @import("../fifo.zig").FIFO;
 const Time = @import("../time.zig").Time;
@@ -380,7 +381,7 @@ pub const IO = struct {
                         .BADF => error.FileDescriptorInvalid,
                         .INTR => {}, // A success, see https://github.com/ziglang/zig/issues/2425
                         .IO => error.InputOutput,
-                        else => |errno| posix.unexpectedErrno(errno),
+                        else => |errno| stdx.unexpectedErrno("close", errno),
                     };
                 }
             },
@@ -496,7 +497,7 @@ pub const IO = struct {
                             .OVERFLOW => error.Unseekable,
                             .SPIPE => error.Unseekable,
                             .TIMEDOUT => error.ConnectionTimedOut,
-                            else => |err| posix.unexpectedErrno(err),
+                            else => |err| stdx.unexpectedErrno("read", err),
                         };
                     }
                 }
@@ -847,7 +848,7 @@ pub const IO = struct {
 
             // not reported but need same error union
             .OPNOTSUPP => return error.OperationNotSupported,
-            else => |errno| return posix.unexpectedErrno(errno),
+            else => |errno| return stdx.unexpectedErrno("fs_allocate", errno),
         }
 
         // Now actually perform the allocation.

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -381,7 +381,7 @@ pub const IO = struct {
                         .BADF => error.FileDescriptorInvalid,
                         .INTR => {}, // A success, see https://github.com/ziglang/zig/issues/2425
                         .IO => error.InputOutput,
-                        else => |errno| stdx.unexpectedErrno("close", errno),
+                        else => |errno| stdx.unexpected_errno("close", errno),
                     };
                 }
             },
@@ -497,7 +497,7 @@ pub const IO = struct {
                             .OVERFLOW => error.Unseekable,
                             .SPIPE => error.Unseekable,
                             .TIMEDOUT => error.ConnectionTimedOut,
-                            else => |err| stdx.unexpectedErrno("read", err),
+                            else => |err| stdx.unexpected_errno("read", err),
                         };
                     }
                 }
@@ -848,7 +848,7 @@ pub const IO = struct {
 
             // not reported but need same error union
             .OPNOTSUPP => return error.OperationNotSupported,
-            else => |errno| return stdx.unexpectedErrno("fs_allocate", errno),
+            else => |errno| return stdx.unexpected_errno("fs_allocate", errno),
         }
 
         // Now actually perform the allocation.

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -529,7 +529,7 @@ pub const IO = struct {
                                 .ALREADY => error.NotInterruptable,
                                 // SQE is invalid.
                                 .INVAL => unreachable,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("cancel", errno),
                             };
                         }
                     };
@@ -556,7 +556,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.OperationNotSupported,
                                 .PERM => error.PermissionDenied,
                                 .PROTO => error.ProtocolFailure,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("accept", errno),
                             };
                             break :blk err;
                         } else {
@@ -575,7 +575,7 @@ pub const IO = struct {
                                 .DQUOT => error.DiskQuota,
                                 .IO => error.InputOutput,
                                 .NOSPC => error.NoSpaceLeft,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("close", errno),
                             };
                             break :blk err;
                         } else {
@@ -609,7 +609,7 @@ pub const IO = struct {
                                 .PERM => error.PermissionDenied,
                                 .PROTOTYPE => error.ProtocolNotSupported,
                                 .TIMEDOUT => error.ConnectionTimedOut,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("connect", errno),
                             };
                             break :blk err;
                         } else {
@@ -648,7 +648,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.FileLocksNotSupported,
                                 .AGAIN => error.WouldBlock,
                                 .TXTBSY => error.FileBusy,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("openat", errno),
                             };
                             break :blk err;
                         } else {
@@ -678,7 +678,7 @@ pub const IO = struct {
                                 .OVERFLOW => error.Unseekable,
                                 .SPIPE => error.Unseekable,
                                 .TIMEDOUT => error.ConnectionTimedOut,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("read", errno),
                             };
                             break :blk err;
                         } else {
@@ -706,7 +706,7 @@ pub const IO = struct {
                                 .CONNRESET => error.ConnectionResetByPeer,
                                 .TIMEDOUT => error.ConnectionTimedOut,
                                 .OPNOTSUPP => error.OperationNotSupported,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("recv", errno),
                             };
                             break :blk err;
                         } else {
@@ -741,7 +741,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.OperationNotSupported,
                                 .PIPE => error.BrokenPipe,
                                 .TIMEDOUT => error.ConnectionTimedOut,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("send", errno),
                             };
                             break :blk err;
                         } else {
@@ -767,7 +767,7 @@ pub const IO = struct {
                                 .NOENT => error.FileNotFound,
                                 .NOMEM => error.SystemResources,
                                 .NOTDIR => error.NotDir,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("statx", errno),
                             };
                             break :blk err;
                         } else {
@@ -785,7 +785,7 @@ pub const IO = struct {
                         },
                         .CANCELED => error.Canceled,
                         .TIME => {}, // A success.
-                        else => |errno| posix.unexpectedErrno(errno),
+                        else => |errno| stdx.unexpectedErrno("timeout", errno),
                     };
                     const result: TimeoutError!void = err;
                     completion.callback(completion.context, completion, &result);
@@ -812,7 +812,7 @@ pub const IO = struct {
                                 .PERM => error.AccessDenied,
                                 .PIPE => error.BrokenPipe,
                                 .SPIPE => error.Unseekable,
-                                else => |errno| posix.unexpectedErrno(errno),
+                                else => |errno| stdx.unexpectedErrno("write", errno),
                             };
                             break :blk err;
                         } else {
@@ -1592,7 +1592,7 @@ pub const IO = struct {
                     .BADF => return error.InvalidFileDescriptor,
                     .NOTTY => return error.BadRequest,
                     .FAULT => return error.InvalidAddress,
-                    else => |err| return posix.unexpectedErrno(err),
+                    else => |err| return stdx.unexpectedErrno("open_file:ioctl", err),
                 }
 
                 if (block_device_size < size) {
@@ -1652,7 +1652,7 @@ pub const IO = struct {
                     return statfs.f_type == stdx.TmpfsMagic;
                 },
                 .INTR => continue,
-                else => |err| return posix.unexpectedErrno(err),
+                else => |err| return stdx.unexpectedErrno("fs_is_tmpfs", err),
             }
         }
     }
@@ -1679,7 +1679,7 @@ pub const IO = struct {
                 },
                 .INTR => continue,
                 .INVAL => return false,
-                else => |err| return posix.unexpectedErrno(err),
+                else => |err| return stdx.unexpectedErrno("fs_supports_direct_io", err),
             }
         }
     }
@@ -1707,7 +1707,7 @@ pub const IO = struct {
                 .PERM => return error.PermissionDenied,
                 .SPIPE => return error.Unseekable,
                 .TXTBSY => return error.FileBusy,
-                else => |errno| return posix.unexpectedErrno(errno),
+                else => |errno| return stdx.unexpectedErrno("fs_allocate", errno),
             }
         }
     }

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -529,7 +529,7 @@ pub const IO = struct {
                                 .ALREADY => error.NotInterruptable,
                                 // SQE is invalid.
                                 .INVAL => unreachable,
-                                else => |errno| stdx.unexpectedErrno("cancel", errno),
+                                else => |errno| stdx.unexpected_errno("cancel", errno),
                             };
                         }
                     };
@@ -556,7 +556,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.OperationNotSupported,
                                 .PERM => error.PermissionDenied,
                                 .PROTO => error.ProtocolFailure,
-                                else => |errno| stdx.unexpectedErrno("accept", errno),
+                                else => |errno| stdx.unexpected_errno("accept", errno),
                             };
                             break :blk err;
                         } else {
@@ -575,7 +575,7 @@ pub const IO = struct {
                                 .DQUOT => error.DiskQuota,
                                 .IO => error.InputOutput,
                                 .NOSPC => error.NoSpaceLeft,
-                                else => |errno| stdx.unexpectedErrno("close", errno),
+                                else => |errno| stdx.unexpected_errno("close", errno),
                             };
                             break :blk err;
                         } else {
@@ -609,7 +609,7 @@ pub const IO = struct {
                                 .PERM => error.PermissionDenied,
                                 .PROTOTYPE => error.ProtocolNotSupported,
                                 .TIMEDOUT => error.ConnectionTimedOut,
-                                else => |errno| stdx.unexpectedErrno("connect", errno),
+                                else => |errno| stdx.unexpected_errno("connect", errno),
                             };
                             break :blk err;
                         } else {
@@ -648,7 +648,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.FileLocksNotSupported,
                                 .AGAIN => error.WouldBlock,
                                 .TXTBSY => error.FileBusy,
-                                else => |errno| stdx.unexpectedErrno("openat", errno),
+                                else => |errno| stdx.unexpected_errno("openat", errno),
                             };
                             break :blk err;
                         } else {
@@ -678,7 +678,7 @@ pub const IO = struct {
                                 .OVERFLOW => error.Unseekable,
                                 .SPIPE => error.Unseekable,
                                 .TIMEDOUT => error.ConnectionTimedOut,
-                                else => |errno| stdx.unexpectedErrno("read", errno),
+                                else => |errno| stdx.unexpected_errno("read", errno),
                             };
                             break :blk err;
                         } else {
@@ -706,7 +706,7 @@ pub const IO = struct {
                                 .CONNRESET => error.ConnectionResetByPeer,
                                 .TIMEDOUT => error.ConnectionTimedOut,
                                 .OPNOTSUPP => error.OperationNotSupported,
-                                else => |errno| stdx.unexpectedErrno("recv", errno),
+                                else => |errno| stdx.unexpected_errno("recv", errno),
                             };
                             break :blk err;
                         } else {
@@ -741,7 +741,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.OperationNotSupported,
                                 .PIPE => error.BrokenPipe,
                                 .TIMEDOUT => error.ConnectionTimedOut,
-                                else => |errno| stdx.unexpectedErrno("send", errno),
+                                else => |errno| stdx.unexpected_errno("send", errno),
                             };
                             break :blk err;
                         } else {
@@ -767,7 +767,7 @@ pub const IO = struct {
                                 .NOENT => error.FileNotFound,
                                 .NOMEM => error.SystemResources,
                                 .NOTDIR => error.NotDir,
-                                else => |errno| stdx.unexpectedErrno("statx", errno),
+                                else => |errno| stdx.unexpected_errno("statx", errno),
                             };
                             break :blk err;
                         } else {
@@ -785,7 +785,7 @@ pub const IO = struct {
                         },
                         .CANCELED => error.Canceled,
                         .TIME => {}, // A success.
-                        else => |errno| stdx.unexpectedErrno("timeout", errno),
+                        else => |errno| stdx.unexpected_errno("timeout", errno),
                     };
                     const result: TimeoutError!void = err;
                     completion.callback(completion.context, completion, &result);
@@ -812,7 +812,7 @@ pub const IO = struct {
                                 .PERM => error.AccessDenied,
                                 .PIPE => error.BrokenPipe,
                                 .SPIPE => error.Unseekable,
-                                else => |errno| stdx.unexpectedErrno("write", errno),
+                                else => |errno| stdx.unexpected_errno("write", errno),
                             };
                             break :blk err;
                         } else {
@@ -1592,7 +1592,7 @@ pub const IO = struct {
                     .BADF => return error.InvalidFileDescriptor,
                     .NOTTY => return error.BadRequest,
                     .FAULT => return error.InvalidAddress,
-                    else => |err| return stdx.unexpectedErrno("open_file:ioctl", err),
+                    else => |err| return stdx.unexpected_errno("open_file:ioctl", err),
                 }
 
                 if (block_device_size < size) {
@@ -1652,7 +1652,7 @@ pub const IO = struct {
                     return statfs.f_type == stdx.TmpfsMagic;
                 },
                 .INTR => continue,
-                else => |err| return stdx.unexpectedErrno("fs_is_tmpfs", err),
+                else => |err| return stdx.unexpected_errno("fs_is_tmpfs", err),
             }
         }
     }
@@ -1679,7 +1679,7 @@ pub const IO = struct {
                 },
                 .INTR => continue,
                 .INVAL => return false,
-                else => |err| return stdx.unexpectedErrno("fs_supports_direct_io", err),
+                else => |err| return stdx.unexpected_errno("fs_supports_direct_io", err),
             }
         }
     }
@@ -1707,7 +1707,7 @@ pub const IO = struct {
                 .PERM => return error.PermissionDenied,
                 .SPIPE => return error.Unseekable,
                 .TXTBSY => return error.FileBusy,
-                else => |errno| return stdx.unexpectedErrno("fs_allocate", errno),
+                else => |errno| return stdx.unexpected_errno("fs_allocate", errno),
             }
         }
     }

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -870,7 +870,7 @@ pub const DateTimeUTC = struct {
 
 /// Like std.posix's `unexpectedErrno()` but log unconditionally, not just when mode=Debug.
 /// The added `label` argument works around the absence of stack traces in ReleaseSafe builds.
-pub fn unexpectedErrno(label: []const u8, err: std.posix.system.E) std.posix.UnexpectedError {
+pub fn unexpected_errno(label: []const u8, err: std.posix.system.E) std.posix.UnexpectedError {
     log.scoped(.stdx).err("unexpected errno: {s}: code={d} name={?s}", .{
         label,
         @intFromEnum(err),

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -867,3 +867,18 @@ pub const DateTimeUTC = struct {
         });
     }
 };
+
+/// Like std.posix's `unexpectedErrno()` but log unconditionally, not just when mode=Debug.
+/// The added `label` argument works around the absence of stack traces in ReleaseSafe builds.
+pub fn unexpectedErrno(label: []const u8, err: std.posix.system.E) std.posix.UnexpectedError {
+    log.scoped(.stdx).err("unexpected errno: {s}: code={d} name={?s}", .{
+        label,
+        @intFromEnum(err),
+        std.enums.tagName(std.posix.system.E, err),
+    });
+
+    if (builtin.mode == .Debug) {
+        std.debug.dumpCurrentStackTrace(null);
+    }
+    return error.Unexpected;
+}

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -125,6 +125,10 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
         return "use stdx." ++ "copy_right instead of std version";
     }
 
+    if (std.mem.indexOf(u8, source, "posix." ++ "unexpectedErrno(") != null) {
+        return "use stdx." ++ "unexpectedErrno instead of std version";
+    }
+
     // Ban "fixme" comments. This allows using fixme as reminders with teeth --- when working on
     // larger pull requests, it is often helpful to leave fixme comments as a reminder to oneself.
     // This tidy rule ensures that the reminder is acted upon before code gets into main. That is:

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -126,7 +126,7 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
     }
 
     if (std.mem.indexOf(u8, source, "posix." ++ "unexpectedErrno(") != null) {
-        return "use stdx.unexpectedErrno instead of std version";
+        return "use stdx.unexpected_errno instead of std version";
     }
 
     // Ban "fixme" comments. This allows using fixme as reminders with teeth --- when working on

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -106,27 +106,27 @@ const SourceFile = struct { path: []const u8, text: [:0]const u8 };
 fn tidy_banned(source: []const u8) ?[]const u8 {
     // Note: must avoid banning ourselves!
     if (std.mem.indexOf(u8, source, "std." ++ "BoundedArray") != null) {
-        return "use stdx." ++ "BoundedArray instead of std version";
+        return "use stdx.BoundedArray instead of std version";
     }
 
     if (std.mem.indexOf(u8, source, "trait." ++ "hasUniqueRepresentation") != null) {
-        return "use stdx." ++ "has_unique_representation instead of std version";
+        return "use stdx.has_unique_representation instead of std version";
     }
 
     if (std.mem.indexOf(u8, source, "mem." ++ "copy(") != null) {
-        return "use stdx." ++ "copy_disjoint instead of std version";
+        return "use stdx.copy_disjoint instead of std version";
     }
 
     if (std.mem.indexOf(u8, source, "mem." ++ "copyForwards(") != null) {
-        return "use stdx." ++ "copy_left instead of std version";
+        return "use stdx.copy_left instead of std version";
     }
 
     if (std.mem.indexOf(u8, source, "mem." ++ "copyBackwards(") != null) {
-        return "use stdx." ++ "copy_right instead of std version";
+        return "use stdx.copy_right instead of std version";
     }
 
     if (std.mem.indexOf(u8, source, "posix." ++ "unexpectedErrno(") != null) {
-        return "use stdx." ++ "unexpectedErrno instead of std version";
+        return "use stdx.unexpectedErrno instead of std version";
     }
 
     // Ban "fixme" comments. This allows using fixme as reminders with teeth --- when working on


### PR DESCRIPTION
If we hit `unexpectedErrno` that indicates a bug in our IO error handling -- we should dump useful information to aid troubleshooting.

`std.posix.unexpectedErrno()` only logs the error in `mode=Debug`.

Add a `stdx.unexpectedErrno()` with useful logging in `ReleaseSafe` mode too.