### PR TITLE
[Go] Run lint during CI

### DIFF
--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -15,6 +15,8 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         return error.GoFmt;
     }
 
+    try shell.exec("go vet", .{});
+
     // `go build`  won't compile the native library automatically, we need to do that ourselves.
     try shell.exec_zig("build clients:go -Drelease", .{});
     try shell.exec_zig("build -Drelease", .{});

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -423,9 +423,9 @@ func doTestClient(t *testing.T, client Client) {
 				})
 
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
-
 				assert.Empty(t, results)
 			}(i)
 		}
@@ -479,7 +479,8 @@ func doTestClient(t *testing.T, client Client) {
 				})
 
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 
 				if i%10 == 0 {


### PR DESCRIPTION
Run [golangci-lint](https://golangci-lint.run/) during CI.

Fixes the violation reported on #2598:  "_the goroutine calls T.Fatal, which must be called in the same goroutine as the test_" by standardizing error checking with `assert.True(t, err == null)` instead of `if err != null t.Fatal()` across all tests.

 Thanks, @AskAlexSharov, for pointing it out!