### PR TITLE
docs: add link checker

### DIFF
--- a/.github/ci/docs_check.sh
+++ b/.github/ci/docs_check.sh
@@ -10,14 +10,7 @@ set -eux
 #   fatal: detected dubious ownership in repository at '/wrk'
 git config --global --add safe.directory /build
 
-# Using a fork of this validate-links check to include checks on
-# absolute links until
-# https://github.com/remarkjs/remark-validate-links/issues/75 is fixed
-# upstream.
-npm install cspell@^6.31.1 remark-cli@^11.0.0 https://github.com/tigerbeetle/remark-validate-links
-
-# Validate links
-npx remark --use remark-validate-links --frail /build
+npm install cspell@^6.31.1
 
 cd /build
 

--- a/docs/about/README.md
+++ b/docs/about/README.md
@@ -89,7 +89,7 @@ TigerBeetle's Zig implementation of io_uring was
 
 BetaBeetle, the beta distributed version of TigerBeetle, was developed from January 2021 through
 August 2021, for strict serializability, fault tolerance and automated leader election with the
-pioneering [Viewstamped Replication](http://pmg.csail.mit.edu/papers/vr-revisited.pdf) and consensus
+pioneering [Viewstamped Replication](https://pmg.csail.mit.edu/papers/vr-revisited.pdf) and consensus
 protocol, plus the CTRL protocol from [Protocol-Aware Recovery for Consensus-Based
 Storage](https://www.youtube.com/watch?v=fDY6Wi0GcPs).
 
@@ -133,10 +133,10 @@ The collection of papers behind TigerBeetle:
   simple way to curb latency variability is to issue the same request to multiple replicas and use
   the results from whichever replica responds first."
 
-- [Viewstamped Replication Revisited](http://pmg.csail.mit.edu/papers/vr-revisited.pdf)
+- [Viewstamped Replication Revisited](https://pmg.csail.mit.edu/papers/vr-revisited.pdf)
 
 - [Viewstamped Replication: A New Primary Copy Method to Support Highly-Available Distributed
-  Systems](http://pmg.csail.mit.edu/papers/vr.pdf)
+  Systems](https://pmg.csail.mit.edu/papers/vr.pdf)
 
 - [ZFS: The Last Word in File Systems (Jeff Bonwick and Bill
   Moore)](https://www.youtube.com/watch?v=NRoUC9P1PmA) - On disk failure and corruption, the need

--- a/docs/about/README.md
+++ b/docs/about/README.md
@@ -106,7 +106,7 @@ The collection of papers behind TigerBeetle:
   a relational database is not the right solution.
 
 - [The LMAX Exchange Architecture - High Throughput, Low Latency and Plain Old Java -
-  2014](https://skillsmatter.com/skillscasts/5247-the-lmax-exchange-architecture-high-throughput-low-latency-and-plain-old-java)
+  2014](https://web.archive.org/web/20230403112934/https://skillsmatter.com/skillscasts/5247-the-lmax-exchange-architecture-high-throughput-low-latency-and-plain-old-java)
 
   - Sam Adams on the high-level design of LMAX.
 

--- a/docs/about/internals/lsm.md
+++ b/docs/about/internals/lsm.md
@@ -105,7 +105,7 @@ Level 2     b───d e─────h i───k l───n o─p q──�
 
 Links:
 - [`Manifest.compaction_table`](https://github.com/tigerbeetle/tigerbeetle/blob/main/src/lsm/manifest.zig)
-- [Constructing and Analyzing the LSM Compaction Design Space](http://vldb.org/pvldb/vol14/p2216-sarkar.pdf) describes the tradeoffs of various data movement policies. TigerBeetle implements the "least overlapping with parent" policy.
+- [Constructing and Analyzing the LSM Compaction Design Space](https://vldb.org/pvldb/vol14/p2216-sarkar.pdf) describes the tradeoffs of various data movement policies. TigerBeetle implements the "least overlapping with parent" policy.
 - [Option of Compaction Priority](https://rocksdb.org/blog/2016/01/29/compaction_pri.html)
 
 ##### Compaction Move Table

--- a/docs/about/safety.md
+++ b/docs/about/safety.md
@@ -29,7 +29,7 @@ as MySQL or an in-memory database such as Redis:
   availability and distributed fault-tolerance.
 
 - TigerBeetle **performs synchronous replication** to a quorum of backup TigerBeetle servers using
-  the pioneering [Viewstamped Replication](http://pmg.csail.mit.edu/papers/vr-revisited.pdf) and
+  the pioneering [Viewstamped Replication](https://pmg.csail.mit.edu/papers/vr-revisited.pdf) and
   consensus protocol for low-latency automated leader election and to eliminate the risk of
   split-brain associated with ad hoc manual failover systems.
 

--- a/docs/coding/time.md
+++ b/docs/coding/time.md
@@ -57,7 +57,7 @@ in seconds, rather than as an absolute timestamp, because it is also managed by 
 ### Timestamps are Totally Ordered
 
 All `timestamp`s within TigerBeetle are unique, immutable and
-[totally ordered](http://book.mixu.net/distsys/time.html). A transfer that is created before another
+[totally ordered](https://book.mixu.net/distsys/time.html). A transfer that is created before another
 transfer is guaranteed to have an earlier `timestamp` (even if they were created in the same
 request).
 

--- a/docs/reference/requests/README.md
+++ b/docs/reference/requests/README.md
@@ -34,14 +34,14 @@ Each request has a corresponding _event_ and _result_ type:
 
 | Request Type            | Event                                               | Result                                                          |
 | ----------------------- | --------------------------------------------------- | --------------------------------------------------------------- |
-| `create_accounts`       | [`Account`](./create_accounts.md#Event)             | [`CreateAccountResult`](./create_accounts.md#Result)            |
-| `create_transfers`      | [`Transfer`](./create_transfers.md#Event)           | [`CreateTransferResult`](./create_transfers.md#Result)          |
-| `lookup_accounts`       | [`Account.id`](./lookup_accounts.md#Event)          | [`Account`](./lookup_accounts.md#Result) or nothing             |
-| `lookup_transfers`      | [`Transfer.id`](./lookup_transfers.md#Event)        | [`Transfer`](./lookup_transfers.md#Result) or nothing           |
-| `get_account_transfers` | [`AccountFilter`](../account-filter.md)             | [`Transfer`](./get_account_transfers.md#Result) or nothing      |
-| `get_account_balances`  | [`AccountFilter`](../account-filter.md)             | [`AccountBalance`](./get_account_balances.md#Result) or nothing |
-| `query_accounts`        | [`QueryFilter`](../query-filter.md)                 | [`Account`](./lookup_accounts.md#Result) or nothing             |
-| `query_transfers`       | [`QueryFilter`](../query-filter.md)                 | [`Transfer`](./lookup_transfers.md#Result) or nothing           |
+| `create_accounts`       | [`Account`](./create_accounts.md#event)             | [`CreateAccountResult`](./create_accounts.md#result)            |
+| `create_transfers`      | [`Transfer`](./create_transfers.md#event)           | [`CreateTransferResult`](./create_transfers.md#result)          |
+| `lookup_accounts`       | [`Account.id`](./lookup_accounts.md#event)          | [`Account`](./lookup_accounts.md#result) or nothing             |
+| `lookup_transfers`      | [`Transfer.id`](./lookup_transfers.md#event)        | [`Transfer`](./lookup_transfers.md#result) or nothing           |
+| `get_account_transfers` | [`AccountFilter`](../account-filter.md)             | [`Transfer`](./get_account_transfers.md#result) or nothing      |
+| `get_account_balances`  | [`AccountFilter`](../account-filter.md)             | [`AccountBalance`](./get_account_balances.md#result) or nothing |
+| `query_accounts`        | [`QueryFilter`](../query-filter.md)                 | [`Account`](./lookup_accounts.md#result) or nothing             |
+| `query_transfers`       | [`QueryFilter`](../query-filter.md)                 | [`Transfer`](./lookup_transfers.md#result) or nothing           |
 
 ### Idempotency
 

--- a/src/docs_website/pandoc/markdown-links.lua
+++ b/src/docs_website/pandoc/markdown-links.lua
@@ -20,15 +20,7 @@ function Link (link)
     local _, target_level = link.target:gsub("/", "")
     local is_client_readme = link.target:find("README.md") and target_level == 4
     if is_client_readme then
-      link.target = link.target:sub(6) -- cut "/src/"
-      -- Figure our how deeply we're nested starting from /docs/
-      -- (This breaks if the tigerbeetle repo is in another folder named docs)
-      local _, endindex = PANDOC_STATE.input_files[1]:find("/docs/")
-      local _, source_level = PANDOC_STATE.input_files[1]:sub(endindex):gsub("/", "")
-      if is_readme then source_level = source_level - 1 end
-      for i=1,source_level do
-        link.target = "../" .. link.target
-      end
+      link.target = link.target:sub(5) -- Cut "/src"
     else
       -- Make GitHub link
       link.target = "https://github.com/tigerbeetle/tigerbeetle/blob/main" .. link.target

--- a/src/docs_website/src/file_checker.zig
+++ b/src/docs_website/src/file_checker.zig
@@ -138,7 +138,11 @@ const http_exceptions = std.StaticStringMap(void).initComptime(.{
 const https_exceptions = std.StaticStringMap(void).initComptime(.{
     .{"https://www.eecg.utoronto.ca/~yuan/papers/failure_analysis_osdi14.pdf"},
     .{"https://pmg.csail.mit.edu/papers/vr-revisited.pdf"},
+    .{"https://pmg.csail.mit.edu/papers/vr.pdf"},
     .{"https://www.infoq.com/presentations/LMAX/"},
+    .{"https://kernel.dk/io_uring.pdf"},
+    .{"https://research.cs.wisc.edu/wind/Publications/latent-sigmetrics07.pdf"},
+    .{"https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html"},
 });
 
 fn check_links(context: FileValidationContext) !void {
@@ -204,7 +208,7 @@ fn check_external_link(arena: std.mem.Allocator, link: Link) !void {
     if (!check_external_links) return;
     if (https_exceptions.has(link.base)) return;
 
-    errdefer |err| log.err("error {} while checking external link '{s}'", .{ err, link.base });
+    errdefer |err| log.err("got {} while checking external link '{s}'", .{ err, link.base });
 
     log.info("checking external link '{s}'", .{link.base});
 

--- a/src/docs_website/src/file_checker.zig
+++ b/src/docs_website/src/file_checker.zig
@@ -100,4 +100,65 @@ fn validate_text_file(arena: std.mem.Allocator, dir: std.fs.Dir, path: []const u
         log.err("file '{s}' doesn't end with a newline", .{try dir.realpathAlloc(arena, path)});
         return error.MissingNewline;
     }
+
+    if (std.mem.endsWith(u8, path, ".html")) {
+        try check_links(arena, dir, path);
+    }
+}
+
+// These links don't work with https.
+const https_exceptions = std.StaticStringMap(void).initComptime(.{
+    .{"http://www.bailis.org/blog/linearizability-versus-serializability/"},
+});
+
+fn check_links(arena: std.mem.Allocator, dir: std.fs.Dir, html_path: []const u8) !void {
+    const html = try dir.readFileAlloc(arena, html_path, file_size_max);
+
+    var line_it = std.mem.tokenizeScalar(u8, html, '\n');
+    var line_number: usize = 1;
+    while (line_it.next()) |line| {
+        defer line_number += 1;
+        errdefer log.err("[link checker] error in {s}:{}", .{ html_path, line_number });
+
+        var link_it = std.mem.tokenizeSequence(u8, line, "href=\"");
+        if (!std.mem.startsWith(u8, line, "href=\"")) _ = link_it.next(); // Skip prefix
+        while (link_it.next()) |chunk| {
+            var url = std.mem.sliceTo(chunk, '"');
+
+            // Strip anchor
+            if (std.mem.lastIndexOfScalar(u8, url, '#')) |i| url = url[0..i];
+            if (url.len == 0) continue;
+
+            if (std.mem.startsWith(u8, url, "http://")) {
+                if (https_exceptions.has(url)) continue;
+                log.err("Found insecure link: {s}", .{url});
+                return error.InsecureLink;
+            }
+
+            // Skip external link
+            if (std.mem.startsWith(u8, url, "https://")) continue;
+            if (std.mem.startsWith(u8, url, "mailto:")) continue;
+
+            const target = if (url[0] == '/')
+                url[1..]
+            else if (std.fs.path.dirname(html_path)) |dirname|
+                try std.fs.path.join(arena, &.{ dirname, url })
+            else
+                url;
+            if (target.len == 0) continue;
+
+            if (!try path_exists(dir, target)) {
+                log.err("Link (\"{s}\") target not found: {s}", .{ url, target });
+                return error.TargetNotFound;
+            }
+        }
+    }
+}
+
+fn path_exists(dir: std.fs.Dir, path: []const u8) !bool {
+    dir.access(path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    return true;
 }

--- a/src/docs_website/src/file_checker.zig
+++ b/src/docs_website/src/file_checker.zig
@@ -238,7 +238,7 @@ fn check_link_fragment(
 
     const html = try read_file_cached(context.arena, context.dir, target_path);
     const needle = try std.mem.concat(context.arena, u8, &.{ "id=\"", fragment, "\"" });
-    if (std.ascii.indexOfIgnoreCase(html, needle) == null) {
+    if (std.mem.indexOf(u8, html, needle) == null) {
         log.err("link target '{s}'' does not contain anchor: '{s}'", .{ target_path, fragment });
         return error.AnchorNotFound;
     }


### PR DESCRIPTION
Replaces `remark-validate-links` with a Zig implementation in `file_checker.zig`.
We also check for any insecure "http" links.