### PR TITLE
vopr: implement pauses 

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -82,7 +82,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             /// A monotonically-increasing list of releases.
             /// Initially:
             /// - All replicas are formatted and started with releases[0].
-            /// - Only releases[0] is "bundled" in each replica. (Use `restart_replica()` to add
+            /// - Only releases[0] is "bundled" in each replica. (Use `replica_restart()` to add
             ///   more).
             releases: []const Release,
             client_release: vsr.Release,
@@ -453,7 +453,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 } else {
                     // Upgrades immediately follow storage.tick(), since upgrades occur at
                     // checkpoint completion. (Downgrades are triggered separately – see
-                    // restart_replica()).
+                    // replica_restart()).
                     storage.tick();
                     if (upgrade.*) |_| cluster.replica_release_execute(@intCast(i));
                     assert(upgrade.* == null);
@@ -489,7 +489,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         }
 
         /// Returns an error when the replica was unable to recover (open).
-        pub fn restart_replica(
+        pub fn replica_restart(
             cluster: *Cluster,
             replica_index: u8,
             releases_bundled: *const vsr.ReleaseList,
@@ -520,7 +520,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         /// Reset a replica to its initial state, simulating a random crash/panic.
         /// Leave the persistent storage untouched, and leave any currently
         /// inflight messages to/from the replica in the network.
-        pub fn crash_replica(cluster: *Cluster, replica_index: u8) void {
+        pub fn replica_crash(cluster: *Cluster, replica_index: u8) void {
             assert(cluster.replica_health[replica_index] == .up);
 
             // Reset the storage before the replica so that pending writes can (partially) finish.
@@ -636,7 +636,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 release,
             });
 
-            cluster.crash_replica(replica_index);
+            cluster.replica_crash(replica_index);
 
             const release_available = for (replica.releases_bundled.const_slice()) |r| {
                 if (r.value == release.value) break true;

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -618,7 +618,7 @@ pub const Simulator = struct {
         while (it.next()) |replica_index| {
             const fault = false;
             if (simulator.cluster.replica_health[replica_index] == .down) {
-                simulator.restart_replica(@intCast(replica_index), fault);
+                simulator.replica_restart(@intCast(replica_index), fault);
             }
             simulator.cluster.storages[replica_index].transition_to_liveness_mode();
         }
@@ -1055,7 +1055,7 @@ pub const Simulator = struct {
         if (!crash_upgrade and !crash_random) return;
 
         log.debug("{}: crash replica", .{replica.replica});
-        simulator.cluster.crash_replica(replica.replica);
+        simulator.cluster.replica_crash(replica.replica);
 
         simulator.replica_crash_stability[replica.replica] =
             simulator.options.replica_crash_stability;
@@ -1090,11 +1090,11 @@ pub const Simulator = struct {
         // To improve VOPR utilization, try to prevent the replica from going into
         // `.recovering_head` state if the replica is needed to form a quorum.
         const fault = recoverable_count >= recoverable_count_min or replica.standby();
-        simulator.restart_replica(replica.replica, fault);
+        simulator.replica_restart(replica.replica, fault);
         maybe(!fault and replica.status == .recovering_head);
     }
 
-    fn restart_replica(simulator: *Simulator, replica_index: u8, fault: bool) void {
+    fn replica_restart(simulator: *Simulator, replica_index: u8, fault: bool) void {
         assert(simulator.cluster.replica_health[replica_index] == .down);
 
         const replica_storage = &simulator.cluster.storages[replica_index];
@@ -1155,7 +1155,7 @@ pub const Simulator = struct {
         }
 
         replica_storage.faulty = fault;
-        simulator.cluster.restart_replica(
+        simulator.cluster.replica_restart(
             replica_index,
             &replica_releases,
         ) catch unreachable;

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -226,8 +226,15 @@ pub fn main() !void {
         .replica_crash_stability = random.uintLessThan(u32, 1_000),
         .replica_restart_probability = 0.0002,
         .replica_restart_stability = random.uintLessThan(u32, 1_000),
+
+        .replica_pause_probability = 0.00008,
+        .replica_pause_stability = random.uintLessThan(u32, 1_000),
+        .replica_unpause_probability = 0.0008,
+        .replica_unpause_stability = random.uintLessThan(u32, 1_000),
+
         .replica_release_advance_probability = 0.0001,
         .replica_release_catchup_probability = 0.001,
+
         .requests_max = constants.journal_slot_count * 3,
         .request_probability = 1 + random.uintLessThan(u8, 99),
         .request_idle_on_probability = random.uintLessThan(u8, 20),
@@ -400,6 +407,12 @@ pub const Simulator = struct {
         replica_restart_probability: f64,
         /// Minimum time a replica is up until it is crashed again.
         replica_restart_stability: u32,
+
+        replica_pause_probability: f64,
+        replica_pause_stability: u32,
+        replica_unpause_probability: f64,
+        replica_unpause_stability: u32,
+
         /// Probability per tick that a healthy replica will be crash-upgraded.
         /// This probability is set to 0 during liveness mode.
         replica_release_advance_probability: f64,
@@ -428,7 +441,7 @@ pub const Simulator = struct {
     replica_releases_limit: usize = 1,
 
     /// Protect a replica from fast successive crash/restarts.
-    replica_stability: []usize,
+    replica_crash_stability: []usize,
     reply_sequence: ReplySequence,
     reply_op_next: u64 = 1, // Skip the root op.
 
@@ -472,12 +485,12 @@ pub const Simulator = struct {
         errdefer allocator.free(replica_releases);
         @memset(replica_releases, 1);
 
-        const replica_stability = try allocator.alloc(
+        const replica_crash_stability = try allocator.alloc(
             usize,
             options.cluster.replica_count + options.cluster.standby_count,
         );
-        errdefer allocator.free(replica_stability);
-        @memset(replica_stability, 0);
+        errdefer allocator.free(replica_crash_stability);
+        @memset(replica_crash_stability, 0);
 
         var reply_sequence = try ReplySequence.init(allocator);
         errdefer reply_sequence.deinit(allocator);
@@ -488,14 +501,14 @@ pub const Simulator = struct {
             .cluster = cluster,
             .workload = workload,
             .replica_releases = replica_releases,
-            .replica_stability = replica_stability,
+            .replica_crash_stability = replica_crash_stability,
             .reply_sequence = reply_sequence,
         };
     }
 
     pub fn deinit(simulator: *Simulator, allocator: std.mem.Allocator) void {
         allocator.free(simulator.replica_releases);
-        allocator.free(simulator.replica_stability);
+        allocator.free(simulator.replica_crash_stability);
         simulator.reply_sequence.deinit(allocator);
         simulator.workload.deinit(allocator);
         simulator.cluster.deinit();
@@ -581,6 +594,7 @@ pub const Simulator = struct {
         simulator.cluster.tick();
         simulator.tick_requests();
         simulator.tick_crash();
+        simulator.tick_pause();
     }
 
     /// Executes the following:
@@ -1013,12 +1027,13 @@ pub const Simulator = struct {
 
     fn tick_crash(simulator: *Simulator) void {
         for (simulator.cluster.replicas) |*replica| {
-            simulator.replica_stability[replica.replica] -|= 1;
-            const stability = simulator.replica_stability[replica.replica];
-            if (stability > 0) continue;
+            simulator.replica_crash_stability[replica.replica] -|= 1;
+            if (simulator.replica_crash_stability[replica.replica] > 0) continue;
 
             switch (simulator.cluster.replica_health[replica.replica]) {
-                .up => simulator.tick_crash_up(replica),
+                .up => |up| {
+                    if (!up.paused) simulator.tick_crash_up(replica);
+                },
                 .down => simulator.tick_crash_down(replica),
             }
         }
@@ -1042,7 +1057,7 @@ pub const Simulator = struct {
         log.debug("{}: crash replica", .{replica.replica});
         simulator.cluster.crash_replica(replica.replica);
 
-        simulator.replica_stability[replica.replica] =
+        simulator.replica_crash_stability[replica.replica] =
             simulator.options.replica_crash_stability;
     }
 
@@ -1151,7 +1166,7 @@ pub const Simulator = struct {
         }
 
         replica_storage.faulty = true;
-        simulator.replica_stability[replica_index] =
+        simulator.replica_crash_stability[replica_index] =
             simulator.options.replica_restart_stability;
     }
 
@@ -1160,6 +1175,40 @@ pub const Simulator = struct {
             @min(simulator.replica_releases[replica_index] + 1, releases.len);
         simulator.replica_releases_limit =
             @max(simulator.replica_releases[replica_index], simulator.replica_releases_limit);
+    }
+
+    // Randomly pause replicas. A paused replica doesn't tick and doesn't complete any asynchronous
+    // work. The goals of pausing are:
+    // - catch more interesting interleaving of events,
+    // - simulate real-world scenario of VM migration.
+    fn tick_pause(simulator: *Simulator) void {
+        for (
+            simulator.cluster.replicas,
+            simulator.replica_crash_stability,
+            0..,
+        ) |*replica, *stability, replica_index| {
+            stability.* -|= 1;
+            if (stability.* > 0) continue;
+
+            if (simulator.cluster.replica_health[replica.replica] == .down) continue;
+            const paused = simulator.cluster.replica_health[replica.replica].up.paused;
+            const pause = chance_f64(
+                simulator.random,
+                simulator.options.replica_pause_probability,
+            );
+            const unpause = chance_f64(
+                simulator.random,
+                simulator.options.replica_unpause_probability,
+            );
+
+            if (!paused and pause) {
+                simulator.cluster.replica_pause(@intCast(replica_index));
+                stability.* = simulator.options.replica_pause_stability;
+            } else if (paused and unpause) {
+                simulator.cluster.replica_unpause(@intCast(replica_index));
+                stability.* = simulator.options.replica_unpause_stability;
+            }
+        }
     }
 
     fn requests_cancelled(simulator: *const Simulator) u32 {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -715,7 +715,10 @@ pub fn ReplicaType(
                 // that SV to a DVC (dropping the hooks), and never finished the view change.
                 if (op_head == null) {
                     assert(self.view > self.log_view);
-                    if (self.journal.op_maximum() < self.op_checkpoint()) {
+                    if (self.journal.op_maximum() < self.op_checkpoint() or
+                        // Corrupted root prepare:
+                        (self.journal.op_maximum() == 0 and self.journal.header_with_op(0) == null))
+                    {
                         const header_checkpoint =
                             &self.superblock.working.vsr_state.checkpoint.header;
                         assert(header_checkpoint.op == self.op_checkpoint());

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2095,10 +2095,15 @@ const TestReplicas = struct {
         return t.replicas.get(0);
     }
 
-    pub fn health(t: *const TestReplicas) ReplicaHealth {
-        var value_all: ?ReplicaHealth = null;
+    const Health = enum { up, down };
+
+    pub fn health(t: *const TestReplicas) Health {
+        var value_all: ?Health = null;
         for (t.replicas.const_slice()) |r| {
-            const value = t.cluster.replica_health[r];
+            const value: Health = switch (t.cluster.replica_health[r]) {
+                .up => .up,
+                .down => .down,
+            };
             if (value_all) |all| {
                 assert(all == value);
             } else {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2039,7 +2039,7 @@ const TestReplicas = struct {
     pub fn stop(t: *const TestReplicas) void {
         for (t.replicas.const_slice()) |r| {
             log.info("{}: crash replica", .{r});
-            t.cluster.crash_replica(r);
+            t.cluster.replica_crash(r);
 
             // For simplicity, ensure that any packets that are in flight to this replica are
             // discarded before it starts up again.
@@ -2053,7 +2053,7 @@ const TestReplicas = struct {
     pub fn open(t: *const TestReplicas) !void {
         for (t.replicas.const_slice()) |r| {
             log.info("{}: restart replica", .{r});
-            t.cluster.restart_replica(
+            t.cluster.replica_restart(
                 r,
                 t.cluster.replicas[r].releases_bundled,
             ) catch |err| {
@@ -2079,7 +2079,7 @@ const TestReplicas = struct {
 
         for (t.replicas.const_slice()) |r| {
             log.info("{}: restart replica", .{r});
-            t.cluster.restart_replica(r, &releases_bundled) catch |err| {
+            t.cluster.replica_restart(r, &releases_bundled) catch |err| {
                 assert(t.replicas.count() == 1);
                 return switch (err) {
                     error.WALCorrupt => return error.WALCorrupt,


### PR DESCRIPTION
Adds a new failure mode for VOPR --- pausing a machine. This can uncover
new interesting interleaving and also models VM migration scenario.

To model the latter case faithfully, we tick the time even if the
machine is paused.

This is vopr-lite green a 450_357 seeds