### PR TITLE
Update link to get_account_transfers.md

### DIFF
--- a/docs/reference/requests/get_account_balances.md
+++ b/docs/reference/requests/get_account_balances.md
@@ -7,7 +7,7 @@ balances.** This is off by default.
 
 - Each balance returned has a corresponding transfer with the same
   [`timestamp`](../transfer.md#timestamp). See the
-  [`get_account_transfers`](get_account_transfers.md) operation for more details.
+  [`get_account_transfers`](../get_account_transfers.md) operation for more details.
 
 - The amounts refer to the account balance recorded _after_ the transfer execution.
 


### PR DESCRIPTION
Currently returns a 404, see screenshot below (look at the url):
<img width="856" alt="Screenshot 2025-01-30 at 9 52 45 AM" src="https://github.com/user-attachments/assets/4ed45940-3a55-4270-8ef4-aed69720b806" />
