### PR TITLE
VSR: State sync logging/tracing/config

### DIFF
--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -70,6 +70,7 @@ const CLIArgs = union(enum) {
         memory_lsm_compaction: ?flags.ByteSize = null,
         trace: ?[:0]const u8 = null,
         log_debug: bool = false,
+        timeout_grid_repair_message_ms: ?u64 = null,
 
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
         /// to the client. The logic behind this code has been kept as simple as possible -
@@ -408,6 +409,7 @@ pub const Command = union(enum) {
         cache_grid_blocks: u32,
         lsm_forest_compaction_block_count: u32,
         lsm_forest_node_count: u32,
+        timeout_grid_repair_message_ticks: ?u64,
         trace: ?[:0]const u8,
         development: bool,
         experimental: bool,
@@ -811,6 +813,10 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         ),
         .lsm_forest_compaction_block_count = lsm_forest_compaction_block_count,
         .lsm_forest_node_count = lsm_forest_node_count,
+        .timeout_grid_repair_message_ticks = parse_timeout_to_ticks(
+            start.timeout_grid_repair_message_ms,
+            "--timeout-grid-repair-message-ms",
+        ),
         .development = start.development,
         .experimental = start.experimental,
         .trace = start.trace,
@@ -970,4 +976,24 @@ fn parse_cache_size_to_count(
     assert(@as(u64, result) * @sizeOf(T) <= size.bytes());
 
     return result;
+}
+
+fn parse_timeout_to_ticks(timeout_ms: ?u64, cli_flag: []const u8) ?u64 {
+    if (timeout_ms) |ms| {
+        if (ms == 0) {
+            vsr.fatal(.cli, "{s}: timeout {}ms be nonzero", .{ cli_flag, ms });
+        }
+
+        if (ms % constants.tick_ms != 0) {
+            vsr.fatal(
+                .cli,
+                "{s}: timeout {}ms must be a multiple of {}ms",
+                .{ cli_flag, ms, constants.tick_ms },
+            );
+        }
+
+        return @divExact(ms, constants.tick_ms);
+    } else {
+        return null;
+    }
 }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -70,6 +70,7 @@ const CLIArgs = union(enum) {
         memory_lsm_compaction: ?flags.ByteSize = null,
         trace: ?[:0]const u8 = null,
         log_debug: bool = false,
+        timeout_prepare_ms: ?u64 = null,
         timeout_grid_repair_message_ms: ?u64 = null,
 
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
@@ -409,6 +410,7 @@ pub const Command = union(enum) {
         cache_grid_blocks: u32,
         lsm_forest_compaction_block_count: u32,
         lsm_forest_node_count: u32,
+        timeout_prepare_ticks: ?u64,
         timeout_grid_repair_message_ticks: ?u64,
         trace: ?[:0]const u8,
         development: bool,
@@ -813,6 +815,10 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         ),
         .lsm_forest_compaction_block_count = lsm_forest_compaction_block_count,
         .lsm_forest_node_count = lsm_forest_node_count,
+        .timeout_prepare_ticks = parse_timeout_to_ticks(
+            start.timeout_prepare_ms,
+            "--timeout-prepare-ms",
+        ),
         .timeout_grid_repair_message_ticks = parse_timeout_to_ticks(
             start.timeout_grid_repair_message_ms,
             "--timeout-grid-repair-message-ms",

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -377,6 +377,7 @@ const Command = struct {
             .message_pool = &message_pool,
             .nonce = nonce,
             .time = .{},
+            .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
             .state_machine_options = .{
                 .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
                 .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -377,6 +377,7 @@ const Command = struct {
             .message_pool = &message_pool,
             .nonce = nonce,
             .time = .{},
+            .timeout_prepare_ticks = args.timeout_prepare_ticks,
             .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
             .state_machine_options = .{
                 .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -541,6 +541,7 @@ pub fn ReplicaType(
             release_execute: *const fn (replica: *Replica, release: vsr.Release) void,
             release_execute_context: ?*anyopaque,
             test_context: ?*anyopaque = null,
+            timeout_grid_repair_message_ticks: ?u64 = null,
         };
 
         /// Initializes and opens the provided replica using the options.
@@ -616,6 +617,7 @@ pub fn ReplicaType(
                 .release_execute = options.release_execute,
                 .release_execute_context = options.release_execute_context,
                 .test_context = options.test_context,
+                .timeout_grid_repair_message_ticks = options.timeout_grid_repair_message_ticks,
             });
 
             // Disable all dynamic allocation from this point onwards.
@@ -962,6 +964,7 @@ pub fn ReplicaType(
             release_execute: *const fn (replica: *Replica, release: vsr.Release) void,
             release_execute_context: ?*anyopaque,
             test_context: ?*anyopaque,
+            timeout_grid_repair_message_ticks: ?u64,
         };
 
         /// NOTE: self.superblock must be initialized and opened prior to this call.
@@ -1205,7 +1208,7 @@ pub fn ReplicaType(
                 .grid_repair_message_timeout = Timeout{
                     .name = "grid_repair_message_timeout",
                     .id = replica_index,
-                    .after = 50,
+                    .after = options.timeout_grid_repair_message_ticks orelse 50,
                 },
                 .grid_scrub_timeout = Timeout{
                     .name = "grid_scrub_timeout",

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -541,6 +541,7 @@ pub fn ReplicaType(
             release_execute: *const fn (replica: *Replica, release: vsr.Release) void,
             release_execute_context: ?*anyopaque,
             test_context: ?*anyopaque = null,
+            timeout_prepare_ticks: ?u64 = null,
             timeout_grid_repair_message_ticks: ?u64 = null,
         };
 
@@ -617,6 +618,7 @@ pub fn ReplicaType(
                 .release_execute = options.release_execute,
                 .release_execute_context = options.release_execute_context,
                 .test_context = options.test_context,
+                .timeout_prepare_ticks = options.timeout_prepare_ticks,
                 .timeout_grid_repair_message_ticks = options.timeout_grid_repair_message_ticks,
             });
 
@@ -964,6 +966,7 @@ pub fn ReplicaType(
             release_execute: *const fn (replica: *Replica, release: vsr.Release) void,
             release_execute_context: ?*anyopaque,
             test_context: ?*anyopaque,
+            timeout_prepare_ticks: ?u64,
             timeout_grid_repair_message_ticks: ?u64,
         };
 
@@ -1153,7 +1156,7 @@ pub fn ReplicaType(
                 .prepare_timeout = Timeout{
                     .name = "prepare_timeout",
                     .id = replica_index,
-                    .after = 25,
+                    .after = options.timeout_prepare_ticks orelse 25,
                 },
                 .primary_abdicate_timeout = Timeout{
                     .name = "primary_abdicate_timeout",

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9290,7 +9290,9 @@ pub fn ReplicaType(
                     );
 
                     switch (enqueue_result) {
-                        .insert => {},
+                        .insert => self.trace.start(.{ .replica_sync_table = .{
+                            .index = self.grid_repair_tables.index(table),
+                        } }, .{}),
                         .duplicate => {
                             // Duplicates are only possible due to move-table.
                             assert(table_info.label.level > 0);
@@ -9337,6 +9339,9 @@ pub fn ReplicaType(
 
                 const table: *RepairTable = @fieldParentPtr("table", queue_table);
                 self.grid_repair_tables.release(table);
+                self.trace.stop(.{ .replica_sync_table = .{
+                    .index = self.grid_repair_tables.index(table),
+                } }, .{});
             }
             assert(self.grid_repair_tables.available() <= constants.grid_missing_tables_max);
 


### PR DESCRIPTION
- Add `--timeout-grid-repair-ms` (experimental) runtime flag for tuning state sync performance.
- Add `--timeout-prepare-ms` (experimental) runtime flag for tuning replication performance in compromised clusters.
- Log and trace state sync progress.