### PR TITLE
docs: fix node samples deprecated behavior

### DIFF
--- a/src/clients/node/samples/basic/main.js
+++ b/src/clients/node/samples/basic/main.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const process = require("process");
 
 const {
     createClient,
@@ -47,7 +48,7 @@ async function main() {
   for (const error of accountErrors) {
     console.error(`Batch account at ${error.index} failed to create: ${CreateAccountError[error.result]}.`);
   }
-  assert.equal(accountErrors.length, 0);
+  assert.strictEqual(accountErrors.length, 0);
 
   let transferErrors = await client.createTransfers([
     {
@@ -69,17 +70,17 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   let accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 10n);
-      assert.equal(account.credits_posted, 0);
+      assert.strictEqual(account.debits_posted, 10n);
+      assert.strictEqual(account.credits_posted, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 10n);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 10n);
     } else {
       assert.fail("Unexpected account: " + JSON.stringify(account, null, 2));
     }

--- a/src/clients/node/samples/two-phase-many/main.js
+++ b/src/clients/node/samples/two-phase-many/main.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const process = require("process");
 
 const {
     createClient,
@@ -49,7 +50,7 @@ async function main() {
   for (const error of accountErrors) {
     console.error(`Batch account at ${error.index} failed to create: ${CreateAccountError[error.result]}.`);
   }
-  assert.equal(accountErrors.length, 0);
+  assert.strictEqual(accountErrors.length, 0);
 
   // Start five pending transfer.
   let transfers = [
@@ -133,23 +134,23 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate accounts pending and posted debits/credits before
   // finishing the two-phase transfer.
   let accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 1500);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 1500);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 1500);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 1500);
     } else {
       assert.fail("Unexpected account: " + JSON.stringify(account, null, 2));
     }
@@ -176,22 +177,22 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate account balances after posting 1st pending transfer.
   accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 100);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 1400);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 100);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 1400);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 100);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 1400);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 100);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 1400);
     } else {
       assert.fail("Unexpected account: " + account.id);
     }
@@ -218,22 +219,22 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate account balances after voiding 2nd pending transfer.
   accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 100);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 1200);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 100);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 1200);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 100);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 1200);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 100);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 1200);
     } else {
       assert.fail("Unexpected account: " + account.id);
     }
@@ -260,22 +261,22 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate account balances after posting 3rd pending transfer.
   accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 400);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 900);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 400);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 900);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 400);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 900);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 400);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 900);
     } else {
       assert.fail("Unexpected account: " + account.id);
     }
@@ -302,22 +303,22 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate account balances after voiding 4th pending transfer.
   accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 400);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 500);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 400);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 500);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 400);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 500);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 400);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 500);
     } else {
       assert.fail("Unexpected account: " + account.id);
     }
@@ -344,22 +345,22 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate account balances after posting 5th pending transfer.
   accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 900);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 900);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 900);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 900);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 0);
     } else {
       assert.fail("Unexpected account: " + account.id);
     }

--- a/src/clients/node/samples/two-phase/main.js
+++ b/src/clients/node/samples/two-phase/main.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const process = require("process");
 
 const {
     createClient,
@@ -49,7 +50,7 @@ async function main() {
   for (const error of accountErrors) {
     console.error(`Batch account at ${error.index} failed to create: ${CreateAccountError[error.result]}.`);
   }
-  assert.equal(accountErrors.length, 0);
+  assert.strictEqual(accountErrors.length, 0);
 
   // Start a pending transfer
   let transferErrors = await client.createTransfers([
@@ -72,22 +73,22 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate accounts pending and posted debits/credits before finishing the two-phase transfer
   let accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 500);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 500);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 500);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 500);
     } else {
       assert.fail("Unexpected account: " + JSON.stringify(account, null, 2));
     }
@@ -114,16 +115,16 @@ async function main() {
   for (const error of transferErrors) {
     console.error(`Batch transfer at ${error.index} failed to create: ${CreateTransferError[error.result]}.`);
   }
-  assert.equal(transferErrors.length, 0);
+  assert.strictEqual(transferErrors.length, 0);
 
   // Validate the contents of all transfers
   let transfers = await client.lookupTransfers([1n, 2n]);
-  assert.equal(transfers.length, 2);
+  assert.strictEqual(transfers.length, 2);
   for (let transfer of transfers) {
     if (transfer.id === 1n) {
-      assert.equal(transfer.flags & TransferFlags.pending, TransferFlags.pending);
+      assert.strictEqual(transfer.flags & TransferFlags.pending, TransferFlags.pending);
     } else if (transfer.id === 2n) {
-      assert.equal(transfer.flags & TransferFlags.post_pending_transfer, TransferFlags.post_pending_transfer);
+      assert.strictEqual(transfer.flags & TransferFlags.post_pending_transfer, TransferFlags.post_pending_transfer);
     } else {
       assert.fail("Unexpected transfer: " + transfer.id);
     }
@@ -131,18 +132,18 @@ async function main() {
 
   // Validate accounts pending and posted debits/credits after finishing the two-phase transfer
   accounts = await client.lookupAccounts([1n, 2n]);
-  assert.equal(accounts.length, 2);
+  assert.strictEqual(accounts.length, 2);
   for (let account of accounts) {
     if (account.id === 1n) {
-      assert.equal(account.debits_posted, 500);
-      assert.equal(account.credits_posted, 0);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 500);
+      assert.strictEqual(account.credits_posted, 0);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 0);
     } else if (account.id === 2n) {
-      assert.equal(account.debits_posted, 0);
-      assert.equal(account.credits_posted, 500);
-      assert.equal(account.debits_pending, 0);
-      assert.equal(account.credits_pending, 0);
+      assert.strictEqual(account.debits_posted, 0);
+      assert.strictEqual(account.credits_posted, 500);
+      assert.strictEqual(account.debits_pending, 0);
+      assert.strictEqual(account.credits_pending, 0);
     } else {
       assert.fail("Unexpected account: " + account.id);
     }

--- a/src/clients/node/samples/walkthrough/main.js
+++ b/src/clients/node/samples/walkthrough/main.js
@@ -1,6 +1,7 @@
 // section:imports
 const { id } = require("tigerbeetle-node");
 const { createClient } = require("tigerbeetle-node");
+const process = require("process");
 
 console.log("Import ok!");
 // endsection:imports


### PR DESCRIPTION
1. `assert.equal` is deprecated since node v9
  - v9 https://nodejs.org/docs/latest-v9.x/api/assert.html#assert_assert_equal_actual_expected_message
  - latest https://nodejs.org/api/assert.html#assertequalactual-expected-message
2. `process` must be imported from `node:process` this is important for environments like deno and recommended for nodejs

It's probably better to rewrite this code in ES modules; new projects usually don't use requirejs.