### PR TITLE
A few cleanups to repl docs

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -496,8 +496,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                 \\  Ctrl+D to exit.
                 \\
                 \\Examples:
-                \\  create_accounts id=1 code=10 ledger=700 flags=linked|history,
-                \\                  id=2 code=10 ledger=700;
+                \\  create_accounts id=1 code=10 ledger=700 flags=linked|history, id=2 code=10 ledger=700;
                 \\  create_transfers id=1 debit_account_id=1 credit_account_id=2 amount=10 ledger=700 code=10;
                 \\  lookup_accounts id=1;
                 \\  lookup_accounts id=1, id=2;


### PR DESCRIPTION
- Don't use multi-line repl commands. These don't currently work - cc https://github.com/tigerbeetle/tigerbeetle/issues/2529
- Don't use semicolons. They are still supported but not necessary and serve no function.
- Update quickstart with current repl output