### PR TITLE
vsr: remove logic to send both start_view and start_view_deprecated

### DIFF
--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -33,7 +33,6 @@ pub const Options = union(vsr.ProcessType) {
                 // Handle bursts.
                 // (e.g. Connection.parse_message(), or sending a ping when the send queue is full).
                 sum += 1;
-                sum += 1; // Extra burst from sending two SV variants.
 
                 // This conditions is necessary (but not sufficient) to prevent deadlocks.
                 assert(sum > 1);
@@ -106,10 +105,6 @@ pub const MessagePool = struct {
         pub const StartViewChange = CommandMessageType(.start_view_change);
         pub const DoViewChange = CommandMessageType(.do_view_change);
         pub const StartView = CommandMessageType(.start_view);
-        pub const StartViewDeprecated = CommandMessageType(.start_view_deprecated);
-        comptime {
-            assert(StartView == StartViewDeprecated);
-        }
         pub const RequestStartView = CommandMessageType(.request_start_view);
         pub const RequestHeaders = CommandMessageType(.request_headers);
         pub const RequestPrepare = CommandMessageType(.request_prepare);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -215,11 +215,6 @@ pub const Command = enum(u8) {
     request_blocks = 19,
     block = 20,
 
-    // Historical version of SV, with the CheckpointStateOld format. Currently, both
-    // `start_view_deprecated` and `start_view` are handled. Next release will ignore
-    // `start_view_deprecated`.
-    start_view_deprecated = 23,
-
     start_view = 24,
 
     // If a command is removed from the protocol, its ordinal is added here and can't be re-used.
@@ -227,6 +222,7 @@ pub const Command = enum(u8) {
         12, // start_view without checkpoint
         21, // request_sync_checkpoint
         22, // sync_checkpoint
+        23, // start_view with an older version of CheckpointState
     };
 
     comptime {

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -88,7 +88,6 @@ pub const Header = extern struct {
             .commit => Commit,
             .start_view_change => StartViewChange,
             .do_view_change => DoViewChange,
-            .start_view_deprecated => StartView,
             .start_view => StartView,
             .request_start_view => RequestStartView,
             .request_headers => RequestHeaders,
@@ -220,7 +219,6 @@ pub const Header = extern struct {
             .start_view_change,
             .do_view_change,
             .start_view,
-            .start_view_deprecated,
             .request_start_view,
             .request_headers,
             .request_prepare,
@@ -1037,7 +1035,7 @@ pub const Header = extern struct {
         reserved: [88]u8 = [_]u8{0} ** 88,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .start_view_deprecated or self.command == .start_view);
+            assert(self.command == .start_view);
             if (self.release.value != 0) return "release != 0";
             if (self.op < self.commit_max) return "op < commit_max";
             if (self.commit_max < self.checkpoint_op) return "commit_max < checkpoint_op";

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2345,7 +2345,6 @@ const TestReplicas = struct {
     ) void {
         const paths = t.peer_paths(peer, direction);
         for (paths.const_slice()) |path| t.cluster.network.link_filter(path).insert(command);
-        if (command == .start_view) t.pass(peer, direction, .start_view_deprecated);
     }
 
     pub fn drop(
@@ -2356,7 +2355,6 @@ const TestReplicas = struct {
     ) void {
         const paths = t.peer_paths(peer, direction);
         for (paths.const_slice()) |path| t.cluster.network.link_filter(path).remove(command);
-        if (command == .start_view) t.drop(peer, direction, .start_view_deprecated);
     }
 
     pub fn filter(


### PR DESCRIPTION
This is the second last PR in the series of the PRs that intends to roll out a new CheckpointState format (the first two were https://github.com/tigerbeetle/tigerbeetle/pull/2662 and https://github.com/tigerbeetle/tigerbeetle/pull/2600). It takes care of removing the logic to send and handle both `start_view` & `start_view_deprecated` messages. Replicas now panic when they receive the `start_view_deprecated` message.

The only thing left to do now is to remove the old checkpoint state format and the translation logic between `CheckpointStateOld` → `CheckpointState`. This can only be taken up when release `0.16.31` is rolled out (assuming no releases are skipped in the middle). Specifically, this translation logic can only be removed when our multiversion binaries stop bundling any release that writes `CheckpointStateOld` to disk (see https://github.com/tigerbeetle/tigerbeetle/pull/2703#discussion_r1945483335 for the reason). 