### PR TITLE
[Benchmark] Forward the `--experimental` flag when setting the object cache.

### DIFF
--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -169,7 +169,14 @@ fn start(allocator: std.mem.Allocator, options: struct {
         }
     }
 
-    if (options.args.trace) |_| {
+    // Some options require the "--experimental" flag.
+    const experimental: bool =
+        options.args.trace != null or
+        options.args.cache_accounts != null or
+        options.args.cache_transfers != null or
+        options.args.cache_transfers_pending != null or
+        options.args.cache_account_balances != null;
+    if (experimental) {
         try start_args.append(arena.allocator(), "--experimental");
     }
 


### PR DESCRIPTION
Error when running the benchmark with any of the `--cache-*` options.
```
❯ ./tigerbeetle benchmark --cache-transfers=2GiB
2024-12-09 20:03:47.713Z error(vsr): --cache-transfers is marked experimental, add `--experimental` to continue.
thread 588607 panic: integer overflow
```
