### PR TITLE
clients: add tb_client_init_parameters and implement for python

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -297,6 +297,13 @@ typedef enum TB_LOG_LEVEL {
     TB_LOG_DEBUG = 3,
 } TB_LOG_LEVEL;
 
+typedef struct tb_init_parameters_t {
+    tb_uint128_t cluster_id;
+    tb_uint128_t client_id;
+    uint8_t* addresses_ptr;
+    uint64_t addresses_len;
+} tb_init_parameters_t;
+
 // Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_INIT_STATUS tb_client_init(
@@ -318,6 +325,14 @@ TB_INIT_STATUS tb_client_init_echo(
     uint32_t address_len,
     uintptr_t completion_ctx,
     void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+);
+
+// Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.
+// Return value: `TB_CLIENT_OK` on success, or `TB_CLIENT_INVALID` if the client handle was
+// not initialized or has already been closed.
+TB_CLIENT_STATUS tb_client_init_parameters(
+    tb_client_t* client,
+    tb_init_parameters_t* init_parameters_out
 );
 
 // Retrieve the callback context initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -12,6 +12,7 @@ const StateMachineType = @import("../../state_machine.zig").StateMachineType;
 const StateMachine = StateMachineType(Storage, constants.state_machine_config);
 
 pub const InitError = @import("tb_client/context.zig").InitError;
+pub const InitParameters = @import("tb_client/context.zig").InitParameters;
 pub const ClientInterface = @import("tb_client/context.zig").ClientInterface;
 pub const CompletionCallback = @import("tb_client/context.zig").CompletionCallback;
 pub const Packet = @import("tb_client/packet.zig").Packet.Extern;

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -23,6 +23,13 @@ const Message = MessagePool.Message;
 const Packet = @import("packet.zig").Packet;
 const Signal = @import("signal.zig").Signal;
 
+pub const InitParameters = extern struct {
+    cluster_id: u128,
+    client_id: u128,
+    addresses_ptr: [*]const u8,
+    addresses_len: u64,
+};
+
 /// Thread-safe client interface allocated by the user.
 /// Contains the `VTable` with function pointers to the StateMachine-specific implementation
 /// and the synchronization status.
@@ -33,6 +40,7 @@ pub const ClientInterface = extern struct {
         submit_fn: *const fn (*anyopaque, *Packet.Extern) void,
         completion_context_fn: *const fn (*anyopaque) usize,
         deinit_fn: *const fn (*anyopaque) void,
+        init_parameters_fn: *const fn (*anyopaque, *InitParameters) void,
     };
 
     /// Magic number used as a tag, preventing the use of uninitialized pointers.
@@ -100,6 +108,16 @@ pub const ClientInterface = extern struct {
         client.vtable.ptr.deinit_fn(context);
     }
 
+    pub fn init_parameters(client: *ClientInterface, out_parameters: *InitParameters) Error!void {
+        if (client.magic_number != beetle) return Error.ClientInvalid;
+        assert(client.reserved == 0);
+
+        client.locker.lock();
+        defer client.locker.unlock();
+        const context = client.context.ptr orelse return Error.ClientInvalid;
+        return client.vtable.ptr.init_parameters_fn(context, out_parameters);
+    }
+
     comptime {
         assert(@sizeOf(ClientInterface) == 32);
         assert(@alignOf(ClientInterface) == 8);
@@ -165,6 +183,8 @@ pub fn ContextType(
 
         allocator: std.mem.Allocator,
         client_id: u128,
+        cluster_id: u128,
+        addresses_copy: []const u8,
 
         addresses: stdx.BoundedArrayType(std.net.Address, constants.replicas_max),
         io: IO,
@@ -196,6 +216,9 @@ pub fn ContextType(
 
             context.allocator = allocator;
             context.client_id = stdx.unique_u128();
+            context.cluster_id = cluster_id;
+            context.addresses_copy = try allocator.dupe(u8, addresses);
+            errdefer allocator.free(context.addresses_copy);
 
             log.debug("{}: init: parsing vsr addresses: {s}", .{ context.client_id, addresses });
             context.addresses = .{};
@@ -269,6 +292,7 @@ pub fn ContextType(
                 .submit_fn = &vtable_submit_fn,
                 .completion_context_fn = &vtable_completion_context_fn,
                 .deinit_fn = &vtable_deinit_fn,
+                .init_parameters_fn = &vtable_init_parameters_fn,
             });
             context.interface = client_out;
             context.submitted = .{
@@ -841,7 +865,18 @@ pub fn ContextType(
             self.message_pool.deinit(self.allocator);
             self.io.deinit();
 
+            self.allocator.free(self.addresses_copy);
             self.allocator.destroy(self);
+        }
+
+        fn vtable_init_parameters_fn(context: *anyopaque, out_parameters: *InitParameters) void {
+            const self: *Context = @ptrCast(@alignCast(context));
+            assert(self.signal.status() == .running);
+
+            out_parameters.cluster_id = self.cluster_id;
+            out_parameters.client_id = self.client_id;
+            out_parameters.addresses_ptr = self.addresses_copy.ptr;
+            out_parameters.addresses_len = self.addresses_copy.len;
         }
 
         fn operation_from_int(op: u8) ?StateMachine.Operation {

--- a/src/clients/c/tb_client_exports.zig
+++ b/src/clients/c/tb_client_exports.zig
@@ -60,6 +60,7 @@ pub const tb_log_level = enum(c_int) {
 
 pub const tb_operation = tb.Operation;
 pub const tb_completion_t = tb.CompletionCallback;
+pub const tb_init_parameters = tb.InitParameters;
 
 pub const tb_account_t = vsr.tigerbeetle.Account;
 pub const tb_transfer_t = vsr.tigerbeetle.Transfer;
@@ -158,6 +159,17 @@ pub fn submit(tb_client: ?*tb_client_t, packet: *tb_packet_t) callconv(.C) tb_cl
 pub fn deinit(tb_client: ?*tb_client_t) callconv(.C) tb_client_status {
     const client: *tb.ClientInterface = if (tb_client) |ptr| ptr.cast() else return .invalid;
     client.deinit() catch |err| switch (err) {
+        error.ClientInvalid => return .invalid,
+    };
+    return .ok;
+}
+
+pub fn init_parameters(
+    tb_client: ?*tb_client_t,
+    out_parameters: *tb_init_parameters,
+) callconv(.C) tb_client_status {
+    const client: *tb.ClientInterface = if (tb_client) |ptr| ptr.cast() else return .invalid;
+    client.init_parameters(out_parameters) catch |err| switch (err) {
         error.ClientInvalid => return .invalid,
     };
     return .ok;

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -36,6 +36,7 @@ const type_mappings = .{
     .{ exports.tb_client_status, "TB_CLIENT_STATUS" },
     .{ exports.tb_register_log_callback_status, "TB_REGISTER_LOG_CALLBACK_STATUS" },
     .{ exports.tb_log_level, "TB_LOG_LEVEL" },
+    .{ exports.tb_init_parameters, "tb_init_parameters_t" },
 };
 
 fn resolve_c_type(comptime Type: type) []const u8 {
@@ -240,6 +241,14 @@ pub fn main() !void {
         \\    uint32_t address_len,
         \\    uintptr_t completion_ctx,
         \\    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+        \\);
+        \\
+        \\// Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.
+        \\// Return value: `TB_CLIENT_OK` on success, or `TB_CLIENT_INVALID` if the client handle was
+        \\// not initialized or has already been closed.
+        \\TB_CLIENT_STATUS tb_client_init_parameters(
+        \\    tb_client_t* client,
+        \\    tb_init_parameters_t* init_parameters_out
         \\);
         \\
         \\// Retrieve the callback context initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -297,6 +297,13 @@ typedef enum TB_LOG_LEVEL {
     TB_LOG_DEBUG = 3,
 } TB_LOG_LEVEL;
 
+typedef struct tb_init_parameters_t {
+    tb_uint128_t cluster_id;
+    tb_uint128_t client_id;
+    uint8_t* addresses_ptr;
+    uint64_t addresses_len;
+} tb_init_parameters_t;
+
 // Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_INIT_STATUS tb_client_init(
@@ -318,6 +325,14 @@ TB_INIT_STATUS tb_client_init_echo(
     uint32_t address_len,
     uintptr_t completion_ctx,
     void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+);
+
+// Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.
+// Return value: `TB_CLIENT_OK` on success, or `TB_CLIENT_INVALID` if the client handle was
+// not initialized or has already been closed.
+TB_CLIENT_STATUS tb_client_init_parameters(
+    tb_client_t* client,
+    tb_init_parameters_t* init_parameters_out
 );
 
 // Retrieve the callback context initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -477,6 +477,10 @@ pub fn main() !void {
         \\                                ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint32)
         \\LogHandler = ctypes.CFUNCTYPE(None, ctypes.c_uint, ctypes.c_void_p, ctypes.c_uint)
         \\
+        \\class InitParameters(ctypes.Structure):
+        \\    _fields_ = [("cluster_id", c_uint128), ("client_id", c_uint128),
+        \\                ("addresses_ptr", ctypes.c_void_p), ("addresses_len", ctypes.c_uint64)]
+        \\
         \\# Initialize a new TigerBeetle client which connects to the addresses provided and
         \\# completes submitted packets by invoking the callback with the given context.
         \\tb_client_init = tbclient.tb_client_init
@@ -491,6 +495,13 @@ pub fn main() !void {
         \\tb_client_init_echo.argtypes = [ctypes.POINTER(CClient), ctypes.POINTER(ctypes.c_uint8 * 16),
         \\                                ctypes.c_char_p, ctypes.c_uint32, ctypes.c_void_p,
         \\                                OnCompletion]
+        \\
+        \\# Returns the cluster_id and addresses passed in to either tb_client_init or
+        \\# tb_client_init_echo.
+        \\tb_client_init_parameters = tbclient.tb_client_init_parameters
+        \\tb_client_init_parameters.restype = ClientStatus
+        \\tb_client_init_parameters.argtypes = [ctypes.POINTER(CClient),
+        \\                                      ctypes.POINTER(InitParameters)]
         \\
         \\# Closes the client, causing any previously submitted packets to be completed with
         \\# `TB_PACKET_CLIENT_SHUTDOWN` before freeing any allocated client resources from init.

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -635,6 +635,10 @@ OnCompletion = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.POINTER(CPacket),
                                 ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint32)
 LogHandler = ctypes.CFUNCTYPE(None, ctypes.c_uint, ctypes.c_void_p, ctypes.c_uint)
 
+class InitParameters(ctypes.Structure):
+    _fields_ = [("cluster_id", c_uint128), ("client_id", c_uint128),
+                ("addresses_ptr", ctypes.c_void_p), ("addresses_len", ctypes.c_uint64)]
+
 # Initialize a new TigerBeetle client which connects to the addresses provided and
 # completes submitted packets by invoking the callback with the given context.
 tb_client_init = tbclient.tb_client_init
@@ -649,6 +653,13 @@ tb_client_init_echo.restype = InitStatus
 tb_client_init_echo.argtypes = [ctypes.POINTER(CClient), ctypes.POINTER(ctypes.c_uint8 * 16),
                                 ctypes.c_char_p, ctypes.c_uint32, ctypes.c_void_p,
                                 OnCompletion]
+
+# Returns the cluster_id and addresses passed in to either tb_client_init or
+# tb_client_init_echo.
+tb_client_init_parameters = tbclient.tb_client_init_parameters
+tb_client_init_parameters.restype = ClientStatus
+tb_client_init_parameters.argtypes = [ctypes.POINTER(CClient),
+                                      ctypes.POINTER(InitParameters)]
 
 # Closes the client, causing any previously submitted packets to be completed with
 # `TB_PACKET_CLIENT_SHUTDOWN` before freeing any allocated client resources from init.

--- a/src/clients/python/tests/test_init_parameters.py
+++ b/src/clients/python/tests/test_init_parameters.py
@@ -1,0 +1,51 @@
+import ctypes
+import itertools
+
+import tigerbeetle as tb
+tb.configure_logging(debug=True)
+
+cluster_ids = [
+    2**8 - 1,
+    2**16 - 1,
+    2**32 - 1,
+    2**64 - 1,
+    2**128 - 1,
+    71274155903562890452255960078140154531,
+]
+
+addresses = [
+    "1.1.1.1",
+    "1.1.1.1:3000",
+    "1.1.1.1:40000",
+    "127.127.127.127:12712",
+    "[0000:0000:0000:0000:0000:ffff:c0a8:64e4]:65535",
+    "[0000:0000:0000:0000:0000:ffff:c0a8:64e4]:65534",
+]
+
+def test_init_parameters():
+    address_permutations = []
+    for address in addresses:
+        address_permutations.append(",".join(itertools.repeat(address, 6)))
+    address_permutations.append(",".join(addresses))
+
+    for cluster_id in cluster_ids:
+        for address_permutation in address_permutations:
+            client = tb.ClientSync(cluster_id=cluster_id, replica_addresses=address_permutation)
+            init_parameters_out = tb.InitParameters()
+
+            status = tb.bindings.tb_client_init_parameters(
+                client._client,
+                ctypes.byref(init_parameters_out),
+            )
+
+            assert status == tb.ClientStatus.OK
+
+            addresses_out_slice = ctypes.cast(init_parameters_out.addresses_ptr,
+                ctypes.POINTER(ctypes.c_char * init_parameters_out.addresses_len))
+            addresses_out = bytes(addresses_out_slice.contents).decode("ascii")
+
+            assert init_parameters_out.client_id.to_python() != 0
+            assert init_parameters_out.cluster_id.to_python() == cluster_id
+            assert addresses_out == address_permutation
+
+            client.close()

--- a/src/tigerbeetle/libtb_client.zig
+++ b/src/tigerbeetle/libtb_client.zig
@@ -29,4 +29,8 @@ comptime {
         exports.register_log_callback,
         .{ .name = "tb_client_register_log_callback", .linkage = .strong },
     );
+    @export(
+        exports.init_parameters,
+        .{ .name = "tb_client_init_parameters", .linkage = .strong },
+    );
 }


### PR DESCRIPTION
This would have caught #2652 - it adds a simple round trip method, tb_client_init_parameters, that allows retrieving the cluster_id and addresses passed in when creating a cluster.

They are stored on the client context, so it works with both the real and echo clients. There's a little bit of overhead doing it this way, but I think it's the most straighforward.

Addresses in particular is duplicated as a string - IPv6 addresses (or even v4) might canonicalize and thus differ from the value passed in if the net.Address were formatted instead.

It also adds a test for Python - which should be extended to all languages.