### PR TITLE
tidy: remove unused imports

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const os = std.os;
 
 const constants = @import("constants.zig");
 const vsr = @import("vsr.zig");
-const tb = @import("tigerbeetle.zig");
 
 const stdx = @import("stdx.zig");
 const IO = @import("io.zig").IO;
@@ -15,8 +13,6 @@ const Storage = vsr.storage.StorageType(IO);
 const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
 
 const Header = vsr.Header;
-const Account = tb.Account;
-const Transfer = tb.Transfer;
 const Client = vsr.ClientType(StateMachine, MessageBus);
 const log = std.log.scoped(.aof);
 

--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -3,7 +3,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
-const log = std.log;
 
 const multiversioning = @import("./multiversioning.zig");
 const flags = @import("flags.zig");

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const os = std.os;
 const assert = std.debug.assert;
 const Atomic = std.atomic.Value;
 
@@ -23,8 +22,6 @@ const Packet = @import("packet.zig").Packet;
 const Signal = @import("signal.zig").Signal;
 
 const api = @import("../tb_client.zig");
-const tb_status_t = api.tb_status_t;
-const tb_client_t = api.tb_client_t;
 const tb_completion_t = api.tb_completion_t;
 
 pub const ContextImplementation = struct {

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -7,7 +7,6 @@ const vsr = @import("../tb_client.zig").vsr;
 const Header = vsr.Header;
 const stdx = vsr.stdx;
 const constants = vsr.constants;
-const RingBuffer = vsr.ring_buffer.RingBuffer;
 const MessagePool = vsr.message_pool.MessagePool;
 const Message = MessagePool.Message;
 

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -10,7 +10,6 @@ const c = @cImport({
 
 const stdx = @import("../../stdx.zig");
 const constants = @import("../../constants.zig");
-const Packet = @import("tb_client/packet.zig").Packet;
 
 const Mutex = std.Thread.Mutex;
 const Condition = std.Thread.Condition;

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -3,8 +3,6 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const flags = @import("../../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 

--- a/src/clients/dotnet/docs.zig
+++ b/src/clients/dotnet/docs.zig
@@ -1,7 +1,3 @@
-const std = @import("std");
-
-const assert = std.debug.assert;
-
 const Docs = @import("../docs_types.zig").Docs;
 
 pub const DotnetDocs = Docs{

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -3,8 +3,6 @@ const std = @import("std");
 const log = std.log;
 const assert = std.debug.assert;
 
-const flags = @import("../../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 

--- a/src/clients/go/go_bindings.zig
+++ b/src/clients/go/go_bindings.zig
@@ -4,7 +4,6 @@ const assert = std.debug.assert;
 
 const stdx = vsr.stdx;
 const tb = vsr.tigerbeetle;
-const tb_client = vsr.tb_client;
 
 const type_mappings = .{
     .{ tb.AccountFlags, "AccountFlags" },

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const log = std.log;
 const assert = std.debug.assert;
 
-const flags = @import("../../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -13,7 +13,8 @@ const builtin = @import("builtin");
 const jni = @import("jni.zig");
 
 // When referenced from unit_test.zig, there is no vsr import module. So use relative path instead.
-pub const vsr = if (builtin.is_test) @import("../../../vsr.zig") else @import("vsr");
+pub const vsr =
+    if (builtin.is_test) @import("../../../vsr.zig") else @import("vsr");
 
 const tb = vsr.tb_client;
 

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -3,8 +3,6 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const flags = @import("../../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -8,16 +8,10 @@ const tb = vsr.tigerbeetle;
 const tb_client = vsr.tb_client;
 
 const Account = tb.Account;
-const AccountFlags = tb.AccountFlags;
 const Transfer = tb.Transfer;
-const TransferFlags = tb.TransferFlags;
-const CreateAccountsResult = tb.CreateAccountsResult;
-const CreateTransfersResult = tb.CreateTransfersResult;
 const AccountFilter = tb.AccountFilter;
-const AccountFilterFlags = tb.AccountFilterFlags;
 const AccountBalance = tb.AccountBalance;
 const QueryFilter = tb.QueryFilter;
-const QueryFilterFlags = tb.QueryFilterFlags;
 
 const vsr = @import("vsr");
 const Storage = vsr.storage.StorageType(vsr.io.IO);

--- a/src/clients/python/ci.zig
+++ b/src/clients/python/ci.zig
@@ -3,8 +3,6 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const flags = @import("../../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -32,7 +32,6 @@
 const std = @import("std");
 const stdx = @import("./stdx.zig");
 const flags = @import("./flags.zig");
-const assert = std.debug.assert;
 
 const log = std.log;
 pub const std_options = .{

--- a/src/counting_allocator.zig
+++ b/src/counting_allocator.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const assert = std.debug.assert;
 
 const CountingAllocator = @This();
 

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -4,7 +4,6 @@ const assert = std.debug.assert;
 const flags = @import("./flags.zig");
 const constants = @import("./constants.zig");
 const fuzz = @import("./testing/fuzz.zig");
-const fatal = flags.fatal;
 
 const log = std.log.scoped(.fuzz);
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -1,9 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const assert = std.debug.assert;
 const os = std.os;
 
-const FIFO = @import("fifo.zig").FIFO;
 const IO_Linux = @import("io/linux.zig").IO;
 const IO_Darwin = @import("io/darwin.zig").IO;
 const IO_Windows = @import("io/windows.zig").IO;

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const os = std.os;
 const posix = std.posix;
 const mem = std.mem;
 const assert = std.debug.assert;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -280,7 +280,6 @@ pub fn CompactionType(
         const TableInfoReference = Manifest.TableInfoReference;
         const CompactionRange = Manifest.CompactionRange;
 
-        const Key = Table.Key;
         const Value = Table.Value;
         const key_from_value = Table.key_from_value;
         const tombstone = Table.tombstone;

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -10,19 +10,14 @@ const constants = @import("../constants.zig");
 
 const schema = @import("schema.zig");
 const GridType = @import("../vsr/grid.zig").GridType;
-const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
-const allocate_block = @import("../vsr/grid.zig").allocate_block;
 const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_node_size, 16);
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
 const ScanBufferPool = @import("scan_buffer.zig").ScanBufferPool;
 const ResourcePoolType = @import("compaction.zig").ResourcePoolType;
 const snapshot_min_for_table_output = @import("compaction.zig").snapshot_min_for_table_output;
-const snapshot_max_for_table_input = @import("compaction.zig").snapshot_max_for_table_input;
 const compaction_op_min = @import("compaction.zig").compaction_op_min;
 const compaction_block_count_bar_max = @import("compaction.zig").compaction_block_count_bar_max;
 const compaction_block_count_beat_min = @import("compaction.zig").compaction_block_count_beat_min;
-
-const IO = @import("../io.zig").IO;
 
 /// The maximum number of tables for the forest as a whole. This is set a bit backwards due to how
 /// the code is structured: a single tree should be able to use all the tables in the forest, so the

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -1,7 +1,6 @@
 // TODO Test scope_open/scope_close.
 
 const std = @import("std");
-const testing = std.testing;
 const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");
@@ -14,15 +13,12 @@ const log = std.log.scoped(.lsm_forest_fuzz);
 const lsm = @import("tree.zig");
 const tb = @import("../tigerbeetle.zig");
 
-const Transfer = @import("../tigerbeetle.zig").Transfer;
 const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
 const StateMachine = @import("../state_machine.zig")
     .StateMachineType(Storage, constants.state_machine_config);
 const Reservation = @import("../vsr/free_set.zig").Reservation;
 const GridType = @import("../vsr/grid.zig").GridType;
-const GrooveType = @import("groove.zig").GrooveType;
-const ScanBuffer = @import("../lsm/scan_buffer.zig").ScanBuffer;
 const ScanRangeType = @import("../lsm/scan_range.zig").ScanRangeType;
 const EvaluateNext = @import("../lsm/scan_range.zig").EvaluateNext;
 const ScanLookupType = @import("../lsm/scan_lookup.zig").ScanLookupType;
@@ -32,7 +28,6 @@ const Forest = StateMachine.Forest;
 
 const Grid = GridType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
-const FreeSet = vsr.FreeSet;
 
 const FuzzOpAction = union(enum) {
     compact: struct {

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -16,7 +16,6 @@ const schema = @import("schema.zig");
 
 const TreeConfig = @import("tree.zig").TreeConfig;
 const Direction = @import("../direction.zig").Direction;
-const GridType = @import("../vsr/grid.zig").GridType;
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
 const ManifestLevelType = @import("manifest_level.zig").ManifestLevelType;
 const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_node_size, 16);

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -11,7 +11,6 @@ const lsm = @import("tree.zig");
 const binary_search = @import("binary_search.zig");
 
 const Direction = @import("../direction.zig").Direction;
-const SegmentedArray = @import("segmented_array.zig").SegmentedArray;
 const SortedSegmentedArrayType = @import("segmented_array.zig").SortedSegmentedArrayType;
 
 pub fn ManifestLevelType(

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -20,7 +20,6 @@
 
 const std = @import("std");
 const assert = std.debug.assert;
-const math = std.math;
 const mem = std.mem;
 const maybe = stdx.maybe;
 
@@ -35,7 +34,6 @@ const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
 const allocate_block = @import("../vsr/grid.zig").allocate_block;
-const BlockType = @import("schema.zig").BlockType;
 const compaction = @import("compaction.zig");
 const RingBufferType = @import("../ring_buffer.zig").RingBufferType;
 const schema = @import("schema.zig");
@@ -52,7 +50,6 @@ pub fn ManifestLogType(comptime Storage: type) type {
 
         const SuperBlock = SuperBlockType(Storage);
         const Grid = GridType(Storage);
-        const Label = schema.ManifestNode.Label;
 
         pub const Callback = *const fn (manifest_log: *ManifestLog) void;
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -11,7 +11,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.fuzz_lsm_manifest_log);
-const maybe = stdx.maybe;
 
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");

--- a/src/lsm/scan_buffer.zig
+++ b/src/lsm/scan_buffer.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const mem = std.mem;
-const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 
 const constants = @import("../constants.zig");

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const testing = std.testing;
 const assert = std.debug.assert;
 const maybe = stdx.maybe;
 

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -1,12 +1,9 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const Allocator = std.mem.Allocator;
-
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 const GridType = @import("../vsr/grid.zig").GridType;
-const ScanType = @import("scan_builder.zig").ScanType;
 
 pub const ScanLookupStatus = enum {
     idle,

--- a/src/lsm/scan_range.zig
+++ b/src/lsm/scan_range.zig
@@ -1,6 +1,3 @@
-const std = @import("std");
-const assert = std.debug.assert;
-
 const ScanTreeType = @import("scan_tree.zig").ScanTreeType;
 const ScanBuffer = @import("scan_buffer.zig").ScanBuffer;
 

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -2,9 +2,6 @@ const std = @import("std");
 const mem = std.mem;
 const meta = std.meta;
 const assert = std.debug.assert;
-const Allocator = std.mem.Allocator;
-
-const log = std.log.scoped(.scan);
 
 const stdx = @import("../stdx.zig");
 const maybe = stdx.maybe;
@@ -14,10 +11,8 @@ const schema = @import("schema.zig");
 const binary_search = @import("binary_search.zig");
 const k_way_merge = @import("k_way_merge.zig");
 
-const BinarySearchRange = binary_search.BinarySearchRange;
 const Direction = @import("../direction.zig").Direction;
 const GridType = @import("../vsr/grid.zig").GridType;
-const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
 const TreeTableInfoType = @import("manifest.zig").TreeTableInfoType;
 const ManifestType = @import("manifest.zig").ManifestType;

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
 const assert = std.debug.assert;
-const maybe = stdx.maybe;
 const math = std.math;
 const mem = std.mem;
 

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
-const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");
 const NodePoolType = @import("node_pool.zig").NodePoolType;
 const table_count_max_for_level = @import("tree.zig").table_count_max_for_level;
-const table_count_max_for_tree = @import("tree.zig").table_count_max_for_tree;
 const SortedSegmentedArrayType = @import("segmented_array.zig").SortedSegmentedArrayType;
 
 const log = std.log;

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -9,9 +9,7 @@ const binary_search = @import("binary_search.zig");
 
 const stdx = @import("../stdx.zig");
 const div_ceil = stdx.div_ceil;
-const snapshot_latest = @import("tree.zig").snapshot_latest;
 
-const allocate_block = @import("../vsr/grid.zig").allocate_block;
 const TreeTableInfoType = @import("manifest.zig").TreeTableInfoType;
 const schema = @import("schema.zig");
 

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const mem = std.mem;
-const math = std.math;
 const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");

--- a/src/lsm/table_value_iterator.zig
+++ b/src/lsm/table_value_iterator.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const mem = std.mem;
-const math = std.math;
 const assert = std.debug.assert;
 
 const schema = @import("schema.zig");

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -3,11 +3,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
-const os = std.os;
 const maybe = stdx.maybe;
-const div_ceil = stdx.div_ceil;
-
-const log = std.log.scoped(.tree);
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
@@ -15,12 +11,10 @@ const schema = @import("schema.zig");
 
 const CompositeKeyType = @import("composite_key.zig").CompositeKeyType;
 const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_node_size, 16);
-const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
 
 pub const ScopeCloseMode = enum { persist, discard };
-const snapshot_min_for_table_output = @import("compaction.zig").snapshot_min_for_table_output;
 
 /// We reserve maxInt(u64) to indicate that a table has not been deleted.
 /// Tables that have not been deleted have snapshot_max of maxInt(u64).

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -12,12 +12,9 @@ const allocator = fuzz.allocator;
 const log = std.log.scoped(.lsm_tree_fuzz);
 
 const Direction = @import("../direction.zig").Direction;
-const Transfer = @import("../tigerbeetle.zig").Transfer;
-const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
 const ClusterFaultAtlas = @import("../testing/storage.zig").ClusterFaultAtlas;
 const GridType = @import("../vsr/grid.zig").GridType;
-const allocate_block = @import("../vsr/grid.zig").allocate_block;
 const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_node_size, 16);
 const TableUsage = @import("table.zig").TableUsage;
 const TableType = @import("table.zig").TableType;

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -10,10 +10,8 @@
 //!
 //!   This is a special case of the following rule-of-thumb: length of `build.zig` should be O(1).
 const std = @import("std");
-const assert = std.debug.assert;
 
 const flags = @import("flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("shell.zig");
 
 const cfo = @import("./scripts/cfo.zig");

--- a/src/scripts/antithesis.zig
+++ b/src/scripts/antithesis.zig
@@ -11,8 +11,6 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const flags = @import("../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../shell.zig");
 
 pub const CLIArgs = struct {

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -51,8 +51,6 @@ const log = std.log;
 const assert = std.debug.assert;
 
 const stdx = @import("../stdx.zig");
-const flags = @import("../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../shell.zig");
 
 pub const CLIArgs = struct {

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -9,8 +9,6 @@ const log = std.log;
 const assert = std.debug.assert;
 
 const stdx = @import("../stdx.zig");
-const flags = @import("../flags.zig");
-const fatal = flags.fatal;
 const Shell = @import("../shell.zig");
 
 const client_readmes = @import("./client_readmes.zig");

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -25,8 +25,6 @@ const multiversioning = @import("../multiversioning.zig");
 const changelog = @import("./changelog.zig");
 
 const multiversion_binary_size_max = multiversioning.multiversion_binary_size_max;
-const multiversion_binary_platform_size_max = multiversioning.multiversion_binary_platform_size_max;
-const section_to_macho_cpu = multiversioning.section_to_macho_cpu;
 
 const Language = enum { dotnet, go, java, node, python, zig, docker };
 const LanguageSet = std.enums.EnumSet(Language);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -23,11 +23,9 @@ const Direction = @import("direction.zig").Direction;
 const TimestampRange = @import("lsm/timestamp_range.zig").TimestampRange;
 
 const Account = tb.Account;
-const AccountFlags = tb.AccountFlags;
 const AccountBalance = tb.AccountBalance;
 
 const Transfer = tb.Transfer;
-const TransferFlags = tb.TransferFlags;
 const TransferPendingStatus = tb.TransferPendingStatus;
 
 const CreateAccountsResult = tb.CreateAccountsResult;
@@ -3054,7 +3052,6 @@ fn ExpirePendingTransfersType(
         const ScanLookupStatus = @import("lsm/scan_lookup.zig").ScanLookupStatus;
 
         const Tree = std.meta.FieldType(TransfersGroove.IndexTrees, .expires_at);
-        const Key = Tree.Table.Key;
         const Value = Tree.Table.Value;
 
         // TODO(zig) Context should be `*ExpirePendingTransfers`,

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -19,7 +19,6 @@
 //!
 const std = @import("std");
 const assert = std.debug.assert;
-const log = std.log.scoped(.test_workload);
 
 const stdx = @import("../stdx.zig");
 const maybe = stdx.maybe;

--- a/src/static_allocator.zig
+++ b/src/static_allocator.zig
@@ -5,7 +5,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
-const log = std.log.scoped(.static_allocator);
 
 const StaticAllocator = @This();
 parent_allocator: mem.Allocator,

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const os = std.os;
 const assert = std.debug.assert;
 const maybe = stdx.maybe;
 const log = std.log.scoped(.storage);

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const log = std.log.scoped(.fuzz_storage);
 
 const vsr = @import("vsr.zig");
 const constants = @import("constants.zig");

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -26,7 +26,6 @@ const ManifestCheckerType = @import("cluster/manifest_checker.zig").ManifestChec
 const vsr = @import("../vsr.zig");
 pub const ReplicaFormat = vsr.ReplicaFormatType(Storage);
 const SuperBlock = vsr.SuperBlockType(Storage);
-const superblock_zone_size = @import("../vsr/superblock.zig").superblock_zone_size;
 
 pub const ReplicaHealth = enum { up, down };
 

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -4,12 +4,9 @@ const assert = std.debug.assert;
 const MessagePool = @import("../../message_pool.zig").MessagePool;
 const Message = MessagePool.Message;
 const vsr = @import("../../vsr.zig");
-const Header = vsr.Header;
 const ProcessType = vsr.ProcessType;
 
 const Network = @import("network.zig").Network;
-
-const log = std.log.scoped(.message_bus);
 
 pub const Process = union(ProcessType) {
     replica: u8,

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const math = std.math;
 const mem = std.mem;
 const assert = std.debug.assert;
 

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -22,8 +22,6 @@ const ReplicaHead = struct {
     op: u64,
 };
 
-const log = std.log.scoped(.state_checker);
-
 pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
     return struct {
         const StateChecker = @This();

--- a/src/testing/fuzz.zig
+++ b/src/testing/fuzz.zig
@@ -2,9 +2,6 @@
 
 const std = @import("std");
 const assert = std.debug.assert;
-const mem = std.mem;
-
-const log = std.log.scoped(.fuzz);
 
 // Use our own allocator in the global scope instead of testing.allocator
 // as the latter now @compileError()'s if referenced outside a `test` block.

--- a/src/testing/hash_log.zig
+++ b/src/testing/hash_log.zig
@@ -6,7 +6,6 @@
 //! Otherwise, calls to `emit` are noops.
 
 const std = @import("std");
-const assert = std.debug.assert;
 const panic = std.debug.panic;
 
 const constants = @import("../constants.zig");

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -1,15 +1,12 @@
 const std = @import("std");
-const os = std.os;
 const posix = std.posix;
 const mem = std.mem;
 const assert = std.debug.assert;
-const log = std.log.scoped(.io);
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const FIFOType = @import("../fifo.zig").FIFOType;
 const buffer_limit = @import("../io.zig").buffer_limit;
-const DirectIO = @import("../io.zig").DirectIO;
 
 /// A very simple mock IO implementation that only implements what is needed to test Storage.
 pub const IO = struct {

--- a/src/testing/reply_sequence.zig
+++ b/src/testing/reply_sequence.zig
@@ -6,11 +6,8 @@ const maybe = stdx.maybe;
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
-const IdPermutation = @import("id.zig").IdPermutation;
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Message = MessagePool.Message;
-const Client = @import("cluster.zig").Client;
-const StateMachine = @import("cluster.zig").StateMachine;
 
 const PriorityQueue = std.PriorityQueue;
 

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const log = std.log.scoped(.state_machine);
 
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");

--- a/src/testing/time.zig
+++ b/src/testing/time.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const assert = std.debug.assert;
 
 pub const OffsetType = enum {
     linear,

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -13,7 +13,6 @@
 //! the load and measuring response latencies and throughput. The load runs in-process.
 
 const std = @import("std");
-const assert = std.debug.assert;
 const ChildProcess = std.process.Child;
 
 const vsr = @import("vsr");

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -27,7 +27,6 @@ const Grid = vsr.GridType(Storage);
 
 const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, Time, AOF);
 const SuperBlock = vsr.SuperBlockType(Storage);
-const superblock_zone_size = vsr.superblock.superblock_zone_size;
 const data_file_size_min = vsr.superblock.data_file_size_min;
 
 /// The runtime maximum log level.

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -18,7 +18,6 @@ const StateMachineType = switch (state_machine) {
     .testing => @import("testing/state_machine.zig").StateMachineType,
 };
 
-const Client = @import("testing/cluster.zig").Client;
 const Cluster = @import("testing/cluster.zig").ClusterType(StateMachineType);
 const Release = @import("testing/cluster.zig").Release;
 const StateMachine = Cluster.StateMachine;
@@ -27,7 +26,6 @@ const PartitionMode = @import("testing/packet_simulator.zig").PartitionMode;
 const PartitionSymmetry = @import("testing/packet_simulator.zig").PartitionSymmetry;
 const Core = @import("testing/cluster/network.zig").Network.Core;
 const ReplySequence = @import("testing/reply_sequence.zig").ReplySequence;
-const IdPermutation = @import("testing/id.zig").IdPermutation;
 const Message = @import("message_pool.zig").MessagePool.Message;
 
 const releases = [_]Release{

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const math = std.math;
-const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const maybe = stdx.maybe;
 const log = std.log.scoped(.vsr);

--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const maybe = stdx.maybe;
 const mem = std.mem;
 
 const vsr = @import("../vsr.zig");

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const stdx = @import("../stdx.zig");
-const maybe = stdx.maybe;
 const mem = std.mem;
 const assert = std.debug.assert;
 
@@ -10,8 +9,6 @@ const Header = vsr.Header;
 
 const MessagePool = @import("../message_pool.zig").MessagePool;
 const Message = @import("../message_pool.zig").MessagePool.Message;
-const IOPS = @import("../iops.zig").IOPS;
-const FIFO = @import("../fifo.zig").FIFO;
 
 const log = stdx.log.scoped(.client);
 

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -21,7 +21,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const maybe = stdx.maybe;
-const mem = std.mem;
 const log = std.log.scoped(.client_replies);
 
 const stdx = @import("../stdx.zig");

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -11,17 +11,12 @@
 //!   corrupt blocks.
 const std = @import("std");
 const assert = std.debug.assert;
-const log = std.log.scoped(.grid_blocks_missing);
-const maybe = stdx.maybe;
 
-const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const schema = @import("../lsm/schema.zig");
 const vsr = @import("../vsr.zig");
 
-const GridType = @import("./grid.zig").GridType;
 const FIFOType = @import("../fifo.zig").FIFOType;
-const IOPS = @import("../iops.zig").IOPS;
 const BlockPtrConst = *align(constants.sector_size) const [constants.block_size]u8;
 
 pub const GridBlocksMissing = struct {

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -30,13 +30,11 @@ const constants = @import("../constants.zig");
 const schema = @import("../lsm/schema.zig");
 const FIFOType = @import("../fifo.zig").FIFOType;
 const IOPSType = @import("../iops.zig").IOPSType;
-const RingBuffer = @import("../ring_buffer.zig").RingBuffer;
 
 const allocate_block = @import("./grid.zig").allocate_block;
 const GridType = @import("./grid.zig").GridType;
 const BlockPtr = @import("./grid.zig").BlockPtr;
 const ForestTableIteratorType = @import("../lsm/forest_table_iterator.zig").ForestTableIteratorType;
-const snapshot_from_op = @import("../lsm/manifest.zig").snapshot_from_op;
 const TestStorage = @import("../testing/storage.zig").Storage;
 
 pub fn GridScrubberType(comptime Forest: type) type {

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
-const math = std.math;
 const maybe = stdx.maybe;
 
 const constants = @import("../constants.zig");

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -25,9 +25,7 @@ const Header = vsr.Header;
 const Timeout = vsr.Timeout;
 const Command = vsr.Command;
 const Version = vsr.Version;
-const VSRState = vsr.VSRState;
 const SyncStage = vsr.SyncStage;
-const SyncTarget = vsr.SyncTarget;
 const ClientSessions = vsr.ClientSessions;
 
 const log = marks.wrap_log(stdx.log.scoped(.replica));

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -17,7 +17,6 @@ const Cluster = @import("../testing/cluster.zig").ClusterType(StateMachineType);
 const ReplicaHealth = @import("../testing/cluster.zig").ReplicaHealth;
 const LinkFilter = @import("../testing/cluster/network.zig").LinkFilter;
 const Network = @import("../testing/cluster/network.zig").Network;
-const Storage = @import("../testing/storage.zig").Storage;
 
 const slot_count = constants.journal_slot_count;
 const checkpoint_1 = vsr.Checkpoint.checkpoint_after(0);

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -29,11 +29,8 @@
 //!
 const std = @import("std");
 const assert = std.debug.assert;
-const crypto = std.crypto;
 const mem = std.mem;
 const meta = std.meta;
-const os = std.os;
-const maybe = stdx.maybe;
 
 const constants = @import("../constants.zig");
 const stdx = @import("../stdx.zig");

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -12,7 +12,6 @@
 //!
 const std = @import("std");
 const assert = std.debug.assert;
-const log = std.log.scoped(.fuzz_vsr_superblock);
 
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -4,7 +4,6 @@ const log = std.log.scoped(.superblock_quorums);
 
 const superblock = @import("./superblock.zig");
 const SuperBlockHeader = superblock.SuperBlockHeader;
-const SuperBlockVersion = superblock.SuperBlockVersion;
 const fuzz = @import("./superblock_quorums_fuzz.zig");
 
 pub const Options = struct {

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const log = std.log.scoped(.fuzz_vsr_superblock_quorums);
 
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -1,9 +1,6 @@
 const std = @import("std");
-const assert = std.debug.assert;
-const maybe = stdx.maybe;
 
 const vsr = @import("../vsr.zig");
-const stdx = @import("../stdx.zig");
 
 pub const Stage = union(enum) {
     idle,


### PR DESCRIPTION
I meant to do this when implementing tidy check for dead code, but the initial implementation missed the `const foo = std.foo` case (it considered it a usage of `foo`), so we actually missed a lot of unused things! 

I am _somewhat_ apprehensive about removing "I will need it later" things like `const log =` and `const assert =`, but, I think, on balance, it's better to stick to simple rule about no unused stuff. 