### PR TITLE
aof: reduce binary size

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -79,10 +79,18 @@ pub const AOFEntry = extern struct {
         // object storage, this must be embedded in the filename or path.
         // Whether this replica is the primary can be determined by the view number from the
         // relevant op.
-        self.* = AOFEntry{
-            .message = undefined,
-        };
+        comptime {
+            const fields = std.meta.fieldNames(AOFEntry);
+            assert(fields.len == 2);
+            assert(std.mem.eql(u8, fields[0], "magic_number"));
+            assert(std.mem.eql(u8, fields[1], "message"));
+        }
 
+        // Using self.* = .{ .message = undefined } notation causes a `constants.message_size_max`
+        // increase in binary size, since Zig embeds the entire static initialization payload in the
+        // binary.
+        self.* = undefined;
+        self.magic_number = magic_number;
         stdx.copy_disjoint(
             .exact,
             u8,


### PR DESCRIPTION
In a surprising turn of events, it turns out the second big spike here:
![image](https://github.com/user-attachments/assets/69cfb245-1f57-4aae-a326-1d3e1a78feab)

was due to https://github.com/tigerbeetle/tigerbeetle/pull/2615! (the first was due to debug logging)

It looks like when using the struct initialization syntax

```zig
        self.* = AOFEntry{
            .message = undefined,
        };
```

Zig is embedding ~1MB of zeros in the binary itself, to later `memcpy` over. It seems this is somewhat optimization dependent, in the below minimal reproduction (in contrast to the real issue), it only happens in `Debug` but not `ReleaseSafe` or `ReleaseFast`. 

(The real `self.*` bloat doesn't go away even when coupled with `@setRuntimeSafety(false)`.)

<details>

```zig
const std = @import("std");

const Example = struct {
    message: [1024*1024]u8,
};

export fn tester() [*]u8 {
    var foo = Example { .message = undefined };
    const bar = std.mem.asBytes(&foo);

    return bar.ptr;
}
```
</details>
