### PR TITLE
VSR: Revert reverse ring replication

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2943,17 +2943,13 @@ pub fn ReplicaType(
                 return;
             }
 
-            // See replicate().
-            const ring_direction: i16 = if (prepare.message.header.op % 2 == 0) 1 else -1;
-
             // The list of remote replicas yet to send a prepare_ok:
             var waiting: [constants.replicas_max]u8 = undefined;
             var waiting_len: usize = 0;
             for (1..self.replica_count) |ring_index| {
-                const replica: u8 = @intCast(@mod(
-                    @as(i16, self.replica) + ring_direction * @as(i16, @intCast(ring_index)),
-                    self.replica_count,
-                ));
+                const replica: u8 = @intCast(
+                    (@as(usize, self.replica) + ring_index) % self.replica_count,
+                );
                 assert(replica != self.replica);
                 if (!prepare.ok_from_all_replicas.isSet(replica)) {
                     waiting[waiting_len] = replica;
@@ -7250,20 +7246,10 @@ pub fn ReplicaType(
                 return;
             }
 
-            // Even ops replicate clockwise.
-            // Odd ops replicate counter-clockwise.
-            //
-            // This means that if the first backup after the primary is down, replication
-            // doesn't necessarily need to wait for prepare_timeout, since the next prepare
-            // (routed backwards) could trigger repair in the other replicas.
-            // TODO Once we use health data to skip faulty replicas, then this isn't needed.
-            const ring_direction: i16 = if (message.header.op % 2 == 0) 1 else -1;
-
             const next = next: {
                 // Replication in the ring of active replicas.
                 if (!self.standby()) {
-                    const next_replica: u8 =
-                        @intCast(@mod(@as(i16, self.replica) + ring_direction, self.replica_count));
+                    const next_replica = @mod(self.replica + 1, self.replica_count);
                     if (next_replica != self.primary_index(message.header.view)) {
                         break :next next_replica;
                     }


### PR DESCRIPTION
This reverts commit da50a79cc0f527fc91a1bcadca6f2c431e2aa059.

I think this has some unexpected consequences around header repair which might make it counterproductive. I am investigating more, but don't want to release it in the mean time.