### PR TITLE
[tb_client] Rework the Packet interface.

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -250,17 +250,13 @@ typedef enum TB_PACKET_STATUS {
 } TB_PACKET_STATUS;
 
 typedef struct tb_packet_t {
-    struct tb_packet_t* next;
     void* user_data;
+    void* data;
+    uint32_t data_size;
+    uint16_t tag;
     uint8_t operation;
     uint8_t status;
-    uint32_t data_size;
-    void* data;
-    struct tb_packet_t* batch_next;
-    struct tb_packet_t* batch_tail;
-    uint32_t batch_size;
-    uint8_t batch_allowed;
-    uint8_t reserved[7];
+    uint8_t reserved[32];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 // When referenced from unit_test.zig, there is no vsr import module. So use relative path instead.
 pub const vsr = if (@import("root") == @This()) @import("vsr") else @import("../../vsr.zig");
 
-pub const tb_packet_t = @import("tb_client/packet.zig").Packet;
-pub const tb_packet_status_t = tb_packet_t.Status;
+pub const tb_packet_t = @import("tb_client/packet.zig").Packet.Extern;
+pub const tb_packet_status_t = @import("tb_client/packet.zig").Packet.Status;
 
 pub const tb_client_t = *anyopaque;
 pub const tb_status_t = enum(c_int) {

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -2,26 +2,13 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
-const FIFOType = @import("../tb_client.zig").vsr.fifo.FIFOType;
+// When referenced from unit_test.zig, there is no vsr import module so use path.
+const vsr = if (@import("root") == @This()) @import("vsr") else @import("../../../vsr.zig");
+const stdx = vsr.stdx;
+const FIFOType = vsr.fifo.FIFOType;
+const maybe = stdx.maybe;
 
 pub const Packet = extern struct {
-    next: ?*Packet,
-    user_data: ?*anyopaque,
-    operation: u8,
-    status: Status,
-    data_size: u32,
-    data: ?*anyopaque,
-    batch_next: ?*Packet,
-    batch_tail: ?*Packet,
-    batch_size: u32,
-    batch_allowed: bool,
-    reserved: [7]u8 = [_]u8{0} ** 7,
-
-    comptime {
-        assert(@sizeOf(Packet) == 64);
-        assert(@alignOf(Packet) == 8);
-    }
-
     pub const Status = enum(u8) {
         ok,
         too_much_data,
@@ -33,7 +20,21 @@ pub const Packet = extern struct {
         invalid_data_size,
     };
 
-    /// Thread-safe FIFO.
+    /// External packet type exposed to the user.
+    pub const Extern = extern struct {
+        user_data: ?*anyopaque,
+        data: ?*anyopaque,
+        data_size: u32,
+        tag: u16,
+        operation: u8,
+        status: Status,
+        reserved: [32]u8 = [_]u8{0} ** 32,
+
+        pub fn cast(self: *Extern) *Packet {
+            return @ptrCast(self);
+        }
+    };
+
     pub const SubmissionQueue = struct {
         fifo: FIFOType(Packet) = .{
             .name = null,
@@ -55,11 +56,118 @@ pub const Packet = extern struct {
             return self.fifo.pop();
         }
 
-        pub fn empty(self: *SubmissionQueue) bool {
-            self.mutex.lock();
-            defer self.mutex.unlock();
-
+        /// Not thread safe, should be called only by the consumer thread.
+        pub fn empty(self: *const SubmissionQueue) bool {
             return self.fifo.count == 0;
         }
     };
+
+    const Phase = enum(u8) {
+        submitted,
+        pending,
+        batched,
+        sent,
+        complete,
+    };
+
+    user_data: ?*anyopaque,
+    data: ?*anyopaque,
+    data_size: u32,
+    tag: u16,
+    operation: u8,
+    status: Status,
+
+    next: ?*Packet,
+
+    batch_next: ?*Packet,
+    batch_tail: ?*Packet,
+    batch_size: u32,
+    batch_allowed: bool,
+    phase: Phase,
+    reserved: [2]u8 = [_]u8{0} ** 2,
+
+    pub fn cast(self: *Packet) *Extern {
+        return @ptrCast(self);
+    }
+
+    pub fn slice(packet: *const Packet) []const u8 {
+        if (packet.data_size == 0) {
+            // It may be an empty array (null pointer)
+            // or a buffer with no elements (valid pointer and size == 0).
+            stdx.maybe(packet.data == null);
+            return &[0]u8{};
+        }
+
+        const data: [*]const u8 = @ptrCast(packet.data.?);
+        return data[0..packet.data_size];
+    }
+
+    /// Asserts the internal state of the packet according to its expected phase.
+    /// Inline function, so `expected` can be comptime known.
+    pub inline fn assert_phase(packet: *const Packet, expected: Phase) void {
+        assert(packet.phase == expected);
+        assert(packet.data_size == 0 or packet.data != null);
+        assert(stdx.zeroed(&packet.reserved));
+        maybe(packet.user_data == null);
+        maybe(packet.tag == 0);
+
+        switch (expected) {
+            .submitted => {
+                assert(packet.next == null);
+                assert(packet.batch_next == null);
+                assert(packet.batch_tail == null);
+                assert(packet.batch_size == 0);
+                assert(!packet.batch_allowed);
+            },
+            .pending => {
+                assert(packet.batch_size >= packet.data_size);
+                assert(packet.batch_size == packet.data_size or packet.batch_next != null);
+                assert(packet.batch_next == null or packet.batch_allowed);
+                assert((packet.batch_next == null) == (packet.batch_tail == null));
+                maybe(packet.next == null);
+            },
+            .batched => {
+                assert(packet.next == null);
+                assert(packet.batch_tail == null);
+                assert(packet.batch_size == 0);
+                assert(!packet.batch_allowed);
+                maybe(packet.batch_next != null);
+            },
+            .sent => {
+                assert(packet.batch_size >= packet.data_size);
+                assert(packet.batch_size == packet.data_size or packet.batch_next != null);
+                assert((packet.batch_next == null) == (packet.batch_tail == null));
+                assert(packet.batch_next == null or packet.batch_allowed);
+                assert(packet.next == null);
+            },
+            .complete => {
+                // The packet pointer isn't available afer completed,
+                // it may be dealocated by the user;
+                unreachable;
+            },
+        }
+    }
+
+    comptime {
+        assert(@sizeOf(Extern) % @alignOf(Extern) == 0);
+        assert(@alignOf(Extern) == 8);
+
+        assert(@sizeOf(Packet) == @sizeOf(Extern));
+        assert(@alignOf(Packet) == @alignOf(Extern));
+
+        // Asseting the fields are identical.
+        for (std.meta.fields(Extern)) |field_extern| {
+            if (std.mem.eql(u8, field_extern.name, "reserved")) continue;
+            const field_packet = std.meta.fields(Packet)[
+                std.meta.fieldIndex(
+                    Packet,
+                    field_extern.name,
+                ).?
+            ];
+            assert(field_packet.type == field_extern.type);
+            assert(field_packet.alignment == field_extern.alignment);
+            assert(@offsetOf(Packet, field_extern.name) ==
+                @offsetOf(Extern, field_extern.name));
+        }
+    }
 };

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -134,14 +134,14 @@ pub const Packet = extern struct {
                 maybe(packet.batch_next != null);
             },
             .sent => {
+                assert(packet.next == null);
                 assert(packet.batch_size >= packet.data_size);
                 assert(packet.batch_size == packet.data_size or packet.batch_next != null);
                 assert((packet.batch_next == null) == (packet.batch_tail == null));
                 assert(packet.batch_next == null or packet.batch_allowed);
-                assert(packet.next == null);
             },
             .complete => {
-                // The packet pointer isn't available afer completed,
+                // The packet pointer isn't available after completed,
                 // it may be dealocated by the user;
                 unreachable;
             },

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -170,7 +170,7 @@ test "c_client echo" {
             packet.user_data = request;
             packet.data = &request.sent_data;
             packet.data_size = request.sent_data_size;
-            packet.next = null;
+            packet.tag = 0;
             packet.status = c.TB_PACKET_OK;
 
             c.tb_client_submit(tb_client, packet);
@@ -285,7 +285,7 @@ test "c_client tb_packet_status" {
             packet.user_data = &request;
             packet.data = &request.sent_data;
             packet.data_size = request_size;
-            packet.next = null;
+            packet.tag = 0;
             packet.status = c.TB_PACKET_OK;
 
             c.tb_client_submit(client, packet);

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1209,13 +1209,13 @@ internal enum TBOperation : byte
 [StructLayout(LayoutKind.Sequential, Size = SIZE)]
 internal unsafe struct TBPacket
 {
-    public const int SIZE = 64;
+    public const int SIZE = 56;
 
 
     [StructLayout(LayoutKind.Sequential, Size = SIZE)]
     private unsafe struct ReservedData
     {
-        public const int SIZE = 7;
+        public const int SIZE = 32;
 
         private fixed byte raw[SIZE];
 
@@ -1242,25 +1242,17 @@ internal unsafe struct TBPacket
         }
     }
 
-    public TBPacket* next;
-
     public IntPtr userData;
+
+    public IntPtr data;
+
+    public uint dataSize;
+
+    public ushort tag;
 
     public byte operation;
 
     public PacketStatus status;
-
-    public uint dataSize;
-
-    public IntPtr data;
-
-    public TBPacket* batchNext;
-
-    public TBPacket* batchTail;
-
-    public uint batchSize;
-
-    public byte batchAllowed;
 
     private ReservedData reserved;
 

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -250,17 +250,13 @@ typedef enum TB_PACKET_STATUS {
 } TB_PACKET_STATUS;
 
 typedef struct tb_packet_t {
-    struct tb_packet_t* next;
     void* user_data;
+    void* data;
+    uint32_t data_size;
+    uint16_t tag;
     uint8_t operation;
     uint8_t status;
-    uint32_t data_size;
-    void* data;
-    struct tb_packet_t* batch_next;
-    struct tb_packet_t* batch_tail;
-    uint32_t batch_size;
-    uint8_t batch_allowed;
-    uint8_t reserved[7];
+    uint8_t reserved[32];
 } tb_packet_t;
 
 typedef void* tb_client_t; 

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -119,26 +119,20 @@ const NativeClient = struct {
             return undefined;
         };
 
-        const packet = global_allocator.create(tb.tb_packet_t) catch {
+        const packet: *tb.tb_packet_t = global_allocator.create(tb.tb_packet_t) catch {
             ReflectionHelper.assertion_error_throw(env, "Request could not allocate a packet");
             return undefined;
         };
 
         // Holds a global reference to prevent GC before the callback.
         const global_ref = JNIHelper.new_global_reference(env, request_obj);
-
         packet.* = .{
-            .next = undefined,
             .user_data = global_ref,
             .operation = operation,
-            .status = undefined,
             .data_size = @intCast(send_buffer.len),
             .data = send_buffer.ptr,
-            .batch_next = undefined,
-            .batch_tail = undefined,
-            .batch_size = undefined,
-            .batch_allowed = undefined,
-            .reserved = undefined,
+            .tag = 0,
+            .status = undefined,
         };
 
         tb.submit(context.client, packet);

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -319,12 +319,13 @@ fn on_completion_js(
 
             switch (packet.status) {
                 .ok => {
+                    const result_buffer = buffer.results();
                     const result_count = packet.tag;
-                    const results = buffer.results()[0..result_count];
+                    assert(result_count <= result_buffer.len);
                     break :blk encode_array(
                         StateMachine.ResultType(operation_comptime),
                         env,
-                        results,
+                        result_buffer[0..result_count],
                     );
                 },
                 .client_shutdown => {

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -273,34 +273,26 @@ class QueryFilter:
 class CPacket(ctypes.Structure):
     @classmethod
     def from_param(cls, obj):
-        validate_uint(bits=8, name="operation", number=obj.operation)
         validate_uint(bits=32, name="data_size", number=obj.data_size)
-        validate_uint(bits=32, name="batch_size", number=obj.batch_size)
+        validate_uint(bits=16, name="tag", number=obj.tag)
+        validate_uint(bits=8, name="operation", number=obj.operation)
         return cls(
-            next=obj.next,
             user_data=obj.user_data,
+            data=obj.data,
+            data_size=obj.data_size,
+            tag=obj.tag,
             operation=obj.operation,
             status=obj.status,
-            data_size=obj.data_size,
-            data=obj.data,
-            batch_next=obj.batch_next,
-            batch_tail=obj.batch_tail,
-            batch_size=obj.batch_size,
-            batch_allowed=obj.batch_allowed,
         )
 
 CPacket._fields_ = [ # noqa: SLF001
-    ("next", ctypes.POINTER(CPacket)),
     ("user_data", ctypes.c_void_p),
+    ("data", ctypes.c_void_p),
+    ("data_size", ctypes.c_uint32),
+    ("tag", ctypes.c_uint16),
     ("operation", ctypes.c_uint8),
     ("status", ctypes.c_uint8),
-    ("data_size", ctypes.c_uint32),
-    ("data", ctypes.c_void_p),
-    ("batch_next", ctypes.POINTER(CPacket)),
-    ("batch_tail", ctypes.POINTER(CPacket)),
-    ("batch_size", ctypes.c_uint32),
-    ("batch_allowed", ctypes.c_bool),
-    ("reserved", ctypes.c_uint8 * 7),
+    ("reserved", ctypes.c_uint8 * 32),
 ]
 
 

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -69,7 +69,7 @@ pub fn main(_: std.mem.Allocator, args: CLIArgs) !void {
             packet.user_data = @constCast(@ptrCast(&context));
             packet.data = @constCast(events.ptr);
             packet.data_size = @intCast(events.len);
-            packet.next = null;
+            packet.tag = 0;
             packet.status = c.TB_PACKET_OK;
 
             c.tb_client_submit(tb_client, &packet);


### PR DESCRIPTION
- Refactored the Packet interface, hiding "private" members within an opaque `reserved` field.
- Added assertions to enforce expectations for each Packet field based on its current phase.
- Improved `Context` with better function names and additional assertions.
- Addressed the repurposed use of `packet.data_size` for replies in the Node client by exposing a new user-defined field, `Packet.tag`.