### PR TITLE
[VSR] Protocol batching

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -429,6 +429,7 @@ pub const AOFReplayClient = struct {
                 .session = 0,
                 .request = 0,
                 .release = header.release,
+                .batch_count = header.batch_count,
             };
 
             self.client.raw_request(AOFReplayClient.replay_callback, @intFromPtr(self), message);
@@ -453,11 +454,13 @@ pub const AOFReplayClient = struct {
         user_data: u128,
         operation: StateMachine.Operation,
         timestamp: u64,
-        result: []u8,
+        result: []const u8,
+        batch_count: u16,
     ) void {
         _ = operation;
         _ = timestamp;
         _ = result;
+        _ = batch_count;
 
         const self: *AOFReplayClient = @ptrFromInt(@as(usize, @intCast(user_data)));
         assert(self.inflight_message != null);

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -699,6 +699,7 @@ test "aof write / read" {
         .command = .prepare,
         .operation = @enumFromInt(4),
         .size = @intCast(@sizeOf(Header) + demo_payload.len),
+        .batch_count = 0,
     };
 
     stdx.copy_disjoint(.exact, u8, demo_message.body_used(), demo_payload);

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -250,13 +250,13 @@ typedef enum TB_PACKET_STATUS {
 } TB_PACKET_STATUS;
 
 typedef struct tb_packet_t {
-    struct tb_packet_t* next;
     void* user_data;
     void* data;
     uint32_t data_size;
+    uint16_t tag;
     uint8_t operation;
     uint8_t status;
-    uint8_t reserved[2];
+    uint8_t reserved[32];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -252,15 +252,11 @@ typedef enum TB_PACKET_STATUS {
 typedef struct tb_packet_t {
     struct tb_packet_t* next;
     void* user_data;
+    void* data;
+    uint32_t data_size;
     uint8_t operation;
     uint8_t status;
-    uint32_t data_size;
-    void* data;
-    struct tb_packet_t* batch_next;
-    struct tb_packet_t* batch_tail;
-    uint32_t batch_size;
-    uint8_t batch_allowed;
-    uint8_t reserved[7];
+    uint8_t reserved[2];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 // When referenced from unit_test.zig, there is no vsr import module. So use relative path instead.
 pub const vsr = if (@import("root") == @This()) @import("vsr") else @import("../../vsr.zig");
 
-pub const tb_packet_t = @import("tb_client/packet.zig").Packet;
-pub const tb_packet_status_t = tb_packet_t.Status;
+pub const tb_packet_t = @import("tb_client/packet.zig").Packet.Extern;
+pub const tb_packet_status_t = @import("tb_client/packet.zig").Packet.Status;
 
 pub const tb_client_t = *anyopaque;
 pub const tb_status_t = enum(c_int) {

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -634,7 +634,7 @@ pub fn ContextType(
                     result_size,
                     reply,
                     batch_count,
-                );
+                ) catch unreachable;
 
                 var it: ?*Packet = packet;
                 while (it) |batched| {

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -468,6 +468,7 @@ pub fn ContextType(
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @sizeOf(vsr.Header) + packet.batch_size,
+                .batch_count = 0,
             };
 
             // Copy all batched packet event data into the message.

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const testing = std.testing;
 const mem = std.mem;
 
 const vsr = @import("../tb_client.zig").vsr;
@@ -22,34 +21,6 @@ pub fn EchoClientType(
         const VSRClient = vsr.ClientType(StateMachine_, MessageBus, Time);
         pub const StateMachine = VSRClient.StateMachine;
         pub const Request = VSRClient.Request;
-
-        /// Custom Demuxer which treats EventType(operation)s as results and echoes them back.
-        pub fn DemuxerType(comptime operation: StateMachine.Operation) type {
-            return struct {
-                const Demuxer = @This();
-
-                results: []u8,
-                events_decoded: u32 = 0,
-
-                pub fn init(reply: []u8) Demuxer {
-                    return Demuxer{ .results = reply };
-                }
-
-                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []u8 {
-                    // Double check the event offset/count are contiguously decoded from results.
-                    assert(self.events_decoded == event_offset);
-                    self.events_decoded += event_count;
-
-                    // Double check the results has enough event bytes to echo back.
-                    const byte_count = @sizeOf(StateMachine.EventType(operation)) * event_count;
-                    assert(self.results.len >= byte_count);
-
-                    // Echo back the result bytes and consume the events.
-                    defer self.results = self.results[byte_count..];
-                    return self.results[0..byte_count];
-                }
-            };
-        }
 
         id: u128,
         cluster: u128,
@@ -121,6 +92,7 @@ pub fn EchoClientType(
                         operation.cast(EchoClient.StateMachine),
                         timestamp,
                         reply.body_used(),
+                        0,
                     );
                 },
                 .register => |callback| {
@@ -228,42 +200,4 @@ pub fn EchoClientType(
             self.message_pool.unref(message);
         }
     };
-}
-
-test "Echo Demuxer" {
-    const StateMachine = vsr.state_machine.StateMachineType(
-        @import("../../../testing/storage.zig").Storage,
-        constants.state_machine_config,
-    );
-    const MessageBus = vsr.message_bus.MessageBusClient;
-    const Time = vsr.time.Time;
-    const Client = EchoClientType(StateMachine, MessageBus, Time);
-
-    var prng = std.rand.DefaultPrng.init(42);
-    inline for ([_]StateMachine.Operation{
-        .create_accounts,
-        .create_transfers,
-    }) |operation| {
-        const Event = StateMachine.EventType(operation);
-        var events: [@divExact(constants.message_body_size_max, @sizeOf(Event))]Event = undefined;
-        prng.fill(std.mem.asBytes(&events));
-
-        for (0..events.len) |i| {
-            const events_total = i + 1;
-            const events_data = std.mem.sliceAsBytes(events[0..events_total]);
-            var demuxer = Client.DemuxerType(operation).init(events_data);
-
-            var events_offset: usize = 0;
-            while (events_offset < events_total) {
-                const events_limit = events_total - events_offset;
-                const events_count = @max(1, prng.random().uintAtMost(usize, events_limit));
-                defer events_offset += events_count;
-
-                const reply_bytes = demuxer.decode(@intCast(events_offset), @intCast(events_count));
-                const reply: []Event = @alignCast(std.mem.bytesAsSlice(Event, reply_bytes));
-                try testing.expectEqual(&reply[0], &events[events_offset]);
-                try testing.expectEqual(reply.len, events[events_offset..][0..events_count].len);
-            }
-        }
-    }
 }

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -151,6 +151,7 @@ pub fn EchoClientType(
                 .command = .request,
                 .operation = .register,
                 .release = vsr.Release.minimum,
+                .batch_count = 0,
             };
 
             assert(self.request_number == 0);

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -2,26 +2,13 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
-const FIFOType = @import("../tb_client.zig").vsr.fifo.FIFOType;
-
 // When referenced from unit_test.zig, there is no vsr import module so use path.
 const vsr = if (@import("root") == @This()) @import("vsr") else @import("../../../vsr.zig");
 const stdx = vsr.stdx;
+const FIFOType = vsr.fifo.FIFOType;
+const maybe = stdx.maybe;
 
 pub const Packet = extern struct {
-    next: ?*Packet,
-    user_data: ?*anyopaque,
-    data: ?*anyopaque,
-    data_size: u32,
-    operation: u8,
-    status: Status,
-    reserved: [2]u8 = [_]u8{0} ** 2,
-
-    comptime {
-        assert(@sizeOf(Packet) == 32);
-        assert(@alignOf(Packet) == 8);
-    }
-
     pub const Status = enum(u8) {
         ok,
         too_much_data,
@@ -33,7 +20,21 @@ pub const Packet = extern struct {
         invalid_data_size,
     };
 
-    /// Thread-safe FIFO.
+    /// External packet type exposed to the user.
+    pub const Extern = extern struct {
+        user_data: ?*anyopaque,
+        data: ?*anyopaque,
+        data_size: u32,
+        tag: u16,
+        operation: u8,
+        status: Status,
+        reserved: [32]u8 = [_]u8{0} ** 32,
+
+        pub fn cast(self: *Extern) *Packet {
+            return @ptrCast(self);
+        }
+    };
+
     pub const SubmissionQueue = struct {
         fifo: FIFOType(Packet) = .{
             .name = null,
@@ -55,15 +56,41 @@ pub const Packet = extern struct {
             return self.fifo.pop();
         }
 
-        pub fn empty(self: *SubmissionQueue) bool {
-            self.mutex.lock();
-            defer self.mutex.unlock();
-
+        /// Not thread safe, should be called only by the consumer thread.
+        pub fn empty(self: *const SubmissionQueue) bool {
             return self.fifo.count == 0;
         }
     };
 
-    pub fn events(packet: *const Packet) []const u8 {
+    const Phase = enum(u8) {
+        submitted = 0,
+        pending,
+        batched,
+        sent,
+        complete,
+    };
+
+    user_data: ?*anyopaque,
+    data: ?*anyopaque,
+    data_size: u32,
+    tag: u16,
+    operation: u8,
+    status: Status,
+
+    next: ?*Packet,
+
+    batch_next: ?*Packet,
+    batch_tail: ?*Packet,
+    batch_count: u16,
+    batch_events: u16,
+    phase: Phase,
+    reserved: [3]u8 = [_]u8{0} ** 3,
+
+    pub fn cast(self: *Packet) *Extern {
+        return @ptrCast(self);
+    }
+
+    pub fn slice(packet: *const Packet) []const u8 {
         if (packet.data_size == 0) {
             // It may be an empty array (null pointer)
             // or a buffer with no elements (valid pointer and size == 0).
@@ -73,5 +100,72 @@ pub const Packet = extern struct {
 
         const data: [*]const u8 = @ptrCast(packet.data.?);
         return data[0..packet.data_size];
+    }
+
+    pub fn assert_phase(packet: *const Packet, comptime expected: Phase) void {
+        assert(packet.phase == expected);
+        assert(packet.data_size == 0 or packet.data != null);
+        assert(stdx.zeroed(&packet.reserved));
+        maybe(packet.user_data == null);
+        maybe(packet.tag == 0);
+
+        switch (expected) {
+            .submitted => {
+                assert(packet.next == null);
+                assert(packet.batch_next == null);
+                assert(packet.batch_tail == null);
+                assert(packet.batch_count == 0);
+                assert(packet.batch_events == 0);
+            },
+            .pending => {
+                assert(packet.batch_count == 0 or packet.batch_next != null);
+                assert(packet.batch_count == 0 or packet.batch_tail != null);
+                maybe(packet.next == null);
+                maybe(packet.batch_count > 0);
+                maybe(packet.batch_events == 0);
+            },
+            .batched => {
+                assert(packet.next == null);
+                assert(packet.batch_count == 0);
+                assert(packet.batch_events == 0);
+                assert(packet.batch_tail == null);
+                maybe(packet.batch_next != null);
+            },
+            .sent => {
+                assert(packet.batch_count == 0 or packet.batch_next != null);
+                assert(packet.batch_count == 0 or packet.batch_tail != null);
+                assert(packet.next == null);
+                maybe(packet.batch_count > 0);
+                maybe(packet.batch_events == 0);
+            },
+            .complete => {
+                // The packet pointer isn't available afer completed,
+                // it may be dealocated by the user;
+                unreachable;
+            },
+        }
+    }
+
+    comptime {
+        assert(@sizeOf(Extern) % @alignOf(Extern) == 0);
+        assert(@alignOf(Extern) == 8);
+
+        assert(@sizeOf(Packet) == @sizeOf(Extern));
+        assert(@alignOf(Packet) == @alignOf(Extern));
+
+        // Asseting the fields are identical.
+        for (std.meta.fields(Extern)) |field_extern| {
+            if (std.mem.eql(u8, field_extern.name, "reserved")) continue;
+            const field_packet = std.meta.fields(Packet)[
+                std.meta.fieldIndex(
+                    Packet,
+                    field_extern.name,
+                ).?
+            ];
+            assert(field_packet.type == field_extern.type);
+            assert(field_packet.alignment == field_extern.alignment);
+            assert(@offsetOf(Packet, field_extern.name) ==
+                @offsetOf(Extern, field_extern.name));
+        }
     }
 };

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -4,21 +4,21 @@ const assert = std.debug.assert;
 
 const FIFOType = @import("../tb_client.zig").vsr.fifo.FIFOType;
 
+// When referenced from unit_test.zig, there is no vsr import module so use path.
+const vsr = if (@import("root") == @This()) @import("vsr") else @import("../../../vsr.zig");
+const stdx = vsr.stdx;
+
 pub const Packet = extern struct {
     next: ?*Packet,
     user_data: ?*anyopaque,
+    data: ?*anyopaque,
+    data_size: u32,
     operation: u8,
     status: Status,
-    data_size: u32,
-    data: ?*anyopaque,
-    batch_next: ?*Packet,
-    batch_tail: ?*Packet,
-    batch_size: u32,
-    batch_allowed: bool,
-    reserved: [7]u8 = [_]u8{0} ** 7,
+    reserved: [2]u8 = [_]u8{0} ** 2,
 
     comptime {
-        assert(@sizeOf(Packet) == 64);
+        assert(@sizeOf(Packet) == 32);
         assert(@alignOf(Packet) == 8);
     }
 
@@ -62,4 +62,16 @@ pub const Packet = extern struct {
             return self.fifo.count == 0;
         }
     };
+
+    pub fn events(packet: *const Packet) []const u8 {
+        if (packet.data_size == 0) {
+            // It may be an empty array (null pointer)
+            // or a buffer with no elements (valid pointer and size == 0).
+            stdx.maybe(packet.data == null);
+            return &[0]u8{};
+        }
+
+        const data: [*]const u8 = @ptrCast(packet.data.?);
+        return data[0..packet.data_size];
+    }
 };

--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const vsr = @import("../tb_client.zig").vsr;
+const maybe = vsr.stdx.maybe;
 const Time = vsr.time.Time;
 const IO = vsr.io.IO;
 
@@ -86,7 +87,7 @@ pub const Signal = struct {
     }
 
     fn wait(self: *Signal) void {
-        assert(!self.stop_requested());
+        maybe(self.stop_requested()); // Stop requested while processing the event.
 
         const state = self.state.swap(.waiting, .acquire);
         self.io.event_listen(self.event, &self.completion, on_event);

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -316,7 +316,7 @@ test "c_client tb_packet_status" {
             packet.user_data = &request;
             packet.data = &request.sent_data;
             packet.data_size = request_size;
-            packet.next = null;
+            packet.tag = 0;
             packet.status = c.TB_PACKET_OK;
 
             c.tb_client_submit(client, packet);

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -202,7 +202,6 @@ test "c_client echo" {
             packet.user_data = request;
             packet.data = &request.sent_data;
             packet.data_size = request.sent_data_size;
-            packet.next = null;
             packet.status = c.TB_PACKET_OK;
 
             c.tb_client_submit(tb_client, packet);

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1999,17 +1999,6 @@ public class IntegrationTests
         Assert.IsTrue(accountResults.Length == 0);
 
         var tasks = new Task<CreateTransferResult>[TASKS_QTY];
-
-        async Task<CreateTransferResult> asyncAction(Transfer transfer)
-        {
-            return await client.CreateTransferAsync(transfer);
-        }
-
-        CreateTransferResult syncAction(Transfer transfer)
-        {
-            return client.CreateTransfer(transfer);
-        }
-
         for (int i = 0; i < TASKS_QTY; i++)
         {
             // The Linked flag will cause the
@@ -2026,9 +2015,7 @@ public class IntegrationTests
                 Flags = flags
             };
 
-            // Starts multiple requests.
-            // Wraps the syncAction into a Task for unified logic handling both async and sync tests.
-            tasks[i] = isAsync ? asyncAction(transfer) : Task.Run(() => syncAction(transfer));
+            tasks[i] = isAsync ? client.CreateTransferAsync(transfer) : Task.Run(() => client.CreateTransfer(transfer));
         }
 
         Task.WhenAll(tasks).Wait();
@@ -2166,16 +2153,6 @@ public class IntegrationTests
         Assert.AreEqual(a.Flags, b.Flags);
         Assert.AreEqual(a.Code, b.Code);
         Assert.AreEqual(a.Ledger, b.Ledger);
-    }
-
-    private static bool AssertException<T>(Exception exception) where T : Exception
-    {
-        while (exception is AggregateException aggregateException && aggregateException.InnerException != null)
-        {
-            exception = aggregateException.InnerException;
-        }
-
-        return exception is T;
     }
 }
 

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1209,13 +1209,13 @@ internal enum TBOperation : byte
 [StructLayout(LayoutKind.Sequential, Size = SIZE)]
 internal unsafe struct TBPacket
 {
-    public const int SIZE = 32;
+    public const int SIZE = 56;
 
 
     [StructLayout(LayoutKind.Sequential, Size = SIZE)]
     private unsafe struct ReservedData
     {
-        public const int SIZE = 2;
+        public const int SIZE = 32;
 
         private fixed byte raw[SIZE];
 
@@ -1242,13 +1242,13 @@ internal unsafe struct TBPacket
         }
     }
 
-    public TBPacket* next;
-
     public IntPtr userData;
 
     public IntPtr data;
 
     public uint dataSize;
+
+    public ushort tag;
 
     public byte operation;
 

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1209,13 +1209,13 @@ internal enum TBOperation : byte
 [StructLayout(LayoutKind.Sequential, Size = SIZE)]
 internal unsafe struct TBPacket
 {
-    public const int SIZE = 64;
+    public const int SIZE = 32;
 
 
     [StructLayout(LayoutKind.Sequential, Size = SIZE)]
     private unsafe struct ReservedData
     {
-        public const int SIZE = 7;
+        public const int SIZE = 2;
 
         private fixed byte raw[SIZE];
 
@@ -1246,21 +1246,13 @@ internal unsafe struct TBPacket
 
     public IntPtr userData;
 
-    public byte operation;
-
-    public PacketStatus status;
+    public IntPtr data;
 
     public uint dataSize;
 
-    public IntPtr data;
+    public byte operation;
 
-    public TBPacket* batchNext;
-
-    public TBPacket* batchTail;
-
-    public uint batchSize;
-
-    public byte batchAllowed;
+    public PacketStatus status;
 
     private ReservedData reserved;
 

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -250,13 +250,13 @@ typedef enum TB_PACKET_STATUS {
 } TB_PACKET_STATUS;
 
 typedef struct tb_packet_t {
-    struct tb_packet_t* next;
     void* user_data;
     void* data;
     uint32_t data_size;
+    uint16_t tag;
     uint8_t operation;
     uint8_t status;
-    uint8_t reserved[2];
+    uint8_t reserved[32];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -252,15 +252,11 @@ typedef enum TB_PACKET_STATUS {
 typedef struct tb_packet_t {
     struct tb_packet_t* next;
     void* user_data;
+    void* data;
+    uint32_t data_size;
     uint8_t operation;
     uint8_t status;
-    uint32_t data_size;
-    void* data;
-    struct tb_packet_t* batch_next;
-    struct tb_packet_t* batch_tail;
-    uint32_t batch_size;
-    uint8_t batch_allowed;
-    uint8_t reserved[7];
+    uint8_t reserved[2];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -128,17 +128,12 @@ const NativeClient = struct {
         const global_ref = JNIHelper.new_global_reference(env, request_obj);
 
         packet.* = .{
-            .next = undefined,
             .user_data = global_ref,
             .operation = operation,
-            .status = undefined,
             .data_size = @intCast(send_buffer.len),
             .data = send_buffer.ptr,
-            .batch_next = undefined,
-            .batch_tail = undefined,
-            .batch_size = undefined,
-            .batch_allowed = undefined,
-            .reserved = undefined,
+            .next = undefined,
+            .status = undefined,
         };
 
         tb.submit(context.client, packet);

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -119,20 +119,19 @@ const NativeClient = struct {
             return undefined;
         };
 
-        const packet = global_allocator.create(tb.tb_packet_t) catch {
+        const packet: *tb.tb_packet_t = global_allocator.create(tb.tb_packet_t) catch {
             ReflectionHelper.assertion_error_throw(env, "Request could not allocate a packet");
             return undefined;
         };
 
         // Holds a global reference to prevent GC before the callback.
         const global_ref = JNIHelper.new_global_reference(env, request_obj);
-
         packet.* = .{
             .user_data = global_ref,
             .operation = operation,
             .data_size = @intCast(send_buffer.len),
             .data = send_buffer.ptr,
-            .next = undefined,
+            .tag = 0,
             .status = undefined,
         };
 

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1048,11 +1048,11 @@ public class IntegrationTest {
     }
 
     /**
-     * This test asserts that the client can handle parallel threads up to concurrencyMax.
+     * This test asserts that the client can handle parallel threads.
      */
     @Test
     public void testConcurrentTasks() throws Throwable {
-        final int TASKS_COUNT = 100;
+        final int TASKS_COUNT = 1000;
         final var barrier = new CountDownLatch(TASKS_COUNT);
 
         try (final var client = new Client(clusterId, new String[] {server.getAddress()})) {
@@ -1295,7 +1295,6 @@ public class IntegrationTest {
     @Test
     public void testAsyncTasks() throws Throwable {
         final int TASKS_COUNT = 1_000_000;
-
         try (final var client = new Client(clusterId, new String[] {server.getAddress()})) {
 
             final var account1Id = UInt128.id();
@@ -1318,13 +1317,10 @@ public class IntegrationTest {
                 transfers.setCode(1);
                 transfers.setAmount(100);
 
-                // Starting async batch.
                 tasks[i] = client.createTransfersAsync(transfers);
             }
 
             // Wait for all tasks.
-            CompletableFuture.allOf(tasks).join();
-
             for (int i = 0; i < TASKS_COUNT; i++) {
                 @SuppressWarnings("unchecked")
                 final var future = (CompletableFuture<CreateTransferResultBatch>) tasks[i];

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -225,9 +225,9 @@ fn request(
     packet.* = .{
         .user_data = callback_ref,
         .operation = @intFromEnum(operation),
-        .data_size = @intCast(packet_data.len),
         .data = packet_data.ptr,
-        .next = undefined,
+        .data_size = @intCast(packet_data.len),
+        .tag = 0,
         .status = undefined,
     };
 

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -223,17 +223,12 @@ fn request(
     };
 
     packet.* = .{
-        .next = undefined,
         .user_data = callback_ref,
         .operation = @intFromEnum(operation),
-        .status = undefined,
         .data_size = @intCast(packet_data.len),
         .data = packet_data.ptr,
-        .batch_next = undefined,
-        .batch_tail = undefined,
-        .batch_size = undefined,
-        .batch_allowed = undefined,
-        .reserved = undefined,
+        .next = undefined,
+        .status = undefined,
     };
 
     tb_client.submit(client, packet);

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -274,24 +274,25 @@ class CPacket(ctypes.Structure):
     @classmethod
     def from_param(cls, obj):
         validate_uint(bits=32, name="data_size", number=obj.data_size)
+        validate_uint(bits=16, name="tag", number=obj.tag)
         validate_uint(bits=8, name="operation", number=obj.operation)
         return cls(
-            next=obj.next,
             user_data=obj.user_data,
             data=obj.data,
             data_size=obj.data_size,
+            tag=obj.tag,
             operation=obj.operation,
             status=obj.status,
         )
 
 CPacket._fields_ = [ # noqa: SLF001
-    ("next", ctypes.POINTER(CPacket)),
     ("user_data", ctypes.c_void_p),
     ("data", ctypes.c_void_p),
     ("data_size", ctypes.c_uint32),
+    ("tag", ctypes.c_uint16),
     ("operation", ctypes.c_uint8),
     ("status", ctypes.c_uint8),
-    ("reserved", ctypes.c_uint8 * 2),
+    ("reserved", ctypes.c_uint8 * 32),
 ]
 
 

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -273,34 +273,25 @@ class QueryFilter:
 class CPacket(ctypes.Structure):
     @classmethod
     def from_param(cls, obj):
-        validate_uint(bits=8, name="operation", number=obj.operation)
         validate_uint(bits=32, name="data_size", number=obj.data_size)
-        validate_uint(bits=32, name="batch_size", number=obj.batch_size)
+        validate_uint(bits=8, name="operation", number=obj.operation)
         return cls(
             next=obj.next,
             user_data=obj.user_data,
+            data=obj.data,
+            data_size=obj.data_size,
             operation=obj.operation,
             status=obj.status,
-            data_size=obj.data_size,
-            data=obj.data,
-            batch_next=obj.batch_next,
-            batch_tail=obj.batch_tail,
-            batch_size=obj.batch_size,
-            batch_allowed=obj.batch_allowed,
         )
 
 CPacket._fields_ = [ # noqa: SLF001
     ("next", ctypes.POINTER(CPacket)),
     ("user_data", ctypes.c_void_p),
+    ("data", ctypes.c_void_p),
+    ("data_size", ctypes.c_uint32),
     ("operation", ctypes.c_uint8),
     ("status", ctypes.c_uint8),
-    ("data_size", ctypes.c_uint32),
-    ("data", ctypes.c_void_p),
-    ("batch_next", ctypes.POINTER(CPacket)),
-    ("batch_tail", ctypes.POINTER(CPacket)),
-    ("batch_size", ctypes.c_uint32),
-    ("batch_allowed", ctypes.c_bool),
-    ("reserved", ctypes.c_uint8 * 7),
+    ("reserved", ctypes.c_uint8 * 2),
 ]
 
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -705,6 +705,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                 @intCast(@intFromPtr(repl)),
                 operation,
                 arguments,
+                0,
             );
         }
 
@@ -852,8 +853,10 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
             user_data: u128,
             operation: StateMachine.Operation,
             timestamp: u64,
-            result: []u8,
+            result: []const u8,
+            batch_count: u16,
         ) void {
+            assert(batch_count == 0);
             client_request_callback_error(
                 user_data,
                 operation,

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -349,7 +349,8 @@ pub const AccountingAuditor = struct {
         results: []const tb.CreateAccountsResult,
     ) void {
         assert(accounts.len >= results.len);
-        assert(self.timestamp < timestamp);
+        assert(self.timestamp < timestamp or
+            (accounts.len == 0 and self.timestamp == timestamp));
         defer self.timestamp = timestamp;
 
         const results_expect = self.take_in_flight(client_index).create_accounts;
@@ -402,7 +403,8 @@ pub const AccountingAuditor = struct {
         results: []const tb.CreateTransfersResult,
     ) void {
         assert(transfers.len >= results.len);
-        assert(self.timestamp < timestamp);
+        assert(self.timestamp < timestamp or
+            (transfers.len == 0 and self.timestamp == timestamp));
         defer self.timestamp = timestamp;
 
         const results_expect = self.take_in_flight(client_index).create_transfers;
@@ -513,7 +515,7 @@ pub const AccountingAuditor = struct {
     ) void {
         _ = client_index;
         assert(ids.len >= results.len);
-        assert(self.timestamp < timestamp);
+        assert(self.timestamp <= timestamp);
         defer self.timestamp = timestamp;
 
         var results_iterator = IteratorForLookupType(tb.Account).init(results);
@@ -564,7 +566,7 @@ pub const AccountingAuditor = struct {
     ) void {
         _ = client_index;
         assert(ids.len >= results.len);
-        assert(self.timestamp < timestamp);
+        assert(self.timestamp <= timestamp);
         defer self.timestamp = timestamp;
 
         var results_iterator = IteratorForLookupType(tb.Transfer).init(results);

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -365,7 +365,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                     switch (action) {
                         .create_accounts => {
                             const batchable = self.batch(tb.Account, action, encoder.writable());
-                            if (!encoder.can_add(batchable.len * event_size)) break;
+                            if (encoder.writable().len < batchable.len * event_size) break;
 
                             const count = self.build_create_accounts(
                                 client_index,
@@ -377,7 +377,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                         },
                         .create_transfers => {
                             const batchable = self.batch(tb.Transfer, action, encoder.writable());
-                            if (!encoder.can_add(batchable.len * event_size)) break;
+                            if (encoder.writable().len < batchable.len * event_size) break;
 
                             const count = self.build_create_transfers(
                                 client_index,
@@ -389,7 +389,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                         },
                         .lookup_accounts => {
                             const batchable = self.batch(u128, action, encoder.writable());
-                            if (!encoder.can_add(batchable.len * event_size)) break;
+                            if (encoder.writable().len < batchable.len * event_size) break;
 
                             const count = self.build_lookup_accounts(batchable);
                             assert(count <= batchable.len);
@@ -398,7 +398,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                         },
                         .lookup_transfers => {
                             const batchable = self.batch(u128, action, encoder.writable());
-                            if (!encoder.can_add(batchable.len * event_size)) break;
+                            if (encoder.writable().len < batchable.len * event_size) break;
 
                             const count = self.build_lookup_transfers(batchable);
                             assert(count <= batchable.len);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -725,12 +725,14 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             user_data: u128,
             operation: StateMachine.Operation,
             timestamp: u64,
-            result: []u8,
+            result: []const u8,
+            batch_count: u16,
         ) void {
             _ = user_data;
             _ = operation;
             _ = timestamp;
             _ = result;
+            _ = batch_count;
         }
 
         fn client_on_reply(

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -691,6 +691,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             request_operation: StateMachine.Operation,
             request_message: *Message,
             request_body_size: usize,
+            batch_count: u16,
         ) void {
             assert(cluster.client_eviction_reasons[client_index] == null);
 
@@ -705,7 +706,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, request_operation),
                 .size = @intCast(@sizeOf(vsr.Header) + request_body_size),
-                .batch_count = 0,
+                .batch_count = batch_count,
             };
 
             client.raw_request(
@@ -740,6 +741,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             request_message: *Message.Request,
             reply_message: *Message.Reply,
         ) void {
+            assert(request_message.header.batch_count == reply_message.header.batch_count);
+
             const cluster: *Cluster = @ptrCast(@alignCast(client.on_reply_context.?));
             assert(reply_message.header.invalid() == null);
             assert(reply_message.header.cluster == cluster.options.cluster_id);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -705,6 +705,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, request_operation),
                 .size = @intCast(@sizeOf(vsr.Header) + request_body_size),
+                .batch_count = 0,
             };
 
             client.raw_request(

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -187,7 +187,7 @@ pub fn StateMachineType(
             state_machine: *const StateMachine,
             client_release: vsr.Release,
             operation: Operation,
-            input: []align(16) const u8,
+            input: []const u8,
         ) bool {
             _ = state_machine;
             _ = client_release;
@@ -200,7 +200,7 @@ pub fn StateMachineType(
             state_machine: *StateMachine,
             client_release: vsr.Release,
             operation: Operation,
-            input: []align(16) const u8,
+            input: []const u8,
         ) void {
             _ = state_machine;
             _ = client_release;
@@ -214,7 +214,7 @@ pub fn StateMachineType(
             client_release: vsr.Release,
             op: u64,
             operation: Operation,
-            input: []align(16) const u8,
+            input: []const u8,
         ) void {
             _ = client_release;
             _ = operation;
@@ -247,8 +247,8 @@ pub fn StateMachineType(
             op: u64,
             timestamp: u64,
             operation: Operation,
-            input: []align(16) const u8,
-            output: *align(16) [constants.message_body_size_max]u8,
+            input: []const u8,
+            output: []u8,
         ) usize {
             assert(op != 0);
 

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -339,6 +339,7 @@ fn WorkloadType(comptime StateMachine: type) type {
         ) struct {
             operation: StateMachine.Operation,
             size: usize,
+            batch_count: u16,
         } {
             _ = client_index;
 
@@ -351,6 +352,7 @@ fn WorkloadType(comptime StateMachine: type) type {
             return .{
                 .operation = .echo,
                 .size = size,
+                .batch_count = 0,
             };
         }
 
@@ -361,9 +363,11 @@ fn WorkloadType(comptime StateMachine: type) type {
             timestamp: u64,
             request_body: []align(@alignOf(vsr.Header)) const u8,
             reply_body: []align(@alignOf(vsr.Header)) const u8,
+            batch_count: u16,
         ) void {
             _ = client_index;
             _ = timestamp;
+            assert(batch_count == 0);
 
             workload.requests_delivered += 1;
             assert(workload.requests_delivered <= workload.requests_sent);
@@ -390,6 +394,7 @@ fn WorkloadType(comptime StateMachine: type) type {
 
             pub fn generate(random: std.rand.Random, options: struct {
                 batch_size_limit: u32,
+                batch_per_request_limit: u32,
                 client_count: usize,
                 in_flight_max: usize,
             }) Options {

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -31,11 +31,6 @@ pub fn StateMachineType(
             pub const message_body_size_max = config.message_body_size_max;
         };
 
-        pub const batch_logical_allowed = std.enums.EnumArray(Operation, bool).init(.{
-            // Batching not supported by test StateMachine.
-            .echo = false,
-        });
-
         pub fn EventType(comptime _: Operation) type {
             return u8; // Must be non-zero-sized for sliceAsBytes().
         }
@@ -48,6 +43,20 @@ pub fn StateMachineType(
             batch_size_limit: u32,
             lsm_forest_node_count: u32,
         };
+
+        pub fn event_size_bytes(
+            _: vsr.Release,
+            _: Operation,
+        ) usize {
+            return @sizeOf(u8);
+        }
+
+        pub fn result_size_bytes(
+            _: vsr.Release,
+            _: Operation,
+        ) usize {
+            return @sizeOf(u8);
+        }
 
         pub const Forest = ForestType(Storage, .{ .things = ThingGroove });
 
@@ -170,16 +179,17 @@ pub fn StateMachineType(
             return true;
         }
 
-        pub fn prepare(
+        pub fn prepare_nanoseconds(
             state_machine: *StateMachine,
             client_release: vsr.Release,
             operation: Operation,
             input: []const u8,
-        ) void {
+        ) u64 {
             _ = state_machine;
             _ = client_release;
             _ = operation;
             _ = input;
+            return 0;
         }
 
         pub fn prefetch(

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -44,32 +44,6 @@ pub fn StateMachineType(
             return u8; // Must be non-zero-sized for sliceAsBytes().
         }
 
-        /// Empty demuxer to be compatible with vsr.Client batching.
-        pub fn DemuxerType(comptime operation: Operation) type {
-            return struct {
-                const Demuxer = @This();
-
-                reply: []ResultType(operation),
-                offset: u32 = 0,
-
-                pub fn init(reply: []u8) Demuxer {
-                    return .{
-                        .reply = @alignCast(std.mem.bytesAsSlice(
-                            ResultType(operation),
-                            reply,
-                        )),
-                    };
-                }
-
-                pub fn decode(self: *Demuxer, event_offset: u32, event_count: u32) []u8 {
-                    assert(self.offset == event_offset);
-                    assert(event_offset + event_count <= self.reply.len);
-                    defer self.offset += event_count;
-                    return std.mem.sliceAsBytes(self.reply[self.offset..][0..event_count]);
-                }
-            };
-        }
-
         pub const Options = struct {
             batch_size_limit: u32,
             lsm_forest_node_count: u32,

--- a/src/testing/vortex/java_driver/src/main/java/Main.java
+++ b/src/testing/vortex/java_driver/src/main/java/Main.java
@@ -1,15 +1,28 @@
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.rmi.UnexpectedException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import com.tigerbeetle.AccountBatch;
+import com.tigerbeetle.AccountFlags;
 import com.tigerbeetle.Client;
+import com.tigerbeetle.CreateAccountResult;
+import com.tigerbeetle.CreateAccountResultBatch;
+import com.tigerbeetle.CreateTransferResult;
+import com.tigerbeetle.CreateTransferResultBatch;
 import com.tigerbeetle.IdBatch;
 import com.tigerbeetle.TransferBatch;
+import com.tigerbeetle.TransferFlags;
 import com.tigerbeetle.UInt128;
 
 /**
@@ -55,24 +68,42 @@ record Driver(Client client, Reader reader, Writer writer) {
   /**
    * Reads the next operation from stdin, runs it, collects the results, and writes them back to
    * stdout.
-   */
-  void next() throws IOException {
+      * @throws ExecutionException
+      * @throws InterruptedException
+      */
+  void next() throws IOException, InterruptedException, ExecutionException {
     reader.read(1 + 4); // operation + count
     var operation = Operation.fromValue(reader.u8());
     var count = reader.u32();
 
+    // Process asynchronously for testing batched requests.
+    final var random = new Random();
+    final boolean isAsync = random.nextBoolean();
+
     switch (operation) {
       case CREATE_ACCOUNTS:
-        createAccounts(reader, writer, count);
+        if (isAsync)
+          createAccountsAsync(reader, writer, count);
+        else
+          createAccounts(reader, writer, count);
         break;
       case CREATE_TRANSFERS:
-        createTransfers(reader, writer, count);
+        if (isAsync)
+          createTransfersAsync(reader, writer, count);
+        else
+          createTransfers(reader, writer, count);
         break;
       case LOOKUP_ACCOUNTS:
-        lookupAccounts(reader, writer, count);
+        if (isAsync)
+          lookupAccountsAsync(reader, writer, count);
+        else
+          lookupAccounts(reader, writer, count);
         break;
       case LOOKUP_TRANSFERS:
-        lookupTransfers(reader, writer, count);
+        if (isAsync)
+          lookupTransfersAsync(reader, writer, count);
+        else
+          lookupTransfers(reader, writer, count);
         break;
       case GET_ACCOUNT_BALANCES:
       case GET_ACCOUNT_TRANSFERS:
@@ -100,7 +131,7 @@ record Driver(Client client, Reader reader, Writer writer) {
       reader.u32(); // `reserved`
       batch.setLedger(reader.u32());
       batch.setCode(reader.u16());
-      batch.setFlags(reader.u16());  
+      batch.setFlags(reader.u16());
       reader.u64(); // `timestamp`
     }
     var results = client.createAccounts(batch);
@@ -109,6 +140,62 @@ record Driver(Client client, Reader reader, Writer writer) {
     while (results.next()) {
       writer.u32(results.getIndex());
       writer.u32(results.getResult().value);
+    }
+    writer.flush();
+  }
+
+  void createAccountsAsync(Reader reader, Writer writer, int count)
+    throws IOException, InterruptedException, ExecutionException {
+    reader.read(Driver.Operation.CREATE_ACCOUNTS.eventSize() * count);
+
+    record Request(CompletableFuture<CreateAccountResultBatch> future, int eventCount) {};
+    final var requests = new ArrayList<Request>(count);
+    var batch = new AccountBatch(count);
+    for (int index = 0; index < count; index++) {
+      batch.add();
+      batch.setId(reader.u128());
+      reader.u128(); // `debits_pending`
+      reader.u128(); // `debits_posted`
+      reader.u128(); // `credits_pending`
+      reader.u128(); // `credits_posted`
+      batch.setUserData128(reader.u128());
+      batch.setUserData64(reader.u64());
+      batch.setUserData32(reader.u32());
+      reader.u32(); // `reserved`
+      batch.setLedger(reader.u32());
+      batch.setCode(reader.u16());
+      batch.setFlags(reader.u16());
+      reader.u64(); // `timestamp`
+
+      if (!AccountFlags.hasLinked(batch.getFlags())) {
+        requests.add(new Request(client.createAccountsAsync(batch), batch.getLength()));
+        batch = new AccountBatch(count - index);
+      }
+    }
+
+    // Sending any eventual non-closed linked chain.
+    if (batch.getLength() > 0) {
+      requests.add(new Request(client.createAccountsAsync(batch), batch.getLength()));
+    }
+
+    record Result(int index, CreateAccountResult result){};
+    var results = new ArrayList<Result>(count);
+
+    // Wait for all tasks.
+    int index = 0;
+    for (final var request : requests) {
+        final var result = request.future.get();
+        while (result.next()) {
+          results.add(new Result(result.getIndex() + index, result.getResult()));
+        }
+        index += request.eventCount;
+    }
+
+    writer.allocate(4 + Driver.Operation.CREATE_ACCOUNTS.resultSize() * results.size());
+    writer.u32(results.size());
+    for (final var result : results) {
+      writer.u32(result.index);
+      writer.u32(result.result.value);
     }
     writer.flush();
   }
@@ -129,8 +216,8 @@ record Driver(Client client, Reader reader, Writer writer) {
       batch.setTimeout(reader.u32());
       batch.setLedger(reader.u32());
       batch.setCode(reader.u16());
-      batch.setFlags(reader.u16());  
-      batch.setTimestamp(reader.u64());  
+      batch.setFlags(reader.u16());
+      batch.setTimestamp(reader.u64());
     }
     var results = client.createTransfers(batch);
     writer.allocate(4 + Driver.Operation.CREATE_ACCOUNTS.resultSize() * results.getLength());
@@ -138,6 +225,62 @@ record Driver(Client client, Reader reader, Writer writer) {
     while (results.next()) {
       writer.u32(results.getIndex());
       writer.u32(results.getResult().value);
+    }
+    writer.flush();
+  }
+
+  void createTransfersAsync(Reader reader, Writer writer, int count)
+    throws IOException, InterruptedException, ExecutionException {
+    reader.read(Driver.Operation.CREATE_TRANSFERS.eventSize() * count);
+
+    record Request(CompletableFuture<CreateTransferResultBatch> future, int eventCount) {};
+    final var requests = new ArrayList<Request>(count);
+    var batch = new TransferBatch(count);
+    for (int index = 0; index < count; index++) {
+      batch.add();
+      batch.setId(reader.u128());
+      batch.setDebitAccountId(reader.u128());
+      batch.setCreditAccountId(reader.u128());
+      batch.setAmount(reader.u64(), reader.u64());
+      batch.setPendingId(reader.u128());
+      batch.setUserData128(reader.u128());
+      batch.setUserData64(reader.u64());
+      batch.setUserData32(reader.u32());
+      batch.setTimeout(reader.u32());
+      batch.setLedger(reader.u32());
+      batch.setCode(reader.u16());
+      batch.setFlags(reader.u16());
+      batch.setTimestamp(reader.u64());
+
+      if (!TransferFlags.hasLinked(batch.getFlags())) {
+        requests.add(new Request(client.createTransfersAsync(batch), batch.getLength()));
+        batch = new TransferBatch(count - index);
+      }
+    }
+
+    // Sending any eventual non-closed linked chain.
+    if (batch.getLength() > 0) {
+      requests.add(new Request(client.createTransfersAsync(batch), batch.getLength()));
+    }
+
+    record Result(int index, CreateTransferResult result){};
+    var results = new ArrayList<Result>(count);
+
+    // Wait for all tasks.
+    int index = 0;
+    for (final var request : requests) {
+        final var result = request.future.get();
+        while (result.next()) {
+          results.add(new Result(result.getIndex() + index, result.getResult()));
+        }
+        index += request.eventCount;
+    }
+
+    writer.allocate(4 + Driver.Operation.CREATE_ACCOUNTS.resultSize() * results.size());
+    writer.u32(results.size());
+    for(final var result : results) {
+      writer.u32(result.index);
+      writer.u32(result.result.value);
     }
     writer.flush();
   }
@@ -170,6 +313,68 @@ record Driver(Client client, Reader reader, Writer writer) {
     writer.flush();
   }
 
+  void lookupAccountsAsync(Reader reader, Writer writer, int count)
+    throws IOException, InterruptedException, ExecutionException {
+    reader.read(Driver.Operation.LOOKUP_ACCOUNTS.eventSize() * count);
+
+    final var requests = new ArrayList<CompletableFuture<AccountBatch>>(count);
+    for (int index = 0; index < count; index++) {
+      var batch = new IdBatch(1);
+      batch.add();
+      batch.setId(reader.u128());
+
+      requests.add(client.lookupAccountsAsync(batch));
+    }
+
+    record Result(
+      byte[] id,
+      BigInteger debitsPending, BigInteger debitsPosted,
+      BigInteger creditsPending, BigInteger creditsPosted,
+      byte[] userData128, long userData64, int userData32,
+      int ledger, int code, int flags, long timestamp) {};
+    var results = new ArrayList<Result>(count);
+
+    // Wait for all tasks.
+    for (final var request : requests) {
+      final var result = request.get();
+
+      if (result.next()) {
+        results.add(new Result(
+          result.getId(),
+          result.getDebitsPending(),
+          result.getDebitsPosted(),
+          result.getCreditsPending(),
+          result.getCreditsPosted(),
+          result.getUserData128(),
+          result.getUserData64(),
+          result.getUserData32(),
+          result.getLedger(),
+          result.getCode(),
+          result.getFlags(),
+          result.getTimestamp()));
+      }
+    }
+
+    writer.allocate(4 + Driver.Operation.LOOKUP_ACCOUNTS.resultSize() * results.size());
+    writer.u32(results.size());
+    for (final var result : results) {
+      writer.u128(result.id);
+      writer.u128(UInt128.asBytes(result.debitsPending));
+      writer.u128(UInt128.asBytes(result.debitsPosted));
+      writer.u128(UInt128.asBytes(result.creditsPending));
+      writer.u128(UInt128.asBytes(result.creditsPosted));
+      writer.u128(result.userData128);
+      writer.u64(result.userData64);
+      writer.u32(result.userData32);
+      writer.u32(0); // `reserved`
+      writer.u32(result.ledger);
+      writer.u16(result.code);
+      writer.u16(result.flags);
+      writer.u64(result.timestamp);
+    }
+    writer.flush();
+  }
+
   void lookupTransfers(Reader reader, Writer writer, int count) throws IOException {
     reader.read(Driver.Operation.LOOKUP_TRANSFERS.eventSize() * count);
     var batch = new IdBatch(count);
@@ -194,6 +399,69 @@ record Driver(Client client, Reader reader, Writer writer) {
       writer.u16(results.getCode());
       writer.u16(results.getFlags());
       writer.u64(results.getTimestamp());
+    }
+    writer.flush();
+  }
+
+  void lookupTransfersAsync(Reader reader, Writer writer, int count)
+    throws IOException, InterruptedException, ExecutionException {
+    reader.read(Driver.Operation.LOOKUP_TRANSFERS.eventSize() * count);
+
+    final var requests = new ArrayList<CompletableFuture<TransferBatch>>(count);
+    for (int index = 0; index < count; index++) {
+      var batch = new IdBatch(count);
+      batch.add();
+      batch.setId(reader.u128());
+
+      requests.add(client.lookupTransfersAsync(batch));
+    }
+
+    record Result(
+      byte[] id,
+      byte[] debitAccountId, byte[] creditAccountId,
+      BigInteger amount, byte[] pendingId,
+      byte[] userData128, long userData64, int userData32,
+      int timeout, int ledger, int code, int flags, long timestamp) {};
+    var results = new ArrayList<Result>(count);
+
+    // Wait for all tasks.
+    for (final var request : requests) {
+      final var result = request.get();
+
+      if (result.next()) {
+        results.add(new Result(
+          result.getId(),
+          result.getDebitAccountId(),
+          result.getCreditAccountId(),
+          result.getAmount(),
+          result.getPendingId(),
+          result.getUserData128(),
+          result.getUserData64(),
+          result.getUserData32(),
+          result.getTimeout(),
+          result.getLedger(),
+          result.getCode(),
+          result.getFlags(),
+          result.getTimestamp()));
+      }
+    }
+
+    writer.allocate(4 + Driver.Operation.LOOKUP_TRANSFERS.resultSize() * results.size());
+    writer.u32(results.size());
+    for (final var result : results) {
+      writer.u128(result.id);
+      writer.u128(result.debitAccountId);
+      writer.u128(result.creditAccountId);
+      writer.u128(UInt128.asBytes(result.amount));
+      writer.u128(result.pendingId);
+      writer.u128(result.userData128);
+      writer.u64(result.userData64);
+      writer.u32(result.userData32);
+      writer.u32(result.timeout);
+      writer.u32(result.ledger);
+      writer.u16(result.code);
+      writer.u16(result.flags);
+      writer.u64(result.timestamp);
     }
     writer.flush();
   }
@@ -271,7 +539,7 @@ record Driver(Client client, Reader reader, Writer writer) {
 
   /**
    * Reads sized chunks into a buffer, and uses that to convert from
-   * the Vortex driver binary protocol data to natively typed values. 
+   * the Vortex driver binary protocol data to natively typed values.
    *
    * The entire `read` buffer must be consumed before calling `read` again.
    */
@@ -321,7 +589,7 @@ record Driver(Client client, Reader reader, Writer writer) {
   }
 
   /**
-   * Allocates a buffer of a certain size, and writes natively typed values as 
+   * Allocates a buffer of a certain size, and writes natively typed values as
    * Vortex driver binary protocol data.
    *
    * The entire allocated buffer must be filled before writing or allocating a

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -69,7 +69,7 @@ pub fn main(_: std.mem.Allocator, args: CLIArgs) !void {
             packet.user_data = @constCast(@ptrCast(&context));
             packet.data = @constCast(events.ptr);
             packet.data_size = @intCast(events.len);
-            packet.next = null;
+            packet.tag = 0;
             packet.status = c.TB_PACKET_OK;
 
             c.tb_client_submit(tb_client, &packet);

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -338,7 +338,7 @@ fn tidy_dead_declarations(
 }
 
 /// As we trim our functions, make sure to update this constant; tidy will error if you do not.
-const function_line_count_max = 414; // fn check in state_machine.zig
+const function_line_count_max = 415; // fn check in state_machine.zig
 
 fn tidy_long_functions(
     file: SourceFile,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -670,6 +670,7 @@ const Benchmark = struct {
             }),
             operation,
             payload,
+            0,
         );
     }
 
@@ -677,8 +678,10 @@ const Benchmark = struct {
         user_data: u128,
         operation: StateMachine.Operation,
         timestamp: u64,
-        result: []u8,
+        result: []const u8,
+        batch_count: u16,
     ) void {
+        assert(batch_count == 0);
         const context: RequestContext = @bitCast(user_data);
         const client = context.client_index;
         const b: *Benchmark = context.benchmark;

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -72,6 +72,7 @@ comptime {
     _ = @import("vsr/free_set.zig");
     _ = @import("vsr/superblock_quorums.zig");
     _ = @import("vsr/sync.zig");
+    _ = @import("vsr/batch.zig");
 
     _ = @import("scripts/release.zig");
     _ = @import("scripts/changelog.zig");

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -120,19 +120,26 @@ pub fn main() !void {
     // See the "Cluster: eviction: session_too_low" replica test for a related scenario.)
     const client_count = @max(1, random.uintAtMost(u8, constants.clients_max * 2 - 1));
 
-    const batch_size_limit_min = comptime batch_size_limit_min: {
-        var event_size_max: u32 = @sizeOf(vsr.RegisterRequest);
+    const event_size_max = comptime event_size_max: {
+        var event_size_max: u32 = 0;
         for (std.enums.values(StateMachine.Operation)) |operation| {
             const event_size = @sizeOf(StateMachine.EventType(operation));
             event_size_max = @max(event_size_max, event_size);
         }
-        break :batch_size_limit_min event_size_max;
+        break :event_size_max event_size_max;
     };
+    const batch_size_limit_min = @max(@sizeOf(vsr.RegisterRequest), event_size_max);
     const batch_size_limit: u32 = if (random.boolean())
         constants.message_body_size_max
     else
         batch_size_limit_min +
             random.uintAtMost(u32, constants.message_body_size_max - batch_size_limit_min);
+
+    const batch_per_request_limit: u32 = random.intRangeAtMost(
+        u32,
+        1,
+        @divFloor(batch_size_limit, event_size_max) - 1,
+    );
 
     const MiB = 1024 * 1024;
     const storage_size_limit = vsr.sector_floor(
@@ -209,11 +216,12 @@ pub fn main() !void {
 
     const workload_options = StateMachine.Workload.Options.generate(random, .{
         .batch_size_limit = batch_size_limit,
+        .batch_per_request_limit = batch_per_request_limit,
         .client_count = client_count,
         // TODO(DJ) Once Workload no longer needs in_flight_max, make stalled_queue_capacity
         // private. Also maybe make it dynamic (computed from the client_count instead of
         // clients_max).
-        .in_flight_max = ReplySequence.stalled_queue_capacity,
+        .in_flight_max = ReplySequence.stalled_queue_capacity * batch_per_request_limit,
     });
 
     const simulator_options = Simulator.Options{
@@ -962,12 +970,14 @@ pub const Simulator = struct {
                 }
 
                 if (!commit.prepare.header.operation.vsr_reserved()) {
+                    assert(commit.prepare.header.batch_count == commit.reply.header.batch_count);
                     simulator.workload.on_reply(
                         commit.client_index.?,
                         commit.reply.header.operation.cast(StateMachine),
                         commit.reply.header.timestamp,
                         commit.prepare.body_used(),
                         commit.reply.body_used(),
+                        commit.reply.header.batch_count,
                     );
                 }
             }
@@ -1057,6 +1067,7 @@ pub const Simulator = struct {
             request_metadata.operation,
             request_message,
             request_metadata.size,
+            request_metadata.batch_count,
         );
         // Since we already checked the client's request queue for free space, `client.request()`
         // should always queue the request.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -67,6 +67,9 @@ pub const CheckpointTrailerType = @import("vsr/checkpoint_trailer.zig").Checkpoi
 pub const GridScrubberType = @import("vsr/grid_scrubber.zig").GridScrubberType;
 pub const CountingAllocator = @import("counting_allocator.zig");
 
+pub const BatchEncoder = @import("vsr/batch.zig").BatchEncoder;
+pub const BatchDecoder = @import("vsr/batch.zig").BatchDecoder;
+
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).
 pub const Version: u16 = 0;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1269,6 +1269,7 @@ pub const Headers = struct {
             .commit = 0,
             .timestamp = 0,
             .request = 0,
+            .batch_count = 0,
         };
     }
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -25,6 +25,7 @@ pub const superblock = @import("vsr/superblock.zig");
 pub const aof = @import("aof.zig");
 pub const repl = @import("repl.zig");
 pub const statsd = @import("statsd.zig");
+pub const batch = @import("vsr/batch.zig");
 pub const lsm = .{
     .tree = @import("lsm/tree.zig"),
     .groove = @import("lsm/groove.zig"),
@@ -66,9 +67,6 @@ pub const FreeSet = @import("vsr/free_set.zig").FreeSet;
 pub const CheckpointTrailerType = @import("vsr/checkpoint_trailer.zig").CheckpointTrailerType;
 pub const GridScrubberType = @import("vsr/grid_scrubber.zig").GridScrubberType;
 pub const CountingAllocator = @import("counting_allocator.zig");
-
-pub const BatchEncoder = @import("vsr/batch.zig").BatchEncoder;
-pub const BatchDecoder = @import("vsr/batch.zig").BatchDecoder;
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.
 /// For backwards compatibility through breaking changes (e.g. upgrading checksums/ciphers).

--- a/src/vsr/batch.zig
+++ b/src/vsr/batch.zig
@@ -178,11 +178,6 @@ pub const BatchEncoder = struct {
             &.{};
     }
 
-    pub fn can_add(self: *const BatchEncoder, bytes_written: usize) bool {
-        assert(constants.verify); // Used only by tests.
-        return self.writable().len >= bytes_written;
-    }
-
     pub fn add(self: *BatchEncoder, bytes_written: usize) void {
         assert(self.buffer != null);
         assert(bytes_written % self.element_size == 0);
@@ -316,7 +311,7 @@ const test_batch = struct {
                 ) * options.element_size;
             };
 
-            try testing.expect(encoder.can_add(bytes_written));
+            try testing.expect(encoder.writable().len >= bytes_written);
 
             const slice = encoder.writable();
             @memset(std.mem.bytesAsSlice(u16, slice[0..bytes_written]), @intCast(index));
@@ -472,7 +467,7 @@ test "batch: invalid format" {
     var event_total_count: usize = 0;
     for (0..batch_count) |_| {
         const event_count = random.intRangeAtMostBiased(usize, 0, 100);
-        try testing.expect(encoder.can_add(element_size * event_count));
+        try testing.expect(encoder.writable().len >= element_size * event_count);
         encoder.add(element_size * event_count);
         event_total_count += event_count;
     }

--- a/src/vsr/batch.zig
+++ b/src/vsr/batch.zig
@@ -111,7 +111,7 @@ pub const BatchDecoder = struct {
             return null;
         }
 
-        const batch_lenght = batch_lenght: {
+        const batch_length = batch_length: {
             assert(self.batch_events.len > 0);
             maybe(self.payload.len == 0);
 
@@ -121,22 +121,22 @@ pub const BatchDecoder = struct {
             assert(batch_event_count != std.math.maxInt(u16));
             maybe(batch_event_count == 0);
 
-            const batch_lenght = batch_event_count * self.element_size;
-            assert(batch_lenght <= self.payload.len);
-            assert(batch_lenght % self.element_size == 0); // Must be aligned.
+            const batch_length = batch_event_count * self.element_size;
+            assert(batch_length <= self.payload.len);
+            assert(batch_length % self.element_size == 0); // Must be aligned.
 
-            break :batch_lenght batch_lenght;
+            break :batch_length batch_length;
         };
 
         defer {
             self.batch_events = self.batch_events[0 .. self.batch_events.len - 1];
-            self.payload = if (self.payload.len > batch_lenght)
-                self.payload[batch_lenght..]
+            self.payload = if (self.payload.len > batch_length)
+                self.payload[batch_length..]
             else
                 &.{};
         }
 
-        return self.payload[0..batch_lenght];
+        return self.payload[0..batch_length];
     }
 };
 
@@ -167,6 +167,7 @@ pub const BatchEncoder = struct {
 
         const trailer_size = batch_trailer_total_size(.{
             .element_size = self.element_size,
+            // Takes into account extra trailer bytes that will need to be included.
             .batch_count = self.batch_count + 1,
         });
 
@@ -178,6 +179,7 @@ pub const BatchEncoder = struct {
     }
 
     pub fn can_add(self: *const BatchEncoder, bytes_written: usize) bool {
+        assert(constants.verify); // Used only by tests.
         return self.writable().len >= bytes_written;
     }
 

--- a/src/vsr/batch.zig
+++ b/src/vsr/batch.zig
@@ -171,22 +171,14 @@ pub const BatchEncoder = struct {
         });
 
         const buffer: []u8 = self.buffer.?;
-        assert(buffer.len >= self.bytes_written + trailer_size);
-
-        return buffer[self.bytes_written .. buffer.len - trailer_size];
+        return if (buffer.len >= self.bytes_written + trailer_size)
+            buffer[self.bytes_written .. buffer.len - trailer_size]
+        else
+            &.{};
     }
 
     pub fn can_add(self: *const BatchEncoder, bytes_written: usize) bool {
-        assert(self.buffer != null);
-        assert(self.bytes_written % self.element_size == 0);
-
-        const trailer_size = batch_trailer_total_size(.{
-            .element_size = self.element_size,
-            .batch_count = self.batch_count + 1,
-        });
-
-        const buffer: []u8 = self.buffer.?;
-        return buffer.len >= self.bytes_written + bytes_written + trailer_size;
+        return self.writable().len >= bytes_written;
     }
 
     pub fn add(self: *BatchEncoder, bytes_written: usize) void {

--- a/src/vsr/batch.zig
+++ b/src/vsr/batch.zig
@@ -13,7 +13,7 @@ const vsr = @import("../vsr.zig");
 /// space occupied by the trailer may be larger, as it must align with the element size.
 /// In the case of operations where `element_size` is zero, the trailer must be aligned
 /// to `@alignOf(u16)` (2 bytes).
-fn trailer_total_size(options: struct {
+pub fn batch_trailer_total_size(options: struct {
     element_size: usize,
     batch_count: u16,
 }) usize {
@@ -46,7 +46,7 @@ pub const BatchDecoder = struct {
         assert(body.len > 0);
         assert(element_size == 0 or body.len % element_size == 0);
 
-        const trailer_size = trailer_total_size(.{
+        const trailer_size = batch_trailer_total_size(.{
             .element_size = element_size,
             .batch_count = batch_count,
         });
@@ -155,7 +155,7 @@ pub const BatchEncoder = struct {
         assert(self.buffer != null);
         assert(self.bytes_written % self.element_size == 0);
 
-        const trailer_size = trailer_total_size(.{
+        const trailer_size = batch_trailer_total_size(.{
             .element_size = self.element_size,
             .batch_count = self.batch_count + 1,
         });
@@ -170,7 +170,7 @@ pub const BatchEncoder = struct {
         assert(self.buffer != null);
         assert(self.bytes_written % self.element_size == 0);
 
-        const trailer_size = trailer_total_size(.{
+        const trailer_size = batch_trailer_total_size(.{
             .element_size = self.element_size,
             .batch_count = self.batch_count + 1,
         });
@@ -187,7 +187,7 @@ pub const BatchEncoder = struct {
         self.batch_count += 1;
         self.bytes_written += bytes_written;
 
-        const trailer_size = trailer_total_size(.{
+        const trailer_size = batch_trailer_total_size(.{
             .element_size = self.element_size,
             .batch_count = self.batch_count,
         });
@@ -220,7 +220,7 @@ pub const BatchEncoder = struct {
 
         const buffer = self.buffer.?;
 
-        const trailer_size = trailer_total_size(.{
+        const trailer_size = batch_trailer_total_size(.{
             .element_size = self.element_size,
             .batch_count = self.batch_count,
         });
@@ -275,7 +275,7 @@ const test_batch = struct {
         const expected = try allocator.alloc(u16, options.batch_count);
         defer allocator.free(expected);
 
-        const trailer_size = trailer_total_size(.{
+        const trailer_size = batch_trailer_total_size(.{
             .element_size = options.element_size,
             .batch_count = options.batch_count,
         });
@@ -377,7 +377,7 @@ test "batch: maximum batches with no elements" {
 
     const batch_count = std.math.maxInt(u16);
     const element_size = 128;
-    const buffer_size = trailer_total_size(.{
+    const buffer_size = batch_trailer_total_size(.{
         .element_size = element_size,
         .batch_count = batch_count,
     });

--- a/src/vsr/batch.zig
+++ b/src/vsr/batch.zig
@@ -1,0 +1,442 @@
+const std = @import("std");
+const testing = std.testing;
+
+const stdx = @import("../stdx.zig");
+const assert = std.debug.assert;
+const maybe = stdx.maybe;
+
+const constants = @import("../constants.zig");
+const vsr = @import("../vsr.zig");
+
+/// The trailer is a `[]u16` containing the number of elements in each batch.
+/// To encode the trailer, `batch_count * @sizeOf(u16)` bytes are needed, but the total
+/// space occupied by the trailer may be larger, as it must align with the element size.
+/// In the case of operations where `element_size` is zero, the trailer must be aligned
+/// to `@alignOf(u16)` (2 bytes).
+fn trailer_total_size(options: struct {
+    element_size: usize,
+    batch_count: u16,
+}) usize {
+    assert(options.batch_count > 0);
+    maybe(options.element_size == 0);
+    const alignment = @max(options.element_size, @alignOf(u16));
+    return stdx.div_ceil(
+        @as(usize, options.batch_count) * @sizeOf(u16),
+        alignment,
+    ) * alignment;
+}
+
+pub const BatchDecoder = struct {
+    /// The batch element size.
+    element_size: usize,
+    /// The message body, excluding the trailer containing the batch metadata.
+    payload: []const u8,
+    /// The batching metadata, containing the number of events for each batch.
+    batch_events: []const u16,
+
+    pub fn init(
+        /// The size of each element.
+        element_size: usize,
+        /// The message body used, including the trailer.
+        body: []const u8,
+        /// The number of batches encoded in this body.
+        batch_count: u16,
+    ) BatchDecoder {
+        assert(batch_count > 0);
+        assert(body.len > 0);
+        assert(element_size == 0 or body.len % element_size == 0);
+
+        const trailer_size = trailer_total_size(.{
+            .element_size = element_size,
+            .batch_count = batch_count,
+        });
+        if (element_size == 0) {
+            assert(body.len == trailer_size);
+        } else {
+            assert(body.len >= trailer_size);
+        }
+
+        const payload: []const u8 = @alignCast(body[0 .. body.len - trailer_size]);
+        if (element_size == 0) {
+            assert(payload.len == 0);
+        } else {
+            assert(payload.len % element_size == 0);
+        }
+
+        const batch_events: []const u16 = @alignCast(
+            std.mem.bytesAsSlice(u16, body[body.len - trailer_size ..]),
+        );
+        assert(batch_events.len >= batch_count);
+
+        const batch_events_used = batch_events[batch_events.len - batch_count ..];
+        assert(batch_events_used.len == batch_count);
+
+        if (constants.verify) {
+            if (batch_events.len > batch_count) {
+                // MaxInt is used as sentinel for the extra slots used for alignment.
+                assert(std.mem.allEqual(
+                    u16,
+                    batch_events[0 .. batch_events.len - batch_count],
+                    std.math.maxInt(u16),
+                ));
+            }
+
+            if (element_size > 0) {
+                var events_count_total: usize = 0;
+                for (batch_events_used) |count| events_count_total += count;
+                assert(payload.len == events_count_total * element_size);
+            }
+        }
+
+        return .{
+            .element_size = element_size,
+            .payload = payload,
+            .batch_events = batch_events_used,
+        };
+    }
+
+    pub fn next(self: *BatchDecoder) ?[]const u8 {
+        if (self.batch_events.len == 0) {
+            assert(self.payload.len == 0);
+            return null;
+        }
+
+        const batch_lenght = batch_lenght: {
+            assert(self.batch_events.len > 0);
+            maybe(self.payload.len == 0);
+
+            // Batch metadata is written from the end of the message, so the last
+            // element corresponds to the first batch.
+            const batch_event_count = self.batch_events[self.batch_events.len - 1];
+            assert(batch_event_count != std.math.maxInt(u16));
+            maybe(batch_event_count == 0);
+
+            const batch_lenght = batch_event_count * self.element_size;
+            assert(batch_lenght <= self.payload.len);
+            assert(batch_lenght % self.element_size == 0); // Must be aligned.
+
+            break :batch_lenght batch_lenght;
+        };
+
+        defer {
+            self.batch_events = self.batch_events[0 .. self.batch_events.len - 1];
+            self.payload = if (self.payload.len > batch_lenght)
+                self.payload[batch_lenght..]
+            else
+                &.{};
+        }
+
+        return self.payload[0..batch_lenght];
+    }
+};
+
+pub const BatchEncoder = struct {
+    element_size: usize,
+    buffer: ?[]u8,
+    bytes_written: usize,
+    batch_count: u16,
+
+    pub fn init(
+        element_size: usize,
+        buffer: []u8,
+    ) BatchEncoder {
+        assert(buffer.len > 0);
+        assert(element_size == 0 or buffer.len % element_size == 0);
+
+        return .{
+            .element_size = element_size,
+            .buffer = buffer,
+            .bytes_written = 0,
+            .batch_count = 0,
+        };
+    }
+
+    pub fn writable(self: *const BatchEncoder) []u8 {
+        assert(self.buffer != null);
+        assert(self.bytes_written % self.element_size == 0);
+
+        const trailer_size = trailer_total_size(.{
+            .element_size = self.element_size,
+            .batch_count = self.batch_count + 1,
+        });
+
+        const buffer: []u8 = self.buffer.?;
+        assert(buffer.len >= self.bytes_written + trailer_size);
+
+        return buffer[self.bytes_written .. buffer.len - trailer_size];
+    }
+
+    pub fn can_add(self: *const BatchEncoder, bytes_written: usize) bool {
+        assert(self.buffer != null);
+        assert(self.bytes_written % self.element_size == 0);
+
+        const trailer_size = trailer_total_size(.{
+            .element_size = self.element_size,
+            .batch_count = self.batch_count + 1,
+        });
+
+        const buffer: []u8 = self.buffer.?;
+        return buffer.len >= self.bytes_written + bytes_written + trailer_size;
+    }
+
+    pub fn add(self: *BatchEncoder, bytes_written: usize) void {
+        assert(self.buffer != null);
+        assert(bytes_written % self.element_size == 0);
+
+        const buffer: []u8 = self.buffer.?;
+        self.batch_count += 1;
+        self.bytes_written += bytes_written;
+
+        const trailer_size = trailer_total_size(.{
+            .element_size = self.element_size,
+            .batch_count = self.batch_count,
+        });
+        assert(buffer.len >= self.bytes_written + trailer_size);
+
+        const batch_events: []u16 = @alignCast(std.mem.bytesAsSlice(
+            u16,
+            buffer[buffer.len - trailer_size ..],
+        ));
+        assert(batch_events.len >= self.batch_count);
+
+        // Batch metadata is written from the end of the message, so the last
+        // element corresponds to the first batch.
+        const batch_event_index = batch_events.len - self.batch_count;
+        if (self.element_size > 0) {
+            maybe(bytes_written == 0);
+            batch_events[batch_event_index] = @intCast(@divExact(bytes_written, self.element_size));
+        } else {
+            assert(bytes_written == 0);
+            batch_events[batch_event_index] = 0;
+        }
+    }
+
+    pub fn finish(self: *BatchEncoder) void {
+        assert(self.buffer != null);
+        assert(self.batch_count > 0);
+        assert(self.bytes_written % self.element_size == 0);
+        assert(self.buffer.?.len > self.bytes_written);
+        maybe(self.bytes_written == 0);
+
+        const buffer = self.buffer.?;
+
+        const trailer_size = trailer_total_size(.{
+            .element_size = self.element_size,
+            .batch_count = self.batch_count,
+        });
+        assert(buffer.len >= self.bytes_written + trailer_size);
+
+        const batch_events: []u16 = @alignCast(std.mem.bytesAsSlice(
+            u16,
+            buffer[self.bytes_written..][0..trailer_size],
+        ));
+
+        // Filling in the extra alignment bytes with `maxInt`.
+        @memset(
+            batch_events[0 .. batch_events.len - self.batch_count],
+            std.math.maxInt(u16),
+        );
+        // While batches are being encoded, the trailer is written at the end of the buffer.
+        // Once all batches are encoded, the trailer needs to be moved closer to the last
+        // element written, along with sentinels to maintain alignment.
+        const source: []u16 = @alignCast(std.mem.bytesAsSlice(
+            u16,
+            buffer[buffer.len - (@as(usize, self.batch_count) * @sizeOf(u16)) ..],
+        ));
+        const target: []u16 = batch_events[batch_events.len - self.batch_count ..];
+        assert(@intFromPtr(target.ptr) <= @intFromPtr(source.ptr));
+        assert(target.len == source.len);
+        if (target.ptr != source.ptr) {
+            stdx.copy_left(
+                .exact,
+                u16,
+                target,
+                source,
+            );
+        }
+
+        // Update `bytes_written` to include the trailer and
+        // set buffer to null to prevent misuse.
+        self.buffer = null;
+        self.bytes_written = self.bytes_written + trailer_size;
+        assert(self.bytes_written % self.element_size == 0);
+    }
+};
+
+const test_batch = struct {
+    fn run(options: struct {
+        random: std.rand.Random,
+        element_size: usize,
+        buffer: []u8,
+        batch_count: u16,
+        elements_per_batch: ?u32 = null,
+    }) !usize {
+        const allocator = testing.allocator;
+        const expected = try allocator.alloc(u16, options.batch_count);
+        defer allocator.free(expected);
+
+        const trailer_size = trailer_total_size(.{
+            .element_size = options.element_size,
+            .batch_count = options.batch_count,
+        });
+
+        // Cleaning the buffer first, so it can assert the bytes.
+        @memset(options.buffer, std.math.maxInt(u8));
+
+        var encoder = BatchEncoder.init(options.element_size, options.buffer);
+        for (0..options.batch_count) |index| {
+            const bytes_available = options.buffer.len - encoder.bytes_written - trailer_size;
+
+            const bytes_written: usize = if (options.elements_per_batch) |elements_per_batch|
+                elements_per_batch * options.element_size
+            else random: {
+                if (index == options.batch_count - 1) {
+                    const batch_full = options.random.uintLessThanBiased(u8, 100) < 30;
+                    if (batch_full) break :random bytes_available;
+                }
+
+                const batch_empty = options.random.uintLessThanBiased(u8, 100) < 30;
+                if (batch_empty) break :random 0;
+
+                break :random @divFloor(
+                    options.random.intRangeAtMostBiased(usize, 0, bytes_available),
+                    options.element_size,
+                ) * options.element_size;
+            };
+
+            try testing.expect(encoder.can_add(bytes_written));
+
+            const slice = encoder.writable();
+            @memset(std.mem.bytesAsSlice(u16, slice[0..bytes_written]), @intCast(index));
+            encoder.add(bytes_written);
+
+            expected[index] = @intCast(@divExact(bytes_written, options.element_size));
+        }
+        encoder.finish();
+        try testing.expect(encoder.batch_count == options.batch_count);
+
+        var decoder = BatchDecoder.init(
+            options.element_size,
+            options.buffer[0..encoder.bytes_written],
+            encoder.batch_count,
+        );
+        var batch_read_index: usize = 0;
+        while (decoder.next()) |batch| : (batch_read_index += 1) {
+            const event_count = @divExact(batch.len, options.element_size);
+            try testing.expect(expected[batch_read_index] == event_count);
+            try testing.expect(std.mem.allEqual(
+                u16,
+                @alignCast(std.mem.bytesAsSlice(u16, batch)),
+                @intCast(batch_read_index),
+            ));
+        }
+        try testing.expect(options.batch_count == batch_read_index);
+
+        return encoder.bytes_written;
+    }
+};
+
+test "batch: encode/decode" {
+    var rng = std.rand.DefaultPrng.init(42);
+    const buffer = try testing.allocator.alignedAlloc(
+        u8,
+        @alignOf(vsr.Header),
+        constants.message_body_size_max,
+    );
+    defer testing.allocator.free(buffer);
+
+    for (0..2048) |_| {
+        const random = rng.random();
+
+        // Element size ranging from 2^4 to 2^8:
+        const element_size = std.math.pow(
+            usize,
+            2,
+            random.intRangeAtMostBiased(usize, 4, 8),
+        );
+
+        // The maximum `batch_count` is a `u16`.
+        // Depending on the element size, this limit can overflow. However, it is large enough
+        // to support a 1MiB message body with batches containing a single 16-byte element each.
+        const batch_count_max: u16 = @intCast(@divExact(buffer.len, element_size) - 1);
+        const batch_count = random.intRangeAtMostBiased(u16, 1, batch_count_max);
+
+        _ = try test_batch.run(.{
+            .random = random,
+            .element_size = element_size,
+            .buffer = buffer,
+            .batch_count = batch_count,
+        });
+    }
+}
+
+// The maximum number of batches, all with zero elements.
+test "batch: maximum batches with no elements" {
+    var rng = std.rand.DefaultPrng.init(42);
+    const random = rng.random();
+
+    const batch_count = std.math.maxInt(u16);
+    const element_size = 128;
+    const buffer_size = trailer_total_size(.{
+        .element_size = element_size,
+        .batch_count = batch_count,
+    });
+
+    const buffer = try testing.allocator.alignedAlloc(
+        u8,
+        @alignOf(vsr.Header),
+        buffer_size,
+    );
+    defer testing.allocator.free(buffer);
+    const written_bytes = try test_batch.run(.{
+        .random = random,
+        .element_size = element_size,
+        .buffer = buffer,
+        .batch_count = batch_count,
+        .elements_per_batch = 0,
+    });
+    try testing.expectEqual(buffer_size, written_bytes);
+}
+
+// The maximum number of batches, when each one has one single element.
+test "batch: maximum batches with a single element" {
+    var rng = std.rand.DefaultPrng.init(42);
+    const random = rng.random();
+
+    const element_size = 128;
+    const buffer_size = (1024 * 1024) - @sizeOf(vsr.Header); // 1MiB message.
+    const batch_count_max: u16 = @divExact(buffer_size, (element_size + @sizeOf(u16)));
+
+    const buffer = try testing.allocator.alignedAlloc(u8, @alignOf(vsr.Header), buffer_size);
+    defer testing.allocator.free(buffer);
+    const written_bytes = try test_batch.run(.{
+        .random = random,
+        .element_size = element_size,
+        .buffer = buffer,
+        .batch_count = batch_count_max,
+        .elements_per_batch = 1,
+    });
+    try testing.expectEqual(buffer_size, written_bytes);
+}
+
+// The maximum number of elements on a single batch.
+test "batch: maximum elements on a single batch" {
+    var rng = std.rand.DefaultPrng.init(42);
+    const random = rng.random();
+
+    const element_size = 128;
+    const buffer_size = (1024 * 1024) - @sizeOf(vsr.Header); // 1MiB message.
+    const batch_size_max = 8189; // maximum number of elements in a single-batch request.
+    assert(batch_size_max == @divExact(buffer_size - element_size, element_size));
+
+    const buffer = try testing.allocator.alignedAlloc(u8, @alignOf(vsr.Header), buffer_size);
+    defer testing.allocator.free(buffer);
+    const written_bytes = try test_batch.run(.{
+        .random = random,
+        .element_size = element_size,
+        .buffer = buffer,
+        .batch_count = 1,
+        .elements_per_batch = batch_size_max,
+    });
+    try testing.expectEqual(buffer_size, written_bytes);
+}

--- a/src/vsr/batch.zig
+++ b/src/vsr/batch.zig
@@ -262,6 +262,14 @@ pub const BatchEncoder = struct {
         self.buffer = null;
         self.bytes_written = self.bytes_written + trailer_size;
         assert(self.bytes_written % self.element_size == 0);
+
+        if (constants.verify) {
+            assert(BatchDecoder.init(
+                self.element_size,
+                buffer[0..self.bytes_written],
+                self.batch_count,
+            ) != error.BatchInvalid);
+        }
     }
 };
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -258,6 +258,7 @@ pub fn ClientType(
                 .command = .request,
                 .operation = .register,
                 .release = self.release,
+                .batch_count = 0,
             };
 
             std.mem.bytesAsValue(
@@ -315,6 +316,7 @@ pub fn ClientType(
                 .release = self.release,
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @intCast(@sizeOf(Header) + events.len),
+                .batch_count = 0,
             };
 
             stdx.copy_disjoint(.exact, u8, message.body_used(), events);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -560,7 +560,7 @@ pub const Header = extern struct {
                             return "reconfigure: size != @sizeOf(Header)" ++
                                 " + @sizeOf(ReconfigurationRequest)";
                         }
-                        if (self.batch_count != 0) return "reconfigure: upgrade: batch_count != 0";
+                        if (self.batch_count != 0) return "reconfigure: batch_count != 0";
                     } else if (@intFromEnum(self.operation) < constants.vsr_operations_reserved) {
                         return "operation is reserved";
                     }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -27,6 +27,8 @@ const Command = vsr.Command;
 const Version = vsr.Version;
 const SyncStage = vsr.SyncStage;
 const ClientSessions = vsr.ClientSessions;
+const BatchDecoder = vsr.BatchDecoder;
+const BatchEncoder = vsr.BatchEncoder;
 
 const log = marks.wrap_log(stdx.log.scoped(.replica));
 
@@ -4222,13 +4224,31 @@ pub fn ReplicaType(
             }
 
             if (StateMachine.operation_from_vsr(prepare.header.operation)) |prepare_operation| {
+                const body: []const u8 = body: {
+                    if (prepare.header.batch_count == 0) break :body prepare.body_used();
+
+                    // If it's a batched request, the message body must be decoded to
+                    // remove the trailer.
+                    // The `prefech` can process all batches at once.
+                    const event_size = StateMachine.event_size_bytes(
+                        prepare.header.release,
+                        prepare_operation,
+                    );
+                    const decoder = BatchDecoder.init(
+                        event_size,
+                        prepare.body_used(),
+                        prepare.header.batch_count,
+                    );
+
+                    break :body decoder.payload;
+                };
                 self.state_machine.prefetch_timestamp = prepare.header.timestamp;
                 self.state_machine.prefetch(
                     commit_prefetch_callback,
                     prepare.header.release,
                     prepare.header.op,
                     prepare_operation,
-                    prepare.body_used(),
+                    body,
                 );
                 return .pending;
             } else {
@@ -4751,15 +4771,80 @@ pub fn ReplicaType(
                     reply.buffer[@sizeOf(Header)..],
                 ),
                 .upgrade => self.execute_op_upgrade(prepare, reply.buffer[@sizeOf(Header)..]),
-                else => self.state_machine.commit(
-                    prepare.header.client,
-                    prepare.header.release,
-                    prepare.header.op,
-                    prepare.header.timestamp,
-                    prepare.header.operation.cast(StateMachine),
-                    prepare.body_used(),
-                    reply.buffer[@sizeOf(Header)..],
-                ),
+                else => reply_body_size: {
+                    const operation = prepare.header.operation.cast(StateMachine);
+                    if (prepare.header.batch_count == 0) {
+                        // No batching required, commiting the entire payload at once.
+                        const bytes_written = self.state_machine.commit(
+                            prepare.header.client,
+                            prepare.header.release,
+                            prepare.header.op,
+                            prepare.header.timestamp,
+                            operation,
+                            prepare.body_used(),
+                            reply.buffer[@sizeOf(Header)..],
+                        );
+                        break :reply_body_size bytes_written;
+                    } else {
+                        var body_decoder = BatchDecoder.init(
+                            StateMachine.event_size_bytes(prepare.header.release, operation),
+                            prepare.body_used(), // The message's with the trailer.
+                            prepare.header.batch_count,
+                        );
+                        var reply_encoder = BatchEncoder.init(
+                            StateMachine.result_size_bytes(prepare.header.release, operation),
+                            reply.buffer[@sizeOf(Header)..],
+                        );
+
+                        var prepare_timestamp: u64 = prepare.header.timestamp -
+                            self.state_machine.prepare_nanoseconds(
+                            prepare.header.release,
+                            operation,
+                            body_decoder.payload, // The entire message's body without the trailer.
+                        );
+                        log.debug(
+                            "{}: execute_op: batch_count={} operation={s}",
+                            .{ self.replica, prepare.header.batch_count, @tagName(operation) },
+                        );
+
+                        while (body_decoder.next()) |batch| {
+                            // Commit each batched set of events
+                            // using the timestamp of the highest result of the response.
+                            prepare_timestamp += self.state_machine.prepare_nanoseconds(
+                                prepare.header.release,
+                                operation,
+                                batch, // The batch's body.
+                            );
+                            const bytes_written = self.state_machine.commit(
+                                prepare.header.client,
+                                prepare.header.release,
+                                prepare.header.op,
+                                prepare_timestamp,
+                                operation,
+                                batch,
+                                reply_encoder.writable(),
+                            );
+                            reply_encoder.add(bytes_written);
+
+                            log.debug(
+                                "{}: execute_op: batch={} elements={} " ++
+                                    "prepare_timestamp={} commit_timestamp={}",
+                                .{
+                                    self.replica,
+                                    reply_encoder.batch_count,
+                                    @divExact(batch.len, body_decoder.element_size),
+                                    prepare_timestamp,
+                                    self.state_machine.commit_timestamp,
+                                },
+                            );
+                        }
+                        reply_encoder.finish();
+                        assert(reply_encoder.batch_count == prepare.header.batch_count);
+                        assert(prepare_timestamp == prepare.header.timestamp);
+
+                        break :reply_body_size reply_encoder.bytes_written;
+                    }
+                },
             };
 
             assert(self.state_machine.commit_timestamp <= prepare.header.timestamp or
@@ -4797,7 +4882,7 @@ pub fn ReplicaType(
                 .timestamp = prepare.header.timestamp,
                 .commit = prepare.header.op,
                 .size = @sizeOf(Header) + @as(u32, @intCast(reply_body_size)),
-                .batch_count = 0,
+                .batch_count = prepare.header.batch_count,
             };
             assert(reply.header.epoch == 0);
 
@@ -6520,10 +6605,30 @@ pub fn ReplicaType(
                     }
                 },
                 else => {
-                    self.state_machine.prepare(
+                    const operation = request.message.header.operation.cast(StateMachine);
+                    const body: []const u8 = body: {
+                        if (request.message.header.batch_count == 0) {
+                            break :body request.message.body_used();
+                        }
+
+                        // If it's a batched request, the message body must be decoded to
+                        // remove the trailer.
+                        const event_size = StateMachine.event_size_bytes(
+                            request.message.header.release,
+                            operation,
+                        );
+                        const decoder = BatchDecoder.init(
+                            event_size,
+                            request.message.body_used(),
+                            request.message.header.batch_count,
+                        );
+
+                        break :body decoder.payload;
+                    };
+                    self.state_machine.prepare_timestamp += self.state_machine.prepare_nanoseconds(
                         request.message.header.release,
-                        request.message.header.operation.cast(StateMachine),
-                        request.message.body_used(),
+                        operation,
+                        body,
                     );
                 },
             }
@@ -6569,7 +6674,7 @@ pub fn ReplicaType(
                 },
                 .request = request_header.request,
                 .operation = request_header.operation,
-                .batch_count = 0,
+                .batch_count = request_header.batch_count,
             };
             message.header.set_checksum_body(message.body_used());
             message.header.set_checksum();

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4229,7 +4229,7 @@ pub fn ReplicaType(
 
                     // If it's a batched request, the message body must be decoded to
                     // remove the trailer.
-                    // The `prefech` can process all batches at once.
+                    // The `prefetch` can process all batches at once.
                     const event_size = StateMachine.event_size_bytes(
                         prepare.header.release,
                         prepare_operation,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4238,7 +4238,7 @@ pub fn ReplicaType(
                         event_size,
                         prepare.body_used(),
                         prepare.header.batch_count,
-                    );
+                    ) catch unreachable; // Validated during `ignore_request_message()`.
 
                     break :body decoder.payload;
                 };
@@ -4790,7 +4790,7 @@ pub fn ReplicaType(
                             StateMachine.event_size_bytes(prepare.header.release, operation),
                             prepare.body_used(), // The message's with the trailer.
                             prepare.header.batch_count,
-                        );
+                        ) catch unreachable; // Validated during `ignore_request_message()`.
                         var reply_encoder = BatchEncoder.init(
                             StateMachine.result_size_bytes(prepare.header.release, operation),
                             reply.buffer[@sizeOf(Header)..],
@@ -5697,17 +5697,42 @@ pub fn ReplicaType(
                 return true;
             }
             if (StateMachine.operation_from_vsr(message.header.operation)) |operation| {
-                if (!self.state_machine.input_valid(
-                    message.header.release,
-                    operation,
-                    message.body_used(),
-                )) {
+                const input_valid = input_valid: {
+                    if (message.header.batch_count == 0) {
+                        break :input_valid self.state_machine.input_valid(
+                            message.header.release,
+                            operation,
+                            message.body_used(),
+                        );
+                    } else {
+                        const decoder = BatchDecoder.init(
+                            StateMachine.event_size_bytes(
+                                message.header.release,
+                                operation,
+                            ),
+                            message.body_used(),
+                            message.header.batch_count,
+                        ) catch |err| switch (err) {
+                            error.BatchInvalid => break :input_valid false,
+                        };
+
+                        break :input_valid self.state_machine.input_valid(
+                            message.header.release,
+                            operation,
+                            decoder.payload,
+                        );
+                    }
+                };
+
+                if (!input_valid) {
                     log.warn(
-                        "{}: on_request: ignoring invalid body (operation={s}, body.len={})",
+                        "{}: on_request: ignoring invalid body " ++
+                            "(operation={s}, body.len={}, batch_count={})",
                         .{
                             self.replica,
                             @tagName(operation),
                             message.body_used().len,
+                            message.header.batch_count,
                         },
                     );
                     self.send_eviction_message_to_client(
@@ -6626,7 +6651,7 @@ pub fn ReplicaType(
                             event_size,
                             request.message.body_used(),
                             request.message.header.batch_count,
-                        );
+                        ) catch unreachable; // Validated during `ignore_request_message()`.
 
                         break :body decoder.payload;
                     };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4797,6 +4797,7 @@ pub fn ReplicaType(
                 .timestamp = prepare.header.timestamp,
                 .commit = prepare.header.op,
                 .size = @sizeOf(Header) + @as(u32, @intCast(reply_body_size)),
+                .batch_count = 0,
             };
             assert(reply.header.epoch == 0);
 
@@ -6568,6 +6569,7 @@ pub fn ReplicaType(
                 },
                 .request = request_header.request,
                 .operation = request_header.operation,
+                .batch_count = 0,
             };
             message.header.set_checksum_body(message.body_used());
             message.header.set_checksum();
@@ -10267,6 +10269,7 @@ pub fn ReplicaType(
                 .parent = 0,
                 .client = 0,
                 .session = 0,
+                .batch_count = 0,
             };
 
             stdx.copy_disjoint(.exact, u8, request.body_used(), body);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -27,8 +27,8 @@ const Command = vsr.Command;
 const Version = vsr.Version;
 const SyncStage = vsr.SyncStage;
 const ClientSessions = vsr.ClientSessions;
-const BatchDecoder = vsr.BatchDecoder;
-const BatchEncoder = vsr.BatchEncoder;
+const BatchDecoder = vsr.batch.BatchDecoder;
+const BatchEncoder = vsr.batch.BatchEncoder;
 
 const log = marks.wrap_log(stdx.log.scoped(.replica));
 
@@ -4803,8 +4803,13 @@ pub fn ReplicaType(
                             body_decoder.payload, // The entire message's body without the trailer.
                         );
                         log.debug(
-                            "{}: execute_op: batch_count={} operation={s}",
-                            .{ self.replica, prepare.header.batch_count, @tagName(operation) },
+                            "{}: execute_op: op={} batch_count={} operation={s}",
+                            .{
+                                self.replica,
+                                prepare.header.op,
+                                prepare.header.batch_count,
+                                @tagName(operation),
+                            },
                         );
 
                         while (body_decoder.next()) |batch| {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2498,7 +2498,13 @@ const TestClients = struct {
 
                         const body_size = 123;
                         @memset(message.buffer[@sizeOf(vsr.Header)..][0..body_size], 42);
-                        t.cluster.request(c, .echo, message, body_size);
+                        t.cluster.request(
+                            c,
+                            .echo,
+                            message,
+                            body_size,
+                            0,
+                        );
                     }
                 }
             }

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1513,6 +1513,7 @@ test "Cluster: client: empty command=request operation=register body" {
         .command = .request,
         .operation = .register,
         .release = releases[0].release,
+        .batch_count = 0,
     };
     request_header.set_checksum_body(&.{}); // Note the absence of a `vsr.RegisterRequest`.
     request_header.set_checksum();


### PR DESCRIPTION
### VSR Protocol Batching

This PR replaces the state machine batching mechanism (aka `Demuxer`) with protocol-integrated batching. Batching consists of the application submitting multiple independent units of work of the same `operation` (the batch payload) within a single VSR message. This amortizes network and consensus costs, enhancing performance in scenarios where highly concurrent user requests submit operations containing only a few events each, sharing the same physical request.

Previously, batching relied on the offset of each payload within the message, splitting the reply based on the `index` of each `Result` type. While this method already improved performance, it was only applicable to operations where the number of events directly correlated with the number of results. Each result had to be tagged with an `index` field indicating the corresponding event that generated it. In practice, batching was only applicable for the `create_accounts` and `create_transfers` operations.

The new batching mechanism is more versatile and can be applied to any state machine operation _capable of handling multiple events_ (queries are not supported yet, but lookups are). It eliminates the need for the state machine to be aware of batched requests by operating at the VSR protocol level, enabling custom state machines to take advantage of it as well.

#### VSR Changes

The VSR header for `request`, `prepare`, and `reply` messages now includes the `batch_count` field, which indicates whether a request is batched.

**`batch_count == 0`**: Treated as a non-batched request, skipping batching logic.
**`batch_count > 0`**: Indicates a batched request that should be split into multiple batch payloads.

Clients from older versions, which are unaware of the `batch_count` field, will always send non-batched requests (`batch_count == 0`), ensuring compatibility with the new protocol version.

**How it works:**

- The client (`tb_client` library) is responsible for accumulating concurrent requests, encoding them into batches, and sending them as a single VSR request.

- Upon receiving a batched request, the replica decodes the message body, splits it into multiple batch payloads based on `batch_count`, and feeds the state machine with independent units of work within the same VSR `op` number.

- Each batch may generate a number of `result`s unrelated to the number of `event`s (e.g., `lookup_accounts` and `lookup_transfers`), which are batched together and sent back to the client.

- The client decodes the reply's body into multiple batch payloads and calls the respective user callback for each one.

**Message layout:**

- Batched requests use a portion at the end of the message body (the batch `trailer`) to encode batch metadata, so batched requests can hold fewer events than non-batched ones.

- The `trailer` size is always a multiple of the `event`/`result` size to keep system invariants.

  - The batch `trailer` is an array of `u16` values representing the _number of events_ in each batch, as defined by the `batch_count` field in the VSR header.

  - The `trailer` has a variable length, depending on the number of batches (one `u16` per batch, in multiples of the `event`/`result` size).

  - To facilitate batch encoding, the trailer is written from the end of the message towards the beginning. For example, the last element of the array corresponds to the number of events in the first batch.

  - Unused elements in the trailer, required for padding, are filled with `maxInt(u16)`.

  Examples:
  For a request with `@sizeOf(Account) == 128` and  `batch_count == 100`, the trailer size will be **256 bytes**.
  For a reply with `@sizeOf(CreateAccountsResult) == 8` and `batch_count == 100`, the trailer size will be **200 bytes**.

```
size == 1280         message.body_used().len == 1024 bytes    
batch_count == 4     payload == 896 bytes                     trailer == 128 bytes 
┌──────────┐ ┌─────────────────────────────────────────────┐┌─────────────────────┐
│          │ │┌─────────┐┌───────────┐┌───────┐┌──────────┐││┌───────┐┌─┐┌─┐┌─┐┌─┐│
│VSR Header│ ││512 bytes││ 128 bytes ││0 bytes││ 256 bytes││││padding││2││0││1││4││
│          │ │└───▲─────┘└───▲───────┘└──▲────┘└───▲──────┘││└───────┘└┬┘└┬┘└┬┘└┬┘│
└──────────┘ └────┼──────────┼───────────┼─────────┼───────┘└──────────┼──┼──┼──┼─┘
                  │          │           │         │                   │  │  │  │  
                  │          │           │         └───────────────────┘  │  │  │  
                  │          │           │                                │  │  │  
                  │          │           └────────────────────────────────┘  │  │  
                  │          │                                               │  │  
                  │          └───────────────────────────────────────────────┘  │  
                  │                                                             │  
                  └─────────────────────────────────────────────────────────────┘  
```

- The `tb_client` avoids batching user requests if the combined payload length and trailer exceed the maximum message body size. Instead, it sends a non-batched request (`batch_count == 0`) to preserve maximum capacity (8190 events per message).

- The client can pack as many batches as the sum of payloads + trailer allows (e.g., up to 8064 single-event batches of `create_accounts` and `create_transfers`, that is VSR Header + 8064 events * 128 bytes + `[8064]u16` of `trailer` == 1MiB message).

### This PR

See the commit messages for the implementation details.
Include VOPR and Vortex (java driver only) tests.