### PR TITLE
docs: simplify

### DIFF
--- a/src/docs_website/src/docs.zig
+++ b/src/docs_website/src/docs.zig
@@ -220,12 +220,7 @@ fn write_404_page(
 }
 
 const Menu = struct {
-    const Item = union(Type) {
-        const Type = enum {
-            menu,
-            page,
-        };
-
+    const Item = union(enum) {
         menu: Menu,
         page: Page,
     };


### PR DESCRIPTION
Thought we can use `std.meta.Tag(Item)` here to avoid duplication, but this turns out to be entirely unused.