### PR TITLE
vopr: state checker checks for truncated ops in the WAL

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -773,13 +773,15 @@ pub const Simulator = struct {
                             }
                         }
                     }
-                    if (simulator.smallest_missing_prepare_between(
-                        &replica,
-                        op_repair_min,
-                        replica.commit_min,
-                    )) |op| {
-                        if (missing_prepare_op == null or op < missing_prepare_op.?) {
-                            missing_prepare_op = op;
+                    if (op_repair_min <= replica.commit_min) {
+                        if (simulator.smallest_missing_prepare_between(
+                            &replica,
+                            op_repair_min,
+                            replica.commit_min,
+                        )) |op| {
+                            if (missing_prepare_op == null or op < missing_prepare_op.?) {
+                                missing_prepare_op = op;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR resolves a VOPR false positive (`./zig/zig build -Drelease vopr -- --lite 12609788692302396595`) wherein the StateChecker erroneously infers that a replica has "lost" a prepare that it has prepare_ok'd. 

### Problem 

StateChecker maintains `replica_head_max`, which is the latest op that is prepare_ok'd across restarts (updated every time a replica sends `prepare_ok` message). Every tick, we assert that in the absence of WAL corruptions, the replica has `replica_head_max` intact in its journal using the below check. 
https://github.com/tigerbeetle/tigerbeetle/blob/875a1051476fe5e7dfe0ac6c3de94b336858cb8b/src/testing/cluster/state_checker.zig#L114-L118

However, asserting `replica.view == head_max.view and replica.op >= head_max.op` is incorrect because an op that a replica has prepare_ok'd *could* be truncated through a view change, overwritten by an op from the next view, and then truncated on start up! This is because replicas that transition into a new view as backups can *immediately* start writing prepares from that view to their WAL, even before that view/log_view are durable. (Remember, we do prevent such a replica from acking prepares, because that would be unsafe, but we don't stop it from making prepares durable!)

### Solution

A potential solution that comes to mind here is that we _could_ ensure that a replica only makes prepares from view V durable *after* it makes view=log_view=V durable (the primary already does this). This makes our invariants clearer and easier to enforce in the StateChecker, i.e. it would *actually* be correct to assert what we currently do.

On the other hand, this would entail dropping prepares while view=log_view=V is not durable... which does *not* seem like a good idea given our recent escapades with replicas lagging and going into state sync as a result of dropped prepares. Therefore, I think it would be ideal if we could *embrace concurrency* and relax our StateChecker checks as explained below.

The solution that this PR implements involves bubbling up *potential truncations* via view change to the StateChecker. Specifically, every time a replica updates its head op via StartView or a DoViewChange quorum by invoking [set_op_and_commit_max](https://github.com/tigerbeetle/tigerbeetle/blob/875a1051476fe5e7dfe0ac6c3de94b336858cb8b/src/vsr/replica.zig#L8506) (in replica.zig), the StateChecker checks if its currently tracked `replica_head_max` has potentially been truncated. In case it has been, the StateChecker marks `replica_head_max` as _null_. While it is _null_ we skip [these](https://github.com/tigerbeetle/tigerbeetle/blob/875a1051476fe5e7dfe0ac6c3de94b336858cb8b/src/testing/cluster/state_checker.zig#L114-L118) checks till the next time this replica sends a `prepare_ok` message and updates `replica_head_max`. Invalidating `replica_head_max` seemed more straightforward than to peek into the replica state and try to infer the *correct* value for the last acked prepare, which IIUC, isn't possible at all.

