### PR TITLE
vsr: simplify the idiom around flush_back 

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7850,6 +7850,7 @@ pub fn ReplicaType(
                 // This is safe only because the primary can verify against the prepare checksum.
                 if (self.journal.header_with_op(op)) |header| {
                     self.send_prepare_ok(header);
+                    if (self.loopback_queue != null) assert(self.journal.has_prepare(header));
                     self.flush_loopback_queue();
                 }
             }


### PR DESCRIPTION
There's not material reason why we need a defer, it's only to underscore
that flusing is _usually_ the last thing to do.

Replace defers with more direct returns when possible.