### PR TITLE
VSR: Ratchet table state-sync progress

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -613,6 +613,28 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             }
         }
 
+        /// Returns whether the forest contains this table (ignoring snapshot_max) at any level.
+        pub fn contains_table(
+            forest: *const Forest,
+            table: *const schema.ManifestNode.TableInfo,
+        ) bool {
+            switch (tree_id_cast(table.tree_id)) {
+                inline else => |tree_id| {
+                    const tree = forest.tree_for_id_const(tree_id);
+                    const Tree = Forest.TreeForIdType(tree_id);
+                    const tree_table = Tree.Manifest.TreeTableInfo.decode(table);
+                    for (&tree.manifest.levels) |manifest_level| {
+                        if (manifest_level.find(&tree_table)) |level_table| {
+                            assert(table.checksum == level_table.table_info.checksum);
+                            assert(table.snapshot_max <= level_table.table_info.snapshot_max);
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+            }
+        }
+
         /// Verify that `ManifestLog.table_extents` has an extent for every active table.
         ///
         /// (Invoked between beats.)

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -100,12 +100,14 @@ const assert = std.debug.assert;
 const log = std.log.scoped(.trace);
 
 const constants = @import("constants.zig");
+const sync = @import("vsr/sync.zig");
 
 const trace_span_size_max = 1024;
 
 pub const Event = union(enum) {
     replica_commit,
     replica_aof_write,
+    replica_sync_stage,
     replica_sync_table: struct { index: usize },
 
     compact_beat,
@@ -147,6 +149,7 @@ pub const Event = union(enum) {
     const event_stack_cardinality = std.enums.EnumArray(EventTag, u32).init(.{
         .replica_commit = 1,
         .replica_aof_write = 1,
+        .replica_sync_stage = 1,
         .replica_sync_table = constants.grid_missing_tables_max,
         .compact_beat = 1,
         .compact_beat_merge = 1,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9106,6 +9106,13 @@ pub fn ReplicaType(
                 @tagName(self.syncing),
             });
 
+            if (state_old != .idle) {
+                self.trace.stop(.replica_sync_stage, .{ .stage = @tagName(state_old) });
+            }
+            if (state_new != .idle) {
+                self.trace.start(.replica_sync_stage, .{ .stage = @tagName(state_new) });
+            }
+
             if (self.event_callback) |hook| hook(self, .sync_stage_changed);
 
             switch (self.syncing) {


### PR DESCRIPTION
## Context

If a replica is lagging behind and state syncs, it often won't finish syncing the tables before the cluster has checkpointed again. And that next checkpoint will kick off table sync all over again.

## Fix

When we kick off a new state sync, don't abandon the progress we have made so far syncing tables. Instead, continue with the old table sync, and then when we finish the old table sync, switch to the new table sync.

(Note that right now we (still) don't persist this incremental content-state sync progress -- if the replica restarts before sync completes, it needs to redo all sync work.)

<details>
<summary>Aside about iterator order</summary>

I was confused why `ForestTableIterator` iterates from level 0 to max rather than starting at the bottom levels, since the latter would prioritize syncing old tables.

Luckily there is already a comment explaining this:

> The iterator must traverse from the top (level 0) to the bottom of each tree to avoid skipping tables that are compacted with move-table.

</details>