### PR TITLE
VOPR: Test misdirected writes

### DIFF
--- a/src/iops.zig
+++ b/src/iops.zig
@@ -25,7 +25,7 @@ pub fn IOPSType(comptime T: type, comptime size: u6) type {
         }
 
         pub fn index(self: *IOPS, item: *T) usize {
-            const i = (@intFromPtr(item) - @intFromPtr(&self.items)) / @sizeOf(T);
+            const i = @divExact((@intFromPtr(item) - @intFromPtr(&self.items)), @sizeOf(T));
             assert(i < size);
             return i;
         }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -854,13 +854,14 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     const table_usage = random.enumValue(TableUsage);
     log.info("table_usage={}", .{table_usage});
 
-    const storage_fault_atlas = ClusterFaultAtlas.init(3, random, .{
+    var storage_fault_atlas = try ClusterFaultAtlas.init(allocator, 3, random, .{
         .faulty_superblock = false,
         .faulty_wal_headers = false,
         .faulty_wal_prepares = false,
         .faulty_client_replies = false,
         .faulty_grid = true,
     });
+    defer storage_fault_atlas.deinit(allocator);
 
     const storage_options = .{
         .seed = random.int(u64),

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -182,11 +182,13 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             const storage_fault_atlas = try allocator.create(StorageFaultAtlas);
             errdefer allocator.destroy(storage_fault_atlas);
 
-            storage_fault_atlas.* = StorageFaultAtlas.init(
+            storage_fault_atlas.* = try StorageFaultAtlas.init(
+                allocator,
                 options.replica_count,
                 random,
                 options.storage_fault_atlas,
             );
+            errdefer storage_fault_atlas.deinit(allocator);
 
             var grid_checker = try allocator.create(GridChecker);
             errdefer allocator.destroy(grid_checker);
@@ -410,6 +412,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             for (cluster.storages) |*storage| storage.deinit(cluster.allocator);
             for (cluster.aofs) |*aof| aof.deinit(cluster.allocator);
 
+            cluster.storage_fault_atlas.deinit(cluster.allocator);
             cluster.grid_checker.deinit(); // (Storage references this.)
 
             cluster.allocator.free(cluster.clients);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -453,13 +453,30 @@ pub const Storage = struct {
             }
         }
 
+        const faulty = storage.faulty and faulty: {
+            if (read.zone != .wal_prepares) break :faulty true;
+
+            // Don't corrupt a WAL prepare if the corresponding WAL header write was misdirected, to
+            // avoid a double-fault which the journal interprets as a torn prepare.
+            const header_slot = @divExact(read.offset, constants.message_size_max);
+            const header_offset = vsr.sector_floor(header_slot * @sizeOf(vsr.Header));
+
+            var overlays_iterator = storage.overlays.iterate();
+            while (overlays_iterator.next()) |overlay| {
+                if (overlay.zone == .wal_headers and overlay.offset == header_offset) {
+                    break :faulty false;
+                }
+            }
+            break :faulty true;
+        };
+
         // Fill faulty or uninitialized sectors with random data.
         var sectors = SectorRange.from_zone(read.zone, read.offset, read.buffer.len);
         const sectors_min = sectors.min;
         while (sectors.next()) |sector| {
-            const faulty = storage.faulty and storage.faults.isSet(sector);
+            const faulty_sector = faulty and storage.faults.isSet(sector);
             const uninit = !storage.memory_written.isSet(sector);
-            if (faulty or uninit) {
+            if (faulty_sector or uninit) {
                 const sector_offset = (sector - sectors_min) * constants.sector_size;
                 const sector_bytes = read.buffer[sector_offset..][0..constants.sector_size];
                 storage.prng.random().bytes(sector_bytes);

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -45,6 +45,7 @@ const GridChecker = @import("./cluster/grid_checker.zig").GridChecker;
 
 const log = std.log.scoped(.storage);
 
+// FIXME tidy:
 // TODOs:
 // less than a majority of replicas may have corruption
 // have an option to enable/disable the following corruption types:

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -30,6 +30,7 @@ const math = std.math;
 const mem = std.mem;
 
 const FIFOType = @import("../fifo.zig").FIFOType;
+const IOPSType = @import("../iops.zig").IOPSType;
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
 const superblock = @import("../vsr/superblock.zig");
@@ -78,6 +79,9 @@ pub const Storage = struct {
         /// Chance out of 100 that a write will corrupt a sector, if the target memory is within
         /// a faulty area of this replica.
         write_fault_probability: u8 = 0,
+        /// Chance out of 100 that a write will misdirect to the wrong sector, if the target memory
+        /// is within a faulty area of this replica.
+        write_misdirect_probability: u8 = 0,
         /// Chance out of 100 that a crash will corrupt a sector of a pending write's target,
         /// if the target memory is within a faulty area of this replica.
         crash_fault_probability: u8 = 0,
@@ -139,6 +143,9 @@ pub const Storage = struct {
 
     pub const NextTickSource = enum { lsm, vsr };
 
+    /// See `Storage.overlays`.
+    const overlays_count_max = 2;
+
     allocator: mem.Allocator,
 
     size: u64,
@@ -151,7 +158,36 @@ pub const Storage = struct {
     /// Set bits correspond to faulty sectors. The underlying sectors of `memory` is left clean.
     faults: std.DynamicBitSetUnmanaged,
 
-    /// Whether to enable faults (when false, this supersedes `faulty_wal_areas`).
+    /// Overlays take precedence over the data in `memory`.
+    ///
+    /// Each misdirected write creates two overlays.
+    /// When a misdirected write is triggered:
+    /// - The intended target is overlaid with its old data.
+    /// - The intended target's `memory` is set to the `write.buffer` data.
+    /// - The mistaken target is overlaid with the `write.buffer` data.
+    /// - The mistaken target's `memory` is left untouched.
+    ///
+    /// The reason for all of this is:
+    /// - By keeping `memory` pristine, we can trivially disable both sides of the misdirected-write
+    ///   fault by flipping the `faulty` flag.
+    /// - By tracking the overlays separately, they can be repaired separately.
+    ///
+    /// Other notes:
+    /// - We allow for (at most) one misdirect fault per Storage for the time being, for simplicity
+    ///   and because double-faults are not covered by our fault model. This will hopefully match
+    ///   physical disks – misdirected faults are an order of magnitude less frequent than bit rot,
+    ///   which in turn is an order of magnitude less frequent than LSEs.
+    /// - In order to keep things interesting:
+    ///   - misdirections are always within the same zone,
+    ///   - the entire write is misdirected (rather than only some of the sectors), and
+    ///   - the misdirected write lands on a convenient offset.
+    ///   Thanks to rigorous checksums, misdirections that break these rules just manifest as
+    ///   corruptions, and corruption is already well-tested (see `faults`). The goal here is to
+    ///   test how TigerBeetle handles well-formed but incorrectly-located data.
+    overlays: IOPSType(struct { zone: vsr.Zone, offset: u64, size: u32 }, overlays_count_max) = .{},
+    overlay_buffers: [overlays_count_max][]align(constants.sector_size) u8,
+
+    /// Whether to enable faults (when false, this supersedes `faulty_wal_areas` &c).
     /// This is used to disable faults during the replica's first startup.
     faulty: bool = true,
 
@@ -167,6 +203,11 @@ pub const Storage = struct {
         assert(options.read_latency_mean >= options.read_latency_min);
         assert(options.fault_atlas == null or options.replica_index != null);
 
+        assert(options.read_fault_probability <= 100);
+        assert(options.write_fault_probability <= 100);
+        assert(options.write_misdirect_probability <= 100);
+        assert(options.crash_fault_probability <= 100);
+
         const prng = std.rand.DefaultPrng.init(options.seed);
         const sector_count = @divExact(size, constants.sector_size);
         const memory = try allocator.alignedAlloc(u8, constants.sector_size, size);
@@ -177,6 +218,16 @@ pub const Storage = struct {
 
         var faults = try std.DynamicBitSetUnmanaged.initEmpty(allocator, sector_count);
         errdefer faults.deinit(allocator);
+
+        var overlay_buffers_allocated: u32 = 0;
+        var overlay_buffers: [overlays_count_max][]align(constants.sector_size) u8 = undefined;
+        errdefer for (overlay_buffers) |b| allocator.free(b);
+
+        for (&overlay_buffers) |*overlay_buffer| {
+            overlay_buffer.* =
+                try allocator.alignedAlloc(u8, constants.sector_size, constants.message_size_max);
+            overlay_buffers_allocated += 1;
+        }
 
         var reads = PriorityQueue(*Storage.Read, void, Storage.Read.less_than).init(allocator, {});
         errdefer reads.deinit();
@@ -195,12 +246,14 @@ pub const Storage = struct {
             .memory = memory,
             .memory_written = memory_written,
             .faults = faults,
+            .overlay_buffers = overlay_buffers,
             .reads = reads,
             .writes = writes,
         };
     }
 
     pub fn deinit(storage: *Storage, allocator: mem.Allocator) void {
+        for (storage.overlay_buffers) |b| allocator.free(b);
         allocator.free(storage.memory);
         storage.memory_written.deinit(allocator);
         storage.faults.deinit(allocator);
@@ -413,6 +466,32 @@ pub const Storage = struct {
             }
         }
 
+        // Apply misdirected data.
+        if (storage.faulty) {
+            var overlays_iterator = storage.overlays.iterate();
+            while (overlays_iterator.next()) |overlay| {
+                if (overlay.zone == read.zone and
+                    overlay.offset == read.offset)
+                {
+                    log.debug("{}: read_sectors_finish: apply misdirect " ++
+                        "zone={s} offset={} size={}", .{
+                        storage.options.replica_index.?,
+                        @tagName(overlay.zone),
+                        overlay.offset,
+                        overlay.size,
+                    });
+
+                    const overlay_buffer = storage.overlay_buffers[storage.overlays.index(overlay)];
+                    stdx.copy_disjoint(
+                        .inexact,
+                        u8,
+                        read.buffer,
+                        overlay_buffer[0..@min(overlay.size, read.buffer.len)],
+                    );
+                }
+            }
+        }
+
         read.callback(read);
     }
 
@@ -450,7 +529,59 @@ pub const Storage = struct {
     }
 
     fn write_sectors_finish(storage: *Storage, write: *Storage.Write) void {
+        assert(storage.overlays.total() >= 2);
+
         hash_log.emit_autohash(.{ write.buffer, write.zone, write.offset }, .DeepRecursive);
+
+        // Clean up old misdirects if they are overwritten.
+        var overlays_iterator = storage.overlays.iterate();
+        while (overlays_iterator.next()) |overlay| {
+            if (overlay.zone == write.zone and
+                overlay.offset == write.offset)
+            {
+                storage.overlays.release(overlay);
+            }
+        }
+
+        // Apply a new misdirect.
+        const misdirect = storage.overlays.available() >= 2 and
+            storage.pick_faulty_sector(write.zone, write.offset, write.buffer.len) != null and
+            storage.x_in_100(storage.options.write_misdirect_probability);
+        const misdirect_offset = if (misdirect) storage.pick_faulty_chunk_offset(write) else null;
+        if (misdirect_offset) |mistaken_offset| {
+            const overlay_mistaken = storage.overlays.acquire().?;
+            const overlay_intended = storage.overlays.acquire().?;
+
+            const overlay_mistaken_index = storage.overlays.index(overlay_mistaken);
+            const overlay_intended_index = storage.overlays.index(overlay_intended);
+
+            log.debug("{}: write_sectors_finish: misdirect zone={s} offset={}->{} size={}", .{
+                storage.options.replica_index.?,
+                @tagName(write.zone),
+                write.offset,
+                mistaken_offset,
+                write.buffer.len,
+            });
+
+            const overlay_size: u32 = @intCast(write.buffer.len);
+            overlay_mistaken.* =
+                .{ .zone = write.zone, .offset = mistaken_offset, .size = overlay_size };
+            overlay_intended.* =
+                .{ .zone = write.zone, .offset = write.offset, .size = overlay_size };
+
+            stdx.copy_disjoint(
+                .inexact,
+                u8,
+                storage.overlay_buffers[overlay_mistaken_index],
+                write.buffer,
+            );
+            stdx.copy_disjoint(
+                .inexact,
+                u8,
+                storage.overlay_buffers[overlay_intended_index],
+                storage.memory[write.zone.offset(write.offset)..][0..write.buffer.len],
+            );
+        }
 
         const offset_in_storage = write.zone.offset(write.offset);
         stdx.copy_disjoint(
@@ -509,6 +640,16 @@ pub const Storage = struct {
             zone,
             offset_in_zone,
             size,
+        );
+    }
+
+    fn pick_faulty_chunk_offset(storage: *Storage, write: *const Write) ?u64 {
+        const atlas = storage.options.fault_atlas orelse return null;
+        return atlas.faulty_chunk_offset(
+            storage.prng.random(),
+            storage.options.replica_index.?,
+            write.zone,
+            write.buffer.len,
         );
     }
 
@@ -716,6 +857,7 @@ pub const Storage = struct {
     pub fn transition_to_liveness_mode(storage: *Storage) void {
         storage.options.read_fault_probability = 0;
         storage.options.write_fault_probability = 0;
+        storage.options.write_misdirect_probability = 0;
         storage.options.crash_fault_probability = 0;
     }
 };
@@ -803,7 +945,6 @@ const SectorRange = struct {
 /// We can't allow WAL storage faults for the same message in a majority of
 /// the replicas as that would make recovery impossible. Instead, we only
 /// allow faults in certain areas which differ between replicas.
-// TODO Support total superblock corruption, forcing a full state transfer.
 pub const ClusterFaultAtlas = struct {
     pub const Options = struct {
         faulty_superblock: bool,
@@ -950,6 +1091,41 @@ pub const ClusterFaultAtlas = struct {
                 .faulty = &atlas.faulty_grid_blocks,
             },
         };
+    }
+
+    /// Given a write of `size` bytes to the given zone, find an interesting offset within the same
+    /// zone to target. (If we want to drop the latter condition, an alternate implementation
+    /// strategy is: on random writes, perform the write successfully, but save the target
+    /// zone/offset/size. Then on a future random write, misdirect to a compatible saved location.)
+    fn faulty_chunk_offset(
+        atlas: *const ClusterFaultAtlas,
+        random: std.Random,
+        replica_index: u8,
+        zone: vsr.Zone,
+        size: u64,
+    ) ?u64 {
+        const chunks = atlas.zone_chunks(zone) orelse return null;
+
+        if (chunks.chunk_size < size) {
+            // When formatting the WAL, we may write many chunks simultaneously (to avoid a storm of
+            // tiny writes).
+            assert(zone == .wal_headers or zone == .wal_prepares);
+            assert(size % constants.sector_size == 0);
+            return null;
+        }
+
+        const chunks_faulty = &chunks.faulty[replica_index];
+        const chunk_count = chunks_faulty.bit_length;
+        const chunk_start = random.uintLessThan(usize, chunk_count);
+        for (0..chunk_count) |i| {
+            const chunk_index = (chunk_start + i) % chunk_count;
+            if (chunks_faulty.isSet(chunk_index)) {
+                // The chunk size of zone=wal_prepares is a multiple of the message_size_max, but
+                // misdirects in the wal_prepares zone always land on the first message of a chunk.
+                return chunk_index * chunks.chunk_size;
+            }
+        }
+        return null;
     }
 
     fn faulty_sector(

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -482,12 +482,8 @@ pub const Storage = struct {
                     });
 
                     const overlay_buffer = storage.overlay_buffers[storage.overlays.index(overlay)];
-                    stdx.copy_disjoint(
-                        .inexact,
-                        u8,
-                        read.buffer,
-                        overlay_buffer[0..@min(overlay.size, read.buffer.len)],
-                    );
+                    const overlay_target = overlay_buffer[0..@min(overlay.size, read.buffer.len)];
+                    stdx.copy_disjoint(.inexact, u8, read.buffer, overlay_target);
                 }
             }
         }
@@ -569,18 +565,13 @@ pub const Storage = struct {
             overlay_intended.* =
                 .{ .zone = write.zone, .offset = write.offset, .size = overlay_size };
 
-            stdx.copy_disjoint(
-                .inexact,
-                u8,
-                storage.overlay_buffers[overlay_mistaken_index],
-                write.buffer,
-            );
-            stdx.copy_disjoint(
-                .inexact,
-                u8,
-                storage.overlay_buffers[overlay_intended_index],
-                storage.memory[write.zone.offset(write.offset)..][0..write.buffer.len],
-            );
+            const overlay_mistaken_buffer = storage.overlay_buffers[overlay_mistaken_index];
+            const overlay_intended_buffer = storage.overlay_buffers[overlay_intended_index];
+            const target_intended_buffer =
+                storage.memory[write.zone.offset(write.offset)..][0..write.buffer.len];
+
+            stdx.copy_disjoint(.inexact, u8, overlay_mistaken_buffer, write.buffer);
+            stdx.copy_disjoint(.inexact, u8, overlay_intended_buffer, target_intended_buffer);
         }
 
         const offset_in_storage = write.zone.offset(write.offset);
@@ -954,13 +945,10 @@ pub const ClusterFaultAtlas = struct {
         faulty_grid: bool,
     };
 
-    const ZoneSet = std.enums.EnumSet(vsr.Zone);
     const ReplicaSet = std.StaticBitSet(constants.replicas_max);
     const headers_per_sector = @divExact(constants.sector_size, @sizeOf(vsr.Header));
-    const header_sectors = @divExact(constants.journal_slot_count, headers_per_sector);
     const members_max = constants.members_max;
 
-    faulty_zones: ZoneSet,
     faulty_wal_header_sectors: [members_max]std.DynamicBitSetUnmanaged,
     faulty_client_reply_slots: [members_max]std.DynamicBitSetUnmanaged,
     /// Bit 0 corresponds to address 1.
@@ -981,6 +969,9 @@ pub const ClusterFaultAtlas = struct {
             assert(!options.faulty_grid);
         }
 
+        // Currently these faulty areas are coupled together, so they should match.
+        assert(options.faulty_wal_headers == options.faulty_wal_prepares);
+
         const fault_bitset_sizes = [3]u32{
             @divExact(constants.journal_size_headers, constants.sector_size), // WAL headers.
             constants.clients_max, // Client replies.
@@ -998,16 +989,9 @@ pub const ClusterFaultAtlas = struct {
         }
 
         var atlas = ClusterFaultAtlas{
-            .faulty_zones = ZoneSet.init(.{
-                .superblock = options.faulty_superblock,
-                .wal_headers = options.faulty_wal_headers,
-                .wal_prepares = options.faulty_wal_prepares,
-                .client_replies = options.faulty_client_replies,
-                .grid = options.faulty_grid,
-            }),
-            .faulty_wal_header_sectors = fault_bitsets[0 * members_max..][0..members_max].*,
-            .faulty_client_reply_slots = fault_bitsets[1 * members_max..][0..members_max].*,
-            .faulty_grid_blocks = fault_bitsets[2 * members_max..][0..members_max].*,
+            .faulty_wal_header_sectors = fault_bitsets[0 * members_max ..][0..members_max].*,
+            .faulty_client_reply_slots = fault_bitsets[1 * members_max ..][0..members_max].*,
+            .faulty_grid_blocks = fault_bitsets[2 * members_max ..][0..members_max].*,
         };
 
         const quorums = vsr.quorums(replica_count);
@@ -1017,32 +1001,29 @@ pub const ClusterFaultAtlas = struct {
         assert(faults_max < quorums.view_change);
         assert(faults_max > 0 or replica_count == 1);
 
-        var sector: usize = 0;
-        while (sector < header_sectors) : (sector += 1) {
-            var wal_header_sector = ReplicaSet.initEmpty();
-            while (wal_header_sector.count() < faults_max) {
-                const replica_index = random.uintLessThan(u8, replica_count);
-                if (atlas.faulty_wal_header_sectors[replica_index].count() + 1 <
-                    atlas.faulty_wal_header_sectors[replica_index].capacity())
-                {
-                    atlas.faulty_wal_header_sectors[replica_index].set(sector);
-                    wal_header_sector.set(replica_index);
-                } else {
-                    // Don't add a fault to this replica, to avoid error.WALInvalid.
+        for ([_]struct { bool, *[members_max]std.DynamicBitSetUnmanaged }{
+            .{ options.faulty_wal_headers, &atlas.faulty_wal_header_sectors },
+            .{ options.faulty_client_replies, &atlas.faulty_client_reply_slots },
+            .{ options.faulty_grid, &atlas.faulty_grid_blocks },
+        }) |zone| {
+            const faulty = zone.@"0";
+            const chunks = zone.@"1";
+            if (!faulty) continue;
+
+            for (0..chunks[0].bit_length) |chunk| {
+                var replicas = ReplicaSet.initEmpty();
+                while (replicas.count() < faults_max) {
+                    const replica_index = random.uintLessThan(u8, replica_count);
+                    if (chunks[replica_index].count() + 1 <
+                        chunks[replica_index].capacity())
+                    {
+                        chunks[replica_index].set(chunk);
+                        replicas.set(replica_index);
+                    } else {
+                        // Never corrupt all chunks of a particular replica.
+                        // (For the WAL, this can cause error.WALInvalid).
+                    }
                 }
-            }
-        }
-
-        var block: usize = 0;
-        while (block < Storage.grid_blocks_max) : (block += 1) {
-            var replicas = std.StaticBitSet(members_max).initEmpty();
-            while (replicas.count() < faults_max) {
-                replicas.set(random.uintLessThan(usize, replica_count));
-            }
-
-            var replicas_iterator = replicas.iterator(.{});
-            while (replicas_iterator.next()) |replica| {
-                atlas.faulty_grid_blocks[replica].set(block);
             }
         }
 
@@ -1059,8 +1040,6 @@ pub const ClusterFaultAtlas = struct {
         chunk_size: u32,
         faulty: *const [members_max]std.DynamicBitSetUnmanaged,
     } {
-        if (!atlas.faulty_zones.contains(zone)) return null;
-
         return switch (zone) {
             // Don't inject additional read/write/misdirect faults into superblock headers.
             // This prevents the quorum from being lost like so:

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1102,6 +1102,7 @@ pub const Simulator = struct {
             for (0..header_sector_count) |header_sector_index| {
                 replica_storage.faults.unset(header_sector_offset + header_sector_index);
             }
+            // TODO Clear misdirects? Waiting for a seed to confirm.
         }
 
         var header_prepare_view_mismatch: bool = false;

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -178,6 +178,7 @@ pub fn main() !void {
             .write_latency_mean = 3 + random.uintLessThan(u16, 100),
             .read_fault_probability = random.uintLessThan(u8, 10),
             .write_fault_probability = random.uintLessThan(u8, 10),
+            .write_misdirect_probability = random.uintLessThan(u8, 10),
             .crash_fault_probability = 80 + random.uintLessThan(u8, 21),
         },
         .storage_fault_atlas = .{

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1875,30 +1875,27 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 journal.prepare_checksums[slot.index] = message.header.checksum;
             }
 
-            if (journal.slot_with_op_and_checksum(
+            const slot = journal.slot_with_op_and_checksum(
                 message.header.op,
                 message.header.checksum,
-            )) |slot| {
-                journal.headers_redundant[slot.index] = message.header.*;
-            } else {
+            ) orelse {
                 journal.write_prepare_debug(message.header, "entry changed while writing sectors");
                 journal.write_prepare_release(write, null);
                 return;
-            }
+            };
+            journal.headers_redundant[slot.index] = message.header.*;
+
             // TODO It's possible within this section that the header has since been replaced but we
             // continue writing, even when the dirty bit is no longer set. This is not a problem
             // but it would be good to stop writing as soon as we see we no longer need to.
             // For this, we'll need to have a way to tweak write_prepare_release() to release locks.
             // At present, we don't return early here simply because it doesn't yet do that.
 
-            const slot_of_message = journal.slot_for_header(message.header);
-            const offset = Ring.headers.offset(slot_of_message);
+            const offset = Ring.headers.offset(slot);
             assert(offset % constants.sector_size == 0);
 
-            const buffer: []u8 = journal.header_sector(
-                @divFloor(slot_of_message.index, headers_per_sector),
-                write,
-            );
+            const buffer: []u8 =
+                journal.header_sector(@divFloor(slot.index, headers_per_sector), write);
 
             log.debug("{}: write_header: op={} sectors[{}..{}]", .{
                 journal.replica,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7070,7 +7070,7 @@ pub fn ReplicaType(
 
             // We may be appending to or repairing the journal concurrently.
             // We do not want to re-request any of these prepares unnecessarily.
-            if (self.journal.writing(op, checksum)) {
+            if (self.journal.writing(op, checksum) == .exact) {
                 log.debug("{}: repair_prepare: op={} checksum={} (already writing)", .{
                     self.replica,
                     op,
@@ -7093,6 +7093,9 @@ pub fn ReplicaType(
                 assert(prepare.header.checksum == checksum);
 
                 if (self.solo()) {
+                    // Solo replicas don't change views and rewrite prepares.
+                    assert(self.journal.writing(op, checksum) == .none);
+
                     // This op won't start writing until all ops in the pipeline preceding it have
                     // been written.
                     log.debug("{}: repair_prepare: op={} checksum={} (serializing append)", .{
@@ -7568,7 +7571,7 @@ pub fn ReplicaType(
                     // that we can help the new primary to repair this prepare.
                     if ((self.journal.prepare_inhabited[slot.index] and
                         self.journal.prepare_checksums[slot.index] == header.checksum) or
-                        self.journal.writing(header.op, header.checksum) or
+                        self.journal.writing(header.op, header.checksum) == .exact or
                         self.pipeline_prepare_by_op_and_checksum(
                         header.op,
                         header.checksum,
@@ -9605,8 +9608,8 @@ pub fn ReplicaType(
                 return;
             }
 
-            if (self.journal.writing(message.header.op, message.header.checksum)) {
-                log.debug("{}: write_prepare: ignoring op={} checksum={} (already writing)", .{
+            if (self.journal.writing(message.header.op, message.header.checksum) != .none) {
+                log.debug("{}: write_prepare: ignoring op={} checksum={} (already writing slot)", .{
                     self.replica,
                     message.header.op,
                     message.header.checksum,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1779,6 +1779,7 @@ test "Cluster: view_change: lagging replica repairs WAL using start_view from po
     b1.pass(.R_, .outgoing, .do_view_change);
 
     t.run();
+    t.run();
 
     try expectEqual(b1.status(), .normal);
     try expectEqual(b1.role(), .primary);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -44,13 +44,14 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
     var prng = std.rand.DefaultPrng.init(seed);
     const random = prng.random();
 
-    const storage_fault_atlas = StorageFaultAtlas.init(1, random, .{
+    var storage_fault_atlas = try StorageFaultAtlas.init(allocator, 1, random, .{
         .faulty_superblock = true,
         .faulty_wal_headers = false,
         .faulty_wal_prepares = false,
         .faulty_client_replies = false,
         .faulty_grid = false,
     });
+    defer storage_fault_atlas.deinit(allocator);
 
     const storage_options = .{
         .replica_index = 0,


### PR DESCRIPTION
(Not ready for review yet.)

Test misdirected writes in the VOPR.

A _misdirected write_ is a disk fault where:

1. the data is not written to the intended location. (i.e. a "lost write"), and
2. the data _is_ written to a different, mistaken location.

Currently:

- We allow for (at most) one misdirect fault per `Storage` (i.e. per replica) for the time being, for simplicity and because double-faults are not covered by our fault model. This will hopefully match physical disks – misdirected faults are an order of magnitude less frequent than bit rot, which in turn is an order of magnitude less frequent than LSEs.
- In order to keep things interesting:
  - misdirections are always within the same zone,
  - the entire write is misdirected (rather than only some of the sectors), and
  - the misdirected write lands on a convenient offset.
  
  Thanks to rigorous checksums, misdirections that break these rules just manifest as corruptions, and corruption is already well-tested. The goal here is to test how TigerBeetle handles well-formed but incorrectly-located data.

The misdirection is implemented with "overlays" over the `Storage.memory` buffer, so that `Storage.memory` is always pristine. That is, `Storage.memory` is what the disk would look like if no faults had ever occurred.

---

Also in this PR:
- Refactoring `Storage`.
- Enable read/write faults in the `client_replies` zone. Previously we were only injecting faults due to crashes ("torn writes").
- With these new faults, the VOPR found:
  - a couple of minor incorrect asserts in the [journal](https://github.com/tigerbeetle/tigerbeetle/pull/2463/commits/176d716f2bb4fa413ac05b04a0cc43a5087097e0).
  - a [correctness bug](https://github.com/tigerbeetle/tigerbeetle/pull/2463/commits/3f309bf1a9fcaf3eb518ab1b99dcf9b53a6bc562) in journal recovery!
  - a bug in the [client replies](https://github.com/tigerbeetle/tigerbeetle/pull/2463/commits/3e9906731f356336a793cd6b7b0f6df9a89d0919).
  - (Fixes in https://github.com/tigerbeetle/tigerbeetle/pull/2506).