### PR TITLE
CFO: Balanced task scheduling

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -203,52 +203,46 @@ fn run_fuzzers(
         }
     };
 
-    var tasks_cache: ?Tasks = null;
+    var tasks = Tasks.init(shell.arena.allocator());
+    defer tasks.deinit();
+
     for (0..options.budget_seconds) |second| {
         const iteration_last = second == options.budget_seconds - 1;
         const iteration_pull = second % options.refresh_seconds == 0;
         const iteration_push = (second % options.refresh_seconds == 0 and second > 0) or
             iteration_last;
 
-        // Note that tasks are allocated by the arena, so they accumulate over the lifetime of CFO.
-        const tasks = tasks: {
-            if (iteration_pull) {
-                // TODO: This is a race -- run_fuzzers_prepare_tasks() modifies the working
-                // directory, which may still be in use by a running fuzzer.
-                const tasks = try run_fuzzers_prepare_tasks(shell, gh_token);
-                if (tasks_cache) |cache| run_fuzzers_prepare_tasks_runtime(tasks, cache);
+        if (iteration_pull) {
+            try run_fuzzers_prepare_tasks(&tasks, shell, gh_token);
 
-                log.info("fuzzing {} tasks", .{tasks.seed_template.len});
-                for (tasks.seed_template, tasks.weight) |seed_template, weight| {
-                    log.info("fuzzing commit={s} timestamp={} fuzzer={s} branch='{s}' weight={}", .{
-                        seed_template.commit_sha[0..7],
-                        seed_template.commit_timestamp,
-                        @tagName(seed_template.fuzzer),
-                        seed_template.branch,
-                        weight,
-                    });
+            for (tasks.list.items) |*task| {
+                if (task.generation == tasks.generation) {
+                    log.info(
+                        "fuzzing commit={s} timestamp={} fuzzer={s} branch='{s}' weight={}",
+                        .{
+                            task.seed_template.commit_sha[0..7],
+                            task.seed_template.commit_timestamp,
+                            @tagName(task.seed_template.fuzzer),
+                            task.seed_template.branch_url,
+                            task.weight,
+                        },
+                    );
                 }
-                break :tasks tasks;
-            } else {
-                break :tasks tasks_cache.?;
             }
-        };
-        tasks_cache = tasks;
+        }
 
         // Start new fuzzer processes.
         for (children) |*child_or_null| {
             if (child_or_null.* == null) {
-                const task_index = run_fuzzers_tasks_sample(tasks);
-                const working_directory = tasks.working_directory[task_index];
-                const seed_template = tasks.seed_template[task_index];
+                const task = tasks.sample();
                 const seed = random.int(u64);
 
                 // Ensure that multiple fuzzers spawned in the same tick are spread out over tasks.
-                tasks.runtimes[task_index] += 1;
+                task.runtime_virtual += 1;
 
                 const child = try run_fuzzers_start_fuzzer(shell, .{
-                    .working_directory = working_directory,
-                    .fuzzer = seed_template.fuzzer,
+                    .working_directory = task.working_directory,
+                    .fuzzer = task.seed_template.fuzzer,
                     .seed = seed,
                 });
                 // NB: take timestamp after spawning to exclude build time.
@@ -257,10 +251,10 @@ fn run_fuzzers(
                 child_or_null.* = .{
                     .child = child.process,
                     .seed = .{
-                        .commit_timestamp = seed_template.commit_timestamp,
-                        .commit_sha = seed_template.commit_sha,
-                        .fuzzer = @tagName(seed_template.fuzzer),
-                        .branch = seed_template.branch,
+                        .commit_timestamp = task.seed_template.commit_timestamp,
+                        .commit_sha = task.seed_template.commit_sha,
+                        .fuzzer = @tagName(task.seed_template.fuzzer),
+                        .branch = task.seed_template.branch_url,
 
                         .count = 1,
                         .seed_timestamp_start = seed_timestamp_start,
@@ -277,14 +271,15 @@ fn run_fuzzers(
         // Increment the runtime of running tasks.
         for (children) |*fuzzer_or_null| {
             if (fuzzer_or_null.*) |*fuzzer| {
-                if (tasks.map.get(.{
-                    .fuzzer = std.meta.stringToEnum(Fuzzer, fuzzer.seed.fuzzer).?,
-                    .commit = fuzzer.seed.commit_sha,
-                })) |task_index| {
-                    tasks.runtimes[task_index] += 1;
-                } else {
-                    // This is a leftover fuzzer from a now-cancelled task.
-                }
+                const task = tasks.get(
+                    std.meta.stringToEnum(Fuzzer, fuzzer.seed.fuzzer).?,
+                    fuzzer.seed.commit_sha,
+                ).?;
+                task.runtime += 1;
+                // Us a large (arbitrary) constant as the numerator to avoid rounding errors.
+                // Also this ensures that the initial +=1 when starting the process has relatively
+                // little impact, to avoid biasing scheduling in favor of long-running fuzzers.
+                task.runtime_virtual += @divFloor(1000, task.weight);
             }
         }
 
@@ -311,10 +306,12 @@ fn run_fuzzers(
                 const seed_expired = !fuzzer_done and seed_duration > options.timeout_seconds;
 
                 if (fuzzer_done or seed_expired or iteration_last) {
-                    log.debug(
-                        "will reap '{s}'{s}",
-                        .{ fuzzer.seed.command, if (fuzzer_done) "" else " (timeout)" },
-                    );
+                    log.debug("will reap '{s}' after {}s{s}", .{
+                        fuzzer.seed.command,
+                        seed_duration,
+                        if (fuzzer_done) "" else " (timeout)",
+                    });
+
                     const term = try if (fuzzer_done) fuzzer.child.wait() else fuzzer.child.kill();
                     if (std.meta.eql(term, .{ .Signal = std.posix.SIG.KILL })) {
                         // Something killed the fuzzer. This is likely OOM, so count this seed
@@ -358,30 +355,170 @@ fn run_fuzzers(
     }
     assert(seeds.items.len == 0);
 
-    for (tasks_cache.?.seed_template, tasks_cache.?.runtimes) |template, runtime| {
-        log.debug("commit={s} fuzzer={s:<24} runtime={}", .{
-            template.commit_sha[0..7],
-            @tagName(template.fuzzer),
-            runtime,
+    for (tasks.list.items) |*task| {
+        log.info("commit={s} fuzzer={s:<24} runtime={}s (active={})", .{
+            task.seed_template.commit_sha[0..7],
+            @tagName(task.seed_template.fuzzer),
+            task.runtime,
+            task.generation == tasks.generation,
         });
     }
 }
 
 const Tasks = struct {
-    /// Map value is the index within the task arrays.
+    /// Map values index into `list`.
     const Map = std.AutoHashMap(struct { fuzzer: Fuzzer, commit: [40]u8 }, usize);
+    const List = std.ArrayList(Task);
 
+    const Task = struct {
+        // Immutable:
+
+        working_directory: []const u8,
+        seed_template: SeedRecord.Template,
+
+        // Mutable:
+
+        /// Higher weight fuzzers are given more runtime.
+        weight: u32,
+        /// Active tasks have `task.generation == tasks.generation`.
+        /// Inactive tasks have `task.generation < tasks.generation`.
+        generation: u64,
+        /// This is just used for logging, not scheduling.
+        runtime: u64,
+        /// Weight-adjusted runtime used for scheduling. Always positive and finite.
+        /// Cumulative `runtime / weight`, but since `weight` can change over time, this is more
+        /// precise.
+        runtime_virtual: u64,
+    };
+
+    generation: u64 = 1,
+    runtime_init: u64 = 1,
+
+    list: List,
     map: Map,
-    working_directory: [][]const u8,
-    seed_template: []SeedRecord.Template,
-    weight: []u32,
-    /// Estimated cumulative runtime of the corresponding task.
-    runtimes: []u64,
+
+    pub fn init(allocator: std.mem.Allocator) Tasks {
+        return .{
+            .list = Tasks.List.init(allocator),
+            .map = Tasks.Map.init(allocator),
+        };
+    }
+
+    pub fn deinit(tasks: *Tasks) void {
+        tasks.map.deinit();
+        tasks.list.deinit();
+        tasks.* = undefined;
+    }
+
+    pub fn verify(tasks: *const Tasks) void {
+        assert(tasks.list.items.len == tasks.map.count());
+
+        var map_iterator = tasks.map.iterator();
+        while (map_iterator.next()) |map_entry| {
+            const task_index = map_entry.value_ptr.*;
+            const task = &tasks.list.items[task_index];
+            assert(@intFromPtr(task) >= @intFromPtr(tasks.list.items.ptr));
+            assert(@intFromPtr(task) < @intFromPtr(tasks.list.items.ptr) +
+                @sizeOf(Task) * tasks.list.items.len);
+            assert(task.seed_template.fuzzer == map_entry.key_ptr.fuzzer);
+            assert(std.mem.eql(u8, &task.seed_template.commit_sha, &map_entry.key_ptr.commit));
+        }
+
+        for (tasks.list.items) |*task| {
+            assert(task.generation <= tasks.generation);
+            assert(task.weight > 0);
+            assert(task.runtime_virtual >= 1);
+        }
+    }
+
+    /// Pick a task to run next.
+    /// Returns the task with the minimal virtual runtime.
+    pub fn sample(tasks: *const Tasks) *Task {
+        assert(tasks.list.items.len == tasks.map.count());
+        assert(tasks.list.items.len > 0);
+
+        var task_best_runtime_virtual: ?u64 = null;
+        var task_best: ?*Task = null;
+        for (tasks.list.items) |*task| {
+            assert(task.runtime_virtual > 0);
+            assert(task.generation <= tasks.generation);
+
+            if (task.generation == tasks.generation) {
+                if (task_best_runtime_virtual == null or
+                    task_best_runtime_virtual.? > task.runtime_virtual)
+                {
+                    task_best_runtime_virtual = task.runtime_virtual;
+                    task_best = task;
+                }
+            }
+        }
+        return task_best.?;
+    }
+
+    pub fn get(tasks: *const Tasks, fuzzer: Fuzzer, commit: [40]u8) ?*Task {
+        const task_index = tasks.map.get(.{
+            .fuzzer = fuzzer,
+            .commit = commit,
+        }) orelse return null;
+        return &tasks.list.items[task_index];
+    }
+
+    /// Either:
+    /// - If the specified task does not already exist, create it.
+    /// - Is the specified task does already exist, activate it for the new generation.
+    pub fn put(
+        tasks: *Tasks,
+        working_directory: []const u8,
+        seed_template: SeedRecord.Template,
+    ) !void {
+        if (tasks.map.get(.{
+            .fuzzer = seed_template.fuzzer,
+            .commit = seed_template.commit_sha,
+        })) |task_existing_index| {
+            const task_existing = &tasks.list.items[task_existing_index];
+            assert(task_existing.generation < tasks.generation);
+            assert(task_existing.seed_template.fuzzer == seed_template.fuzzer);
+            assert(std.mem.eql(u8, task_existing.working_directory, working_directory));
+
+            if (tasks.runtime_init < task_existing.runtime_virtual) {
+                tasks.runtime_init = task_existing.runtime_virtual;
+            } else {
+                if (task_existing.generation == tasks.generation - 1) {
+                    // For tasks that were already active, leave their low `runtime_virtual`
+                    // unmodified, to ensure they get some runtime soon.
+                } else {
+                    // For tasks which were active in the past, but not in the latest generation,
+                    // ensure that they are not starved in the new generation.
+                    task_existing.runtime_virtual = tasks.runtime_init;
+                }
+            }
+            task_existing.generation = tasks.generation;
+        } else {
+            try tasks.list.append(.{
+                .working_directory = working_directory,
+                .seed_template = seed_template,
+                .generation = tasks.generation,
+                .weight = 0, // To be initialized later.
+                .runtime = 0,
+                .runtime_virtual = tasks.runtime_init,
+            });
+
+            try tasks.map.putNoClobber(.{
+                .fuzzer = seed_template.fuzzer,
+                .commit = seed_template.commit_sha,
+            }, tasks.list.items.len - 1);
+        }
+    }
+
+    pub fn soft_remove_all(tasks: *Tasks) void {
+        tasks.verify();
+        tasks.generation += 1;
+    }
 };
 
-fn run_fuzzers_prepare_tasks(shell: *Shell, gh_token: ?[]const u8) !Tasks {
-    var working_directory = std.ArrayList([]const u8).init(shell.arena.allocator());
-    var seed_template = std.ArrayList(SeedRecord.Template).init(shell.arena.allocator());
+fn run_fuzzers_prepare_tasks(tasks: *Tasks, shell: *Shell, gh_token: ?[]const u8) !void {
+    tasks.soft_remove_all();
+    defer tasks.verify();
 
     { // Main branch fuzzing.
         const commit = if (gh_token == null)
@@ -399,16 +536,16 @@ fn run_fuzzers_prepare_tasks(shell: *Shell, gh_token: ?[]const u8) !Tasks {
         };
 
         for (std.enums.values(Fuzzer)) |fuzzer| {
-            try working_directory.append(if (gh_token == null) "." else "./working/main");
-            try seed_template.append(.{
+            const working_directory = if (gh_token == null) "." else "./working/main";
+            _ = try tasks.put(working_directory, .{
                 .commit_timestamp = commit.timestamp,
                 .commit_sha = commit.sha,
                 .fuzzer = fuzzer,
-                .branch = "https://github.com/tigerbeetle/tigerbeetle",
+                .branch = .main,
+                .branch_url = "https://github.com/tigerbeetle/tigerbeetle",
             });
         }
     }
-    const task_main_count: u32 = @intCast(seed_template.items.len);
 
     if (gh_token != null) {
         // Any PR labeled like 'fuzz lsm_tree'
@@ -461,12 +598,12 @@ fn run_fuzzers_prepare_tasks(shell: *Shell, gh_token: ?[]const u8) !Tasks {
 
                 if (labeled or fuzzer == .canary) {
                     pr_fuzzers_count += 1;
-                    try working_directory.append(pr_directory);
-                    try seed_template.append(.{
+                    try tasks.put(pr_directory, .{
                         .commit_timestamp = commit.timestamp,
                         .commit_sha = commit.sha,
                         .fuzzer = fuzzer,
-                        .branch = try shell.fmt(
+                        .branch = .{ .pull = pr.number },
+                        .branch_url = try shell.fmt(
                             "https://github.com/tigerbeetle/tigerbeetle/pull/{d}",
                             .{pr.number},
                         ),
@@ -476,105 +613,52 @@ fn run_fuzzers_prepare_tasks(shell: *Shell, gh_token: ?[]const u8) !Tasks {
             assert(pr_fuzzers_count >= 2); // The canary and at least one different fuzzer.
         }
     }
-    const task_pr_count: u32 = @intCast(seed_template.items.len - task_main_count);
+
+    const task_main_count, const task_pull_count = counts: {
+        var task_main_count: u32 = 0;
+        var task_pull_count: u32 = 0;
+        for (tasks.list.items) |*task| {
+            if (task.generation == tasks.generation) {
+                task_main_count += @intFromBool(task.seed_template.branch == .main);
+                task_pull_count += @intFromBool(task.seed_template.branch == .pull);
+            }
+        }
+        break :counts .{ task_main_count, task_pull_count };
+    };
 
     // Split time 50:50 between fuzzing main and fuzzing labeled PRs.
-    const weight = try shell.arena.allocator().alloc(u32, working_directory.items.len);
-    var weight_main_total: usize = 0;
-    var weight_pr_total: usize = 0;
-    for (weight[0..task_main_count]) |*weight_main| {
-        weight_main.* = @max(task_pr_count, 1);
-        weight_main_total += weight_main.*;
-    }
-    for (weight[task_main_count..]) |*weight_pr| {
-        weight_pr.* = @max(task_main_count, 1);
-        weight_pr_total += weight_pr.*;
-    }
-    if (weight_main_total > 0 and weight_pr_total > 0) {
-        assert(weight_main_total == weight_pr_total);
-    }
-
-    for (weight, seed_template.items) |*weight_ptr, seed| {
-        if (seed.fuzzer == .vopr or seed.fuzzer == .vopr_lite or
-            seed.fuzzer == .vopr_testing or seed.fuzzer == .vopr_testing_lite)
-        {
-            weight_ptr.* *= 2; // Bump relative priority of VOPR runs.
+    var weight_main_total: u32 = 0;
+    var weight_pull_total: u32 = 0;
+    for (tasks.list.items) |*task| {
+        if (task.generation == tasks.generation) {
+            switch (task.seed_template.branch) {
+                .main => {
+                    task.weight = @max(task_pull_count, 1);
+                    weight_main_total += task.weight;
+                },
+                .pull => {
+                    task.weight = @max(task_main_count, 1);
+                    weight_pull_total += task.weight;
+                },
+            }
         }
     }
-
-    const runtimes = try shell.arena.allocator().alloc(u64, working_directory.items.len);
-    @memset(runtimes, 1);
-
-    var map = Tasks.Map.init(shell.arena.allocator());
-    for (seed_template.items, 0..) |template, i| {
-        try map.putNoClobber(.{
-            .fuzzer = template.fuzzer,
-            .commit = template.commit_sha,
-        }, i);
+    if (weight_main_total > 0 and weight_pull_total > 0) {
+        assert(weight_main_total == weight_pull_total);
     }
 
-    return .{
-        .map = map,
-        .working_directory = working_directory.items,
-        .seed_template = seed_template.items,
-        .weight = weight,
-        .runtimes = runtimes,
-    };
-}
-
-/// Initialize the runtime of each task in `tasks`.
-fn run_fuzzers_prepare_tasks_runtime(tasks: Tasks, tasks_cache: Tasks) void {
-    assert(tasks.runtimes.len == tasks.weight.len);
-    assert(tasks.runtimes.len > 0);
-    assert(tasks_cache.runtimes.len == tasks_cache.weight.len);
-    assert(tasks_cache.runtimes.len > 0);
-
-    const runtime_min = runtime_min: {
-        var runtime_min: u64 = std.math.maxInt(u64);
-        for (tasks_cache.runtimes) |task_cached_runtime| {
-            runtime_min = @min(runtime_min, task_cached_runtime);
-        }
-        assert(runtime_min < std.math.maxInt(u64));
-        assert(runtime_min > 0);
-        break :runtime_min runtime_min;
-    };
-
-    for (tasks.seed_template, tasks.runtimes) |*task, *task_runtime| {
-        if (tasks_cache.map.get(.{
-            .fuzzer = task.fuzzer,
-            .commit = task.commit_sha,
-        })) |task_cached_index| {
-            // Tasks that were already being fuzzed inherit their original runtime.
-            task_runtime.* = tasks_cache.runtimes[task_cached_index];
-        } else {
-            // Brand-new tasks are assigned the smallest existing task's runtime, to ensure that the
-            // new tasks don't starve old tasks.
-            task_runtime.* = runtime_min;
+    for (tasks.list.items) |*task| {
+        if (task.generation == tasks.generation) {
+            const fuzzer = task.seed_template.fuzzer;
+            if (fuzzer == .vopr or fuzzer == .vopr_lite or
+                fuzzer == .vopr_testing or fuzzer == .vopr_testing_lite)
+            {
+                task.weight = 2; // Bump relative priority of VOPR runs.
+            } else {
+                task.weight = 1;
+            }
         }
     }
-}
-
-/// Returns the index of the task with the minimal `runtime / weight`.
-fn run_fuzzers_tasks_sample(tasks: Tasks) usize {
-    assert(tasks.runtimes.len == tasks.weight.len);
-    assert(tasks.runtimes.len > 0);
-
-    var task_best_runtime_weighted: ?u64 = null;
-    var task_best_index: ?usize = null;
-    for (tasks.runtimes, tasks.weight, 0..) |task_runtime, task_weight, i| {
-        assert(task_runtime > 0);
-        assert(task_weight > 0);
-
-        // Multiply by a large (arbitrary) constant to avoid rounding errors.
-        const task_runtime_weighted = @divFloor(task_runtime * 1024, task_weight);
-        if (task_best_runtime_weighted == null or
-            task_best_runtime_weighted.? > task_runtime_weighted)
-        {
-            task_best_runtime_weighted = task_runtime_weighted;
-            task_best_index = i;
-        }
-    }
-    return task_best_index.?;
 }
 
 const Commit = struct {
@@ -771,7 +855,8 @@ const SeedRecord = struct {
     branch: []const u8,
 
     const Template = struct {
-        branch: []const u8,
+        branch: union(enum) { main, pull: u32 },
+        branch_url: []const u8,
         commit_timestamp: u64,
         commit_sha: [40]u8,
         fuzzer: Fuzzer,


### PR DESCRIPTION
## Bug

Right now the CFO chooses which fuzzer to run via a probability-proportional sampling from the task weights. The intent is that we can prioritize certain fuzzers (e.g. the VOPR).

But the sampling doesn't take into account how long fuzzers tend to run. This leads to long-running fuzzers spending more than their fair share of time on the CPU.

More specifically, CFO spends the vast majority of its time on LSM fuzzers, starving the VOPR:

- In my local tests, when fuzzing main + 2 PR's, the CFO spends 50-95% of its time fuzzing main's LSM. (Lots of variance).
- Only 1-10% of its time was spent on main's VOPRs.

(Less quantitatively, if you `ssh` into a CFO box and run `top`, it is rare to see the VOPR running.)

## Fix

Change how we sample tasks to fuzz:

- Track estimate cumulative runtime for each task.
- When selecting a task to fuzz, choose the task with the minimum `task_cumulative_runtime / task_weight`.
- When a new task is added to the pool (e.g. because we discover a new PR to fuzz), initialize its runtime to the minimum runtime of any task.
  - This ensures that a new task doesn't starve the old tasks by starting with zero runtime.
  - It also allows the old tasks to reuse their old runtimes. Tallying runtimes over larger timespans gives us more accurate estimates and thus more balanced scheduling.

The above algorithm is inspired by Linux's "Completely Fair Scheduler".

Note that the runtime estimate doesn't exactly correlate to "real" time:
- we increment the runtime when starting a fuzzer,
- the runtime doesn't count time that the fuzzer is running while the CFO is also compiling another task, and
- if a fuzzer completes in less than 1 second (the CFO's loop-sleep) then it still counts as 1 second of runtime.

## Follow-up

We should probably adjust the weights as well, e.g. not run the canary so often.

## Measurements

These are just 20 minute samples (with concurrency=1).

<details>
<summary>Cumulative estimated runtimes, pre-fair-scheduling</summary>

```
debug: commit=bb40482 fuzzer=canary                   runtime=11
debug: commit=bb40482 fuzzer=ewah                     runtime=5
debug: commit=bb40482 fuzzer=lsm_cache_map            runtime=206
debug: commit=bb40482 fuzzer=lsm_forest               runtime=302
debug: commit=bb40482 fuzzer=lsm_manifest_level       runtime=15
debug: commit=bb40482 fuzzer=lsm_manifest_log         runtime=15
debug: commit=bb40482 fuzzer=lsm_scan                 runtime=9
debug: commit=bb40482 fuzzer=lsm_segmented_array      runtime=13
debug: commit=bb40482 fuzzer=lsm_tree                 runtime=189
debug: commit=bb40482 fuzzer=storage                  runtime=13
debug: commit=bb40482 fuzzer=vopr_lite                runtime=27
debug: commit=bb40482 fuzzer=vopr_testing_lite        runtime=27
debug: commit=bb40482 fuzzer=vopr_testing             runtime=45
debug: commit=bb40482 fuzzer=vopr                     runtime=49
debug: commit=bb40482 fuzzer=vsr_free_set             runtime=12
debug: commit=bb40482 fuzzer=vsr_journal_format       runtime=5
debug: commit=bb40482 fuzzer=vsr_superblock_quorums   runtime=17
debug: commit=bb40482 fuzzer=vsr_superblock           runtime=13
debug: commit=3f4fe4f fuzzer=canary                   runtime=37
debug: commit=3f4fe4f fuzzer=vopr_lite                runtime=58
debug: commit=d7167fd fuzzer=canary                   runtime=39
debug: commit=d7167fd fuzzer=vopr_lite                runtime=88
debug: commit=d7167fd fuzzer=vopr                     runtime=278
```

</details>

<details>
<summary>Cumulative estimated runtimes, post-fair-scheduling</summary>


(Note that `lsm_tree` only ran once, just for a long time:)

```
debug: commit=bb40482 fuzzer=canary                   runtime=35
debug: commit=bb40482 fuzzer=ewah                     runtime=35
debug: commit=bb40482 fuzzer=lsm_cache_map            runtime=34
debug: commit=bb40482 fuzzer=lsm_forest               runtime=64
debug: commit=bb40482 fuzzer=lsm_manifest_level       runtime=35
debug: commit=bb40482 fuzzer=lsm_manifest_log         runtime=34
debug: commit=bb40482 fuzzer=lsm_scan                 runtime=41
debug: commit=bb40482 fuzzer=lsm_segmented_array      runtime=34
debug: commit=bb40482 fuzzer=lsm_tree                 runtime=104
debug: commit=bb40482 fuzzer=storage                  runtime=34
debug: commit=bb40482 fuzzer=vopr_lite                runtime=68
debug: commit=bb40482 fuzzer=vopr_testing_lite        runtime=69
debug: commit=bb40482 fuzzer=vopr_testing             runtime=84
debug: commit=bb40482 fuzzer=vopr                     runtime=68
debug: commit=bb40482 fuzzer=vsr_free_set             runtime=34
debug: commit=bb40482 fuzzer=vsr_journal_format       runtime=35
debug: commit=bb40482 fuzzer=vsr_superblock_quorums   runtime=35
debug: commit=bb40482 fuzzer=vsr_superblock           runtime=35
debug: commit=3f4fe4f fuzzer=canary                   runtime=121
debug: commit=3f4fe4f fuzzer=vopr_lite                runtime=239
debug: commit=d7167fd fuzzer=canary                   runtime=119
debug: commit=d7167fd fuzzer=vopr_lite                runtime=238
debug: commit=d7167fd fuzzer=vopr                     runtime=238
```
