### PR TITLE
VOPR: Test misdirected writes

### DIFF
--- a/src/iops.zig
+++ b/src/iops.zig
@@ -25,7 +25,7 @@ pub fn IOPSType(comptime T: type, comptime size: u6) type {
         }
 
         pub fn index(self: *IOPS, item: *T) usize {
-            const i = (@intFromPtr(item) - @intFromPtr(&self.items)) / @sizeOf(T);
+            const i = @divExact((@intFromPtr(item) - @intFromPtr(&self.items)), @sizeOf(T));
             assert(i < size);
             return i;
         }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -878,13 +878,14 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     const table_usage = random.enumValue(TableUsage);
     log.info("table_usage={}", .{table_usage});
 
-    const storage_fault_atlas = ClusterFaultAtlas.init(3, random, .{
+    var storage_fault_atlas = try ClusterFaultAtlas.init(allocator, 3, random, .{
         .faulty_superblock = false,
         .faulty_wal_headers = false,
         .faulty_wal_prepares = false,
         .faulty_client_replies = false,
         .faulty_grid = true,
     });
+    defer storage_fault_atlas.deinit(allocator);
 
     const storage_options = .{
         .seed = random.int(u64),

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -41,6 +41,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
 
         /// Tracks the latest op acked by a replica across restarts.
         replica_head_max: []ReplicaHead,
+
         pub fn init(allocator: mem.Allocator, options: struct {
             cluster_id: u128,
             replica_count: u8,

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -44,16 +44,6 @@ const GridChecker = @import("./cluster/grid_checker.zig").GridChecker;
 
 const log = std.log.scoped(.storage);
 
-// TODOs:
-// less than a majority of replicas may have corruption
-// have an option to enable/disable the following corruption types:
-// bitrot
-// misdirected read/write
-// corrupt sector
-// latent sector error
-// - emulate by zeroing sector, as this is how we handle this in the real Storage implementation
-// - likely that surrounding sectors also corrupt
-// - likely that stuff written at the same time is also corrupt even if written to a far away sector
 pub const Storage = struct {
     /// Options for fault injection during fuzz testing
     pub const Options = struct {

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -443,12 +443,29 @@ pub const Storage = struct {
             }
         }
 
+        const faulty = storage.faulty and faulty: {
+            if (read.zone != .wal_prepares) break :faulty true;
+
+            // Don't corrupt a WAL prepare if the corresponding WAL header write was misdirected, to
+            // avoid a double-fault which the journal interprets as a torn prepare.
+            const header_slot = @divExact(read.offset, constants.message_size_max);
+            const header_offset = vsr.sector_floor(header_slot * @sizeOf(vsr.Header));
+
+            var overlays_iterator = storage.overlays.iterate();
+            while (overlays_iterator.next()) |overlay| {
+                if (overlay.zone == .wal_headers and overlay.offset == header_offset) {
+                    break :faulty false;
+                }
+            }
+            break :faulty true;
+        };
+
         var sectors = SectorRange.from_zone(read.zone, read.offset, read.buffer.len);
         const sectors_min = sectors.min;
         while (sectors.next()) |sector| {
             const sector_offset = (sector - sectors_min) * constants.sector_size;
             const sector_bytes = read.buffer[sector_offset..][0..constants.sector_size];
-            const sector_corrupt = storage.faulty and storage.faults.isSet(sector);
+            const sector_corrupt = faulty and storage.faults.isSet(sector);
             const sector_uninitialized = !storage.memory_written.isSet(sector);
 
             if (sector_corrupt) {

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -385,7 +385,9 @@ pub const Storage = struct {
         );
 
         if (storage.x_in_100(storage.options.read_fault_probability)) {
-            storage.fault_faulty_sectors(read.zone, read.offset, read.buffer.len);
+            if (storage.pick_faulty_sector(read.zone, read.offset, read.buffer.len)) |sector| {
+                storage.fault_sector(read.zone, sector);
+            }
         }
 
         var sectors = SectorRange.from_zone(read.zone, read.offset, read.buffer.len);
@@ -468,7 +470,9 @@ pub const Storage = struct {
         }
 
         if (storage.x_in_100(storage.options.write_fault_probability)) {
-            storage.fault_faulty_sectors(write.zone, write.offset, write.buffer.len);
+            if (storage.pick_faulty_sector(write.zone, write.offset, write.buffer.len)) |sector| {
+                storage.fault_sector(write.zone, sector);
+            }
         }
 
         write.callback(write);
@@ -495,27 +499,20 @@ pub const Storage = struct {
         return x > storage.prng.random().uintLessThan(u8, 100);
     }
 
-    fn fault_faulty_sectors(
+    fn pick_faulty_sector(
         storage: *Storage,
         zone: vsr.Zone,
         offset_in_zone: u64,
         size: u64,
-    ) void {
-        const atlas = storage.options.fault_atlas orelse return;
-        const replica_index = storage.options.replica_index.?;
-        const faulty_sectors = switch (zone) {
-            .superblock => atlas.faulty_superblock(replica_index, offset_in_zone, size),
-            .wal_headers => atlas.faulty_wal_headers(replica_index, offset_in_zone, size),
-            .wal_prepares => atlas.faulty_wal_prepares(replica_index, offset_in_zone, size),
-            .client_replies => atlas.faulty_client_replies(replica_index, offset_in_zone, size),
-            // We assert that the padding is never read, so there's no need to fault it.
-            .grid_padding => return,
-            .grid => atlas.faulty_grid(replica_index, offset_in_zone, size),
-        } orelse return;
-
-        // Randomly corrupt one of the faulty sectors the operation targeted.
-        // TODO: inject more realistic and varied storage faults as described above.
-        storage.fault_sector(zone, faulty_sectors.random(storage.prng.random()));
+    ) ?usize {
+        const atlas = storage.options.fault_atlas orelse return null;
+        return atlas.faulty_sector(
+            storage.prng.random(),
+            storage.options.replica_index.?,
+            zone,
+            offset_in_zone,
+            size,
+        );
     }
 
     fn fault_sector(storage: *Storage, zone: vsr.Zone, sector: usize) void {
@@ -819,36 +816,61 @@ pub const ClusterFaultAtlas = struct {
         faulty_grid: bool,
     };
 
+    const ZoneSet = std.enums.EnumSet(vsr.Zone);
     const ReplicaSet = std.StaticBitSet(constants.replicas_max);
     const headers_per_sector = @divExact(constants.sector_size, @sizeOf(vsr.Header));
     const header_sectors = @divExact(constants.journal_slot_count, headers_per_sector);
+    const members_max = constants.members_max;
 
-    const FaultyWALHeaders = std.StaticBitSet(@divExact(
-        constants.journal_size_headers,
-        constants.sector_size,
-    ));
-    const FaultyClientReplies = std.StaticBitSet(constants.clients_max);
-    const FaultyGridBlocks = std.StaticBitSet(Storage.grid_blocks_max);
-
-    options: Options,
-    faulty_wal_header_sectors: [constants.members_max]FaultyWALHeaders =
-        [_]FaultyWALHeaders{FaultyWALHeaders.initEmpty()} ** constants.members_max,
-    faulty_client_reply_slots: [constants.members_max]FaultyClientReplies =
-        [_]FaultyClientReplies{FaultyClientReplies.initEmpty()} ** constants.members_max,
+    faulty_zones: ZoneSet,
+    faulty_wal_header_sectors: [members_max]std.DynamicBitSetUnmanaged,
+    faulty_client_reply_slots: [members_max]std.DynamicBitSetUnmanaged,
     /// Bit 0 corresponds to address 1.
-    faulty_grid_blocks: [constants.members_max]FaultyGridBlocks =
-        [_]FaultyGridBlocks{FaultyGridBlocks.initEmpty()} ** constants.members_max,
+    faulty_grid_blocks: [members_max]std.DynamicBitSetUnmanaged,
 
-    pub fn init(replica_count: u8, random: std.rand.Random, options: Options) ClusterFaultAtlas {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        replica_count: u8,
+        random: std.rand.Random,
+        options: Options,
+    ) !ClusterFaultAtlas {
         if (replica_count == 1) {
             // If there is only one replica in the cluster, WAL/Grid faults are not recoverable.
+            maybe(options.faulty_superblock);
             assert(!options.faulty_wal_headers);
             assert(!options.faulty_wal_prepares);
             assert(!options.faulty_client_replies);
             assert(!options.faulty_grid);
         }
 
-        var atlas = ClusterFaultAtlas{ .options = options };
+        const fault_bitset_sizes = [3]u32{
+            @divExact(constants.journal_size_headers, constants.sector_size), // WAL headers.
+            constants.clients_max, // Client replies.
+            Storage.grid_blocks_max, // Grid.
+        };
+
+        var fault_bitsets_allocated: u32 = 0;
+        var fault_bitsets: [3 * members_max]std.DynamicBitSetUnmanaged = undefined;
+        errdefer for (fault_bitsets[0..fault_bitsets_allocated]) |*b| b.deinit(allocator);
+
+        for (&fault_bitsets, 0..) |*fault_bitset, i| {
+            const fault_bitset_size = fault_bitset_sizes[@divFloor(i, members_max)];
+            fault_bitset.* = try std.DynamicBitSetUnmanaged.initEmpty(allocator, fault_bitset_size);
+            fault_bitsets_allocated += 1;
+        }
+
+        var atlas = ClusterFaultAtlas{
+            .faulty_zones = ZoneSet.init(.{
+                .superblock = options.faulty_superblock,
+                .wal_headers = options.faulty_wal_headers,
+                .wal_prepares = options.faulty_wal_prepares,
+                .client_replies = options.faulty_client_replies,
+                .grid = options.faulty_grid,
+            }),
+            .faulty_wal_header_sectors = fault_bitsets[0 * members_max..][0..members_max].*,
+            .faulty_client_reply_slots = fault_bitsets[1 * members_max..][0..members_max].*,
+            .faulty_grid_blocks = fault_bitsets[2 * members_max..][0..members_max].*,
+        };
 
         const quorums = vsr.quorums(replica_count);
         const faults_max = quorums.replication - 1;
@@ -875,7 +897,7 @@ pub const ClusterFaultAtlas = struct {
 
         var block: usize = 0;
         while (block < Storage.grid_blocks_max) : (block += 1) {
-            var replicas = std.StaticBitSet(constants.members_max).initEmpty();
+            var replicas = std.StaticBitSet(members_max).initEmpty();
             while (replicas.count() < faults_max) {
                 replicas.set(random.uintLessThan(usize, replica_count));
             }
@@ -889,112 +911,66 @@ pub const ClusterFaultAtlas = struct {
         return atlas;
     }
 
-    /// Returns a range of faulty sectors which intersect the specified range.
-    fn faulty_superblock(
-        atlas: *const ClusterFaultAtlas,
-        replica_index: usize,
-        offset_in_zone: u64,
-        size: u64,
-    ) ?SectorRange {
-        _ = replica_index;
-        _ = offset_in_zone;
-        _ = size;
-        if (!atlas.options.faulty_superblock) return null;
-
-        // Don't inject additional read/write faults into superblock headers.
-        // This prevents the quorum from being lost like so:
-        // - copy₀: B (ok)
-        // - copy₁: B (torn write)
-        // - copy₂: A (corrupt)
-        // - copy₃: A (ok)
-        // TODO Use hash-chaining to safely load copy₀, so that we can inject a superblock fault.
-        return null;
+    pub fn deinit(atlas: *ClusterFaultAtlas, allocator: std.mem.Allocator) void {
+        for (&atlas.faulty_grid_blocks) |*b| b.deinit(allocator);
+        for (&atlas.faulty_client_reply_slots) |*b| b.deinit(allocator);
+        for (&atlas.faulty_wal_header_sectors) |*b| b.deinit(allocator);
     }
 
-    /// Returns a range of faulty sectors which intersect the specified range.
-    fn faulty_wal_headers(
-        atlas: *const ClusterFaultAtlas,
-        replica_index: usize,
-        offset_in_zone: u64,
-        size: u64,
-    ) ?SectorRange {
-        if (!atlas.options.faulty_wal_headers) return null;
-        return faulty_sectors(
-            FaultyWALHeaders.bit_length,
-            constants.sector_size,
-            .wal_headers,
-            &atlas.faulty_wal_header_sectors[replica_index],
-            offset_in_zone,
-            size,
-        );
+    fn zone_chunks(atlas: *const ClusterFaultAtlas, zone: vsr.Zone) ?struct {
+        chunk_size: u32,
+        faulty: *const [members_max]std.DynamicBitSetUnmanaged,
+    } {
+        if (!atlas.faulty_zones.contains(zone)) return null;
+
+        return switch (zone) {
+            // Don't inject additional read/write/misdirect faults into superblock headers.
+            // This prevents the quorum from being lost like so:
+            // - copy₀: B (ok)
+            // - copy₁: B (torn write)
+            // - copy₂: A (corrupt)
+            // - copy₃: A (ok)
+            // TODO Use hash-chaining to safely load copy₀, so that we can inject a superblock
+            // fault.
+            .superblock => null,
+            // We assert that the padding is never read, so there's no need to fault it.
+            .grid_padding => unreachable,
+
+            .wal_headers => .{
+                .chunk_size = constants.sector_size,
+                .faulty = &atlas.faulty_wal_header_sectors,
+            },
+            .wal_prepares => .{
+                .chunk_size = constants.message_size_max * headers_per_sector,
+                .faulty = &atlas.faulty_wal_header_sectors,
+            },
+            .client_replies => .{
+                .chunk_size = constants.message_size_max,
+                .faulty = &atlas.faulty_client_reply_slots,
+            },
+            .grid => .{
+                .chunk_size = constants.block_size,
+                .faulty = &atlas.faulty_grid_blocks,
+            },
+        };
     }
 
-    /// Returns a range of faulty sectors which intersect the specified range.
-    fn faulty_wal_prepares(
+    fn faulty_sector(
         atlas: *const ClusterFaultAtlas,
-        replica_index: usize,
+        random: std.Random,
+        replica_index: u8,
+        zone: vsr.Zone,
         offset_in_zone: u64,
         size: u64,
-    ) ?SectorRange {
-        if (!atlas.options.faulty_wal_prepares) return null;
-        return faulty_sectors(
-            FaultyWALHeaders.bit_length,
-            constants.message_size_max * headers_per_sector,
-            .wal_prepares,
-            &atlas.faulty_wal_header_sectors[replica_index],
-            offset_in_zone,
-            size,
-        );
-    }
+    ) ?usize {
+        const chunks = atlas.zone_chunks(zone) orelse return null;
 
-    fn faulty_client_replies(
-        atlas: *const ClusterFaultAtlas,
-        replica_index: usize,
-        offset_in_zone: u64,
-        size: u64,
-    ) ?SectorRange {
-        if (!atlas.options.faulty_client_replies) return null;
-        return faulty_sectors(
-            constants.clients_max,
-            constants.message_size_max,
-            .client_replies,
-            &atlas.faulty_client_reply_slots[replica_index],
-            offset_in_zone,
-            size,
-        );
-    }
-
-    fn faulty_grid(
-        atlas: *const ClusterFaultAtlas,
-        replica_index: usize,
-        offset_in_zone: u64,
-        size: u64,
-    ) ?SectorRange {
-        if (!atlas.options.faulty_grid) return null;
-        return faulty_sectors(
-            Storage.grid_blocks_max,
-            constants.block_size,
-            .grid,
-            &atlas.faulty_grid_blocks[replica_index],
-            offset_in_zone,
-            size,
-        );
-    }
-
-    fn faulty_sectors(
-        comptime chunk_count: usize,
-        comptime chunk_size: usize,
-        comptime zone: vsr.Zone,
-        faulty_chunks: *const std.StaticBitSet(chunk_count),
-        offset_in_zone: u64,
-        size: u64,
-    ) ?SectorRange {
         var fault_start: ?usize = null;
         var fault_count: usize = 0;
 
-        var chunk: usize = @divFloor(offset_in_zone, chunk_size);
-        while (chunk * chunk_size < offset_in_zone + size) : (chunk += 1) {
-            if (faulty_chunks.isSet(chunk)) {
+        var chunk: usize = @divFloor(offset_in_zone, chunks.chunk_size);
+        while (chunk * chunks.chunk_size < offset_in_zone + size) : (chunk += 1) {
+            if (chunks.faulty[replica_index].isSet(chunk)) {
                 if (fault_start == null) fault_start = chunk;
                 fault_count += 1;
             } else {
@@ -1005,9 +981,9 @@ pub const ClusterFaultAtlas = struct {
         if (fault_start) |start| {
             return SectorRange.from_zone(
                 zone,
-                chunk_size * start,
-                chunk_size * fault_count,
-            ).intersect(SectorRange.from_zone(zone, offset_in_zone, size)).?;
+                chunks.chunk_size * start,
+                chunks.chunk_size * fault_count,
+            ).intersect(SectorRange.from_zone(zone, offset_in_zone, size)).?.random(random);
         } else {
             return null;
         }

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -728,7 +728,14 @@ pub const Storage = struct {
         while (sector < sectors.max) : (sector += 1) {
             faulty = faulty or storage.faults.isSet(sector);
         }
-        return faulty;
+
+        var misdirected: bool = false;
+        var overlays = storage.overlays.iterate_const();
+        while (overlays.next()) |overlay| {
+            misdirected = misdirected or
+                (overlay.zone == area and overlay.offset == area.offset_in_zone());
+        }
+        return faulty or misdirected;
     }
 
     pub fn superblock_header(
@@ -877,41 +884,34 @@ pub const Storage = struct {
     }
 };
 
-pub const Area = union(enum) {
+pub const Area = union(vsr.Zone) {
     superblock: struct { copy: u8 },
     wal_headers: struct { sector: usize },
     wal_prepares: struct { slot: usize },
     client_replies: struct { slot: usize },
+    grid_padding,
     grid: struct { address: u64 },
 
-    fn sectors(area: Area) SectorRange {
+    fn offset_in_zone(area: Area) u64 {
         return switch (area) {
-            .superblock => |data| SectorRange.from_zone(
-                .superblock,
-                vsr.superblock.superblock_copy_size * @as(u64, data.copy),
-                vsr.superblock.superblock_copy_size,
-            ),
-            .wal_headers => |data| SectorRange.from_zone(
-                .wal_headers,
-                constants.sector_size * data.sector,
-                constants.sector_size,
-            ),
-            .wal_prepares => |data| SectorRange.from_zone(
-                .wal_prepares,
-                constants.message_size_max * data.slot,
-                constants.message_size_max,
-            ),
-            .client_replies => |data| SectorRange.from_zone(
-                .client_replies,
-                constants.message_size_max * data.slot,
-                constants.message_size_max,
-            ),
-            .grid => |data| SectorRange.from_zone(
-                .grid,
-                constants.block_size * (data.address - 1),
-                constants.block_size,
-            ),
+            .superblock => |data| vsr.superblock.superblock_copy_size * @as(u64, data.copy),
+            .wal_headers => |data| constants.sector_size * data.sector,
+            .wal_prepares => |data| constants.message_size_max * data.slot,
+            .client_replies => |data| constants.message_size_max * data.slot,
+            .grid_padding => unreachable,
+            .grid => |data| constants.block_size * (data.address - 1),
         };
+    }
+
+    fn sectors(area: Area) SectorRange {
+        return SectorRange.from_zone(area, area.offset_in_zone(), switch (area) {
+            .superblock => vsr.superblock.superblock_copy_size,
+            .wal_headers => constants.sector_size,
+            .wal_prepares => constants.message_size_max,
+            .client_replies => constants.message_size_max,
+            .grid_padding => unreachable,
+            .grid => constants.block_size,
+        });
     }
 };
 

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -176,6 +176,7 @@ pub fn main() !void {
             .write_latency_mean = 3 + random.uintLessThan(u16, 100),
             .read_fault_probability = random.uintLessThan(u8, 10),
             .write_fault_probability = random.uintLessThan(u8, 10),
+            .write_misdirect_probability = random.uintLessThan(u8, 10),
             .crash_fault_probability = 80 + random.uintLessThan(u8, 21),
         },
         .storage_fault_atlas = .{

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -389,6 +389,8 @@ pub fn main() !void {
             output.warn("no liveness, op={} is not available in core", .{header.op});
         } else if (try simulator.core_missing_blocks(allocator)) |blocks| {
             output.warn("no liveness, {} blocks are not available in core", .{blocks});
+        } else if (simulator.core_missing_reply()) |header| {
+            output.warn("no liveness, reply op={} is not available in core", .{header.op});
         } else {
             output.info("no liveness, final cluster state (core={b}):", .{simulator.core.mask});
             simulator.cluster.log_cluster();
@@ -897,6 +899,44 @@ pub const Simulator = struct {
         } else {
             return blocks_missing.items.len;
         }
+    }
+
+    /// Check whether the cluster is stuck because the entire core is missing the same reply[s].
+    pub fn core_missing_reply(simulator: *const Simulator) ?vsr.Header.Reply {
+        assert(simulator.core.count() > 0);
+
+        var replies_latest = [_]?vsr.Header.Reply{null} ** constants.clients_max;
+        for (simulator.cluster.replicas) |replica| {
+            for (replica.client_sessions.entries, 0..) |entry, entry_slot| {
+                if (entry.session != 0) {
+                    if (replies_latest[entry_slot] == null or
+                        replies_latest[entry_slot].?.op < entry.header.op)
+                    {
+                        replies_latest[entry_slot] = entry.header;
+                    }
+                }
+            }
+        }
+
+        for (replies_latest, 0..) |reply_or_empty, reply_slot| {
+            const reply = reply_or_empty orelse continue;
+            var reply_in_core: bool = false;
+            for (simulator.cluster.replicas) |replica| {
+                const storage = &simulator.cluster.storages[replica.replica];
+                const storage_replies = storage.client_replies();
+                const storage_reply = storage_replies[reply_slot];
+
+                if (simulator.core.isSet(replica.replica) and !replica.standby()) {
+                    if (storage_reply.header.checksum == reply.checksum and
+                        !storage.area_faulty(.{ .client_replies = .{ .slot = reply_slot } }))
+                    {
+                        reply_in_core = true;
+                    }
+                }
+            }
+            if (!reply_in_core) return reply;
+        }
+        return null;
     }
 
     fn core_release_max(simulator: *const Simulator) vsr.Release {

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -920,8 +920,7 @@ pub const Simulator = struct {
 
         for (replies_latest, 0..) |reply_or_empty, reply_slot| {
             const reply = reply_or_empty orelse continue;
-            var reply_in_core: bool = false;
-            for (simulator.cluster.replicas) |replica| {
+            const reply_in_core = for (simulator.cluster.replicas) |replica| {
                 const storage = &simulator.cluster.storages[replica.replica];
                 const storage_replies = storage.client_replies();
                 const storage_reply = storage_replies[reply_slot];
@@ -930,10 +929,10 @@ pub const Simulator = struct {
                     if (storage_reply.header.checksum == reply.checksum and
                         !storage.area_faulty(.{ .client_replies = .{ .slot = reply_slot } }))
                     {
-                        reply_in_core = true;
+                        break true;
                     }
                 }
-            }
+            } else false;
             if (!reply_in_core) return reply;
         }
         return null;

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1163,6 +1163,7 @@ pub const Simulator = struct {
             for (0..header_sector_count) |header_sector_index| {
                 replica_storage.faults.unset(header_sector_offset + header_sector_index);
             }
+            // TODO Clear misdirects? Waiting for a seed to confirm.
         }
 
         var header_prepare_view_mismatch: bool = false;

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -43,13 +43,14 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
     var prng = std.rand.DefaultPrng.init(seed);
     const random = prng.random();
 
-    const storage_fault_atlas = StorageFaultAtlas.init(1, random, .{
+    var storage_fault_atlas = try StorageFaultAtlas.init(allocator, 1, random, .{
         .faulty_superblock = true,
         .faulty_wal_headers = false,
         .faulty_wal_prepares = false,
         .faulty_client_replies = false,
         .faulty_grid = false,
     });
+    defer storage_fault_atlas.deinit(allocator);
 
     const storage_options = .{
         .replica_index = 0,


### PR DESCRIPTION
(Supersedes https://github.com/tigerbeetle/tigerbeetle/pull/2463.)

Test misdirected writes in the VOPR.

A _misdirected write_ is a disk fault where:

1. the data is not written to the intended location. (i.e. a "lost write"), and
2. the data _is_ written to a different, mistaken location.

Currently:

- We allow for (at most) one misdirect fault per `Storage` (i.e. per replica) for the time being, for simplicity and because double-faults are not covered by our fault model. This will hopefully match physical disks – misdirected faults are an order of magnitude less frequent than bit rot, which in turn is an order of magnitude less frequent than LSEs.
- In order to keep things interesting:
  - misdirections are always within the same zone,
  - the entire write is misdirected (rather than only some of the sectors), and
  - the misdirected write lands on a convenient offset.
  
  Thanks to rigorous checksums, misdirections that break these rules just manifest as corruptions, and corruption is already well-tested. The goal here is to test how TigerBeetle handles well-formed but incorrectly-located data.

The misdirection is implemented with "overlays" over the `Storage.memory` buffer, so that `Storage.memory` is always pristine. That is, `Storage.memory` is what the disk would look like if no faults had ever occurred.

---

Also in this PR:
- Refactoring `Storage`.
- Enable read/write faults in the `client_replies` zone. Previously we were only injecting faults due to crashes ("torn writes").
- With these new faults, the VOPR found:
  - a couple of minor incorrect asserts in the [journal](https://github.com/tigerbeetle/tigerbeetle/pull/2463/commits/176d716f2bb4fa413ac05b04a0cc43a5087097e0).
  - a [correctness bug](https://github.com/tigerbeetle/tigerbeetle/pull/2463/commits/3f309bf1a9fcaf3eb518ab1b99dcf9b53a6bc562) in journal recovery!
  - a bug in the [client replies](https://github.com/tigerbeetle/tigerbeetle/pull/2463/commits/3e9906731f356336a793cd6b7b0f6df9a89d0919).
  - (Fixes in https://github.com/tigerbeetle/tigerbeetle/pull/2506, https://github.com/tigerbeetle/tigerbeetle/pull/2653 and https://github.com/tigerbeetle/tigerbeetle/pull/2711).