### PR TITLE
docs: add a compatibility note about nested CSS selectors

### DIFF
--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -22,6 +22,9 @@
   --orange-10: #EF5F00;
   --yellow-10: #F1A600;
   --sky-10: #32C6F6;
+  --amber-2: #FEFBE9;
+  --amber-6: #F3D673;
+  --amber-12: #4F3422;
 
   --highlight-active: #FFFFFF4D;
 
@@ -65,6 +68,9 @@
     --orange-10: #FF801F;
     --yellow-10: #FFEF5C;
     --sky-10: #A8EEFF;
+    --amber-2: #1D180F;
+    --amber-6: #5C3D05;
+    --amber-12: #FFE7B3;
 
     --highlight-active: #FFFFFFB2;
 
@@ -637,6 +643,23 @@ body.sidenav-collapsed {
 
   &:hover {
     color: var(--gray-12);
+  }
+}
+
+#note-nested-css {
+  color: var(--amber-12);
+  background-color: var(--amber-2);
+  border: 1px solid var(--amber-6);
+  border-radius: 6px;
+  margin: 20px;
+  padding: 12px 16px;
+  max-width: 850px;
+  font-size: 16px;
+  line-height: 24px;
+
+  & {
+    /* Hide this note in supported browsers. */
+    display: none;
   }
 }
 

--- a/src/docs_website/src/html/page.html
+++ b/src/docs_website/src/html/page.html
@@ -97,6 +97,7 @@
     <div class="resizer"></div>
     <main>
       <article>
+        <aside id="note-nested-css">Note: this site uses nested CSS selectors. The future is already here, it's just not evenly distributed yet! Support the latest version of your browser, which will render these properly.</aside>
         <a id="github-link" href="https://github.com/tigerbeetle/tigerbeetle">
           GitHub
           <svg width="16" height="16">

--- a/src/docs_website/src/html/page.html
+++ b/src/docs_website/src/html/page.html
@@ -97,7 +97,7 @@
     <div class="resizer"></div>
     <main>
       <article>
-        <aside id="note-nested-css">Note: this site uses nested CSS selectors. The future is already here, it's just not evenly distributed yet! Support the latest version of your browser, which will render these properly.</aside>
+        <aside id="note-nested-css">Note: this site uses nested CSS selectors. Please upgrade your browser or use the reader mode.</aside>
         <a id="github-link" href="https://github.com/tigerbeetle/tigerbeetle">
           GitHub
           <svg width="16" height="16">


### PR DESCRIPTION
<img width="1392" alt="Screenshot 2025-02-28 at 14 09 03" src="https://github.com/user-attachments/assets/5177c814-158f-49b0-9cfc-7d7b63da3f63" />

This change adds a note that informs users of older browsers that this is not the way we intend the docs site to be rendered.

Addresses #2777.