### PR TITLE
docs: only spell check files checked into git

### DIFF
--- a/src/docs_website/build.zig
+++ b/src/docs_website/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) !void {
 
     const check_spelling = std.Build.Step.Run.create(b, "run vale");
     check_spelling.addFileArg(vale_bin);
-    const md_files = try exec_stdout(b.allocator, &.{ "git", "ls-files", "../../**/*.md" });
+    const md_files = b.run(&.{ "git", "ls-files", "../../**/*.md" });
     var md_files_iter = std.mem.tokenize(u8, md_files, "\n");
     while (md_files_iter.next()) |md_file| {
         check_spelling.addArg(md_file);
@@ -125,16 +125,4 @@ fn get_vale_bin(b: *std.Build) ?std.Build.LazyPath {
     } else {
         return null;
     }
-}
-
-fn exec_stdout(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
-    var child = std.process.Child.init(argv, allocator);
-    child.stdout_behavior = .Pipe;
-
-    try child.spawn();
-    const output = try child.stdout.?.readToEndAlloc(allocator, 10 * 1024);
-    const term = try child.wait();
-    std.debug.assert(term == .Exited);
-
-    return output;
 }

--- a/src/docs_website/build.zig
+++ b/src/docs_website/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) !void {
     const md_files = b.run(&.{ "git", "ls-files", "../../**/*.md" });
     var md_files_iter = std.mem.tokenize(u8, md_files, "\n");
     while (md_files_iter.next()) |md_file| {
-        check_spelling.addArg(md_file);
+        check_spelling.addFileArg(b.path(md_file));
     }
 
     const content = b.addWriteFiles();


### PR DESCRIPTION
We want to restrict spell checking to files checked into git so we avoid checking build artifacts and failing the release CI: https://github.com/tigerbeetle/tigerbeetle/actions/runs/13502735251/job/37724965046

Downside of this is if we're working on a new Markdown file it is only spell checked until it's committed. However, in this case the CI will still catch it.