### PR TITLE
fix: 2 broken links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tigerbeetle
 
-*TigerBeetle is the financial transactions database designed for mission critical safety and performance to power the next 30 years of [OLTP](https://docs.tigerbeetle.com/concepts/oltp).*
+*TigerBeetle is the financial transactions database designed for mission critical safety and performance to power the next 30 years of [OLTP](https://docs.tigerbeetle.com/about/oltp).*
 
 ## Documentation
 
@@ -14,7 +14,7 @@
 
 ## Start
 
-Run a single-replica cluster on Linux (or [other platforms](https://docs.tigerbeetle.com/start/)):
+Run a single-replica cluster on Linux (or [other platforms](https://docs.tigerbeetle.com/quick-start/)):
 
 ```console
 $ curl -Lo tigerbeetle.zip https://linux.tigerbeetle.com && unzip tigerbeetle.zip && ./tigerbeetle version


### PR DESCRIPTION
I noticed that the very first and last links on our `README.md` were broken!

Updated them based on taking a look at where the docs are now, however please let me know if my educated guesses were wrong. 



