### PR TITLE
node: don't crash when a client closed concurrent

### DIFF
--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -140,10 +140,6 @@ fn create(
         std.log.warn("Failed to release allocated thread-safe function on error.", .{});
     };
 
-    if (c.napi_acquire_threadsafe_function(completion_tsfn) != c.napi_ok) {
-        return translate.throw(env, "Failed to acquire reference to thread-safe function.");
-    }
-
     const client = tb_client.init(
         allocator,
         cluster_id,
@@ -176,7 +172,7 @@ fn destroy(env: c.napi_env, context: c.napi_value) !void {
     const completion_ctx = tb_client.completion_context(client);
     const completion_tsfn: c.napi_threadsafe_function = @ptrFromInt(completion_ctx);
 
-    if (c.napi_release_threadsafe_function(completion_tsfn, c.napi_tsfn_abort) != c.napi_ok) {
+    if (c.napi_release_threadsafe_function(completion_tsfn, c.napi_tsfn_release) != c.napi_ok) {
         return translate.throw(env, "Failed to release allocated thread-safe function on error.");
     }
 }

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -1427,6 +1427,19 @@ test('accept zero-length lookup_transfers', async (): Promise<void> => {
   assert.deepStrictEqual(transfers, [])
 })
 
+test("destroy client in-flight", async (): Promise<void> => {
+  // Non-existing cluster.
+  const client = createClient({ cluster_id: 92n, replica_addresses: ["99"] });
+  setTimeout(() => client.destroy(), 30);
+  try {
+    await client.lookupAccounts([0n]);
+  } catch (error) {
+    assert.strictEqual(error.message, "Client was shutdown.");
+    return;
+  }
+  throw "expected an error";
+});
+
 async function main () {
   const start = new Date().getTime()
   try {


### PR DESCRIPTION
Problem: if JS calls client.destroy() while there are outstanding requests, the native part crashes with unreachable.

Cause: two bugs, actually!

_First_, `destroy` was using `napi_tsfn_abort` for cleaning-up the trampoline used to invoke the JS callback. But before that, client_deinint would actually enqueue several calls to that callback. We only should be actually destroying it once all callbacks are fired, that is, when node-side refcount reaches zero. That's exactly what release is for!

_Second_, using `release` uncovered an off-by-one error in our reference counting, with the function never released. That's because in the `init` we end up with ref-count 2, we get one from

```
1, // Number of acquires/threads that will be calling this TSFN.
```

and a redundant one from explicit acquire, which is removed.

The relevant node docs are at

<https://nodejs.org/api/n-api.html#n_api_reference_counting_of_thread_safe_functions>

I wish I didn't have to write a manual test here, and that instead we hade some sort of language-agnostic client test harness, some sort of vörtex where you'll only have to write a client-specific driver, and let the fuzzer find lifecycle bugs for you. But I'll leave that for future work!

Closes: #2636