### PR TITLE
vopr: increase ticks_max_convergence

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -68,7 +68,7 @@ const CLIArgs = struct {
     // "lite" mode runs a small cluster and only looks for crashes.
     lite: bool = false,
     ticks_max_requests: u32 = 40_000_000,
-    ticks_max_convergence: u32 = 10_000_000,
+    ticks_max_convergence: u32 = 20_000_000,
     positional: struct {
         seed: ?[]const u8 = null,
     },


### PR DESCRIPTION
This PR resolves the failed VOPR false positive `./zig/zig build -Drelease vopr -- 6175602010311320490` at fccba09ee0ea9ddf90af0ea8f9af3448641fed57. 

```C
[info] (cluster): no liveness, final cluster state (core=111001):
[info] (cluster):  0   \ .          3V  99/117/119C  88:119Jo  0/_0J!  88:119Wo <__0:__0> v1:1    50Ga  0G!   0G?
[info] (cluster):  1   \  .         3V  99/119/119C  88:119Jo  0/_0J!  88:119Wo <__0:__0> v1:1    50Ga  0G!   0G?
[info] (cluster):  2   \   .        3V  99/119/119C  88:119Jo  0/_0J!  88:119Wo <__0:__0> v1:1    50Ga  0G!   0G?
[info] (cluster):  3   /    .       3V  99/119/119C  88:119Jo  0/_0J!  88:119Wo <__0:__0> v1:1    50Ga  0G!   0G?   0/4Pp  0/3Rq
[info] (cluster):  4   \     .      3V  99/119/119C  88:119Jo  0/_0J!  88:119Wo <__0:__0> v1:1    50Ga  0G!   0G?
[info] (cluster):  5   |      .     3V  99/119/119C  88:119Jo  0/_0J!  88:119Wo <__0:__0> v1:1    50Ga  0G!   0G?
```

In this run, before transitioning to liveness mode, R2 is primary, which is connected to R1 and R3, but partitioned from R0 and R4. Thereafter, for liveness mode, R0, R3, and R4 are chosen as the fully connected core (the primary R2 is therefore outside of the fully connected core), and partitions between R2 ↔ R4 & R2 ↔ R0 are frozen. Therefore, R4 and R0 are not able to make commit progress while R2 is primary, since they can't receive any `commit` messages from R2.

We do have `core_missing_primary` to identify this condition, and to mark such VOPR runs as passed. However, in this run, the cluster transitions into view change and R3 steps up as primary *right* before the run ends. Thereafter, R0 doesn't get enough time to commit ops 118 → 119 (though R4 does).

This PR implements a stopgap solution to this problem: increasing `ticks_max_convergence` from 10_000_000 → 20_000_000, which merely _reduces_ the probability of this bug occurring. The *actual* solution is implementing partial connectivity awareness, which would allow an indirectly reachable primary to send `commit` messages to backups. In this case, the cluster could've made progress if `commit` messages could be sent from R2 → R1/R3 → R0/R4.