### PR TITLE
LSM/CacheMap: Scoped insert may be evicted into stash

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -157,7 +157,8 @@ pub fn CacheMapType(
                 } else {
                     // If it was an insert, append a tombstone to the scope rollback log.
                     const key = key_from_value(value);
-                    self.scope_rollback_log.appendAssumeCapacity(tombstone_from_key(key));
+                    const key_tombstone = tombstone_from_key(key);
+                    self.scope_rollback_log.appendAssumeCapacity(key_tombstone);
                 }
             }
         }

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -157,9 +157,7 @@ pub fn CacheMapType(
                 } else {
                     // If it was an insert, append a tombstone to the scope rollback log.
                     const key = key_from_value(value);
-                    self.scope_rollback_log.appendAssumeCapacity(
-                        tombstone_from_key(key),
-                    );
+                    self.scope_rollback_log.appendAssumeCapacity(tombstone_from_key(key));
                 }
             }
         }
@@ -282,15 +280,12 @@ pub fn CacheMapType(
 
                     // A tombstone in the rollback log can only occur when the value doesn't exist
                     // in _both_ the cache and stash on insert.
-                    if (self.cache) |*cache| {
-                        // If we have cache enabled, it must be there.
-                        const cache_removed = cache.remove(key) != null;
-                        assert(cache_removed);
-                    }
+                    const cache_removed =
+                        if (self.cache) |*cache| cache.remove(key) != null else false;
 
-                    // It should be in the stash _iif_ we don't have cache enabled.
+                    // The key should be in the stash iff it wasn't in the cache.
                     const stash_removed = self.stash_remove(key) != null;
-                    assert(stash_removed == (self.cache == null));
+                    assert(stash_removed != cache_removed);
                 } else {
                     // Reverting an update or delete consists of an insert of the original value.
                     self.upsert(rollback_value);

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -374,16 +374,13 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
                 break :blk FuzzOp{ .compact = {} };
             },
             .scope => blk: {
-                if (!scope_is_open) {
-                    scope_is_open = true;
-                    operations_since_scope_open = 0;
+                operations_since_scope_open = 0;
+                defer scope_is_open = !scope_is_open;
 
-                    break :blk FuzzOp{ .scope = .open };
-                } else {
-                    scope_is_open = false;
-                    operations_since_scope_open = 0;
-
+                if (scope_is_open) {
                     break :blk FuzzOp{ .scope = if (random.boolean()) .persist else .discard };
+                } else {
+                    break :blk FuzzOp{ .scope = .open };
                 }
             },
         };

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -13,6 +13,11 @@ const log = std.log.scoped(.lsm_cache_map_fuzz);
 const Key = TestTable.Key;
 const Value = TestTable.Value;
 
+const map_value_count_max = 1024;
+// Use a large scope (relative to map_value_count_max) to increase the chances of
+// (SetAssociativeCache) hash collisions.
+const scope_value_count_max = map_value_count_max;
+
 const OpValue = struct {
     op: u32,
     value: Value,
@@ -307,9 +312,9 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
     //       the maximum capacity...?
     var op: u64 = 0;
     var operations_since_scope_open: usize = 0;
-    const operations_since_scope_open_max: usize = 32;
+    const operations_since_scope_open_max: usize = scope_value_count_max;
     var upserts_since_compact: usize = 0;
-    const upserts_since_compact_max: usize = 1024;
+    const upserts_since_compact_max: usize = map_value_count_max;
     var scope_is_open = false;
     for (fuzz_ops, 0..) |*fuzz_op, i| {
         var fuzz_op_tag: FuzzOpTag = undefined;
@@ -392,8 +397,8 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     const random = rng.random();
 
     const fuzz_op_count = @min(
-        fuzz_args.events_max orelse @as(usize, 1E7),
-        fuzz.random_int_exponential(random, usize, 1E6),
+        fuzz_args.events_max orelse @as(usize, 1E9),
+        fuzz.random_int_exponential(random, usize, 1E8),
     );
 
     const fuzz_ops = try generate_fuzz_ops(random, fuzz_op_count);
@@ -403,8 +408,8 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     inline for (&.{ TestCacheMap.Cache.value_count_max_multiple, 0 }) |cache_value_count_max| {
         const options = TestCacheMap.Options{
             .cache_value_count_max = cache_value_count_max,
-            .map_value_count_max = 1024,
-            .scope_value_count_max = 32,
+            .map_value_count_max = map_value_count_max,
+            .scope_value_count_max = scope_value_count_max,
             .name = "fuzz map",
         };
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -1,3 +1,5 @@
+// TODO Test scope_open/scope_close.
+
 const std = @import("std");
 const testing = std.testing;
 const assert = std.debug.assert;


### PR DESCRIPTION
This crash was originally found by a [VOPR running with extra requests](https://github.com/tigerbeetle/tigerbeetle/pull/2508).
The cache map fuzzer with this branch's [modifications](https://github.com/tigerbeetle/tigerbeetle/pull/2513/commits/95ca2f70d069f3e0d81f490f85890a723418b904) can find it now as well.

## Bug

Consider this scenario for the transfers `CacheMap`:

1. `cache_map.scope_open()` (A linked transfer begins.)
2. `cache_map.upsert(.{ .key = 123 })`. This is an insert (the key does not already exist in the database), so we also `self.scope_rollback_log.appendAssumeCapacity(tombstone_from_key(key));`.
3. `cache_map.upsert(.{ .key = 456 })`.
    - Suppose `456` collides with `123` in the `SetAssociativeCache`, and the `123` insert is evicted from the cache.
    - Then `123`'s value is moved into the stash.
4. `cache_map.scope_close(.discard)` (The linked transfer fails and is rolled back).

In `cache_map.scope_close()`, we iterate the rollback log...

```zig
// The scope_rollback_log stores the operations we need to reverse the changes a scope
// made. They get replayed in reverse order.
var i: usize = self.scope_rollback_log.items.len;
while (i > 0) {
    i -= 1;
```

... when we reach the tombstone for `123` in our rollback log...

```zig
    const rollback_value = &self.scope_rollback_log.items[i];
    if (tombstone(rollback_value)) {
        // Reverting an insert consists of a .remove call.
        // The value in here will be a tombstone indicating the original value didn't
        // exist.
        const key = key_from_value(rollback_value);

        // A tombstone in the rollback log can only occur when the value doesn't exist
        // in _both_ the cache and stash on insert.
        if (self.cache) |*cache| {
```

... we find that `123` isn't in the cache (`!cache_removed`), so we panic:

```zig
            // If we have cache enabled, it must be there.
            const cache_removed = cache.remove(key) != null;
            assert(cache_removed);
        }
```

It is actually in the stash instead:

```zig
        // It should be in the stash _iif_ we don't have cache enabled.
        const stash_removed = self.stash_remove(key) != null;
        assert(stash_removed == (self.cache == null));
    } else {
        // Reverting an update or delete consists of an insert of the original value.
        self.upsert(rollback_value);
    }
}
```

<details>
<summary>Stack trace</summary>

    /var/home/djg/C/t/db/review/src/lsm/cache_map.zig:293:31: 0x159e6f3 in scope_close (vopr)
                            assert(cache_removed);
                                  ^
    /var/home/djg/C/t/db/review/src/lsm/groove.zig:1399:45: 0x154d500 in scope_close (vopr)
                groove.objects_cache.scope_close(mode);
                                                ^
    /var/home/djg/C/t/db/review/src/state_machine.zig:1565:62: 0x1504fce in scope_close (vopr)
                        self.forest.grooves.transfers.scope_close(mode);
                                                                 ^
    /var/home/djg/C/t/db/review/src/state_machine.zig:1652:45: 0x14d1174 in execute_create__anon_29789 (vopr)
                                self.scope_close(operation, .discard);
                                                ^
    /var/home/djg/C/t/db/review/src/state_machine.zig:1490:57: 0x147abad in commit (vopr)

</details>

## Fix

A tombstone in the rollback log means that there is a value in the cache *xor* in the stash.

## Why didn't we find this bug sooner?

- **Why didn't the VOPR find this bug?** The bug requires a cache collision (between two values both inserted in the same scope) and a linked transfer rollback – each of these are rare events in the VOPR.
- **Why didn't forest or tree fuzzers find this bug?** They don't test scopes. (Added a TODO.)
- **Why didn't cache map fuzzer find this bug?** Scopes were limited to 32 updates and hash collisions are rare. The fuzzer is now updated to use larger scopes, so it is capable of finding this bug.