### PR TITLE
misc: add random_int_nonzero

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -324,7 +324,7 @@ pub const AOFReplayClient = struct {
         client.* = try Client.init(
             allocator,
             .{
-                .id = std.crypto.random.int(u128),
+                .id = stdx.unique_u128(),
                 .cluster = 0,
                 .replica_count = @intCast(addresses.len),
                 .message_pool = message_pool,

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -125,8 +125,7 @@ pub fn ContextType(
             errdefer allocator.destroy(context);
 
             context.allocator = allocator;
-            context.client_id = std.crypto.random.int(u128);
-            assert(context.client_id != 0); // Broken CSPRNG is the likeliest explanation for zero.
+            context.client_id = stdx.unique_u128();
 
             log.debug("{}: init: parsing vsr addresses: {s}", .{ context.client_id, addresses });
             context.addresses = .{};

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -636,8 +636,7 @@ pub const Multiversion = struct {
         );
         errdefer allocator.free(source_buffer);
 
-        const nonce = std.crypto.random.int(u128);
-        assert(nonce != 0); // Broken CSPRNG is the likeliest explanation for zero.
+        const nonce = stdx.unique_u128();
 
         const target_path: [:0]const u8 = switch (builtin.target.os.tag) {
             .linux => try allocator.dupeZ(u8, multiversion_uuid),

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -859,7 +859,7 @@ pub fn ReplType(comptime MessageBus: type) type {
             io.* = try IO.init(32, 0);
             errdefer io.deinit();
 
-            const client_id = std.crypto.random.int(u128);
+            const client_id = stdx.unique_u128();
             const client = try Client.init(
                 allocator,
                 .{

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -940,3 +940,13 @@ pub fn unexpected_errno(label: []const u8, err: std.posix.system.E) std.posix.Un
     }
     return error.Unexpected;
 }
+
+pub fn unique_u128() u128 {
+    const value = std.crypto.random.int(u128);
+
+    // Broken CSPRNG is the likeliest explanation for zero or all ones.
+    assert(value != 0);
+    assert(value != std.math.maxInt(u128));
+
+    return value;
+}

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -70,7 +70,7 @@ pub fn main(
         .{cli_args.transfer_hot_percent},
     );
 
-    const client_id = std.crypto.random.int(u128);
+    const client_id = stdx.unique_u128();
     const cluster_id: u128 = 0;
 
     var io = try IO.init(32, 0);

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -303,8 +303,7 @@ const Command = struct {
             });
         }
 
-        const nonce = std.crypto.random.int(u128);
-        assert(nonce != 0); // Broken CSPRNG is the likeliest explanation for zero.
+        const nonce = stdx.unique_u128();
 
         var multiversion: ?vsr.multiversioning.Multiversion = blk: {
             if (constants.config.process.release.value ==


### PR DESCRIPTION
Quite a few places (and some that forget!) use the pattern of generating a random u128 then checking it's non-zero, in case there's a broken CSPRNG.

Factor that out into a function and use it everywhere `std.crypto.random.int(u128)` was used directly before.