### PR TITLE
vsr: disable costly cache map verification

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -302,16 +302,6 @@ pub fn CacheMapType(
             assert(self.scope_rollback_log.items.len == 0);
             maybe(self.stash.count() <= self.options.map_value_count_max);
 
-            if (constants.verify) {
-                if (self.cache) |*cache| {
-                    var it = self.stash.keyIterator();
-                    while (it.next()) |value| {
-                        const key = key_from_value(value);
-                        assert(cache.get(key) == null);
-                    }
-                }
-            }
-
             self.stash.clearRetainingCapacity();
         }
     };


### PR DESCRIPTION
At the moment, we ship production releases with `verify=true`, and I think this might be a bit too costly for that: effectively, here we are re-doing a bar-worth of work. While it is ok for constants.verify in terms of amortized big-O, it might be not ok for latencies.