### PR TITLE
[Java] Expose the VSR timestamp to the client

### DIFF
--- a/src/clients/c/samples/main.c
+++ b/src/clients/c/samples/main.c
@@ -52,6 +52,7 @@ void on_completion(
     uintptr_t context,
     tb_client_t client,
     tb_packet_t *packet,
+    uint64_t timestamp,
     const uint8_t *data,
     uint32_t size
 );
@@ -246,9 +247,12 @@ void on_completion(
     uintptr_t context,
     tb_client_t client,
     tb_packet_t *packet,
+    uint64_t timestamp,
     const uint8_t *data,
     uint32_t size
 ) {
+    (void)timestamp; // Not used.
+
     // The user_data gives context to a request:
     completion_context_t* ctx = (completion_context_t*)packet->user_data;
 

--- a/src/clients/c/samples/main.c
+++ b/src/clients/c/samples/main.c
@@ -328,9 +328,11 @@ void on_completion(
     uintptr_t context,
     tb_client_t client,
     tb_packet_t *packet,
+    uint64_t timestamp,
     const uint8_t *data,
     uint32_t size
 ) {
+    (void)timestamp; // Not used.
     // The user_data gives context to a request:
     completion_context_t* ctx = (completion_context_t*)packet->user_data;
 

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -280,7 +280,7 @@ TB_STATUS tb_client_init(
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,
-    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
+    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
 );
 
 // Initialize a new TigerBeetle client which echos back any data submitted.
@@ -290,7 +290,7 @@ TB_STATUS tb_client_init_echo(
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,
-    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
+    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
 );
 
 // Retrieve the callback context initially passed into `tb_client_init` or

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -22,6 +22,7 @@ pub const tb_completion_t = *const fn (
     context: usize,
     client: tb_client_t,
     packet: *tb_packet_t,
+    timestamp: u64,
     result_ptr: ?[*]const u8,
     result_len: u32,
 ) callconv(.C) void;

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -208,7 +208,7 @@ pub fn main() !void {
         \\    const char* address_ptr,
         \\    uint32_t address_len,
         \\    uintptr_t on_completion_ctx,
-        \\    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
+        \\    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
         \\);
         \\
         \\// Initialize a new TigerBeetle client which echos back any data submitted.
@@ -218,7 +218,7 @@ pub fn main() !void {
         \\    const char* address_ptr,
         \\    uint32_t address_len,
         \\    uintptr_t on_completion_ctx,
-        \\    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
+        \\    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
         \\);
         \\
         \\// Retrieve the callback context initially passed into `tb_client_init` or

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -27,6 +27,7 @@ fn RequestContextType(comptime request_size_max: comptime_int) type {
             tb_context: usize,
             tb_client: c.tb_client_t,
             tb_packet: *c.tb_packet_t,
+            timestamp: u64,
             result: ?[request_size_max]u8,
             result_len: u32,
         } = null,
@@ -35,6 +36,7 @@ fn RequestContextType(comptime request_size_max: comptime_int) type {
             tb_context: usize,
             tb_client: c.tb_client_t,
             tb_packet: [*c]c.tb_packet_t,
+            timestamp: u64,
             result_ptr: [*c]const u8,
             result_len: u32,
         ) callconv(.C) void {
@@ -45,6 +47,7 @@ fn RequestContextType(comptime request_size_max: comptime_int) type {
                 .tb_context = tb_context,
                 .tb_client = tb_client,
                 .tb_packet = tb_packet,
+                .timestamp = timestamp,
                 .result = if (result_ptr != null and result_len > 0) blk: {
                     // Copy the message's body to the context buffer:
                     assert(result_len <= request_size_max);

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1271,7 +1271,9 @@ internal static class TBClient
         byte* address_ptr,
         uint address_len,
         IntPtr on_completion_ctx,
-        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
+        delegate* unmanaged[Cdecl]<IntPtr, IntPtr,
+                                   TBPacket*, ulong,
+                                   byte*, uint, void> on_completion_fn
     );
 
     [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
@@ -1281,7 +1283,9 @@ internal static class TBClient
         byte* address_ptr,
         uint address_len,
         IntPtr on_completion_ctx,
-        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
+        delegate* unmanaged[Cdecl]<IntPtr, IntPtr,
+                                   TBPacket*, ulong,
+                                   byte*, uint, void> on_completion_fn
     );
 
     [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1271,7 +1271,7 @@ internal static class TBClient
         byte* address_ptr,
         uint address_len,
         IntPtr on_completion_ctx,
-        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
     );
 
     [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
@@ -1281,7 +1281,7 @@ internal static class TBClient
         byte* address_ptr,
         uint address_len,
         IntPtr on_completion_ctx,
-        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
     );
 
     [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -22,7 +22,7 @@ internal sealed class NativeClient : IDisposable
                 byte* address_ptr,
                 uint address_len,
                 IntPtr on_completion_ctx,
-                delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+                delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
             );
 
 
@@ -140,8 +140,10 @@ internal sealed class NativeClient : IDisposable
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-    private unsafe static void OnCompletionCallback(IntPtr ctx, IntPtr client, TBPacket* packet, byte* result, uint resultLen)
+    private unsafe static void OnCompletionCallback(IntPtr ctx, IntPtr client, TBPacket* packet, ulong timestamp, byte* result, uint resultLen)
     {
+        _ = timestamp;
+
         try
         {
             AssertTrue(ctx == IntPtr.Zero);

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -484,7 +484,9 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        byte* address_ptr,
         \\        uint address_len,
         \\        IntPtr on_completion_ctx,
-        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
+        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr,
+        \\                                   TBPacket*, ulong,
+        \\                                   byte*, uint, void> on_completion_fn
         \\    );
         \\
         \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
@@ -494,7 +496,9 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        byte* address_ptr,
         \\        uint address_len,
         \\        IntPtr on_completion_ctx,
-        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
+        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr,
+        \\                                   TBPacket*, ulong,
+        \\                                   byte*, uint, void> on_completion_fn
         \\    );
         \\
         \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -484,7 +484,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        byte* address_ptr,
         \\        uint address_len,
         \\        IntPtr on_completion_ctx,
-        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
         \\    );
         \\
         \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
@@ -494,7 +494,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\        byte* address_ptr,
         \\        uint address_len,
         \\        IntPtr on_completion_ctx,
-        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, byte*, uint, void> on_completion_fn
+        \\        delegate* unmanaged[Cdecl]<IntPtr, IntPtr, TBPacket*, ulong, byte*, uint, void> on_completion_fn
         \\    );
         \\
         \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -280,7 +280,7 @@ TB_STATUS tb_client_init(
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,
-    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
+    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
 );
 
 // Initialize a new TigerBeetle client which echos back any data submitted.
@@ -290,7 +290,7 @@ TB_STATUS tb_client_init_echo(
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,
-    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, const uint8_t*, uint32_t)
+    void (*on_completion)(uintptr_t, tb_client_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
 );
 
 // Retrieve the callback context initially passed into `tb_client_init` or

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -22,6 +22,7 @@ extern __declspec(dllexport) void onGoPacketCompletion(
 	uintptr_t ctx,
 	tb_client_t client,
 	tb_packet_t* packet,
+	uint64_t timestamp,
 	tb_result_bytes_t result_ptr,
 	uint32_t result_len
 );
@@ -244,11 +245,13 @@ func onGoPacketCompletion(
 	_context C.uintptr_t,
 	client C.tb_client_t,
 	packet *C.tb_packet_t,
+	timestamp C.uint64_t,
 	result_ptr C.tb_result_bytes_t,
 	result_len C.uint32_t,
 ) {
 	_ = _context
 	_ = client
+	_ = timestamp
 
 	// Get the request from the packet user data.
 	req := (*request)(unsafe.Pointer(packet.user_data))

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -177,6 +177,7 @@ const NativeClient = struct {
                     ReflectionHelper.set_reply_buffer(
                         env,
                         request_obj,
+                        timestamp,
                         ptr[0..@as(usize, @intCast(result_len))],
                     );
                 },
@@ -189,6 +190,7 @@ const NativeClient = struct {
             request_obj,
             packet_operation,
             packet_status,
+            timestamp,
         );
     }
 };
@@ -357,7 +359,7 @@ const ReflectionHelper = struct {
             env,
             request_class,
             "endRequest",
-            "(BB)V",
+            "(BBJ)V",
         );
 
         // Asserting we are full initialized:
@@ -449,10 +451,16 @@ const ReflectionHelper = struct {
         return direct_buffer[0..@as(usize, @intCast(buffer_len))];
     }
 
-    pub fn set_reply_buffer(env: *jni.JNIEnv, this_obj: jni.JObject, reply: []const u8) void {
+    pub fn set_reply_buffer(
+        env: *jni.JNIEnv,
+        this_obj: jni.JObject,
+        timestamp: u64,
+        reply: []const u8,
+    ) void {
         assert(this_obj != null);
         assert(request_reply_buffer_field_id != null);
         assert(reply.len > 0);
+        assert(timestamp > 0);
 
         const reply_buffer_obj = env.new_byte_array(
             @intCast(reply.len),
@@ -519,6 +527,7 @@ const ReflectionHelper = struct {
         this_obj: jni.JObject,
         packet_operation: u8,
         packet_status: tb.tb_packet_status_t,
+        timestamp: u64,
     ) void {
         assert(this_obj != null);
         assert(request_class != null);
@@ -531,6 +540,7 @@ const ReflectionHelper = struct {
             &[_]jni.JValue{
                 jni.JValue.to_jvalue(@as(jni.JByte, @bitCast(packet_operation))),
                 jni.JValue.to_jvalue(@as(jni.JByte, @bitCast(@intFromEnum(packet_status)))),
+                jni.JValue.to_jvalue(@as(jni.JLong, @bitCast(timestamp))),
             },
         );
 

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -146,6 +146,7 @@ const NativeClient = struct {
         context_ptr: usize,
         client: tb.tb_client_t,
         packet: *tb.tb_packet_t,
+        timestamp: u64,
         result_ptr: ?[*]const u8,
         result_len: u32,
     ) callconv(.C) void {
@@ -162,6 +163,12 @@ const NativeClient = struct {
         const packet_operation = packet.operation;
         const packet_status = packet.status;
         global_allocator.destroy(packet);
+
+        if (packet_status != .ok) {
+            assert(timestamp == 0);
+            assert(result_ptr == null);
+            assert(result_len == 0);
+        }
 
         if (result_len > 0) {
             switch (packet_status) {

--- a/src/clients/java/src/main/java/com/tigerbeetle/Batch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Batch.java
@@ -13,6 +13,24 @@ import static com.tigerbeetle.AssertionError.assertTrue;
  * {@link #next}, {@link #add}, or {@link #setPosition} prior to reading or writing an element.
  */
 public abstract class Batch {
+    /**
+     * Information about the protocol header for debugging and diagnostic purposes. This is a
+     * temporary API and may be removed without notice.
+     */
+    public static class Header {
+        private final long timestamp;
+
+        Header(final long timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        /**
+         * Gets the cluster timestamp when the reply was generated.
+         */
+        public final long getTimestamp() {
+            return this.timestamp;
+        }
+    }
 
     // @formatter:off
     /*
@@ -47,6 +65,8 @@ public abstract class Batch {
     private int position;
     private CursorStatus cursorStatus;
     private int length;
+
+    private Header header = null;
 
     private final int capacity;
     private final ByteBuffer buffer;
@@ -90,6 +110,21 @@ public abstract class Batch {
         this.cursorStatus = CursorStatus.Begin;
 
         this.buffer = buffer.order(BYTE_ORDER);
+    }
+
+    /**
+     * Retrieves information about the protocol header for debugging and diagnostic purposes.
+     * This is a temporary API and may be removed without notice.
+     *
+     * @return may return null if this batch wasn't generated in response to a VSR operation.
+     */
+    public final Header getHeader() {
+        return this.header;
+    }
+
+    void setHeader(Header header) {
+        Objects.requireNonNull(header);
+        this.header = header;
     }
 
     /**

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -82,7 +82,7 @@ abstract class Request<TResponse extends Batch> {
     // Unchecked: Since we just support a limited set of operations, it is safe to cast the
     // result to T[]
     @SuppressWarnings("unchecked")
-    void endRequest(final byte receivedOperation, final byte status) {
+    void endRequest(final byte receivedOperation, final byte status, final long timestamp) {
 
         // This method is called from the JNI side, on the tb_client thread
         // We CAN'T throw any exception here, any event must be stored and
@@ -176,6 +176,7 @@ abstract class Request<TResponse extends Batch> {
 
         try {
             if (exception == null) {
+                result.setHeader(new Batch.Header(timestamp));
                 setResult((TResponse) result);
             } else {
                 setException(exception);

--- a/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/AsyncRequestTest.java
@@ -74,12 +74,14 @@ public class AsyncRequestTest {
         assert false;
     }
 
+    @Test
     public void testConstructorWithZeroCapacityBatch() {
         var client = getDummyClient();
         var batch = new AccountBatch(0);
         AsyncRequest.createAccounts(client, batch);
     }
 
+    @Test
     public void testConstructorWithZeroItemsBatch() {
         var client = getDummyClient();
         var batch = new AccountBatch(1);
@@ -155,6 +157,8 @@ public class AsyncRequestTest {
 
         var result = future.get();
         assertEquals(0, result.getLength());
+        assertNotNull(result.getHeader());
+        assertTrue(result.getHeader().getTimestamp() != 0L);
     }
 
     @Test(expected = AssertionError.class)
@@ -267,6 +271,8 @@ public class AsyncRequestTest {
 
         var result = future.get();
         assertEquals(2, result.getLength());
+        assertNotNull(result.getHeader());
+        assertTrue(result.getHeader().getTimestamp() != 0L);
 
         assertTrue(result.next());
         assertEquals(0, result.getIndex());
@@ -303,6 +309,8 @@ public class AsyncRequestTest {
 
         var result = future.get();
         assertEquals(2, result.getLength());
+        assertNotNull(result.getHeader());
+        assertTrue(result.getHeader().getTimestamp() != 0L);
 
         assertTrue(result.next());
         assertEquals(0, result.getIndex());
@@ -337,6 +345,8 @@ public class AsyncRequestTest {
 
         var result = future.get();
         assertEquals(2, result.getLength());
+        assertNotNull(result.getHeader());
+        assertTrue(result.getHeader().getTimestamp() != 0L);
 
         assertTrue(result.next());
         assertEquals(100L, result.getId(UInt128.LeastSignificant));
@@ -371,6 +381,8 @@ public class AsyncRequestTest {
 
         var result = future.get();
         assertEquals(2, result.getLength());
+        assertNotNull(result.getHeader());
+        assertTrue(result.getHeader().getTimestamp() != 0L);
 
         assertTrue(result.next());
         assertEquals(100L, result.getId(UInt128.LeastSignificant));
@@ -416,6 +428,8 @@ public class AsyncRequestTest {
         // Wait for completion
         var result = future.get();
         assertEquals(2, result.getLength());
+        assertNotNull(result.getHeader());
+        assertTrue(result.getHeader().getTimestamp() != 0L);
 
         assertTrue(result.next());
         assertEquals(100L, result.getId(UInt128.LeastSignificant));
@@ -454,6 +468,8 @@ public class AsyncRequestTest {
             // to avoid flaky results due to thread scheduling.
             var result = future.get(5000, TimeUnit.MILLISECONDS);
             assertEquals(2, result.getLength());
+            assertNotNull(result.getHeader());
+            assertTrue(result.getHeader().getTimestamp() != 0L);
 
             assertTrue(result.next());
             assertEquals(100L, result.getId(UInt128.LeastSignificant));
@@ -570,7 +586,7 @@ public class AsyncRequestTest {
                 if (buffer != null) {
                     request.setReplyBuffer(buffer.array());
                 }
-                request.endRequest(receivedOperation, status);
+                request.endRequest(receivedOperation, status, System.nanoTime());
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -259,10 +259,12 @@ fn on_completion(
     completion_ctx: usize,
     client: tb_client.tb_client_t,
     packet: *tb_client.tb_packet_t,
+    timestamp: u64,
     result_ptr: ?[*]const u8,
     result_len: u32,
 ) callconv(.C) void {
     _ = client;
+    _ = timestamp;
 
     switch (packet.status) {
         .ok, .client_shutdown => {}, // Handled on the JS side to throw exception.

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -103,11 +103,13 @@ pub fn on_complete(
     tb_context: usize,
     tb_client: c.tb_client_t,
     tb_packet: [*c]c.tb_packet_t,
+    timestamp: u64,
     result_ptr: [*c]const u8,
     result_len: u32,
 ) callconv(.C) void {
     _ = tb_context;
     _ = tb_client;
+    _ = timestamp;
     const context: *RequestContext = @ptrCast(@alignCast(tb_packet.*.user_data.?));
 
     context.lock.lock();


### PR DESCRIPTION
For diagnostics and debug purposes, this PR wires the VSR timestamp to all the language clients and exposes it in the Java Client API.

Reference: #2440

Usage:
```java
var results = client.createTransfers(batch);
long timestamp = results.getHeader().getTimestamp()
```