### PR TITLE
VSR: Assert constants.verify at comptime

### DIFF
--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -158,7 +158,7 @@ pub fn ewah(comptime Word: type) type {
         /// Decodes the compressed bitset in `source` into `target_words`.
         /// Returns the number of *words* written to `target_words`.
         pub fn decode_all(source: []align(@alignOf(Word)) const u8, target_words: []Word) usize {
-            assert(constants.verify);
+            comptime assert(constants.verify);
             assert(source.len % @sizeOf(Word) == 0);
             assert(disjoint_slices(u8, Word, source, target_words));
 
@@ -277,7 +277,7 @@ pub fn ewah(comptime Word: type) type {
         // (This is a helper for testing only.)
         // Returns the number of bytes written to `target`.
         pub fn encode_all(source_words: []const Word, target: []align(@alignOf(Word)) u8) usize {
-            assert(constants.verify);
+            comptime assert(constants.verify);
             assert(target.len == encode_size_max(source_words.len));
             assert(disjoint_slices(Word, u8, source_words, target));
 

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -222,7 +222,7 @@ pub fn CacheMapType(
         pub fn remove(self: *CacheMap, key: Key) void {
             // The only thing that tests this in any depth is the cache_map fuzz itself.
             // Make sure we aren't being called in regular code without another once over.
-            assert(constants.verify);
+            comptime assert(constants.verify);
 
             const cache_removed: ?Value = if (self.cache) |*cache|
                 cache.remove(key)

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -539,7 +539,7 @@ pub fn ManifestLevelType(
 
         /// The function is only used for verification; it is not performance-critical.
         pub fn contains(level: ManifestLevel, table: *const TableInfo) bool {
-            assert(constants.verify);
+            comptime assert(constants.verify);
             var level_tables = level.iterator(.visible, &.{
                 table.snapshot_min,
             }, .ascending, KeyRange{

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1237,7 +1237,7 @@ pub fn GridType(comptime Storage: type) type {
         }
 
         fn verify_read(grid: *Grid, address: u64, cached_block: BlockPtrConst) void {
-            assert(constants.verify);
+            comptime assert(constants.verify);
 
             const TestStorage = @import("../testing/storage.zig").Storage;
             if (Storage != TestStorage) return;


### PR DESCRIPTION
When we assert `constants.verify`, do so at comptime, not runtime. The intent of these asserts is to make sure that these functions are not even compiled into non-verify builds.

I left one assert unmodified (in `free_set.zig`) to avoid conflicting with https://github.com/tigerbeetle/tigerbeetle/pull/2600.

Tested with `zig build -Dconfig_verify=false`.