### PR TITLE
build: don't expose VSR module to dependents

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -340,7 +340,7 @@ fn build_vsr_module(b: *std.Build, options: struct {
     vsr_options.addOption(bool, "config_aof_recovery", options.config_aof_recovery);
     vsr_options.addOption(config.HashLogMode, "hash_log_mode", options.hash_log_mode);
 
-    const vsr_module = b.addModule("vsr", .{
+    const vsr_module = b.createModule(.{
         .root_source_file = b.path("src/vsr.zig"),
     });
     vsr_module.addOptions("vsr_options", vsr_options);


### PR DESCRIPTION
`addModule` was called also from `build_test_integration` which resulted in the VSR module built for integration tests being exposed (with hardcoded options) to dependents.

`build_test_integration` now calls `createModule` instead, resulting in a private module.