### PR TITLE
misc: use --save-exact for node and better log on eviction

### DIFF
--- a/docs/operating/upgrading.md
+++ b/docs/operating/upgrading.md
@@ -114,7 +114,7 @@ Edit your `pom.xml`:
 
 ### Node.js
 ```
-npm install tigerbeetle-node@0.15.4
+npm install --save-exact tigerbeetle-node@0.15.4
 ```
 
 ### Python

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -20,7 +20,7 @@ First, create a directory for your project and `cd` into the directory.
 Then, install the TigerBeetle client:
 
 ```console
-npm install tigerbeetle-node
+npm install --save-exact tigerbeetle-node
 ```
 
 Now, create `main.js` and copy this into it:

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -21,7 +21,7 @@ pub const NodeDocs = Docs{
     .project_file_name = "",
     .test_file_name = "main",
 
-    .install_commands = "npm install tigerbeetle-node",
+    .install_commands = "npm install --save-exact tigerbeetle-node",
     .run_commands = "node main.js",
 
     .examples =

--- a/src/clients/node/samples/basic/README.md
+++ b/src/clients/node/samples/basic/README.md
@@ -16,7 +16,7 @@ First, clone this repo and `cd` into `tigerbeetle/src/clients/node/samples/basic
 Then, install the TigerBeetle client:
 
 ```console
-npm install tigerbeetle-node
+npm install --save-exact tigerbeetle-node
 ```
 
 ## Start the TigerBeetle server

--- a/src/clients/node/samples/two-phase-many/README.md
+++ b/src/clients/node/samples/two-phase-many/README.md
@@ -16,7 +16,7 @@ First, clone this repo and `cd` into `tigerbeetle/src/clients/node/samples/two-p
 Then, install the TigerBeetle client:
 
 ```console
-npm install tigerbeetle-node
+npm install --save-exact tigerbeetle-node
 ```
 
 ## Start the TigerBeetle server

--- a/src/clients/node/samples/two-phase/README.md
+++ b/src/clients/node/samples/two-phase/README.md
@@ -16,7 +16,7 @@ First, clone this repo and `cd` into `tigerbeetle/src/clients/node/samples/two-p
 Then, install the TigerBeetle client:
 
 ```console
-npm install tigerbeetle-node
+npm install --save-exact tigerbeetle-node
 ```
 
 ## Start the TigerBeetle server

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -599,11 +599,16 @@ fn publish(
             \\minutes after the release for this version to appear in the package
             \\manager.
             \\
+            \\You cannot run a newer client against an older cluster: clients are only compatible
+            \\with replicas from their own release *or newer*, subject to the newer release's
+            \\`Oldest supported client version`.
+            \\
             \\* .NET: `dotnet add package tigerbeetle --version {[tag]s}`
             \\* Go: `go mod edit -require github.com/tigerbeetle/tigerbeetle-go@v{[tag]s}`
             \\* Java: Update the version of `com.tigerbeetle.tigerbeetle-java` in `pom.xml`
             \\  to `{[tag]s}`.
-            \\* Node.js: `npm install tigerbeetle-node@{[tag]s}`
+            \\* Node.js: `npm install --save-exact tigerbeetle-node@{[tag]s}`
+            \\* Python: `pip install tigerbeetle=={[tag]s}`
             \\
             \\## Changelog
             \\

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -395,11 +395,23 @@ pub fn ClientType(comptime StateMachine_: type, comptime MessageBus: type) type 
             assert(eviction.header.view >= self.view);
 
             if (self.on_eviction_callback) |callback| {
-                log.err("{}: session evicted: reason={?s} (cluster_release={})", .{
-                    self.id,
-                    std.enums.tagName(vsr.Header.Eviction.Reason, eviction.header.reason),
-                    eviction.header.release,
-                });
+                const eviction_specific_log = switch (eviction.header.reason) {
+                    .client_release_too_low => " - your client is too old; upgrade to a version " ++
+                        "compatible with your cluster",
+                    .client_release_too_high => " - your client is too new; downgrade to the " ++
+                        "same version as your cluster",
+                    else => "",
+                };
+                log.err(
+                    "{}: session evicted: reason={?s} (cluster_release={}, client_release={}){s}",
+                    .{
+                        self.id,
+                        std.enums.tagName(vsr.Header.Eviction.Reason, eviction.header.reason),
+                        eviction.header.release,
+                        self.release,
+                        eviction_specific_log,
+                    },
+                );
 
                 self.evicted = true;
                 self.on_eviction_callback = null;


### PR DESCRIPTION
Without `--save-exact`, node will record the package as eg `^0.16.16` which will bump patch versions. This is incompatible with how we handle versions between clients and replicas.

Additionally, note that down in the release notes, and include Python there which was missing.

Lastly, when logging the eviction, include the client release and hint on what to do, if it was due to mismatched versions.