### PR TITLE
VSR: Request extra headers during repair

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6540,7 +6540,10 @@ pub fn ReplicaType(
                             .command = .request_headers,
                             .cluster = self.cluster,
                             .replica = self.replica,
-                            .op_min = range.op_min,
+                            // Pessimistically request as many headers as we might need.
+                            // Requesting/sending extra headers is inexpensive, and it may save us
+                            // extra round-trips to repair earlier breaks.
+                            .op_min = self.op_repair_min(),
                             .op_max = range.op_max,
                         }),
                     );


### PR DESCRIPTION
When our journal has a break in the headers, don't repair the breaks serially. Instead request as many headers as possible, to hopefully repair multiple breaks.

Suppose a backup's journal header suffix has a pattern like: `1 _ 3 _ 5 _ 7` (where `_` indicates a gap where we don't know the header). Instead of requiring three separate `request_headers`/`headers` round-trips, we can do it in one.

This alternating header/gap pattern is common in a cluster of three when the ring replication direction alternates and one of the backups is unavailable.