### PR TITLE
main: switch to GPA as base allocator

### DIFF
--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -76,6 +76,7 @@ pub fn main(
     var io = try IO.init(32, 0);
 
     var message_pool = try MessagePool.init(allocator, .client);
+    defer message_pool.deinit(allocator);
 
     std.log.info("Benchmark running against {any}", .{addresses});
 
@@ -92,6 +93,7 @@ pub fn main(
             },
         },
     );
+    defer client.deinit(allocator);
 
     var batch_accounts =
         try std.ArrayListUnmanaged(tb.Account).initCapacity(allocator, cli_args.account_batch_size);

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -189,7 +189,6 @@ const Inspector = struct {
         std.posix.close(inspector.fd);
         std.posix.close(inspector.dir_fd);
         inspector.allocator.destroy(inspector);
-        inspector.* = undefined;
     }
 
     fn work(inspector: *Inspector) !void {


### PR DESCRIPTION
The arena allocator likes to overallocate quite generously. This isn't normally a problem, but after enabling mlockall() in #2478, that unused but mmap'd memory is now forcefully paged in and contributes to our real RSS.

With default grid cache, this takes memory usage from 2.9GiB to 4.7GiB! With a large grid cache (24GiB) it takes a whole extra 3GiB of memory.

Switch to using Zig's general purpose allocator, which overallocates much less. This is still a bit of a workaround - but one that seems to work rather well. A nice side-effect is that it makes it much easier to catch leaks and use-after-frees, like the little fixes you'll see included in this commit.

In terms of usage, both with the default grid cache size and a 24GiB grid cache, the RSS is now identical with and without mlockall.

The performance difference isn't noticeable when starting with the default grid cache, and grows to around ~30% slower for 24GiB grid cache vs the arena allocator.

This can be solved in future by optimizing how the grid cache allocates blocks...

---

The future is now!

Rather than allocating each 512KiB grid block individually, allocate a bulk backing buffer and slice that up. There's still the BlockPtr indirection layer, so this doesn't change much other than how the physical memory is allocated.

Takes startup with a 24GiB grid cache from ~7s (originally, ~5s) to ~4s.