### PR TITLE
VSR: Misc misdirected write + client reply fixes

### DIFF
--- a/src/iops.zig
+++ b/src/iops.zig
@@ -55,7 +55,24 @@ pub fn IOPSType(comptime T: type, comptime size: u6) type {
             }
         };
 
+        pub const IteratorConst = struct {
+            iops: *const IOPS,
+            bitset_iterator: Map.Iterator(.{ .kind = .unset }),
+
+            pub fn next(iterator: *@This()) ?*const T {
+                const i = iterator.bitset_iterator.next() orelse return null;
+                return &iterator.iops.items[i];
+            }
+        };
+
         pub fn iterate(self: *IOPS) Iterator {
+            return .{
+                .iops = self,
+                .bitset_iterator = self.free.iterator(.{ .kind = .unset }),
+            };
+        }
+
+        pub fn iterate_const(self: *const IOPS) IteratorConst {
             return .{
                 .iops = self,
                 .bitset_iterator = self.free.iterator(.{ .kind = .unset }),

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -521,13 +521,13 @@ pub fn ClientRepliesType(comptime Storage: type) type {
         }
 
         fn writes_executing_by_trigger(
-            client_replies: *ClientReplies,
+            client_replies: *const ClientReplies,
             trigger: WriteTrigger,
         ) u32 {
             assert(client_replies.writing.count() + client_replies.write_queue.count ==
                 client_replies.writes.executing());
 
-            var writes = client_replies.writes.iterate();
+            var writes = client_replies.writes.iterate_const();
             var writes_by_trigger: u32 = 0;
             while (writes.next()) |write| {
                 writes_by_trigger += @intFromBool(write.trigger == trigger);

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1312,6 +1312,16 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 });
             }
 
+            for (cases, 0..) |case, index| journal.recover_slot(Slot{ .index = index }, case);
+            assert(cases.len == slot_count);
+
+            stdx.copy_disjoint(
+                .exact,
+                Header.Prepare,
+                journal.headers_redundant,
+                journal.headers,
+            );
+
             // Discard headers which we are certain do not belong in the current log_view.
             // - This ensures that we don't accidentally set our new head op to be a message
             //   which was truncated but not yet overwritten.
@@ -1326,32 +1336,26 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             //
             // (These headers can originate if we join a view, write some prepares from the new
             // view, and then crash before the view_durable_update() finished.)
-            for ([_][]align(constants.sector_size) Header.Prepare{
-                journal.headers_redundant,
-                journal.headers,
-            }) |headers| {
-                for (headers, 0..) |*header_untrusted, index| {
-                    const slot = Slot{ .index = index };
-                    if (header_ok(replica.cluster, slot, header_untrusted)) |header| {
-                        var view_range = view_change_headers.view_for_op(header.op, log_view);
-                        assert(view_range.max <= log_view);
+            for (journal.headers, 0..) |*header_untrusted, index| {
+                const slot = Slot{ .index = index };
+                if (header_ok(replica.cluster, slot, header_untrusted)) |header| {
+                    var view_range = view_change_headers.view_for_op(header.op, log_view);
+                    assert(view_range.max <= log_view);
 
-                        if (header.operation != .reserved and !view_range.contains(header.view)) {
-                            cases[index] = &case_cut_view_range;
-                        }
+                    if (header.operation != .reserved and !view_range.contains(header.view)) {
+                        log.warn("{}: recover_slots: drop header " ++
+                            "view_range={}..{} view={} op={} checksum={}", .{
+                            journal.replica,
+                            view_range.min,
+                            view_range.max,
+                            header.view,
+                            header.op,
+                            header.checksum,
+                        });
+                        journal.remove_entry(slot);
                     }
                 }
             }
-
-            for (cases, 0..) |case, index| journal.recover_slot(Slot{ .index = index }, case);
-            assert(cases.len == slot_count);
-
-            stdx.copy_disjoint(
-                .exact,
-                Header.Prepare,
-                journal.headers_redundant,
-                journal.headers,
-            );
 
             log.debug("{}: recover_slots: dirty={} faulty={}", .{
                 journal.replica,
@@ -1583,24 +1587,26 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             switch (decision) {
                 .eql, .nil => {
                     log.debug("{}: recover_slot: recovered " ++
-                        "slot={:0>4} label={s} decision={s} operation={} op={}", .{
+                        "slot={:0>4} label={s} decision={s} operation={} op={} view={}", .{
                         journal.replica,
                         slot.index,
                         case.label,
                         @tagName(decision),
                         journal.headers[slot.index].operation,
                         journal.headers[slot.index].op,
+                        journal.headers[slot.index].view,
                     });
                 },
                 .fix, .vsr, .cut_torn, .cut_view_range => {
                     log.warn("{}: recover_slot: recovered " ++
-                        "slot={:0>4} label={s} decision={s} operation={} op={}", .{
+                        "slot={:0>4} label={s} decision={s} operation={} op={} view={}", .{
                         journal.replica,
                         slot.index,
                         case.label,
                         @tagName(decision),
                         journal.headers[slot.index].operation,
                         journal.headers[slot.index].op,
+                        journal.headers[slot.index].view,
                     });
                 },
             }
@@ -2296,13 +2302,6 @@ const case_cut_torn = Case{
     .label = "@TruncateTorn",
     .decision_multiple = .cut_torn,
     .decision_single = .cut_torn,
-    .pattern = undefined,
-};
-
-const case_cut_view_range = Case{
-    .label = "@TruncateViewRange",
-    .decision_multiple = .cut_view_range,
-    .decision_single = .cut_view_range,
     .pattern = undefined,
 };
 

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -925,7 +925,10 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 //     this entry it turns out not to have the right op.
                 //   (This case (and the accompanying unnecessary read) could be prevented by
                 //   storing the op along with the checksum in `prepare_checksums`.)
-                assert(slot == null);
+                if (slot) |s| {
+                    journal.faulty.set(s);
+                    journal.dirty.set(s);
+                }
 
                 journal.read_prepare_log(op, checksum, "op changed during read");
                 callback(replica, null, null);
@@ -934,7 +937,10 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
             if (message.header.checksum != checksum) {
                 // This can also be caused by a misdirected read/write.
-                assert(slot == null);
+                if (slot) |s| {
+                    journal.faulty.set(s);
+                    journal.dirty.set(s);
+                }
 
                 journal.read_prepare_log(op, checksum, "checksum changed during read");
                 callback(replica, null, null);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6718,7 +6718,7 @@ pub fn ReplicaType(
         /// The mistake in this example was not that we ignored the break to the left, which we must
         /// do to repair reordered ops, but that we did not check for connection to the right.
         fn repair_header_would_connect_hash_chain(
-            self: *Replica,
+            self: *const Replica,
             header: *const Header.Prepare,
         ) bool {
             var entry = header;
@@ -6745,7 +6745,7 @@ pub fn ReplicaType(
         /// Primary must have no missing headers and no faulty prepares between op_repair_min
         /// and self.op, to maintain the invariant that a replica can repair everything back
         /// till op_repair_min
-        fn primary_journal_repaired(self: *Replica) bool {
+        fn primary_journal_repaired(self: *const Replica) bool {
             assert(self.status == .normal or self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
             assert(self.view == self.log_view);
@@ -6755,7 +6755,7 @@ pub fn ReplicaType(
                 self.primary_journal_prepares_repaired();
         }
 
-        fn primary_journal_prepares_repaired(self: *Replica) bool {
+        fn primary_journal_prepares_repaired(self: *const Replica) bool {
             assert(self.status == .normal or self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
             assert(self.view == self.log_view);
@@ -6771,7 +6771,7 @@ pub fn ReplicaType(
             return true;
         }
 
-        fn primary_journal_headers_repaired(self: *Replica) bool {
+        fn primary_journal_headers_repaired(self: *const Replica) bool {
             assert(self.status == .normal or self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
             assert(self.view == self.log_view);
@@ -8914,6 +8914,7 @@ pub fn ReplicaType(
                     if (primary_repairing or op > view_headers_op_max) break :header null;
 
                     const header = &self.view_headers.array.const_slice()[view_headers_op_max - op];
+                    assert(header.op == op);
                     break :header switch (vsr.Headers.dvc_header_type(header)) {
                         .valid => header,
                         .blank => null,


### PR DESCRIPTION
These are all fixes for bugs found by [VOPR misdirected write fault injection](https://github.com/tigerbeetle/tigerbeetle/pull/2463). (I am upstreaming the fixes in advance while still working out liveness issues with the fault injection.)

I recommended reviewing this PR commit-by-commit.

Note that the seeds mentioned in the respective commit messages won't work on this branch -- they require the fault injection of https://github.com/tigerbeetle/tigerbeetle/pull/2463.

The bugs are:
- [Journal: Fix assertion after misdirected read/write](https://github.com/tigerbeetle/tigerbeetle/commit/417a23f2b1304b8f5030ab7d3fb3a6332de4444c)
- [Journal: Don't cut_view_range for redundant headers](https://github.com/tigerbeetle/tigerbeetle/commit/cc4927e4748f872e979f918ef029b9018477aa8b): This is a correctness bug.
- [VSR: Fix ClientReplies write/checkpoint race](https://github.com/tigerbeetle/tigerbeetle/commit/c0ee15983a68baeebff1be48c7d3cc97396ce4f1): Unrelated to misdirected writes -- that same PR adds more corruption to the client replies zone, which revealed this race.