### PR TITLE
vsr: replicate committed messages

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7320,23 +7320,8 @@ pub fn ReplicaType(
             // accordingly).
             maybe(message.header.op < self.op);
 
-            // TODO: Prepares are normally ring replicated, but commits are broadcast. It's possible
-            // for a commit to arrive before prepares, because they are broadcast directly from the
-            // primary whereas the prepares have to go through the ring. This will result in that
-            // replica not replicating, even though it should!
             if (message.header.op <= self.commit_max) {
                 log.debug("{}: replicate: not replicating (committed)", .{self.replica});
-                return;
-            }
-
-            // Broadcasting uses 5x the bandwidth of ring topology, but is significantly faster for
-            // smaller messages. Only broadcast if the message size is 5x less than
-            // message_size_max, to keep the maximum total bandwidth usage around the same.
-            const broadcast_threshold = @divFloor(constants.message_size_max, 5);
-            if (self.status == .normal and self.primary() and
-                message.header.size < broadcast_threshold)
-            {
-                self.send_message_to_other_replicas_and_standbys(message.base());
                 return;
             }
 


### PR DESCRIPTION
Previously, only messages advancing op and not known to be committed were replicated. This played badly with a pipeline: if two prepares get reordered on _one_ replica, it creates a bubble that rides until the end of the ring, triggering repairs on any replicas along the way.

With this commit, we replicate any prepare that we haven't seen before.

I originally considered explicitly amounting for a pipeline, and repairing after `op -| pipeline`, but I think that would be worse.

Consider a scenario where half of the cluster gets odd prepares, and half of the cluster gets even ones. Here, if a replica from the first half gets a lucky even prepare, it can be well-advised to forward it along.

Another case: consider replica re-joining the cluster after a delay. This replica will be requesting all prepares, and it, at the first sight, seems wasteful to replicate them all. But actually, as the replica were missing, it is likely that anyone in front of it is now missing these prepares either! So it actually is good if it can replay them.