### PR TITLE
aof: improve efficiency

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -274,10 +274,15 @@ const Command = struct {
         defer message_pool.deinit(allocator);
 
         var aof: ?AOF = if (args.aof) blk: {
-            const aof_path = try std.fmt.allocPrint(allocator, "{s}.aof", .{args.path});
+            const aof_path = try std.fmt.allocPrint(
+                allocator,
+                "{s}.aof",
+                .{std.fs.path.basename(args.path)},
+            );
             defer allocator.free(aof_path);
+            std.log.info("{s}", .{aof_path});
 
-            break :blk try AOF.from_absolute_path(aof_path);
+            break :blk try AOF.init(command.dir_fd, aof_path, &command.io);
         } else null;
         defer if (aof != null) aof.?.close();
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3660,6 +3660,7 @@ pub fn ReplicaType(
 
         const CommitStage = union(enum) {
             const CheckpointData = enum {
+                aof,
                 state_machine,
                 client_replies,
                 client_sessions,
@@ -4183,6 +4184,11 @@ pub fn ReplicaType(
                 // parallel (as much possible) rather than in sequence.
                 self.send_commit();
             }
+            if (self.aof) |aof| {
+                aof.checkpoint(self, commit_checkpoint_data_aof_callback);
+            } else {
+                self.commit_checkpoint_data_callback_join(.aof);
+            }
             self.grid_scrubber.checkpoint();
             self.state_machine.checkpoint(commit_checkpoint_data_state_machine_callback);
             self.client_sessions_checkpoint
@@ -4197,6 +4203,12 @@ pub fn ReplicaType(
             });
             self.grid.checkpoint(commit_checkpoint_data_grid_callback);
             return .pending;
+        }
+
+        fn commit_checkpoint_data_aof_callback(replica: *anyopaque) void {
+            const self: *Replica = @alignCast(@ptrCast(replica));
+            assert(self.commit_stage == .checkpoint_data);
+            self.commit_checkpoint_data_callback_join(.aof);
         }
 
         fn commit_checkpoint_data_state_machine_callback(state_machine: *StateMachine) void {
@@ -4509,10 +4521,7 @@ pub fn ReplicaType(
                 self.trace.start(.replica_aof_write, .{
                     .op = prepare.header.op,
                 });
-                aof.write(prepare, .{
-                    .replica = self.replica,
-                    .primary = self.primary_index(self.view),
-                }) catch @panic("aof failure");
+                aof.write(prepare) catch @panic("aof failure");
                 self.trace.stop(.replica_aof_write, .{
                     .op = prepare.header.op,
                 });


### PR DESCRIPTION
This reworks the AOF to be significantly more efficient, both in space and performance, by:
* Relying on the WAL for durability between checkpoints.
* Switching to buffered read / writes and fsync.
* Removing unneeded metadata and  padding.

The unholy mix of sync buffered IO with async fsync is a stopgap measure, until a fully async AOF which will have a ton of other things as a precursor to DR comes along.

It also completely changes the on disk format: that's fine, past entries should be replayed with a matching version!

In terms of numbers:

## Before:
25000 batches in 52.22 s
transfer batch size = 2 txs
transfer batch delay = 0 us
load accepted = 957 tx/s

AOF size: 202 080KiB

## After:
25000 batches in 24.68 s
transfer batch size = 2 txs
transfer batch delay = 0 us
load accepted = 2025 tx/s

AOF size: 15 552KiB
