### PR TITLE
vopr: disable pauses before transition to liveness mode

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -68,7 +68,7 @@ const CLIArgs = struct {
     // "lite" mode runs a small cluster and only looks for crashes.
     lite: bool = false,
     ticks_max_requests: u32 = 40_000_000,
-    ticks_max_convergence: u32 = 20_000_000,
+    ticks_max_convergence: u32 = 10_000_000,
     positional: struct {
         seed: ?[]const u8 = null,
     },
@@ -641,6 +641,7 @@ pub const Simulator = struct {
         simulator.cluster.network.transition_to_liveness_mode(simulator.core);
         simulator.options.replica_crash_probability = 0;
         simulator.options.replica_restart_probability = 0;
+        simulator.options.replica_pause_probability = 0;
         simulator.options.replica_release_advance_probability = 0;
         simulator.options.replica_release_catchup_probability = 0;
     }


### PR DESCRIPTION
This PR implements the _correct_ solution for the VOPR false positive `./zig/zig build -Drelease vopr -- 6175602010311320490` at fccba09ee0ea9ddf90af0ea8f9af3448641fed57. Additionally, the increased ticks_max_convergence introduced in https://github.com/tigerbeetle/tigerbeetle/pull/2678 is reverted.

Before transitioning to liveness mode, _future_ storage & process-level faults must be disabled, to ensure that a view-change quorum of replicas (the core) get a _fixed_ environment to converge. Currently, `replica_pause_probability` isn't zeroed, which can lead to unexpected view changes during liveness mode. This PR sets `replica_pause_probability` to 0, to ensure liveness mode indeed is a fixed environment.

  