### PR TITLE
[dotnet] Fix the final index when slicing an array in the walkthrough example

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -356,14 +356,14 @@ is 8190.
 ```cs
 var batch = new Transfer[] { }; // Array of transfer to create.
 var BATCH_SIZE = 8190;
-for (int i = 0; i < batch.Length; i += BATCH_SIZE)
+for (int firstIndex = 0; firstIndex < batch.Length; firstIndex += BATCH_SIZE)
 {
-    var batchSize = BATCH_SIZE;
-    if (i + BATCH_SIZE > batch.Length)
+    var lastIndex = firstIndex + BATCH_SIZE;
+    if (lastIndex > batch.Length)
     {
-        batchSize = batch.Length - i;
+        lastIndex = batch.Length;
     }
-    var transferErrors = client.CreateTransfers(batch[i..batchSize]);
+    var transferErrors = client.CreateTransfers(batch[firstIndex..lastIndex]);
     // Error handling omitted.
 }
 ```

--- a/src/clients/dotnet/samples/walkthrough/Program.cs
+++ b/src/clients/dotnet/samples/walkthrough/Program.cs
@@ -220,14 +220,14 @@ using (var client = new Client(clusterID, addresses))
         // section:batch
         var batch = new Transfer[] { }; // Array of transfer to create.
         var BATCH_SIZE = 8190;
-        for (int i = 0; i < batch.Length; i += BATCH_SIZE)
+        for (int firstIndex = 0; firstIndex < batch.Length; firstIndex += BATCH_SIZE)
         {
-            var batchSize = BATCH_SIZE;
-            if (i + BATCH_SIZE > batch.Length)
+            var lastIndex = firstIndex + BATCH_SIZE;
+            if (lastIndex > batch.Length)
             {
-                batchSize = batch.Length - i;
+                lastIndex = batch.Length;
             }
-            var transferErrors = client.CreateTransfers(batch[i..batchSize]);
+            var transferErrors = client.CreateTransfers(batch[firstIndex..lastIndex]);
             // Error handling omitted.
         }
         // endsection:batch


### PR DESCRIPTION
Ref https://github.com/tigerbeetle/tigerbeetle/pull/1443#discussion_r1831353756

As a side note ... I was tempted to use Zig's slice-by-length syntax `batch[i..][..batchSize]`, but it isn't idiomatic in C#! So I just decided to design the problem away, replacing `batchSize` with `endIndex`.