### PR TITLE
clients: add application_logger and always log warn and err regardless

### DIFF
--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -25,9 +25,8 @@ else
     @compileError("tb_client must be built with libc");
 
 pub const std_options = .{
-    // Since this is running in application space, log only critical messages to reduce noise.
-    .log_level = std.log.Level.err,
-    .logFn = vsr.constants.log_nop,
+    .log_level = vsr.constants.log_level,
+    .logFn = tb.Logging.application_logger,
 };
 
 /// Context for a client instance.

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -26,9 +26,8 @@ const Operation = StateMachine.Operation;
 const constants = vsr.constants;
 
 pub const std_options = .{
-    // Since this is running in application space, log only critical messages to reduce noise.
-    .log_level = .err,
-    .logFn = vsr.constants.log_nop,
+    .log_level = vsr.constants.log_level,
+    .logFn = tb_client.Logging.application_logger,
 };
 
 // Cached value for JS (null).

--- a/src/tb_client_exports.zig
+++ b/src/tb_client_exports.zig
@@ -6,9 +6,8 @@ const vsr = @import("vsr.zig");
 const tb = vsr.tb_client;
 
 pub const std_options = .{
-    // Since this is running in application space, log only critical messages to reduce noise.
-    .log_level = std.log.Level.err,
-    .logFn = vsr.constants.log_nop,
+    .log_level = vsr.constants.log_level,
+    .logFn = tb.Logging.application_logger,
 };
 
 comptime {
@@ -16,6 +15,10 @@ comptime {
         @compileError("Must be built with libc to export tb_client symbols");
     }
 
+    @export(
+        tb.register_log_callback,
+        .{ .name = "tb_client_register_log_callback", .linkage = .strong },
+    );
     @export(init, .{ .name = "tb_client_init", .linkage = .strong });
     @export(init_echo, .{ .name = "tb_client_init_echo", .linkage = .strong });
     @export(tb.completion_context, .{ .name = "tb_client_completion_context", .linkage = .strong });


### PR DESCRIPTION
This adds the scaffolding for log messages to be passed up into client languages and eventually handled by language-native logging libraries (eg, pino, log4j, etc).

No client library actually uses this yet, however (except for one heavily requested WIP client 🐍) - it's more to get the change out there and we can start adapting the clients.

As part of this, change the default back to logging .warn and .err messages from TigerBeetle. While it's not ideal for a library to be hijacking and printing things on stderr by itself, the current situation - where there's no logging at all - makes tracking down mistakes much harder.

This is hopefully a middle-ground until language clients all set their own log handlers.