### PR TITLE
Temp fix for Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here are a few key pages you might be interested in:
 ## Community
 
 * [Projects using TigerBeetle developed by community members.](./docs/COMMUNITY_PROJECTS.md)
-* [Join the TigerBeetle chat on Slack.](https://join.slack.com/t/tigerbeetle/shared_invite/zt-21xk62q7l-p~~G7~H01zQb88rQn7tWfQ)
+* [Join the TigerBeetle chat on Slack.](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg)
 * [Follow us on Twitter](https://twitter.com/TigerBeetleDB), [YouTube](https://www.youtube.com/@tigerbeetledb), and [Twitch](https://www.twitch.tv/tigerbeetle).
 * [Subscribe to our monthly newsletter for the backstory on recent database changes.](https://mailchi.mp/8e9fa0f36056/subscribe-to-tigerbeetle)
 * [Check out past and upcoming talks.](/docs/TALKS.md)

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -143,7 +143,7 @@ Developer-oriented documentation is at
 
 ## Getting In Touch
 
-Say hello in our [Slack](https://slack.tigerbeetle.com/invite)!
+Say hello in our [Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg)!
 
 ## Pull Requests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,6 @@ Learn more about TigerBeetle's [mission, history](./about/README.md),
 
 - [𝕏](https://twitter.com/tigerbeetledb)
 - [GitHub](https://github.com/tigerbeetle/tigerbeetle)
-- [Slack](https://slack.tigerbeetle.com/invite)
+- [Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg)
 - [Monthly Newsletter](https://mailchi.mp/8e9fa0f36056/subscribe-to-tigerbeetle)
 - [YouTube](https://www.youtube.com/@tigerbeetledb)

--- a/docs/coding/README.md
+++ b/docs/coding/README.md
@@ -57,7 +57,7 @@ Depending on your use case, you may find these additional design patterns helpfu
 Have questions about TigerBeetle's data model, how to design your application on top of it, or
 anything else?
 
-Come join our [Community Slack](https://slack.tigerbeetle.com/invite) and ask any and all questions
+Come join our [Community Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg) and ask any and all questions
 you might have!
 
 ### Dedicated Consultation

--- a/docs/coding/financial-accounting.md
+++ b/docs/coding/financial-accounting.md
@@ -190,7 +190,7 @@ determines whether the given type of account is increased with a debit or a cred
 Have questions about debits and credits, TigerBeetle's data model, how to design your application on
 top of it, or anything else?
 
-Come join our [Community Slack](https://slack.tigerbeetle.com/invite) and ask any and all questions
+Come join our [Community Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg) and ask any and all questions
 you might have!
 
 ### Dedicated Consultation

--- a/src/docs_website/src/html/page.html
+++ b/src/docs_website/src/html/page.html
@@ -87,7 +87,7 @@
         </picture>
         <p>
           Still haven't found what you're looking for?<br>
-          <a href="https://join.slack.com/t/tigerbeetle/shared_invite/zt-21xk62q7l-p~~G7~H01zQb88rQn7tWfQ">Ask the TigerBeetle Slack Community.</a>
+          <a href="https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg">Ask the TigerBeetle Slack Community.</a>
         </p>
       </div>
       <nav class="side">


### PR DESCRIPTION
Ref: https://github.com/tigerbeetle/tigerbeetle/issues/2731#event-16300037934 

Update Slack invite link in source code to our 'expiring link'. Once we have adjusted the redirect, these can be reverted to https://slack.tigerbeetle.com/invite so we don't have to do this again in future and can update in one place.