### PR TITLE
docs: add note about atomic lookups being limited to batch size

### DIFF
--- a/docs/reference/requests/lookup_accounts.md
+++ b/docs/reference/requests/lookup_accounts.md
@@ -10,6 +10,11 @@ transfer. Instead, set the
 accounts to limit their account balances. More complex conditional transfers can be expressed using
 [balance-conditional transfers](../../coding/recipes/balance-conditional-transfers.md).
 
+⚠️ It is not possible currently to look up more than a full batch (8190) of accounts atomically.
+When issuing multiple `lookup_accounts` calls, it can happen that other operations will interleave
+between the calls leading to read skew. Consider using the
+[`history`](../account.md#flagshistory) flag to enable atomic lookups.
+
 ## Event
 
 An [`id`](../account.md#id) belonging to a [`Account`](../account.md).

--- a/docs/reference/requests/query_accounts.md
+++ b/docs/reference/requests/query_accounts.md
@@ -2,6 +2,11 @@
 
 Query [`Account`](../account.md)s by the intersection of some fields and by timestamp range.
 
+⚠️ It is not possible currently to query more than a full batch (8190) of accounts atomically.
+When issuing multiple `query_accounts` calls, it can happen that other operations will interleave
+between the calls leading to read skew. Consider using the
+[`history`](../account.md#flagshistory) flag to enable atomic lookups.
+
 ## Event
 
 The query filter.


### PR DESCRIPTION
This mainly applies to accounts, because they appear as mutable...