### PR TITLE
devhub: track format and startup time 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,23 @@ jobs:
       - run: ./zig/download.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
       - run: ./zig/zig build scripts -- ci --language=${{ matrix.language }}
 
+  devhub_dry_run:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2147483647
+      - run: sudo apt-get update && sudo apt-get install -y kcov
+      - run: ./zig/download.sh
+      # Run under sudo to enable memory locking for accurate RSS stats.
+      - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not providing DEVHUBDB_PAT and NYRKIO_TOKEN stops devhub from uploading its results, but
+          # it still runs everything.
+
   devhub:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,27 +178,9 @@ jobs:
       - run: ./zig/download.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
       - run: ./zig/zig build scripts -- ci --language=${{ matrix.language }}
 
-  devhub_dry_run:
-    if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2147483647
-      - run: sudo apt-get update && sudo apt-get install -y kcov
-      - run: ./zig/download.sh
-      # Run under sudo to enable memory locking for accurate RSS stats.
-      - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Not providing DEVHUBDB_PAT and NYRKIO_TOKEN stops devhub from uploading its results, but
-          # it still runs everything.
-
   devhub:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    environment: devhub
+    environment: ${{ github.ref == 'refs/heads/main' && 'devhub' || '' }}
     permissions:
       pages: write
       id-token: write
@@ -209,17 +191,31 @@ jobs:
           fetch-depth: 2147483647
       - run: sudo apt-get update && sudo apt-get install -y kcov
       - run: ./zig/download.sh
+
+      # Dummy devhub run - checks that all the devhub tests pass in CI. They are run again, in main
+      # once merged. Kcov is skipped to avoid adding to the pipeline time.
+      - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }} --skip-kcov
+        if: github.ref != 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not providing DEVHUBDB_PAT and NYRKIO_TOKEN stops devhub from uploading its results, but
+          # it still runs everything.
+
       # Run under sudo to enable memory locking for accurate RSS stats.
       - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
+        if: github.ref == 'refs/heads/main'
         env:
           DEVHUBDB_PAT: ${{ secrets.DEVHUBDB_PAT }}
           NYRKIO_TOKEN: ${{ secrets.NYRKIO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/main'
         with:
           path: ./src/devhub
+
       - uses: actions/deploy-pages@v4
+        if: github.ref == 'refs/heads/main'
 
   # Work around GitHub considering Skipped jobs success for "Require status checks before merging"
   # See also:

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -19,11 +19,17 @@ const log = std.log;
 
 pub const CLIArgs = struct {
     sha: []const u8,
+    skip_kcov: bool = false,
 };
 
 pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
     try devhub_metrics(shell, cli_args);
-    try devhub_coverage(shell);
+
+    if (!cli_args.skip_kcov) {
+        try devhub_coverage(shell);
+    } else {
+        log.info("--skip-kcov enabled, not computing coverage.", .{});
+    }
 }
 
 fn devhub_coverage(shell: *Shell) !void {

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -103,12 +103,12 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     if (no_changelog_flag) {
         try shell.exec_zig(
             \\build scripts -- release --build --no-changelog --sha={sha}
-            \\    --language=zig
+            \\    --language=zig --devhub
         , .{ .sha = cli_args.sha });
     } else {
         try shell.exec_zig(
             \\build scripts -- release --build --sha={sha}
-            \\    --language=zig
+            \\    --language=zig --devhub
         , .{ .sha = cli_args.sha });
     }
     try shell.project_root.deleteFile("tigerbeetle");

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -38,6 +38,8 @@ pub const CLIArgs = struct {
     //
     // This flag is used to test the release process on the main branch.
     no_changelog: bool = false,
+    // Allow targeting only production x86_64 Linux, to speed up when invoked via devhub.
+    devhub: bool = false,
 };
 
 const VersionInfo = struct {
@@ -60,6 +62,12 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
         LanguageSet.initOne(language)
     else
         LanguageSet.initFull();
+
+    if (cli_args.devhub) {
+        if (cli_args.language == null or cli_args.language.? != .zig) {
+            @panic("--devhub is only supported with --languages=zig.");
+        }
+    }
 
     const changelog_text = try shell.project_root.readFileAlloc(
         shell.arena.allocator(),
@@ -151,16 +159,17 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     }
 
     if (cli_args.build) {
-        try build(shell, languages, version_info);
+        try build(shell, languages, version_info, cli_args.devhub);
     }
 
     if (cli_args.publish) {
         assert(!cli_args.no_changelog);
+        assert(!cli_args.devhub);
         try publish(shell, languages, changelog_body, version_info);
     }
 }
 
-fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
+fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo, devhub: bool) !void {
     var section = try shell.open_section("build all");
     defer section.close();
 
@@ -176,7 +185,11 @@ fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
         var dist_dir_tigerbeetle = try dist_dir.makeOpenPath("tigerbeetle", .{});
         defer dist_dir_tigerbeetle.close();
 
-        try build_tigerbeetle(shell, info, dist_dir_tigerbeetle);
+        if (devhub) {
+            try build_tigerbeetle_target(shell, info, dist_dir_tigerbeetle, false, "x86_64-linux");
+        } else {
+            try build_tigerbeetle(shell, info, dist_dir_tigerbeetle);
+        }
     }
 
     if (languages.contains(.dotnet)) {
@@ -216,12 +229,6 @@ fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo) !void {
 }
 
 fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
-    var section = try shell.open_section("build tigerbeetle");
-    defer section.close();
-
-    // We shell out to `zip` for creating archives, so we need an absolute path here.
-    const dist_dir_path = try dist_dir.realpathAlloc(shell.arena.allocator(), ".");
-
     const targets = .{
         "x86_64-linux",
         "x86_64-windows",
@@ -229,65 +236,83 @@ fn build_tigerbeetle(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !vo
         "aarch64-macos", // Will build a universal binary.
     };
 
+    inline for (.{ true, false }) |debug| {
+        inline for (targets) |target| {
+            try build_tigerbeetle_target(shell, info, dist_dir, debug, target);
+        }
+    }
+}
+
+fn build_tigerbeetle_target(
+    shell: *Shell,
+    info: VersionInfo,
+    dist_dir: std.fs.Dir,
+    comptime debug: bool,
+    comptime target: []const u8,
+) !void {
+    var section = try shell.open_section(
+        "build tigerbeetle - " ++ target ++ " debug: " ++ if (debug) "true" else "false",
+    );
+    defer section.close();
+
+    // We shell out to `zip` for creating archives, so we need an absolute path here.
+    const dist_dir_path = try dist_dir.realpathAlloc(shell.arena.allocator(), ".");
+
     const sha_date = try shell.exec_stdout("git show --no-patch --no-notes --pretty=%cI {sha}", .{
         .sha = info.sha,
     });
 
     // Build tigerbeetle binary for all OS/CPU combinations we support and copy the result to
     // `dist`.
-    inline for (.{ true, false }) |debug| {
-        inline for (targets) |target| {
-            try shell.exec_zig(
-                \\build
-                \\    -Dtarget={target}
-                \\    -Drelease={release}
-                \\    -Dgit-commit={commit}
-                \\    -Dconfig-release={release_triple}
-                \\    -Dconfig-release-client-min={release_triple_client_min}
-                \\    -Dmultiversion={tag_multiversion}
-            , .{
-                .target = target,
-                .release = if (debug) "false" else "true",
-                .commit = info.sha,
-                .release_triple = info.release_triple,
-                .release_triple_client_min = info.release_triple_client_min,
-                .tag_multiversion = info.tag_multiversion,
-            });
+    try shell.exec_zig(
+        \\build
+        \\    -Dtarget={target}
+        \\    -Drelease={release}
+        \\    -Dgit-commit={commit}
+        \\    -Dconfig-release={release_triple}
+        \\    -Dconfig-release-client-min={release_triple_client_min}
+        \\    -Dmultiversion={tag_multiversion}
+    , .{
+        .target = target,
+        .release = if (debug) "false" else "true",
+        .commit = info.sha,
+        .release_triple = info.release_triple,
+        .release_triple_client_min = info.release_triple_client_min,
+        .tag_multiversion = info.tag_multiversion,
+    });
 
-            const windows = comptime std.mem.eql(u8, target, "x86_64-windows");
-            const macos = comptime std.mem.eql(u8, target, "aarch64-macos");
+    const windows = comptime std.mem.eql(u8, target, "x86_64-windows");
+    const macos = comptime std.mem.eql(u8, target, "aarch64-macos");
 
-            const exe_name = "tigerbeetle" ++ if (windows) ".exe" else "";
-            const zip_name = "tigerbeetle-" ++
-                (if (macos) "universal-macos" else target) ++
-                (if (debug) "-debug" else "") ++
-                ".zip";
+    const exe_name = "tigerbeetle" ++ if (windows) ".exe" else "";
+    const zip_name = "tigerbeetle-" ++
+        (if (macos) "universal-macos" else target) ++
+        (if (debug) "-debug" else "") ++
+        ".zip";
 
-            if ((std.mem.eql(u8, target, "x86_64-linux") and builtin.target.os.tag == .linux) or
-                (macos and builtin.target.os.tag == .macos) or
-                (windows and builtin.target.os.tag == .windows))
-            {
-                const output = try shell.exec_stdout("./{exe_name} version --verbose", .{
-                    .exe_name = exe_name,
-                });
-                assert(std.mem.indexOf(u8, output, "process.verify=true") != null);
-                const build_mode = if (debug)
-                    "build.mode=builtin.OptimizeMode.Debug"
-                else
-                    "build.mode=builtin.OptimizeMode.ReleaseSafe";
-                assert(std.mem.indexOf(u8, output, build_mode) != null);
-            }
-
-            try shell.exec("touch -d {sha_date} {exe_name}", .{
-                .sha_date = sha_date,
-                .exe_name = exe_name,
-            });
-            try shell.exec("zip -9 {zip_path} {exe_name}", .{
-                .zip_path = try shell.fmt("{s}/{s}", .{ dist_dir_path, zip_name }),
-                .exe_name = exe_name,
-            });
-        }
+    if ((std.mem.eql(u8, target, "x86_64-linux") and builtin.target.os.tag == .linux) or
+        (macos and builtin.target.os.tag == .macos) or
+        (windows and builtin.target.os.tag == .windows))
+    {
+        const output = try shell.exec_stdout("./{exe_name} version --verbose", .{
+            .exe_name = exe_name,
+        });
+        assert(std.mem.indexOf(u8, output, "process.verify=true") != null);
+        const build_mode = if (debug)
+            "build.mode=builtin.OptimizeMode.Debug"
+        else
+            "build.mode=builtin.OptimizeMode.ReleaseSafe";
+        assert(std.mem.indexOf(u8, output, build_mode) != null);
     }
+
+    try shell.exec("touch -d {sha_date} {exe_name}", .{
+        .sha_date = sha_date,
+        .exe_name = exe_name,
+    });
+    try shell.exec("zip -9 {zip_path} {exe_name}", .{
+        .zip_path = try shell.fmt("{s}/{s}", .{ dist_dir_path, zip_name }),
+        .exe_name = exe_name,
+    });
 }
 
 fn build_dotnet(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1148,6 +1148,12 @@ pub fn ReplicaType(
             );
             errdefer self.grid_scrubber.deinit(allocator);
 
+            // Initialize the MessageBus last. This brings the time when the replica can be
+            // externally spoken to (ie, MessageBus will accept TCP connections) closer to the time
+            // when Replica is actually listening for messages and won't simply drop them.
+            //
+            // Specifically, the grid cache in Grid.init above can take a long period of time while
+            // faulting in.
             self.message_bus = try MessageBus.init(
                 allocator,
                 options.cluster,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1115,16 +1115,6 @@ pub fn ReplicaType(
             });
             errdefer client_replies.deinit();
 
-            self.message_bus = try MessageBus.init(
-                allocator,
-                options.cluster,
-                .{ .replica = options.replica_index },
-                options.message_pool,
-                Replica.on_message_from_bus,
-                options.message_bus_options,
-            );
-            errdefer self.message_bus.deinit(allocator);
-
             self.grid = try Grid.init(allocator, .{
                 .superblock = &self.superblock,
                 .trace = &self.trace,
@@ -1157,6 +1147,16 @@ pub fn ReplicaType(
                 &self.client_sessions_checkpoint,
             );
             errdefer self.grid_scrubber.deinit(allocator);
+
+            self.message_bus = try MessageBus.init(
+                allocator,
+                options.cluster,
+                .{ .replica = options.replica_index },
+                options.message_pool,
+                Replica.on_message_from_bus,
+                options.message_bus_options,
+            );
+            errdefer self.message_bus.deinit(allocator);
 
             self.* = .{
                 .static_allocator = self.static_allocator,


### PR DESCRIPTION
Add tracking of format time and startup time (with an 8gb grid cache) to the devhub, so we can see it come down :smile:.

Additionally, defer MessageBus.init until after the grid cache is done.