### PR TITLE
vsr: speed up commit during repair

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1995,6 +1995,9 @@ pub fn ReplicaType(
 
                 log.debug("{}: on_repair: repairing journal", .{self.replica});
                 self.write_prepare(message, .repair);
+                // Write prepare adds it synchronously to in-memory pipeline cache.
+                // Optimistically start committing without waiting for the disk write to finish.
+                if (self.status == .normal and self.backup()) self.commit_journal();
             }
         }
 


### PR DESCRIPTION
Previously, the on_repair kicked off commit process asynchronously, in the journal_write callback (through `.repair` call).

This is unnecessary: even before the prepare is written to storage, the replica keeps it in memory in pipeline cache, and we can commit from memory.

This potentially is quite harmful --- if a lagging replica catches up with a cluster and repairs a lot of prepares, it could be the case that, by the time the write finishes, the prepare is already evicted from the pipeline cache! This in turn can lead to a situation where up-to-date replicas commit mostly from memory, while a lagging replica commits by reading from storage, preventing it from catching up forever.