### PR TITLE
VOPR: Bump vopr-lite `requests_max`

### DIFF
--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -11,7 +11,7 @@ const Message = @import("../message_pool.zig").MessagePool.Message;
 const log = std.log.scoped(.aof);
 
 // Arbitrary value.
-const backing_size = 32 * 1024 * 1024;
+const backing_size = 384 * 1024 * 1024;
 
 const InMemoryAOF = struct {
     backing_store: []align(constants.sector_size) u8,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -411,6 +411,8 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
         .in_flight_max = ReplySequence.stalled_queue_capacity,
     });
 
+    const simulator_requests_max = constants.journal_slot_count * 1000;
+
     return .{
         .cluster = cluster_options,
         .network = network_options,
@@ -431,7 +433,7 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
         .replica_release_advance_probability = ratio(1, 1_000_000),
         .replica_release_catchup_probability = ratio(1, 100_000),
 
-        .requests_max = constants.journal_slot_count * 3,
+        .requests_max = simulator_requests_max,
         .request_probability = ratio(prng.range_inclusive(u8, 1, 100), 100),
         .request_idle_on_probability = ratio(prng.range_inclusive(u8, 0, 20), 100),
         .request_idle_off_probability = ratio(prng.range_inclusive(u8, 10, 20), 100),
@@ -443,6 +445,7 @@ fn options_lite(prng: *stdx.PRNG) Simulator.Options {
     base.cluster.replica_count = 3;
     base.cluster.standby_count = 0;
     base.network.node_count = 3;
+    base.requests_max = constants.journal_slot_count * 50;
     return base;
 }
 


### PR DESCRIPTION
Since vopr-lite is green, bump up the `requests_max` to see what happens.