### PR TITLE
ci: fetch kcov ourselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
 
   devhub:
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: devhub
     permissions:
       pages: write
@@ -190,7 +190,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2147483647
-      - run: sudo apt-get update && sudo apt-get install -y kcov
       - run: ./zig/download.sh
       # Run under sudo to enable memory locking for accurate RSS stats.
       - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }}


### PR DESCRIPTION
Previously, we depended on Ubuntu distribution to install kcov. This broke once Ubuntu stopped packaging kcov.

In build.zig, we already have a `fetch` utility for conveniently downloadid hash-pinned dependencies from the internet. Use it to fetch pre-build version of kcov from the upstream source.