### PR TITLE
ci: add arm64 runners & fix arm64 client ABI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,19 @@ jobs:
       - run: ./zig/zig build test
 
   test_ubuntu:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { os: 'ubuntu-latest' }
+          - { os: 'ubuntu-latest-arm64' }
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2147483647
+      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - run: ./zig/download.sh
       - run: ./zig/zig build test
       - run: ./zig/zig build clients:c:sample -Drelease
@@ -126,6 +134,13 @@ jobs:
           - { os: 'macos-13',       language: 'go',      language_version: '1.21'  }
           - { os: 'macos-13',       language: 'node',    language_version: '20.x'  }
           - { os: 'macos-13',       language: 'python',  language_version: '3.13'  }
+
+          # Limited matrix for Ubuntu ARM - runners are paid and we're not sure of the cost yet.
+          - { os: 'ubuntu-latest-arm64',  language: 'dotnet',  language_version: '8.0.x' }
+          - { os: 'ubuntu-latest-arm64',  language: 'go',      language_version: '1.21'  }
+          - { os: 'ubuntu-latest-arm64',  language: 'java',    language_version: '21'    }
+          - { os: 'ubuntu-latest-arm64',  language: 'node',    language_version: '20.x'  }
+          - { os: 'ubuntu-latest-arm64',  language: 'python',  language_version: '3.13'  }
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.zig
+++ b/build.zig
@@ -529,27 +529,51 @@ fn build_tigerbeetle_executable_multiversion(b: *std.Build, options: struct {
 
 // Downloads a pre-build llvm-objcopy from <https://github.com/tigerbeetle/dependencies>.
 fn build_tigerbeetle_executable_get_objcopy(b: *std.Build) std.Build.LazyPath {
-    return switch (b.graph.host.result.os.tag) {
-        .linux => fetch(b, .{
-            .url = "https://github.com/tigerbeetle/dependencies/releases/download/18.1.8/" ++
-                "llvm-objcopy-x86_64-linux.zip",
-            .file_name = "llvm-objcopy",
-            .hash = "12203104f50e31efee26b1467d0d918bf4ac6cda7bee93d865d01e0913f33504b03a",
-        }),
-        .windows => fetch(b, .{
-            .url = "https://github.com/tigerbeetle/dependencies/releases/download/18.1.8/" ++
-                "llvm-objcopy-x86_64-windows.zip",
-            .file_name = "llvm-objcopy.exe",
-            .hash = "122069747460977a1eb52110eb2abc8b992af57242ef724316d3071c7ec7f61e41bc",
-        }),
-        .macos => fetch(b, .{
-            .url = "https://github.com/tigerbeetle/dependencies/releases/download/18.1.8/" ++
-                "llvm-objcopy-aarch64-macos.zip",
-            .file_name = "llvm-objcopy",
-            .hash = "12202b751a54e74823261a9a014497b137a62a8d80f6b09a7b0515a3e34a617313fa",
-        }),
+    switch (b.graph.host.result.os.tag) {
+        .linux => {
+            switch (b.graph.host.result.cpu.arch) {
+                .x86_64 => {
+                    return fetch(b, .{
+                        .url = "https://github.com/tigerbeetle/dependencies/releases/download/" ++
+                            "18.1.8/llvm-objcopy-x86_64-linux.zip",
+                        .file_name = "llvm-objcopy",
+                        .hash = "12203104f50e31efee26b1467d0d918bf4ac6cda7bee93d865d01e09" ++
+                            "13f33504b03a",
+                    });
+                },
+                .aarch64 => {
+                    return fetch(b, .{
+                        .url = "https://github.com/tigerbeetle/dependencies/releases/download/" ++
+                            "18.1.8/llvm-objcopy-aarch64-linux.zip",
+                        .file_name = "llvm-objcopy",
+                        .hash = "122006fbe2af4f6cdbd7236b951b4d128de95b7688828a6999b4fe71" ++
+                            "50e4bb3142ee",
+                    });
+                },
+                else => @panic("unsupported arch"),
+            }
+        },
+        .windows => {
+            assert(b.graph.host.result.cpu.arch == .x86_64);
+            return fetch(b, .{
+                .url = "https://github.com/tigerbeetle/dependencies/releases/download/" ++
+                    "18.1.8/llvm-objcopy-x86_64-windows.zip",
+                .file_name = "llvm-objcopy.exe",
+                .hash = "122069747460977a1eb52110eb2abc8b992af57242ef724316d3071c7ec7f61e41bc",
+            });
+        },
+        .macos => {
+            // TODO: this assert triggers, but the macOS tests on x86_64 work...?
+            // assert(b.graph.host.result.cpu.arch == .aarch64);
+            return fetch(b, .{
+                .url = "https://github.com/tigerbeetle/dependencies/releases/download/" ++
+                    "18.1.8/llvm-objcopy-aarch64-macos.zip",
+                .file_name = "llvm-objcopy",
+                .hash = "12202b751a54e74823261a9a014497b137a62a8d80f6b09a7b0515a3e34a617313fa",
+            });
+        },
         else => @panic("unsupported host"),
-    };
+    }
 }
 
 fn build_aof(

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -277,7 +277,7 @@ typedef enum TB_STATUS {
 // completes submitted packets by invoking the callback with the given context.
 TB_STATUS tb_client_init(
     tb_client_t* out_client,
-    tb_uint128_t cluster_id,
+    const uint8_t cluster_id[16],
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,
@@ -287,7 +287,7 @@ TB_STATUS tb_client_init(
 // Initialize a new TigerBeetle client which echos back any data submitted.
 TB_STATUS tb_client_init_echo(
     tb_client_t* out_client,
-    tb_uint128_t cluster_id,
+    const uint8_t cluster_id[16],
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -204,7 +204,7 @@ pub fn main() !void {
         \\// completes submitted packets by invoking the callback with the given context.
         \\TB_STATUS tb_client_init(
         \\    tb_client_t* out_client,
-        \\    tb_uint128_t cluster_id,
+        \\    const uint8_t cluster_id[16],
         \\    const char* address_ptr,
         \\    uint32_t address_len,
         \\    uintptr_t on_completion_ctx,
@@ -214,7 +214,7 @@ pub fn main() !void {
         \\// Initialize a new TigerBeetle client which echos back any data submitted.
         \\TB_STATUS tb_client_init_echo(
         \\    tb_client_t* out_client,
-        \\    tb_uint128_t cluster_id,
+        \\    const uint8_t cluster_id[16],
         \\    const char* address_ptr,
         \\    uint32_t address_len,
         \\    uintptr_t on_completion_ctx,

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -125,13 +125,13 @@ test "c_client echo" {
     // We ensure that the retry mechanism is being tested
     // by allowing more simultaneous packets than "client_request_queue_max".
     var tb_client: c.tb_client_t = undefined;
-    const cluster_id = 0;
+    const cluster_id: u128 = 0;
     const address = "3000";
     const concurrency_max: u32 = constants.client_request_queue_max * 2;
     const tb_context: usize = 42;
     const result = c.tb_client_init_echo(
         &tb_client,
-        cluster_id,
+        std.mem.asBytes(&cluster_id),
         address,
         @intCast(address.len),
         tb_context,
@@ -208,11 +208,11 @@ test "c_client tb_status" {
             expected_status: c_uint,
         ) !void {
             var tb_client: c.tb_client_t = undefined;
-            const cluster_id = 0;
+            const cluster_id: u128 = 0;
             const tb_context: usize = 0;
             const result = c.tb_client_init_echo(
                 &tb_client,
-                cluster_id,
+                std.mem.asBytes(&cluster_id),
                 addresses.ptr,
                 @intCast(addresses.len),
                 tb_context,
@@ -250,12 +250,12 @@ test "c_client tb_packet_status" {
     const RequestContext = RequestContextType(constants.message_body_size_max);
 
     var tb_client: c.tb_client_t = undefined;
-    const cluster_id = 0;
+    const cluster_id: u128 = 0;
     const address = "3000";
     const tb_context: usize = 42;
     const result = c.tb_client_init_echo(
         &tb_client,
-        cluster_id,
+        std.mem.asBytes(&cluster_id),
         address,
         @intCast(address.len),
         tb_context,

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1269,7 +1269,7 @@ internal static class TBClient
     [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
     public static unsafe extern InitializationStatus tb_client_init(
         IntPtr* out_client,
-        UInt128Extensions.UnsafeU128 cluster_id,
+        UInt128Extensions.UnsafeU128* cluster_id,
         byte* address_ptr,
         uint address_len,
         IntPtr on_completion_ctx,
@@ -1281,7 +1281,7 @@ internal static class TBClient
     [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
     public static unsafe extern InitializationStatus tb_client_init_echo(
         IntPtr* out_client,
-        UInt128Extensions.UnsafeU128 cluster_id,
+        UInt128Extensions.UnsafeU128* cluster_id,
         byte* address_ptr,
         uint address_len,
         IntPtr on_completion_ctx,

--- a/src/clients/dotnet/TigerBeetle/NativeClient.cs
+++ b/src/clients/dotnet/TigerBeetle/NativeClient.cs
@@ -18,7 +18,7 @@ internal sealed class NativeClient : IDisposable
 
     private unsafe delegate InitializationStatus InitFunction(
                 IntPtr* out_client,
-                UInt128Extensions.UnsafeU128 cluster_id,
+                UInt128Extensions.UnsafeU128* cluster_id,
                 byte* address_ptr,
                 uint address_len,
                 IntPtr on_completion_ctx,
@@ -64,7 +64,7 @@ internal sealed class NativeClient : IDisposable
 
                 var status = initFunction(
                     &handle,
-                    clusterID,
+                    &clusterID,
                     addressPtr,
                     (uint)addresses_byte.Length - 1,
                     IntPtr.Zero,

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -480,7 +480,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         \\    public static unsafe extern InitializationStatus tb_client_init(
         \\        IntPtr* out_client,
-        \\        UInt128Extensions.UnsafeU128 cluster_id,
+        \\        UInt128Extensions.UnsafeU128* cluster_id,
         \\        byte* address_ptr,
         \\        uint address_len,
         \\        IntPtr on_completion_ctx,
@@ -492,7 +492,7 @@ pub fn generate_bindings(buffer: *std.ArrayList(u8)) !void {
         \\    [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         \\    public static unsafe extern InitializationStatus tb_client_init_echo(
         \\        IntPtr* out_client,
-        \\        UInt128Extensions.UnsafeU128 cluster_id,
+        \\        UInt128Extensions.UnsafeU128* cluster_id,
         \\        byte* address_ptr,
         \\        uint address_len,
         \\        IntPtr on_completion_ctx,

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -277,7 +277,7 @@ typedef enum TB_STATUS {
 // completes submitted packets by invoking the callback with the given context.
 TB_STATUS tb_client_init(
     tb_client_t* out_client,
-    tb_uint128_t cluster_id,
+    const uint8_t cluster_id[16],
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,
@@ -287,7 +287,7 @@ TB_STATUS tb_client_init(
 // Initialize a new TigerBeetle client which echos back any data submitted.
 TB_STATUS tb_client_init_echo(
     tb_client_t* out_client,
-    tb_uint128_t cluster_id,
+    const uint8_t cluster_id[16],
     const char* address_ptr,
     uint32_t address_len,
     uintptr_t on_completion_ctx,

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -80,11 +80,12 @@ func NewClient(
 	defer C.free(unsafe.Pointer(c_addresses))
 
 	var tb_client C.tb_client_t
+	var cluster_id = C.tb_uint128_t(clusterID)
 
 	// Create the tb_client.
 	status := C.tb_client_init(
 		&tb_client,
-		C.tb_uint128_t(clusterID),
+		(*C.uint8_t)(unsafe.Pointer(&cluster_id)),
 		c_addresses,
 		C.uint32_t(len(addresses_raw)),
 		C.uintptr_t(0), // on_completion_ctx

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -475,14 +475,16 @@ pub fn main() !void {
         \\# completes submitted packets by invoking the callback with the given context.
         \\tb_client_init = tbclient.tb_client_init
         \\tb_client_init.restype = Status
-        \\tb_client_init.argtypes = [ctypes.POINTER(Client), c_uint128, ctypes.c_char_p,
-        \\                           ctypes.c_uint32, ctypes.c_void_p, OnCompletion]
+        \\tb_client_init.argtypes = [ctypes.POINTER(Client), ctypes.POINTER(ctypes.c_uint8 * 16),
+        \\                           ctypes.c_char_p, ctypes.c_uint32, ctypes.c_void_p,
+        \\                           OnCompletion]
         \\
         \\# Initialize a new TigerBeetle client which echos back any data submitted.
         \\tb_client_init_echo = tbclient.tb_client_init_echo
         \\tb_client_init_echo.restype = Status
-        \\tb_client_init.argtypes = [ctypes.POINTER(Client), c_uint128, ctypes.c_char_p,
-        \\                           ctypes.c_uint32, ctypes.c_void_p, OnCompletion]
+        \\tb_client_init_echo.argtypes = [ctypes.POINTER(Client), ctypes.POINTER(ctypes.c_uint8 * 16),
+        \\                                ctypes.c_char_p, ctypes.c_uint32, ctypes.c_void_p,
+        \\                                OnCompletion]
         \\
         \\# Closes the client, causing any previously submitted packets to be completed with
         \\# `TB_PACKET_CLIENT_SHUTDOWN` before freeing any allocated client resources from init.

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -615,14 +615,16 @@ OnCompletion = ctypes.CFUNCTYPE(None, ctypes.c_void_p, Client, ctypes.POINTER(CP
 # completes submitted packets by invoking the callback with the given context.
 tb_client_init = tbclient.tb_client_init
 tb_client_init.restype = Status
-tb_client_init.argtypes = [ctypes.POINTER(Client), c_uint128, ctypes.c_char_p,
-                           ctypes.c_uint32, ctypes.c_void_p, OnCompletion]
+tb_client_init.argtypes = [ctypes.POINTER(Client), ctypes.POINTER(ctypes.c_uint8 * 16),
+                           ctypes.c_char_p, ctypes.c_uint32, ctypes.c_void_p,
+                           OnCompletion]
 
 # Initialize a new TigerBeetle client which echos back any data submitted.
 tb_client_init_echo = tbclient.tb_client_init_echo
 tb_client_init_echo.restype = Status
-tb_client_init.argtypes = [ctypes.POINTER(Client), c_uint128, ctypes.c_char_p,
-                           ctypes.c_uint32, ctypes.c_void_p, OnCompletion]
+tb_client_init_echo.argtypes = [ctypes.POINTER(Client), ctypes.POINTER(ctypes.c_uint8 * 16),
+                                ctypes.c_char_p, ctypes.c_uint32, ctypes.c_void_p,
+                                OnCompletion]
 
 # Closes the client, causing any previously submitted packets to be completed with
 # `TB_PACKET_CLIENT_SHUTDOWN` before freeing any allocated client resources from init.

--- a/src/clients/python/src/tigerbeetle/client.py
+++ b/src/clients/python/src/tigerbeetle/client.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from . import bindings
-from .lib import tb_assert
+from .lib import tb_assert, c_uint128
 
 logger = logging.getLogger("tigerbeetle")
 
@@ -93,7 +93,9 @@ class Client:
 
         init_status = bindings.tb_client_init(
             ctypes.byref(self._client),
-            cluster_id,
+            ctypes.cast(
+                ctypes.byref(c_uint128.from_param(cluster_id)), ctypes.POINTER(ctypes.c_uint8 * 16)
+            ),
             replica_addresses.encode("ascii"),
             len(replica_addresses),
             self._client_key,

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -35,7 +35,7 @@ pub fn main(_: std.mem.Allocator, args: CLIArgs) !void {
     var tb_client: c.tb_client_t = undefined;
     const result = c.tb_client_init(
         &tb_client,
-        cluster_id,
+        std.mem.asBytes(&cluster_id),
         args.positional.addresses.ptr,
         @intCast(args.positional.addresses.len),
         0,


### PR DESCRIPTION
We consider arm64 Linux a supported platform, for development at least, but currently haven't been running any CI against it.

This PR adds arm64 runners, testing both the replica and clients, and fixes a few bugs along the way.

Multiversion tests on Linux arm64 were broken because they were trying to use x86_64 objcopy, so add the new objcopy platform to our [dependencies](https://github.com/tigerbeetle/dependencies) repo and use it where appropriate.

The dotnet and Python clients were affected by an ABI difference on arm64 Linux: a `struct {u64, u64}` does not have the same ABI as a `u128`, so trying to pass this by value (which is how they internally treat `u128`s) would lead to the function call to `tb_client_init` getting passed parameters incorrectly and segfaulting.

Fix this, by treating the `u128` as a `*const [16]u8` and copying and casting the raw bytes to avoid alignment and ABI issues.