### PR TITLE
vsr: throttle repair a bit

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -74,6 +74,14 @@ comptime {
     assert(vsr_checkpoint_ops % lsm_compaction_ops == 0);
 }
 
+pub const vsr_repair_message_budget_max = replicas_max * 2;
+pub const vsr_repair_message_budget_refill = @divFloor(vsr_repair_message_budget_max, 2);
+
+comptime {
+    assert(vsr_repair_message_budget_max > 0);
+    assert(vsr_repair_message_budget_refill > 0);
+}
+
 /// The maximum number of clients allowed per cluster, where each client has a unique 128-bit ID.
 /// This impacts the amount of memory allocated at initialization by the server.
 /// This determines the size of the VR client table used to cache replies to clients by client ID.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -420,6 +420,9 @@ pub fn ReplicaType(
         /// Unique do_view_change messages for the same view from ALL replicas (including ourself).
         do_view_change_from_all_replicas: DVCQuorumMessages = dvc_quorum_messages_null,
 
+        // +1 to make it easier to decrement budget with -|.
+        repair_messages_budget: u32 = constants.vsr_repair_message_budget_max + 1,
+
         /// Whether the primary has received a quorum of do_view_change messages for the view
         /// change. Determines whether the primary may effect repairs according to the CTRL
         /// protocol.
@@ -3116,6 +3119,12 @@ pub fn ReplicaType(
 
         fn on_repair_timeout(self: *Replica) void {
             assert(self.status == .normal or self.status == .view_change);
+            assert(self.repair_messages_budget <= constants.vsr_repair_message_budget_max + 1);
+            self.repair_messages_budget = @min(
+                (self.repair_messages_budget + constants.vsr_repair_message_budget_refill),
+                // +1 to make it easier to decrement budget with -|.
+                constants.vsr_repair_message_budget_max + 1,
+            );
             self.repair();
         }
 
@@ -6405,17 +6414,19 @@ pub fn ReplicaType(
                         self.view_headers.array.get(0).op,
                     },
                 );
-
-                self.send_header_to_replica(
-                    self.primary_index(self.view),
-                    @bitCast(Header.RequestStartView{
-                        .command = .request_start_view,
-                        .cluster = self.cluster,
-                        .replica = self.replica,
-                        .view = self.view,
-                        .nonce = self.nonce,
-                    }),
-                );
+                self.repair_messages_budget -|= 1;
+                if (self.repair_messages_budget > 0) {
+                    self.send_header_to_replica(
+                        self.primary_index(self.view),
+                        @bitCast(Header.RequestStartView{
+                            .command = .request_start_view,
+                            .cluster = self.cluster,
+                            .replica = self.replica,
+                            .view = self.view,
+                            .nonce = self.nonce,
+                        }),
+                    );
+                }
             }
 
             if (self.op < self.op_repair_max()) return;
@@ -6444,16 +6455,19 @@ pub fn ReplicaType(
                     },
                 );
 
-                self.send_header_to_replica(
-                    self.choose_any_other_replica(),
-                    @bitCast(Header.RequestHeaders{
-                        .command = .request_headers,
-                        .cluster = self.cluster,
-                        .replica = self.replica,
-                        .op_min = range.op_min,
-                        .op_max = range.op_max,
-                    }),
-                );
+                self.repair_messages_budget -|= 1;
+                if (self.repair_messages_budget > 0) {
+                    self.send_header_to_replica(
+                        self.choose_any_other_replica(),
+                        @bitCast(Header.RequestHeaders{
+                            .command = .request_headers,
+                            .cluster = self.cluster,
+                            .replica = self.replica,
+                            .op_min = range.op_min,
+                            .op_max = range.op_max,
+                        }),
+                    );
+                }
             }
 
             if (self.journal.dirty.count > 0) {
@@ -7143,7 +7157,7 @@ pub fn ReplicaType(
                         reason,
                     },
                 );
-
+                // Not checking our repair budget here, as we are to be the primary.
                 self.send_header_to_other_replicas(@bitCast(request_prepare));
             } else {
                 const nature = if (op > self.commit_max) "uncommitted" else "committed";
@@ -7156,10 +7170,13 @@ pub fn ReplicaType(
                     reason,
                 });
 
-                self.send_header_to_replica(
-                    self.choose_any_other_replica(),
-                    @bitCast(request_prepare),
-                );
+                self.repair_messages_budget -|= 1;
+                if (self.repair_messages_budget > 0) {
+                    self.send_header_to_replica(
+                        self.choose_any_other_replica(),
+                        @bitCast(request_prepare),
+                    );
+                }
             }
 
             return true;

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1787,6 +1787,7 @@ test "Cluster: view_change: lagging replica repairs WAL using start_view from po
 
     t.run();
     t.run();
+    t.run();
 
     try expectEqual(b1.status(), .normal);
     try expectEqual(b1.role(), .primary);


### PR DESCRIPTION
Our repair can create a feedback loop. repair requests prepares and headers, but, upon receiving either back, we re-trigger repair, which could lead to duplicate repair work.

To avoid that, make sure that we are not sending more than one repair message per replica per our repair timeout.