### PR TITLE
Test/Integration: Debug flock test flake

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -256,6 +256,8 @@ test "benchmark/inspect smoke" {
         "{tigerbeetle} inspect manifest                {path}",
         "{tigerbeetle} inspect tables --tree=transfers {path}",
     }) |command| {
+        log.debug("{s}", .{command});
+
         try shell.exec(
             command,
             .{ .tigerbeetle = tigerbeetle, .path = data_file },


### PR DESCRIPTION
There was a [test flake](https://github.com/tigerbeetle/tigerbeetle/actions/runs/11894772933/job/33142761406) in the `benchmark/inspect smoke` integration test.

One of the `inspect` exec's failed with:

    info(io): opening "0_0-eda91bbe.tigerbeetle.benchmark"...
    thread 1701 panic: another process holds the data file lock
    /__w/tigerbeetle/tigerbeetle/zig/lib/std/posix.zig:5268:23: 0x1270208 in flock (tigerbeetle)
                .AGAIN => return error.WouldBlock, // TODO: integrate with async instead of just returning an error
                          ^
    /__w/tigerbeetle/tigerbeetle/src/io/linux.zig:1481:33: 0x126f046 in open_file (tigerbeetle)
                error.WouldBlock => @panic("another process holds the data file lock"),
                                    ^
    /__w/tigerbeetle/tigerbeetle/src/tigerbeetle/inspect.zig:150:47: 0x12db7bb in create (tigerbeetle)

What _seems_ to be happening is the lock on the data file is not released synchronously relative to when the process holding the lock terminates.

...But I failed to reproduce this locally -- both using the integration test, and with a simplified version). (I tried on ext4 since that is what the CI would be using, though I'm not sure if that matters).

I want to distinguish whether:
1. any (e.g. `tigerbeetle inspect`) process that terminates might hold a file lock for a few extra moments, or
2. this is only an issue with `tigerbeetle benchmark` because of the nested child processes.

If it is the former, that hints that we might need to explicitly unlock the file before exec-ing during a multiversion auto-upgrade. And if so, then it is _possible_ that this flock race is behind the (currently unexplained) `in-place upgrade` integration test flake.

---

As an alternate approach, we could instead add a `log.debug()` statement any time we use `shell.exec()`.