### PR TITLE
CFO: Configurable fuzzer weights

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -380,11 +380,15 @@ fn run_fuzzers(
     }
     assert(seeds.items.len == 0);
 
+    var runtime_total_ticks: u64 = 0;
+    for (tasks.list.items) |*task| runtime_total_ticks += task.runtime_ticks;
     for (tasks.list.items) |*task| {
-        log.info("commit={s} fuzzer={s:<24} runtime={}s (active={})", .{
+        log.info("commit={s} fuzzer={s:<24} runtime={}s {d:.2}% (active={})", .{
             task.seed_template.commit_sha[0..7],
             @tagName(task.seed_template.fuzzer),
             @divFloor(task.runtime_ticks, second_ticks),
+            @as(f64, @floatFromInt(task.runtime_ticks * 100)) /
+                @as(f64, @floatFromInt(runtime_total_ticks)),
             task.generation == tasks.generation,
         });
     }


### PR DESCRIPTION
The weights I set are very rough -- I want to spend less on canary and fuzzers of "cold" code, and more on LSM/VOPR fuzzers. We can modify these over time, as code gets changed, or if we look at the CFO results and don't like the fuzz ratios.

Here is some data on where a production cfo spent its time over its hour budget (pre-configurable-weights):
(Note that `93d5be5` is `main` and the other commits are PR's.)

```
commit=93d5be5 fuzzer=canary                   runtime=2.3%
commit=93d5be5 fuzzer=ewah                     runtime=2.3%
commit=93d5be5 fuzzer=lsm_cache_map            runtime=2.4%
commit=93d5be5 fuzzer=lsm_forest               runtime=2.4%
commit=93d5be5 fuzzer=lsm_manifest_level       runtime=2.3%
commit=93d5be5 fuzzer=lsm_manifest_log         runtime=2.3%
commit=93d5be5 fuzzer=lsm_scan                 runtime=2.7%
commit=93d5be5 fuzzer=lsm_segmented_array      runtime=2.3%
commit=93d5be5 fuzzer=lsm_tree                 runtime=2.3%
commit=93d5be5 fuzzer=storage                  runtime=2.3%
commit=93d5be5 fuzzer=vopr_lite                runtime=4.7%
commit=93d5be5 fuzzer=vopr_testing_lite        runtime=4.7%
commit=93d5be5 fuzzer=vopr_testing             runtime=4.8%
commit=93d5be5 fuzzer=vopr                     runtime=4.7%
commit=93d5be5 fuzzer=vsr_free_set             runtime=2.3%
commit=93d5be5 fuzzer=vsr_journal_format       runtime=2.3%
commit=93d5be5 fuzzer=vsr_superblock_quorums   runtime=2.3%
commit=93d5be5 fuzzer=vsr_superblock           runtime=2.3%
commit=93d5be5 fuzzer=signal                   runtime=2.3%
commit=ab40fce fuzzer=canary                   runtime=2.3%
commit=ab40fce fuzzer=vopr_lite                runtime=4.7%
commit=ab40fce fuzzer=vopr                     runtime=4.7%
commit=c9d01b8 fuzzer=canary                   runtime=2.3%
commit=c9d01b8 fuzzer=vopr                     runtime=4.7%
commit=ab3ecf0 fuzzer=canary                   runtime=2.3%
commit=ab3ecf0 fuzzer=vopr_lite                runtime=4.7%
commit=ab3ecf0 fuzzer=vopr                     runtime=4.7%
commit=9e009ea fuzzer=canary                   runtime=2.3%
commit=9e009ea fuzzer=vopr_lite                runtime=4.7%
commit=61b0080 fuzzer=canary                   runtime=2.3%
commit=61b0080 fuzzer=vopr                     runtime=4.7%
```

---

Also fix a bug introduced by my most recent CFO PR, where we were overwriting the weight instead of multiplying it. This means that the main/PR split was not being set properly.
