### PR TITLE
replica: add in star replication and closed loop replication

### DIFF
--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -73,6 +73,10 @@ const CLIArgs = union(enum) {
         timeout_prepare_ms: ?u64 = null,
         timeout_grid_repair_message_ms: ?u64 = null,
 
+        // Highly experimental options that will be removed in a future release:
+        replicate_closed_loop: bool = false,
+        replicate_star: bool = false,
+
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
         /// to the client. The logic behind this code has been kept as simple as possible -
         /// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple
@@ -415,6 +419,8 @@ pub const Command = union(enum) {
         trace: ?[:0]const u8,
         development: bool,
         experimental: bool,
+        replicate_closed_loop: bool,
+        replicate_star: bool,
         aof: bool,
         path: [:0]const u8,
         log_debug: bool,
@@ -826,6 +832,8 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         .development = start.development,
         .experimental = start.experimental,
         .trace = start.trace,
+        .replicate_closed_loop = start.replicate_closed_loop,
+        .replicate_star = start.replicate_star,
         .aof = start.aof,
         .path = start.positional.path,
         .log_debug = start.log_debug,

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -400,6 +400,10 @@ const Command = struct {
             },
             .grid_cache_blocks_count = args.cache_grid_blocks,
             .tracer_options = .{ .writer = if (trace_writer) |writer| writer.any() else null },
+            .replicate_options = .{
+                .closed_loop = args.replicate_closed_loop,
+                .star = args.replicate_star,
+            },
         }) catch |err| switch (err) {
             error.NoAddress => vsr.fatal(.cli, "all --addresses must be provided", .{}),
             else => |e| return e,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7451,6 +7451,14 @@ pub fn ReplicaType(
             assert(!self.journal.has_prepare(message.header));
             assert(message.header.op > self.commit_min);
 
+            if (self.replicate_options.star) {
+                if (self.status == .normal and self.primary()) {
+                    self.send_message_to_other_replicas_and_standbys(message.base());
+                }
+
+                return;
+            }
+
             const next = next: {
                 // Replication in the ring of active replicas.
                 if (!self.standby()) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -114,6 +114,11 @@ pub fn ReplicaType(
         const Clock = vsr.ClockType(Time);
         const ForestTableIterator = ForestTableIteratorType(StateMachine.Forest);
 
+        const ReplicateOptions = struct {
+            closed_loop: bool = false,
+            star: bool = false,
+        };
+
         const BlockRead = struct {
             read: Grid.Read,
             replica: *Replica,
@@ -531,6 +536,8 @@ pub fn ReplicaType(
 
         aof: ?*AOF,
 
+        replicate_options: ReplicateOptions,
+
         const OpenOptions = struct {
             node_count: u8,
             pipeline_requests_limit: u32,
@@ -552,6 +559,7 @@ pub fn ReplicaType(
             test_context: ?*anyopaque = null,
             timeout_prepare_ticks: ?u64 = null,
             timeout_grid_repair_message_ticks: ?u64 = null,
+            replicate_options: ReplicateOptions = .{},
         };
 
         /// Initializes and opens the provided replica using the options.
@@ -629,6 +637,7 @@ pub fn ReplicaType(
                 .test_context = options.test_context,
                 .timeout_prepare_ticks = options.timeout_prepare_ticks,
                 .timeout_grid_repair_message_ticks = options.timeout_grid_repair_message_ticks,
+                .replicate_options = options.replicate_options,
             });
 
             // Disable all dynamic allocation from this point onwards.
@@ -977,6 +986,7 @@ pub fn ReplicaType(
             test_context: ?*anyopaque,
             timeout_prepare_ticks: ?u64,
             timeout_grid_repair_message_ticks: ?u64,
+            replicate_options: ReplicateOptions,
         };
 
         /// NOTE: self.superblock must be initialized and opened prior to this call.
@@ -1243,6 +1253,7 @@ pub fn ReplicaType(
                 .trace = self.trace,
                 .test_context = options.test_context,
                 .aof = options.aof,
+                .replicate_options = options.replicate_options,
             };
 
             log.debug("{}: init: replica_count={} quorum_view_change={} quorum_replication={} " ++

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3105,6 +3105,12 @@ pub fn ReplicaType(
                     }
                 } else {
                     self.prepare_timeout.stop();
+
+                    // There are no prepares in the pipeline waiting for a prepare_ok quorum, give
+                    // the primary another shot at staying primary even if it currently abdicating.
+                    maybe(self.primary_abdicating);
+                    self.primary_abdicating = false;
+                    self.primary_abdicate_timeout.stop();
                 }
 
                 return self.commit_pipeline();


### PR DESCRIPTION
# Background
When running high control-plane load against a cluster (most easily simulated by tiny batches within the benchmark), it's possible for the replicas that don't form part of the replication quorum to start lagging behind and enter a state sync loop.

This is somewhat by design for failure tolerance: replication in TigerBeetle effectively consists of two phases:
1. a closed loop wait for a replication quorum and,
2. open loop replication to the remaining replicas.

Any latency in the first gets exposed directly to the client, while the second does not. This causes some problems here, however, especially when combined with a ring topology that effectively favors replicas 'closer' to the primary in the ring.

The open loop system is not nearly as stable as it should be; this can be tested by starting a benchmark like above and slightly perturbing (eg, `timeout 0.2 stress -d 10`) only one replica. 

What happens is that a combination of factors (#2626, #2627, dropping messages on the floor when no journal IOPS are available, slow repair vs prepare) lead to the replica falling behind and entering state sync when it shouldn't be, and since the cluster is loaded, it currently has no hope of exiting a state-sync -> repair -> state-sync loop. (#2621).

While that loop doesn't directly affect the cluster, the added IO load on what is already a loaded cluster, can increase latencies significantly.

# The Workaround
This PR adds two new options: `--replicate-star` which switches to a star topology, and `--replicate-closed-loop` which enforces closed loop replication on the entire cluster.

These options are *highly* experimental, designed to work around for a specific use case, and are going to be removed in future.

Switching to a star topology places additional network load on the primary, but mitigates the impact a single break in the ring might have, which is currently unoptimized. 

(Before #2627 it was also a critical piece of the puzzle as to why replicas could fall behind so easily: only prepares get ring replicated, so other replicas can learn about a newer committed op, then refuse to commit any prepares until they've received _all_ prepares up to the committed op they know about.)

Switching to closed loop makes the primary wait until _all_ replicas have acknowledged a prepare, with an escape hatch built into the `prepare_timeout`: if it takes more than the current 25 ticks / ~250ms, the whole pipeline will be unblocked if they have received at least a `quorum_replication` number of `prepare_ok`s.

This helps prevent cluster unavailability if a single replica goes down, at the cost of increased latency if it does.
