### PR TITLE
clients: switch to using gpa as backing allocator

### DIFF
--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -208,6 +208,7 @@ pub const MessagePool = struct {
                     .buffer = buffer[0..constants.message_size_max],
                     .link = .{},
                 };
+
                 pool.free_list.push(message);
             }
         }


### PR DESCRIPTION
Currently, libtbclient (via `tb_client_exports.zig`) uses `std.heap.c_allocator` directly. Rather, wrap it inside a GeneralPurposeAllocator, so we can get access to all of the nice safety features and leak detection it provides.