### PR TITLE
VSR: get rid of awaiting_checkpoint sync state

### DIFF
--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -64,6 +64,7 @@ pub const Options = union(vsr.ProcessType) {
                 sum += 1; // Replica.loopback_queue
                 sum += pipeline_limit; // Replica.Pipeline{Queue|Cache}
                 sum += 1; // Replica.commit_prepare
+                sum += 1; // Replica.sync_start_view
                 // Replica.do_view_change_from_all_replicas quorum:
                 // All other quorums are bitsets.
                 //

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1873,6 +1873,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             } else {
                 journal.write_prepare_debug(message.header, "entry changed while writing sectors");
                 journal.write_prepare_release(write, null);
+                // We just overwrote a (potentially-clean) prepare with the "wrong" header.
+                journal.dirty.set(slot);
                 return;
             }
             // TODO It's possible within this section that the header has since been replaced but we

--- a/src/vsr/sync.zig
+++ b/src/vsr/sync.zig
@@ -14,26 +14,15 @@ pub const Stage = union(enum) {
     /// Waiting for `Grid.cancel()`.
     canceling_grid,
 
-    /// We received an SV, decided to sync, but were committing at that point. So instead we
-    /// requested cancellation of the commit process and entered `awaiting_checkpoint` to get
-    /// a new SV in the future, while commit stage is idle.
-    ///
-    /// TODO: Right now this works by literally requesting a new SV from the primary, but it would
-    ///       be better to hold onto the original SV in memory and re-trigger `on_start_view` after
-    ///       cancellation is done.
-    awaiting_checkpoint,
-
-    /// We received a new checkpoint and a log suffix are in process of writing them to disk.
+    /// Superblock is being updated with the new checkpoint and log suffix (view headers).
     updating_checkpoint: vsr.CheckpointState,
 
     pub fn valid_transition(from: std.meta.Tag(Stage), to: std.meta.Tag(Stage)) bool {
         return switch (from) {
             .idle => to == .canceling_commit or
-                to == .canceling_grid or
-                to == .awaiting_checkpoint,
+                to == .canceling_grid,
             .canceling_commit => to == .canceling_grid,
-            .canceling_grid => to == .awaiting_checkpoint,
-            .awaiting_checkpoint => to == .awaiting_checkpoint or to == .updating_checkpoint,
+            .canceling_grid => to == .updating_checkpoint,
             .updating_checkpoint => to == .idle,
         };
     }


### PR DESCRIPTION
Building on https://github.com/tigerbeetle/tigerbeetle/pull/2457.

(The first commit in this PR is #2457's squashed and rebased commits.)

---

Previously, state sync required receiving _two_ SV messages:

- the first SV message triggers grid cancelation, which is asynchronous, and
- the second SV message, received after cancelation completes, does the
  actual sync work.

This adds considerable delay, especially since the replica doesn't sync tables while in `awaiting_checkpoint`.

To fix this, make `on_start_view` asynchronous: if a replica receives SV that requires state sync, it _stores_ this particular SV message, and resumes its processing after cancelation is done.

<details>
<summary>Trace</summary>

In this trace, the blue bars each ~5s of `awaiting_checkpoint`, on a replica that is falling behind a (rapidly committing/checkpointing) cluster:

![chrome___tracing_](https://github.com/user-attachments/assets/6e2da1e3-5d33-413c-8f58-973220b6337a)

</details>