### PR TITLE
io: fix race condition in fs_supports_direct_io

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -512,8 +512,8 @@ test "vortex smoke" {
     try shell.exec(
         \\ unshare --net --fork --map-root-user --pid
         \\   {vortex} supervisor
-        \\      --test-duration-minutes=1 
-        \\      --tigerbeetle-executable={tigerbeetle} 
+        \\      --test-duration-minutes=1
+        \\      --tigerbeetle-executable={tigerbeetle}
     , .{
         .vortex = vortex_exe,
         .tigerbeetle = tigerbeetle,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1662,7 +1662,10 @@ pub const IO = struct {
     fn fs_supports_direct_io(dir_fd: fd_t) !bool {
         if (!@hasField(posix.O, "DIRECT")) return false;
 
-        const path = "fs_supports_direct_io";
+        var cookie: [16]u8 = .{'0'} ** 16;
+        _ = stdx.array_print(16, &cookie, "{0x}", .{std.crypto.random.int(u64)});
+
+        const path: [:0]const u8 = "fs_supports_direct_io-" ++ cookie ++ "";
         const dir = std.fs.Dir{ .fd = dir_fd };
         const flags: posix.O = .{ .CLOEXEC = true, .CREAT = true, .TRUNC = true };
         const fd = try posix.openatZ(dir_fd, path, flags, 0o666);


### PR DESCRIPTION
This fixes (at least one issue) flaky upgrade test. There, several
replicas are being run in the same directory, and they all try to create
this `fs_supports_direct_io` probe file, which mostly succeeds, but
sometimes can fail!

Add a random cookie to prevent this.

And, as this is the 1274278th time I need to print a number to a
stack-allocated buffer, also add an `stdx.array_print` utility to check
buffer's size automatically.