### PR TITLE
Journal: Don't write invalid redundant headers during repair

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -22,6 +22,7 @@ const StateCheckerType = @import("cluster/state_checker.zig").StateCheckerType;
 const StorageChecker = @import("cluster/storage_checker.zig").StorageChecker;
 const GridChecker = @import("cluster/grid_checker.zig").GridChecker;
 const ManifestCheckerType = @import("cluster/manifest_checker.zig").ManifestCheckerType;
+const JournalCheckerType = @import("cluster/journal_checker.zig").JournalCheckerType;
 
 const vsr = @import("../vsr.zig");
 pub const ReplicaFormat = vsr.ReplicaFormatType(Storage);
@@ -63,6 +64,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         pub const Client = vsr.ClientType(StateMachine, MessageBus, Time);
         pub const StateChecker = StateCheckerType(Client, Replica);
         pub const ManifestChecker = ManifestCheckerType(StateMachine.Forest);
+        pub const JournalChecker = JournalCheckerType(Replica);
 
         pub const Options = struct {
             cluster_id: u128,
@@ -461,7 +463,10 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                         .up => |up| {
                             assert(!up.paused);
                             replica.tick();
-                            cluster.check_wal(replica.replica);
+
+                            // For performance, don't run every tick.
+                            if (i % 100 == 0) JournalChecker.check(replica);
+
                             cluster.state_checker.check_state(replica.replica) catch |err| {
                                 fatal(.correctness, "state checker error: {}", .{err});
                             };
@@ -836,41 +841,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         fn fatal(failure: Failure, comptime fmt_string: []const u8, args: anytype) noreturn {
             std.log.scoped(.state_checker).err(fmt_string, args);
             std.posix.exit(@intFromEnum(failure));
-        }
-
-        // Sanity-check: If the journal is clean and idle, there should be no zeroed entries
-        // (representing faulty journal entries) in the redundant WAL headers.
-        fn check_wal(cluster: *const Cluster, replica_index: u8) void {
-            const replica = &cluster.replicas[replica_index];
-            const replica_storage = &cluster.storages[replica_index];
-            assert(cluster.replica_health[replica_index] == .up);
-
-            if (replica.journal.dirty.count == 0 and
-                replica.journal.writes.executing() == 0)
-            {
-                assert(replica.journal.faulty.count == 0);
-
-                var wal_header_errors: u32 = 0;
-                for (
-                    replica_storage.wal_headers(),
-                    replica_storage.wal_prepares(),
-                    replica.journal.headers,
-                    0..,
-                ) |*wal_header, *wal_prepare, *journal_header, slot| {
-                    if (journal_header.operation == .reserved) {
-                        // Ignore reserved headers -- when Journal.remove_entries_from() truncates
-                        // the log, it cleans the in-memory journal without writing to the WAL.
-                    } else {
-                        if (wal_header.checksum == 0) {
-                            log.err("{}: check_wal: slot={} checksum=0", .{ replica_index, slot });
-                            wal_header_errors += 1;
-                        } else {
-                            assert(wal_header.checksum == wal_prepare.header.checksum);
-                        }
-                    }
-                }
-                assert(wal_header_errors == 0);
-            }
         }
 
         /// Print the current state of the cluster, intended for printf debugging.

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -624,7 +624,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         /// version, this allows the replica to clean up properly (e.g. release Message's via
         /// `defer`).
         fn replica_release_execute(cluster: *Cluster, replica_index: u8) void {
-            const replica = cluster.replicas[replica_index];
+            const replica = &cluster.replicas[replica_index];
             assert(cluster.replica_health[replica_index] == .up);
 
             const release = cluster.replica_upgrades[replica_index].?;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -461,6 +461,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                         .up => |up| {
                             assert(!up.paused);
                             replica.tick();
+                            cluster.check_wal(replica.replica);
                             cluster.state_checker.check_state(replica.replica) catch |err| {
                                 fatal(.correctness, "state checker error: {}", .{err});
                             };
@@ -835,6 +836,41 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         fn fatal(failure: Failure, comptime fmt_string: []const u8, args: anytype) noreturn {
             std.log.scoped(.state_checker).err(fmt_string, args);
             std.posix.exit(@intFromEnum(failure));
+        }
+
+        // Sanity-check: If the journal is clean and idle, there should be no zeroed entries
+        // (representing faulty journal entries) in the redundant WAL headers.
+        fn check_wal(cluster: *const Cluster, replica_index: u8) void {
+            const replica = &cluster.replicas[replica_index];
+            const replica_storage = &cluster.storages[replica_index];
+            assert(cluster.replica_health[replica_index] == .up);
+
+            if (replica.journal.dirty.count == 0 and
+                replica.journal.writes.executing() == 0)
+            {
+                assert(replica.journal.faulty.count == 0);
+
+                var wal_header_errors: u32 = 0;
+                for (
+                    replica_storage.wal_headers(),
+                    replica_storage.wal_prepares(),
+                    replica.journal.headers,
+                    0..,
+                ) |*wal_header, *wal_prepare, *journal_header, slot| {
+                    if (journal_header.operation == .reserved) {
+                        // Ignore reserved headers -- when Journal.remove_entries_from() truncates
+                        // the log, it cleans the in-memory journal without writing to the WAL.
+                    } else {
+                        if (wal_header.checksum == 0) {
+                            log.err("{}: check_wal: slot={} checksum=0", .{ replica_index, slot });
+                            wal_header_errors += 1;
+                        } else {
+                            assert(wal_header.checksum == wal_prepare.header.checksum);
+                        }
+                    }
+                }
+                assert(wal_header_errors == 0);
+            }
         }
 
         /// Print the current state of the cluster, intended for printf debugging.

--- a/src/testing/cluster/journal_checker.zig
+++ b/src/testing/cluster/journal_checker.zig
@@ -1,0 +1,48 @@
+//! Verify Journal/WAL properties.
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.journal_checker);
+
+const TestStorage = @import("../storage.zig").Storage;
+
+pub fn JournalCheckerType(comptime Replica: type) type {
+    return struct {
+        pub fn check(replica: *const Replica) void {
+            const replica_index = replica.replica;
+            const replica_storage = replica.superblock.storage;
+            comptime assert(@TypeOf(replica_storage) == *TestStorage);
+
+            if (replica.journal.writes.executing() == 0) {
+                // Sanity-check: Where the journal is clean and not being written to:
+                // - Redundant headers exactly match their corresponding prepares.
+                // - The WAL's content matches `journal.headers`.
+                // - There are no zeroed entries (representing faulty journal entries) in the
+                //   redundant WAL headers.
+                var wal_header_errors: u32 = 0;
+                for (
+                    replica_storage.wal_headers(),
+                    replica_storage.wal_prepares(),
+                    replica.journal.headers,
+                    0..,
+                ) |*wal_header, *wal_prepare, *journal_header, slot| {
+                    if (!replica.journal.dirty.bit(.{ .index = slot })) {
+                        if (journal_header.operation == .reserved) {
+                            // Ignore reserved headers -- when Journal.remove_entries_from()
+                            // truncates the log, it cleans the in-memory journal without writing to
+                            // the WAL.
+                        } else {
+                            if (wal_header.checksum == 0) {
+                                log.err("{}: check: slot={} checksum=0", .{ replica_index, slot });
+                                wal_header_errors += 1;
+                            } else {
+                                assert(wal_header.checksum == wal_prepare.header.checksum);
+                                assert(wal_header.checksum == journal_header.checksum);
+                            }
+                        }
+                    }
+                }
+                assert(wal_header_errors == 0);
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Overview

To hit this bug:

1. Recover from a WAL with a faulty entry, then
2. repair that entry,
3. then crash and recover again before the WAL wraps and overwrites that entry.

If the bug is hit, the just-repaired slot is recovered as faulty.

## Bug

Suppose we are repairing a faulty prepare:
1. (The dirty/faulty bits are already set.)
2. We start by writing the prepare...
3. Then when the prepare is written, we write the redundant header sector...
4. Then when the redundant header sector is written, we clear the dirty/faulty bits.

The problem is that during step 3, since the faulty bit is set, the sector of redundant headers that we write contains garbage (i.e. "deliberately" invalid headers -- incorrectly so, in this case). This is the code (from `Journal.header_sector()`) which generates the redundant headers to write:

    var i: usize = 0;
    while (i < headers_per_sector) : (i += 1) {
        const slot = Slot{ .index = sector_slot.index + i };

        if (journal.faulty.bit(slot)) {
            // Redundant faulty headers are deliberately written as invalid.
            // This ensures that faulty headers are still faulty when they are read back
            // from disk during recovery. This prevents faulty entries from changing to
            // reserved (and clean) after a crash and restart (e.g. accidentally converting
            // a case `@D` to a `@I` after a restart).
            sector_headers[i] = Header.Prepare.reserved(replica.cluster, i);
            sector_headers[i].checksum = 0; // Invalidate the checksum.
            assert(!sector_headers[i].valid_checksum());
        } else {
            // Write headers from `headers_redundant` instead of `headers` — we need to
            // avoid writing (leaking) a redundant header before its corresponding prepare
            // is on disk.
            sector_headers[i] = journal.headers_redundant[slot.index];
        }
    }

This garbage means that after step 4, if we crash/recover, we can end up with the same slot as faulty, even though we just repaired it.

#### Why didn't the VOPR find this bug?

(Note that with the `JournalChecker` (added in this PR), the VOPR _does_ catch this bug now.)

Redundant headers only influence the test during WAL recovery.

The fault atlas mostly ensures that we don't inject a pattern of WAL faults that the cluster cannot repair.
The caveat of that "mostly" is that the fault atlas doesn't try to prevent `status=recovering_head`.

Instead, when the VOPR restarts a replica, it suppresses storage faults during recovery if the replica entering `status=recovering_head` would possibly deadlock the cluster:

    // To improve VOPR utilization, try to prevent the replica from going into
    // `.recovering_head` state if the replica is needed to form a quorum.
    const fault = recoverable_count >= recoverable_count_min or replica.standby();
    simulator.replica_restart(replica.replica, fault);

Because corrupt WAL prepares can leak into "corrupt" (zeroed) WAL headers, when `replica_restart()` is invoked with faults disabled, it actually repairs the zeroed WAL headers:

    var header_prepare_view_mismatch: bool = false;
    if (!fault) {
        // The journal writes redundant headers of faulty ops as zeroes to ensure
        // that they remain faulty after a crash/recover. Since that fault cannot
        // be disabled by `storage.faulty`, we must manually repair it here to
        // ensure a cluster cannot become stuck in status=recovering_head.
        // See recover_slots() for more detail.
        const headers_offset = vsr.Zone.wal_headers.offset(0);
        const headers_size = vsr.Zone.wal_headers.size().?;
        const headers_bytes = replica_storage.memory[headers_offset..][0..headers_size];
        for (
            mem.bytesAsSlice(vsr.Header.Prepare, headers_bytes),
            replica_storage.wal_prepares(),
        ) |*wal_header, *wal_prepare| {
            if (wal_header.checksum == 0) {
                wal_header.* = wal_prepare.header;
            } else {
                if (wal_header.view != wal_prepare.header.view) {
                    header_prepare_view_mismatch = true;
                }
            }
        }
    }

This bug was hit by the VOPR with [misdirected write injection](https://github.com/tigerbeetle/tigerbeetle/pull/2463) as part of a liveness bug. I ran into it because the restart in question was due to an upgrade (`release_execute()`), and upgrades don't use the above redundant-header-repair.

## Fix

- Rather than ignoring `headers_redundant` during `Journal.header_sector()` when `faulty.bit(slot)`, maintain it properly so `Journal.header_sector()` can just use it as-is. That is, `headers_redundant` always contains "what we would write to the redundant headers, is we were to write to it right now".
- When `set_header_as_dirty` replaces a header, set the corresponding `headers_redundant` to an invalid header.
- During journal recovery, initialize `headers_redundant` with invalid headers corresponding to faulty prepares.

(We still set `headers_redundant` to the proper value in `Journal.write_prepare_header()`, just before generating the sector of redundant headers.)