### PR TITLE
Message: rename `.body()` to `.body_used()`, and use it for `state_machine.commit()`

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -654,7 +654,7 @@ test "aof write / read" {
         .size = @intCast(@sizeOf(Header) + demo_payload.len),
     };
 
-    stdx.copy_disjoint(.exact, u8, demo_message.body(), demo_payload);
+    stdx.copy_disjoint(.exact, u8, demo_message.body_used(), demo_payload);
     demo_message.header.set_checksum_body(demo_payload);
     demo_message.header.set_checksum();
 

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -453,7 +453,7 @@ pub fn ContextType(
                     stdx.maybe(batched.data == null);
                     break :empty &[0]u8{};
                 };
-                stdx.copy_disjoint(.inexact, u8, message.body()[offset..], event_data);
+                stdx.copy_disjoint(.inexact, u8, message.body_used()[offset..], event_data);
                 offset += @intCast(event_data.len);
             }
 

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -112,7 +112,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
                         inflight.user_data,
                         operation.cast(Self.StateMachine),
                         timestamp,
-                        reply.body(),
+                        reply.body_used(),
                     );
                 },
                 .register => |callback| {
@@ -181,7 +181,7 @@ pub fn EchoClient(comptime StateMachine_: type, comptime MessageBus: type) type 
                 .size = @intCast(@sizeOf(Header) + events.len),
             };
 
-            stdx.copy_disjoint(.exact, u8, message.body(), events);
+            stdx.copy_disjoint(.exact, u8, message.body_used(), events);
             self.raw_request(callback, user_data, message);
         }
 

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -129,7 +129,7 @@ pub const MessagePool = struct {
             return message;
         }
 
-        pub fn body(message: *const Message) []align(@sizeOf(Header)) u8 {
+        pub fn body_used(message: *const Message) []align(@sizeOf(Header)) u8 {
             return message.buffer[@sizeOf(Header)..message.header.size];
         }
 
@@ -316,8 +316,8 @@ fn MessageType(comptime command: vsr.Command) type {
             return @ptrCast(message.base().ref());
         }
 
-        pub fn body(message: *const CommandMessage) []align(@sizeOf(Header)) u8 {
-            return message.base_const().body();
+        pub fn body_used(message: *const CommandMessage) []align(@sizeOf(Header)) u8 {
+            return message.base_const().body_used();
         }
     };
 }

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -907,8 +907,8 @@ pub const Simulator = struct {
                         commit.client_index.?,
                         commit.reply.header.operation.cast(StateMachine),
                         commit.reply.header.timestamp,
-                        commit.prepare.body(),
-                        commit.reply.body(),
+                        commit.prepare.body_used(),
+                        commit.reply.body_used(),
                     );
                 }
             }

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -256,7 +256,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             };
 
             if (!message.header.valid_checksum() or
-                !message.header.valid_checksum_body(message.body()))
+                !message.header.valid_checksum_body(message.body_used()))
             {
                 log.warn("{}: read_reply: corrupt reply (client={} reply={})", .{
                     client_replies.replica,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -941,7 +941,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 return;
             }
 
-            if (!message.header.valid_checksum_body(message.body())) {
+            if (!message.header.valid_checksum_body(message.body_used())) {
                 if (slot) |s| {
                     journal.faulty.set(s);
                     journal.dirty.set(s);
@@ -1176,7 +1176,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             // Check `valid_checksum_body` here rather than in `recover_done` so that we don't need
             // to hold onto the whole message (just the header).
             if (read.message.header.valid_checksum() and
-                read.message.header.valid_checksum_body(read.message.body()))
+                read.message.header.valid_checksum_body(read.message.body_used()))
             {
                 journal.headers[slot.index] = read.message.header.*;
             }


### PR DESCRIPTION
This matches the convention inside the LSM, and makes it more clear at a glance that you're getting the portion of the body bounded by the header's size.

This was prompted by seeing that `replica.zig` calls the state machine with a manual `prepare.buffer[@sizeOf(Header)..prepare.header.size]` and wondering why that didn't use the original `.body()`. Turns out, there doesn't seem to be a reason, so change that to use `.body_used()` too.