### PR TITLE
List: Change order of asserts to clarify failure

### DIFF
--- a/src/list.zig
+++ b/src/list.zig
@@ -67,8 +67,8 @@ pub fn DoublyLinkedListType(
         }
 
         pub fn push(list: *DoublyLinkedList, node: *Node) void {
-            if (constants.verify) list.verify();
             if (constants.verify) assert(!list.contains(node));
+            if (constants.verify) list.verify();
             assert(@field(node, field_back) == null);
             assert(@field(node, field_next) == null);
 
@@ -110,8 +110,8 @@ pub fn DoublyLinkedListType(
         }
 
         pub fn remove(list: *DoublyLinkedList, node: *Node) void {
-            if (constants.verify) list.verify();
             if (constants.verify) assert(list.contains(node));
+            if (constants.verify) list.verify();
             assert(list.count > 0);
             assert(list.tail != null);
 


### PR DESCRIPTION
If a node is (incorrectly) pushed to a list when it is already in the list, then the list will likely fail in `list.verify()` (because the node's back/next pointers would likely have been reset). But it is clearer to fail on `assert(!list.contains(node))` instead.