### PR TITLE
vsr: assert against ABA problem during commit

### DIFF
--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -725,13 +725,10 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             ) void,
             op: u64,
             checksum: u128,
-            destination_replica: ?u8,
         ) void {
             assert(journal.status == .recovered);
             assert(checksum != 0);
-            if (destination_replica == null) {
-                assert(journal.reads.available() > 0);
-            }
+            assert(journal.reads.available() > 0);
 
             const replica: *Replica = @alignCast(@fieldParentPtr("journal", journal));
             if (op > replica.op) {
@@ -753,7 +750,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                     callback,
                     op,
                     checksum,
-                    destination_replica,
+                    null,
                 );
             } else {
                 journal.read_prepare_log(op, checksum, "no matching prepare");

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3903,7 +3903,6 @@ pub fn ReplicaType(
                         commit_start_journal_callback,
                         op,
                         header.checksum,
-                        null,
                     );
                     return .pending;
                 }
@@ -6875,7 +6874,7 @@ pub fn ReplicaType(
                 op,
                 op_checksum,
             });
-            self.journal.read_prepare(repair_pipeline_read_callback, op, op_checksum, null);
+            self.journal.read_prepare(repair_pipeline_read_callback, op, op_checksum);
         }
 
         fn repair_pipeline_read_callback(

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3952,6 +3952,7 @@ pub fn ReplicaType(
 
             const op = self.commit_min + 1;
             assert(prepare.?.header.op == op);
+            assert(self.journal.has(prepare.?.header));
 
             self.commit_prepare = prepare.?.ref();
             return self.commit_dispatch_resume();
@@ -3974,6 +3975,7 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.operation != .reserved);
             assert(self.commit_prepare.?.header.op == self.commit_min + 1);
             assert(self.commit_prepare.?.header.op <= self.op);
+            assert(self.journal.has(self.commit_prepare.?.header));
 
             const prepare = self.commit_prepare.?;
 


### PR DESCRIPTION
Reading prepare from the journal is asynchronous operation. Generally
speaking, there's no guarantee that, by te time the read finishes, the
prepare remains correct. E.g., you can start reading from slot=20  in
view=5, but finish in view=6, where that slot would have been occupied
by a different prepare with the same op number.

This actually cannot happen on the commit path, but for a very
non-trivial reason (general VSR correctness), so let's assert this via
`journal.has` which will compare the checksum of the prepare we have on
hand with the checksum we are supposed to be having.

Add the assert to the read callback and prefetch. We already assert
later this in execute.

Inspired by https://github.com/tigerbeetle/tigerbeetle/pull/2571, where a past read from a specific slot in journal was
interpreted as a recent one.