### PR TITLE
clients/go: `t` is not thread-safe

### DIFF
--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -421,9 +421,8 @@ func doTestClient(t *testing.T, client Client) {
 						Code:            1,
 					},
 				})
-
 				if err != nil {
-					t.Fatal(err)
+					panic(err)
 				}
 
 				assert.Empty(t, results)
@@ -477,9 +476,8 @@ func doTestClient(t *testing.T, client Client) {
 						Flags:           flags,
 					},
 				})
-
 				if err != nil {
-					t.Fatal(err)
+					panic(err)
 				}
 
 				if i%10 == 0 {


### PR DESCRIPTION
```
golangci-lint run .
tb_client_test.go:426:6: testinggoroutine: call to (*testing.T).Fatal from a non-test goroutine (govet)
					t.Fatal(err)
					^
tb_client_test.go:482:6: testinggoroutine: call to (*testing.T).Fatal from a non-test goroutine (govet)
					t.Fatal(err)
					^
```