### PR TITLE
ISSUE - fresh install error on download.sh

### DIFF
--- a/zig/download.sh
+++ b/zig/download.sh
@@ -115,6 +115,11 @@ case "$ZIG_ARCHIVE_EXT" in
 esac
 rm "$ZIG_ARCHIVE"
 
+#check if the zig directory already exists if not create zig directory
+if [ ! -d "zig" ]; then
+    mkdir zig
+fi
+
 # Replace these existing directories and files so that we can install or upgrade:
 rm -rf zig/doc
 rm -rf zig/lib


### PR DESCRIPTION
**Issue**
zig install via download.sh script Failing with zig folder not exist error 

`git clone https://github.com/tigerbeetle/tigerbeetle && cd tigerbeetle
./zig/download.sh # or .bat if you're on Windows.
`
 The above fails because there is no zig folder present as part of git clone.

![Screenshot_2024-12-27_00-49-40](https://github.com/user-attachments/assets/3059e6b3-e678-4877-97af-422ef83dc67c)
![Screenshot_2024-12-27_00-54-42](https://github.com/user-attachments/assets/e12b4003-7fa5-494f-b100-0269adb2cbbc)

**Fix**
Created Zig directory if folder is not present.

![Screenshot_2024-12-27_00-57-02](https://github.com/user-attachments/assets/d57e3cf4-5245-4d6e-9804-5f9b0f9dcf9d)
