### PR TITLE
vopr: smallest_missing_prepare_between called with invalid input

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -761,17 +761,18 @@ pub const Simulator = struct {
                     // as commit progress depends on them. Then, check prepares between
                     // [op_repair_min, commit_min] as view changing replicas cannot step up as
                     // primary unless they have all prepares intact.
-                    if (simulator.smallest_missing_prepare_between(
-                        &replica,
-                        replica.commit_min + 1,
-                        commit_max,
-                    )) |op| {
-                        if (missing_prepare_op == null or op < missing_prepare_op.?) {
-                            missing_prepare_op = op;
-                            continue;
+                    if (replica.commit_min < commit_max) {
+                        if (simulator.smallest_missing_prepare_between(
+                            &replica,
+                            replica.commit_min + 1,
+                            commit_max,
+                        )) |op| {
+                            if (missing_prepare_op == null or op < missing_prepare_op.?) {
+                                missing_prepare_op = op;
+                                continue;
+                            }
                         }
                     }
-
                     if (simulator.smallest_missing_prepare_between(
                         &replica,
                         op_repair_min,


### PR DESCRIPTION
Fixes the following failing seed: `./zig/zig build -Drelease vopr -- 9281226428384535959`

In `smallest_missing_prepare_between` (added in https://github.com/tigerbeetle/tigerbeetle/pull/2637), we assert `assert(op_min <= op_max);`. However, in `core_missing_prepare`, we call the function over commit_min + 1 → commit_max, even when commit_min == commit_max. This PR fixes this incorrect invocation.

https://github.com/tigerbeetle/tigerbeetle/blob/e5db17670272d8d162bcb345dcd659190582687b/src/vopr.zig#L696-L702