### PR TITLE
docs: cancel preview on escape

### DIFF
--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -9,6 +9,7 @@ const searchHotkey = document.querySelector(".search-box>.hotkey");
 const searchClearButton = document.querySelector(".search-box>.clear-button");
 
 let sidenavWasCollapsed = false;
+let searchPreviewUsed = false;
 document.addEventListener("keydown", event => {
   if (event.ctrlKey || event.altKey || event.metaKey) return;
   if (event.key === "/" && searchInput !== document.activeElement) {
@@ -21,6 +22,10 @@ document.addEventListener("keydown", event => {
   } else if (event.key === "Escape") {
     if (searchInput === document.activeElement || searchInput.value !== "") {
       closeSearch();
+      if (searchPreviewUsed) {
+        history.back();
+        searchPreviewUsed = false;
+      }
       event.preventDefault();
     }
   } else if (searchInput.value !== "") {
@@ -38,6 +43,7 @@ document.addEventListener("keydown", event => {
           details.open = !details.open;
         } else {
           closeSearch();
+          searchPreviewUsed = false;
         }
         event.preventDefault();
       }
@@ -57,6 +63,7 @@ searchClearButton.addEventListener("click", () => {
   onSearchInput();
   if (searchInput !== document.activeElement) searchHotkey.style.display = "block";
   removeTextHighlight(content);
+  searchPreviewUsed = false;
 });
 
 initSearch();
@@ -208,10 +215,11 @@ function selectResult(node) {
   content.innerHTML = page.html;
   addContentEventHandlers();
   const state = { pageIndex: node.pageIndex };
-  if (history.state) {
+  if (searchPreviewUsed) {
     history.replaceState(state, page.title, node.href);
   } else {
     history.pushState(state, page.title, node.href);
+    searchPreviewUsed = true;
   }
   statePathname = location.pathname;
   if (page.title === "TigerBeetle Docs") {


### PR DESCRIPTION
Hitting Escape should undo the previewing of search results, restoring the content that was viewed before searching.

This implementation uses the history stack to cancel the previewing by going one step back. The downside of this is it leaves one history step for the user to go forward after canceling. I think we need to accept this downside for the following reason:
During previewing we need to update the URL for anchor highlights to work and also to match the content. This can only be achieved using the `history.pushState`/`replaceState` API which affects the history. The only way around this is to fully virtualize page navigation (SPA relying on JS) so we can use `replaceState` when canceling. `replaceState` doesn't work if we reached the current page through normal navigation (there is no state on the stack to replace).