### PR TITLE
VSR/Grid: Remove invalid zero-padding assert 

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -845,7 +845,10 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                     assert(connection.recv_parsed <= connection.recv_progress);
                 }
 
-                if (message.header.command == .request or message.header.command == .prepare) {
+                if (message.header.command == .request or
+                    message.header.command == .prepare or
+                    message.header.command == .block)
+                {
                     const sector_ceil = vsr.sector_ceil(message.header.size);
                     if (message.header.size != sector_ceil) {
                         assert(message.header.size < sector_ceil);

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -302,7 +302,8 @@ pub const Network = struct {
         });
 
         if (target_message.header.command == .request or
-            target_message.header.command == .prepare)
+            target_message.header.command == .prepare or
+            target_message.header.command == .block)
         {
             const sector_ceil = vsr.sector_ceil(target_message.header.size);
             if (target_message.header.size != sector_ceil) {

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -86,7 +86,7 @@ pub const Storage = struct {
         /// Does not impact crash faults or manual faults.
         fault_atlas: ?*const ClusterFaultAtlas = null,
 
-        fault_granularity: enum { sector, byte } = .sector,
+        fault_granularity: enum { sector, bit } = .sector,
 
         /// Accessed by the Grid for extra verification of grid coherence.
         grid_checker: ?*GridChecker = null,
@@ -410,16 +410,17 @@ pub const Storage = struct {
 
             if (sector_corrupt) {
                 switch (storage.options.fault_granularity) {
-                    .byte => {
+                    .bit => {
                         // Rather than corrupting the entire sector, inject a localized error.
                         // (In some cases this will just corrupt sector padding.)
                         // Inject the fault at a deterministic position (by using the pristine bytes
                         // as consistent seed) so that read-retries don't resolve the corruption.
                         const corrupt_seed: u64 = @bitCast(sector_bytes[0..@sizeOf(u64)].*);
                         var corrupt_prng = std.rand.DefaultPrng.init(corrupt_seed);
-                        const corrupt_byte =
-                            corrupt_prng.random().uintLessThan(u32, sector_bytes.len);
-                        sector_bytes[corrupt_byte] +%= 1;
+                        const corrupt_random = corrupt_prng.random();
+                        const corrupt_byte = corrupt_random.uintLessThan(u32, sector_bytes.len);
+                        const corrupt_bit = corrupt_random.uintAtMost(u3, @bitSizeOf(u8) - 1);
+                        sector_bytes[corrupt_byte] ^= @as(u8, 1) << corrupt_bit;
                     },
                     .sector => {
                         storage.prng.random().bytes(sector_bytes);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -177,7 +177,7 @@ pub fn main() !void {
             .read_fault_probability = random.uintLessThan(u8, 10),
             .write_fault_probability = random.uintLessThan(u8, 10),
             .crash_fault_probability = 80 + random.uintLessThan(u8, 21),
-            .fault_granularity = if (random.boolean()) .sector else .byte,
+            .fault_granularity = if (random.boolean()) .sector else .bit,
         },
         .storage_fault_atlas = .{
             .faulty_superblock = true,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -177,7 +177,6 @@ pub fn main() !void {
             .read_fault_probability = random.uintLessThan(u8, 10),
             .write_fault_probability = random.uintLessThan(u8, 10),
             .crash_fault_probability = 80 + random.uintLessThan(u8, 21),
-            .fault_granularity = if (random.boolean()) .sector else .bit,
         },
         .storage_fault_atlas = .{
             .faulty_superblock = true,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -177,6 +177,7 @@ pub fn main() !void {
             .read_fault_probability = random.uintLessThan(u8, 10),
             .write_fault_probability = random.uintLessThan(u8, 10),
             .crash_fault_probability = 80 + random.uintLessThan(u8, 21),
+            .fault_granularity = if (random.boolean()) .sector else .byte,
         },
         .storage_fault_atlas = .{
             .faulty_superblock = true,

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1179,10 +1179,6 @@ pub fn GridType(comptime Storage: type) type {
 
             if (header.checksum != expect.checksum) return .unexpected_checksum;
 
-            if (constants.verify) {
-                assert(stdx.zeroed(block[header.size..vsr.sector_ceil(header.size)]));
-            }
-
             assert(header.address == expect.address);
             return .{ .valid = block };
         }

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1179,13 +1179,13 @@ pub fn GridType(comptime Storage: type) type {
 
             if (header.checksum != expect.checksum) return .unexpected_checksum;
 
-            if (constants.verify) {
-                if (!stdx.zeroed(block[header.size..vsr.sector_ceil(header.size)])) {
-                    log.warn("{}: read_block_validate: found corrupted padding for address={}", .{
-                        grid.superblock.replica_index.?,
-                        expect.address,
-                    });
-                }
+            const block_padding = block[header.size..vsr.sector_ceil(header.size)];
+            if (!stdx.zeroed(block_padding)) {
+                @memset(block_padding, 0);
+                log.warn("{}: read_block_validate: found corrupted padding for address={}", .{
+                    grid.superblock.replica_index.?,
+                    expect.address,
+                });
             }
 
             assert(header.address == expect.address);

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1160,7 +1160,7 @@ pub fn GridType(comptime Storage: type) type {
             grid.read_block_resolve(read, result);
         }
 
-        fn read_block_validate(grid: *const Grid, block: BlockPtrConst, expect: struct {
+        fn read_block_validate(grid: *const Grid, block: BlockPtr, expect: struct {
             address: u64,
             checksum: u128,
         }) ReadBlockResult {

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1179,6 +1179,12 @@ pub fn GridType(comptime Storage: type) type {
 
             if (header.checksum != expect.checksum) return .unexpected_checksum;
 
+            if (constants.verify) {
+                // We wrote the padding as zeroes, but it may have been corrupted, and the padding
+                // is not covered by any checksums.
+                maybe(stdx.zeroed(block[header.size..vsr.sector_ceil(header.size)]));
+            }
+
             assert(header.address == expect.address);
             return .{ .valid = block };
         }

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -934,6 +934,16 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             } else {
                 assert(message.header.checksum == checksum);
 
+                const message_padding =
+                    message.buffer[message.header.size..vsr.sector_ceil(message.header.size)];
+                if (!stdx.zeroed(message_padding)) {
+                    @memset(message_padding, 0);
+                    log.warn("{}: read_prepare: found corrupted padding for op={}", .{
+                        journal.replica,
+                        message.header.op,
+                    });
+                }
+
                 callback(replica, message, destination_replica);
             }
         }

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -506,7 +506,8 @@ pub const SuperBlockHeader = extern struct {
     }
 
     pub fn valid_checksum(superblock: *const SuperBlockHeader) bool {
-        return superblock.checksum == superblock.calculate_checksum();
+        return superblock.checksum == superblock.calculate_checksum() and
+            superblock.checksum_padding == 0;
     }
 
     pub fn checkpoint_id(superblock: *const SuperBlockHeader) u128 {


### PR DESCRIPTION
In the grid, after we read a block, we:
1. verify that the block has a valid header, then
2. verify that the block has a valid body, then
3. verify that it is the block we were expecting to find, then
4. assert that the block's sector padding is zeroed.

The last step can fail due to disk corruption -- sector padding isn't covered by any checksum.

Despite injecting many storage faults the VOPR (previously) couldn't detect this.
This is because when the VOPR injects a storage fault, it corrupts the whole sector -- if the padding is corrupt, then the header or body (or both) is also corrupt.

We missed this bug because we injected "too many" faults!

Accordingly, this PR adds single-bit fault storage injection.

---

Edit: VOPR found a similar bug [in the superblock header padding](https://github.com/tigerbeetle/tigerbeetle/pull/2681/commits/cac302db920e6f7a80174aedb70e87eb4e939a62) and [journal prepare padding](https://github.com/tigerbeetle/tigerbeetle/pull/2681/commits/1ea02eb5fcc600d853126a275d5ee647e0f425f1).

---

And a bug in the superblock `copy` index handling: https://github.com/tigerbeetle/tigerbeetle/pull/2681/commits/f38f2921435c71ad1eb20369bc52674edb1dcfe6

Each copy of the superblock includes a copy index (0...3) so that we can detect misdirects.

We want the superblock header checksums to match even though the copies are different, so the copy index is not covered by the checksum. We read in a superblock quorum, pick arbitrarily which of the identical headers to load into memory (well, near-identical -- they have distinct copy indexes). Then later when we are about to write our superblock, when we go to compute the superblock's checksum, we assert that (`superblock.copy < constants.superblock_copies`).

But if the copy of the superblock we loaded was corrupt, this may not be true!
