### PR TITLE
CLI/Benchmark: Add `--clients` flag

### DIFF
--- a/docs/coding/recipes/balance-invariant-transfers.md
+++ b/docs/coding/recipes/balance-invariant-transfers.md
@@ -7,7 +7,7 @@ sidebar_position: 8
 For some accounts, it may be useful to enforce
 [`flags.debits_must_not_exceed_credits`](../../reference/account.md#flagsdebits_must_not_exceed_credits)
 or
-[`flags.credits_must_not_exceed_debits`](../../reference/account.md#flagscredits_must_not_exceed_debits).
+[`flags.credits_must_not_exceed_debits`](../../reference/account.md#flagscredits_must_not_exceed_debits)
 balance invariants for only a subset of all transfers, rather than all transfers.
 
 ## Per-transfer `credits_must_not_exceed_debits`

--- a/src/testing/time.zig
+++ b/src/testing/time.zig
@@ -21,7 +21,7 @@ pub const Time = struct {
     /// which the jumps occur. A is the amplitude of the step.
     /// Non-ideal is similar to periodic except the phase is adjusted using a random number taken
     /// from a normal distribution with mean=0, stddev=10. Finally, a random offset (up to
-    /// offset_coefficientC) is added to the result.
+    /// offset_coefficient_C) is added to the result.
     offset_coefficient_A: i64,
     offset_coefficient_B: i64,
     offset_coefficient_C: u32 = 0,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -1,15 +1,19 @@
-//! This script is a Zig TigerBeetle client that connects to a TigerBeetle
-//! cluster and runs a workload on it (described below) while measuring
-//! (and at the end, printing) observed latencies and throughput.
+//! Start TigerBeetle clients to run a workload (described below) against a cluster while measuring
+//! observed latencies and throughput.
 //!
-//! It uses a single client to 1) create `account_count` accounts then 2)
-//! generate `transfer_count` transfers between random different
-//! accounts. It does not validate that the transfers succeed.
+//! The benchmark only generates valid data -- i.e., all accounts/transfers succeed.
+//!
+//! Workload steps:
+//! 1. Create accounts.
+//! 2. Create transfers.
+//! 3. Query account transfers (`get_account_transfers`).
+//! 4. Lookup accounts (when verification is enabled).
+//! 5. Lookup transfers (when verification is enabled).
 const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const panic = std.debug.panic;
-const log = std.log;
+const log = std.log.scoped(.benchmark);
 
 const vsr = @import("vsr");
 const constants = vsr.constants;
@@ -35,16 +39,14 @@ pub fn main(
     addresses: []const std.net.Address,
     cli_args: *const cli.Command.Benchmark,
 ) !void {
-    const stderr = std.io.getStdErr().writer();
-
     if (builtin.mode != .ReleaseSafe and builtin.mode != .ReleaseFast) {
-        try stderr.print("Benchmark must be built with '-Drelease' for reasonable results.\n", .{});
+        log.warn("Benchmark must be built with '-Drelease' for reasonable results.", .{});
     }
     if (!vsr.constants.config.process.direct_io) {
-        log.warn("direct io is disabled", .{});
+        log.warn("Direct IO is disabled.", .{});
     }
     if (vsr.constants.config.process.verify) {
-        log.warn("extra assertions are enabled", .{});
+        log.warn("Extra assertions are enabled.", .{});
     }
 
     if (cli_args.account_count < 2) vsr.fatal(
@@ -67,57 +69,61 @@ pub fn main(
         .{cli_args.transfer_hot_percent},
     );
 
-    const client_id = stdx.unique_u128();
+    if (cli_args.clients == 0 or cli_args.clients > constants.clients_max) vsr.fatal(
+        .cli,
+        "--clients: must be between 1 and {}, got {}",
+        .{ constants.clients_max, cli_args.clients },
+    );
+
+    if (cli_args.clients > 1 and cli_args.transfer_batch_delay_us > 0) {
+        vsr.fatal(.cli, "--clients: mutually exclusive with --transfer-batch-delay-us", .{});
+    }
+
     const cluster_id: u128 = 0;
 
     var io = try IO.init(32, 0);
+    defer io.deinit();
 
-    var message_pool = try MessagePool.init(allocator, .client);
+    var message_pools = stdx.BoundedArrayType(MessagePool, constants.clients_max){};
+    defer for (message_pools.slice()) |*message_pool| message_pool.deinit(allocator);
+    for (0..cli_args.clients) |_| {
+        message_pools.append_assume_capacity(try MessagePool.init(allocator, .client));
+    }
 
     std.log.info("Benchmark running against {any}", .{addresses});
 
-    var client = try Client.init(
-        allocator,
-        .{
-            .id = client_id,
+    var clients = stdx.BoundedArrayType(Client, constants.clients_max){};
+    defer for (clients.slice()) |*client| client.deinit(allocator);
+
+    for (0..cli_args.clients) |i| {
+        clients.append_assume_capacity(try Client.init(allocator, .{
+            .id = stdx.unique_u128(),
             .cluster = cluster_id,
             .replica_count = @intCast(addresses.len),
             .time = .{},
-            .message_pool = &message_pool,
-            .message_bus_options = .{
-                .configuration = addresses,
-                .io = &io,
-            },
-        },
-    );
-
-    var batch_accounts =
-        try std.ArrayListUnmanaged(tb.Account).initCapacity(allocator, cli_args.account_batch_size);
-    defer batch_accounts.deinit(allocator);
+            .message_pool = &message_pools.slice()[i],
+            .message_bus_options = .{ .configuration = addresses, .io = &io },
+        }));
+    }
 
     // Each array position corresponds to a histogram bucket of 1ms. The last bucket is 10_000ms+.
-    const batch_latency_histogram = try allocator.alloc(u64, 10_001);
-    @memset(batch_latency_histogram, 0);
-    defer allocator.free(batch_latency_histogram);
+    const request_latency_histogram = try allocator.alloc(u64, 10_001);
+    @memset(request_latency_histogram, 0);
+    defer allocator.free(request_latency_histogram);
 
-    const query_latency_histogram = try allocator.alloc(u64, 10_001);
-    @memset(query_latency_histogram, 0);
-    defer allocator.free(query_latency_histogram);
-
-    var batch_transfers =
-        try std.ArrayListUnmanaged(tb.Transfer).initCapacity(
-        allocator,
-        cli_args.transfer_batch_size,
+    const client_requests = try allocator.alignedAlloc(
+        [constants.message_body_size_max]u8,
+        constants.sector_size,
+        clients.count(),
     );
-    defer batch_transfers.deinit(allocator);
+    defer allocator.free(client_requests);
 
-    var batch_account_ids =
-        try std.ArrayListUnmanaged(u128).initCapacity(allocator, cli_args.account_batch_size);
-    defer batch_account_ids.deinit(allocator);
-
-    var batch_transfer_ids =
-        try std.ArrayListUnmanaged(u128).initCapacity(allocator, cli_args.transfer_batch_size);
-    defer batch_transfer_ids.deinit(allocator);
+    const client_replies = try allocator.alignedAlloc(
+        [constants.message_body_size_max]u8,
+        constants.sector_size,
+        clients.count(),
+    );
+    defer allocator.free(client_replies);
 
     var statsd_opt: ?StatsD = null;
     defer if (statsd_opt) |*statsd| statsd.deinit(allocator);
@@ -164,89 +170,95 @@ pub fn main(
 
     var benchmark = Benchmark{
         .io = &io,
-        .message_pool = &message_pool,
-        .client = &client,
-        .batch_accounts = batch_accounts,
+        .statsd = if (statsd_opt) |*statsd| statsd else null,
+        .random = random,
+        .timer = try std.time.Timer.start(),
+        .output = std.io.getStdOut().writer().any(),
+        .clients = clients.slice(),
+        .client_requests = client_requests,
+        .client_replies = client_replies,
+        .request_latency_histogram = request_latency_histogram,
+        .account_id_permutation = account_id_permutation,
+        .account_batch_size = cli_args.account_batch_size,
         .account_count = cli_args.account_count,
         .account_count_hot = cli_args.account_count_hot,
         .account_generator = account_generator,
         .account_generator_hot = account_generator_hot,
-        .flag_history = cli_args.flag_history,
-        .flag_imported = cli_args.flag_imported,
-        .account_index = 0,
-        .query_count = cli_args.query_count,
-        .query_index = 0,
-        .account_id_permutation = account_id_permutation,
-        .rng = rng,
-        .timer = try std.time.Timer.start(),
-        .batch_latency_histogram = batch_latency_histogram,
-        .query_latency_histogram = query_latency_histogram,
-        .batch_transfers = batch_transfers,
-        .batch_start_ns = 0,
+        .transfer_id_permutation = account_id_permutation,
+        .transfer_batch_size = cli_args.transfer_batch_size,
+        .transfer_batch_delay_us = cli_args.transfer_batch_delay_us,
         .transfer_count = cli_args.transfer_count,
         .transfer_hot_percent = cli_args.transfer_hot_percent,
         .transfer_pending = cli_args.transfer_pending,
-        .transfer_batch_size = cli_args.transfer_batch_size,
-        .transfer_batch_delay_us = cli_args.transfer_batch_delay_us,
+        .query_count = cli_args.query_count,
+        .flag_history = cli_args.flag_history,
+        .flag_imported = cli_args.flag_imported,
         .validate = cli_args.validate,
-        .batch_index = 0,
-        .transfers_sent = 0,
-        .transfer_index = 0,
-        .transfer_next_arrival_ns = 0,
-        .callback = null,
-        .done = false,
-        .statsd = if (statsd_opt) |*statsd| statsd else null,
         .print_batch_timings = cli_args.print_batch_timings,
-        .id_order = cli_args.id_order,
-        .batch_account_ids = batch_account_ids,
-        .batch_transfer_ids = batch_transfer_ids,
     };
 
-    benchmark.client.register(Benchmark.register_callback, @intCast(@intFromPtr(&benchmark)));
-    while (!benchmark.done) {
-        benchmark.client.tick();
+    benchmark.run(.register);
+    while (benchmark.stage != .idle) {
+        for (benchmark.clients) |*client| client.tick();
         try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
-    benchmark.done = false;
 
-    benchmark.create_accounts();
+    var rng_init = rng;
+    {
+        benchmark.run(.create_accounts);
+        while (benchmark.stage != .idle) {
+            for (benchmark.clients) |*client| client.tick();
+            try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        }
 
-    while (!benchmark.done) {
-        benchmark.client.tick();
-        try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        benchmark.run(.create_transfers);
+        while (benchmark.stage != .idle) {
+            for (benchmark.clients) |*client| client.tick();
+            try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        }
+
+        if (benchmark.query_count > 0) {
+            benchmark.run(.get_account_transfers);
+            while (benchmark.stage != .idle) {
+                for (benchmark.clients) |*client| client.tick();
+                try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+            }
+        }
     }
-    benchmark.done = false;
+
+    if (benchmark.validate) {
+        // Reset our state so we can check our work.
+        benchmark.random = rng_init.random();
+        benchmark.run(.validate_accounts);
+        while (benchmark.stage != .idle) {
+            for (benchmark.clients) |*client| client.tick();
+            try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        }
+
+        benchmark.run(.validate_transfers);
+        while (benchmark.stage != .idle) {
+            for (benchmark.clients) |*client| client.tick();
+            try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        }
+    }
 
     if (cli_args.checksum_performance) {
-        const stdout = std.io.getStdOut().writer();
-        stdout.print("\nmessage size max = {} bytes\n", .{
-            constants.message_size_max,
-        }) catch unreachable;
-
         const buffer = try allocator.alloc(u8, constants.message_size_max);
         defer allocator.free(buffer);
-        benchmark.rng.fill(buffer);
+        benchmark.random.bytes(buffer);
 
         benchmark.timer.reset();
         _ = vsr.checksum(buffer);
         const checksum_duration_ns = benchmark.timer.read();
 
-        stdout.print("checksum message size max = {} us\n", .{
+        benchmark.output.print(
+            \\message size max = {} bytes
+            \\checksum message size max = {} us
+            \\
+        , .{
+            constants.message_size_max,
             @divTrunc(checksum_duration_ns, std.time.ns_per_us),
         }) catch unreachable;
-    }
-
-    if (!benchmark.validate) return;
-
-    // Reset our state so we can check our work.
-    benchmark.rng = rng;
-    benchmark.account_index = 0;
-    benchmark.transfer_index = 0;
-    benchmark.validate_accounts();
-
-    while (!benchmark.done) {
-        benchmark.client.tick();
-        try benchmark.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
 }
 
@@ -261,12 +273,8 @@ const Generator = union(enum) {
         random: std.Random,
     ) Generator {
         return switch (distribution) {
-            .zipfian => .{
-                .zipfian = ZipfianShuffled.init(count, random),
-            },
-            .latest => .{
-                .latest = ZipfianGenerator.init(count),
-            },
+            .zipfian => .{ .zipfian = ZipfianShuffled.init(count, random) },
+            .latest => .{ .latest = ZipfianGenerator.init(count) },
             .uniform => .{ .uniform = count },
         };
     }
@@ -274,111 +282,533 @@ const Generator = union(enum) {
 
 const Benchmark = struct {
     io: *IO,
-    message_pool: *MessagePool,
-    client: *Client,
-    batch_accounts: std.ArrayListUnmanaged(tb.Account),
+    statsd: ?*StatsD,
+    random: std.rand.Random,
+    timer: std.time.Timer,
+    output: std.io.AnyWriter,
+    clients: []Client,
+
+    // Configuration:
+    account_id_permutation: IdPermutation,
+    account_batch_size: usize,
     account_count: usize,
     account_count_hot: usize,
     account_generator: Generator,
     account_generator_hot: Generator,
-    flag_history: bool,
-    flag_imported: bool,
-    account_index: usize,
-    query_count: usize,
-    query_index: usize,
-    account_id_permutation: IdPermutation,
-    rng: std.rand.DefaultPrng,
-    timer: std.time.Timer,
-    batch_latency_histogram: []u64,
-    query_latency_histogram: []u64,
-    batch_transfers: std.ArrayListUnmanaged(tb.Transfer),
-    batch_start_ns: usize,
-    transfers_sent: usize,
+    transfer_id_permutation: IdPermutation,
+    transfer_batch_size: usize,
+    transfer_batch_delay_us: usize,
     transfer_count: usize,
     transfer_hot_percent: usize,
     transfer_pending: bool,
-    transfer_batch_size: usize,
-    transfer_batch_delay_us: usize,
+    query_count: usize,
+    flag_history: bool,
+    flag_imported: bool,
     validate: bool,
-    batch_index: usize,
-    transfer_index: usize,
-    transfer_next_arrival_ns: usize,
-    callback: ?*const fn (*Benchmark, StateMachine.Operation, u64, []const u8) void,
-    done: bool,
-    statsd: ?*StatsD,
     print_batch_timings: bool,
-    id_order: cli.Command.Benchmark.IdOrder,
-    batch_account_ids: std.ArrayListUnmanaged(u128),
-    batch_transfer_ids: std.ArrayListUnmanaged(u128),
 
-    fn create_account(b: *Benchmark) tb.Account {
-        const random = b.rng.random();
+    // State:
+    clients_busy: std.StaticBitSet(constants.clients_max) =
+        std.StaticBitSet(constants.clients_max).initEmpty(),
+    clients_request_ns: [constants.clients_max]u64 = .{undefined} ** constants.clients_max,
+    client_requests: []align(constants.sector_size) [constants.message_body_size_max]u8,
+    client_replies: []align(constants.sector_size) [constants.message_body_size_max]u8,
+    request_latency_histogram: []u64,
+    request_index: usize = 0,
+    account_index: usize = 0,
+    transfer_index: usize = 0,
+    transfers_created: usize = 0,
+    query_index: usize = 0,
+    stage: Stage = .idle,
 
-        defer b.account_index += 1;
-        return .{
-            .id = b.account_id_permutation.encode(b.account_index + 1),
-            .user_data_128 = random.int(u128),
-            .user_data_64 = random.int(u64),
-            .user_data_32 = random.int(u32),
-            .reserved = 0,
-            .ledger = 2,
-            .code = 1,
-            .flags = .{
-                .history = b.flag_history,
-                .imported = b.flag_imported,
-            },
-            .debits_pending = 0,
-            .debits_posted = 0,
-            .credits_pending = 0,
-            .credits_posted = 0,
-            .timestamp = if (b.flag_imported) b.account_index + 1 else 0,
-        };
+    const Stage = enum {
+        idle,
+        register,
+        create_accounts,
+        create_transfers,
+        get_account_transfers,
+        validate_accounts,
+        validate_transfers,
+    };
+
+    pub fn run(b: *Benchmark, stage: Stage) void {
+        assert(b.stage == .idle);
+        assert(b.clients.len > 0);
+        assert(b.clients_busy.count() == 0);
+        assert(stdx.zeroed(std.mem.sliceAsBytes(b.request_latency_histogram)));
+        assert(b.request_index == 0);
+        assert(b.account_index == 0);
+        assert(b.transfer_index == 0);
+        assert(b.query_index == 0);
+        assert(stage != .idle);
+
+        b.stage = stage;
+        b.timer.reset();
+
+        for (0..b.clients.len) |_| {
+            switch (b.stage) {
+                .register => b.register(),
+                .create_accounts => b.create_accounts(),
+                .create_transfers => b.create_transfers(),
+                .get_account_transfers => b.get_account_transfers(),
+                .validate_accounts => b.validate_accounts(),
+                .validate_transfers => b.validate_transfers(),
+                .idle => break, // i-1 decided not to start any work.
+            }
+        }
+    }
+
+    fn run_finish(b: *Benchmark) void {
+        assert(b.stage != .idle);
+        assert(b.clients_busy.count() == 0);
+
+        b.stage = .idle;
+        b.request_index = 0;
+        b.account_index = 0;
+        b.transfer_index = 0;
+        b.query_index = 0;
+        @memset(b.request_latency_histogram, 0);
+    }
+
+    fn register(b: *Benchmark) void {
+        assert(b.stage == .register);
+
+        var clients_idle = b.clients_busy.iterator(.{ .kind = .unset });
+        const client_index = clients_idle.next().?;
+
+        b.clients_busy.set(client_index);
+        b.clients[client_index].register(register_callback, @bitCast(RequestContext{
+            .benchmark = b,
+            .client_index = @intCast(client_index),
+            .request_index = undefined,
+        }));
+        b.request_index += 1;
+    }
+
+    fn register_callback(user_data: u128, _: *const vsr.RegisterResult) void {
+        const context: RequestContext = @bitCast(user_data);
+        const b: *Benchmark = context.benchmark;
+        assert(b.stage == .register);
+        assert(b.clients_busy.isSet(context.client_index));
+
+        b.clients_busy.unset(context.client_index);
+        if (b.clients_busy.count() == 0) b.run_finish();
     }
 
     fn create_accounts(b: *Benchmark) void {
+        assert(b.stage == .create_accounts);
+        assert(b.account_batch_size > 0);
+
         if (b.account_index >= b.account_count) {
-            b.create_transfers();
-            return;
+            if (b.clients_busy.count() == 0) b.run_finish();
+        } else {
+            const client = b.request_client();
+            const accounts_count = @min(b.account_count, b.account_batch_size);
+            const accounts =
+                std.mem.bytesAsSlice(tb.Account, &b.client_requests[client])[0..accounts_count];
+            b.build_accounts(accounts);
+            b.request(client, .create_accounts, std.mem.sliceAsBytes(accounts));
         }
-
-        // Reset batch.
-        b.batch_accounts.clearRetainingCapacity();
-
-        // Fill batch.
-        while (b.account_index < b.account_count and
-            b.batch_accounts.items.len < b.batch_accounts.capacity)
-        {
-            b.batch_accounts.appendAssumeCapacity(b.create_account());
-        }
-
-        // Submit batch.
-        b.send(
-            create_accounts_finish,
-            .create_accounts,
-            std.mem.sliceAsBytes(b.batch_accounts.items),
-        );
     }
 
-    fn create_accounts_finish(
-        b: *Benchmark,
-        operation: StateMachine.Operation,
-        timestamp: u64,
-        result: []const u8,
-    ) void {
-        assert(operation == .create_accounts);
-        assert(timestamp > 0);
-        const create_accounts_results = std.mem.bytesAsSlice(
-            tb.CreateAccountsResult,
-            result,
-        );
+    fn create_accounts_callback(b: *Benchmark, _: u32, result: []const u8) void {
+        assert(b.stage == .create_accounts);
+
+        const create_accounts_results = std.mem.bytesAsSlice(tb.CreateAccountsResult, result);
         if (create_accounts_results.len > 0) {
             panic("CreateAccountsResults: {any}", .{create_accounts_results});
         }
-
         b.create_accounts();
     }
 
-    fn gen_account_index(b: *Benchmark, hint: enum { hot, cold }) u64 {
+    fn create_transfers(b: *Benchmark) void {
+        assert(b.stage == .create_transfers);
+        assert(b.transfer_batch_size > 0);
+
+        if (b.transfer_index >= b.transfer_count) {
+            if (b.clients_busy.count() == 0) b.create_transfers_finish();
+        } else {
+            const client = b.request_client();
+            const transfers_count = @min(b.transfer_count, b.transfer_batch_size);
+            const transfers =
+                std.mem.bytesAsSlice(tb.Transfer, &b.client_requests[client])[0..transfers_count];
+            b.build_transfers(transfers);
+            b.request(client, .create_transfers, std.mem.sliceAsBytes(transfers));
+        }
+    }
+
+    fn create_transfers_callback(b: *Benchmark, client_index: u32, result: []const u8) void {
+        const create_transfers_results = std.mem.bytesAsSlice(tb.CreateTransfersResult, result);
+        if (create_transfers_results.len > 0) {
+            panic("CreateTransfersResults: {any}", .{create_transfers_results});
+        }
+
+        const requests_complete = b.request_index - b.clients_busy.count();
+        const request_duration_ns = b.timer.read() - b.clients_request_ns[client_index];
+        const request_duration_ms = @divTrunc(request_duration_ns, std.time.ns_per_ms);
+        const transfers_created = @min(b.transfer_count, b.transfer_batch_size);
+        b.transfers_created += transfers_created;
+
+        if (b.statsd) |statsd| {
+            statsd.gauge("benchmark.txns", transfers_created) catch {};
+            statsd.timing("benchmark.timings", request_duration_ns) catch {};
+            statsd.gauge("benchmark.batch", requests_complete) catch {};
+            statsd.gauge("benchmark.completed", b.transfers_created) catch {};
+        }
+
+        if (b.print_batch_timings) {
+            log.info("batch {}: {} tx in {} ms", .{
+                requests_complete,
+                b.transfer_batch_size,
+                request_duration_ms,
+            });
+        }
+
+        std.time.sleep(b.transfer_batch_delay_us * std.time.ns_per_us);
+        b.create_transfers();
+    }
+
+    fn create_transfers_finish(b: *Benchmark) void {
+        assert(b.stage == .create_transfers);
+
+        b.output.print(
+            \\{[batch_count]} batches in {[batch_duration_s]d:.2} s
+            \\transfer batch size = {[batch_size]} txs
+            \\transfer batch delay = {[batch_delay_us]} us
+            \\load accepted = {[transfer_rate]} tx/s
+            \\
+        , .{
+            .batch_count = b.request_index,
+            .batch_duration_s = @as(f64, @floatFromInt(b.timer.read())) / std.time.ns_per_s,
+            .batch_size = b.transfer_batch_size,
+            .batch_delay_us = b.transfer_batch_delay_us,
+            .transfer_rate = @divTrunc(b.transfer_count * std.time.ns_per_s, b.timer.read()),
+        }) catch unreachable;
+        print_percentiles_histogram(b.output, "batch", b.request_latency_histogram);
+
+        b.run_finish();
+    }
+
+    fn get_account_transfers(b: *Benchmark) void {
+        assert(b.stage == .get_account_transfers);
+
+        if (b.query_index >= b.query_count) {
+            if (b.clients_busy.count() == 0) b.get_account_transfers_finish();
+            return;
+        }
+        b.query_index += 1;
+
+        const client = b.request_client();
+        const request_body = b.client_requests[client][0..@sizeOf(tb.AccountFilter)];
+        // Use hot accounts for queries to equalize the number of results
+        // returned on each execution.
+        const account_index = b.choose_account_index(.hot);
+        std.mem.bytesAsValue(tb.AccountFilter, request_body).* = .{
+            .account_id = b.account_id_permutation.encode(account_index + 1),
+            .user_data_128 = 0,
+            .user_data_64 = 0,
+            .user_data_32 = 0,
+            .code = 0,
+            .timestamp_min = 0,
+            .timestamp_max = 0,
+            .limit = @divExact(
+                constants.message_size_max - @sizeOf(vsr.Header),
+                @sizeOf(tb.Transfer),
+            ),
+            .flags = .{
+                .credits = true,
+                .debits = true,
+                .reversed = false,
+            },
+        };
+        b.request(client, .get_account_transfers, request_body);
+    }
+
+    fn get_account_transfers_callback(b: *Benchmark, client_index: u32, result: []const u8) void {
+        assert(b.stage == .get_account_transfers);
+
+        const request_body = b.client_requests[client_index][0..@sizeOf(tb.AccountFilter)];
+        const request_filter = std.mem.bytesAsValue(tb.AccountFilter, request_body);
+        for (std.mem.bytesAsSlice(tb.Transfer, result)) |*transfer| {
+            assert((transfer.debit_account_id == request_filter.account_id) !=
+                (transfer.credit_account_id == request_filter.account_id));
+        }
+        b.get_account_transfers();
+    }
+
+    fn get_account_transfers_finish(b: *Benchmark) void {
+        assert(b.stage == .get_account_transfers);
+
+        b.output.print("\n{[query_count]} queries in {[query_duration_s]d:.1} s\n", .{
+            .query_count = b.request_index,
+            .query_duration_s = @as(f64, @floatFromInt(b.timer.read())) / std.time.ns_per_s,
+        }) catch unreachable;
+        print_percentiles_histogram(b.output, "query", b.request_latency_histogram);
+
+        b.run_finish();
+    }
+
+    fn validate_accounts(b: *Benchmark) void {
+        assert(b.stage == .validate_accounts);
+
+        if (b.account_index >= b.account_count) {
+            if (b.clients_busy.count() == 0) b.validate_accounts_finish();
+        } else {
+            const client = b.request_client();
+            const account_count = @min(b.account_count, b.account_batch_size);
+            const account_ids =
+                std.mem.bytesAsSlice(u128, &b.client_requests[client])[0..account_count];
+            const accounts =
+                std.mem.bytesAsSlice(tb.Account, &b.client_replies[client])[0..account_count];
+            b.build_accounts(accounts);
+            for (account_ids, accounts) |*account_id, account| account_id.* = account.id;
+            b.request(client, .lookup_accounts, std.mem.sliceAsBytes(account_ids));
+        }
+    }
+
+    fn validate_accounts_callback(
+        b: *Benchmark,
+        client_index: u32,
+        result: []align(@sizeOf(tb.Account)) const u8,
+    ) void {
+        assert(b.stage == .validate_accounts);
+
+        const accounts_count = @min(b.account_count, b.account_batch_size);
+        const accounts_expected_body = &b.client_replies[client_index];
+        const accounts_expected =
+            std.mem.bytesAsSlice(tb.Account, accounts_expected_body)[0..accounts_count];
+        const accounts_actual = std.mem.bytesAsSlice(tb.Account, result);
+        assert(accounts_actual.len == accounts_count);
+        for (accounts_expected, accounts_actual) |expected, actual| {
+            assert(expected.id == actual.id);
+            assert(expected.user_data_128 == actual.user_data_128);
+            assert(expected.user_data_64 == actual.user_data_64);
+            assert(expected.user_data_32 == actual.user_data_32);
+            assert(expected.code == actual.code);
+            assert(@as(u16, @bitCast(expected.flags)) == @as(u16, @bitCast(actual.flags)));
+        }
+        b.validate_accounts();
+    }
+
+    fn validate_accounts_finish(b: *Benchmark) void {
+        assert(b.stage == .validate_accounts);
+
+        b.output.print(
+            "validated {d} accounts\n",
+            .{b.account_count},
+        ) catch unreachable;
+        b.run_finish();
+    }
+
+    fn validate_transfers(b: *Benchmark) void {
+        assert(b.stage == .validate_transfers);
+
+        if (b.transfer_index >= b.transfer_count) {
+            if (b.clients_busy.count() == 0) b.validate_transfers_finish();
+        } else {
+            const client = b.request_client();
+            const transfer_count = @min(b.transfer_count, b.transfer_batch_size);
+            const transfer_ids =
+                std.mem.bytesAsSlice(u128, &b.client_requests[client])[0..transfer_count];
+            const transfers =
+                std.mem.bytesAsSlice(tb.Transfer, &b.client_replies[client])[0..transfer_count];
+            b.build_transfers(transfers);
+            for (transfer_ids, transfers) |*transfer_id, transfer| transfer_id.* = transfer.id;
+            b.request(client, .lookup_transfers, std.mem.sliceAsBytes(transfer_ids));
+        }
+    }
+
+    fn validate_transfers_callback(
+        b: *Benchmark,
+        client_index: u32,
+        result: []align(@sizeOf(tb.Transfer)) const u8,
+    ) void {
+        assert(b.stage == .validate_transfers);
+
+        const transfers_count = @min(b.transfer_count, b.transfer_batch_size);
+        const transfers_expected_body = &b.client_replies[client_index];
+        const transfers_expected =
+            std.mem.bytesAsSlice(tb.Transfer, transfers_expected_body)[0..transfers_count];
+        const transfers_actual = std.mem.bytesAsSlice(tb.Transfer, result);
+        assert(transfers_actual.len == transfers_count);
+        for (transfers_expected, transfers_actual) |expected, actual| {
+            assert(expected.id == actual.id);
+            assert(expected.debit_account_id == actual.debit_account_id);
+            assert(expected.credit_account_id == actual.credit_account_id);
+            assert(expected.amount == actual.amount);
+            assert(expected.pending_id == actual.pending_id);
+            assert(expected.user_data_128 == actual.user_data_128);
+            assert(expected.user_data_64 == actual.user_data_64);
+            assert(expected.user_data_32 == actual.user_data_32);
+            assert(expected.timeout == actual.timeout);
+            assert(expected.ledger == actual.ledger);
+            assert(expected.code == actual.code);
+            assert(@as(u16, @bitCast(expected.flags)) == @as(u16, @bitCast(actual.flags)));
+        }
+        b.validate_transfers();
+    }
+
+    fn validate_transfers_finish(b: *Benchmark) void {
+        assert(b.stage == .validate_transfers);
+
+        b.output.print(
+            "validated {d} transfers\n",
+            .{b.transfer_count},
+        ) catch unreachable;
+
+        b.run_finish();
+    }
+
+    const RequestContext = extern struct {
+        benchmark: *Benchmark,
+        client_index: u32,
+        request_index: u32,
+
+        comptime {
+            assert(@sizeOf(RequestContext) == @sizeOf(u128));
+        }
+    };
+
+    fn request_client(b: *Benchmark) usize {
+        var clients_idle = b.clients_busy.iterator(.{ .kind = .unset });
+        return clients_idle.next().?;
+    }
+
+    fn request(
+        b: *Benchmark,
+        client_index: usize,
+        operation: StateMachine.Operation,
+        payload: []const u8,
+    ) void {
+        assert(b.stage != .idle);
+        assert(b.clients_busy.count() < b.clients.len);
+        assert(!b.clients_busy.isSet(client_index));
+
+        b.clients_busy.set(client_index);
+        b.clients_request_ns[client_index] = b.timer.read();
+        b.request_index += 1;
+
+        b.clients[client_index].request(
+            request_complete,
+            @bitCast(RequestContext{
+                .benchmark = b,
+                .client_index = @intCast(client_index),
+                .request_index = @intCast(b.request_index - 1),
+            }),
+            operation,
+            payload,
+        );
+    }
+
+    fn request_complete(
+        user_data: u128,
+        operation: StateMachine.Operation,
+        timestamp: u64,
+        result: []u8,
+    ) void {
+        const context: RequestContext = @bitCast(user_data);
+        const client = context.client_index;
+        const b: *Benchmark = context.benchmark;
+        assert(b.clients_busy.isSet(client));
+        assert(b.stage != .idle);
+        assert(timestamp > 0);
+
+        b.clients_busy.unset(client);
+
+        const duration_ns = b.timer.read() - b.clients_request_ns[client];
+        const duration_ms = @divTrunc(duration_ns, std.time.ns_per_ms);
+        b.request_latency_histogram[@min(duration_ms, b.request_latency_histogram.len - 1)] += 1;
+
+        switch (operation) {
+            .create_accounts => b.create_accounts_callback(client, result),
+            .create_transfers => b.create_transfers_callback(client, result),
+            .lookup_accounts => b.validate_accounts_callback(client, @alignCast(result)),
+            .lookup_transfers => b.validate_transfers_callback(client, @alignCast(result)),
+            .get_account_transfers => b.get_account_transfers_callback(client, result),
+            else => unreachable,
+        }
+    }
+
+    fn build_accounts(b: *Benchmark, accounts: []tb.Account) void {
+        for (accounts) |*account| {
+            account.* = .{
+                .id = b.account_id_permutation.encode(b.account_index + 1),
+                .user_data_128 = b.random.int(u128),
+                .user_data_64 = b.random.int(u64),
+                .user_data_32 = b.random.int(u32),
+                .reserved = 0,
+                .ledger = 2,
+                .code = 1,
+                .flags = .{
+                    .history = b.flag_history,
+                    .imported = b.flag_imported,
+                },
+                .debits_pending = 0,
+                .debits_posted = 0,
+                .credits_pending = 0,
+                .credits_posted = 0,
+                .timestamp = if (b.flag_imported) b.account_index + 1 else 0,
+            };
+            b.account_index += 1;
+        }
+    }
+
+    fn build_transfers(b: *Benchmark, transfers: []tb.Transfer) void {
+        for (transfers) |*transfer| {
+            // The set of accounts is divided into two different "worlds" by
+            // `account_count_hot`. Sometimes the debit account will be selected
+            // from the first `account_count_hot` accounts; otherwise both
+            // debit and credit will be selected from an account >= `account_count_hot`.
+
+            const debit_account_index = b.choose_account_index(
+                if (b.random.intRangeAtMost(usize, 1, 100) <= b.transfer_hot_percent)
+                    .hot
+                else
+                    .cold,
+            );
+
+            const credit_account_index = index: {
+                var index = b.choose_account_index(.cold);
+                if (index == debit_account_index) {
+                    index = (index + 1) % b.account_count;
+                }
+                break :index index;
+            };
+            assert(debit_account_index < b.account_count);
+            assert(credit_account_index < b.account_count);
+            assert(debit_account_index != credit_account_index);
+
+            const debit_account_id = b.transfer_id_permutation.encode(debit_account_index + 1);
+            const credit_account_id = b.transfer_id_permutation.encode(credit_account_index + 1);
+            assert(debit_account_id != credit_account_id);
+
+            // 30% of pending transfers.
+            const pending = b.transfer_pending and b.random.intRangeAtMost(u8, 0, 9) < 3;
+
+            transfer.* = .{
+                .id = b.transfer_id_permutation.encode(b.transfer_index + 1),
+                .debit_account_id = debit_account_id,
+                .credit_account_id = credit_account_id,
+                .user_data_128 = b.random.int(u128),
+                .user_data_64 = b.random.int(u64),
+                .user_data_32 = b.random.int(u32),
+                // TODO Benchmark posting/voiding pending transfers.
+                .pending_id = 0,
+                .ledger = 2,
+                .code = b.random.int(u16) +| 1,
+                .flags = .{
+                    .pending = pending,
+                    .imported = b.flag_imported,
+                },
+                .timeout = if (pending) b.random.intRangeAtMost(u32, 1, 60) else 0,
+                .amount = random_int_exponential(b.random, u64, 10_000) +| 1,
+                .timestamp = if (b.flag_imported) b.account_index + b.transfer_index + 1 else 0,
+            };
+            b.transfer_index += 1;
+        }
+    }
+
+    fn choose_account_index(b: *Benchmark, hint: enum { hot, cold }) u64 {
         assert(b.account_count > 0);
         stdx.maybe(b.account_count_hot == 0);
         assert(b.account_count >= b.account_count_hot);
@@ -398,23 +828,22 @@ const Benchmark = struct {
         };
         assert(account_count > 0);
 
-        const random = b.rng.random();
         const index = switch (generator.*) {
             .zipfian => |gen| index: {
                 // zipfian set size must be same as account set size
                 assert(account_count == gen.gen.n);
-                const index = gen.next(random);
+                const index = gen.next(b.random);
                 assert(index < account_count);
                 break :index index;
             },
             .latest => |gen| index: {
                 assert(account_count == gen.n);
-                const index_rev = gen.next(random);
+                const index_rev = gen.next(b.random);
                 assert(index_rev < account_count);
                 break :index account_count - index_rev - 1;
             },
             .uniform => |count| index: {
-                const index = random.uintLessThan(u64, count);
+                const index = b.random.uintLessThan(u64, count);
                 assert(index < account_count);
                 break :index index;
             },
@@ -425,403 +854,10 @@ const Benchmark = struct {
             .cold => index + b.account_count_hot,
         };
     }
-
-    fn create_transfer(b: *Benchmark) tb.Transfer {
-        const random = b.rng.random();
-
-        // The set of accounts is divided into two different "worlds" by
-        // `account_count_hot`. Sometimes the debit account will be selected
-        // from the first `account_count_hot` accounts; otherwise both
-        // debit and credit will be selected from an account >= `account_count_hot`.
-        const debit_account_index = b.gen_account_index(
-            if (random.intRangeAtMost(usize, 1, 100) <= b.transfer_hot_percent)
-                .hot
-            else
-                .cold,
-        );
-        const credit_account_index = index: {
-            var index = b.gen_account_index(.cold);
-            if (index == debit_account_index) {
-                index = (index + 1) % b.account_count;
-            }
-            break :index index;
-        };
-        assert(debit_account_index < b.account_count);
-        assert(credit_account_index < b.account_count);
-        assert(debit_account_index != credit_account_index);
-
-        const debit_account_id = b.account_id_permutation.encode(debit_account_index + 1);
-        const credit_account_id = b.account_id_permutation.encode(credit_account_index + 1);
-        assert(debit_account_id != credit_account_id);
-
-        // 30% of pending transfers.
-        const pending = b.transfer_pending and random.intRangeAtMost(u8, 0, 9) < 3;
-
-        defer b.transfer_index += 1;
-        return .{
-            .id = b.account_id_permutation.encode(b.transfer_index + 1),
-            .debit_account_id = debit_account_id,
-            .credit_account_id = credit_account_id,
-            .user_data_128 = random.int(u128),
-            .user_data_64 = random.int(u64),
-            .user_data_32 = random.int(u32),
-            // TODO Benchmark posting/voiding pending transfers.
-            .pending_id = 0,
-            .ledger = 2,
-            .code = random.int(u16) +| 1,
-            .flags = .{
-                .pending = pending,
-                .imported = b.flag_imported,
-            },
-            .timeout = if (pending) random.intRangeAtMost(u32, 1, 60) else 0,
-            .amount = random_int_exponential(random, u64, 10_000) +| 1,
-            .timestamp = if (b.flag_imported) b.account_index + b.transfer_index + 1 else 0,
-        };
-    }
-
-    fn create_transfers(b: *Benchmark) void {
-        if (b.transfer_index >= b.transfer_count) {
-            b.summary_transfers();
-            return;
-        }
-
-        if (b.transfer_index == 0) {
-            // Init timer.
-            b.timer.reset();
-            b.transfer_next_arrival_ns = b.timer.read();
-        }
-
-        b.batch_transfers.clearRetainingCapacity();
-
-        b.batch_start_ns = b.timer.read();
-
-        // Fill batch.
-        while (b.transfer_index < b.transfer_count and
-            b.batch_transfers.items.len < b.batch_transfers.capacity)
-        {
-            b.batch_transfers.appendAssumeCapacity(b.create_transfer());
-        }
-
-        assert(b.batch_transfers.items.len > 0);
-
-        // Submit batch.
-        b.send(
-            create_transfers_finish,
-            .create_transfers,
-            std.mem.sliceAsBytes(b.batch_transfers.items),
-        );
-    }
-
-    fn create_transfers_finish(
-        b: *Benchmark,
-        operation: StateMachine.Operation,
-        timestamp: u64,
-        result: []const u8,
-    ) void {
-        assert(operation == .create_transfers);
-        assert(timestamp > 0);
-        const create_transfers_results = std.mem.bytesAsSlice(
-            tb.CreateTransfersResult,
-            result,
-        );
-        if (create_transfers_results.len > 0) {
-            panic("CreateTransfersResults: {any}", .{create_transfers_results});
-        }
-
-        // Record latencies.
-        const batch_end_ns = b.timer.read();
-        const ms_time = @divTrunc(batch_end_ns - b.batch_start_ns, std.time.ns_per_ms);
-
-        if (b.print_batch_timings) {
-            log.info("batch {}: {} tx in {} ms", .{
-                b.batch_index,
-                b.batch_transfers.items.len,
-                ms_time,
-            });
-        }
-
-        b.batch_latency_histogram[@min(ms_time, b.batch_latency_histogram.len - 1)] += 1;
-
-        b.batch_index += 1;
-        b.transfers_sent += b.batch_transfers.items.len;
-
-        if (b.statsd) |statsd| {
-            statsd.gauge("benchmark.txns", b.batch_transfers.items.len) catch {};
-            statsd.timing("benchmark.timings", ms_time) catch {};
-            statsd.gauge("benchmark.batch", b.batch_index) catch {};
-            statsd.gauge("benchmark.completed", b.transfers_sent) catch {};
-        }
-
-        std.time.sleep(b.transfer_batch_delay_us * std.time.ns_per_us);
-        b.create_transfers();
-    }
-
-    fn summary_transfers(b: *Benchmark) void {
-        const total_ns = b.timer.read();
-        const stdout = std.io.getStdOut().writer();
-
-        stdout.print("{} batches in {d:.2} s\n", .{
-            b.batch_index,
-            @as(f64, @floatFromInt(total_ns)) / std.time.ns_per_s,
-        }) catch unreachable;
-        stdout.print("transfer batch size = {} txs\n", .{
-            b.transfer_batch_size,
-        }) catch unreachable;
-        stdout.print("transfer batch delay = {} us\n", .{
-            b.transfer_batch_delay_us,
-        }) catch unreachable;
-        stdout.print("load accepted = {} tx/s\n", .{
-            @divTrunc(
-                b.transfer_count * std.time.ns_per_s,
-                total_ns,
-            ),
-        }) catch unreachable;
-        print_percentiles_histogram(stdout, "batch", b.batch_latency_histogram);
-
-        if (b.query_count > 0) {
-            b.timer.reset();
-            b.account_index = 0;
-            b.query_account_transfers();
-        } else {
-            b.done = true;
-        }
-    }
-
-    fn query_account_transfers(b: *Benchmark) void {
-        if (b.query_index >= b.query_count) {
-            b.summary_query();
-            return;
-        }
-
-        // Use hot accounts for queries to equalize the number of results
-        // returned on each execution.
-        b.account_index = b.gen_account_index(.hot);
-        var filter = tb.AccountFilter{
-            .account_id = b.account_id_permutation.encode(b.account_index + 1),
-            .user_data_128 = 0,
-            .user_data_64 = 0,
-            .user_data_32 = 0,
-            .code = 0,
-            .timestamp_min = 0,
-            .timestamp_max = 0,
-            .limit = @divExact(
-                constants.message_size_max - @sizeOf(vsr.Header),
-                @sizeOf(tb.Transfer),
-            ),
-            .flags = .{
-                .credits = true,
-                .debits = true,
-                .reversed = false,
-            },
-        };
-
-        b.batch_start_ns = b.timer.read();
-        b.send(
-            query_account_transfers_finish,
-            .get_account_transfers,
-            std.mem.asBytes(&filter),
-        );
-    }
-
-    fn query_account_transfers_finish(
-        b: *Benchmark,
-        operation: StateMachine.Operation,
-        timestamp: u64,
-        result: []const u8,
-    ) void {
-        assert(operation == .get_account_transfers);
-        assert(timestamp > 0);
-
-        const batch_end_ns = b.timer.read();
-        const transfers = std.mem.bytesAsSlice(tb.Transfer, result);
-        const account_id = b.account_id_permutation.encode(b.account_index + 1);
-        for (transfers) |*transfer| {
-            assert(transfer.debit_account_id == account_id or
-                transfer.credit_account_id == account_id);
-        }
-
-        const ms_time = @divTrunc(batch_end_ns - b.batch_start_ns, std.time.ns_per_ms);
-        b.query_latency_histogram[@min(ms_time, b.query_latency_histogram.len - 1)] += 1;
-
-        b.query_index += 1;
-        b.query_account_transfers();
-    }
-
-    fn summary_query(b: *Benchmark) void {
-        const total_ns = b.timer.read();
-
-        const stdout = std.io.getStdOut().writer();
-
-        stdout.print("\n{} queries in {d:.2} s\n", .{
-            b.query_count,
-            @as(f64, @floatFromInt(total_ns)) / std.time.ns_per_s,
-        }) catch unreachable;
-        print_percentiles_histogram(stdout, "query", b.query_latency_histogram);
-
-        b.done = true;
-    }
-
-    fn validate_accounts(b: *Benchmark) void {
-        if (b.account_index >= b.account_count) {
-            b.validate_transfers();
-            return;
-        }
-
-        // Reset batch.
-        b.batch_accounts.clearRetainingCapacity();
-        b.batch_account_ids.clearRetainingCapacity();
-
-        // Fill batch.
-        while (b.account_index < b.account_count and
-            b.batch_accounts.items.len < b.batch_accounts.capacity)
-        {
-            const account = b.create_account();
-            b.batch_accounts.appendAssumeCapacity(account);
-            b.batch_account_ids.appendAssumeCapacity(account.id);
-        }
-
-        b.send(
-            validate_accounts_finish,
-            .lookup_accounts,
-            std.mem.sliceAsBytes(b.batch_account_ids.items),
-        );
-    }
-
-    fn validate_accounts_finish(
-        b: *Benchmark,
-        operation: StateMachine.Operation,
-        timestamp: u64,
-        result: []const u8,
-    ) void {
-        assert(operation == .lookup_accounts);
-        assert(timestamp > 0);
-
-        const accounts = std.mem.bytesAsSlice(tb.Account, result);
-
-        for (b.batch_accounts.items, accounts) |expected, actual| {
-            assert(expected.id == actual.id);
-            assert(expected.user_data_128 == actual.user_data_128);
-            assert(expected.user_data_64 == actual.user_data_64);
-            assert(expected.user_data_32 == actual.user_data_32);
-            assert(expected.code == actual.code);
-            assert(@as(u16, @bitCast(expected.flags)) == @as(u16, @bitCast(actual.flags)));
-        }
-
-        b.validate_accounts();
-    }
-
-    fn validate_transfers(b: *Benchmark) void {
-        if (b.transfer_index >= b.transfer_count) {
-            b.summary_validate();
-            return;
-        }
-
-        b.batch_transfers.clearRetainingCapacity();
-        b.batch_transfer_ids.clearRetainingCapacity();
-
-        b.batch_start_ns = b.timer.read();
-
-        // Fill batch.
-        while (b.transfer_index < b.transfer_count and
-            b.batch_transfers.items.len < b.batch_transfers.capacity)
-        {
-            const transfer = b.create_transfer();
-            b.batch_transfers.appendAssumeCapacity(transfer);
-            b.batch_transfer_ids.appendAssumeCapacity(transfer.id);
-        }
-
-        assert(b.batch_transfer_ids.items.len > 0);
-
-        // Submit batch.
-        b.send(
-            validate_transfers_finish,
-            .lookup_transfers,
-            std.mem.sliceAsBytes(b.batch_transfer_ids.items),
-        );
-    }
-
-    fn validate_transfers_finish(
-        b: *Benchmark,
-        operation: StateMachine.Operation,
-        timestamp: u64,
-        result: []const u8,
-    ) void {
-        assert(operation == .lookup_transfers);
-        assert(timestamp > 0);
-
-        const transfers = std.mem.bytesAsSlice(tb.Transfer, result);
-
-        for (b.batch_transfers.items, transfers) |expected, actual| {
-            assert(expected.id == actual.id);
-            assert(expected.debit_account_id == actual.debit_account_id);
-            assert(expected.credit_account_id == actual.credit_account_id);
-            assert(expected.amount == actual.amount);
-            assert(expected.pending_id == actual.pending_id);
-            assert(expected.user_data_128 == actual.user_data_128);
-            assert(expected.user_data_64 == actual.user_data_64);
-            assert(expected.user_data_32 == actual.user_data_32);
-            assert(expected.timeout == actual.timeout);
-            assert(expected.ledger == actual.ledger);
-            assert(expected.code == actual.code);
-            assert(@as(u16, @bitCast(expected.flags)) == @as(u16, @bitCast(actual.flags)));
-        }
-
-        b.validate_transfers();
-    }
-
-    fn summary_validate(b: *Benchmark) void {
-        const stdout = std.io.getStdOut().writer();
-
-        stdout.print("validated {d} accounts, {d} transfers\n", .{
-            b.account_count,
-            b.transfer_count,
-        }) catch unreachable;
-
-        b.done = true;
-    }
-
-    fn send(
-        b: *Benchmark,
-        callback: *const fn (*Benchmark, StateMachine.Operation, u64, []const u8) void,
-        operation: StateMachine.Operation,
-        payload: []u8,
-    ) void {
-        b.callback = callback;
-        b.client.request(
-            send_complete,
-            @intCast(@intFromPtr(b)),
-            operation,
-            payload,
-        );
-    }
-
-    fn send_complete(
-        user_data: u128,
-        operation: StateMachine.Operation,
-        timestamp: u64,
-        result: []u8,
-    ) void {
-        const b: *Benchmark = @ptrFromInt(@as(usize, @intCast(user_data)));
-        const callback = b.callback.?;
-        b.callback = null;
-
-        callback(b, operation, timestamp, result);
-    }
-
-    fn register_callback(
-        user_data: u128,
-        result: *const vsr.RegisterResult,
-    ) void {
-        _ = result;
-
-        const b: *Benchmark = @ptrFromInt(@as(usize, @intCast(user_data)));
-        assert(!b.done);
-        b.done = true;
-    }
 };
 
 fn print_percentiles_histogram(
-    stdout: anytype,
+    stdout: std.io.AnyWriter,
     label: []const u8,
     histogram_buckets: []const u64,
 ) void {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -108,8 +108,7 @@ const CLIArgs = union(enum) {
         account_count_hot: usize = 0,
         log_debug: bool = false,
         log_debug_replica: bool = false,
-        /// The probability distribution used to select accounts when making
-        /// transfers or queries.
+        /// The probability distribution used to select accounts when making transfers or queries.
         account_distribution: Command.Benchmark.Distribution = .uniform,
         flag_history: bool = false,
         flag_imported: bool = false,
@@ -130,6 +129,7 @@ const CLIArgs = union(enum) {
         query_count: usize = 100,
         print_batch_timings: bool = false,
         id_order: Command.Benchmark.IdOrder = .sequential,
+        clients: u32 = 1,
         statsd: bool = false,
         trace: ?[:0]const u8 = null,
         /// When set, don't delete the data file when the benchmark completes.
@@ -482,6 +482,7 @@ pub const Command = union(enum) {
         query_count: usize,
         print_batch_timings: bool,
         id_order: IdOrder,
+        clients: u32,
         statsd: bool,
         trace: ?[:0]const u8,
         file: ?[]const u8,
@@ -902,6 +903,7 @@ fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
         .checksum_performance = benchmark.checksum_performance,
         .query_count = benchmark.query_count,
         .print_batch_timings = benchmark.print_batch_timings,
+        .clients = benchmark.clients,
         .id_order = benchmark.id_order,
         .statsd = benchmark.statsd,
         .trace = benchmark.trace,


### PR DESCRIPTION
Add the `--clients` flag to run the benchmark across multiple clients. When not set, use one client by default.

(The motivation is so that I can use this as a load generator to reproduce a scenario that requires many clients.)

Adding this feature involved a lot of refactoring -- some necessary, some incidental. I think I kept all of the many existing features intact though.

Some notes:
- The workload generation logic didn't change, it just moved around.
- I tried to keep the output the same, modulo some cleanup.

<details>
<summary>Benchmark output before</summary>

```
1222 batches in 30.45 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 328409 tx/s
batch latency p1 = 9 ms
batch latency p10 = 13 ms
batch latency p20 = 14 ms
batch latency p30 = 16 ms
batch latency p40 = 18 ms
batch latency p50 = 21 ms
batch latency p60 = 25 ms
batch latency p70 = 28 ms
batch latency p80 = 30 ms
batch latency p90 = 31 ms
batch latency p95 = 34 ms
batch latency p99 = 111 ms
batch latency p100 = 121 ms

100 queries in 3.97 s
query latency p1 = 26 ms
query latency p10 = 28 ms
query latency p20 = 29 ms
query latency p30 = 31 ms
query latency p40 = 33 ms
query latency p50 = 39 ms
query latency p60 = 43 ms
query latency p70 = 45 ms
query latency p80 = 47 ms
query latency p90 = 51 ms
query latency p95 = 54 ms
query latency p99 = 62 ms
query latency p100 = 101 ms
validated 10000 accounts, 10000000 transfers
2024-12-16 14:45:21.589Z info(main): stdin closed, exiting

rss = 3125112832 bytes

datafile empty = 1141374976 bytes
datafile = 14824247296 bytes
```

</details>

<details>
<summary>Benchmark output after</summary>

```
1222 batches in 30.36 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 329362 tx/s
batch latency p1 = 7 ms
batch latency p10 = 11 ms
batch latency p20 = 12 ms
batch latency p30 = 14 ms
batch latency p40 = 16 ms
batch latency p50 = 18 ms
batch latency p60 = 22 ms
batch latency p70 = 25 ms
batch latency p80 = 27 ms
batch latency p90 = 29 ms
batch latency p95 = 32 ms
batch latency p99 = 106 ms
batch latency p100 = 129 ms

100 queries in 4.1 s
query latency p1 = 26 ms
query latency p10 = 28 ms
query latency p20 = 30 ms
query latency p30 = 31 ms
query latency p40 = 33 ms
query latency p50 = 38 ms
query latency p60 = 44 ms
query latency p70 = 45 ms
query latency p80 = 48 ms
query latency p90 = 50 ms
query latency p95 = 56 ms
query latency p99 = 64 ms
query latency p100 = 114 ms
validated 10000 accounts
validated 10000000 transfers
2024-12-16 15:10:16.318Z info(main): stdin closed, exiting

rss = 3124719616 bytes

datafile empty = 1141374976 bytes
datafile = 14856753152 bytes
```

</details>

<details>
<summary>Benchmark output after (with clients=2)</summary>

```
1222 batches in 30.08 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 332410 tx/s
batch latency p1 = 37 ms
batch latency p10 = 41 ms
batch latency p20 = 47 ms
batch latency p30 = 72 ms
batch latency p40 = 78 ms
batch latency p50 = 90 ms
batch latency p60 = 107 ms
batch latency p70 = 116 ms
batch latency p80 = 125 ms
batch latency p90 = 150 ms
batch latency p95 = 183 ms
batch latency p99 = 198 ms
batch latency p100 = 218 ms

100 queries in 4.2 s
query latency p1 = 109 ms
query latency p10 = 116 ms
query latency p20 = 118 ms
query latency p30 = 132 ms
query latency p40 = 175 ms
query latency p50 = 181 ms
query latency p60 = 185 ms
query latency p70 = 192 ms
query latency p80 = 194 ms
query latency p90 = 203 ms
query latency p95 = 207 ms
query latency p99 = 214 ms
query latency p100 = 252 ms
validated 10000 accounts
validated 10000000 transfers
2024-12-16 15:16:57.048Z info(main): stdin closed, exiting

rss = 3124981760 bytes

datafile empty = 1141374976 bytes
datafile = 14841548800 bytes
```

</details>