### PR TITLE
vsr: log anomalous behaviour and important state transitions for alerting

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -114,6 +114,7 @@ const ConfigProcess = struct {
     journal_iops_write_max: usize = 8,
     client_replies_iops_read_max: usize = 1,
     client_replies_iops_write_max: usize = 2,
+    client_request_completion_warn_ms: u64 = 200,
     tick_ms: u63 = 10,
     rtt_ms: u64 = 300,
     rtt_multiple: u8 = 2,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -525,6 +525,9 @@ pub const client_replies_iops_read_max = config.process.client_replies_iops_read
 /// The maximum number of concurrent writes to the client-replies zone.
 /// Client replies are written after every commit.
 pub const client_replies_iops_write_max = config.process.client_replies_iops_write_max;
+/// The amount of time (in milliseconds) within which a client must receive a response from the
+/// cluster, after which it emits a warning log (for alerting/metrics).
+pub const client_request_completion_warn_ms = config.process.client_request_completion_warn_ms;
 
 /// The maximum number of concurrent grid read I/O operations to allow at once.
 pub const grid_iops_read_max = config.process.grid_iops_read_max;

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -151,9 +151,7 @@ pub fn ClientType(comptime StateMachine_: type, comptime MessageBus: type) type 
                 .id = options.id,
                 .cluster = options.cluster,
                 .replica_count = options.replica_count,
-                .request_completion_timer = std.time.Timer.start() catch @panic(
-                    "std.time.Timer.start() unsupported",
-                ),
+                .request_completion_timer = try std.time.Timer.start(),
                 .request_timeout = .{
                     .name = "request_timeout",
                     .id = options.id,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1102,9 +1102,7 @@ pub fn ReplicaType(
             self.* = .{
                 .static_allocator = self.static_allocator,
                 .cluster = options.cluster,
-                .commit_completion_timer = std.time.Timer.start() catch @panic(
-                    "std.time.Timer.start() unsupported",
-                ),
+                .commit_completion_timer = try std.time.Timer.start(),
                 .replica_count = replica_count,
                 .standby_count = standby_count,
                 .node_count = node_count,


### PR DESCRIPTION
On replicas, we now info log the following:
* State transitions from normal → view_change, view_change → normal
* Starting/ending state sync
* Starting/ending data/superblock checkpoint
* Free set acquired & released blocks before checkpoint

On clients, we emit a warning when request completion time (which we start measuring it when `raw_request` is invoked, and stop when `on_reply` in invoked) exceeds a certain threshold. The threshold is currently configured at 200ms.

Additionally, on replicas, we emit a warning when time taken to commit a request (prefetch → reply_setup → execute → compact → checkpoint_data → checkpoint_superblock) exceeds a certain threshold. We currently use the same threshold as the one used for the client. 

Sample log output:
```C
[replica] (info): 2: commit_checkpoint_data: checkpoint_data start (op=63 current_checkpoint=39 next_checkpoint=59)
[replica] (info): 2: commit_checkpoint_data: free_set.acquired=77 free_set.released=16
[replica] (info): 2: commit_checkpoint_data_callback_join: checkpoint_data done (op=63 current_checkpoint=39 next_checkpoint=59)
[replica] (info): 2: sync: done
[replica] (info): 2: commit_checkpoint_superblock: checkpoint_superblock start (op=63 checkpoint=39..59 view_durable=1..1 log_view_durable=1..1)
[replica] (info): 2: commit_checkpoint_superblock_callback: checkpoint_superblock done (op=63 new_checkpoint=59)
[replica] (info): 2: transition_to_normal_from_recovering_status: view=0 backup
[client] (warn): 340282366920938463463374607431768211441: on_reply: request=0 size=320 register time=6689ms
```