### PR TITLE
ci: try to fix devhub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2147483647
-      - run: sudo apt install kcov
+      - run: sudo apt-get update && sudo apt-get install -y kcov
       - run: ./zig/download.sh
       # Run under sudo to enable memory locking for accurate RSS stats.
       - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
@@ -229,7 +229,7 @@ jobs:
         with:
           fetch-depth: 2147483647
       - name: Install dependencies
-        run: sudo apt install -y jq curl
+        run: sudo apt-get install -y jq curl
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"


### PR DESCRIPTION
Main fails with

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package kcov

Seems the package list is outdated? Let's use update to refresh it.

While we are at it, switch from apt to apt-get --- I didn't realize that apt doesn't have a stable CLI!