### PR TITLE
LSM/Scan: Fix missing intersection results bug 

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -77,6 +77,7 @@ fn main_smoke() !void {
             .lsm_cache_map => 20_000,
             .lsm_forest => 10_000,
             .lsm_manifest_log => 2_000,
+            .lsm_scan => 100,
             .lsm_tree => 400,
             .vsr_free_set => 10_000,
             .vsr_superblock => 3,
@@ -86,7 +87,6 @@ fn main_smoke() !void {
             .lsm_manifest_level,
             .vsr_journal_format,
             .vsr_superblock_quorums,
-            .lsm_scan,
             .storage,
             => null,
         };

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -925,16 +925,10 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
 
     const commits_max: u32 = @intCast(
         fuzz_args.events_max orelse
-            random.intRangeAtMost(u32, 1, 2048),
+            random.intRangeAtMost(u32, 1, 1024),
     );
 
     try Environment.run(&storage, random, commits_max);
 
     log.info("Passed!", .{});
-}
-
-/// Returns true, `p` percent of the time, else false.
-fn chance(random: std.rand.Random, p: u8) bool {
-    assert(p <= 100);
-    return random.uintLessThanBiased(u8, 100) < p;
 }

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -828,6 +828,7 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             assert(self.values == .fetching);
 
             assert(self.scan.state == .seeking or
+                self.scan.state == .needs_data or
                 self.scan.state == .buffering);
 
             const manifest: *Manifest = &self.scan.tree.manifest;

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -787,17 +787,28 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                         // If the next key is out of the range,
                         // there are no more `table_info`s to scan next.
                         const key_exclusive_next = iterating.key_exclusive_next;
-                        if (self.scan.key_min <= key_exclusive_next and
-                            key_exclusive_next <= self.scan.key_max)
-                        {
-                            // Load the next `table_info`.
-                            self.state = .loading_manifest;
-                            self.values = .fetching;
-                            self.move_next_manifest_table(key_exclusive_next);
-                        } else {
+                        if (switch (self.scan.direction) {
+                            .ascending => key_exclusive_next > self.scan.key_max,
+                            .descending => key_exclusive_next < self.scan.key_min,
+                        }) {
                             // The next `table_info` is out of the key range, so it's finished.
                             self.state = .{ .finished = .{} };
                             self.values = .finished;
+                        } else {
+                            // Load the next `table_info`.
+                            self.state = .loading_manifest;
+                            self.values = .fetching;
+                            if (switch (self.scan.direction) {
+                                .ascending => key_exclusive_next < self.scan.key_min,
+                                .descending => key_exclusive_next > self.scan.key_max,
+                            }) {
+                                // A probe() skipped past the last table we iterated, so our
+                                // key_exclusive_next is now out of bounds, superseded by the
+                                // tightened key_min (ascending) or key_max (descending) bound.
+                                self.move_next_manifest_table(null);
+                            } else {
+                                self.move_next_manifest_table(key_exclusive_next);
+                            }
                         }
                     } else {
                         // Keep iterating to the next `value_block`.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -917,6 +917,11 @@ pub fn StateMachineType(
             assert(self.scan_lookup_result_count == null);
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
 
+            log.debug("{?}: get_account_transfers: {}", .{
+                self.forest.grid.superblock.replica_index,
+                filter,
+            });
+
             if (self.get_scan_from_account_filter(filter)) |scan| {
                 assert(self.forest.scan_buffer_pool.scan_buffer_used > 0);
 
@@ -967,6 +972,11 @@ pub fn StateMachineType(
 
         fn prefetch_get_account_balances(self: *StateMachine, filter: AccountFilter) void {
             assert(self.scan_lookup_result_count == null);
+
+            log.debug("{?}: get_account_balances: {}", .{
+                self.forest.grid.superblock.replica_index,
+                filter,
+            });
 
             self.forest.grooves.accounts.prefetch_enqueue(filter.account_id);
             self.forest.grooves.accounts.prefetch(
@@ -1215,6 +1225,11 @@ pub fn StateMachineType(
         fn prefetch_query_accounts(self: *StateMachine, filter: QueryFilter) void {
             assert(self.scan_lookup_result_count == null);
 
+            log.debug("{?}: query_accounts: {}", .{
+                self.forest.grid.superblock.replica_index,
+                filter,
+            });
+
             if (self.get_scan_from_query_filter(
                 AccountsGroove,
                 &self.forest.grooves.accounts,
@@ -1268,6 +1283,11 @@ pub fn StateMachineType(
 
         fn prefetch_query_transfers(self: *StateMachine, filter: QueryFilter) void {
             assert(self.scan_lookup_result_count == null);
+
+            log.debug("{?}: query_transfers: {}", .{
+                self.forest.grid.superblock.replica_index,
+                filter,
+            });
 
             if (self.get_scan_from_query_filter(
                 TransfersGroove,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1023,15 +1023,22 @@ pub fn StateMachineType(
                         );
 
                         return;
+                    } else {
+                        // TODO(batiati): Improve the way we do validations on the state machine.
+                        log.info("get_account_balances: invalid filter: {any}", .{filter});
                     }
+                } else {
+                    log.info(
+                        "get_account_balances: cannot query account.id={}; flags.history=false",
+                        .{filter.account_id},
+                    );
                 }
+            } else {
+                log.info(
+                    "get_account_balances: cannot query account.id={}; account does not exist",
+                    .{filter.account_id},
+                );
             }
-
-            // TODO(batiati): Improve the way we do validations on the state machine.
-            log.info(
-                "invalid filter for get_account_balances: {any}",
-                .{filter},
-            );
 
             // Returning an empty array on the next tick.
             self.forest.grid.on_next_tick(

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -205,8 +205,8 @@ pub const AccountingAuditor = struct {
         errdefer allocator.free(accounts_state);
         @memset(accounts_state, AccountState{});
 
-        // The number of known intersection values ​​for the secondary indices is kept
-        // low enough to explore different cardinalities.
+        // The number of known intersection values for the secondary indices is kept low enough to
+        // explore different cardinalities.
         const query_intersections = try allocator.alloc(
             QueryIntersection,
             options.accounts_max / 2,


### PR DESCRIPTION
## Summary

Fix a correctness bug in which some queries erroneously end a scan too early, truncating the results.

This bug is only in the read-path -- the omitted objects are still safely durable in the LSM.

This bug can affect any scan which intersects multiple secondary index trees.
That is, depending on what filters are included, it can be hit by `get_account_balances`, `get_account_transfer`, `query_accounts`, and `query_transfers`.

This bug is deterministic -- when one replica hits this bug, all of them will, regardless of how their IO is reordered.
(So even with this bug, the checkpoint won't diverge due to distinct client replies.)

## Bug

A scan may intersect many `ScanTree`s together.
The intersection is implemented with zig-zag merge join.

When any of the intersected `ScanTree`s races ahead, the merge algorithm informs the lagging trees about the leading key (`ScanTree.probe()`).
This lets those other trees skip past ranges of keys that it now knows will definitely not intersect.

Suppose that `ScanTree.probe()` is called, which increases the `ScanTree`'s `key_min` (ascending) or decreases the `key_max` (descending).
Then this calls `ScanTreeLevel.probe()` for each level:

```zig
pub fn probe(self: *ScanTreeLevel, probe_key: Key) void {
    switch (self.values) {
        .fetching => {},
        .buffered => |buffer| {
```

If `ScanTreeLevel.probe()` has values already buffered in memory...

```zig
            const slice: []const Value = ScanTree.probe_values(
                self.scan.direction,
                buffer,
                probe_key,
            );

            if (slice.len == 0) {
                // ...
                self.move_next();
```

...and none of the buffered values intersect with the new shrunk range, then we need to get a new value block, so it calls `ScanTreeLevel.move_next()`.

```zig
fn move_next(self: *ScanTreeLevel) void {
    switch (self.state) {
        .loading_manifest => self.move_next_manifest_table(null),
        .loading_index => unreachable,
        .iterating => |*iterating| {
            if (iterating.values == .none or
                iterating.values.iterator.empty())
            {
```

If we are all out of value blocks for the current table, then we need a new table:

```zig
                const key_exclusive_next = iterating.key_exclusive_next;
                if (self.scan.key_min <= key_exclusive_next and
                    key_exclusive_next <= self.scan.key_max)
                {
                    // Load the next `table_info`.
                    self.state = .loading_manifest;
                    self.values = .fetching;
                    self.move_next_manifest_table(key_exclusive_next); // <---
                } else {
                    // The next `table_info` is out of the key range, so it's finished.
                    self.state = .{ .finished = .{} };
                    self.values = .finished;
                }
```

In the code above, `key_exclusive_next` tracks the `table_info.key_max` (ascending) or `table_info.key_min` (descending) of the most recent table we iterated, to ensure that we don't scan the same table twice.
Typically the condition would check whether we are done iterating tables for this level, because the extreme key of the most recent iterated table lies outside of our target range (`scan.key_kin`/`scan.key_max`).

But because the target range has shrunk, our exclusive key may now lie outside of that range from the wrong end, causing the `ScanTreeLevel` to incorrectly consider itself finished.

## Fix

Separate the conditions:

- The `key_exclusive_next` is out of bounds because we iterated all the tables we need to iterate: Stop scanning (same as before).
- The `key_exclusive_next` is out of bounds because our target range shrunk: Keep scanning, but ignore the `key_exclusive_next`.

## Testing

### Why didn't we find this bug sooner?

There are four fuzzers that perform scans: `vopr`, `fuzz_lsm_scan`, `fuzz_lsm_forest`, and `fuzz_lsm_tree`:

- `fuzz_lsm_tree` only scans a single tree, so it wouldn't ever hit this bug.
- `fuzz_lsm_forest` also only scans a single tree -- it never intersects across multiple trees.
- `vopr` and `fuzz_lsm_scan` do intersect multiple trees, but they generate objects according to templates based on the queries they plan to run. Because of the common prefix for the query's target fields, the objects matching each query are consecutive in each index, so it never needs to "zig-zag". (See below for more detail.)

Also, coverage checking of fuzzing could help find issues like these earlier.
(We track coverage in the devhub, though since we only get coverage for a single seed per fuzzer, it underestimates fuzzer coverage.)

<details>
<summary>Why didn't the VOPR find this bug?</summary>

The generated queries intersect across multiple trees, but never in such a way that `ScanTreeLevel.probe()` is called.

The workload pre-generates its queries at startup:

```zig
for (query_intersections, 1..) |*query_intersection, index| {
    query_intersection.* = .{
        .user_data_64 = @intcast(index * 1_000_000),
        .user_data_32 = @intcast(index * 1_000),
        .code         = @intcast(index), // It will be used to recover the index.
    };
}
```

Each object is generated to match exactly one of these disjoint queries:

```zig
const query_intersection_index = self.random.uintLessThanBiased(usize, self.auditor.query_intersections.len);
const query_intersection = self.auditor.query_intersections[query_intersection_index];

transfer.* = .{
    ...
    .user_data_64 = query_intersection.user_data_64,
    .user_data_32 = query_intersection.user_data_32,
    .code         = query_intersection.code,
    ...
};
```

The `query_intersection` counts how many (created) objects match its filter:

```zig
const query_intersection_index = transfer.code - 1;
const query_intersection = &self.query_intersections[query_intersection_index];
assert(transfer.user_data_64 == query_intersection.user_data_64);
assert(transfer.user_data_32 == query_intersection.user_data_32);
assert(transfer.code == query_intersection.code);
query_intersection.transfers.count += 1;
if (query_intersection.transfers.timestamp_min == 0) {
    query_intersection.transfers.timestamp_min = transfer_timestamp;
}
query_intersection.transfers.timestamp_max = transfer_timestamp;
```

But the queries generated are such that `user_data_64 / 1e6 == user_data_u32 / 1e3 == code`, which means that the objects matching a given query are consecutive in each of those three indexes, so the merge-join never needs to discard values on probe.

</details>

<details>
<summary>Why didn't the scan-fuzzer find this bug?</summary>

`ScanTreeLevel.probe()` does get called, but never such that `ScanTreeLevel.move_next_manifest_table()` gets called.

Similar to the VOPR, the fuzzer carefully chooses the prefix of generated objects based on what query they should match.
So the matching objects of each query are consecutive in the respective indices.
It inserts "noise" objects that don't match any query, but they use `std.math.maxInt(u32)` as a prefix, so they don't interleave with the consecutive runs of target values.

</details>

### Improvements

The scan fuzzer has been rewritten (see https://github.com/tigerbeetle/tigerbeetle/commit/73f13ee2d092fe6998c315b0c4ae5fbc2983154a) and can now easily find this bug.

Additionally, greatly increase the number of queries run and the number of objects inserted per test run.