### PR TITLE
Various repl fixes and improvements.

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -495,9 +495,13 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
             };
 
             if (input.len > 0) {
-                if (repl.history.empty() or
-                    !std.mem.eql(u8, repl.history.tail_ptr_const().?[0..input.len], input))
-                {
+                const add_to_history = brk: {
+                    const last_entry = repl.history.tail_ptr_const() orelse break :brk true;
+                    const last_entry_str = std.mem.sliceTo(last_entry, '\x00');
+                    break :brk !std.mem.eql(u8, last_entry_str, input);
+                };
+
+                if (add_to_history) {
                     // NB: Avoiding big stack allocations below.
 
                     assert(input.len < repl_history_entry_bytes_with_nul);

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -227,6 +227,9 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                     },
                     .backspace => if (buffer_index > 0) {
                         terminal_screen.update_cursor_position(-1);
+                        // move to new position, write the remaining buffer,
+                        // write a space (\x20) to overwrite the last character,
+                        // move back to the new position.
                         try repl.terminal.print("\x1b[{};{}H{s}\x20\x1b[{};{}H", .{
                             terminal_screen.cursor_row,
                             terminal_screen.cursor_column,
@@ -240,6 +243,16 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                             terminal_screen.cursor_column,
                         });
                         buffer_index -= 1;
+                        _ = repl.buffer.ordered_remove(buffer_index);
+                    },
+                    .delete => if (buffer_index < repl.buffer.count()) {
+                        try repl.terminal.print("\x1b[{};{}H{s}\x20\x1b[{};{}H", .{
+                            terminal_screen.cursor_row,
+                            terminal_screen.cursor_column,
+                            repl.buffer.const_slice()[buffer_index + 1 ..],
+                            terminal_screen.cursor_row,
+                            terminal_screen.cursor_column,
+                        });
                         _ = repl.buffer.ordered_remove(buffer_index);
                     },
                     .tab => {
@@ -349,7 +362,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         repl.buffer.append_slice_assume_capacity(repl.completion.suffix.slice());
                         buffer_index = repl.buffer.count() - repl.completion.suffix.count();
                     },
-                    .left => if (buffer_index > 0) {
+                    .left, .ctrlb => if (buffer_index > 0) {
                         terminal_screen.update_cursor_position(-1);
                         try repl.terminal.print("\x1b[{};{}H", .{
                             terminal_screen.cursor_row,
@@ -357,7 +370,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         });
                         buffer_index -= 1;
                     },
-                    .right => if (buffer_index < repl.buffer.count()) {
+                    .right, .ctrlf => if (buffer_index < repl.buffer.count()) {
                         terminal_screen.update_cursor_position(1);
                         try repl.terminal.print("\x1b[{};{}H", .{
                             terminal_screen.cursor_row,
@@ -365,7 +378,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         });
                         buffer_index += 1;
                     },
-                    .up => if (history_index > 0) {
+                    .up, .ctrlp => if (history_index > 0) {
                         const history_index_next = history_index - 1;
                         const buffer_next_full = repl.history.get_ptr(history_index_next).?;
                         const buffer_next = std.mem.sliceTo(buffer_next_full, '\x00');
@@ -402,7 +415,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         repl.buffer.append_slice_assume_capacity(buffer_next);
                         buffer_index = repl.buffer.count();
                     },
-                    .down => if (history_index < repl.history.count) {
+                    .down, .ctrln => if (history_index < repl.history.count) {
                         const history_index_next = history_index + 1;
 
                         const buffer_next = if (history_index_next == repl.history.count)
@@ -460,6 +473,53 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                             terminal_screen.cursor_column,
                         });
                         buffer_index = backward;
+                    },
+                    .ctrla => {
+                        // move to start of line
+                        const position_start_diff = -@as(isize, @intCast(buffer_index));
+                        terminal_screen.update_cursor_position(position_start_diff);
+                        try repl.terminal.print("\x1b[{};{}H", .{
+                            terminal_screen.cursor_row,
+                            terminal_screen.cursor_column,
+                        });
+                        buffer_index = 0;
+                    },
+                    .ctrle => {
+                        // move to end of line
+                        const position_end_diff = @as(
+                            isize,
+                            @intCast(repl.buffer.count() - buffer_index),
+                        );
+                        terminal_screen.update_cursor_position(position_end_diff);
+                        try repl.terminal.print("\x1b[{};{}H", .{
+                            terminal_screen.cursor_row,
+                            terminal_screen.cursor_column,
+                        });
+                        buffer_index = repl.buffer.count();
+                    },
+                    .ctrlk => {
+                        // clear screen from cursor
+                        try repl.terminal.print("\x1b[J", .{});
+                        repl.buffer.resize(buffer_index) catch unreachable;
+                    },
+                    .ctrll => {
+                        // move to 0,0 and clear the screen from cursor,
+                        // print the prompt, then ask the terminal for the new position
+                        try repl.terminal.print("\x1b[0;0H\x1b[J", .{});
+                        try repl.terminal.print(prompt, .{});
+                        terminal_screen = try repl.terminal.get_screen();
+
+                        // print whatever is in the buffer and move cursor
+                        // back to buffer_index
+                        terminal_screen.update_cursor_position(
+                            @as(isize, @intCast(buffer_index)),
+                        );
+
+                        try repl.terminal.print("{s}\x1b[{};{}H", .{
+                            repl.buffer.const_slice(),
+                            terminal_screen.cursor_row,
+                            terminal_screen.cursor_column,
+                        });
                     },
                     .unhandled => {},
                 }

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -155,7 +155,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         }
                     },
                     .ctrlc => {
-                        // move to end of line, print "^C" and abort the command
+                        // Move to end of line, print "^C" and abort the command.
                         const position_end_diff = @as(
                             isize,
                             @intCast(repl.buffer.count() - buffer_index),
@@ -170,7 +170,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         return &.{};
                     },
                     .newline => {
-                        // move to end of buffer then return
+                        // Move to end of buffer, then return.
                         const position_end_diff = @as(
                             isize,
                             @intCast(repl.buffer.count() - buffer_index),
@@ -227,9 +227,9 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                     },
                     .backspace => if (buffer_index > 0) {
                         terminal_screen.update_cursor_position(-1);
-                        // move to new position, write the remaining buffer,
+                        // Move to new position, write the remaining buffer,
                         // write a space (\x20) to overwrite the last character,
-                        // move back to the new position.
+                        // then move back to the new position.
                         try repl.terminal.print("\x1b[{};{}H{s}\x20\x1b[{};{}H", .{
                             terminal_screen.cursor_row,
                             terminal_screen.cursor_column,
@@ -475,7 +475,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         buffer_index = backward;
                     },
                     .ctrla => {
-                        // move to start of line
+                        // Move to start of line.
                         const position_start_diff = -@as(isize, @intCast(buffer_index));
                         terminal_screen.update_cursor_position(position_start_diff);
                         try repl.terminal.print("\x1b[{};{}H", .{
@@ -485,7 +485,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         buffer_index = 0;
                     },
                     .ctrle => {
-                        // move to end of line
+                        // Move to end of line.
                         const position_end_diff = @as(
                             isize,
                             @intCast(repl.buffer.count() - buffer_index),
@@ -498,19 +498,18 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         buffer_index = repl.buffer.count();
                     },
                     .ctrlk => {
-                        // clear screen from cursor
+                        // Clear screen from cursor.
                         try repl.terminal.print("\x1b[J", .{});
                         repl.buffer.resize(buffer_index) catch unreachable;
                     },
                     .ctrll => {
-                        // move to 0,0 and clear the screen from cursor,
-                        // print the prompt, then ask the terminal for the new position
+                        // Move to 0,0 and clear the screen from cursor, print the prompt, then ask
+                        // the terminal for the new position.
                         try repl.terminal.print("\x1b[0;0H\x1b[J", .{});
                         try repl.terminal.print(prompt, .{});
                         terminal_screen = try repl.terminal.get_screen();
 
-                        // print whatever is in the buffer and move cursor
-                        // back to buffer_index
+                        // Print whatever is in the buffer and move the cursor back to buffer_index.
                         terminal_screen.update_cursor_position(
                             @as(isize, @intCast(buffer_index)),
                         );

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -170,6 +170,16 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         return &.{};
                     },
                     .newline => {
+                        // move to end of buffer then return
+                        const position_end_diff = @as(
+                            isize,
+                            @intCast(repl.buffer.count() - buffer_index),
+                        );
+                        terminal_screen.update_cursor_position(position_end_diff);
+                        try repl.terminal.print("\x1b[{};{}H", .{
+                            terminal_screen.cursor_row,
+                            terminal_screen.cursor_column,
+                        });
                         try repl.terminal.print("\n", .{});
                         return repl.buffer.const_slice();
                     },

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -452,7 +452,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         repl.buffer.append_slice_assume_capacity(buffer_next);
                         buffer_index = repl.buffer.count();
                     },
-                    .altf => {
+                    .altf, .ctrlright => {
                         const forward = move_forward_by_word(repl.buffer.slice(), buffer_index);
                         terminal_screen.update_cursor_position(
                             @as(isize, @intCast(forward - buffer_index)),
@@ -463,7 +463,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         });
                         buffer_index = forward;
                     },
-                    .altb => {
+                    .altb, .ctrlleft => {
                         const backward = move_backward_by_word(repl.buffer.slice(), buffer_index);
                         terminal_screen.update_cursor_position(
                             -@as(isize, @intCast(buffer_index - backward)),
@@ -474,7 +474,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         });
                         buffer_index = backward;
                     },
-                    .ctrla => {
+                    .ctrla, .home => {
                         // Move to start of line.
                         const position_start_diff = -@as(isize, @intCast(buffer_index));
                         terminal_screen.update_cursor_position(position_start_diff);
@@ -484,7 +484,7 @@ pub fn ReplType(comptime MessageBus: type, comptime Time: type) type {
                         });
                         buffer_index = 0;
                     },
-                    .ctrle => {
+                    .ctrle, .end => {
                         // Move to end of line.
                         const position_end_diff = @as(
                             isize,

--- a/src/repl/terminal.zig
+++ b/src/repl/terminal.zig
@@ -120,6 +120,29 @@ pub const Terminal = struct {
                             'B' => return .down,
                             'C' => return .right,
                             'D' => return .left,
+                            'H' => return .home,
+                            'F' => return .end,
+                            '1' => {
+                                const fourth_byte = try stdin.readByte();
+                                switch (fourth_byte) {
+                                    ';' => {
+                                        const fifth_byte = try stdin.readByte();
+                                        switch (fifth_byte) {
+                                            '5' => {
+                                                const sixth_byte = try stdin.readByte();
+                                                switch (sixth_byte) {
+                                                    'C' => return .ctrlright,
+                                                    'D' => return .ctrlleft,
+                                                    else => return .unhandled,
+                                                }
+                                            },
+                                            else => return .unhandled,
+                                        }
+                                    },
+
+                                    else => return .unhandled,
+                                }
+                            },
                             '3' => {
                                 const fourth_byte = try stdin.readByte();
                                 switch (fourth_byte) {
@@ -344,6 +367,10 @@ const UserInput = union(enum) {
     down,
     altf,
     altb,
+    ctrlleft,
+    ctrlright,
+    home,
+    end,
     unhandled,
 };
 

--- a/src/repl/terminal.zig
+++ b/src/repl/terminal.zig
@@ -91,8 +91,8 @@ pub const Terminal = struct {
         assert(self.mode_start != null);
         const stdin = self.stdin.reader();
 
-        // nb many control codes have names unrelated to their modern function
-        // cc https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+        // NB: Many control codes have names unrelated to their modern function.
+        // https://en.wikipedia.org/wiki/C0_and_C1_control_codes
         switch (try stdin.readByte()) {
             std.ascii.control_code.eot => return .ctrld,
             std.ascii.control_code.etx => return .ctrlc,
@@ -108,10 +108,9 @@ pub const Terminal = struct {
             std.ascii.control_code.bs, std.ascii.control_code.del => return .backspace,
             std.ascii.control_code.ht => return .tab,
             std.ascii.control_code.esc => {
-                // todo: it would be nice fully parse unhandled escape codes,
-                // not just give up partway through and return `.unhandled`;
-                // but ansi escape codes are extremely complicated, so that
-                // may not be completely possible.
+                // TODO: It would be nice to fully parse unhandled escape codes, and not just give
+                // up partway through and return `.unhandled` - but ansi escape codes are extremely
+                // complicated, so that may not be completely possible.
                 const second_byte = try stdin.readByte();
                 switch (second_byte) {
                     '[' => {
@@ -125,8 +124,8 @@ pub const Terminal = struct {
                                 const fourth_byte = try stdin.readByte();
                                 switch (fourth_byte) {
                                     '~' => {
-                                        // this is just one of multiple non-standard
-                                        // escape codes for delete. wfm
+                                        // This is just one of multiple non-standard escape codes
+                                        // for delete.
                                         return .delete;
                                     },
                                     else => return .unhandled,


### PR DESCRIPTION
These changes bring the TigerBeetle repl more inline with Python and Julia.

- Ctrl-C - previous behavior was odd when the cursor was in the middle of the buffer. Now the cursor moves to the end of the buffer, prints "^C", and starts a new command.
- Fix the logic for deduplicating history. Previous the comparison was wrong and treated "abc" and "a" as duplicates.
- Fix newlines when cursor is in the middle of the buffer. Previously if the line was longer than the screen, a newline would cause the following lines to be overwritten. This moves the cursor to the end of the buffer before emitting the newline.

Add a variety of standard navigation shortcuts:

- DEL - delete the character after the cursor
- Ctrl-B / Ctrl-F - back / forward
- Ctrl-P / Ctrl-N - history up / down
- Ctrl-A / Ctrl-E - move to start / end of input
- Ctrl-K - delete buffer after cursor
- Ctrl-L - clear screen



