### PR TITLE
Vortex: write formatted timestamp in trace event

### DIFF
--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -1030,7 +1030,7 @@ const TraceWriter = struct {
         try writer.stream.endObject();
     }
 
-    fn write(writer: *TraceWriter, event: TraceEvent, args: anytype) !void {
+    fn write(writer: *TraceWriter, event: TraceEvent, metadata: anytype) !void {
         try writer.stream.beginObject();
 
         try writer.stream.objectField("pid");
@@ -1062,8 +1062,16 @@ const TraceWriter = struct {
             try writer.stream.write(@tagName(name));
         }
 
+        const datetime = stdx.DateTimeUTC.from_timestamp_ms(timestamp / 1000);
+        var datetime_buffer: [128]u8 = undefined;
+        var datetime_stream = std.io.fixedBufferStream(&datetime_buffer);
+        stdx.DateTimeUTC.format(datetime, "", .{}, datetime_stream.writer()) catch return;
+
         try writer.stream.objectField("args");
-        try writer.stream.write(args);
+        try writer.stream.write(.{
+            .metadata = metadata,
+            .timestamp = datetime_stream.getWritten(),
+        });
 
         try writer.stream.endObject();
     }

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -1063,7 +1063,7 @@ const TraceWriter = struct {
         }
 
         const datetime = stdx.DateTimeUTC.from_timestamp_ms(timestamp / 1000);
-        var datetime_buffer: [128]u8 = undefined;
+        var datetime_buffer: [24]u8 = undefined;
         var datetime_stream = std.io.fixedBufferStream(&datetime_buffer);
         stdx.DateTimeUTC.format(datetime, "", .{}, datetime_stream.writer()) catch return;
 


### PR DESCRIPTION
It's hard to correlate events in the tracing UI with log lines. Now that we have timestamps in the log, it's nice to also have formatted timestamps in the trace events (Chrome only shows relative time since start).

![image](https://github.com/user-attachments/assets/36003802-6ebe-45fd-a218-88951662eda4)
