### PR TITLE
tidy: ban `!comptime ...`

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -160,6 +160,10 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
         return "use a type name instead of Self";
     }
 
+    if (std.mem.indexOf(u8, source, "!" ++ "comptime") != null) {
+        return "use ! inside comptime";
+    }
+
     return null;
 }
 

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -842,7 +842,7 @@ fn print_struct(
 
     const Type = @typeInfo(@TypeOf(value)).Pointer.child;
     // Print structs *without* a custom format() function.
-    if (@typeInfo(Type) == .Struct and !comptime std.meta.hasFn(Type, "format")) {
+    if (comptime @typeInfo(Type) == .Struct and !std.meta.hasFn(Type, "format")) {
         if (@typeInfo(Type).Struct.is_tuple) {
             try output.writeAll(label);
             // Print tuples as a single line.


### PR DESCRIPTION
Sometimes, you need to reach for an explicit `comptime` in an if condition:
```
if (comptime foo) {
    std.log.info("foo!", .{});
}
```

and sometimes you need to negate that:

```
if (!comptime foo) {
    std.log.info("not foo!", .{});
}
```

all good so far. The problem is that this comptime expression spans across the entire condition, so:

```
if (!comptime foo and bar) {
    std.log.info("not foo, bar!", .{});
}
```

is really `!comptime (foo and bar)` and not `!(comptime (foo)) and bar`.