### PR TITLE
REPL: Switch to static allocation

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -57,7 +57,7 @@ pub fn main() !void {
         }),
         .start => |*args| try Command.start(arena.allocator(), args),
         .version => |*args| try Command.version(allocator, args.verbose),
-        .repl => |*args| try Command.repl(&arena, args),
+        .repl => |*args| try Command.repl(arena.allocator(), args),
         .benchmark => |*args| try benchmark_driver.main(allocator, args),
         .inspect => |*args| inspect.main(allocator, args) catch |err| {
             // Ignore BrokenPipe so that e.g. "tigerbeetle inspect ... | head -n12" succeeds.
@@ -600,15 +600,18 @@ const Command = struct {
         try stdout_buffer.flush();
     }
 
-    pub fn repl(arena: *std.heap.ArenaAllocator, args: *const cli.Command.Repl) !void {
+    pub fn repl(allocator: mem.Allocator, args: *const cli.Command.Repl) !void {
         const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient);
-        try Repl.run(
-            arena,
+
+        var repl_instance = try Repl.init(
+            allocator,
             args.addresses.const_slice(),
             args.cluster,
-            args.statements,
             args.verbose,
         );
+        defer repl_instance.deinit(allocator);
+
+        try repl_instance.run(args.statements);
     }
 };
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -44,8 +44,6 @@ pub fn ClientType(comptime StateMachine_: type, comptime MessageBus: type) type 
             },
         };
 
-        allocator: mem.Allocator,
-
         message_bus: MessageBus,
 
         /// A universally unique identifier for the client (must not be zero).
@@ -148,7 +146,6 @@ pub fn ClientType(comptime StateMachine_: type, comptime MessageBus: type) type 
             errdefer message_bus.deinit(allocator);
 
             var self = Client{
-                .allocator = allocator,
                 .message_bus = message_bus,
                 .id = options.id,
                 .cluster = options.cluster,


### PR DESCRIPTION
This was bothering me when I was making the REPL evented (the REPL currently doesn't process any IO while waiting for user input...) :smile:.

Went with stack allocation (`BoundedArray`) for most small things, with an `ArrayListUnmanaged` for `arguments` which stores the events sent by the client; and an `init` / `deinit` that handles the setup and teardown for `run()`.

Also, remove the dangling `allocator` reference that was in client.zig.

Closes #2528 and #2515.