### PR TITLE
ci: run devhub in ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
 
   devhub:
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: devhub
     permissions:
       pages: write


### PR DESCRIPTION
kcov has been removed from Ubuntu 24.04, which is the new `ubuntu-latest`. This is a temporary workaround!