### PR TITLE
[tb_client] Fix incorrect assertion and clarify the API 

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -238,7 +238,7 @@ pub fn ContextType(
         /// Only one thread calls `deinit()`.
         /// Since it frees the Context, any further interaction is undefined behavior.
         pub fn deinit(self: *Context) void {
-            self.signal.shutdown();
+            self.signal.stop();
             self.thread.join();
             self.io.cancel_all();
 
@@ -280,7 +280,7 @@ pub fn ContextType(
             }
         }
         pub fn run(self: *Context) void {
-            while (self.signal.status() != .shutdown) {
+            while (self.signal.status() != .stopped) {
                 self.tick();
                 self.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms) catch |err| {
                     log.err("{}: IO.run() failed: {s}", .{

--- a/src/clients/c/tb_client/signal_fuzz.zig
+++ b/src/clients/c/tb_client/signal_fuzz.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.fuzz_signal);
+
+const Signal = @import("./signal.zig").Signal;
+const IO = @import("../../../io.zig").IO;
+const stdx = @import("../../../stdx.zig");
+const fuzz = @import("../../../testing/fuzz.zig");
+
+const Context = struct {
+    const Atomic = std.atomic.Value(enum(u8) {
+        none,
+        from_io_thread,
+        from_user_thread,
+    });
+
+    io: IO,
+    main_thread_id: std.Thread.Id,
+    signal: Signal,
+
+    random: std.Random,
+    running_count: u32 = 0,
+    stop_request: Atomic = Atomic.init(.none),
+};
+
+const Threads = stdx.BoundedArrayType(std.Thread, threads_limit);
+
+const threads_limit = 8;
+const stop_chance_percentage = 10;
+
+pub fn main(args: fuzz.FuzzArgs) !void {
+    var prng = std.rand.DefaultPrng.init(args.seed);
+    const events_max = args.events_max orelse 1_000_000;
+
+    var context: Context = .{
+        .io = try IO.init(32, 0),
+        .main_thread_id = std.Thread.getCurrentId(),
+        .signal = undefined,
+        .random = prng.random(),
+    };
+    defer context.io.deinit();
+
+    try Signal.init(&context.signal, &context.io, on_signal);
+    defer context.signal.deinit();
+
+    const threads_max = context.random.intRangeAtMost(u32, 1, threads_limit);
+    var threads: Threads = .{};
+    for (0..threads_max) |_| {
+        const thread: *std.Thread = threads.add_one_assume_capacity();
+        thread.* = try std.Thread.spawn(.{}, notify, .{&context});
+    }
+
+    while (context.signal.status() != .stopped) {
+        if (context.running_count >= events_max) {
+            if (context.stop_request.cmpxchgStrong(
+                .none,
+                .from_io_thread,
+                .acquire,
+                .monotonic,
+            ) == null) context.signal.stop();
+        }
+        try context.io.tick();
+    }
+
+    for (threads.slice()) |*thread| {
+        thread.join();
+    }
+
+    assert(context.stop_request.load(.monotonic) != .none);
+}
+
+fn notify(context: *Context) void {
+    const delay = 10 * std.time.ns_per_us;
+    assert(std.Thread.getCurrentId() != context.main_thread_id);
+    while (context.signal.status() != .stopped) {
+        std.time.sleep(delay);
+
+        // Chance to stop the signal between notifications.
+        if (chance(context.random, stop_chance_percentage)) {
+            if (context.stop_request.cmpxchgStrong(
+                .none,
+                .from_user_thread,
+                .acquire,
+                .monotonic,
+            ) == null) context.signal.stop();
+        }
+
+        // Notify has no effect if called after `stop()`.
+        context.signal.notify();
+    }
+}
+
+fn on_signal(signal: *Signal) void {
+    const context: *Context = @fieldParentPtr("signal", signal);
+    assert(std.Thread.getCurrentId() == context.main_thread_id);
+    switch (context.signal.status()) {
+        .running => {
+            context.running_count += 1;
+
+            // Chance to stop the signal while the notification is running.
+            if (chance(context.random, stop_chance_percentage)) {
+                if (context.stop_request.cmpxchgStrong(
+                    .none,
+                    .from_io_thread,
+                    .acquire,
+                    .monotonic,
+                ) == null) context.signal.stop();
+            }
+        },
+        .stop_requested => {
+            // It's not possible if `stop` was called from the IO thread.
+            assert(context.stop_request.load(.monotonic) == .from_user_thread);
+
+            // Requested while running, so still counts as one event.
+            context.running_count += 1;
+        },
+        .stopped => unreachable,
+    }
+}
+
+/// Returns true, `p` percent of the time, else false.
+fn chance(random: std.rand.Random, p: u8) bool {
+    assert(p <= 100);
+    return random.uintLessThanBiased(u8, 100) < p;
+}

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -952,25 +953,34 @@ public class IntegrationTest {
     public void testClientEvicted() throws Throwable {
         final int CLIENTS_MAX = 64;
 
+        final var barrier = new CountDownLatch(CLIENTS_MAX);
+        final var executor = Executors.newFixedThreadPool(CLIENTS_MAX);
+
         // Use a separate server to avoid evicting the test's shared client.
         try (final var server = new Server("testClientEvicted")) {
+
             try (final var client_evict =
                     new Client(clusterId, new String[] {server.getAddress()})) {
                 var accounts_first = client_evict.lookupAccounts(new IdBatch(UInt128.id()));
                 assertTrue(accounts_first.getLength() == 0);
 
-
                 for (int i = 0; i < CLIENTS_MAX; i++) {
-                    try (final var client =
-                            new Client(clusterId, new String[] {server.getAddress()})) {
-                        var accounts = client.lookupAccounts(new IdBatch(UInt128.id()));
-                        assertTrue(accounts.getLength() == 0);
-                    }
+                    executor.submit(() -> {
+                        try (final var client =
+                                new Client(clusterId, new String[] {server.getAddress()})) {
+                            var accounts = client.lookupAccounts(new IdBatch(UInt128.id()));
+                            assertTrue(accounts.getLength() == 0);
+                        } finally {
+                            barrier.countDown();
+                        }
+                    });
                 }
 
+                barrier.await();
+                executor.shutdown();
+
                 try {
-                    var accounts = client_evict.lookupAccounts(new IdBatch(UInt128.id()));
-                    assertTrue(accounts.getLength() == 0);
+                    client_evict.lookupAccounts(new IdBatch(UInt128.id()));
                     assert false;
                 } catch (RequestException requestException) {
                     assertEquals(PacketStatus.ClientEvicted.value, requestException.getStatus());

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -34,6 +34,7 @@ const Fuzzers = .{
     .vsr_journal_format = @import("./vsr/journal_format_fuzz.zig"),
     .vsr_superblock = @import("./vsr/superblock_fuzz.zig"),
     .vsr_superblock_quorums = @import("./vsr/superblock_quorums_fuzz.zig"),
+    .signal = @import("./clients/c/tb_client/signal_fuzz.zig"),
     // A fuzzer that intentionally fails, to test fuzzing infrastructure itself
     .canary = {},
     // Quickly run all fuzzers as a smoke test
@@ -87,6 +88,7 @@ fn main_smoke() !void {
             .vsr_journal_format,
             .vsr_superblock_quorums,
             .storage,
+            .signal,
             => null,
         };
 

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -90,6 +90,7 @@ const Fuzzer = enum {
     vsr_journal_format,
     vsr_superblock_quorums,
     vsr_superblock,
+    signal,
 
     fn args_build(comptime fuzzer: Fuzzer) []const []const u8 {
         return comptime switch (fuzzer) {


### PR DESCRIPTION
Fix the assertion too tight, as `signal.wait()` may be called if shutdown is requested during the callback.
Clarify the API regarding the status `running`, `stop_requested`, and `shutdown` to disambiguate.

Related the CI failure:
https://github.com/tigerbeetle/tigerbeetle/actions/runs/12989943988/job/36224019457