### PR TITLE
style: document  preferred way to cache field loads

### DIFF
--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -261,6 +261,11 @@ Beyond these rules:
 
 - Be explicit. Minimize dependence on the compiler to do the right thing for you.
 
+  In particular, extract hot loops into stand-alone functions with primitive arguments without
+  `self` (see [an example](https://github.com/tigerbeetle/tigerbeetle/blob/0.16.19/src/lsm/compaction.zig#L1932-L1937)).
+  That way, the complier doesn't need to prove that it can cache struct's fields in registers, and a
+  human reader can spot redundant computations easier.
+
 ## Developer Experience
 
 > “There are only two hard things in Computer Science: cache invalidation, naming things, and

--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -263,7 +263,7 @@ Beyond these rules:
 
   In particular, extract hot loops into stand-alone functions with primitive arguments without
   `self` (see [an example](https://github.com/tigerbeetle/tigerbeetle/blob/0.16.19/src/lsm/compaction.zig#L1932-L1937)).
-  That way, the complier doesn't need to prove that it can cache struct's fields in registers, and a
+  That way, the compiler doesn't need to prove that it can cache struct's fields in registers, and a
   human reader can spot redundant computations easier.
 
 ## Developer Experience


### PR DESCRIPTION
Inspired by https://github.com/tigerbeetle/tigerbeetle/pull/2592#discussion_r1895033487 and the change from

https://github.com/tigerbeetle/tigerbeetle/blob/d58190b29425f5adff315f924d6190fbdc1eb108/src/lsm/compaction.zig#L1982-L1988

to

https://github.com/tigerbeetle/tigerbeetle/blob/530105887eb4b4b9030f588ed543455db8f3fdb2/src/lsm/compaction.zig#L1856-L1863