### PR TITLE
Remove duplicate IO.init/deinit

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -198,9 +198,6 @@ const Command = struct {
         else
             .direct_io_required;
 
-        command.io = try IO.init(128, 0);
-        errdefer command.io.deinit();
-
         const basename = std.fs.path.basename(path);
         command.fd = try command.io.open_data_file(
             command.dir_fd,


### PR DESCRIPTION
`Command.init` calls `IO.init` twice, and errdefers `IO.deinit` twice. The result of this is that when `Command.init` fails after the second init, `deinit` is called twice on the same `IO_Uring` object, triggering an assert in the standard library (below).

Having two calls here looks like an accident, and removing the second one passes the test suite.

Here's the assert:

```
$ zig/zig build run -- format --replica-count=1 --replica=0 --cluster=0 0_0.tigerbeetle                                                                                                                                          
2025-02-03 23:09:32.009Z warning: a cluster id of 0 is reserved for testing and benchmarking, do not use in production                                                                                                           
2025-02-03 23:09:32.009Z warning: omit --cluster=0 to randomly generate a suitable id                                                                                                                                            
                                                                                                                                                                                                                                 
2025-02-03 23:09:32.009Z info(io): creating "0_0.tigerbeetle"...                                                                                                                                                                 
thread 2451388 panic: reached unreachable code                                                                                                                                                                                   
/home/brian/.homes/dev/tigerbeetle/zig/lib/std/debug.zig:412:14: 0x11e94bd in assert (tigerbeetle)                                                                                                                               
    if (!ok) unreachable; // assertion failure                                                                                                                                                                                   
             ^                                                                                                  
/home/brian/.homes/dev/tigerbeetle/zig/lib/std/os/linux/IoUring.zig:120:11: 0x12dc621 in deinit (tigerbeetle)                                                                                                                    
    assert(self.fd >= 0);                                                                                       
          ^                                                                                                                                                                                                                      
/home/brian/.homes/dev/tigerbeetle/src/io/linux.zig:85:25: 0x11f3888 in deinit (tigerbeetle)                                                                                                                                     
        self.ring.deinit();                                                                                                                                                                                                      
                        ^                                                                                                                                                                                                        
/home/brian/.homes/dev/tigerbeetle/src/tigerbeetle/main.zig:186:35: 0x11f36d3 in init (tigerbeetle)                                                                                                                              
        errdefer command.io.deinit();                                                                                                                                                                                                                              ^                                                                                                                                                                                              
/home/brian/.homes/dev/tigerbeetle/src/tigerbeetle/main.zig:235:25: 0x11f6f6f in format (tigerbeetle)                                                                                                                            
        try command.init(allocator, args.path, .{                                                                                                                                                                                
                        ^                                                                                                                                                                                                        
/home/brian/.homes/dev/tigerbeetle/src/tigerbeetle/main.zig:78:46: 0x12d2a47 in main (tigerbeetle)                                                                                                                               
        .format => |*args| try Command.format(allocator, args, .{                                                                                                                                                                
                                             ^                                                                                                                                                                                   
/home/brian/.homes/dev/tigerbeetle/zig/lib/std/start.zig:524:37: 0x11e9285 in posixCallMainAndExit (tigerbeetle)                                                                                                                 
            const result = root.main() catch |err| {                                                            
                                    ^                                                                           
/home/brian/.homes/dev/tigerbeetle/zig/lib/std/start.zig:266:5: 0x11e8da1 in _start (tigerbeetle)                                                                                                                                
    asm volatile (switch (native_arch) { 
```