### PR TITLE
VSR: Flush loopback queue before queueing another prepare_ok

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10050,8 +10050,12 @@ pub fn ReplicaType(
             // `null` indicates that we did not complete the write for some reason.
             const message = wrote orelse return;
 
-            self.send_prepare_ok(message.header);
-            defer self.flush_loopback_queue();
+            {
+                // repair() may send prepare_ok's to ourself if we are the primary, so we must flush
+                // the loopback queue immediately.
+                self.send_prepare_ok(message.header);
+                defer self.flush_loopback_queue();
+            }
 
             switch (trigger) {
                 .append => {},


### PR DESCRIPTION
In `Replica.write_prepare_callback()`:

```
self.send_prepare_ok(message.header);
defer self.flush_loopback_queue();

switch (trigger) {
    .append => {},
    // If this was a repair, continue immediately to repair the next prepare:
    // This is an optimization to eliminate waiting until the next repair timeout.
    .repair => self.repair(),
    .pipeline => self.repair(),
    .fix => unreachable,
}
```

...we are deferring the flush until after we call `repair()`. But `repair()` can itself send more `prepare_ok`'s -- it can call `send_prepare_oks_after_syncing_tables` (through several layers of indirection).
