### PR TITLE
logging: expose more debug logging on cli and python client

### DIFF
--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -124,10 +124,12 @@ pub const Logging = struct {
 
 pub fn register_log_callback(
     callback_maybe: ?Logging.Callback,
+    debug: bool,
 ) callconv(.C) tb_register_log_callback_status_t {
     if (logging.callback == null) {
         if (callback_maybe) |callback| {
             logging.callback = callback;
+            logging.debug = debug;
             return .success;
         } else {
             return .not_registered;
@@ -135,6 +137,7 @@ pub fn register_log_callback(
     } else {
         if (callback_maybe == null) {
             logging.callback = null;
+            logging.debug = debug;
             return .success;
         } else {
             return .already_registered;

--- a/src/clients/python/README.md
+++ b/src/clients/python/README.md
@@ -31,6 +31,10 @@ import os
 import tigerbeetle as tb
 
 print("Import OK!")
+
+# To enable debug logging, via Python's built in logging module:
+# logging.basicConfig(level=logging.DEBUG)
+# tb.configure_logging(debug=True)
 ```
 
 Finally, build and run:

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -17,6 +17,7 @@ const mappings_vsr = .{
     .{ tb_client.tb_packet_t, "Packet" },
     .{ tb_client.tb_client_t, "Client" },
     .{ tb_client.tb_status_t, "Status" },
+    .{ tb_client.tb_register_log_callback_status_t, "RegisterLogCallbackStatus" },
 };
 
 /// State machine specific mappings: in future, these should be pulled automatically from the state
@@ -470,6 +471,7 @@ pub fn main() !void {
         \\# Don't be tempted to use c_char_p for bytes_ptr - it's for null terminated strings only.
         \\OnCompletion = ctypes.CFUNCTYPE(None, ctypes.c_void_p, Client, ctypes.POINTER(CPacket),
         \\                                ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint32)
+        \\LogHandler = ctypes.CFUNCTYPE(None, ctypes.c_uint8, ctypes.c_void_p, ctypes.c_uint)
         \\
         \\# Initialize a new TigerBeetle client which connects to the addresses provided and
         \\# completes submitted packets by invoking the callback with the given context.
@@ -499,6 +501,13 @@ pub fn main() !void {
         \\tb_client_submit = tbclient.tb_client_submit
         \\tb_client_submit.restype = None
         \\tb_client_submit.argtypes = [Client, ctypes.POINTER(CPacket)]
+        \\
+        \\tb_client_register_log_callback = tbclient.tb_client_register_log_callback
+        \\tb_client_register_log_callback.restype = RegisterLogCallbackStatus
+        \\# Need to pass in None to clear - ctypes will error if argtypes is set.
+        \\#tb_client_register_log_callback.argtypes = [LogHandler, ctypes.c_bool]
+        \\
+        \\
         \\
     , .{});
 

--- a/src/clients/python/samples/walkthrough/main.py
+++ b/src/clients/python/samples/walkthrough/main.py
@@ -4,6 +4,10 @@ import os
 import tigerbeetle as tb
 
 print("Import OK!")
+
+# To enable debug logging, via Python's built in logging module:
+# logging.basicConfig(level=logging.DEBUG)
+# tb.configure_logging(debug=True)
 # endsection:imports
 
 # section:client

--- a/src/clients/python/src/tigerbeetle/__init__.py
+++ b/src/clients/python/src/tigerbeetle/__init__.py
@@ -1,3 +1,3 @@
 from .bindings import * # noqa
-from .client import ClientAsync, ClientSync, id, amount_max # noqa
+from .client import ClientAsync, ClientSync, id, amount_max, configure_logging # noqa
 from .lib import IntegerOverflowError, NativeError

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -47,6 +47,12 @@ class Status(enum.IntEnum):
     NETWORK_SUBSYSTEM = 6
 
 
+class RegisterLogCallbackStatus(enum.IntEnum):
+    SUCCESS = 0
+    ALREADY_REGISTERED = 1
+    NOT_REGISTERED = 2
+
+
 class AccountFlags(enum.IntFlag):
     NONE = 0
     LINKED = 1 << 0
@@ -612,6 +618,7 @@ CQueryFilter._fields_ = [ # noqa: SLF001
 # Don't be tempted to use c_char_p for bytes_ptr - it's for null terminated strings only.
 OnCompletion = ctypes.CFUNCTYPE(None, ctypes.c_void_p, Client, ctypes.POINTER(CPacket),
                                 ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint32)
+LogHandler = ctypes.CFUNCTYPE(None, ctypes.c_uint8, ctypes.c_void_p, ctypes.c_uint)
 
 # Initialize a new TigerBeetle client which connects to the addresses provided and
 # completes submitted packets by invoking the callback with the given context.
@@ -641,6 +648,13 @@ tb_client_deinit.argtypes = [Client]
 tb_client_submit = tbclient.tb_client_submit
 tb_client_submit.restype = None
 tb_client_submit.argtypes = [Client, ctypes.POINTER(CPacket)]
+
+tb_client_register_log_callback = tbclient.tb_client_register_log_callback
+tb_client_register_log_callback.restype = RegisterLogCallbackStatus
+# Need to pass in None to clear - ctypes will error if argtypes is set.
+#tb_client_register_log_callback.argtypes = [LogHandler, ctypes.c_bool]
+
+
 class AsyncStateMachineMixin:
     _submit: Callable[[Operation, Any, Any, Any], Any]
     async def create_accounts(self, accounts: list[Account]) -> list[CreateAccountsResult]:

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -5,7 +5,7 @@ from dataclasses import asdict
 import pytest
 
 import tigerbeetle as tb
-
+tb.configure_logging(debug=True)
 
 @pytest.fixture
 def client():

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -72,6 +72,10 @@ pub fn main(allocator: std.mem.Allocator, args: *const cli.Command.Benchmark) !v
                 vsr.fatal(.cli, "--" ++ arg_name ++ ": incompatible with --addresses", .{});
             }
         }
+
+        if (args.log_debug_replica) {
+            vsr.fatal(.cli, "--log-debug-replica: incompatible with --addresses", .{});
+        }
     }
 
     const addresses = if (args.addresses) |*addresses|
@@ -179,11 +183,15 @@ fn start(allocator: std.mem.Allocator, options: struct {
         }
     }
 
+    if (options.args.log_debug_replica) {
+        try start_args.append(arena.allocator(), "--log-debug");
+    }
+
     // Some of the forwarded arguments require the "--experimental" flag.
     const experimental: bool = inline for (forward_args) |forward_arg| {
         if (forward_arg[0] != null) break true;
     } else false;
-    if (experimental) {
+    if (experimental or options.args.log_debug_replica) {
         try start_args.append(arena.allocator(), "--experimental");
     }
 

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -10,9 +10,6 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 const panic = std.debug.panic;
 const log = std.log;
-pub const std_options = .{
-    .log_level = .info,
-};
 
 const vsr = @import("vsr");
 const constants = vsr.constants;

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -37,6 +37,7 @@ const CLIArgs = union(enum) {
         standby: ?u8 = null,
         replica_count: u8,
         development: bool = false,
+        log_debug: bool = false,
 
         positional: struct {
             path: [:0]const u8,
@@ -87,6 +88,7 @@ const CLIArgs = union(enum) {
         cluster: u128,
         verbose: bool = false,
         command: []const u8 = "",
+        log_debug: bool = false,
     };
 
     // Experimental: the interface is subject to change.
@@ -98,6 +100,8 @@ const CLIArgs = union(enum) {
         cache_grid: ?[]const u8 = null,
         account_count: usize = 10_000,
         account_count_hot: usize = 0,
+        log_debug: bool = false,
+        log_debug_replica: bool = false,
         /// The probability distribution used to select accounts when making
         /// transfers or queries.
         account_distribution: Command.Benchmark.Distribution = .uniform,
@@ -216,6 +220,7 @@ const CLIArgs = union(enum) {
 
     // Internal: used to validate multiversion binaries.
     const Multiversion = struct {
+        log_debug: bool = false,
         positional: struct {
             path: [:0]const u8,
         },
@@ -384,6 +389,7 @@ pub const Command = union(enum) {
         replica_count: u8,
         development: bool,
         path: [:0]const u8,
+        log_debug: bool,
     };
 
     pub const Start = struct {
@@ -419,6 +425,7 @@ pub const Command = union(enum) {
         cluster: u128,
         verbose: bool,
         statements: []const u8,
+        log_debug: bool,
     };
 
     pub const Benchmark = struct {
@@ -441,6 +448,8 @@ pub const Command = union(enum) {
         cache_transfers_pending: ?[]const u8,
         cache_account_balances: ?[]const u8,
         cache_grid: ?[]const u8,
+        log_debug: bool,
+        log_debug_replica: bool,
         account_count: usize,
         account_count_hot: usize,
         account_distribution: Distribution,
@@ -492,6 +501,7 @@ pub const Command = union(enum) {
 
     pub const Multiversion = struct {
         path: [:0]const u8,
+        log_debug: bool,
     };
 
     format: Format,
@@ -583,6 +593,7 @@ fn parse_args_format(format: CLIArgs.Format) Command.Format {
         .replica_count = format.replica_count,
         .development = format.development,
         .path = format.positional.path,
+        .log_debug = format.log_debug,
     };
 }
 
@@ -823,6 +834,7 @@ fn parse_args_repl(repl: CLIArgs.Repl) Command.Repl {
         .cluster = repl.cluster,
         .verbose = repl.verbose,
         .statements = repl.command,
+        .log_debug = repl.log_debug,
     };
 }
 
@@ -842,6 +854,8 @@ fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
         .cache_transfers_pending = benchmark.cache_transfers_pending,
         .cache_account_balances = benchmark.cache_account_balances,
         .cache_grid = benchmark.cache_grid,
+        .log_debug = benchmark.log_debug,
+        .log_debug_replica = benchmark.log_debug_replica,
         .account_count = benchmark.account_count,
         .account_count_hot = benchmark.account_count_hot,
         .account_distribution = benchmark.account_distribution,
@@ -899,6 +913,7 @@ fn parse_args_inspect(inspect: CLIArgs.Inspect) Command.Inspect {
 fn parse_args_multiversion(multiversion: CLIArgs.Multiversion) Command.Multiversion {
     return .{
         .path = multiversion.positional.path,
+        .log_debug = multiversion.log_debug,
     };
 }
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -66,18 +66,22 @@ pub fn main() !void {
     var command = cli.parse_args(&arg_iterator);
 
     switch (command) {
+        .inspect, .version => {},
+        inline else => |*args| {
+            if (args.log_debug) {
+                log_level_runtime = .debug;
+            }
+        },
+    }
+
+    switch (command) {
         .format => |*args| try Command.format(allocator, args, .{
             .cluster = args.cluster,
             .replica = args.replica,
             .replica_count = args.replica_count,
             .release = config.process.release,
         }),
-        .start => |*args| {
-            if (args.log_debug) {
-                log_level_runtime = .debug;
-            }
-            try Command.start(arena.allocator(), args);
-        },
+        .start => |*args| try Command.start(arena.allocator(), args),
         .version => |*args| try Command.version(allocator, args.verbose),
         .repl => |*args| try Command.repl(arena.allocator(), args),
         .benchmark => |*args| try benchmark_driver.main(allocator, args),


### PR DESCRIPTION
This PR adds `--log-debug` for the `format`, `benchmark`, `multiversion` and `repl` subcommands.

`benchmark` gets two parameters - `--log-debug`, which controls the debug logging of the benchmark load, and `--log-debug-replica` which controls the debug logging of the started replica.

Additionally, expose debug logging to the Python client, and have it register a log callback - making it the first language log integrated client!