### PR TITLE
docs: Improve keyboard navigation

### DIFF
--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -196,7 +196,7 @@ function selectResult(node) {
   if (isMobileView()) {
     closeSearch();
     document.body.classList.remove("mobile-expanded");
-    if (node.href) location.href = node.href;
+    location.href = node.href;
     return;
   }
   searchResults.querySelectorAll(".selected").forEach(r => r.classList.remove("selected"));
@@ -221,7 +221,7 @@ function selectResult(node) {
   }
   handleAnchor();
   highlightText(searchInput.value, content);
-  markActiveHighlight(content);
+  if (node.tagName == "A") markActiveHighlight(content);
 }
 
 function markActiveHighlight(container) {

--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -110,6 +110,8 @@ function onSearchInput() {
     details.open = true;
     const summary = document.createElement("summary");
     details.appendChild(summary);
+    summary.pageIndex = group.pageIndex;
+    summary.href = urlPrefix + "/" + group.results[0].section.path + "/";
     const p = document.createElement("p");
     summary.appendChild(p);
     p.innerText = pages[group.pageIndex].title;
@@ -201,26 +203,25 @@ function selectResult(node) {
   node.classList.add("selected");
   scrollIntoViewIfNeeded(node, searchResults.parentNode);
 
-  if (node.pageIndex) { // Show page preview.
-    const page = pages[node.pageIndex];
-    content.innerHTML = page.html;
-    addContentEventHandlers();
-    const state = { pageIndex: node.pageIndex };
-    if (history.state) {
-      history.replaceState(state, page.title, node.href);
-    } else {
-      history.pushState(state, page.title, node.href);
-    }
-    statePathname = location.pathname;
-    if (page.title === "TigerBeetle Docs") {
-      document.title = page.title;
-    } else {
-      document.title = "TigerBeetle Docs | " + page.title;
-    }
-    handleAnchor();
-    highlightText(searchInput.value, content);
-    markActiveHighlight(content);
+  // Show page preview.
+  const page = pages[node.pageIndex];
+  content.innerHTML = page.html;
+  addContentEventHandlers();
+  const state = { pageIndex: node.pageIndex };
+  if (history.state) {
+    history.replaceState(state, page.title, node.href);
+  } else {
+    history.pushState(state, page.title, node.href);
   }
+  statePathname = location.pathname;
+  if (page.title === "TigerBeetle Docs") {
+    document.title = page.title;
+  } else {
+    document.title = "TigerBeetle Docs | " + page.title;
+  }
+  handleAnchor();
+  highlightText(searchInput.value, content);
+  markActiveHighlight(content);
 }
 
 function markActiveHighlight(container) {

--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -38,8 +38,8 @@ document.addEventListener("keydown", event => {
           details.open = !details.open;
         } else {
           closeSearch();
-          event.preventDefault();
         }
+        event.preventDefault();
       }
     }
   }
@@ -263,6 +263,8 @@ function handleAnchor() {
       anchor.classList.add("target");
       scrollIntoViewIfNeeded(anchor, content.parentNode);
     }
+  } else {
+    content.parentNode.scrollTop = 0;
   }
 }
 window.addEventListener("load", () => {

--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -194,7 +194,7 @@ function selectResult(node) {
   if (isMobileView()) {
     closeSearch();
     document.body.classList.remove("mobile-expanded");
-    location.href = node.href;
+    if (node.href) location.href = node.href;
     return;
   }
   searchResults.querySelectorAll(".selected").forEach(r => r.classList.remove("selected"));

--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -32,9 +32,15 @@ document.addEventListener("keydown", event => {
       event.preventDefault();
     } else if (event.key === "Enter") {
       const selected = searchResults.querySelector(".selected");
-      if (!selected) selectNextResult();
-      closeSearch();
-      event.preventDefault();
+      if (selected) {
+        if (selected.tagName == "SUMMARY") {
+          const details = selected.parentElement;
+          details.open = !details.open;
+        } else {
+          closeSearch();
+          event.preventDefault();
+        }
+      }
     }
   }
 })
@@ -194,25 +200,27 @@ function selectResult(node) {
   searchResults.querySelectorAll(".selected").forEach(r => r.classList.remove("selected"));
   node.classList.add("selected");
   scrollIntoViewIfNeeded(node, searchResults.parentNode);
-  // Preview result
-  const page = pages[node.pageIndex];
-  content.innerHTML = page.html;
-  addContentEventHandlers();
-  const state = { pageIndex: node.pageIndex };
-  if (history.state) {
-    history.replaceState(state, page.title, node.href);
-  } else {
-    history.pushState(state, page.title, node.href);
+
+  if (node.pageIndex) { // Show page preview.
+    const page = pages[node.pageIndex];
+    content.innerHTML = page.html;
+    addContentEventHandlers();
+    const state = { pageIndex: node.pageIndex };
+    if (history.state) {
+      history.replaceState(state, page.title, node.href);
+    } else {
+      history.pushState(state, page.title, node.href);
+    }
+    statePathname = location.pathname;
+    if (page.title === "TigerBeetle Docs") {
+      document.title = page.title;
+    } else {
+      document.title = "TigerBeetle Docs | " + page.title;
+    }
+    handleAnchor();
+    highlightText(searchInput.value, content);
+    markActiveHighlight(content);
   }
-  statePathname = location.pathname;
-  if (page.title === "TigerBeetle Docs") {
-    document.title = page.title;
-  } else {
-    document.title = "TigerBeetle Docs | " + page.title;
-  }
-  handleAnchor();
-  highlightText(searchInput.value, content);
-  markActiveHighlight(content);
 }
 
 function markActiveHighlight(container) {
@@ -261,7 +269,7 @@ window.addEventListener("load", () => {
 });
 
 function selectNextResult() {
-  const nodes = [...searchResults.querySelectorAll("details[open] a")];
+  const nodes = [...searchResults.querySelectorAll("summary, details[open] a")];
   if (nodes.length === 0) return;
   const selected = searchResults.querySelector(".selected");
   const i = selected ? nodes.indexOf(selected) + 1 : 0;
@@ -269,7 +277,7 @@ function selectNextResult() {
 }
 
 function selectPreviousResult() {
-  const nodes = [...searchResults.querySelectorAll("details[open] a")];
+  const nodes = [...searchResults.querySelectorAll("summary, details[open] a")];
   if (nodes.length === 0) return;
   const selected = searchResults.querySelector(".selected");
   const i = selected ? nodes.indexOf(selected) - 1 : -1;

--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -186,6 +186,8 @@ function makeContext(text, i, length) {
 
 function selectResult(node) {
   if (isMobileView()) {
+    closeSearch();
+    document.body.classList.remove("mobile-expanded");
     location.href = node.href;
     return;
   }

--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -57,7 +57,7 @@
     --gray-11: #CCCCCC;
     --gray-12: #EEEEEE;
 
-    --gray-alpha-5: #FFFFFF21;
+    --gray-alpha-3: #FFFFFF21;
 
     --red-10: #EC5D5E;
     --blue-10: #3B9EFF;

--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -343,13 +343,16 @@ nav.left-pane {
     list-style: none;
   }
 
-  summary:has(a.target)::before {
+  summary:has(a.target)::before,
+  summary.selected::before {
     /* color: var(--gray-0); */
     filter: invert(100%);
   }
 
   @media (prefers-color-scheme: dark) {
-    summary:has(a.target)::before {
+
+    summary:has(a.target)::before,
+    summary.selected::before {
       filter: none;
     }
 
@@ -403,6 +406,16 @@ nav.left-pane {
       &::before {
         /* color: var(--gray-12); */
         filter: invert(12%);
+      }
+    }
+
+    &.selected {
+      background-color: var(--primary-9);
+      color: var(--gray-1);
+
+      .highlight {
+        background-color: var(--highlight-active);
+        color: var(--gray-0);
       }
     }
   }

--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -355,16 +355,6 @@ nav.left-pane {
     summary.selected::before {
       filter: none;
     }
-
-    .search-results {
-      summary::before {
-        filter: invert(48%);
-      }
-
-      summary:hover::before {
-        filter: invert(93%);
-      }
-    }
   }
 }
 
@@ -391,6 +381,10 @@ nav.left-pane {
     &::before {
       /* color: var(--gray-10); */
       filter: invert(51%);
+
+      @media (prefers-color-scheme: dark) {
+        filter: invert(48%);
+      }
     }
 
     p {
@@ -406,6 +400,10 @@ nav.left-pane {
       &::before {
         /* color: var(--gray-12); */
         filter: invert(12%);
+
+        @media (prefers-color-scheme: dark) {
+          filter: invert(93%);
+        }
       }
     }
 


### PR DESCRIPTION
In search you can now use the up and down arrow keys to select page folders and enter to collapse and expand the folder. When selecting a folder, a preview of the page is opened in the right pane.

I deployed a preview version on https://tbdocs.fabioware.com.

https://github.com/user-attachments/assets/df78ed49-1ff3-4099-9e23-1d035afd46ee

