### PR TITLE
VSR: Reverse ring replication for odd ops

### DIFF
--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -114,8 +114,9 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
 
             if (replica.status != .recovering_head) {
                 const head_max = &state_checker.replica_head_max[replica_index];
-                const wal_headers = replica.superblock.storage.wal_headers();
-                const head_max_journal = wal_headers[head_max.op % constants.journal_slot_count];
+                const wal_prepares = replica.superblock.storage.wal_prepares();
+                const head_max_journal =
+                    wal_prepares[head_max.op % constants.journal_slot_count].header;
 
                 assert(replica.view > head_max.view or
                     (replica.view == head_max.view and (replica.op >= head_max.op or

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3182,13 +3182,17 @@ pub fn ReplicaType(
                 return self.commit_pipeline();
             }
 
+            // See replicate().
+            const ring_direction: i16 = if (prepare.message.header.op % 2 == 0) 1 else -1;
+
             // The list of remote replicas yet to send a prepare_ok:
             var waiting: [constants.replicas_max]u8 = undefined;
             var waiting_len: usize = 0;
             for (1..self.replica_count) |ring_index| {
-                const replica: u8 = @intCast(
-                    (@as(usize, self.replica) + ring_index) % self.replica_count,
-                );
+                const replica: u8 = @intCast(@mod(
+                    @as(i16, self.replica) + ring_direction * @as(i16, @intCast(ring_index)),
+                    self.replica_count,
+                ));
                 assert(replica != self.replica);
                 if (!prepare.ok_from_all_replicas.isSet(replica)) {
                     waiting[waiting_len] = replica;
@@ -7611,10 +7615,20 @@ pub fn ReplicaType(
                 return;
             }
 
+            // Even ops replicate clockwise.
+            // Odd ops replicate counter-clockwise.
+            //
+            // This means that if the first backup after the primary is down, replication
+            // doesn't necessarily need to wait for prepare_timeout, since the next prepare
+            // (routed backwards) could trigger repair in the other replicas.
+            // TODO Once we use health data to skip faulty replicas, then this isn't needed.
+            const ring_direction: i16 = if (message.header.op % 2 == 0) 1 else -1;
+
             const next = next: {
                 // Replication in the ring of active replicas.
                 if (!self.standby()) {
-                    const next_replica = @mod(self.replica + 1, self.replica_count);
+                    const next_replica: u8 =
+                        @intCast(@mod(@as(i16, self.replica) + ring_direction, self.replica_count));
                     if (next_replica != self.primary_index(message.header.view)) {
                         break :next next_replica;
                     }


### PR DESCRIPTION
Alternate ring replication direction such that, if a single replica is down, the replicas after it learn that they are missing a prepare, and can repair it.


We originally reverted this commit as it wasn't playing well with our repair, which insisted on everything being done strictly in order. We have since relaxed our repair to be more concurrent:

* https://github.com/tigerbeetle/tigerbeetle/pull/2628 
* https://github.com/tigerbeetle/tigerbeetle/pull/2593

We don't yet have a deterministic performance test here yet, so I used the following script to test the behavior

```ts
#!/usr/bin/env -S deno run --allow-all
import $ from "jsr:@david/dax";

$.setPrintCommand(true);
const working_directory = "zig-out/cluster";
const replica_count = 6;
const replica_indexes = [...Array(replica_count)].map((_, index) => index);
const cluster = 0;
const addresses = [...Array(replica_count)].map((_, index) => `${3000 + index}`)
    .join(",");

await $`./zig/zig build -Drelease`;
try {
    await Deno.remove(working_directory, { recursive: true });
} catch {

}
await Deno.mkdir(working_directory);

await Promise.all(replica_indexes.map((replica) => {
    return $`./tigerbeetle format
            --cluster=${cluster} --replica=${replica} --replica-count=${replica_count}
            ${working_directory}/${cluster}_${replica}.tigerbeetle`;
}));

const dead_replica = 2;
const processes = [];
for (let replica = 0; replica < replica_count; replica += 1) {
    if (replica == dead_replica) continue;
    const process = $`./tigerbeetle start
            --addresses=${addresses}
            ${working_directory}/${cluster}_${replica}.tigerbeetle
            2> ./${working_directory}/${cluster}_${replica}.log`.spawn();
    processes.push(process);
}

await $`./tigerbeetle benchmark --print-batch-timings
         --id-order=random --seed=3 --transfer-batch-size=1000 --transfer-count=200_000
         --addresses=${addresses}
         --clients=4`;

console.log("ok.");
```

In all-healthy cluster, benchmark finishes in about 7 seconds for me, with or without bidirectional replication. 

If a single replica is down:

- with unidirectional, it takes either 7 seconds still (last replica is down) or takes a lot longer, with individual requests taking up to 12 seconds
- with bidirectional, it takes 30 seconds regardless of which replica is down.