### PR TITLE
tidy: fix false positive in dead-code detector

### DIFF
--- a/src/clients/docs_types.zig
+++ b/src/clients/docs_types.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 // The purpose of these types is to help in reading this doc, not
 // because the types matter.
 const String = []const u8;

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -1,4 +1,3 @@
-const builtin = @import("builtin");
 const std = @import("std");
 
 const assert = std.debug.assert;

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 const Docs = @import("../docs_types.zig").Docs;
 
 pub const GoDocs = Docs{

--- a/src/clients/java/docs.zig
+++ b/src/clients/java/docs.zig
@@ -1,5 +1,3 @@
-const builtin = @import("builtin");
-
 const Docs = @import("../docs_types.zig").Docs;
 
 pub const JavaDocs = Docs{

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 const Docs = @import("../docs_types.zig").Docs;
 
 pub const NodeDocs = Docs{

--- a/src/clients/python/docs.zig
+++ b/src/clients/python/docs.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 const Docs = @import("../docs_types.zig").Docs;
 
 pub const PythonDocs = Docs{

--- a/src/lsm/segmented_array_fuzz.zig
+++ b/src/lsm/segmented_array_fuzz.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 const fuzz = @import("../testing/fuzz.zig");
 const segmented_array = @import("segmented_array.zig");
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -291,8 +291,10 @@ fn tidy_dead_declarations(
             assert(used.get(token_text).? == 1);
             var declaration_keyword = false;
             for (0..3) |context_offset| {
-                if (index - context_offset < 2) break;
-                const context_tag = tree.tokens.get(index - context_offset - 2).tag;
+                const context_tag = if (index - context_offset < 2)
+                    .eof
+                else
+                    tree.tokens.get(index - context_offset - 2).tag;
                 if (!declaration_keyword) {
                     switch (context_tag) {
                         .keyword_fn, .keyword_const => declaration_keyword = true,


### PR DESCRIPTION
There's a bigger false positive of `const flags = stdx.flags`, but I want to deal with that separately.