### PR TITLE
LSM: Fix object cache update TOCTOU

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -403,15 +403,15 @@ const Environment = struct {
         }
     }
 
-    fn put_account(env: *Environment, a: *const Account, maybe_old: ?*const Account) void {
-        if (maybe_old) |old| {
+    fn put_account(env: *Environment, a: *const Account, maybe_old: ?Account) void {
+        if (maybe_old) |*old| {
             env.forest.grooves.accounts.update(.{ .old = old, .new = a });
         } else {
             env.forest.grooves.accounts.insert(a);
         }
     }
 
-    fn get_account(env: *Environment, id: u128) ?*const Account {
+    fn get_account(env: *Environment, id: u128) ?Account {
         return switch (env.forest.grooves.accounts.get(id)) {
             .found_object => |a| a,
             .found_orphaned_id => unreachable,
@@ -696,7 +696,7 @@ const Environment = struct {
                     if (model.checkpointed.objects.get(id)) |*checkpointed_account| {
                         try env.prefetch_account(id);
                         if (env.get_account(id)) |lsm_account| {
-                            assert(stdx.equal_bytes(Account, lsm_account, checkpointed_account));
+                            assert(stdx.equal_bytes(Account, &lsm_account, checkpointed_account));
                         } else {
                             std.debug.panic(
                                 "Account checkpointed but not in lsm after crash.\n {}\n",
@@ -756,7 +756,7 @@ const Environment = struct {
                 if (model_account == null) {
                     assert(lsm_account == null);
                 } else {
-                    assert(stdx.equal_bytes(Account, &model_account.?, lsm_account.?));
+                    assert(stdx.equal_bytes(Account, &model_account.?, &lsm_account.?));
                 }
             },
             .exists_account => |timestamp| {

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -734,7 +734,7 @@ pub fn GrooveType(
         }
 
         pub fn get(groove: *const Groove, key: PrimaryKey) union(enum) {
-            found_object: *const Object,
+            found_object: Object,
             found_orphaned_id,
             not_found,
         } {
@@ -745,7 +745,7 @@ pub fn GrooveType(
                     return .found_orphaned_id;
                 }
 
-                return .{ .found_object = object };
+                return .{ .found_object = object.* };
             }
 
             return .not_found;
@@ -1257,12 +1257,7 @@ pub fn GrooveType(
 
             if (constants.verify) {
                 const old_from_cache = groove.objects_cache.get(@field(old, primary_field)).?;
-
-                // While all that's actually required is that the _contents_ of the old_from_cache
-                // and old objects are identical, in current usage they're always the same piece of
-                // memory. We'll assert that for now, and this can be weakened in future if
-                // required.
-                assert(old_from_cache == old);
+                assert(stdx.equal_bytes(Object, old_from_cache, old));
             }
 
             // Sanity check to ensure the caller didn't accidentally pass in an alias.


### PR DESCRIPTION
This is an availability bug (rather than correctness) thanks to the groove's asserts.

This should be a hard bug to hit  as it requires a SAC bucket collision _and_ for the SAC eviction to have been inserted immediately prior.

### Workaround

If a replica hits this assert, it _may_ be automatically fixed by restarting the replica, to permute the cache.

If it still fails when replaying the WAL, then try restarting the replica with `--experimental --cache-accounts=256MiB` (i.e. double the usual account object cache size) to get it unstuck so that you can upgrade.

## Bug

During transfer expiry we:
1. Get the debit account from the groove's object cache.
2. Get the credit account from the groove's object cache.
3. Update the debug account's balance.
4. Update the credit account's balance.

Suppose in particular that:
1. The debit account is fetched from the object cache's stash.
2. The credit account if fetched from the object cache's set-associative cache (SAC).
3. When we update the debit account's balance, the update evicts the credit account from the SAC.

Now both the references from 1 + 2 are invalid:
1. The debit account reference is invalid because when we promote it to the SAC, we remove its old entry from the stash, so that pointer now references junk data.
2. The credit account reference is invalid because the credit account was evicted, so that pointer now references the debit account.

I think regular `create_transfers` balance updates are vulnerable to this same bug. I'm confused why the VOPR found it for expiries though, since those should be rarer.

### VOPR

(Note that the seed is from d64ecdb2ed04c1d7fd09e23fb6b77987155e9fbc / https://github.com/tigerbeetle/tigerbeetle/pull/2508. The bug exists on main but I don't have a more recent seed.)

<details>
<summary>Stack trace</summary>

```
thread 16882 panic: reached unreachable code
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/debug.zig:412:14: 0x116de4d in assert (vopr)
    if (!ok) unreachable; // assertion failure
             ^
/var/home/djg/C/t/db/e/src/lsm/groove.zig:1282:31: 0x143738d in update (vopr)
            if (has_id) assert(old.id == new.id);
                              ^
/var/home/djg/C/t/db/e/src/state_machine.zig:2806:56: 0x140af8e in execute_expire_pending_transfers (vopr)
                    self.forest.grooves.accounts.update(.{
                                                       ^
/var/home/djg/C/t/db/e/src/state_machine.zig:1514:64: 0x13d79c2 in commit (vopr)
                .pulse => self.execute_expire_pending_transfers(timestamp),
                                                               ^
/var/home/djg/C/t/db/e/src/vsr/replica.zig:4464:50: 0x13a88fc in execute_op (vopr)
                else => self.state_machine.commit(
                                                 ^
/var/home/djg/C/t/db/e/src/vsr/replica.zig:4045:28: 0x1370c43 in commit_execute (vopr)
            self.execute_op(self.commit_prepare.?);
                           ^
/var/home/djg/C/t/db/e/src/vsr/replica.zig:3738:40: 0x1332b66 in commit_dispatch (vopr)
                    self.commit_execute();
                                       ^
/var/home/djg/C/t/db/e/src/vsr/replica.zig:3825:33: 0x13d43bf in commit_dispatch_resume (vopr)
            self.commit_dispatch();
                                ^
/var/home/djg/C/t/db/e/src/vsr/replica.zig:4024:47: 0x13a7821 in commit_prefetch_callback (vopr)
            return self.commit_dispatch_resume();
                                              ^
/var/home/djg/C/t/db/e/src/state_machine.zig:757:21: 0x1430ca5 in prefetch_finish (vopr)
            callback(self);
                    ^
/var/home/djg/C/t/db/e/src/state_machine.zig:1491:33: 0x14ad248 in prefetch_expire_pending_transfers_callback_transfers_pending (vopr)
            self.prefetch_finish();
                                ^
/var/home/djg/C/t/db/e/src/lsm/groove.zig:1025:33: 0x157bb57 in finish (vopr)
                context.callback(context);
                                ^
/var/home/djg/C/t/db/e/src/lsm/groove.zig:1005:31: 0x1519b29 in worker_next_tick (vopr)
                context.finish();
                              ^
/var/home/djg/C/t/db/e/src/testing/storage.zig:316:31: 0x1178980 in tick (vopr)
            next_tick.callback(next_tick);
                              ^
/var/home/djg/C/t/db/e/src/testing/cluster.zig:439:59: 0x1205960 in tick (vopr)
            for (cluster.storages) |*storage| storage.tick();
                                                          ^
/var/home/djg/C/t/db/e/src/vopr.zig:584:31: 0x11cb006 in tick (vopr)
        simulator.cluster.tick();
                              ^
/var/home/djg/C/t/db/e/src/vopr.zig:320:23: 0x11c7d88 in main (vopr)
        simulator.tick();
                      ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/start.zig:524:37: 0x11ce137 in main (vopr)
            const result = root.main() catch |err| {
                                    ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/libc/musl/src/env/__libc_start_main.c:95:7: 0x171250f in libc_start_main_stage2 (/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/libc/musl/src/env/__libc_start_main.c)
 exit(main(argc, argv, envp));
      ^
Unwind error at address `exe:0x171250f` (error.AddressOutOfRange), trace may be incomplete
```

</details>

### Why didn't we find this sooner?

The VOPR only found this when running for a long time with `requests_max=1000` on the CFO (https://github.com/tigerbeetle/tigerbeetle/pull/2508).

So more specifically, why didn't main's VOPR find this bug?:

- I _think_ we are not creating enough accounts, relative to the accounts object cache size.
- The accounts object cache holds 256 objects. (This is the minimum size allowed by the SAC layout.)
- The state machine workload creates at most `2 + random.uintLessThan(usize, 128)` accounts.
- Since `accounts < SAC cache size`, collisions which would cause an eviction are rare.

Even so I am still surprised that main's VOPR didn't hit this bug.

I looped the VOPR locally with this diff, and it still didn't hit the bug, so I am probably missing another aspect of why this bug is hard to hit:

<details>
<summary>(diff)</summary>

```diff
diff --git a/src/state_machine/workload.zig b/src/state_machine/workload.zig
index 76346f5e7..f9de0dacc 100644
--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -1491,7 +1491,7 @@ fn OptionsType(comptime StateMachine: type, comptime Action: type) type {

             return .{
                 .auditor_options = .{
-                    .accounts_max = 2 + random.uintLessThan(usize, 128),
+                    .accounts_max = 2 + random.uintLessThan(usize, 1024),
                     .account_id_permutation = IdPermutation.generate(random),
                     .client_count = options.client_count,
                     .transfers_pending_max = 256,
@@ -1500,7 +1500,7 @@ fn OptionsType(comptime StateMachine: type, comptime Action: type) type {
                 },
                 .transfer_id_permutation = IdPermutation.generate(random),
                 .operations = .{
-                    .create_accounts = 1 + random.uintLessThan(usize, 10),
+                    .create_accounts = 1 + random.uintLessThan(usize, 100),
                     .create_transfers = 1 + random.uintLessThan(usize, 100),
                     .lookup_accounts = 1 + random.uintLessThan(usize, 20),
                     .lookup_transfers = 1 + random.uintLessThan(usize, 20),
```

</details>

## Fix

Change `Groove.get()` to return a value rather than a reference.

Alternative approaches:
- Defer groove inserts/updates (and maybe removes, for symmetry?) until the end of each sub-operation.
  - i.e. `groove.insert()`/`groove.update()` would queue up any changes they make without applying them. And then at the end (before we start to expire the next transfer) we would apply those changes all at once.
  - This increases the surface area of the `Forest`.

I also considered:
- Instead of incrementing a SAC entry's counter on read, set it to the maximum.
  - But this implicitly relies on the SAC's set size being greater than the working set of objects. Which is true for our state machine, but not necessarily in general.
  - And also even if the SAC set size was definitely greater than the working set size, I think this still wouldn't work because some of the "other" values in the set might also have the highest count just by chance, so we could remove a working-set value anyway.

### Performance

Unfortunately this approach reduces throughput by ~2%:

<details>
<summary>Benchmark before</summary>

```
1222 batches in 32.97 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 303328 tx/s
batch latency p1 = 9 ms
batch latency p10 = 10 ms
batch latency p20 = 11 ms
batch latency p30 = 16 ms
batch latency p40 = 18 ms
batch latency p50 = 20 ms
batch latency p60 = 26 ms
batch latency p70 = 29 ms
batch latency p80 = 30 ms
batch latency p90 = 32 ms
batch latency p95 = 34 ms
batch latency p99 = 114 ms
batch latency p100 = 119 ms

100 queries in 3.6 s
query latency p1 = 24 ms
query latency p10 = 26 ms
query latency p20 = 27 ms
query latency p30 = 27 ms
query latency p40 = 27 ms
query latency p50 = 28 ms
query latency p60 = 36 ms
query latency p70 = 41 ms
query latency p80 = 44 ms
query latency p90 = 48 ms
query latency p95 = 51 ms
query latency p99 = 63 ms
query latency p100 = 110 ms
```
</details>
<details>
<summary>Benchmark after</summary>

```
1222 batches in 33.63 s
transfer batch size = 8190 txs
transfer batch delay = 0 us
load accepted = 297389 tx/s
batch latency p1 = 10 ms
batch latency p10 = 10 ms
batch latency p20 = 11 ms
batch latency p30 = 16 ms
batch latency p40 = 18 ms
batch latency p50 = 21 ms
batch latency p60 = 27 ms
batch latency p70 = 29 ms
batch latency p80 = 31 ms
batch latency p90 = 33 ms
batch latency p95 = 36 ms
batch latency p99 = 114 ms
batch latency p100 = 116 ms

100 queries in 3.7 s
query latency p1 = 25 ms
query latency p10 = 26 ms
query latency p20 = 27 ms
query latency p30 = 27 ms
query latency p40 = 28 ms
query latency p50 = 29 ms
query latency p60 = 35 ms
query latency p70 = 40 ms
query latency p80 = 46 ms
query latency p90 = 52 ms
query latency p95 = 58 ms
query latency p99 = 69 ms
query latency p100 = 101 ms
2025-02-26 16:54:54.204Z info(message_bus): peer performed an orderly shutdown: message_bus.MessageBusType(.replica).Connection.Peer{ .client = 57055707183858379068156330289776870467 }
2025-02-26 16:54:54.204Z info(main): stdin closed, exiting
```

</details>
