### PR TITLE
client: clarify slow request warning

### DIFF
--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -554,7 +554,7 @@ pub fn ClientType(
                 std.time.ns_per_ms,
             );
             if (request_completion_time_ms > constants.client_request_completion_warn_ms) {
-                log.warn("{}: on_reply: request={} size={} {s} time={}ms", .{
+                log.warn("{}: on_reply: slow request, request={} size={} {s} time={}ms", .{
                     self.id,
                     reply.header.request,
                     reply.header.size,


### PR DESCRIPTION
I see this warning regularly and could not tell what it meant without looking at the source. This adds the words "slow request".