### PR TITLE
vsr: explicitly crash on unknown commands

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -717,6 +717,18 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         return null;
                     }
 
+                    comptime assert(@sizeOf(vsr.Command) == @sizeOf(u8) and
+                        @TypeOf(header.command) == vsr.Command);
+                    const command_raw: u8 = data[@offsetOf(Header, "command")];
+                    _ = std.meta.intToEnum(vsr.Command, @intFromEnum(header.command)) catch {
+                        log.err(
+                            "unknown vsr command, crashing for safety: " ++
+                                "command={d} protocol={d} replica={d} release={}",
+                            .{ command_raw, header.protocol, header.replica, header.release },
+                        );
+                        @panic("unknown vsr command");
+                    };
+
                     switch (process_type) {
                         // Replicas may forward messages from clients or from other replicas so we
                         // may receive messages from a peer before we know who they are:


### PR DESCRIPTION
I've spend a couple of hours in analysis-paralisys today (and like a day cummulatievly before) over what to do with unknown messages.

I think it's best to preserve our current behavior of crashing, _but_ to make it explicit, with a clear log message explaining _what_ unknown command was received.

The motivation here is abundance of caution, and desier to avoid knight capital kind of situation, where a replica _incorrectly_ ignores the command.

One potential issue here is that we'll also crash on unknown commands from clients, and we don't require clients to run with ECC ram. But the thing is, if we recive an unknown command, we can't tell if it is from the client or from the replica! So, yes, a bit flip in a client that happens right before the client checksums can kill a replica, but that should be fine, as replica will just restart.

We still don't have a good way to verify that this code works correctly, so I manually patched our client to send an invalid command, and verified that it does print:

```
2025-02-25 17:23:03.980Z error(message_bus): unknown vsr command, crashing for safety: '92'
thread 2892524 panic: unknown vsr command
```

Closes: #1850