### PR TITLE
VSR: Improve `prepare_timeout`/`replicate` replica selection

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2945,13 +2945,17 @@ pub fn ReplicaType(
                 return;
             }
 
+            // See replicate().
+            const ring_direction: i16 = if (prepare.message.header.op % 2 == 0) 1 else -1;
+
             // The list of remote replicas yet to send a prepare_ok:
             var waiting: [constants.replicas_max]u8 = undefined;
             var waiting_len: usize = 0;
             for (1..self.replica_count) |ring_index| {
-                const replica: u8 = @intCast(
-                    (@as(usize, self.replica) + ring_index) % self.replica_count,
-                );
+                const replica: u8 = @intCast(@mod(
+                    @as(i16, self.replica) + ring_direction * @as(i16, @intCast(ring_index)),
+                    self.replica_count,
+                ));
                 assert(replica != self.replica);
                 if (!prepare.ok_from_all_replicas.isSet(replica)) {
                     waiting[waiting_len] = replica;
@@ -7247,10 +7251,20 @@ pub fn ReplicaType(
                 return;
             }
 
+            // Even ops replicate clockwise.
+            // Odd ops replicate counter-clockwise.
+            //
+            // This means that if the first backup after the primary is down, replication
+            // doesn't necessarily need to wait for prepare_timeout, since the next prepare
+            // (routed backwards) could trigger repair in the other replicas.
+            // TODO Once we use health data to skip faulty replicas, then this isn't needed.
+            const ring_direction: i16 = if (message.header.op % 2 == 0) 1 else -1;
+
             const next = next: {
                 // Replication in the ring of active replicas.
                 if (!self.standby()) {
-                    const next_replica = @mod(self.replica + 1, self.replica_count);
+                    const next_replica: u8 =
+                        @intCast(@mod(@as(i16, self.replica) + ring_direction, self.replica_count));
                     if (next_replica != self.primary_index(message.header.view)) {
                         break :next next_replica;
                     }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1146,7 +1146,7 @@ pub fn ReplicaType(
                 .prepare_timeout = Timeout{
                     .name = "prepare_timeout",
                     .id = replica_index,
-                    .after = 50,
+                    .after = 25,
                 },
                 .primary_abdicate_timeout = Timeout{
                     .name = "primary_abdicate_timeout",

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6231,9 +6231,10 @@ pub fn ReplicaType(
             message.header.set_checksum_body(message.body_used());
             message.header.set_checksum();
 
-            log.debug("{}: primary_pipeline_prepare: prepare {}", .{
+            log.debug("{}: primary_pipeline_prepare: prepare checksum={} op={}", .{
                 self.replica,
                 message.header.checksum,
+                message.header.op,
             });
 
             if (self.primary_pipeline_pending()) |_| {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1788,6 +1788,7 @@ test "Cluster: view_change: lagging replica repairs WAL using start_view from po
     b1.pass(.R_, .outgoing, .do_view_change);
 
     t.run();
+    t.run();
 
     try expectEqual(b1.status(), .normal);
     try expectEqual(b1.role(), .primary);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1788,7 +1788,6 @@ test "Cluster: view_change: lagging replica repairs WAL using start_view from po
     b1.pass(.R_, .outgoing, .do_view_change);
 
     t.run();
-    t.run();
 
     try expectEqual(b1.status(), .normal);
     try expectEqual(b1.role(), .primary);


### PR DESCRIPTION
# Bug

Consider the following scenario:

1. `view=2`, so `R2` is primary.
2. `R3` is killed.
3. `R2`: Primary receives a request.
4. `R2`: Primary replicates request to `R3`.
5. `R2`: `prepare_timeout` fires after 500ms, and we replicate to `R1`.
6. `R1`: Ack, but don't replicate, since the next node in the ring is `R2`, which is primary. (So `R1` assumes replication is done).
7. `R2`: After another >500ms (longer due to backoff), `prepare_timeout` fires again, this time replicating to `R4`.
8. `R4`: Ack, replicate to `R0`.
9. `R2`: Commit + reply.

So the cluster isn't deadlocked, just slow.

Steps 3-9 repeat for each prepare.

Due to how `prepare_timeout` selects its target replica, for this particular `view`/`replica_count` combination, `R2` always picks `R1` as its first retry.

# Fix

A complete solution for efficient ring replication in compromised clusters will involve tracking the health of all replicas.

But in the mean time, mitigate the issue by:
- In `prepare_timeout`, leapfrog the (most likely down) replica for the first retry. (That is, in the above scenario, the first retry would go to `R4` instead of `R3`).
- In `replicate`/`prepare_timeout`, use a counter-clockwise replication ring for odd ops.
- Reduce `prepare_timeout`'s timeout from 500ms to 250ms.