### PR TITLE
docs: enable 404 tracking

### DIFF
--- a/src/docs_website/src/html/404.html
+++ b/src/docs_website/src/html/404.html
@@ -20,6 +20,8 @@
   <link rel="icon" href="$url_prefix/img/favicon.png">
   <link rel="stylesheet" type="text/css" href="$url_prefix/style/style.css">
   <script defer data-domain="docs.tigerbeetle.com" src="https://plausible.io/js/script.js"></script>
+  <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+  <script>document.addEventListener('DOMContentLoaded', function () { plausible('404', { props: { path: document.location.pathname } }); });</script>
   <style>
     article>.content {
       padding: 0;


### PR DESCRIPTION
This change enables 404 error tracking on plausible.io.