### PR TITLE
log: change comptime log to .debug and add runtime filtering

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,7 +106,6 @@ pub fn build(b: *std.Build) !void {
             "config-aof-recovery",
             "Enable AOF Recovery mode.",
         ) orelse false,
-        .config_log_level = b.option(std.log.Level, "config-log-level", "Log level.") orelse .info,
         .config_release = b.option([]const u8, "config-release", "Release triple."),
         .config_release_client_min = b.option(
             []const u8,
@@ -153,7 +152,6 @@ pub fn build(b: *std.Build) !void {
         .config_verify = build_options.config_verify,
         .config_release = build_options.config_release,
         .config_release_client_min = build_options.config_release_client_min,
-        .config_log_level = build_options.config_log_level,
         .config_aof_recovery = build_options.config_aof_recovery,
         .hash_log_mode = build_options.hash_log_mode,
     });
@@ -309,7 +307,6 @@ fn build_vsr_module(b: *std.Build, options: struct {
     config_verify: bool,
     config_release: ?[]const u8,
     config_release_client_min: ?[]const u8,
-    config_log_level: std.log.Level,
     config_aof_recovery: bool,
     hash_log_mode: config.HashLogMode,
 }) struct { *std.Build.Step.Options, *std.Build.Module } {
@@ -328,7 +325,6 @@ fn build_vsr_module(b: *std.Build, options: struct {
         "release_client_min",
         options.config_release_client_min,
     );
-    vsr_options.addOption(std.log.Level, "config_log_level", options.config_log_level);
     vsr_options.addOption(bool, "config_aof_recovery", options.config_aof_recovery);
     vsr_options.addOption(config.HashLogMode, "hash_log_mode", options.hash_log_mode);
 
@@ -653,7 +649,6 @@ fn build_test_integration(
         .config_verify = true,
         .config_release = "0.16.99",
         .config_release_client_min = "0.15.3",
-        .config_log_level = .info,
         .config_aof_recovery = false,
         .hash_log_mode = .none,
     });

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -28,7 +28,7 @@ else
     @compileError("tb_client must be built with libc");
 
 pub const std_options = .{
-    .log_level = vsr.constants.log_level,
+    .log_level = .debug,
     .logFn = tb.Logging.application_logger,
 };
 

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -26,7 +26,7 @@ const Operation = StateMachine.Operation;
 const constants = vsr.constants;
 
 pub const std_options = .{
-    .log_level = vsr.constants.log_level,
+    .log_level = .debug,
     .logFn = tb_client.Logging.application_logger,
 };
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -13,7 +13,6 @@ const assert = std.debug.assert;
 const root = @import("root");
 
 const BuildOptions = struct {
-    config_log_level: std.log.Level,
     config_verify: bool,
     hash_log_mode: HashLogMode,
     git_commit: ?[40]u8,
@@ -302,7 +301,6 @@ pub const configs = struct {
             vsr.Release.minimum;
 
         // TODO Use additional build options to overwrite other fields.
-        base.process.log_level = build_options.config_log_level;
         base.process.hash_log_mode = build_options.hash_log_mode;
         base.process.release = release;
         base.process.release_client_min = release_client_min;

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -18,27 +18,6 @@ pub const semver = std.SemanticVersion{
     .build = if (config.process.git_commit) |sha_full| sha_full[0..7] else null,
 };
 
-/// The maximum log level.
-/// One of: .err, .warn, .info, .debug
-pub const log_level: std.log.Level = config.process.log_level;
-
-pub const log = std.log.defaultLog;
-
-/// A log function that discards all log entries.
-pub fn log_nop(
-    comptime message_level: std.log.Level,
-    comptime scope: @Type(.EnumLiteral),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    _ = .{
-        message_level,
-        scope,
-        format,
-        args,
-    };
-}
-
 // Which mode to use for ./testing/hash_log.zig.
 pub const hash_log_mode = config.process.hash_log_mode;
 

--- a/src/tb_client_exports.zig
+++ b/src/tb_client_exports.zig
@@ -6,7 +6,7 @@ const vsr = @import("vsr.zig");
 const tb = vsr.tb_client;
 
 pub const std_options = .{
-    .log_level = vsr.constants.log_level,
+    .log_level = .debug,
     .logFn = tb.Logging.application_logger,
 };
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -68,6 +68,7 @@ const CLIArgs = union(enum) {
         memory_lsm_manifest: ?flags.ByteSize = null,
         memory_lsm_compaction: ?flags.ByteSize = null,
         trace: ?[:0]const u8 = null,
+        log_debug: bool = false,
 
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
         /// to the client. The logic behind this code has been kept as simple as possible -
@@ -405,6 +406,7 @@ pub const Command = union(enum) {
         experimental: bool,
         aof: bool,
         path: [:0]const u8,
+        log_debug: bool,
     };
 
     pub const Version = struct {
@@ -791,6 +793,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         .trace = start.trace,
         .aof = start.aof,
         .path = start.positional.path,
+        .log_debug = start.log_debug,
     };
 }
 


### PR DESCRIPTION
Previously, .debug log messages were filtered out at comptime. While nice from a binary size and performance (more on that later) point of view, this meant that a user couldn't specify `--log-debug` or similar and would need a new binary to get debug logging.

Make it so that we do runtime log filtering instead. The performance penalty for this was negligible in testing; both microbenchmarks and the actual benchmark.

The one downside is binary bloat: this increases the size of a release build by ~300KiB.

To use, specify `--log-debug --experimental` on the CLI when starting a replica. `--log-debug` instead of `--log=...` because I feel we don't want to allow levels quieter than `.info` in any case.

It's currently only supported for `start`. Scaffolding for clients is there too, with filtering of the messages before they cross FFI and requiring an additional flag to be set. Actually setting this flag from any client libraries is still unimplemented - but this makes it no harder than before to change client logging (edit code & recompile).

Things like the VOPR and fuzzers use their own way of setting logging, and are unaffected.