### PR TITLE
docs: fix `SecurityError` exception in search

### DIFF
--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -109,7 +109,8 @@ function onSearchInput() {
     const summary = document.createElement("summary");
     details.appendChild(summary);
     summary.pageIndex = group.pageIndex;
-    summary.href = urlPrefix + "/" + group.hits[0].section.path + "/";
+    summary.href = urlPrefix + "/"
+    if (group.hits[0].section.path) summary.href += group.hits[0].section.path + "/";
     const p = document.createElement("p");
     summary.appendChild(p);
     p.innerText = pages[group.pageIndex].title;
@@ -125,7 +126,9 @@ function onSearchInput() {
         e.preventDefault();
         selectResult(a);
       });
-      a.href = urlPrefix + "/" + result.section.path + "/" + result.section.hash;
+      a.href = urlPrefix + "/";
+      if (result.section.path) a.href += result.section.path + "/";
+      a.href += result.section.hash;
       a.pageIndex = result.section.pageIndex;
       const h3 = document.createElement("h3");
       a.appendChild(h3);

--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -111,6 +111,7 @@ function onSearchInput() {
     summary.pageIndex = group.pageIndex;
     summary.href = urlPrefix + "/"
     if (group.hits[0].section.path) summary.href += group.hits[0].section.path + "/";
+    assert(URL.canParse(summary.href, location.href));
     const p = document.createElement("p");
     summary.appendChild(p);
     p.innerText = pages[group.pageIndex].title;
@@ -129,6 +130,7 @@ function onSearchInput() {
       a.href = urlPrefix + "/";
       if (result.section.path) a.href += result.section.path + "/";
       a.href += result.section.hash;
+      assert(URL.canParse(a.href, location.href));
       a.pageIndex = result.section.pageIndex;
       const h3 = document.createElement("h3");
       a.appendChild(h3);

--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -233,6 +233,10 @@ nav.left-pane {
   }
 
   .search-box {
+    @media (scripting: none) {
+      display: none;
+    }
+
     position: relative;
     overflow: hidden;
     margin-top: 16px;

--- a/src/docs_website/src/html/page-script.js
+++ b/src/docs_website/src/html/page-script.js
@@ -7,9 +7,6 @@ function assert(condition) {
 
 window.urlPrefix = "$url_prefix";
 
-// Enable search if JavaScript is enabled.
-document.querySelector(".search-box").style.removeProperty("display");
-
 if ("serviceWorker" in navigator) {
   navigator.serviceWorker.register(urlPrefix + "/service-worker.js");
 }

--- a/src/docs_website/src/html/page-script.js
+++ b/src/docs_website/src/html/page-script.js
@@ -1,3 +1,10 @@
+function assert(condition) {
+  if (!condition) {
+    alert("Assertion failed");
+    throw "Assertion failed";
+  }
+}
+
 window.urlPrefix = "$url_prefix";
 
 // Enable search if JavaScript is enabled.

--- a/src/docs_website/src/html/page.html
+++ b/src/docs_website/src/html/page.html
@@ -61,7 +61,7 @@
               </svg>
             </a>
           </header>
-          <div class="search-box" style="display: none;">
+          <div class="search-box">
             <input type="search" placeholder="Search" />
             <svg class="search-icon" width="16" height="16" fill="none">
               <circle cx="6.5" cy="6.5" r="4.5" stroke-width="1.5" stroke="currentColor"/>


### PR DESCRIPTION
When the `section.path` was empty we were creating URLs with double forward slashes such as: `"//"` and `"//#tigerbeetle"`. This lead to the following exception being thrown when trying to use these URLs with the `history.pushState` and `history.replaceState` APIs:

```
SecurityError: A history state object with URL 'http:' cannot be created in a document with origin 'http://localhost:8000' and URL 'http://localhost:8000/'.
```

Bonus: fix flashing search box while navigating by using CSS media query instead of JS to unhide the search box.