### PR TITLE
Assert the `cache_map.stash` count

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -61,7 +61,7 @@ pub fn CacheMapType(
 
         pub const Options = struct {
             cache_value_count_max: u32,
-            map_value_count_max: u32,
+            stash_value_count_max: u32,
             scope_value_count_max: u32,
             name: []const u8,
         };
@@ -82,7 +82,7 @@ pub fn CacheMapType(
         options: Options,
 
         pub fn init(allocator: std.mem.Allocator, options: Options) !CacheMap {
-            assert(options.map_value_count_max > 0);
+            assert(options.stash_value_count_max > 0);
             maybe(options.cache_value_count_max == 0);
             maybe(options.scope_value_count_max == 0);
 
@@ -94,7 +94,7 @@ pub fn CacheMapType(
             errdefer if (cache) |*cache_unwrapped| cache_unwrapped.deinit(allocator);
 
             var stash: Map = .{};
-            try stash.ensureTotalCapacity(allocator, options.map_value_count_max);
+            try stash.ensureTotalCapacity(allocator, options.stash_value_count_max);
             errdefer stash.deinit(allocator);
 
             var scope_rollback_log = try std.ArrayListUnmanaged(Value).initCapacity(
@@ -114,7 +114,7 @@ pub fn CacheMapType(
         pub fn deinit(self: *CacheMap, allocator: std.mem.Allocator) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            assert(self.stash.count() <= self.options.map_value_count_max);
+            assert(self.stash.count() <= self.options.stash_value_count_max);
 
             self.scope_rollback_log.deinit(allocator);
             self.stash.deinit(allocator);
@@ -124,7 +124,7 @@ pub fn CacheMapType(
         pub fn reset(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            assert(self.stash.count() <= self.options.map_value_count_max);
+            assert(self.stash.count() <= self.options.stash_value_count_max);
 
             if (self.cache) |*cache| cache.reset();
             self.stash.clearRetainingCapacity();
@@ -207,7 +207,7 @@ pub fn CacheMapType(
         }
 
         fn stash_upsert(self: *CacheMap, value: *const Value) ?Value {
-            defer assert(self.stash.count() <= self.options.map_value_count_max);
+            defer assert(self.stash.count() <= self.options.stash_value_count_max);
             // Using `getOrPutAssumeCapacity` instead of `putAssumeCapacity` is
             // critical, since we use HashMaps with no Value, `putAssumeCapacity`
             // _will not_ clobber the existing value.
@@ -244,7 +244,7 @@ pub fn CacheMapType(
         }
 
         fn stash_remove(self: *CacheMap, key: Key) ?Value {
-            assert(self.stash.count() <= self.options.map_value_count_max);
+            assert(self.stash.count() <= self.options.stash_value_count_max);
             return if (self.stash.fetchRemove(tombstone_from_key(key))) |kv|
                 kv.key
             else
@@ -302,7 +302,7 @@ pub fn CacheMapType(
         pub fn compact(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            assert(self.stash.count() <= self.options.map_value_count_max);
+            assert(self.stash.count() <= self.options.stash_value_count_max);
 
             self.stash.clearRetainingCapacity();
         }
@@ -356,7 +356,7 @@ test "cache_map: unit" {
     var cache_map = try TestCacheMap.init(allocator, .{
         .cache_value_count_max = TestCacheMap.Cache.value_count_max_multiple,
         .scope_value_count_max = 32,
-        .map_value_count_max = 32,
+        .stash_value_count_max = 32,
         .name = "test map",
     });
     defer cache_map.deinit(allocator);

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -207,6 +207,7 @@ pub fn CacheMapType(
         }
 
         fn stash_upsert(self: *CacheMap, value: *const Value) ?Value {
+            defer assert(self.stash.count() <= self.options.map_value_count_max);
             // Using `getOrPutAssumeCapacity` instead of `putAssumeCapacity` is
             // critical, since we use HashMaps with no Value, `putAssumeCapacity`
             // _will not_ clobber the existing value.
@@ -243,6 +244,7 @@ pub fn CacheMapType(
         }
 
         fn stash_remove(self: *CacheMap, key: Key) ?Value {
+            assert(self.stash.count() <= self.options.map_value_count_max);
             return if (self.stash.fetchRemove(tombstone_from_key(key))) |kv|
                 kv.key
             else
@@ -300,7 +302,7 @@ pub fn CacheMapType(
         pub fn compact(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            maybe(self.stash.count() <= self.options.map_value_count_max);
+            assert(self.stash.count() <= self.options.map_value_count_max);
 
             self.stash.clearRetainingCapacity();
         }

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -13,10 +13,10 @@ const log = std.log.scoped(.lsm_cache_map_fuzz);
 const Key = TestTable.Key;
 const Value = TestTable.Value;
 
-const map_value_count_max = 1024;
-// Use a large scope (relative to map_value_count_max) to increase the chances of
+const stash_value_count_max = 1024;
+// Use a large scope (relative to stash_value_count_max) to increase the chances of
 // (SetAssociativeCache) hash collisions.
-const scope_value_count_max = map_value_count_max;
+const scope_value_count_max = stash_value_count_max;
 
 const OpValue = struct {
     op: u32,
@@ -314,7 +314,7 @@ pub fn generate_fuzz_ops(random: std.rand.Random, fuzz_op_count: usize) ![]const
     var operations_since_scope_open: usize = 0;
     const operations_since_scope_open_max: usize = scope_value_count_max;
     var upserts_since_compact: usize = 0;
-    const upserts_since_compact_max: usize = map_value_count_max;
+    const upserts_since_compact_max: usize = stash_value_count_max;
     var scope_is_open = false;
     for (fuzz_ops, 0..) |*fuzz_op, i| {
         var fuzz_op_tag: FuzzOpTag = undefined;
@@ -405,7 +405,7 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     inline for (&.{ TestCacheMap.Cache.value_count_max_multiple, 0 }) |cache_value_count_max| {
         const options = TestCacheMap.Options{
             .cache_value_count_max = cache_value_count_max,
-            .map_value_count_max = map_value_count_max,
+            .stash_value_count_max = stash_value_count_max,
             .scope_value_count_max = scope_value_count_max,
             .name = "fuzz map",
         };

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -705,14 +705,14 @@ const Environment = struct {
                         }
 
                         // There are strict limits around how many values can be prefetched by one
-                        // commit, see `map_value_count_max` in groove.zig. Thus, we need to make
+                        // commit, see `stash_value_count_max` in groove.zig. Thus, we need to make
                         // sure we manually call groove.objects_cache.compact() every
-                        // `map_value_count_max` operations here. This is specific to this fuzzing
+                        // `stash_value_count_max` operations here. This is specific to this fuzzing
                         // code.
-                        const groove_map_value_count_max =
-                            env.forest.grooves.accounts.objects_cache.options.map_value_count_max;
+                        const groove_stash_value_count_max =
+                            env.forest.grooves.accounts.objects_cache.options.stash_value_count_max;
 
-                        if (log_index % groove_map_value_count_max == 0) {
+                        if (log_index % groove_stash_value_count_max == 0) {
                             env.forest.grooves.accounts.objects_cache.compact();
                         }
                     }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -605,11 +605,11 @@ pub fn GrooveType(
             groove.objects_cache = try ObjectsCache.init(allocator, .{
                 .cache_value_count_max = options.cache_entries_max,
 
-                // In the worst case, each Map must be able to store batch_value_count_limit per
+                // In the worst case, each stash must be able to store batch_value_count_limit per
                 // beat (to contain either TableMutable or TableImmutable) as well as the maximum
                 // number of prefetches a bar may perform, excluding prefetches already accounted
                 // for by batch_value_count_limit.
-                .map_value_count_max = constants.lsm_compaction_ops *
+                .stash_value_count_max = constants.lsm_compaction_ops *
                     (options.tree_options_object.batch_value_count_limit +
                     options.prefetch_entries_for_read_max),
 


### PR DESCRIPTION
Since `ensureTotalCapacity` might allocate more than the exact capacity, it's necessary to assert that `stash.count() <= map_value_count_max`.

This change addresses two points:
- Use `assert` instead of `maybe` during compaction.
- Assert when adding or removing items from the stash.

For more context: I just hit the existing assert in `deinit()` during unrelated work while experimenting with different values for prefetch limits and was wondering why I didn’t hit the assertion earlier when the extra element was inserted.