### PR TITLE
VSR: Explicit deprecated message types

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -217,27 +217,14 @@ pub const Command = enum(u8) {
     start_view = 24,
 
     // If a command is removed from the protocol, its ordinal is added here and can't be re-used.
-    const gaps = .{
-        12, // start_view without checkpoint
-        21, // request_sync_checkpoint
-        22, // sync_checkpoint
-        23, // start_view with an older version of CheckpointState
-    };
+    deprecated_12 = 12, // start_view without checkpoint
+    deprecated_21 = 21, // request_sync_checkpoint
+    deprecated_22 = 22, // sync_checkpoint
+    deprecated_23 = 23, // start_view with an older version of CheckpointState
 
     comptime {
-        var value_previous: ?u8 = null;
         for (std.enums.values(Command)) |command| {
-            const value_current = @intFromEnum(command);
-            assert(std.mem.indexOfScalar(u8, &gaps, value_current) == null);
-            if (value_previous == null) {
-                assert(value_current == 0);
-            } else {
-                assert(value_previous.? < value_current);
-                for (value_previous.? + 1..value_current) |value_gap| {
-                    assert(std.mem.indexOfScalar(u8, &gaps, value_gap) != null);
-                }
-            }
-            value_previous = value_current;
+            assert(@intFromEnum(command) < std.enums.values(Command).len);
         }
     }
 };

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -97,6 +97,10 @@ pub const Header = extern struct {
             .eviction => Eviction,
             .request_blocks => RequestBlocks,
             .block => Block,
+            .deprecated_12 => Deprecated,
+            .deprecated_21 => Deprecated,
+            .deprecated_22 => Deprecated,
+            .deprecated_23 => Deprecated,
         };
     }
 
@@ -208,6 +212,10 @@ pub const Header = extern struct {
             .prepare => return .unknown,
             .block => return .unknown,
             .reply => return .unknown,
+            .deprecated_12 => return .unknown,
+            .deprecated_21 => return .unknown,
+            .deprecated_22 => return .unknown,
+            .deprecated_23 => return .unknown,
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
             // All other messages identify the peer as a replica:
@@ -295,6 +303,33 @@ pub const Header = extern struct {
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .reserved);
             return "reserved is invalid";
+        }
+    };
+
+    /// This type isn't ever actually a constructed, but makes Type() simpler by providing a header
+    /// type for each command.
+    pub const Deprecated = extern struct {
+        pub usingnamespace HeaderFunctionsType(@This());
+
+        checksum: u128,
+        checksum_padding: u128 = 0,
+        checksum_body: u128,
+        checksum_body_padding: u128 = 0,
+        nonce_reserved: u128,
+        cluster: u128,
+        size: u32,
+        epoch: u32 = 0,
+        view: u32 = 0,
+        release: vsr.Release,
+        protocol: u16 = vsr.Version,
+        command: Command,
+        replica: u8 = 0,
+        reserved_frame: [12]u8,
+
+        reserved: [128]u8 = [_]u8{0} ** 128,
+
+        fn invalid_header(_: *const @This()) ?[]const u8 {
+            return "deprecated message type";
         }
     };
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1499,6 +1499,10 @@ pub fn ReplicaType(
                     return;
                 },
                 .reserved => unreachable,
+                .deprecated_12 => unreachable,
+                .deprecated_21 => unreachable,
+                .deprecated_22 => unreachable,
+                .deprecated_23 => unreachable,
             }
 
             if (self.loopback_queue) |loopback_message| {
@@ -8186,6 +8190,11 @@ pub fn ReplicaType(
             // TODO According to message.header.command, assert on the destination replica.
             switch (message.header.into_any()) {
                 .reserved => unreachable,
+                // Deprecated messages are always `invalid()`.
+                .deprecated_12 => unreachable,
+                .deprecated_21 => unreachable,
+                .deprecated_22 => unreachable,
+                .deprecated_23 => unreachable,
                 .request => {
                     assert(!self.standby());
                     // Do not assert message.header.replica because we forward .request messages.


### PR DESCRIPTION
## Bug

The `Command` enum lists all message types, with explicit values. But if a replica receives a deprecated message type (e.g. via network replay), we would `switch` on the value, and panic.

Stack (from a replica on 0.16.28):

```
thread 24341 panic: switch on corrupt value
.../tigerbeetle/src/vsr/message_header.zig:144:17: 0x1304df3 in into_any (tigerbeetle)
.../tigerbeetle/src/vsr/message_header.zig:198:30: 0x18d9e98 in peer_type (tigerbeetle)
.../tigerbeetle/src/message_bus.zig:878:78: 0x18330e3 in set_and_verify_peer (tigerbeetle)
.../tigerbeetle/src/message_bus.zig:786:72: 0x17aeffc in parse_message (tigerbeetle)
.../tigerbeetle/src/message_bus.zig:732:48: 0x174e8e3 in parse_messages (tigerbeetle)
.../tigerbeetle/src/message_bus.zig:1007:42: 0x16edbab in on_recv (tigerbeetle)
.../tigerbeetle/src/io/linux.zig:1160:29: 0x16a6046 in wrapper (tigerbeetle)
.../tigerbeetle/src/io/linux.zig:686:40: 0x11f8ff5 in complete (tigerbeetle)
.../tigerbeetle/src/io/linux.zig:192:49: 0x11f775f in flush (tigerbeetle)
.../tigerbeetle/src/io/linux.zig:147:27: 0x1234796 in run_for_ns (tigerbeetle)
.../tigerbeetle/src/tigerbeetle/main.zig:510:38: 0x12362b4 in start (tigerbeetle)
.../tigerbeetle/src/tigerbeetle/main.zig:84:44: 0x12cfb3f in main (tigerbeetle)
.../tigerbeetle/zig/lib/std/start.zig:524:37: 0x11e6335 in posixCallMainAndExit (tigerbeetle)
.../tigerbeetle/zig/lib/std/start.zig:266:5: 0x11e5e51 in _start (tigerbeetle)
???:?:?: 0x4 in ??? (???)
Unwind information for `???:0x4` was not available, trace may be incomplete
```

## Fix

List deprecated message types in the `Command` enum, so that they are handled by switch statements.

Note that when we roll out a new message type, we need to make sure there is a transition release where the message type is received+ignored but not sent, otherwise we would be vulnerable to this bug in the other direction.