### PR TITLE
Spring cleaning: make sure that MessageBus does all io through IO

### DIFF
--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -1,0 +1,96 @@
+//! Code shared across several IO implementations, because, eg, it is expressible via POSIX layer.
+const builtin = @import("builtin");
+const std = @import("std");
+const posix = std.posix;
+
+const assert = std.debug.assert;
+
+const is_linux = builtin.target.os.tag == .linux;
+
+pub const ListenOptions = struct {
+    rcvbuf: c_int,
+    sndbuf: c_int,
+    keepalive: ?struct {
+        keepidle: c_int,
+        keepintvl: c_int,
+        keepcnt: c_int,
+    },
+    user_timeout_ms: c_int,
+    nodelay: bool,
+    backlog: u31,
+};
+
+pub fn listen(
+    fd: posix.socket_t,
+    address: std.net.Address,
+    options: ListenOptions,
+) !std.net.Address {
+    const set = struct {
+        fn set(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
+            try posix.setsockopt(_fd, level, option, &std.mem.toBytes(value));
+        }
+    }.set;
+
+    if (options.rcvbuf > 0) rcvbuf: {
+        if (is_linux) {
+            // Requires CAP_NET_ADMIN privilege (settle for SO_RCVBUF in case of an EPERM):
+            if (set(fd, posix.SOL.SOCKET, posix.SO.RCVBUFFORCE, options.rcvbuf)) |_| {
+                break :rcvbuf;
+            } else |err| switch (err) {
+                error.PermissionDenied => {},
+                else => |e| return e,
+            }
+        }
+        try set(fd, posix.SOL.SOCKET, posix.SO.RCVBUF, options.rcvbuf);
+    }
+
+    if (options.sndbuf > 0) sndbuf: {
+        if (is_linux) {
+            // Requires CAP_NET_ADMIN privilege (settle for SO_SNDBUF in case of an EPERM):
+            if (set(fd, posix.SOL.SOCKET, posix.SO.SNDBUFFORCE, options.sndbuf)) |_| {
+                break :sndbuf;
+            } else |err| switch (err) {
+                error.PermissionDenied => {},
+                else => |e| return e,
+            }
+        }
+        try set(fd, posix.SOL.SOCKET, posix.SO.SNDBUF, options.sndbuf);
+    }
+
+    if (options.keepalive) |keepalive| {
+        try set(fd, posix.SOL.SOCKET, posix.SO.KEEPALIVE, 1);
+        if (is_linux) {
+            try set(fd, posix.IPPROTO.TCP, posix.TCP.KEEPIDLE, keepalive.keepidle);
+            try set(fd, posix.IPPROTO.TCP, posix.TCP.KEEPINTVL, keepalive.keepintvl);
+            try set(fd, posix.IPPROTO.TCP, posix.TCP.KEEPCNT, keepalive.keepcnt);
+        }
+    }
+
+    if (options.user_timeout_ms > 0) {
+        if (is_linux) {
+            const timeout_ms = options.user_timeout_ms;
+            try set(fd, posix.IPPROTO.TCP, posix.TCP.USER_TIMEOUT, timeout_ms);
+        }
+    }
+
+    // Set tcp no-delay
+    if (options.nodelay) {
+        if (is_linux) {
+            try set(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, 1);
+        }
+    }
+
+    try set(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, 1);
+    try posix.bind(fd, &address.any, address.getOsSockLen());
+
+    // Resolve port 0 to an actual port picked by the OS.
+    var address_resolved: std.net.Address = .{ .any = undefined };
+    var addrlen: posix.socklen_t = @sizeOf(std.net.Address);
+    try posix.getsockname(fd, &address_resolved.any, &addrlen);
+    assert(address_resolved.getOsSockLen() == addrlen);
+    assert(address_resolved.any.family == address.any.family);
+
+    try posix.listen(fd, options.backlog);
+
+    return address_resolved;
+}

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -199,13 +199,13 @@ pub const IO = struct {
 
     const Operation = union(enum) {
         accept: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
         },
         close: struct {
             fd: fd_t,
         },
         connect: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             address: std.net.Address,
             initiated: bool,
         },
@@ -219,12 +219,12 @@ pub const IO = struct {
             offset: u64,
         },
         recv: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             buf: [*]u8,
             len: u32,
         },
         send: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             buf: [*]const u8,
             len: u32,
         },
@@ -305,10 +305,10 @@ pub const IO = struct {
         comptime callback: fn (
             context: Context,
             completion: *Completion,
-            result: AcceptError!posix.socket_t,
+            result: AcceptError!socket_t,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
     ) void {
         self.submit(
             context,
@@ -319,7 +319,7 @@ pub const IO = struct {
                 .socket = socket,
             },
             struct {
-                fn do_operation(op: anytype) AcceptError!posix.socket_t {
+                fn do_operation(op: anytype) AcceptError!socket_t {
                     const fd = try posix.accept(
                         op.socket,
                         null,
@@ -403,7 +403,7 @@ pub const IO = struct {
             result: ConnectError!void,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
         address: std.net.Address,
     ) void {
         self.submit(
@@ -550,7 +550,7 @@ pub const IO = struct {
             result: RecvError!usize,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
         buffer: []u8,
     ) void {
         self.submit(
@@ -583,7 +583,7 @@ pub const IO = struct {
             result: SendError!usize,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
         buffer: []const u8,
     ) void {
         self.submit(
@@ -767,10 +767,11 @@ pub const IO = struct {
         assert(polled == 0);
     }
 
+    pub const socket_t = posix.socket_t;
     pub const INVALID_SOCKET = -1;
 
     /// Creates a socket that can be used for async operations with the IO instance.
-    pub fn open_socket(self: *IO, family: u32, sock_type: u32, protocol: u32) !posix.socket_t {
+    pub fn open_socket(self: *IO, family: u32, sock_type: u32, protocol: u32) !socket_t {
         const fd = try posix.socket(family, sock_type | posix.SOCK.NONBLOCK, protocol);
         errdefer self.close_socket(fd);
 
@@ -784,7 +785,7 @@ pub const IO = struct {
     }
 
     /// Closes a socket opened by the IO instance.
-    pub fn close_socket(self: *IO, socket: posix.socket_t) void {
+    pub fn close_socket(self: *IO, socket: socket_t) void {
         _ = self;
         posix.close(socket);
     }

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -807,6 +807,10 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
+    pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {
+        return posix.shutdown(socket, how);
+    }
+
     /// Opens a directory with read only access.
     pub fn open_dir(dir_path: []const u8) !fd_t {
         return posix.open(dir_path, .{ .CLOEXEC = true, .ACCMODE = .RDONLY }, 0);

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -6,6 +6,7 @@ const log = std.log.scoped(.io);
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
+const common = @import("./common.zig");
 const FIFOType = @import("../fifo.zig").FIFOType;
 const Time = @import("../time.zig").Time;
 const buffer_limit = @import("../io.zig").buffer_limit;
@@ -788,6 +789,18 @@ pub const IO = struct {
     pub fn close_socket(self: *IO, socket: socket_t) void {
         _ = self;
         posix.close(socket);
+    }
+
+    /// Listen on the given TCP socket.
+    /// Returns socket resolved address, which might be more specific
+    /// than the input address (e.g., listening on port 0).
+    pub fn listen(
+        _: *IO,
+        fd: socket_t,
+        address: std.net.Address,
+        options: common.ListenOptions,
+    ) !std.net.Address {
+        return common.listen(fd, address, options);
     }
 
     /// Opens a directory with read only access.

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -605,6 +605,10 @@ pub const IO = struct {
         );
     }
 
+    pub fn send_now(_: *IO, _: socket_t, _: []const u8) ?usize {
+        return null; // No support for best-effort non-blocking synchronous send.
+    }
+
     pub const TimeoutError = error{Canceled} || posix.UnexpectedError;
 
     pub fn timeout(

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1229,6 +1229,16 @@ pub const IO = struct {
         self.enqueue(completion);
     }
 
+    /// Best effort to synchroneously transfer bytes to the kernel.
+    pub fn send_now(self: *IO, socket: socket_t, buffer: []const u8) ?usize {
+        _ = self;
+        return posix.send(socket, buffer, posix.MSG.DONTWAIT) catch |err| switch (err) {
+            error.WouldBlock => return null,
+            // To avoid duplicating error handling, force the caller to fallback to normal send.
+            else => return null,
+        };
+    }
+
     pub const StatxError = error{
         SymLinkLoop,
         FileNotFound,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -484,7 +484,7 @@ pub const IO = struct {
                     completion.callback(completion.context, completion, &result);
                 },
                 .accept => {
-                    const result: AcceptError!posix.socket_t = blk: {
+                    const result: AcceptError!socket_t = blk: {
                         if (completion.result < 0) {
                             const err = switch (@as(posix.E, @enumFromInt(-completion.result))) {
                                 .INTR => {
@@ -803,7 +803,7 @@ pub const IO = struct {
             target: *Completion,
         },
         accept: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             address: posix.sockaddr = undefined,
             address_size: posix.socklen_t = @sizeOf(posix.sockaddr),
         },
@@ -811,7 +811,7 @@ pub const IO = struct {
             fd: fd_t,
         },
         connect: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             address: std.net.Address,
         },
         fsync: struct {
@@ -830,11 +830,11 @@ pub const IO = struct {
             offset: u64,
         },
         recv: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             buffer: []u8,
         },
         send: struct {
-            socket: posix.socket_t,
+            socket: socket_t,
             buffer: []const u8,
         },
         statx: struct {
@@ -875,10 +875,10 @@ pub const IO = struct {
         comptime callback: fn (
             context: Context,
             completion: *Completion,
-            result: AcceptError!posix.socket_t,
+            result: AcceptError!socket_t,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
     ) void {
         completion.* = .{
             .io = self,
@@ -888,7 +888,7 @@ pub const IO = struct {
                     callback(
                         @ptrCast(@alignCast(ctx)),
                         comp,
-                        @as(*const AcceptError!posix.socket_t, @ptrCast(@alignCast(res))).*,
+                        @as(*const AcceptError!socket_t, @ptrCast(@alignCast(res))).*,
                     );
                 }
             }.wrapper,
@@ -972,7 +972,7 @@ pub const IO = struct {
             result: ConnectError!void,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
         address: std.net.Address,
     ) void {
         completion.* = .{
@@ -1151,7 +1151,7 @@ pub const IO = struct {
             result: RecvError!usize,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
         buffer: []u8,
     ) void {
         completion.* = .{
@@ -1203,7 +1203,7 @@ pub const IO = struct {
             result: SendError!usize,
         ) void,
         completion: *Completion,
-        socket: posix.socket_t,
+        socket: socket_t,
         buffer: []const u8,
     ) void {
         completion.* = .{
@@ -1440,16 +1440,17 @@ pub const IO = struct {
         posix.close(event);
     }
 
+    pub const socket_t = posix.socket_t;
     pub const INVALID_SOCKET = -1;
 
     /// Creates a socket that can be used for async operations with the IO instance.
-    pub fn open_socket(self: *IO, family: u32, sock_type: u32, protocol: u32) !posix.socket_t {
+    pub fn open_socket(self: *IO, family: u32, sock_type: u32, protocol: u32) !socket_t {
         _ = self;
         return posix.socket(family, sock_type | posix.SOCK.CLOEXEC, protocol);
     }
 
     /// Closes a socket opened by the IO instance.
-    pub fn close_socket(self: *IO, socket: posix.socket_t) void {
+    pub fn close_socket(self: *IO, socket: socket_t) void {
         _ = self;
         posix.close(socket);
     }

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1478,6 +1478,10 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
+    pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {
+        return posix.shutdown(socket, how);
+    }
+
     /// Opens a directory with read only access.
     pub fn open_dir(dir_path: []const u8) !fd_t {
         return posix.open(dir_path, .{ .CLOEXEC = true, .ACCMODE = .RDONLY }, 0);

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -10,6 +10,7 @@ const log = std.log.scoped(.io);
 
 const constants = @import("../constants.zig");
 const stdx = @import("../stdx.zig");
+const common = @import("./common.zig");
 const FIFOType = @import("../fifo.zig").FIFOType;
 const buffer_limit = @import("../io.zig").buffer_limit;
 const DirectIO = @import("../io.zig").DirectIO;
@@ -1453,6 +1454,18 @@ pub const IO = struct {
     pub fn close_socket(self: *IO, socket: socket_t) void {
         _ = self;
         posix.close(socket);
+    }
+
+    /// Listen on the given TCP socket.
+    /// Returns socket resolved address, which might be more specific
+    /// than the input address (e.g., listening on port 0).
+    pub fn listen(
+        _: *IO,
+        fd: socket_t,
+        address: std.net.Address,
+        options: common.ListenOptions,
+    ) !std.net.Address {
+        return common.listen(fd, address, options);
     }
 
     /// Opens a directory with read only access.

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -3,6 +3,7 @@ const os = std.os;
 const assert = std.debug.assert;
 const log = std.log.scoped(.io);
 const constants = @import("../constants.zig");
+const common = @import("./common.zig");
 
 const FIFOType = @import("../fifo.zig").FIFOType;
 const Time = @import("../time.zig").Time;
@@ -1119,6 +1120,18 @@ pub const IO = struct {
     pub fn close_socket(self: *IO, socket: socket_t) void {
         _ = self;
         std.posix.close(socket);
+    }
+
+    /// Listen on the given TCP socket.
+    /// Returns socket resolved address, which might be more specific
+    /// than the input address (e.g., listening on port 0).
+    pub fn listen(
+        _: *IO,
+        fd: socket_t,
+        address: std.net.Address,
+        options: common.ListenOptions,
+    ) !std.net.Address {
+        return common.listen(fd, address, options);
     }
 
     /// Opens a directory with read only access.

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1139,6 +1139,10 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
+    pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {
+        return posix.shutdown(socket, how);
+    }
+
     /// Opens a directory with read only access.
     pub fn open_dir(dir_path: []const u8) !fd_t {
         const dir = try std.fs.cwd().openDir(dir_path, .{});

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -705,6 +705,10 @@ pub const IO = struct {
         );
     }
 
+    pub fn send_now(_: *IO, _: socket_t, _: []const u8) ?usize {
+        return null; // No support for best-effort non-blocking synchronous send.
+    }
+
     pub const RecvError = std.posix.RecvFromError;
 
     pub fn recv(

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -189,7 +189,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             const fd = try io.open_socket(
                 address.any.family,
                 posix.SOCK.STREAM,
-                posix.IPPROTO.TCP
+                posix.IPPROTO.TCP,
             );
             errdefer io.close_socket(fd);
 
@@ -630,7 +630,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         //
                         // TODO: Investigate differences between shutdown() on Linux vs Darwin.
                         // Especially how this interacts with our assumptions around pending I/O.
-                        posix.shutdown(connection.fd, .both) catch |err| switch (err) {
+                        bus.io.shutdown(connection.fd, .both) catch |err| switch (err) {
                             error.SocketNotConnected => {
                                 // This should only happen if we for some reason decide to terminate
                                 // a connection while a connect operation is in progress.

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -54,7 +54,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             .replica => struct {
                 replica: u8,
                 /// The file descriptor for the process on which to accept connections.
-                accept_fd: posix.socket_t,
+                accept_fd: IO.socket_t,
                 /// Address the accept_fd is bound to, as reported by `getsockname`.
                 ///
                 /// This allows passing port 0 as an address for the OS to pick an open port for us
@@ -192,7 +192,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         }
 
         fn init_tcp(io: *IO, address: std.net.Address) !struct {
-            fd: posix.socket_t,
+            fd: IO.socket_t,
             address: std.net.Address,
         } {
             const fd = try io.open_socket(
@@ -203,7 +203,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             errdefer io.close_socket(fd);
 
             const set = struct {
-                fn set(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
+                fn set(_fd: IO.socket_t, level: i32, option: u32, value: c_int) !void {
                     try posix.setsockopt(_fd, level, option, &mem.toBytes(value));
                 }
             }.set;
@@ -375,7 +375,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         fn on_accept(
             bus: *MessageBus,
             completion: *IO.Completion,
-            result: IO.AcceptError!posix.socket_t,
+            result: IO.AcceptError!IO.socket_t,
         ) void {
             _ = completion;
 
@@ -465,7 +465,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             /// IO.INVALID_SOCKET instead of undefined here for safety to ensure an error if the
             /// invalid value is ever used, instead of potentially performing an action on an
             /// active fd.
-            fd: posix.socket_t = IO.INVALID_SOCKET,
+            fd: IO.socket_t = IO.INVALID_SOCKET,
 
             /// This completion is used for all recv operations.
             /// It is also used for the initial connect when establishing a replica connection.
@@ -611,7 +611,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
             /// Given a newly accepted fd, start receiving messages on it.
             /// Callbacks will be continuously re-registered until terminate() is called.
-            pub fn on_accept(connection: *Connection, bus: *MessageBus, fd: posix.socket_t) void {
+            pub fn on_accept(connection: *Connection, bus: *MessageBus, fd: IO.socket_t) void {
                 assert(connection.peer == .none);
                 assert(connection.state == .accepting);
                 assert(connection.fd == IO.INVALID_SOCKET);


### PR DESCRIPTION
MessageBus contained a bunch of platform specific code for working with sockets. Move all this code to IO, to make MessageBus a logical abstraction over byte streams, rather than a mixture of logical and physical. 

There's no _immediate_ benefits here, but this opens up MessageBus for fuzzing, as now you can just substitute its IO with a fake implementation. 