### PR TITLE
Vortex: support tracing and check liveness

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -515,21 +515,14 @@ test "vortex smoke" {
     });
     defer shell.cwd.deleteTree(script_path) catch {};
 
-    const trace_path = try shell.fmt("./.zig-cache/tmp/{}.json", .{
-        std.crypto.random.int(u64),
-    });
-    defer shell.cwd.deleteTree(trace_path) catch {};
-
     const script_contents = try shell.fmt(
         \\ ip link set up dev lo && \
         \\   {s} supervisor \
         \\   --test-duration-minutes=1 \
-        \\   --tigerbeetle-executable={s} \
-        \\   --trace={s}
+        \\   --tigerbeetle-executable={s}
     , .{
         vortex_exe,
         tigerbeetle,
-        trace_path,
     });
     _ = try shell.cwd.writeFile(.{
         .sub_path = script_path,

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -515,14 +515,21 @@ test "vortex smoke" {
     });
     defer shell.cwd.deleteTree(script_path) catch {};
 
+    const trace_path = try shell.fmt("./.zig-cache/tmp/{}.json", .{
+        std.crypto.random.int(u64),
+    });
+    defer shell.cwd.deleteTree(trace_path) catch {};
+
     const script_contents = try shell.fmt(
         \\ ip link set up dev lo && \
         \\   {s} supervisor \
         \\   --test-duration-minutes=1 \
-        \\   --tigerbeetle-executable={s}
+        \\   --tigerbeetle-executable={s} \
+        \\   --trace={s}
     , .{
         vortex_exe,
         tigerbeetle,
+        trace_path,
     });
     _ = try shell.cwd.writeFile(.{
         .sub_path = script_path,

--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const constants = @import("../../constants.zig");
 
 pub usingnamespace constants;
@@ -9,7 +10,7 @@ pub const connections_count_max = @divFloor(constants.clients_max, replica_count
 // We allow the cluster to not make progress processing requests for this amount of time. After
 // that it's considered a test failure.
 pub const liveness_requirement_seconds = 120;
-pub const liveness_requirement_micros = liveness_requirement_seconds * 1_000_000;
+pub const liveness_requirement_micros = liveness_requirement_seconds * std.time.us_per_s;
 
 // How many replicas can be faulty while still expecting the cluster to make progress (based on
 // 2f+1).

--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -5,3 +5,11 @@ pub usingnamespace constants;
 pub const cluster_id = 1;
 pub const replica_count = 3;
 pub const connections_count_max = @divFloor(constants.clients_max, replica_count);
+
+// We allow the cluster to not make progress processing requests for this amount of time. After
+// that it's considered a test failure.
+pub const liveness_requirement_seconds = 120;
+
+// How many replicas can be faulty while still expecting the cluster to make progress (based on
+// 2f+1).
+pub const liveness_faulty_replicas_max = @divFloor(replica_count - 1, 2);

--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -9,6 +9,7 @@ pub const connections_count_max = @divFloor(constants.clients_max, replica_count
 // We allow the cluster to not make progress processing requests for this amount of time. After
 // that it's considered a test failure.
 pub const liveness_requirement_seconds = 120;
+pub const liveness_requirement_micros = liveness_requirement_seconds * 1_000_000;
 
 // How many replicas can be faulty while still expecting the cluster to make progress (based on
 // 2f+1).

--- a/src/testing/vortex/logged_process.zig
+++ b/src/testing/vortex/logged_process.zig
@@ -17,6 +17,10 @@ const LoggedProcess = @This();
 pub const State = enum(u8) { running, stopped, terminated };
 const AtomicState = std.atomic.Value(State);
 
+const Options = struct {
+    stdout_behavior: std.process.Child.StdIo = .Ignore,
+};
+
 // Allocated by init
 child: std.process.Child,
 stdin_thread: std.Thread,
@@ -28,6 +32,7 @@ current_state: AtomicState,
 pub fn spawn(
     allocator: std.mem.Allocator,
     argv: []const []const u8,
+    options: Options,
 ) !*LoggedProcess {
     const self = try allocator.create(LoggedProcess);
     errdefer allocator.destroy(self);
@@ -40,7 +45,7 @@ pub fn spawn(
     };
 
     self.child.stdin_behavior = .Pipe;
-    self.child.stdout_behavior = .Ignore;
+    self.child.stdout_behavior = options.stdout_behavior;
     self.child.stderr_behavior = .Inherit;
 
     try self.child.spawn();

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -958,9 +958,10 @@ const Workload = struct {
     fn find_slow_request_since(workload: *const Workload, start_ns: u64) ?RequestInfo {
         var it = workload.requests_finished.iterator();
         while (it.next()) |request| {
+            assert(request.timestamp_start_micros < request.timestamp_end_micros);
             // If a request started before the acceptably-faulty period, we ignore that part of
             // its duration.
-            const duration_adjusted = request.timestamp_end_micros -
+            const duration_adjusted = request.timestamp_end_micros -|
                 @max(request.timestamp_start_micros, @divFloor(start_ns, 1000));
             if (duration_adjusted > constants.liveness_requirement_micros) return request;
         }

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -956,9 +956,9 @@ const Workload = struct {
             assert(request.timestamp_start_micros < request.timestamp_end_micros);
             // If a request started before the acceptably-faulty period, we ignore that part of
             // its duration.
-            const duration_adjusted = request.timestamp_end_micros -|
+            const duration_adjusted_micros = request.timestamp_end_micros -|
                 @max(request.timestamp_start_micros, @divFloor(start_ns, 1000));
-            if (duration_adjusted > constants.liveness_requirement_micros) return request;
+            if (duration_adjusted_micros > constants.liveness_requirement_micros) return request;
         }
         return null;
     }


### PR DESCRIPTION
This PR adds two things:

1. the ability to trace Vortex test runs
2. a liveness check

Both additions are based on a new progress event sent by the workload on stdout. The supervisor reads those and tracks finished requests and event counts.

## Tracing

Tracing is done with Chrome's [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.yr4qxyxotyw), which can be viewed in Chromium/Chrome by visiting `chrome://tracing`. Use WASD keys to move around and the tools at hotkeys 1-4.

Traces are enabled by passing the `--trace=<output path>` option to Vortex.

Here's a screenshot of how a trace might look.

![tracing](https://github.com/user-attachments/assets/811143e3-7729-4fd0-939d-1f02d802e08c)

## Liveness Checking

The progress events, in combination with the state of process and network faults controlled by the supervisor, is used to implement the liveness check. During _acceptably_ faulty periods we require some requests to finish after a certain amount of time (120 seconds). If there are network faults, which are currently global, or if there are more than `f` process faults (based on the `2f+1` equation), the liveness check is disabled.

Here's a case where a request took over 2 minutes to complete (in an acceptably faulty state), failing the test:

![image](https://github.com/user-attachments/assets/ad7f1efd-c324-4b36-a2a1-b2f72b39f941)

_(this was screenshot before I fixed the recording of the last request, so there's a lengthy yellow request bar missing)_
