### PR TITLE
[Java] Call `DetachCurrentThread` when the Client is closed.

### DIFF
--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -773,9 +773,9 @@ const JNIThreadHelper = struct {
     }
 
     // Will be called by the OS with the JVM handler when the thread finalizes.
-    fn destructor_callback(tls_value: *anyopaque) callconv(.C) void {
+    fn destructor_callback(jvm: *anyopaque) callconv(.C) void {
         assert(tls_key != null);
-        JNIHelper.detach_current_thread(@ptrCast(tls_value));
+        JNIHelper.detach_current_thread(@ptrCast(jvm));
     }
 
     /// Thread-local storage abstraction,
@@ -900,10 +900,10 @@ test "JNIThreadHelper:tls" {
             event.wait();
         }
 
-        fn destructor_callback(value: *anyopaque) callconv(.C) void {
+        fn destructor_callback(tls_value: *anyopaque) callconv(.C) void {
             assert(tls_key != null);
 
-            const self: *TestContext = @alignCast(@ptrCast(value));
+            const self: *TestContext = @alignCast(@ptrCast(tls_value));
             _ = self.counter.fetchAdd(1, .monotonic);
         }
     };

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -21,6 +21,7 @@ comptime {
     _ = @import("clients/c/test.zig");
     _ = @import("clients/c/tb_client/echo_client.zig");
     _ = @import("clients/c/tb_client_header_test.zig");
+    _ = @import("clients/java/src/client.zig");
 
     _ = @import("io/test.zig");
 


### PR DESCRIPTION
The thread exit is detected by thread-local storage (TLS) destructors using `pthread_key_create` on POSIX systems and `FlsAlloc` on Windows.