### PR TITLE
mem: `mlockall` pages to prevent swap bypassing storage fault tolerance

### DIFF
--- a/docs/.cspell.json
+++ b/docs/.cspell.json
@@ -156,6 +156,7 @@
         "replayability",
         "Riccomini",
         "Rivacindela",
+        "RLIMIT",
         "roadmap",
         "roadmaps",
         "ronomon",

--- a/docs/.cspell.json
+++ b/docs/.cspell.json
@@ -166,6 +166,7 @@
         "seccomp",
         "sentientwaffle",
         "serializability",
+        "setcap",
         "shellcheck",
         "Sidenote",
         "SIGTERM",

--- a/docs/operating/docker.md
+++ b/docs/operating/docker.md
@@ -170,7 +170,12 @@ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle:deb
 #### `error: SystemResources`
 
 If you get `error: SystemResources` when running TigerBeetle in Docker on macOS,
-you will need to do one of the following:
+the container is blocking tigerbeetle from locking memory which is necessary for io_uring
+and optionally to avoid kernel swap bypassing TigerBeetle's storage fault tolerance.
+
+#### Allowing MEMLOCK 
+
+To raise the memory lock limits under Docker, execute one of the following:
 
 1. Run `docker run` with `--cap-add IPC_LOCK`
 2. Run `docker run` with `--ulimit memlock=-1:-1`

--- a/docs/operating/docker.md
+++ b/docs/operating/docker.md
@@ -170,8 +170,8 @@ docker run -p 3000:3000 -v $(pwd)/data:/data ghcr.io/tigerbeetle/tigerbeetle:deb
 #### `error: SystemResources`
 
 If you get `error: SystemResources` when running TigerBeetle in Docker on macOS,
-the container is blocking tigerbeetle from locking memory which is necessary for io_uring
-and optionally to avoid kernel swap bypassing TigerBeetle's storage fault tolerance.
+the container may be blocking TigerBeetle from locking memory, which is necessary both for io_uring
+and to prevent the kernel's use of swap from bypassing TigerBeetle's storage fault tolerance.
 
 #### Allowing MEMLOCK 
 

--- a/docs/operating/linux.md
+++ b/docs/operating/linux.md
@@ -141,8 +141,17 @@ In case you want to use this service for development as well, you may need to ad
 
 ### Memory Locking
 
-TigerBeetle relies on `RLIMIT_MEMLOCK` being adequate enough to initialize io_uring. It also locks all allocated memory to avoid the kernel swapping pages to disk and bypassing TigerBeetle's storage determinism. If enough memory cannot be locked, the environment can be appropriately modified either by disabling swap, adding the `CAP_IPC_LOCK` capability (provided by the systemd service), or raising the `memlock` value under `/etc/security/limits.conf`.
+TigerBeetle requires `RLIMIT_MEMLOCK` to be set high enough to:
 
-Memory locking is disabled for development environments using the `--development` flag.
+1. initialize io_uring, which requires memory shared with the kernel to be locked, as well as
+2. lock all allocated memory, and so prevent the kernel from swapping any pages to disk, which would not only affect performance but also bypass TigerBeetle's storage fault-tolerance.
 
-For linux running under Docker, refer to [Allowing MEMLOCK](docker.md#allowing-memlock).
+If the required memory cannot be locked, then the environment should be modified either by (in order of preference):
+
+1. giving the local `tigerbeetle` binary the `CAP_IPC_LOCK` capability, or
+2. raising the global `memlock` value under `/etc/security/limits.conf`, or else
+3. disabling swap (io_uring may still require an RLIMIT increase).
+
+Memory locking is disabled for development environments when using the `--development` flag.
+
+For Linux running under Docker, refer to [Allowing MEMLOCK](docker.md#allowing-memlock).

--- a/docs/operating/linux.md
+++ b/docs/operating/linux.md
@@ -148,7 +148,7 @@ TigerBeetle requires `RLIMIT_MEMLOCK` to be set high enough to:
 
 If the required memory cannot be locked, then the environment should be modified either by (in order of preference):
 
-1. giving the local `tigerbeetle` binary the `CAP_IPC_LOCK` capability, or
+1. giving the local `tigerbeetle` binary the `CAP_IPC_LOCK` capability (`sudo setcap "cap_ipc_lock=+ep" ./tigerbeetle`), or
 2. raising the global `memlock` value under `/etc/security/limits.conf`, or else
 3. disabling swap (io_uring may still require an RLIMIT increase).
 

--- a/docs/operating/linux.md
+++ b/docs/operating/linux.md
@@ -20,6 +20,8 @@ After=network-online.target
 Wants=network-online.target systemd-networkd-wait-online.service
 
 [Service]
+AmbientCapabilities=CAP_IPC_LOCK
+
 Environment=TIGERBEETLE_CACHE_GRID_SIZE=1GiB
 Environment=TIGERBEETLE_ADDRESSES=3001
 Environment=TIGERBEETLE_REPLICA_COUNT=1
@@ -136,3 +138,11 @@ If you wish to change those, you are expected to understand those implications a
 The service was created assuming it'll be used in a production scenario.
 
 In case you want to use this service for development as well, you may need to adjust the `ExecStart` line to include the `--development` flag if your development environment doesn't support Direct IO, or if you require smaller cache sizes and/or batch sizes due to memory constraints.
+
+### Memory Locking
+
+TigerBeetle relies on `RLIMIT_MEMLOCK` being adequate enough to initialize io_uring. It also locks all allocated memory to avoid the kernel swapping pages to disk and bypassing TigerBeetle's storage determinism. If enough memory cannot be locked, the environment can be appropriately modified either by disabling swap, adding the `CAP_IPC_LOCK` capability (provided by the systemd service), or raising the `memlock` value under `/etc/security/limits.conf`.
+
+Memory locking is disabled for development environments using the `--development` flag.
+
+For linux running under Docker, refer to [Allowing MEMLOCK](docker.md#allowing-memlock).

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -457,7 +457,7 @@ const Command = struct {
                 const MCL_CURRENT = 1; // Lock all currently mapped pages.
                 const MCL_ONFAULT = 3; // Lock all pages faulted in (i.e. stack space).
                 const rc = os.linux.syscall1(.mlockall, MCL_CURRENT | MCL_ONFAULT);
-                switch (os.linux.E.errnoFromSyscall(rc)) {
+                switch (os.linux.E.init(rc)) {
                     .AGAIN => log.warn(lock_mem_err, .{"some addresses could not be locked"}),
                     .NOMEM => log.warn(lock_mem_err, .{"total memory would exceed RLIMIT_MEMLOCK"}),
                     .PERM => log.warn(lock_mem_err, .{"not enough privileges to lock memory"}),

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -463,7 +463,7 @@ const Command = struct {
                     .NOMEM => log.warn(lock_mem_err, .{"total memory would exceed RLIMIT_MEMLOCK"}),
                     .PERM => log.warn(lock_mem_err, .{"not enough privileges to lock memory"}),
                     .INVAL => unreachable, // MCL_ONFAULT specified with MCL_CURRENT.
-                    else => |err| return stdx.unexpected_errno(err),
+                    else => |err| return stdx.unexpected_errno("mlockall", err),
                 }
             },
             .macos => {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -7,6 +7,7 @@ const os = std.os;
 const log = std.log.scoped(.main);
 
 const vsr = @import("vsr");
+const stdx = vsr.stdx;
 const constants = vsr.constants;
 const config = constants.config;
 
@@ -462,7 +463,7 @@ const Command = struct {
                     .NOMEM => log.warn(lock_mem_err, .{"total memory would exceed RLIMIT_MEMLOCK"}),
                     .PERM => log.warn(lock_mem_err, .{"not enough privileges to lock memory"}),
                     .INVAL => unreachable, // MCL_ONFAULT specified with MCL_CURRENT.
-                    else => |err| return std.posix.unexpectedErrno(err),
+                    else => |err| return stdx.unexpected_errno(err),
                 }
             },
             .macos => {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -529,6 +529,7 @@ const Command = struct {
                     log.warn(lock_mem_err, .{std.unicode.fmtUtf16Le(buf_wstr[0..len])});
                 }
             },
+            else => @compileError("unsupported platform"),
         }
 
         while (true) {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -446,6 +446,91 @@ const Command = struct {
             watchdog.detach();
         }
 
+        // Try to lock all memory in the process to avoid the kernel swapping pages to disk and
+        // potentially introducting undetectable disk corruption into memory.
+        // This is a best-effort attempt not a hard rule (as it may not cover all memory edge cases)
+        // so warn on error to notify the operator that they should disable swap if possible.
+        const lock_mem_err = "Unable to lock pages in memory ({s}) " ++
+            " - swap paging may trigger undetectable IO to disk";
+        switch (builtin.os.tag) {
+            .linux => {
+                const MCL_CURRENT = 1; // Lock all currently mapped pages.
+                const MCL_ONFAULT = 3; // Lock all pages faulted in (i.e. stack space).
+                const rc = os.linux.syscall1(.mlockall, MCL_CURRENT | MCL_ONFAULT);
+                switch (os.linux.E.errnoFromSyscall(rc)) {
+                    .AGAIN => log.warn(lock_mem_err, .{"some addresses could not be locked"}),
+                    .NOMEM => log.warn(lock_mem_err, .{"total memory would exceed RLIMIT_MEMLOCK"}),
+                    .PERM => log.warn(lock_mem_err, .{"not enough privileges to lock memory"}),
+                    .INVAL => unreachable, // MCL_ONFAULT specified with MCL_CURRENT.
+                    else => |err| return std.posix.unexpectedErrno(err),
+                }
+            },
+            .macos => {
+                // macOS has mlock() but not mlockall().
+            },
+            .windows => {
+                const set_process_working_set_size = @extern(
+                    *const fn (
+                        hProcess: os.windows.HANDLE,
+                        dwMinimumWorkingSetSize: os.windows.SIZE_T,
+                        dwMaximumWorkingSetSize: os.windows.SIZE_T,
+                    ) callconv(os.windows.WINAPI) os.windows.BOOL,
+                    .{
+                        .library_name = "kernel32",
+                        .name = "SetProcessWorkingSetSize",
+                    },
+                );
+                const get_process_working_set_size = @extern(
+                    *const fn (
+                        hProcess: os.windows.HANDLE,
+                        lpMinimumWorkingSetSize: *os.windows.SIZE_T,
+                        lpMaximumWorkingSetSize: *os.windows.SIZE_T,
+                    ) callconv(os.windows.WINAPI) os.windows.BOOL,
+                    .{
+                        .library_name = "kernel32",
+                        .name = "GetProcessWorkingSetSize",
+                    },
+                );
+
+                const process_handle = os.windows.kernel32.GetCurrentProcess();
+                var working_set_min: os.windows.SIZE_T = 0;
+                var working_set_max: os.windows.SIZE_T = 0;
+
+                if (get_process_working_set_size(
+                    process_handle,
+                    &working_set_min,
+                    &working_set_max,
+                ) == os.windows.FALSE) {
+                    working_set_min = counting_allocator.size; // Count bytes allocated so far.
+                    working_set_min += 64 * 1024 * 1024; // 64mb buffer room for stack/globals.
+                    working_set_max = working_set_min * 2; // Buffer room for new page faults.
+                }
+
+                if (set_process_working_set_size(
+                    process_handle,
+                    working_set_min,
+                    working_set_max,
+                ) == os.windows.FALSE) {
+                    // From std.os.windows.unexpectedError():
+                    const fmt_flags = os.windows.FORMAT_MESSAGE_FROM_SYSTEM |
+                        os.windows.FORMAT_MESSAGE_IGNORE_INSERTS;
+
+                    // 614 is the length of the longest windows error description
+                    var buf_wstr: [614:0]os.windows.WCHAR = undefined;
+                    const len = os.windows.kernel32.FormatMessageW(
+                        fmt_flags,
+                        null,
+                        os.windows.kernel32.GetLastError(),
+                        os.windows.LANG.NEUTRAL | (os.windows.SUBLANG.DEFAULT << 10),
+                        &buf_wstr,
+                        buf_wstr.len,
+                        null,
+                    );
+                    log.warn(lock_mem_err, .{std.unicode.fmtUtf16Le(buf_wstr[0..len])});
+                }
+            },
+        }
+
         while (true) {
             replica.tick();
             if (multiversion != null) multiversion.?.tick();


### PR DESCRIPTION
Attempt to prevent swap from introducing disk errors into memory by locking all allocated pages before running the replica. On failure, hint to the operator that they should try to disable swap system-wide instead.