### PR TITLE
devhub: track ci pipeline duration on the devhub

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -129,6 +129,21 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         "us",
     );
 
+    const ci_pipeline_duration_s = blk: {
+        const times_gh = try shell.exec_stdout("gh run list -c {sha} -e merge_group " ++
+            "--json startedAt,updatedAt -L 1 --template {template}", .{
+            .sha = cli_args.sha,
+            .template = "{{range .}}{{.startedAt}} {{.updatedAt}}{{end}}",
+        });
+        const iso8601_started_at, const iso8601_updated_at =
+            (stdx.cut(times_gh, " ") orelse break :blk null).unpack();
+
+        const epoch_started_at = try shell.iso8601_to_timestamp_seconds(iso8601_started_at);
+        const epoch_updated_at = try shell.iso8601_to_timestamp_seconds(iso8601_updated_at);
+
+        break :blk epoch_updated_at - epoch_started_at;
+    };
+
     const batch = MetricBatch{
         .timestamp = commit_timestamp,
         .attributes = .{
@@ -137,7 +152,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             .branch = "main",
         },
         .metrics = &[_]Metric{
-            .{ .name = "build time", .value = build_time_ms, .unit = "ms" },
+            .{ .name = "ci pipeline duration", .value = ci_pipeline_duration_s.?, .unit = "s" },
             .{ .name = "executable size", .value = executable_size_bytes, .unit = "bytes" },
             .{ .name = "TPS", .value = tps, .unit = "count" },
             .{ .name = "batch p100", .value = batch_p100_ms, .unit = "ms" },
@@ -150,6 +165,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
                 .value = checksum_message_size_max_us,
                 .unit = "us",
             },
+            .{ .name = "build time", .value = build_time_ms, .unit = "ms" },
         },
     };
 

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -909,3 +909,11 @@ pub fn http_post(shell: *Shell, url: []const u8, body: []const u8, options: Http
         return error.WrongStatusResponse;
     }
 }
+
+/// Converts an ISO8601 timestamp into seconds from the epoch by shelling out to the `date` util.
+pub fn iso8601_to_timestamp_seconds(shell: *Shell, datetime_iso8601: []const u8) !u64 {
+    return try std.fmt.parseInt(u64, try shell.exec_stdout(
+        "date -d {datetime_iso8601} +%s",
+        .{ .datetime_iso8601 = datetime_iso8601 },
+    ), 10);
+}


### PR DESCRIPTION
Specifically, this tracks the merge_group duration for a specific commit, which is the time said commit spent in the merge queue running CI.

Since the tip of the merge queue becomes the tip on `main`, and this *must* happen before the devhub runs, we can reliably extract this info and publish it to our metrics.