### PR TITLE
vsr: rollout new CheckpointState format, stage 0

### DIFF
--- a/src/docs_website/src/docs.zig
+++ b/src/docs_website/src/docs.zig
@@ -408,22 +408,6 @@ const Page = struct {
     }
 };
 
-fn make_title(arena: Allocator, input: []const u8) ![]const u8 {
-    const output = try arena.dupe(u8, input);
-    var needs_upper = true;
-    for (output) |*c| {
-        if (needs_upper) {
-            c.* = std.ascii.toUpper(c.*);
-            needs_upper = false;
-        }
-        switch (c.*) {
-            ' ' => needs_upper = true,
-            else => {},
-        }
-    }
-    return output;
-}
-
 fn path_exists(path: []const u8) !bool {
     std.fs.cwd().access(path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -216,6 +216,11 @@ pub const Command = enum(u8) {
 
     start_view = 23,
 
+    // A reserved command for a StartView message that sends the new CheckpointState format.
+    // At the moment, replica ignores this command (as opposed to panicking on an unknown command),
+    // to allow the next release to send both versions of StartView.
+    start_view_new = 24,
+
     // If a command is removed from the protocol, its ordinal is added here and can't be re-used.
     const gaps = .{
         12, // start_view without checkpoint

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -89,6 +89,7 @@ pub const Header = extern struct {
             .start_view_change => StartViewChange,
             .do_view_change => DoViewChange,
             .start_view => StartView,
+            .start_view_new => StartView,
             .request_start_view => RequestStartView,
             .request_headers => RequestHeaders,
             .request_prepare => RequestPrepare,
@@ -210,7 +211,8 @@ pub const Header = extern struct {
             .reply => return .unknown,
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
-
+            // At the current version, start_view_new is completely ignored.
+            .start_view_new => return .unknown,
             // All other messages identify the peer as a replica:
             .ping,
             .pong,
@@ -1036,7 +1038,7 @@ pub const Header = extern struct {
         reserved: [88]u8 = [_]u8{0} ** 88,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .start_view);
+            assert(self.command == .start_view or self.command == .start_view_new);
             if (self.release.value != 0) return "release != 0";
             if (self.op < self.commit_max) return "op < commit_max";
             if (self.commit_max < self.checkpoint_op) return "commit_max < checkpoint_op";

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1394,6 +1394,14 @@ pub fn ReplicaType(
                 return;
             }
 
+            if (message.header.command == .start_view_new) {
+                log.err("{}: on_message: ignoring (command={})", .{
+                    self.replica,
+                    message.header.command,
+                });
+                return;
+            }
+
             // No client or replica should ever send a .reserved message.
             assert(message.header.command != .reserved);
 
@@ -1433,6 +1441,7 @@ pub fn ReplicaType(
                 .start_view_change => |m| self.on_start_view_change(m),
                 .do_view_change => |m| self.on_do_view_change(m),
                 .start_view => |m| self.on_start_view(m),
+                .start_view_new => unreachable,
                 .request_start_view => |m| self.on_request_start_view(m),
                 .request_prepare => |m| self.on_request_prepare(m),
                 .request_headers => |m| self.on_request_headers(m),
@@ -8148,6 +8157,7 @@ pub fn ReplicaType(
                     assert(header.commit_max == self.commit_max);
                     assert(header.checkpoint_op == self.op_checkpoint());
                 },
+                .start_view_new => unreachable, // Only a future version of a replica can send this.
                 .headers => {
                     assert(!self.standby());
                     assert(message.header.view == self.view);


### PR DESCRIPTION
This is a prerequisite for https://github.com/tigerbeetle/tigerbeetle/pull/2600, which ensures blocks released during a checkpoint are freed only when the next checkpoint is durable, solving a long-standing liveness issue. Since this involves changing the on-disk format of `CheckpointState`, which is sent as part of the `StartView` message, we need to safely upgrade the VSR protocol (preferably without bumping up the VSR protocol version, which would require more intrusive changes).

Inspired from https://github.com/tigerbeetle/tigerbeetle/pull/2181, this PR adds a no-op `start_view_new` command, which is ignored by replicas running on this version. Then, https://github.com/tigerbeetle/tigerbeetle/pull/2600 will take up the change to send _both_ `start_view` and `start_view_new` messages, so replicas running on a version that is aware of only the old CheckpointState can process a StartView message sent by a replica that is aware of the new CheckpointState  format. Finally, in the subsequent release, we can remove the `start_view` message and rename `start_view_new` → `start_view`. 

Multi-version binary upgrades ensure all releases bundled within a binary are visited while upgrading to the highest version in the binary. Additionally, the upgrade quorum is equal to replica_count. Therefore, even clusters that are lagging behind multiple releases will still upgrade correctly.