### PR TITLE
VSR: Timeout backoff is too aggressive

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3174,7 +3174,8 @@ pub fn ReplicaType(
             if (self.sync_tables != null) return;
             assert(self.grid.callback != .cancel);
 
-            self.grid_scrub_timeout.after = std.math.clamp(
+            assert(self.grid_scrub_timeout.after_dynamic != null);
+            self.grid_scrub_timeout.after_dynamic = std.math.clamp(
                 @divFloor(
                     constants.grid_scrubber_cycle_ticks,
                     @max(1, self.grid.free_set.count_acquired()),

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1786,6 +1786,7 @@ test "Cluster: view_change: lagging replica repairs WAL using start_view from po
     b1.pass(.R_, .outgoing, .do_view_change);
 
     t.run();
+    t.run();
 
     try expectEqual(b1.status(), .normal);
     try expectEqual(b1.role(), .primary);


### PR DESCRIPTION
## Bug

For timeouts which use backoff, the backoff never gets "reset".
- The first time a timeout ever backs off, that timeout interval is forever increased to at least `700ms` (`constants.rtt_ms * constants.rtt_multiple + constants.backoff_min_ms`)
- (Added to this is a jitter, which varies. The jitter's contribution to the timeout is _not_ permanent.)

There are two timeouts which use backoff:
- The primary's `prepare_timeout` (for retrying prepare replication).
- The client's `request_timeout`.

## Fix

When we stop the timeout, restore its duration to the original value.

(The extra `t.run()` is to fix a test that broke due to the permutation.)