### PR TITLE
vsr: always repair if header being repaired has the same view as op_head

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -559,7 +559,7 @@ pub const Simulator = struct {
             if (simulator.core.isSet(replica.replica)) {
                 for (replica.op_checkpoint() + 1..commit_max + 1) |op| {
                     const header = simulator.cluster.state_checker.header_with_op(op);
-                    if (!replica.journal.has_clean(&header)) return "pending journal";
+                    if (!replica.journal.has_prepare(&header)) return "pending journal";
                 }
                 // It's okay for a replica to miss some prepares older than the current checkpoint.
                 maybe(replica.journal.faulty.count > 0);
@@ -731,7 +731,7 @@ pub const Simulator = struct {
                     // Find earliest missing prepare as we repair prepares from low -> high ops.
                     for (op_repair_min..commit_max + 1) |op| {
                         const header = simulator.cluster.state_checker.header_with_op(op);
-                        if (!replica.journal.has_clean(&header)) {
+                        if (!replica.journal.has_prepare(&header)) {
                             if (missing_prepare_op == null or missing_prepare_op.? > op) {
                                 missing_prepare_op = op;
                             }
@@ -748,7 +748,7 @@ pub const Simulator = struct {
 
         for (simulator.cluster.replicas) |replica| {
             if (simulator.core.isSet(replica.replica) and !replica.standby()) {
-                if (replica.journal.has_clean(&missing_header)) {
+                if (replica.journal.has_prepare(&missing_header)) {
                     // Prepare *was* found on an active core replica, so the header isn't
                     // actually missing.
                     return null;

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -515,27 +515,19 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             return op;
         }
 
-        pub fn has(journal: *const Journal, header: *const Header.Prepare) bool {
+        pub fn has_header(journal: *const Journal, header: *const Header.Prepare) bool {
             assert(journal.status == .recovered);
             assert(header.command == .prepare);
             assert(header.operation != .reserved);
 
-            const slot = journal.slot_for_op(header.op);
-            const existing = &journal.headers[slot.index];
-            if (existing.operation == .reserved) {
-                return false;
+            if (journal.header_with_op_and_checksum(header.op, header.checksum)) |_| {
+                return true;
             } else {
-                if (existing.checksum == header.checksum) {
-                    assert(existing.checksum_body == header.checksum_body);
-                    assert(existing.op == header.op);
-                    return true;
-                } else {
-                    return false;
-                }
+                return false;
             }
         }
 
-        pub fn has_clean(journal: *const Journal, header: *const Header.Prepare) bool {
+        pub fn has_prepare(journal: *const Journal, header: *const Header.Prepare) bool {
             if (journal.slot_with_op_and_checksum(header.op, header.checksum)) |slot| {
                 if (!journal.dirty.bit(slot)) {
                     assert(journal.prepare_inhabited[slot.index]);
@@ -547,7 +539,9 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         }
 
         pub fn has_dirty(journal: *const Journal, header: *const Header.Prepare) bool {
-            return journal.has(header) and journal.dirty.bit(journal.slot_with_header(header).?);
+            return journal.has_header(header) and journal.dirty.bit(
+                journal.slot_with_header(header).?,
+            );
         }
 
         /// Copies latest headers between `op_min` and `op_max` (both inclusive) as fit in `dest`.
@@ -1764,7 +1758,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
             const slot = journal.slot_for_header(header);
 
-            if (journal.has(header)) {
+            if (journal.has_header(header)) {
                 assert(journal.dirty.bit(slot));
                 maybe(journal.faulty.bit(slot));
                 // Do not clear any faulty bit for the same entry.
@@ -1806,7 +1800,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(message.header.operation != .reserved);
             assert(message.header.size >= @sizeOf(Header));
             assert(message.header.size <= message.buffer.len);
-            assert(journal.has(message.header));
+            assert(journal.has_header(message.header));
             assert(!journal.writing(message.header.op, message.header.checksum));
             if (replica.solo()) assert(journal.writes.executing() == 0);
 
@@ -1918,7 +1912,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             const journal = write.journal;
             const message = write.message;
 
-            if (!journal.has(message.header)) {
+            if (!journal.has_header(message.header)) {
                 journal.write_prepare_debug(message.header, "entry changed while writing headers");
                 journal.write_prepare_release(write, null);
                 return;


### PR DESCRIPTION
This PR adds an optimization in `repair_header`, wherein we always repair a header if it has the same view as the replica's head op.

Currently, in `repair_header`, _any_ header being repaired must have hash chain connectivity all the way up till the head op.
https://github.com/tigerbeetle/tigerbeetle/blob/7140db636c3a4e5adfff963898e7221113c738e1/src/vsr/replica.zig#L6743-L6753

If `repair_header` returns `False`, we skip repairing the corresponding prepare:
https://github.com/tigerbeetle/tigerbeetle/blob/7140db636c3a4e5adfff963898e7221113c738e1/src/vsr/replica.zig#L1980-L1985

While this check is critical for safety in cases where the cluster has removed certain prepares through view changes (so that we don't install an old, removed header in place of a potentially committed, fresh one), it is suboptimal for cases where the cluster hasn't gone through a view change recently. In these cases (where the header being repaired has the same view number as the head op), we can safely install the header without checking hash chain connectivity, as the primary of the view would've already done so, in `on_prepare`:
https://github.com/tigerbeetle/tigerbeetle/blob/7140db636c3a4e5adfff963898e7221113c738e1/src/vsr/replica.zig#L1709-L1713

This is especially useful in cases where a replica is trying to repair a prepare and has gaps in its log suffix (for example, if the replica misses receiving some prepares, or advances its head op using a start_view, leaving gaps in its journal). Currently, a replica with gaps in its journal would *first* have to repair all of its headers, and *then* its prepares. By that time, that replica may have already have already advanced it head, and may have new gaps in its journal! This could lead to a vicious state where such a replica is stuck committing an old missing prepare in the journal, as it can't be repaired.