### PR TITLE
stdx: move memory lock to stdx from main

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -8,6 +8,8 @@ pub const BoundedArrayType = @import("./stdx/bounded_array.zig").BoundedArrayTyp
 pub const ZipfianGenerator = @import("./stdx/zipfian.zig").ZipfianGenerator;
 pub const ZipfianShuffled = @import("./stdx/zipfian.zig").ZipfianShuffled;
 
+pub const memory_lock_allocated = @import("./stdx/mlock.zig").memory_lock_allocated;
+
 pub inline fn div_ceil(numerator: anytype, denominator: anytype) @TypeOf(numerator, denominator) {
     comptime {
         switch (@typeInfo(@TypeOf(numerator))) {

--- a/src/stdx/mlock.zig
+++ b/src/stdx/mlock.zig
@@ -1,0 +1,112 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const os = std.os;
+
+const stdx = @import("../stdx.zig");
+
+const log = std.log.scoped(.mlock);
+
+const MemoryLockError = error{memory_not_locked} || std.posix.UnexpectedError;
+
+const mlockall_error = "Unable to lock pages in memory ({s})" ++
+    " - kernel swap would otherwise bypass TigerBeetle's storage fault tolerance. ";
+
+/// Pin virtual memory pages allocated so far to physical pages in RAM, preventing the pages from
+/// being swapped out and introducing storage error into memory, bypassing ECC RAM.
+pub fn memory_lock_allocated(options: struct { allocated_size: usize }) MemoryLockError!void {
+    switch (builtin.os.tag) {
+        .linux => try memory_lock_allocated_linux(),
+        .macos => {
+            // macOS has mlock() but not mlockall(). mlock() requires an address range which
+            // would be difficult to gather for non-heap memory that is also faulted in,
+            // such as the stack, globals, etc.
+        },
+        .windows => try memory_lock_allocated_windows(options.allocated_size),
+        else => @compileError("unsupported platform"),
+    }
+}
+
+fn memory_lock_allocated_linux() MemoryLockError!void {
+    const MCL_CURRENT = 1; // Lock all currently mapped pages.
+    const MCL_ONFAULT = 3; // Lock all pages faulted in (i.e. stack space).
+    const result = os.linux.syscall1(.mlockall, MCL_CURRENT | MCL_ONFAULT);
+    switch (os.linux.E.init(result)) {
+        .SUCCESS => return,
+        .AGAIN => log.warn(mlockall_error, .{"some addresses could not be locked"}),
+        .NOMEM => log.warn(mlockall_error, .{"memory would exceed RLIMIT_MEMLOCK"}),
+        .PERM => log.warn(mlockall_error, .{
+            "insufficient privileges to lock memory",
+        }),
+        .INVAL => unreachable, // MCL_ONFAULT specified without MCL_CURRENT.
+        else => |err| return stdx.unexpected_errno("mlockall", err),
+    }
+    return error.memory_not_locked;
+}
+
+fn memory_lock_allocated_windows(allocated_size: usize) MemoryLockError!void {
+    // Windows has VirtualLock which works similar to mlock with an address range.
+    // It would be difficult to gather the addresses of non-heap memory that is also
+    // faulted in, such as the stack, globals, etc. SetProcessWorkingSetSize can be
+    // used instead to lock all existing pages into memory to avoid swapping.
+    const set_process_working_set_size = @extern(
+        *const fn (
+            hProcess: os.windows.HANDLE,
+            dwMinimumWorkingSetSize: os.windows.SIZE_T,
+            dwMaximumWorkingSetSize: os.windows.SIZE_T,
+        ) callconv(os.windows.WINAPI) os.windows.BOOL,
+        .{
+            .library_name = "kernel32",
+            .name = "SetProcessWorkingSetSize",
+        },
+    );
+    const get_process_working_set_size = @extern(
+        *const fn (
+            hProcess: os.windows.HANDLE,
+            lpMinimumWorkingSetSize: *os.windows.SIZE_T,
+            lpMaximumWorkingSetSize: *os.windows.SIZE_T,
+        ) callconv(os.windows.WINAPI) os.windows.BOOL,
+        .{
+            .library_name = "kernel32",
+            .name = "GetProcessWorkingSetSize",
+        },
+    );
+
+    const process_handle = os.windows.kernel32.GetCurrentProcess();
+    var working_set_min: os.windows.SIZE_T = 0;
+    var working_set_max: os.windows.SIZE_T = 0;
+
+    if (get_process_working_set_size(
+        process_handle,
+        &working_set_min,
+        &working_set_max,
+    ) == os.windows.FALSE) {
+        working_set_min = allocated_size; // Count bytes allocated so far.
+        working_set_min += 64 * 1024 * 1024; // 64mb buffer room for stack/globals.
+        working_set_max = working_set_min * 2; // Buffer room for new page faults.
+    }
+
+    if (set_process_working_set_size(
+        process_handle,
+        working_set_min,
+        working_set_max,
+    ) == os.windows.FALSE) {
+        // From std.os.windows.unexpectedError():
+        const format_flags = os.windows.FORMAT_MESSAGE_FROM_SYSTEM |
+            os.windows.FORMAT_MESSAGE_IGNORE_INSERTS;
+
+        // 614 is the length of the longest windows error description.
+        var buffer: [614:0]os.windows.WCHAR = undefined;
+        const buffer_size = os.windows.kernel32.FormatMessageW(
+            format_flags,
+            null,
+            os.windows.kernel32.GetLastError(),
+            os.windows.LANG.NEUTRAL | (os.windows.SUBLANG.DEFAULT << 10),
+            &buffer,
+            buffer.len,
+            null,
+        );
+
+        log.warn(mlockall_error, .{std.unicode.fmtUtf16Le(buffer[0..buffer_size])});
+        return error.memory_not_locked;
+    }
+}

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -472,108 +472,18 @@ const Command = struct {
 
         if (!args.development) {
             // Try to lock all memory in the process to avoid the kernel swapping pages to disk and
-            // potentially introducting undetectable disk corruption into memory.
+            // potentially introducing undetectable disk corruption into memory.
             // This is a best-effort attempt and not a hard rule as it may not cover all memory edge
             // case. So warn on error to notify the operator to adjust conditions if possible.
-            const mlockall_error = "Unable to lock pages in memory ({s})" ++
-                " - kernel swap would otherwise bypass TigerBeetle's storage fault tolerance. ";
-
-            switch (builtin.os.tag) {
-                .linux => blk: {
-                    const MCL_CURRENT = 1; // Lock all currently mapped pages.
-                    const MCL_ONFAULT = 3; // Lock all pages faulted in (i.e. stack space).
-                    const result = os.linux.syscall1(.mlockall, MCL_CURRENT | MCL_ONFAULT);
-                    switch (os.linux.E.init(result)) {
-                        .SUCCESS => break :blk,
-                        .AGAIN => log.warn(mlockall_error, .{"some addresses could not be locked"}),
-                        .NOMEM => log.warn(mlockall_error, .{"memory would exceed RLIMIT_MEMLOCK"}),
-                        .PERM => log.warn(mlockall_error, .{
-                            "insufficient privileges to lock memory",
-                        }),
-                        .INVAL => unreachable, // MCL_ONFAULT specified with MCL_CURRENT.
-                        else => |err| return stdx.unexpected_errno("mlockall", err),
-                    }
-                    log.warn(
-                        "If this is a production replica, consider either " ++
-                            "running the replica with CAP_IPC_LOCK privilege, " ++
-                            "increasing the MEMLOCK process limit, " ++
-                            "or disabling swap system-wide.",
-                        .{},
-                    );
-                },
-                .macos => {
-                    // macOS has mlock() but not mlockall(). mlock() requires an address range which
-                    // would be difficult to gather for non-heap memory that is also faulted in,
-                    // such as the stack, globals, etc.
-                },
-                .windows => {
-                    // Windows has VirtualLock which works similar to mlock with an address range.
-                    // It would be difficult to gather the addresses of non-heap memory that is also
-                    // faulted in, such as the stack, globals, etc. SetProcessWorkingSetSize can be
-                    // used instead to lock all existing pages into memory to avoid swapping.
-                    const set_process_working_set_size = @extern(
-                        *const fn (
-                            hProcess: os.windows.HANDLE,
-                            dwMinimumWorkingSetSize: os.windows.SIZE_T,
-                            dwMaximumWorkingSetSize: os.windows.SIZE_T,
-                        ) callconv(os.windows.WINAPI) os.windows.BOOL,
-                        .{
-                            .library_name = "kernel32",
-                            .name = "SetProcessWorkingSetSize",
-                        },
-                    );
-                    const get_process_working_set_size = @extern(
-                        *const fn (
-                            hProcess: os.windows.HANDLE,
-                            lpMinimumWorkingSetSize: *os.windows.SIZE_T,
-                            lpMaximumWorkingSetSize: *os.windows.SIZE_T,
-                        ) callconv(os.windows.WINAPI) os.windows.BOOL,
-                        .{
-                            .library_name = "kernel32",
-                            .name = "GetProcessWorkingSetSize",
-                        },
-                    );
-
-                    const process_handle = os.windows.kernel32.GetCurrentProcess();
-                    var working_set_min: os.windows.SIZE_T = 0;
-                    var working_set_max: os.windows.SIZE_T = 0;
-
-                    if (get_process_working_set_size(
-                        process_handle,
-                        &working_set_min,
-                        &working_set_max,
-                    ) == os.windows.FALSE) {
-                        working_set_min = counting_allocator.size; // Count bytes allocated so far.
-                        working_set_min += 64 * 1024 * 1024; // 64mb buffer room for stack/globals.
-                        working_set_max = working_set_min * 2; // Buffer room for new page faults.
-                    }
-
-                    if (set_process_working_set_size(
-                        process_handle,
-                        working_set_min,
-                        working_set_max,
-                    ) == os.windows.FALSE) {
-                        // From std.os.windows.unexpectedError():
-                        const format_flags = os.windows.FORMAT_MESSAGE_FROM_SYSTEM |
-                            os.windows.FORMAT_MESSAGE_IGNORE_INSERTS;
-
-                        // 614 is the length of the longest windows error description.
-                        var buffer: [614:0]os.windows.WCHAR = undefined;
-                        const buffer_size = os.windows.kernel32.FormatMessageW(
-                            format_flags,
-                            null,
-                            os.windows.kernel32.GetLastError(),
-                            os.windows.LANG.NEUTRAL | (os.windows.SUBLANG.DEFAULT << 10),
-                            &buffer,
-                            buffer.len,
-                            null,
-                        );
-
-                        log.warn(mlockall_error, .{std.unicode.fmtUtf16Le(buffer[0..buffer_size])});
-                    }
-                },
-                else => @compileError("unsupported platform"),
-            }
+            stdx.memory_lock_allocated(.{ .allocated_size = counting_allocator.size }) catch {
+                log.warn(
+                    "If this is a production replica, consider either " ++
+                        "running the replica with CAP_IPC_LOCK privilege, " ++
+                        "increasing the MEMLOCK process limit, " ++
+                        "or disabling swap system-wide.",
+                    .{},
+                );
+            };
         }
 
         while (true) {


### PR DESCRIPTION
Two motivations here:

- `pub fn main` is the "face" of our source code, and it is a bad style if we have a bunch of fiddly platform-specific code getting in a way of understanding what _actually_ goes on in our main.
- I want to re-use some of the logic to lock memory used by fuzzers