### PR TITLE
[Client] Add Events for efficient cross-thread notification

### DIFF
--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -1,295 +1,200 @@
 const std = @import("std");
-const builtin = @import("builtin");
+const assert = std.debug.assert;
 
 const vsr = @import("../tb_client.zig").vsr;
+const Time = vsr.time.Time;
 const IO = vsr.io.IO;
 
-const os = std.os;
-const assert = std.debug.assert;
 const Atomic = std.atomic.Value;
-const log = std.log.scoped(.tb_client_signal);
 
 /// A Signal is a way to trigger a registered callback on a tigerbeetle IO instance
 /// when notification occurs from another thread.
-/// It does this by using OS sockets (which are thread safe)
-/// to resolve IO.Completions on the tigerbeetle thread.
 pub const Signal = struct {
     io: *IO,
-    server_socket: std.posix.socket_t,
-    accept_socket: std.posix.socket_t,
-    connect_socket: std.posix.socket_t,
-
+    event: IO.Event,
+    listening: Atomic(bool),
     completion: IO.Completion,
-    recv_buffer: [1]u8,
-    send_buffer: [1]u8,
 
     on_signal_fn: *const fn (*Signal) void,
     state: Atomic(enum(u8) {
         running,
         waiting,
         notified,
+        shutdown,
     }),
 
     pub fn init(self: *Signal, io: *IO, on_signal_fn: *const fn (*Signal) void) !void {
-        self.io = io;
-        self.server_socket = std.posix.socket(
-            std.posix.AF.INET,
-            std.posix.SOCK.STREAM | std.posix.SOCK.NONBLOCK,
-            std.posix.IPPROTO.TCP,
-        ) catch |err| {
-            log.err("failed to create signal server socket: {}", .{err});
-            return switch (err) {
-                error.PermissionDenied,
-                error.ProtocolNotSupported,
-                error.SocketTypeNotSupported,
-                error.AddressFamilyNotSupported,
-                error.ProtocolFamilyNotAvailable,
-                => error.NetworkSubsystemFailed,
+        const event = try io.open_event();
+        errdefer io.close_event(event);
 
-                error.ProcessFdQuotaExceeded,
-                error.SystemFdQuotaExceeded,
-                error.SystemResources,
-                => error.SystemResources,
-
-                error.Unexpected => error.Unexpected,
-            };
-        };
-        errdefer self.io.close_socket(self.server_socket);
-
-        // Windows requires that the socket is bound before listening.
-        if (builtin.target.os.tag == .windows) {
-            // Port zero lets the OS choose.
-            const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
-            std.posix.bind(self.server_socket, &addr.any, addr.getOsSockLen()) catch |err| {
-                log.err("failed to bind the server socket to a local random port: {}", .{err});
-                return switch (err) {
-                    error.AccessDenied => unreachable,
-                    error.AlreadyBound => unreachable,
-                    error.AddressFamilyNotSupported => unreachable,
-                    error.AddressInUse, error.AddressNotAvailable => unreachable,
-                    error.SymLinkLoop => unreachable,
-                    error.NameTooLong => unreachable,
-                    error.FileNotFound, error.FileDescriptorNotASocket => unreachable,
-                    error.NotDir => unreachable,
-                    error.ReadOnlyFileSystem => unreachable,
-                    error.SystemResources, error.NetworkSubsystemFailed, error.Unexpected => |e| e,
-                };
-            };
-        }
-
-        std.posix.listen(self.server_socket, 1) catch |err| {
-            log.err("failed to listen on signal server socket: {}", .{err});
-            return switch (err) {
-                error.AddressInUse => unreachable,
-                error.FileDescriptorNotASocket => unreachable,
-                error.AlreadyConnected => unreachable,
-                error.SocketNotBound => unreachable,
-                error.OperationNotSupported,
-                error.NetworkSubsystemFailed,
-                => error.NetworkSubsystemFailed,
-                error.SystemResources => error.SystemResources,
-                error.Unexpected => error.Unexpected,
-            };
+        self.* = .{
+            .io = io,
+            .event = event,
+            .listening = Atomic(bool).init(true),
+            .completion = undefined,
+            .on_signal_fn = on_signal_fn,
+            .state = @TypeOf(self.state).init(.running),
         };
 
-        var addr = std.net.Address.initIp4(undefined, undefined);
-        var addr_len = addr.getOsSockLen();
-        std.posix.getsockname(self.server_socket, &addr.any, &addr_len) catch |err| {
-            log.err("failed to get address of signal server socket: {}", .{err});
-            return switch (err) {
-                error.SocketNotBound => unreachable,
-                error.FileDescriptorNotASocket => unreachable,
-                error.SystemResources => error.SystemResources,
-                error.NetworkSubsystemFailed => error.NetworkSubsystemFailed,
-                error.Unexpected => error.Unexpected,
-            };
-        };
-
-        self.connect_socket = self.io.open_socket(
-            std.posix.AF.INET,
-            std.posix.SOCK.STREAM,
-            std.posix.IPPROTO.TCP,
-        ) catch |err| {
-            log.err("failed to create signal connect socket: {}", .{err});
-            return error.Unexpected;
-        };
-        errdefer self.io.close_socket(self.connect_socket);
-
-        // Tracks when the connect_socket connects to the server_socket.
-        const DoConnect = struct {
-            result: IO.ConnectError!void = undefined,
-            completion: IO.Completion = undefined,
-            is_connected: bool = false,
-
-            fn on_connect(
-                do_connect: *@This(),
-                _completion: *IO.Completion,
-                result: IO.ConnectError!void,
-            ) void {
-                assert(&do_connect.completion == _completion);
-                assert(!do_connect.is_connected);
-                do_connect.is_connected = true;
-                do_connect.result = result;
-            }
-        };
-
-        var do_connect = DoConnect{};
-        self.io.connect(
-            *DoConnect,
-            &do_connect,
-            DoConnect.on_connect,
-            &do_connect.completion,
-            self.connect_socket,
-            addr,
-        );
-
-        // Wait for the connect_socket to connect to the server_socket.
-        self.accept_socket = IO.INVALID_SOCKET;
-        while (!do_connect.is_connected or self.accept_socket == IO.INVALID_SOCKET) {
-            self.io.tick() catch |err| {
-                log.err("failed to tick IO when setting up signal: {}", .{err});
-                return error.Unexpected;
-            };
-
-            // Try to accept the connection from the connect_socket as the accept_socket.
-            if (self.accept_socket == IO.INVALID_SOCKET) {
-                self.accept_socket = std.posix.accept(
-                    self.server_socket,
-                    null,
-                    null,
-                    0,
-                ) catch |e| switch (e) {
-                    error.WouldBlock => continue,
-                    error.ConnectionAborted => unreachable,
-                    error.ConnectionResetByPeer => unreachable,
-                    error.FileDescriptorNotASocket => unreachable,
-                    error.ProcessFdQuotaExceeded,
-                    error.SystemFdQuotaExceeded,
-                    error.SystemResources,
-                    => return error.SystemResources,
-                    error.SocketNotListening => unreachable,
-                    error.BlockedByFirewall => unreachable,
-                    error.ProtocolFailure,
-                    error.OperationNotSupported,
-                    error.NetworkSubsystemFailed,
-                    => return error.NetworkSubsystemFailed,
-                    error.Unexpected => return error.Unexpected,
-                };
-            }
-        }
-
-        _ = do_connect.result catch |err| {
-            log.err("failed to connect on signal client socket: {}", .{err});
-            return error.Unexpected;
-        };
-
-        assert(do_connect.is_connected);
-        assert(self.accept_socket != IO.INVALID_SOCKET);
-        assert(self.connect_socket != IO.INVALID_SOCKET);
-
-        self.completion = undefined;
-        self.recv_buffer = undefined;
-        self.send_buffer = undefined;
-
-        self.state = @TypeOf(self.state).init(.running);
-        self.on_signal_fn = on_signal_fn;
         self.wait();
     }
 
     pub fn deinit(self: *Signal) void {
-        self.io.close_socket(self.server_socket);
-        self.io.close_socket(self.accept_socket);
-        self.io.close_socket(self.connect_socket);
+        assert(self.event != IO.INVALID_EVENT);
+        assert(self.stop_requested());
+
+        self.io.close_event(self.event);
+        self.* = undefined;
+    }
+
+    /// Stops the current event.
+    /// Further calls to "notify" will not fire the signal.
+    /// Safe to call from multiple threads.
+    pub fn stop(self: *Signal) void {
+        const listening = self.listening.swap(false, .release);
+        if (listening) {
+            self.notify();
+        }
+    }
+
+    pub fn stop_requested(self: *const Signal) bool {
+        return !self.listening.load(.acquire);
     }
 
     /// Schedules the on_signal callback to be invoked on the IO thread.
     /// Safe to call from multiple threads.
     pub fn notify(self: *Signal) void {
-        if (self.state.swap(.notified, .release) == .waiting) {
-            self.wake();
+        // Try to transition from `waiting` to `notified`.
+        // If it fails, analyze the current state to determine if a notification is needed.
+        var state: @TypeOf(self.state.raw) = .waiting;
+        while (self.state.cmpxchgStrong(
+            state,
+            .notified,
+            .release,
+            .acquire,
+        )) |state_actual| {
+            switch (state_actual) {
+                .waiting, .running => state = state_actual, // Try again.
+                .notified => return, // Already notified.
+                .shutdown => return, // Ignore notifications after shutdown.
+            }
         }
-    }
 
-    fn wake(self: *Signal) void {
-        assert(self.accept_socket != IO.INVALID_SOCKET);
-        self.send_buffer[0] = 0;
-
-        // TODO: use std.posix.send() instead when it gets fixed for windows
-        if (builtin.target.os.tag != .windows) {
-            _ = std.posix.send(self.accept_socket, &self.send_buffer, 0) catch unreachable;
-            return;
+        if (state == .waiting) {
+            self.io.event_trigger(self.event, &self.completion);
         }
-
-        const buf: []const u8 = &self.send_buffer;
-        const rc = os.windows.sendto(self.accept_socket, buf.ptr, buf.len, 0, null, 0);
-        assert(rc != os.windows.ws2_32.SOCKET_ERROR);
     }
 
     fn wait(self: *Signal) void {
-        const state = self.state.cmpxchgStrong(
-            .running,
-            .waiting,
-            .acquire,
-            .acquire,
-        ) orelse return self.io.recv(
-            *Signal,
-            self,
-            on_recv,
-            &self.completion,
-            self.connect_socket,
-            &self.recv_buffer,
-        );
+        assert(!self.stop_requested());
 
+        const state = self.state.swap(.waiting, .acquire);
+        self.io.event_listen(self.event, &self.completion, on_event);
         switch (state) {
-            .running => unreachable, // Not possible due to CAS semantics.
-            .waiting => unreachable, // We should be the only ones who could've started waiting.
-            .notified => {}, // A thread woke us up before we started waiting so reschedule below.
+            // We should be the only ones who could've started waiting.
+            .waiting => unreachable,
+            // Wait for a `notify`.
+            .running => {},
+            // A `notify` was already called in the meantime,
+            // calling it again asynchronously.
+            .notified => self.notify(),
+            // Cannot be called after shutdown.
+            .shutdown => unreachable,
         }
-
-        self.io.timeout(
-            *Signal,
-            self,
-            on_timeout,
-            &self.completion,
-            0, // zero-timeout functions as a yield.
-        );
     }
 
-    fn on_recv(
-        self: *Signal,
-        completion: *IO.Completion,
-        result: IO.RecvError!usize,
-    ) void {
-        assert(completion == &self.completion);
-        _ = result catch |err| std.debug.panic("Signal recv error: {}", .{err});
-        self.on_signal();
-    }
-
-    fn on_timeout(
-        self: *Signal,
-        completion: *IO.Completion,
-        result: IO.TimeoutError!void,
-    ) void {
-        assert(completion == &self.completion);
-        _ = result catch |err| std.debug.panic("Signal timeout error: {}", .{err});
-        self.on_signal();
-    }
-
-    fn on_signal(self: *Signal) void {
+    fn on_event(completion: *IO.Completion) void {
+        const self: *Signal = @fieldParentPtr("completion", completion);
+        const stopped = self.stop_requested();
         const state = self.state.cmpxchgStrong(
             .notified,
-            .running,
-            .acquire,
+            if (stopped) .shutdown else .running,
+            .release,
             .acquire,
         ) orelse {
+            if (stopped) return;
+
             (self.on_signal_fn)(self);
-            return self.wait();
+            self.wait();
+            return;
         };
 
         switch (state) {
             .running => unreachable, // Multiple racing calls to on_signal().
             .waiting => unreachable, // on_signal() called without transitioning to a waking state.
             .notified => unreachable, // Not possible due to CAS semantics.
+            .shutdown => unreachable, // Shutdown is a final state.
         }
     }
 };
+
+test "signal" {
+    try struct {
+        const Context = @This();
+
+        io: IO,
+        count: u32 = 0,
+        main_thread_id: std.Thread.Id,
+        signal: Signal,
+
+        const delay = 100 * std.time.ns_per_ms;
+        const events_count = 5;
+
+        fn run_test() !void {
+            var self: Context = .{
+                .io = try IO.init(32, 0),
+                .main_thread_id = std.Thread.getCurrentId(),
+                .signal = undefined,
+            };
+            defer self.io.deinit();
+
+            try Signal.init(&self.signal, &self.io, on_signal);
+            defer self.signal.deinit();
+
+            var timer = Time{};
+            const start = timer.monotonic();
+
+            const thread = try std.Thread.spawn(.{}, Context.notify, .{&self});
+
+            // Wait for the number of events to complete.
+            while (self.count < events_count) try self.io.tick();
+
+            // Begin shutdown and keep ticking until it's completed.
+            self.signal.stop();
+            thread.join();
+
+            // Notify after shutdown should be ignored.
+            self.signal.notify();
+
+            // Make sure the event was triggered multiple times.
+            assert(self.count == events_count);
+
+            // Make sure at least some time has passed.
+            const elapsed = timer.monotonic() - start;
+            assert(elapsed >= delay);
+        }
+
+        fn notify(self: *Context) void {
+            assert(std.Thread.getCurrentId() != self.main_thread_id);
+            while (!self.signal.stop_requested()) {
+                std.time.sleep(delay + 1);
+
+                // Triggering the event:
+                self.signal.notify();
+
+                // The same signal may be triggered multiple times,
+                // but it should only fire once.
+                self.signal.notify();
+            }
+        }
+
+        fn on_signal(signal: *Signal) void {
+            const self: *Context = @fieldParentPtr("signal", signal);
+            assert(std.Thread.getCurrentId() == self.main_thread_id);
+            assert(!self.signal.stop_requested());
+            assert(self.count < events_count);
+
+            self.count += 1;
+        }
+    }.run_test();
+}

--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -137,7 +137,7 @@ test "signal" {
         main_thread_id: std.Thread.Id,
         signal: Signal,
 
-        const delay = 100 * std.time.ns_per_ms;
+        const delay = 5 * std.time.ns_per_ms;
         const events_count = 5;
 
         fn run_test() !void {

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -244,10 +244,6 @@ test "c_client tb_status" {
     // All other status are not testable.
 }
 
-test {
-    _ = @import("tb_client/signal.zig");
-}
-
 // Asserts the validation rules associated with the "TB_PACKET_STATUS" enum.
 test "c_client tb_packet_status" {
     const RequestContext = RequestContextType(constants.message_body_size_max);

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -244,6 +244,10 @@ test "c_client tb_status" {
     // All other status are not testable.
 }
 
+test {
+    _ = @import("tb_client/signal.zig");
+}
+
 // Asserts the validation rules associated with the "TB_PACKET_STATUS" enum.
 test "c_client tb_packet_status" {
     const RequestContext = RequestContextType(constants.message_body_size_max);

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -342,7 +342,7 @@ test "event" {
         event: IO.Event = IO.INVALID_EVENT,
         event_completion: IO.Completion = undefined,
 
-        const delay = 100 * std.time.ns_per_ms;
+        const delay = 5 * std.time.ns_per_ms;
         const events_count = 5;
 
         fn run_test() !void {

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -332,6 +332,71 @@ test "timeout" {
     }.run_test();
 }
 
+test "event" {
+    try struct {
+        const Context = @This();
+
+        io: IO,
+        count: u32 = 0,
+        main_thread_id: std.Thread.Id,
+        event: IO.Event = IO.INVALID_EVENT,
+        event_completion: IO.Completion = undefined,
+
+        const delay = 100 * std.time.ns_per_ms;
+        const events_count = 5;
+
+        fn run_test() !void {
+            var self: Context = .{
+                .io = try IO.init(32, 0),
+                .main_thread_id = std.Thread.getCurrentId(),
+            };
+            defer self.io.deinit();
+
+            self.event = try self.io.open_event();
+            defer self.io.close_event(self.event);
+
+            var timer = Time{};
+            const start = timer.monotonic();
+
+            // Listen to the event and spawn a thread that triggers the completion after some time.
+            self.io.event_listen(self.event, &self.event_completion, on_event);
+            const thread = try std.Thread.spawn(.{}, Context.trigger_event, .{&self});
+
+            // Wait for the number of events to complete.
+            while (self.count < events_count) try self.io.tick();
+            thread.join();
+
+            // Make sure the event was triggered multiple times.
+            assert(self.count == events_count);
+
+            // Make sure at least some time has passed.
+            const elapsed = timer.monotonic() - start;
+            assert(elapsed >= delay);
+        }
+
+        fn trigger_event(self: *Context) void {
+            assert(std.Thread.getCurrentId() != self.main_thread_id);
+            while (self.count < events_count) {
+                std.time.sleep(delay + 1);
+
+                // Triggering the event:
+                self.io.event_trigger(self.event, &self.event_completion);
+            }
+        }
+
+        fn on_event(completion: *IO.Completion) void {
+            const self: *Context = @fieldParentPtr("event_completion", completion);
+            assert(std.Thread.getCurrentId() == self.main_thread_id);
+
+            self.count += 1;
+            if (self.count == events_count) return;
+
+            // Reattaching the event.
+            self.io.event_listen(self.event, &self.event_completion, on_event);
+        }
+    }.run_test();
+}
+
 test "submission queue full" {
     const ms = 20;
     const count = 10;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -230,6 +230,7 @@ pub const IO = struct {
             timeout: struct {
                 deadline: u64,
             },
+            event: Overlapped,
         };
     };
 
@@ -980,6 +981,61 @@ pub const IO = struct {
                 }
             },
         );
+    }
+
+    pub const Event = u1;
+    pub const INVALID_EVENT: Event = 0;
+
+    pub fn open_event(
+        self: *IO,
+    ) !Event {
+        _ = self;
+        // Events on Windows don't need an identifier,
+        // they're handled just by the OVERLAPPED structure.
+        return INVALID_EVENT + 1;
+    }
+
+    pub fn event_listen(
+        self: *IO,
+        event: Event,
+        completion: *Completion,
+        comptime on_event: fn (*Completion) void,
+    ) void {
+        assert(event != INVALID_EVENT);
+        completion.* = .{
+            .next = null,
+            .context = null,
+            .operation = .{
+                .event = .{
+                    .raw = std.mem.zeroes(os.windows.OVERLAPPED),
+                    .completion = completion,
+                },
+            },
+            .callback = struct {
+                fn on_complete(ctx: Completion.Context) void {
+                    on_event(ctx.completion);
+                }
+            }.on_complete,
+        };
+
+        // Conceptually start listening by bumping the io_pending count.
+        self.io_pending += 1;
+    }
+
+    pub fn event_trigger(self: *IO, event: Event, completion: *Completion) void {
+        assert(event != INVALID_EVENT);
+        os.windows.PostQueuedCompletionStatus(
+            self.iocp,
+            undefined,
+            undefined,
+            &completion.operation.event.raw,
+        ) catch unreachable;
+    }
+
+    pub fn close_event(self: *IO, event: Event) void {
+        _ = self;
+        // Nothing to close as events are just intrusive OVERLAPPED structs.
+        assert(event != INVALID_EVENT);
     }
 
     pub const INVALID_SOCKET = os.windows.ws2_32.INVALID_SOCKET;

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -19,6 +19,7 @@ comptime {
 
     _ = @import("clients/c/test.zig");
     _ = @import("clients/c/tb_client/echo_client.zig");
+    _ = @import("clients/c/tb_client/signal.zig");
     _ = @import("clients/c/tb_client_header_test.zig");
     _ = @import("clients/java/src/client.zig");
 


### PR DESCRIPTION
Removes the local TCP server hack being used in `tb_client.Signal` to facilitate cross-thread notification.

Instead, it uses the most efficient mechanism for waking the IO abstraction: `eventfd` on Linux, `EVFILT_USER` on macOS, and `PostQueuedCompletionStatus` on Windows.

Reviewed from previous work https://github.com/tigerbeetle/tigerbeetle/pull/622