### PR TITLE
Fix comptime zig version comparison, allow patched zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -49,7 +49,11 @@ const zig_version = std.SemanticVersion{
 };
 
 comptime {
-    if (builtin.zig_version.order(zig_version) != .eq) {
+    // Compare versions while allowing different pre/patch metadata.
+    const zig_version_eq = zig_version.major == builtin.zig_version.major and
+        zig_version.minor == builtin.zig_version.minor and
+        zig_version.patch == builtin.zig_version.patch;
+    if (!zig_version_eq) {
         @compileError(std.fmt.comptimePrint(
             "unsupported zig version: expected {}, found {}",
             .{ zig_version, builtin.zig_version },

--- a/build.zig
+++ b/build.zig
@@ -50,9 +50,10 @@ const zig_version = std.SemanticVersion{
 
 comptime {
     if (builtin.zig_version.order(zig_version) != .eq) {
-        std.log.err("expected zig version: {}", .{zig_version});
-        std.log.err("found zig version:    {}", .{builtin.zig_version});
-        @panic("unsupported zig version");
+        @compileError(std.fmt.comptimePrint(
+            "unsupported zig version: expected {}, found {}",
+            .{ zig_version, builtin.zig_version },
+        ));
     }
 }
 


### PR DESCRIPTION
Two fixes.

First, build.zig is attempting to print an error at comptime if the compiler is incompatible, but the `std.log.err` function it is calling does not work at comptime. When it is called we see this error instead:

```
zig/lib/std/Thread.zig:1050:30: error: unable to evaluate comptime expression                                                        
        return tls_thread_id orelse {                                                                                                
               ~~~~~~~~~~~~~~^~~~~~                                                                                                  
zig/lib/std/Thread.zig:277:29: note: called from here                                                                                
    return Impl.getCurrentId();                                                                                                      
           ~~~~~~~~~~~~~~~~~^~                                                                                                       
zig/lib/std/Thread/Mutex.zig:80:47: note: called from here                                                                           
        const current_id = Thread.getCurrentId();                                                                                    
                           ~~~~~~~~~~~~~~~~~~~^~                                                                                     
zig/lib/std/Thread/Mutex.zig:44:19: note: called from here                                                                           
    self.impl.lock();                                                                                                                
    ~~~~~~~~~~~~~~^~                                                                                                                 
zig/lib/std/Progress.zig:525:22: note: called from here                                                                              
    stderr_mutex.lock();                                                                                                             
    ~~~~~~~~~~~~~~~~~^~                                                                                                              
zig/lib/std/debug.zig:84:28: note: called from here                                                                                  
    std.Progress.lockStdErr();                                                                                                       
    ~~~~~~~~~~~~~~~~~~~~~~~^~                                                                                                        
zig/lib/std/log.zig:155:25: note: called from here                                                                                   
    std.debug.lockStdErr();                                                                                                          
    ~~~~~~~~~~~~~~~~~~~~^~                                                                                                           
zig/lib/std/log.zig:125:22: note: called from here                                                                                   
    std.options.logFn(message_level, scope, format, args);                                                                           
    ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                            
zig/lib/std/log.zig:175:16: note: called from here                                                                                   
            log(.err, scope, format, args);                                                                                          
            ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                           
/home/brian/.homes/dev/tigerbeetle/build.zig:53:20: note: called from here                                                           
        std.log.err("expected zig version: {}", .{zig_version});                                                                     
        ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                 
```

The fix is to use `@compileError`.

Second, I have relaxed the version comparison logic to allow local builds of zig to be used, comparing only the major/minor/patch versions, while allowing the pre-release and build metadata to differ. I am using this as I experiment with building my own zig.