### PR TITLE
vsr: check some more invariants

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -820,6 +820,7 @@ pub fn ReplicaType(
             // Asynchronously open the free set and then the (Forest inside) StateMachine so that we
             // can repair grid blocks if necessary:
             self.grid.open(grid_open_callback);
+            self.invariants();
         }
 
         fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
@@ -1312,6 +1313,10 @@ pub fn ReplicaType(
             }
         }
 
+        pub fn invariants(self: *const Replica) void {
+            _ = self;
+        }
+
         /// Time is measured in logical ticks that are incremented on every call to tick().
         /// This eliminates a dependency on the system time and enables deterministic testing.
         pub fn tick(self: *Replica) void {
@@ -1321,6 +1326,7 @@ pub fn ReplicaType(
             // delay the delivery of messages (e.g. a prepare_ok from the primary to itself) and
             // decrease throughput significantly.
             assert(self.loopback_queue == null);
+            defer self.invariants();
 
             // TODO Replica owns Time; should it tick() here instead of Clock?
             self.clock.tick();
@@ -1372,6 +1378,7 @@ pub fn ReplicaType(
             assert(self.opened);
             assert(self.loopback_queue == null);
             assert(message.references > 0);
+            defer self.invariants();
 
             // Switch on the header type so that we don't log opaque bytes for the per-command data.
             switch (message.header.into_any()) {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1314,7 +1314,7 @@ pub fn ReplicaType(
         }
 
         pub fn invariants(self: *const Replica) void {
-            _ = self;
+            assert(self.journal.header_with_op(self.op) != null);
         }
 
         /// Time is measured in logical ticks that are incremented on every call to tick().
@@ -1645,7 +1645,8 @@ pub fn ReplicaType(
             // Sanity check --- if the prepare is definitely from the current log-wrap, it should be
             // appended.
             defer {
-                if (self.status == .normal and message.header.view == self.view and
+                if (self.status == .normal and self.syncing == .idle and
+                    message.header.view == self.view and
                     message.header.op > self.op_checkpoint() and
                     message.header.op <= self.op_checkpoint_next_trigger())
                 {


### PR DESCRIPTION
- add Replica.invariants method which is called on_tick and on_message, as a central spot to verify invariants
- add the basic invariant that the head op is always present
- separately from this infrastructure, assert that obviously correct prepares are added to the journal. 