### PR TITLE
[Go client] Don't pre-allocate the reply buffer.

### DIFF
--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -236,7 +236,6 @@ func (c *c_client) doRequest(
 		}
 	}
 
-	// Return the amount of bytes written into result
 	return reply, nil
 }
 
@@ -277,7 +276,7 @@ func onGoPacketCompletion(
 			}
 		}
 
-		// Write the result data into the request's result.
+		// Copy the result data into a new buffer.
 		reply = make([]uint8, result_len)
 		C.memcpy(unsafe.Pointer(&reply[0]), unsafe.Pointer(result_ptr), C.size_t(result_len))
 	}


### PR DESCRIPTION
Rather than pre-allocating the reply buffer with the worst-case length, allocate it during the result callback when the actual reply size is known.

This more efficient approach is particularly important for query operations where the result size cannot be inferred from the input length, avoiding the need to allocate an oversized buffer with the maximum message size (1 MiB).