### PR TITLE
IO: Async disk I/O on Windows

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -732,7 +732,7 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
-        self: ?*IO,
+        self: *IO,
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -732,12 +732,15 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
+        self: ?*IO,
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,
         method: enum { create, create_or_open, open, open_read_only },
         direct_io: DirectIO,
     ) !fd_t {
+        _ = self;
+
         assert(relative_path.len > 0);
         assert(size % constants.sector_size == 0);
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -731,7 +731,7 @@ pub const IO = struct {
     /// - Ensures that the file data (and file inode in the parent directory) is durable on disk.
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
-    pub fn open_file(
+    pub fn open_data_file(
         self: *IO,
         dir_fd: fd_t,
         relative_path: []const u8,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1398,7 +1398,7 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
-        self: ?*IO,
+        self: *IO,
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1397,7 +1397,7 @@ pub const IO = struct {
     /// - Ensures that the file data (and file inode in the parent directory) is durable on disk.
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
-    pub fn open_file(
+    pub fn open_data_file(
         self: *IO,
         dir_fd: fd_t,
         relative_path: []const u8,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1398,12 +1398,15 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
+        self: ?*IO,
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,
         method: enum { create, create_or_open, open, open_read_only },
         direct_io: DirectIO,
     ) !fd_t {
+        _ = self;
+
         assert(relative_path.len > 0);
         assert(size % constants.sector_size == 0);
         // Be careful with openat(2): "If pathname is absolute, then dirfd is ignored." (man page)

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -217,12 +217,16 @@ pub const IO = struct {
                 buf: [*]u8,
                 len: u32,
                 offset: u64,
+                overlapped: Overlapped,
+                pending: bool,
             },
             write: struct {
                 fd: fd_t,
                 buf: [*]const u8,
                 len: u32,
                 offset: u64,
+                overlapped: Overlapped,
+                pending: bool,
             },
             close: struct {
                 fd: fd_t,
@@ -805,6 +809,51 @@ pub const IO = struct {
 
     pub const OpenatError = std.posix.OpenError || std.posix.UnexpectedError;
 
+    fn do_file_io(ctx: Completion.Context, op: anytype, comptime overlapped_fn: anytype) !usize {
+        var transferred: os.windows.DWORD = undefined;
+        const rc = blk: {
+            // Poll result if already started.
+            if (op.pending) break :blk os.windows.kernel32.GetOverlappedResult(
+                op.fd,
+                &op.overlapped.raw,
+                &transferred,
+                os.windows.FALSE, // Don't wait here.
+            );
+
+            // Start the operation.
+            op.pending = true;
+            op.overlapped = .{
+                .raw = .{
+                    .Internal = 0,
+                    .InternalHigh = 0,
+                    .DUMMYUNIONNAME = .{
+                        .DUMMYSTRUCTNAME = .{
+                            .Offset = @truncate(op.offset),
+                            .OffsetHigh = @truncate(op.offset >> 32),
+                        },
+                    },
+                    .hEvent = null,
+                },
+                .completion = ctx.completion,
+            };
+            break :blk overlapped_fn(op.fd, op.buf, op.len, &transferred, &op.overlapped.raw);
+        };
+
+        // Operation completed successfully.
+        if (rc != os.windows.FALSE) {
+            return transferred;
+        }
+
+        return switch (os.windows.kernel32.GetLastError()) {
+            .IO_PENDING => error.WouldBlock,
+            .INVALID_USER_BUFFER, .NOT_ENOUGH_MEMORY => error.SystemResources,
+            .NOT_ENOUGH_QUOTA => error.SystemResources,
+            .OPERATION_ABORTED => unreachable, // overlapped_fn() doesn't get cancelled.
+            .HANDLE_EOF => unreachable,
+            else => |err| return os.windows.unexpectedError(err),
+        };
+    }
+
     pub const ReadError = error{
         WouldBlock,
         NotOpenForReading,
@@ -841,23 +890,12 @@ pub const IO = struct {
                 .buf = buffer.ptr,
                 .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
+                .overlapped = undefined,
+                .pending = false,
             },
             struct {
                 fn do_operation(ctx: Completion.Context, op: anytype) ReadError!usize {
-                    // Do a synchronous read for now.
-                    _ = ctx;
-                    return std.posix.pread(
-                        op.fd,
-                        op.buf[0..op.len],
-                        op.offset,
-                    ) catch |err| switch (err) {
-                        error.OperationAborted => unreachable,
-                        error.BrokenPipe => unreachable,
-                        error.ConnectionTimedOut => unreachable,
-                        error.AccessDenied => error.InputOutput,
-                        error.SocketNotConnected => unreachable,
-                        else => |e| e,
-                    };
+                    return do_file_io(ctx, op, os.windows.kernel32.ReadFile);
                 }
             },
         );
@@ -889,12 +927,12 @@ pub const IO = struct {
                 .buf = buffer.ptr,
                 .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
+                .overlapped = undefined,
+                .pending = false,
             },
             struct {
                 fn do_operation(ctx: Completion.Context, op: anytype) WriteError!usize {
-                    // Do a synchronous write for now.
-                    _ = ctx;
-                    return std.posix.pwrite(op.fd, op.buf[0..op.len], op.offset);
+                    return do_file_io(ctx, op, os.windows.kernel32.WriteFile);
                 }
             },
         );
@@ -1001,19 +1039,21 @@ pub const IO = struct {
         );
         errdefer self.close_socket(socket);
 
-        const socket_iocp = try os.windows.CreateIoCompletionPort(socket, self.iocp, 0, 0);
-        assert(socket_iocp == self.iocp);
+        try self.register_handle(@ptrCast(socket));
+
+        return socket;
+    }
+
+    fn register_handle(self: *IO, handle: os.windows.HANDLE) !void {
+        const iocp_handle = try os.windows.CreateIoCompletionPort(handle, self.iocp, 0, 0);
+        assert(iocp_handle == self.iocp);
 
         // Ensure that synchronous IO completion doesn't queue an unneeded overlapped
-        // and that the event for the socket (WaitForSingleObject) doesn't need to be set.
+        // and that the event for the handle (WaitForSingleObject) doesn't need to be set.
         var mode: os.windows.BYTE = 0;
         mode |= os.windows.FILE_SKIP_COMPLETION_PORT_ON_SUCCESS;
         mode |= os.windows.FILE_SKIP_SET_EVENT_ON_HANDLE;
-
-        const handle: os.windows.HANDLE = @ptrCast(socket);
         try os.windows.SetFileCompletionNotificationModes(handle, mode);
-
-        return socket;
     }
 
     /// Closes a socket opened by the IO instance.
@@ -1033,6 +1073,7 @@ pub const IO = struct {
 
     // TODO open_read_only should open the file as read-only.
     fn open_file_handle(
+        self: ?*IO,
         dir_handle: fd_t,
         relative_path: []const u8,
         method: enum { create, open, open_read_only },
@@ -1077,15 +1118,29 @@ pub const IO = struct {
         // TODO: Add ReadFileEx/WriteFileEx support.
         // Not currently needed for O_DIRECT disk IO.
         // attributes |= os.windows.FILE_FLAG_OVERLAPPED;
-        const handle = try windows_open_file(path_w.span(), .{
-            .access_mask = access_mask,
-            .dir = dir_handle,
-            .sa = null,
-            .share_access = shared_mode,
-            .creation = creation_disposition,
-            .filter = .file_only,
-            .follow_symlinks = true,
-        }, attributes);
+        // const handle = try windows_open_file(path_w.span(), .{
+        //     .access_mask = access_mask,
+        //     .dir = dir_handle,
+        //     .sa = null,
+        //     .share_access = shared_mode,
+        //     .creation = creation_disposition,
+        //     .filter = .file_only,
+        //     .follow_symlinks = true,
+        // }, attributes);
+        // Add overlapped IO support if the IO instance was provided.
+        if (self != null) {
+            attributes |= os.windows.FILE_FLAG_OVERLAPPED;
+        }
+
+        const handle = os.windows.kernel32.CreateFileW(
+            path_w.span(),
+            access_mask,
+            shared_mode,
+            null, // no security attributes required
+            creation_disposition,
+            attributes,
+            null, // no existing template file
+        );
 
         if (handle == os.windows.INVALID_HANDLE_VALUE) {
             return switch (os.windows.kernel32.GetLastError()) {
@@ -1096,6 +1151,13 @@ pub const IO = struct {
                     return os.windows.unexpectedError(err);
                 },
             };
+        }
+
+        errdefer os.windows.CloseHandle(handle);
+
+        // Register the file with the IO handle (if provided) for overlapped operations.
+        if (self) |io| {
+            try io.register_handle(handle);
         }
 
         return handle;
@@ -1110,6 +1172,7 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
+        self: ?*IO,
         dir_handle: fd_t,
         relative_path: []const u8,
         size: u64,
@@ -1122,15 +1185,16 @@ pub const IO = struct {
         _ = direct_io;
 
         const handle = switch (method) {
-            .open => try open_file_handle(dir_handle, relative_path, .open),
-            .open_read_only => try open_file_handle(dir_handle, relative_path, .open_read_only),
-            .create => try open_file_handle(dir_handle, relative_path, .create),
+            .open => try open_file_handle(self, dir_handle, relative_path, .open),
+            .open_read_only => try open_file_handle(self, dir_handle, relative_path, .open_read_only),
+            .create => try open_file_handle(self, dir_handle, relative_path, .create),
             .create_or_open => open_file_handle(
+                self,
                 dir_handle,
                 relative_path,
                 .open,
             ) catch |err| switch (err) {
-                error.FileNotFound => try open_file_handle(dir_handle, relative_path, .create),
+                error.FileNotFound => try open_file_handle(self, dir_handle, relative_path, .create),
                 else => return err,
             },
         };

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -849,7 +849,9 @@ pub const IO = struct {
             .INVALID_USER_BUFFER, .NOT_ENOUGH_MEMORY => error.SystemResources,
             .NOT_ENOUGH_QUOTA => error.SystemResources,
             .OPERATION_ABORTED => unreachable, // overlapped_fn() doesn't get cancelled.
-            .HANDLE_EOF => unreachable,
+            // ReadFile and WriteFile don't allow partial IO (acting more like readAll/writeAll)
+            // so assume the offset is correct and simulate partial IO by returning 0 bytes moved.
+            .HANDLE_EOF => return 0,
             else => |err| return os.windows.unexpectedError(err),
         };
     }

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1075,7 +1075,7 @@ pub const IO = struct {
 
     // TODO open_read_only should open the file as read-only.
     fn open_file_handle(
-        self: ?*IO,
+        self: *IO,
         dir_handle: fd_t,
         relative_path: []const u8,
         method: enum { create, open, open_read_only },
@@ -1130,10 +1130,8 @@ pub const IO = struct {
         //     .follow_symlinks = true,
         // }, attributes);
         // Add overlapped IO support if the IO instance was provided.
-        if (self != null) {
-            attributes |= os.windows.FILE_FLAG_OVERLAPPED;
-        }
 
+        attributes |= os.windows.FILE_FLAG_OVERLAPPED;
         const handle = os.windows.kernel32.CreateFileW(
             path_w.span(),
             access_mask,
@@ -1157,10 +1155,8 @@ pub const IO = struct {
 
         errdefer os.windows.CloseHandle(handle);
 
-        // Register the file with the IO handle (if provided) for overlapped operations.
-        if (self) |io| {
-            try io.register_handle(handle);
-        }
+        // Register the file with the IO handle for overlapped operations.
+        try self.register_handle(handle);
 
         return handle;
     }
@@ -1174,7 +1170,7 @@ pub const IO = struct {
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
     pub fn open_file(
-        self: ?*IO,
+        self: *IO,
         dir_handle: fd_t,
         relative_path: []const u8,
         size: u64,

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1119,7 +1119,7 @@ pub const IO = struct {
 
         // It's a little confusing, but with NtCreateFile, which is what windows_open_file uses
         // under the hood, not specifying anything gets you a file capable of overlapped IO.
-        // FILE_FLAG_OVERLAPPED and co belong to the higher level ... API.
+        // FILE_FLAG_OVERLAPPED and co belong to the higher level kernel32 API.
         const handle = try windows_open_file(path_w.span(), .{
             .access_mask = access_mask,
             .dir = dir_handle,
@@ -1156,7 +1156,7 @@ pub const IO = struct {
     /// - Ensures that the file data is durable on disk.
     ///   The caller is responsible for ensuring that the parent directory inode is durable.
     /// - Verifies that the file size matches the expected file size before returning.
-    pub fn open_file(
+    pub fn open_data_file(
         self: *IO,
         dir_handle: fd_t,
         relative_path: []const u8,

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -150,7 +150,7 @@ const Inspector = struct {
         errdefer std.posix.close(inspector.dir_fd);
 
         const basename = std.fs.path.basename(path);
-        inspector.fd = try inspector.io.open_file(
+        inspector.fd = try inspector.io.open_data_file(
             inspector.dir_fd,
             basename,
             vsr.superblock.data_file_size_min,

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -142,12 +142,15 @@ const Inspector = struct {
             .superblock_headers = undefined,
         };
 
+        inspector.io = try vsr.io.IO.init(128, 0);
+        errdefer inspector.io.deinit();
+
         const dirname = std.fs.path.dirname(path) orelse ".";
         inspector.dir_fd = try vsr.io.IO.open_dir(dirname);
         errdefer std.posix.close(inspector.dir_fd);
 
         const basename = std.fs.path.basename(path);
-        inspector.fd = try vsr.io.IO.open_file(
+        inspector.fd = try inspector.io.open_file(
             inspector.dir_fd,
             basename,
             vsr.superblock.data_file_size_min,
@@ -155,9 +158,6 @@ const Inspector = struct {
             .direct_io_optional,
         );
         errdefer std.posix.close(inspector.fd);
-
-        inspector.io = try vsr.io.IO.init(128, 0);
-        errdefer inspector.io.deinit();
 
         inspector.storage = try Storage.init(&inspector.io, inspector.fd);
         errdefer inspector.storage.deinit();

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -202,7 +202,7 @@ const Command = struct {
         errdefer command.io.deinit();
 
         const basename = std.fs.path.basename(path);
-        command.fd = try command.io.open_file(
+        command.fd = try command.io.open_data_file(
             command.dir_fd,
             basename,
             data_file_size_min,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -202,8 +202,7 @@ const Command = struct {
         errdefer command.io.deinit();
 
         const basename = std.fs.path.basename(path);
-        command.fd = try IO.open_file(
-            &command.io,
+        command.fd = try command.io.open_file(
             command.dir_fd,
             basename,
             data_file_size_min,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -198,8 +198,12 @@ const Command = struct {
         else
             .direct_io_required;
 
+        command.io = try IO.init(128, 0);
+        errdefer command.io.deinit();
+
         const basename = std.fs.path.basename(path);
         command.fd = try IO.open_file(
+            &command.io,
             command.dir_fd,
             basename,
             data_file_size_min,


### PR DESCRIPTION
This replaces #1133, which did all the heavy lifting. It's a rebase, a small cleanup, and some modifications to make overlapped IO work with NtCreateFile instead of `kernel32.CreateFileW`.

There's also a bonus fix which makes tigerbeetle run under `wine` again!