### PR TITLE
[Java] Remove `Batch.EMPTY` Shared Objects

### DIFF
--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -446,8 +446,6 @@ fn emit_batch(
     try buffer.writer().print(
         \\    }}
         \\
-        \\    static final {[name]s} EMPTY = new {[name]s}(0);
-        \\
         \\    /**
         \\     * Creates an empty batch with the desired maximum capacity.
         \\     * <p>

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -177,7 +177,6 @@ const NativeClient = struct {
                     ReflectionHelper.set_reply_buffer(
                         env,
                         request_obj,
-                        timestamp,
                         ptr[0..@as(usize, @intCast(result_len))],
                     );
                 },
@@ -454,13 +453,11 @@ const ReflectionHelper = struct {
     pub fn set_reply_buffer(
         env: *jni.JNIEnv,
         this_obj: jni.JObject,
-        timestamp: u64,
         reply: []const u8,
     ) void {
         assert(this_obj != null);
         assert(request_reply_buffer_field_id != null);
         assert(reply.len > 0);
-        assert(timestamp > 0);
 
         const reply_buffer_obj = env.new_byte_array(
             @intCast(reply.len),
@@ -532,6 +529,7 @@ const ReflectionHelper = struct {
         assert(this_obj != null);
         assert(request_class != null);
         assert(request_end_request_method_id != null);
+        assert((timestamp > 0) == (packet_status == .ok));
 
         env.call_nonvirtual_void_method(
             this_obj,

--- a/src/clients/java/src/main/java/com/tigerbeetle/AccountBalanceBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AccountBalanceBatch.java
@@ -22,8 +22,6 @@ public final class AccountBalanceBatch extends Batch {
         int Reserved = 72;
     }
 
-    static final AccountBalanceBatch EMPTY = new AccountBalanceBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/AccountBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AccountBatch.java
@@ -29,8 +29,6 @@ public final class AccountBatch extends Batch {
         int Timestamp = 120;
     }
 
-    static final AccountBatch EMPTY = new AccountBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/AccountFilterBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/AccountFilterBatch.java
@@ -26,8 +26,6 @@ final class AccountFilterBatch extends Batch {
         int Flags = 124;
     }
 
-    static final AccountFilterBatch EMPTY = new AccountFilterBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/CreateAccountResultBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/CreateAccountResultBatch.java
@@ -18,8 +18,6 @@ public final class CreateAccountResultBatch extends Batch {
         int Result = 4;
     }
 
-    static final CreateAccountResultBatch EMPTY = new CreateAccountResultBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/CreateTransferResultBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/CreateTransferResultBatch.java
@@ -18,8 +18,6 @@ public final class CreateTransferResultBatch extends Batch {
         int Result = 4;
     }
 
-    static final CreateTransferResultBatch EMPTY = new CreateTransferResultBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/IdBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/IdBatch.java
@@ -12,8 +12,6 @@ public final class IdBatch extends Batch {
         int SIZE = 16;
     }
 
-    static final IdBatch EMPTY = new IdBatch(0);
-
     /**
      * Constructs an empty batch of ids with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/QueryFilterBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/QueryFilterBatch.java
@@ -26,8 +26,6 @@ final class QueryFilterBatch extends Batch {
         int Flags = 60;
     }
 
-    static final QueryFilterBatch EMPTY = new QueryFilterBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/main/java/com/tigerbeetle/Request.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Request.java
@@ -48,6 +48,8 @@ abstract class Request<TResponse extends Batch> {
         }
     }
 
+    static final ByteBuffer REPLY_EMPTY = ByteBuffer.allocate(0).asReadOnlyBuffer();
+
     // Used only by the JNI side
     @Native
     private final ByteBuffer sendBuffer;
@@ -111,56 +113,56 @@ abstract class Request<TResponse extends Batch> {
 
                 switch (operation) {
                     case CREATE_ACCOUNTS: {
-                        result = replyBuffer == null ? CreateAccountResultBatch.EMPTY
-                                : new CreateAccountResultBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new CreateAccountResultBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         exception = checkResultLength(result);
                         break;
                     }
 
                     case CREATE_TRANSFERS: {
-                        result = replyBuffer == null ? CreateTransferResultBatch.EMPTY
-                                : new CreateTransferResultBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new CreateTransferResultBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         exception = checkResultLength(result);
                         break;
                     }
 
                     case ECHO_ACCOUNTS:
                     case LOOKUP_ACCOUNTS: {
-                        result = replyBuffer == null ? AccountBatch.EMPTY
-                                : new AccountBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new AccountBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         exception = checkResultLength(result);
                         break;
                     }
 
                     case ECHO_TRANSFERS:
                     case LOOKUP_TRANSFERS: {
-                        result = replyBuffer == null ? TransferBatch.EMPTY
-                                : new TransferBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new TransferBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         exception = checkResultLength(result);
                         break;
                     }
 
                     case GET_ACCOUNT_TRANSFERS: {
-                        result = replyBuffer == null ? TransferBatch.EMPTY
-                                : new TransferBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new TransferBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         break;
                     }
 
                     case GET_ACCOUNT_BALANCES: {
-                        result = replyBuffer == null ? AccountBalanceBatch.EMPTY
-                                : new AccountBalanceBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new AccountBalanceBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         break;
                     }
 
                     case QUERY_ACCOUNTS: {
-                        result = replyBuffer == null ? AccountBatch.EMPTY
-                                : new AccountBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new AccountBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         break;
                     }
 
                     case QUERY_TRANSFERS: {
-                        result = replyBuffer == null ? TransferBatch.EMPTY
-                                : new TransferBatch(ByteBuffer.wrap(replyBuffer));
+                        result = new TransferBatch(
+                                replyBuffer == null ? REPLY_EMPTY : ByteBuffer.wrap(replyBuffer));
                         break;
                     }
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
@@ -30,8 +30,6 @@ public final class TransferBatch extends Batch {
         int Timestamp = 120;
     }
 
-    static final TransferBatch EMPTY = new TransferBatch(0);
-
     /**
      * Creates an empty batch with the desired maximum capacity.
      * <p>

--- a/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
@@ -172,7 +172,7 @@ public class BatchTest {
 
     @Test
     public void testNextEmptyBatch() {
-        var batch = TransferBatch.EMPTY;
+        var batch = new TransferBatch(Request.REPLY_EMPTY);
 
         // Empty batch
         // Expected position = -1 and length = 0

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -2193,7 +2193,7 @@ public class IntegrationTest {
      */
     @Test
     public void testEmptyReply() throws Throwable {
-        final int TASKS_COUNT = 1_000;
+        final int TASKS_COUNT = 100;
 
         try (final var client2 = new Client(clusterId, new String[] {server.getAddress()})) {
             for (int i = 0; i < TASKS_COUNT; i++) {


### PR DESCRIPTION
Since the introduction of `batch.getHeader()` by #2481, we must create a new instance per request instead of sharing the same `Batch.EMPTY` instance.
However, to reduce allocations, the underlying buffer is still a shared empty object.

This PR fixes a problem where concurrent requests with `reply.len == 0` were overriding each other's headers.