### PR TITLE
VSR/Journal: `writing() → enum{none,slot,exact}`

### DIFF
--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1781,7 +1781,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(message.header.size >= @sizeOf(Header));
             assert(message.header.size <= message.buffer.len);
             assert(journal.has_header(message.header));
-            assert(!journal.writing(message.header.op, message.header.checksum));
+            assert(journal.writing(message.header) == .none);
             if (replica.solo()) assert(journal.writes.executing() == 0);
 
             // The underlying header memory must be owned by the buffer and not by journal.headers:
@@ -1840,6 +1840,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             const journal = write.journal;
             const message = write.message;
             assert(journal.status == .recovered);
+            assert(journal.writing(message.header) == .exact);
 
             // `prepare_inhabited[slot.index]` is usually false here, but may be true if two
             // (or more) writes to the same slot were queued concurrently and this is not the
@@ -1952,6 +1953,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             // This allows us to enforce journal.writes.len≤1 when replica_count=1, because the
             // callback may immediately start the next write.
             journal.writes.release(write);
+            assert(journal.writing(write_message.header) == .none);
+
             write_callback(replica, wrote, write_trigger);
             replica.message_bus.unref(write_message);
         }
@@ -2142,25 +2145,34 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             return sector;
         }
 
-        pub fn writing(journal: *Journal, op: u64, checksum: u128) bool {
-            const slot = journal.slot_for_op(op);
-            var found: bool = false;
-            var it = journal.writes.iterate();
-            while (it.next()) |write| {
-                const write_slot = journal.slot_for_op(write.message.header.op);
+        const Writing = enum {
+            none,
+            /// Either the prepare or the redundant header of a message with the same slot as the
+            /// given op is being written. It may be a different version of the same op, or a
+            /// different op which shares the prepare slot.
+            slot,
+            /// Either the prepare or the redundant header of a message with the exact op/checksum
+            /// is being written.
+            exact,
+        };
 
-                // It's possible that we might be writing the same op but with a different checksum.
-                // For example, if the op we are writing did not survive the view change and was
-                // replaced by another op. We must therefore do the search primarily on checksum.
-                // However, we compare against the 64-bit op first, since it's a cheap machine word.
-                if (write.message.header.op == op and write.message.header.checksum == checksum) {
-                    // If we truly are writing, then the dirty bit must be set:
-                    assert(journal.dirty.bit(journal.slot_for_op(op)));
-                    found = true;
-                } else if (write_slot.index == slot.index) {
-                    // If the in-progress write of '{op, checksum}' will be overwritten by another
-                    // write to the same slot, writing() must return false.
-                    found = false;
+        pub fn writing(journal: *Journal, header: *const Header.Prepare) Writing {
+            const slot = journal.slot_for_header(header);
+            var found: Writing = .none;
+            var writes = journal.writes.iterate();
+            while (writes.next()) |write| {
+                const write_slot = journal.slot_for_op(write.message.header.op);
+                if (write.message.header.op == header.op and
+                    write.message.header.checksum == header.checksum)
+                {
+                    assert(write_slot.index == slot.index);
+                    assert(found == .none);
+                    found = .exact;
+                } else {
+                    if (write_slot.index == slot.index) {
+                        assert(found == .none);
+                        found = .slot;
+                    }
                 }
             }
             return found;


### PR DESCRIPTION
## Bug

`Journal.writing()`'s implementation made the (incorrect) assumption that `journal.writes` were ordered chronologically. (This didn't manifest in the VOPR since incorrect results just lead to retries.)

Also, the previous version allowed hard-to-reason-about sequences of writes to the same slot.

## Fix

Since in practice contention of WAL writes at the same slot is rare (requiring either a view-change or a very weird checkpoint + WAL-repair scenario), just disallow it to simplify journal invariants.

`writing(op, checksum)` now returns either:
- `exact`: A message with the given `op`/`checksum` is being written.
- `slot`: A message with the given `op`/`checksum` is not being written, but a message _is_ being written to the same slot.
- `none`: None of the above.

(I'm not 100% happy with this solution, but the other things I tried were even more complicated.)

## Also

Rewrite `Journal.writing()` to take a header instead of `op`/`checksum`.