### PR TITLE
VSR/Journal: Fix misguided misdirect `fix`

### DIFF
--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1515,7 +1515,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                     assert(header.?.checksum == prepare.?.checksum);
                     assert(journal.prepare_inhabited[slot.index]);
                     assert(journal.prepare_checksums[slot.index] == prepare.?.checksum);
-                    journal.headers[slot.index] = header.?.*;
+                    journal.headers[slot.index] = header.?;
                     journal.dirty.clear(slot);
                     journal.faulty.clear(slot);
                 },
@@ -1530,13 +1530,13 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                     );
                     assert(!journal.prepare_inhabited[slot.index]);
                     assert(journal.prepare_checksums[slot.index] == 0);
-                    journal.headers[slot.index] = header.?.*;
+                    journal.headers[slot.index] = header.?;
                     journal.dirty.clear(slot);
                     journal.faulty.clear(slot);
                 },
                 .fix => {
                     assert(prepare.?.command == .prepare);
-                    journal.headers[slot.index] = prepare.?.*;
+                    journal.headers[slot.index] = prepare.?;
                     journal.faulty.clear(slot);
                     assert(journal.dirty.bit(slot));
                     if (replica.solo()) {
@@ -2427,8 +2427,8 @@ const Case = struct {
 };
 
 fn recovery_case(
-    header: ?*const Header.Prepare,
-    prepare: ?*const Header.Prepare,
+    header: ?Header.Prepare,
+    prepare: ?Header.Prepare,
     data: struct {
         prepare_op_max: u64,
         op_checkpoint: u64,
@@ -2482,7 +2482,7 @@ fn header_ok(
     cluster: u128,
     slot: Slot,
     header: *const Header.Prepare,
-) ?*const Header.Prepare {
+) ?Header.Prepare {
     // We must first validate the header checksum before accessing any fields.
     // Otherwise, we may hit undefined data or an out-of-bounds enum and cause a runtime crash.
     if (!header.valid_checksum()) return null;
@@ -2497,7 +2497,7 @@ fn header_ok(
     };
 
     // Do not check the checksum here, because that would run only after the other field accesses.
-    return if (valid_cluster_command_and_slot) header else null;
+    return if (valid_cluster_command_and_slot) header.* else null;
 }
 
 test "recovery_cases" {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -659,11 +659,6 @@ pub fn ReplicaType(
             self.opened = false;
             self.journal.recover(journal_recover_callback);
             while (!self.opened) self.superblock.storage.tick();
-            for (self.journal.headers, 0..constants.journal_slot_count) |*header, slot| {
-                if (self.journal.faulty.bit(.{ .index = slot })) {
-                    assert(header.operation == .reserved);
-                }
-            }
 
             // Abort if all slots are faulty, since something is very wrong.
             if (self.journal.faulty.count == constants.journal_slot_count) return error.WALInvalid;


### PR DESCRIPTION
Fix a recovery correctness bug caused by a misdirected write in the WAL (discovered by the VOPR in https://github.com/tigerbeetle/tigerbeetle/pull/2677).

I recommend reviewing commit-by-commit.

## Bug

Scenario:

1. Write prepare/header `op=X view=V₁`.
2. Write prepare/header `op=X view=V₂`, but the prepare write is lost/misdirected.
3. (Checkpoint, so that `X` precedes our `op_checkpoint`, but is not yet overwritten.)
4. Crash. Recovery.
5. `op=X` is recovered with `decision=fix` (case `@M`) -- but we keep the wrong header!

## Fix

`op⌊` in the recovery table branched on `prepare.op < op_checkpoint`. This case was added to protect us from falling into `status=recovering_head` if we recover soon after checkpointing with a bunch of corrupt ops between `op_checkpoint` and `trigger_for_checkpoint(op_checkpoint)`.

But thanks to https://github.com/tigerbeetle/tigerbeetle/pull/2345, this case is not needed any more -- it is impossible for an op prior to our checkpoint to become our `op_head`.

Therefore we can merge recovery cases `@L`/`@M`, and remove the `op⌊` pattern. The former `@N` has been renamed to `@M`.