### PR TITLE
log: include UTC timestamp (RFC 3999) as prefix

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -42,7 +42,7 @@ pub fn log_runtime(
 ) void {
     // A microbenchmark places the cost of this if at somewhere around 1600us for 10 million calls.
     if (@intFromEnum(message_level) <= @intFromEnum(log_level_runtime)) {
-        std.log.defaultLog(message_level, scope, format, args);
+        stdx.log_with_timestamp(message_level, scope, format, args);
     }
 }
 

--- a/src/vortex.zig
+++ b/src/vortex.zig
@@ -7,6 +7,7 @@
 /// * _workload_: a separate process that, given a driver, runs commands and queries against the
 /// cluster, verifying its correctness.
 const std = @import("std");
+const stdx = @import("./stdx.zig");
 const builtin = @import("builtin");
 const flags = @import("flags.zig");
 
@@ -17,7 +18,11 @@ const Workload = @import("testing/vortex/workload.zig");
 const assert = std.debug.assert;
 
 const log = std.log.scoped(.vortex);
-pub const log_level: std.log.Level = .info;
+
+pub const std_options = .{
+    .log_level = .info,
+    .logFn = stdx.log_with_timestamp,
+};
 
 pub const CLIArgs = union(enum) {
     supervisor: Supervisor.CLIArgs,


### PR DESCRIPTION
Adds a new logging fn that prepends the UTC timestamp (now including milliseconds), and makes that the default log fn.

Example:

```
2024-12-05T11:22:49.274Z info(replica): superblock release=0.0.1
2024-12-05T11:22:49.581Z info(main): 0: Allocated 2983MiB during replica init
2024-12-05T11:22:49.581Z info(main): 0: Grid cache: 1024MiB, LSM-tree manifests: 128MiB
2024-12-05T11:22:49.581Z info(main): 0: cluster=1: listening on 127.0.0.1:4000
2024-12-05T11:22:49.581Z info(main): 0: started with extra verification checks
2024-12-05T11:22:49.630Z info(io): opening "1_2.tigerbeetle"...
2024-12-05T11:22:49.675Z info(faulty_network): proxying 0.0.0.0:3000 -> 0.0.0.0:4000
2024-12-05T11:22:49.675Z info(faulty_network): proxying 0.0.0.0:3001 -> 0.0.0.0:4001
2024-12-05T11:22:49.675Z info(faulty_network): proxying 0.0.0.0:3002 -> 0.0.0.0:4002
2024-12-05T11:22:49.675Z info(supervisor): launching workload with driver: /home/owi/projects/tigerbeetle/tigerbeetle/zig-out/bin/vortex driver
2024-12-05T11:22:49.684Z info(zig_driver): addresses: 3000,3001,3002
2024-12-05T11:22:49.688Z info(supervisor): terminating replica 2
2024-12-05T11:22:49.758Z info(message_bus): connected to replica 0
2024-12-05T11:22:49.783Z info(message_bus): connected to replica 1
2024-12-05T11:22:49.785Z info(message_bus): connected to replica 2
2024-12-05T11:22:49.821Z info(replica): superblock release=0.0.1
```