### PR TITLE
VSR: Set timeout RTTs dynamically

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -13,7 +13,7 @@ const Storage = vsr.storage.StorageType(IO);
 const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
 
 const Header = vsr.Header;
-const Client = vsr.ClientType(StateMachine, MessageBus);
+const Client = vsr.ClientType(StateMachine, MessageBus, vsr.time.Time);
 const log = std.log.scoped(.aof);
 
 const magic_number: u128 = 312960301372567410560647846651901451202;
@@ -327,6 +327,7 @@ pub const AOFReplayClient = struct {
                 .id = stdx.unique_u128(),
                 .cluster = 0,
                 .replica_count = @intCast(addresses.len),
+                .time = .{},
                 .message_pool = message_pool,
                 .message_bus_options = .{
                     .configuration = addresses,

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -45,13 +45,13 @@ pub const InitError = @import("tb_client/context.zig").Error;
 
 const DefaultContext = blk: {
     const ClientType = @import("../../vsr/client.zig").ClientType;
-    const Client = ClientType(StateMachine, MessageBus);
+    const Client = ClientType(StateMachine, MessageBus, vsr.time.Time);
     break :blk ContextType(Client);
 };
 
 const TestingContext = blk: {
     const EchoClientType = @import("tb_client/echo_client.zig").EchoClientType;
-    const EchoClient = EchoClientType(StateMachine, MessageBus);
+    const EchoClient = EchoClientType(StateMachine, MessageBus, vsr.time.Time);
     break :blk ContextType(EchoClient);
 };
 

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -174,6 +174,7 @@ pub fn ContextType(
                     .id = context.client_id,
                     .cluster = cluster_id,
                     .replica_count = context.addresses.count_as(u8),
+                    .time = .{},
                     .message_pool = &context.message_pool,
                     .message_bus_options = .{
                         .configuration = context.addresses.const_slice(),

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -10,12 +10,16 @@ const constants = vsr.constants;
 const MessagePool = vsr.message_pool.MessagePool;
 const Message = MessagePool.Message;
 
-pub fn EchoClientType(comptime StateMachine_: type, comptime MessageBus: type) type {
+pub fn EchoClientType(
+    comptime StateMachine_: type,
+    comptime MessageBus: type,
+    comptime Time: type,
+) type {
     return struct {
         const EchoClient = @This();
 
         // Exposing the same types the real client does:
-        const VSRClient = vsr.ClientType(StateMachine_, MessageBus);
+        const VSRClient = vsr.ClientType(StateMachine_, MessageBus, Time);
         pub const StateMachine = VSRClient.StateMachine;
         pub const Request = VSRClient.Request;
 
@@ -61,6 +65,7 @@ pub fn EchoClientType(comptime StateMachine_: type, comptime MessageBus: type) t
                 id: u128,
                 cluster: u128,
                 replica_count: u8,
+                time: Time,
                 message_pool: *MessagePool,
                 message_bus_options: MessageBus.Options,
                 eviction_callback: ?*const fn (
@@ -230,7 +235,8 @@ test "Echo Demuxer" {
         constants.state_machine_config,
     );
     const MessageBus = vsr.message_bus.MessageBusClient;
-    const Client = EchoClientType(StateMachine, MessageBus);
+    const Time = vsr.time.Time;
+    const Client = EchoClientType(StateMachine, MessageBus, Time);
 
     var prng = std.rand.DefaultPrng.init(42);
     inline for ([_]StateMachine.Operation{

--- a/src/config.zig
+++ b/src/config.zig
@@ -116,6 +116,7 @@ const ConfigProcess = struct {
     client_replies_iops_write_max: usize = 2,
     tick_ms: u63 = 10,
     rtt_ms: u64 = 300,
+    rtt_max_ms: u64 = 1000 * 60,
     rtt_multiple: u8 = 2,
     backoff_min_ms: u64 = 100,
     backoff_max_ms: u64 = 10000,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -725,6 +725,9 @@ pub const tick_ms = config.process.tick_ms;
 /// This should be set higher rather than lower to avoid flooding the network at startup.
 pub const rtt_ticks = config.process.rtt_ms / tick_ms;
 
+/// Maximum RTT, to prevent too-long timeouts.
+pub const rtt_max_ticks = config.process.rtt_max_ms / tick_ms;
+
 /// The multiple of round-trip time for RTT-sensitive timeouts.
 pub const rtt_multiple = 2;
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -59,14 +59,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
         pub const MessageBus = @import("cluster/message_bus.zig").MessageBus;
         pub const StateMachine = StateMachineType(Storage, constants.state_machine_config);
-        pub const Replica = vsr.ReplicaType(
-            StateMachine,
-            MessageBus,
-            Storage,
-            TimePointer,
-            AOF,
-        );
-        pub const Client = vsr.ClientType(StateMachine, MessageBus);
+        pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, TimePointer, AOF);
+        pub const Client = vsr.ClientType(StateMachine, MessageBus, Time);
         pub const StateChecker = StateCheckerType(Client, Replica);
         pub const ManifestChecker = ManifestCheckerType(StateMachine.Forest);
 
@@ -288,6 +282,12 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                         .id = client_id_permutation.encode(i + client_id_permutation_shift),
                         .cluster = options.cluster_id,
                         .replica_count = options.replica_count,
+                        .time = .{
+                            .resolution = constants.tick_ms * std.time.ns_per_ms,
+                            .offset_type = .linear,
+                            .offset_coefficient_A = 0,
+                            .offset_coefficient_B = 0,
+                        },
                         .message_pool = &client_pools[i],
                         .message_bus_options = .{ .network = network },
                         .eviction_callback = client_on_eviction,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -24,7 +24,7 @@ const Storage = vsr.storage.StorageType(IO);
 const MessagePool = vsr.message_pool.MessagePool;
 const MessageBus = vsr.message_bus.MessageBusClient;
 const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
-const Client = vsr.ClientType(StateMachine, MessageBus);
+const Client = vsr.ClientType(StateMachine, MessageBus, vsr.time.Time);
 const tb = vsr.tigerbeetle;
 const StatsD = vsr.statsd.StatsD;
 const IdPermutation = vsr.testing.IdPermutation;
@@ -85,6 +85,7 @@ pub fn main(
             .id = client_id,
             .cluster = cluster_id,
             .replica_count = @intCast(addresses.len),
+            .time = .{},
             .message_pool = &message_pool,
             .message_bus_options = .{
                 .configuration = addresses,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -537,13 +537,16 @@ const Command = struct {
     }
 
     pub fn repl(allocator: mem.Allocator, args: *const cli.Command.Repl) !void {
-        const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient);
+        const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient, Time);
 
         var repl_instance = try Repl.init(
             allocator,
-            args.addresses.const_slice(),
-            args.cluster,
-            args.verbose,
+            .{},
+            .{
+                .cluster_id = args.cluster,
+                .addresses = args.addresses.const_slice(),
+                .verbose = args.verbose,
+            },
         );
         defer repl_instance.deinit(allocator);
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -720,7 +720,7 @@ pub const Timeout = struct {
     /// Sets the value of `after` as a function of `rtt` and `attempts`.
     /// Adds exponential backoff and jitter.
     /// May be called only after a timeout has been stopped or reset, to prevent backward jumps.
-    pub fn set_after_for_rtt_and_attempts(self: *Timeout, random: std.rand.Random) void {
+    fn set_after_for_rtt_and_attempts(self: *Timeout, random: std.rand.Random) void {
         // If `after` is reduced by this function to less than `ticks`, then `fired()` will panic:
         assert(self.ticks == 0);
         assert(self.rtt > 0);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -753,14 +753,16 @@ pub const Timeout = struct {
         assert(self.rtt > 0);
         assert(rtt_ticks > 0);
 
-        log.debug("{}: {s} rtt={}..{}", .{
-            self.id,
-            self.name,
-            self.rtt,
-            rtt_ticks,
-        });
+        if (self.rtt != rtt_ticks) {
+            log.debug("{}: {s} rtt={}..{}", .{
+                self.id,
+                self.name,
+                self.rtt,
+                rtt_ticks,
+            });
 
-        self.rtt = rtt_ticks;
+            self.rtt = rtt_ticks;
+        }
     }
 
     pub fn start(self: *Timeout) void {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -749,9 +749,11 @@ pub const Timeout = struct {
         assert(self.after_dynamic.? > 0);
     }
 
-    pub fn set_rtt(self: *Timeout, rtt_ticks: u64) void {
+    pub fn set_rtt_ns(self: *Timeout, rtt_ns: u64) void {
         assert(self.rtt > 0);
-        assert(rtt_ticks > 0);
+
+        const rtt_ms = @divFloor(rtt_ns, std.time.ns_per_ms);
+        const rtt_ticks = @max(1, @divFloor(rtt_ms, constants.tick_ms));
 
         if (self.rtt != rtt_ticks) {
             log.debug("{}: {s} rtt={}..{}", .{

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -754,16 +754,17 @@ pub const Timeout = struct {
 
         const rtt_ms = @divFloor(rtt_ns, std.time.ns_per_ms);
         const rtt_ticks = @max(1, @divFloor(rtt_ms, constants.tick_ms));
+        const rtt_ticks_clamped = @min(rtt_ticks, constants.rtt_max_ticks);
 
-        if (self.rtt != rtt_ticks) {
+        if (self.rtt != rtt_ticks_clamped) {
             log.debug("{}: {s} rtt={}..{}", .{
                 self.id,
                 self.name,
                 self.rtt,
-                rtt_ticks,
+                rtt_ticks_clamped,
             });
 
-            self.rtt = rtt_ticks;
+            self.rtt = rtt_ticks_clamped;
         }
     }
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -460,6 +460,7 @@ pub fn ClientType(
                     }
                 }
                 std.mem.sort(u64, round_trip_times_ns.slice(), {}, std.sort.asc(u64));
+                assert(round_trip_times_ns.count() > 0);
 
                 const rtt_median_ns =
                     round_trip_times_ns.get(@divFloor(round_trip_times_ns.count(), 2));

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -565,6 +565,8 @@ pub fn ClientType(comptime StateMachine_: type, comptime MessageBus: type) type 
         }
 
         fn on_request_timeout(self: *Client) void {
+            // TODO Compute round-trip time and call self.request_timeout.set_rtt(...).
+            // Right now the timeout uses the default RTT, which is typically too high.
             self.request_timeout.backoff(self.prng.random());
 
             const message = self.request_inflight.?.message;

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -379,7 +379,7 @@ pub fn ClockType(comptime Time: type) type {
                 }
             }
 
-            if (one_way_delays.count() == 0) {
+            if (one_way_delays.count() < self.quorum) {
                 return null;
             } else {
                 std.mem.sort(u64, one_way_delays.slice(), {}, std.sort.asc(u64));

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -403,7 +403,8 @@ pub const Header = extern struct {
         reserved_frame: [12]u8 = [_]u8{0} ** 12,
 
         client: u128,
-        reserved: [112]u8 = [_]u8{0} ** 112,
+        ping_timestamp_monotonic: u64,
+        reserved: [104]u8 = [_]u8{0} ** 104,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .ping_client);
@@ -436,7 +437,8 @@ pub const Header = extern struct {
         replica: u8,
         reserved_frame: [12]u8 = [_]u8{0} ** 12,
 
-        reserved: [128]u8 = [_]u8{0} ** 128,
+        ping_timestamp_monotonic: u64,
+        reserved: [120]u8 = [_]u8{0} ** 120,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .pong_client);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1489,6 +1489,11 @@ pub fn ReplicaType(
             const m2 = self.clock.monotonic();
 
             self.clock.learn(message.header.replica, m0, t1, m2);
+            if (self.clock.round_trip_time_median_ns()) |rtt_ns| {
+                const rtt_ms = @divFloor(rtt_ns, std.time.ns_per_ms);
+                const rtt_ticks = @divFloor(rtt_ms, constants.tick_ms);
+                self.prepare_timeout.set_rtt(@max(1, rtt_ticks));
+            }
         }
 
         /// Pings are used by clients to learn about the current view.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1490,9 +1490,7 @@ pub fn ReplicaType(
 
             self.clock.learn(message.header.replica, m0, t1, m2);
             if (self.clock.round_trip_time_median_ns()) |rtt_ns| {
-                const rtt_ms = @divFloor(rtt_ns, std.time.ns_per_ms);
-                const rtt_ticks = @divFloor(rtt_ms, constants.tick_ms);
-                self.prepare_timeout.set_rtt(@max(1, rtt_ticks));
+                self.prepare_timeout.set_rtt_ns(rtt_ns);
             }
         }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1509,6 +1509,7 @@ pub fn ReplicaType(
                 .replica = self.replica,
                 .view = self.view,
                 .release = self.release,
+                .ping_timestamp_monotonic = message.header.ping_timestamp_monotonic,
             }));
         }
 


### PR DESCRIPTION
## Bug

From `constants.zig`:

    /// The conservative round-trip time at startup when there is no network knowledge.
    /// Adjusted dynamically thereafter for RTT-sensitive timeouts according to network congestion.
    /// This should be set higher rather than lower to avoid flooding the network at startup.
    pub const rtt_ticks = config.process.rtt_ms / tick_ms;

We weren't ever actually adjusting the RTT for timeouts.
So when computing backoff, we always used `600ms` as the RTT, which is typically too long.

Two timeouts use backoff:
- the replica's `prepare_timeout`, and
- the client's `request_timeout`.

## Fix

Estimate the RTT and use that to dynamically set the timeout. This is _very_ rough right now -- ideally we would be using more samples, and distinguishing between different replicas.

For the client:
- `vsr.ClientType()` now takes a `Time` type.
- `ping_client` messages now include the client's monotonic timestamp.
- `pong_client` echoes back the client's monotonic timestamp.
- Right now the client doesn't do any sort of averaging over RTTs, it just always uses the latest one from the *primary*.   (Since the primary is where requests are being sent.)

## Benchmark

The `prepare_timeout` fix is a huge improvement for throughput in a compromised cluster -- p100 is 8s instead of 27s. (...There is still a lot of room for improvement.)

To test that, run the benchmark against a cluster-of-3 that only has 2 replicas running:

```
$ ./tigerbeetle benchmark --clients=32 --transfer-batch-size=5 --transfer-count=2000
```

(The small batches are to focus the benchmark on consensus rather than compaction.)

<details>
<summary>Results before</summary>

```
400 batches in 329.70 s
transfer batch size = 5 txs
transfer batch delay = 0 us
load accepted = 6 tx/s
batch latency p1 = 3343 ms
batch latency p10 = 25688 ms
batch latency p20 = 25932 ms
batch latency p30 = 26034 ms
batch latency p40 = 26133 ms
batch latency p50 = 26255 ms
batch latency p60 = 26374 ms
batch latency p70 = 26554 ms
batch latency p80 = 26687 ms
batch latency p90 = 26832 ms
batch latency p95 = 27013 ms
batch latency p99 = 27192 ms
batch latency p100 = 27277 ms
```

</details>

<details>
<summary>Results after</summary>

```
400 batches in 91.80 s
transfer batch size = 5 txs
transfer batch delay = 0 us
load accepted = 21 tx/s
batch latency p1 = 1443 ms
batch latency p10 = 6718 ms
batch latency p20 = 6961 ms
batch latency p30 = 7054 ms
batch latency p40 = 7189 ms
batch latency p50 = 7289 ms
batch latency p60 = 7361 ms
batch latency p70 = 7443 ms
batch latency p80 = 7538 ms
batch latency p90 = 7640 ms
batch latency p95 = 7767 ms
batch latency p99 = 7920 ms
batch latency p100 = 8042 ms
```

</details>