### PR TITLE
vsr: on_commit must check hash chain from message.header.commit → self.op

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1884,7 +1884,7 @@ pub fn ReplicaType(
             if (self.journal.header_with_op(message.header.commit)) |commit_entry| {
                 if (commit_entry.checksum == message.header.commit_checksum) {
                     log.debug("{}: on_commit: checksum verified", .{self.replica});
-                } else if (self.valid_hash_chain(@src())) {
+                } else if (self.valid_hash_chain_between(message.header.commit, self.op)) {
                     @panic("commit checksum verification failed");
                 } else {
                     // We may still be repairing after receiving the start_view message.


### PR DESCRIPTION
This PR resolves a failing VOPR seed (`./zig/zig build -Drelease vopr -- 13768260193285844595`) on main (3cd7cf4799f65c81ffbc36eda788b8b26fd7da72), wherein a _syncing_ standby crashes while processing a commit message from a *solo* replica. IIUC, this is could happen with multiple replicas as well, even in the absence of standbys. 
```C
hread 59349857 panic: commit checksum verification failed
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vsr/replica.zig:1899:21: 0x1004f1b63 in on_commit (vopr)
                    @panic("commit checksum verification failed");
                    ^
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vsr/replica.zig:1383:46: 0x1004d933b in on_message (vopr)
                .commit => |m| self.on_commit(m),
                                             ^
```

**This is the crux of the issue:** Replica with a *hash chain break* in its journal transitions to state sync *before* it can repair the break. While its syncing to the new checkpoint (writing it to its superblock), it receives a `commit` message from the primary, for a prepare that's part of the broken hash chain. As state sync advances the in-memory `commit_min` to the new checkpoint, it is possible for a replica to have a valid hash chain starting from the new commit_min to its head op (this is what `valid_hash_chain` checks).  Therefore, replica could pass the below hash chain verification and hit `@panic("commit checksum verification failed")`.  This is precisely what happens in the failed VOPR seed.
https://github.com/tigerbeetle/tigerbeetle/blob/5a5b605ebbdfa5e912c25b39e510485d1c8c493a/src/vsr/replica.zig#L1879-L1889

The naive solution here could be to _drop commit messages while sync is underway_ (in `on_commit)`, similar to how we pause commit pipeline (see `commit_journal`). However, this wouldn't work - even _after_ a replica has finished state sync, it *could* get a duplicated commit message for a prepare that is part of the broken hash chain, and it would panic similarly. 

**The correct solution is simple:** `valid_hash_chain` in the above snippet is imprecise, as it checks whether the replica is safe to start committing (by checking the hash chain between `@max(self.op_checkpoint() + 1, self.commit_min)` → `self.op`). However, this is *not* what the above code intends to do; it intends to check the validity of the `message.header.commit` op. So, we must check the hash chain between `message.header.commit` → `self.op`. 

For example, in the failed seed, we are receiving a commit message for op=17, when a replica has op_checkpoint=0 (being updated to op_checkpoint=19 via state sync), commit_min=19 (via state sync), and head_op=31. `valid_hash_chain` checks the hash chain between 20 → 31, which doesn't include op=17 at all! Checking the hash chain from 17 → 31, on the other hand, *correctly* finds a break at op=17 (which we will just never repair during state sync). 