### PR TITLE
[Client] Prevent IO thread starvation

### DIFF
--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1292,15 +1292,11 @@ public class IntegrationTest {
     }
 
     /**
-     * This test asserts that async tasks will respect client's concurrencyMax.
+     * This test asserts that async calls will not block.
      */
     @Test
     public void testAsyncTasks() throws Throwable {
         final int TASKS_COUNT = 1_000_000;
-        final int CONCURRENCY_MAX = 8192;
-        final var semaphore = new Semaphore(CONCURRENCY_MAX);
-
-        final var executor = Executors.newFixedThreadPool(4);
 
         try (final var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
@@ -1325,11 +1321,7 @@ public class IntegrationTest {
                 transfers.setAmount(100);
 
                 // Starting async batch.
-                semaphore.acquire();
-                tasks[i] = client.createTransfersAsync(transfers).thenApplyAsync((result) -> {
-                    semaphore.release();
-                    return result;
-                }, executor);
+                tasks[i] = client.createTransfersAsync(transfers);
             }
 
             // Wait for all tasks.


### PR DESCRIPTION
This is a "not react to stimuli" problem: The `tb_client` IO thread consumes packets produced by multiple user threads in a tight loop, potentially blocking the IO under heavy load for as long as packets are available to consume.

- Now `on_signal` only consumes the number of packets necessary to batch one more request into `pending`. Additionally, it enforces an upper limit to prevent too many invalid packets from blocking the IO thread.
- `SubmissionStack` was a first-in-last-out data structure, effectively reordering requests when moving them from `submitted` to `pending`. It has been replaced with a FIFO structure guarded by a mutex, which has minimal impact compared to the previous spin lock (in the past a Mutex was used to guard the pool of packets before packets implemented intrusive memory).
- ~The `notify()` signal does not use `timeout=0` anymore if fired while running, allowing other IO completions to run between notifications.~ (Superseded by #2611)