### PR TITLE
cli: optionally generate random cluster id in format

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -483,6 +483,11 @@ const Command = struct {
                     .{},
                 );
             };
+
+            if (replica.cluster == 0) {
+                log.warn("a cluster id of 0 is reserved for testing and benchmarking, " ++
+                    "do not use in production", .{});
+            }
         }
 
         while (true) {


### PR DESCRIPTION
When formatting a TigerBeetle cluster, it's important to give it a random cluster ID to differentiate it from other clusters. Cluster IDs can't be changed after format, so it's important to get this right at the beginning.

However, currently you have to generate this externally which is cumbersome and leads to our docs and most people using `--cluster=0`, which is potentially unsafe.

This PR allows omitting the `--cluster` argument from format entirely, which will make it generate a random ID and print that out, so it can be used when formatting other replicas and for the client.

It also makes `--cluster=0` an explicit warning.