### PR TITLE
Use Stack (LIFO) instead of FIFO for free blocks during compaction for better temporal locality. 

### DIFF
--- a/src/lifo.zig
+++ b/src/lifo.zig
@@ -67,14 +67,13 @@ pub fn LIFOType(comptime T: type) type {
 
         /// Returns whether the linked list contains the given *exact element* (pointer comparison).
         fn contains(self: *const LIFO, needle: *const T) bool {
-            var iterator = self.head;
-            var count: u64 = 1;
-            while (iterator) |node| : (iterator = node.next) {
+            assert(self.count <= self.count_max);
+            var next = self.head;
+            for (0..self.count + 1) |_| {
+                const node = next orelse return false;
                 if (node == needle) return true;
-                count += 1;
-                assert(count <= self.count_max);
-            }
-            return false;
+                next = node.next;
+            } else unreachable;
         }
 
         /// Resets the state.

--- a/src/lifo.zig
+++ b/src/lifo.zig
@@ -10,87 +10,187 @@ pub fn LIFOType(comptime T: type) type {
         const LIFO = @This();
 
         head: ?*T = null,
+
         count: u64 = 0,
+        count_max: u64,
 
         // This should only be null if you're sure we'll never want to monitor `count`.
         name: ?[]const u8,
 
         // If the number of elements is large, the constants.verify check in push() can be too
         // expensive. Allow the user to gate it. Could also be a comptime param?
-        verify_push: bool = true,
+        verify_push: bool,
 
-        pub fn push(self: *LIFO, elem: *T) void {
-            if (constants.verify and self.verify_push) assert(!self.contains(elem));
-            assert(elem.next == null);
+        pub fn init(count_max: u64, name: ?[]const u8, verify_push: bool) LIFO {
+            return LIFO{
+                .name = name,
+                .count_max = count_max,
+                .verify_push = verify_push,
+            };
+        }
+
+        /// Pushes a new node to the first position of the LIFO.
+        pub fn push(self: *LIFO, node: *T) void {
+            if (constants.verify and self.verify_push) assert(!self.contains(node));
+
+            assert((self.count == 0) == (self.head == null));
+            assert(node.next == null);
+            assert(self.count < self.count_max);
+
             // Insert the new element at the head.
-            elem.next = self.head;
-            self.head = elem;
+            node.next = self.head;
+            self.head = node;
             self.count += 1;
         }
 
+        /// Returns the first element of the stack, and removes it.
         pub fn pop(self: *LIFO) ?*T {
-            const ret = self.head orelse return null;
-            self.head = ret.next;
-            ret.next = null;
+            assert((self.count == 0) == (self.head == null));
+
+            const node = self.head orelse return null;
+            self.head = node.next;
+            node.next = null;
             self.count -= 1;
-            return ret;
+            return node;
         }
 
+        /// Returns the first element of the stack, but does not remove it.
         pub fn peek(self: LIFO) ?*T {
             return self.head;
         }
 
+        /// Checks if the LIFO is empty.
         pub fn empty(self: LIFO) bool {
+            assert((self.count == 0) == (self.head == null));
             return self.head == null;
         }
 
         /// Returns whether the linked list contains the given *exact element* (pointer comparison).
-        pub fn contains(self: *const LIFO, elem_needle: *const T) bool {
+        fn contains(self: *const LIFO, needle: *const T) bool {
             var iterator = self.head;
-            while (iterator) |elem| : (iterator = elem.next) {
-                if (elem == elem_needle) return true;
+            var count: u64 = 1;
+            while (iterator) |node| : (iterator = node.next) {
+                if (node == needle) return true;
+                count += 1;
+                assert(count <= self.count_max);
             }
             return false;
         }
 
-        /// Remove an element from the stack. Asserts that the element is in the stack.
-        /// This operation is O(N); if done frequently, consider a different data structure.
-        pub fn remove(self: *LIFO, to_remove: *T) void {
-            if (to_remove == self.head) {
-                _ = self.pop();
-                return;
-            }
-            var current = self.head;
-            while (current) |elem| {
-                if (elem.next == to_remove) {
-                    elem.next = to_remove.next;
-                    to_remove.next = null;
-                    self.count -= 1;
-                    return;
-                }
-                current = elem.next;
-            }
-            unreachable; // to_remove must be in the stack.
-        }
-
+        /// Resets the state.
         pub fn reset(self: *LIFO) void {
-            self.* = .{ .name = self.name };
+            self.* = .{
+                .name = self.name,
+                .count_max = self.count_max,
+                .verify_push = self.verify_push,
+            };
         }
     };
 }
 
-test "LIFO: push/pop/peek/remove/empty" {
-    const testing = @import("std").testing;
+test "LIFO: fuzz" {
+    // Fuzzy test to compare behavioud of LIFO against ArrayList (reference model).
+    comptime assert(constants.verify);
 
+    const fuzz = @import("testing/fuzz.zig");
+    const allocator = std.testing.allocator;
+
+    var prng = std.Random.DefaultPrng.init(0);
+    const random = prng.random();
+
+    const Node = struct {
+        id: u32,
+        next: ?*@This() = null,
+    };
+    const LIFO = LIFOType(Node);
+
+    const node_count_max = 1024;
+    const events_max = 1 << 8;
+
+    const Event = enum { push, pop };
+    const event_distribution = fuzz.DistributionType(Event){
+        .push = 2,
+        .pop = 1,
+    };
+
+    // Allocate a pool of nodes.
+    var nodes = try allocator.alloc(Node, node_count_max);
+    defer allocator.free(nodes);
+    for (nodes, 0..) |*node, i| {
+        node.* = Node{ .id = @intCast(i), .next = null };
+    }
+
+    // A bit set that tracks which nodes are available.
+    var nodes_free = try std.DynamicBitSetUnmanaged.initFull(allocator, node_count_max);
+    defer nodes_free.deinit(allocator);
+
+    var stack = LIFO.init(node_count_max, "fuzz", true);
+
+    // Reference model: a dynamic array of node IDs in LIFO order (last is the top).
+    var model = try std.ArrayList(u32).initCapacity(allocator, node_count_max);
+    defer model.deinit();
+
+    // Run a sequence of randomized events.
+    for (0..events_max) |_| {
+        std.debug.assert(model.items.len <= node_count_max);
+        std.debug.assert(model.items.len == stack.count);
+        std.debug.assert(model.items.len == 0 or !stack.empty());
+
+        const event = fuzz.random_enum(random, Event, event_distribution);
+        switch (event) {
+            .push => {
+                // Only push if a free node is available.
+                const free_index = nodes_free.findFirstSet() orelse continue;
+                const node = &nodes[free_index];
+                stack.push(node);
+                try model.append(node.id);
+                nodes_free.unset(node.id);
+            },
+            .pop => {
+                if (stack.pop()) |node| {
+                    // The reference model should have the same node at the top.
+                    const id = node.id;
+                    const expected = model.pop();
+                    std.debug.assert(id == expected);
+                    nodes_free.set(id);
+                } else {
+                    std.debug.assert(model.items.len == 0);
+                }
+            },
+        }
+        // Verify that peek() returns the same as the last element in our model.
+        if (model.items.len > 0) {
+            const top = stack.peek() orelse unreachable;
+            const top_ref = model.pop();
+            std.debug.assert(top.id == top_ref);
+            try model.append(top_ref);
+        } else {
+            std.debug.assert(stack.peek() == null);
+        }
+    }
+
+    // Finally, empty the LIFO and ensure our reference model agrees.
+    while (stack.pop()) |node| {
+        const id = node.id;
+        const expected = model.pop();
+        std.debug.assert(id == expected);
+        nodes_free.set(id);
+    }
+    std.debug.assert(model.items.len == 0);
+}
+
+test "LIFO: push/pop/peek/empty" {
+    const testing = @import("std").testing;
     const Foo = struct { next: ?*@This() = null };
 
     var one: Foo = .{};
     var two: Foo = .{};
     var three: Foo = .{};
 
-    var lifo: LIFOType(Foo) = .{ .name = null };
+    var lifo: LIFOType(Foo) = LIFOType(Foo).init(3, "test", true);
     try testing.expect(lifo.empty());
 
+    // Push one element and verify
     lifo.push(&one);
     try testing.expect(!lifo.empty());
     try testing.expectEqual(@as(?*Foo, &one), lifo.peek());
@@ -98,6 +198,7 @@ test "LIFO: push/pop/peek/remove/empty" {
     try testing.expect(!lifo.contains(&two));
     try testing.expect(!lifo.contains(&three));
 
+    // Push two more elements
     lifo.push(&two);
     lifo.push(&three);
     try testing.expect(!lifo.empty());
@@ -106,44 +207,10 @@ test "LIFO: push/pop/peek/remove/empty" {
     try testing.expect(lifo.contains(&two));
     try testing.expect(lifo.contains(&three));
 
-    lifo.remove(&one);
-    try testing.expect(!lifo.empty());
-    try testing.expectEqual(@as(?*Foo, &three), lifo.pop());
-    try testing.expectEqual(@as(?*Foo, &two), lifo.pop());
-    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
-    try testing.expect(lifo.empty());
-    try testing.expect(!lifo.contains(&one));
-    try testing.expect(!lifo.contains(&two));
-    try testing.expect(!lifo.contains(&three));
-
-    lifo.push(&one);
-    lifo.push(&two);
-    lifo.push(&three);
-    lifo.remove(&two);
-    try testing.expect(!lifo.empty());
-    try testing.expectEqual(@as(?*Foo, &three), lifo.pop());
-    try testing.expectEqual(@as(?*Foo, &one), lifo.pop());
-    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
-    try testing.expect(lifo.empty());
-
-    lifo.push(&one);
-    lifo.push(&two);
-    lifo.push(&three);
-    lifo.remove(&three);
-    try testing.expect(!lifo.empty());
-    try testing.expectEqual(@as(?*Foo, &two), lifo.pop());
-    try testing.expect(!lifo.empty());
-    try testing.expectEqual(@as(?*Foo, &one), lifo.pop());
-    try testing.expect(lifo.empty());
-    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
-    try testing.expect(lifo.empty());
-
-    lifo.push(&one);
-    lifo.push(&two);
-    lifo.push(&three);
+    // Pop elements and check LIFO order
     try testing.expectEqual(@as(?*Foo, &three), lifo.pop());
     try testing.expectEqual(@as(?*Foo, &two), lifo.pop());
     try testing.expectEqual(@as(?*Foo, &one), lifo.pop());
-    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
     try testing.expect(lifo.empty());
+    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
 }

--- a/src/lifo.zig
+++ b/src/lifo.zig
@@ -1,0 +1,149 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const constants = @import("./constants.zig");
+
+/// An intrusive last in/first out (LIFO, stack) linked list.
+/// The element type T must have a field called "next" of type ?*T.
+pub fn LIFOType(comptime T: type) type {
+    return struct {
+        const LIFO = @This();
+
+        head: ?*T = null,
+        count: u64 = 0,
+
+        // This should only be null if you're sure we'll never want to monitor `count`.
+        name: ?[]const u8,
+
+        // If the number of elements is large, the constants.verify check in push() can be too
+        // expensive. Allow the user to gate it. Could also be a comptime param?
+        verify_push: bool = true,
+
+        pub fn push(self: *LIFO, elem: *T) void {
+            if (constants.verify and self.verify_push) assert(!self.contains(elem));
+            assert(elem.next == null);
+            // Insert the new element at the head.
+            elem.next = self.head;
+            self.head = elem;
+            self.count += 1;
+        }
+
+        pub fn pop(self: *LIFO) ?*T {
+            const ret = self.head orelse return null;
+            self.head = ret.next;
+            ret.next = null;
+            self.count -= 1;
+            return ret;
+        }
+
+        pub fn peek(self: LIFO) ?*T {
+            return self.head;
+        }
+
+        pub fn empty(self: LIFO) bool {
+            return self.head == null;
+        }
+
+        /// Returns whether the linked list contains the given *exact element* (pointer comparison).
+        pub fn contains(self: *const LIFO, elem_needle: *const T) bool {
+            var iterator = self.head;
+            while (iterator) |elem| : (iterator = elem.next) {
+                if (elem == elem_needle) return true;
+            }
+            return false;
+        }
+
+        /// Remove an element from the stack. Asserts that the element is in the stack.
+        /// This operation is O(N); if done frequently, consider a different data structure.
+        pub fn remove(self: *LIFO, to_remove: *T) void {
+            if (to_remove == self.head) {
+                _ = self.pop();
+                return;
+            }
+            var current = self.head;
+            while (current) |elem| {
+                if (elem.next == to_remove) {
+                    elem.next = to_remove.next;
+                    to_remove.next = null;
+                    self.count -= 1;
+                    return;
+                }
+                current = elem.next;
+            }
+            unreachable; // to_remove must be in the stack.
+        }
+
+        pub fn reset(self: *LIFO) void {
+            self.* = .{ .name = self.name };
+        }
+    };
+}
+
+test "LIFO: push/pop/peek/remove/empty" {
+    const testing = @import("std").testing;
+
+    const Foo = struct { next: ?*@This() = null };
+
+    var one: Foo = .{};
+    var two: Foo = .{};
+    var three: Foo = .{};
+
+    var lifo: LIFOType(Foo) = .{ .name = null };
+    try testing.expect(lifo.empty());
+
+    lifo.push(&one);
+    try testing.expect(!lifo.empty());
+    try testing.expectEqual(@as(?*Foo, &one), lifo.peek());
+    try testing.expect(lifo.contains(&one));
+    try testing.expect(!lifo.contains(&two));
+    try testing.expect(!lifo.contains(&three));
+
+    lifo.push(&two);
+    lifo.push(&three);
+    try testing.expect(!lifo.empty());
+    try testing.expectEqual(@as(?*Foo, &three), lifo.peek());
+    try testing.expect(lifo.contains(&one));
+    try testing.expect(lifo.contains(&two));
+    try testing.expect(lifo.contains(&three));
+
+    lifo.remove(&one);
+    try testing.expect(!lifo.empty());
+    try testing.expectEqual(@as(?*Foo, &three), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, &two), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
+    try testing.expect(lifo.empty());
+    try testing.expect(!lifo.contains(&one));
+    try testing.expect(!lifo.contains(&two));
+    try testing.expect(!lifo.contains(&three));
+
+    lifo.push(&one);
+    lifo.push(&two);
+    lifo.push(&three);
+    lifo.remove(&two);
+    try testing.expect(!lifo.empty());
+    try testing.expectEqual(@as(?*Foo, &three), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, &one), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
+    try testing.expect(lifo.empty());
+
+    lifo.push(&one);
+    lifo.push(&two);
+    lifo.push(&three);
+    lifo.remove(&three);
+    try testing.expect(!lifo.empty());
+    try testing.expectEqual(@as(?*Foo, &two), lifo.pop());
+    try testing.expect(!lifo.empty());
+    try testing.expectEqual(@as(?*Foo, &one), lifo.pop());
+    try testing.expect(lifo.empty());
+    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
+    try testing.expect(lifo.empty());
+
+    lifo.push(&one);
+    lifo.push(&two);
+    lifo.push(&three);
+    try testing.expectEqual(@as(?*Foo, &three), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, &two), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, &one), lifo.pop());
+    try testing.expectEqual(@as(?*Foo, null), lifo.pop());
+    try testing.expect(lifo.empty());
+}

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -177,11 +177,11 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             }
             assert(blocks_allocated == block_count);
 
-            var blocks = LIFOType(Block).init(
-                blocks_allocated,
-                "compaction_blocks",
-                false,
-            );
+            var blocks = LIFOType(Block).init(.{
+                .capacity = blocks_allocated,
+                .name = "compaction_blocks",
+                .verify_push = false,
+            });
             for (blocks_backing_storage) |*block| blocks.push(block);
 
             return .{

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -43,7 +43,7 @@ const stdx = @import("../stdx.zig");
 const maybe = stdx.maybe;
 const vsr = @import("../vsr.zig");
 const trace = @import("../trace.zig");
-const FIFOType = @import("../fifo.zig").FIFOType;
+const LIFOType = @import("../lifo.zig").LIFOType;
 const IOPSType = @import("../iops.zig").IOPSType;
 const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
@@ -86,8 +86,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         reads: IOPSType(BlockRead, constants.lsm_compaction_iops_read_max) = .{},
         writes: IOPSType(BlockWrite, constants.lsm_compaction_iops_write_max) = .{},
         cpus: IOPSType(CPU, 1) = .{},
-        // Use FIFO instead of IOPS here because blocks are allocated at runtime.
-        blocks: FIFOType(Block),
+        blocks: LIFOType(Block),
         blocks_backing_storage: []Block,
 
         const ResourcePool = @This();
@@ -154,7 +153,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             // to the next index block.
             last_block_in_the_table: bool,
 
-            next: ?*Block, // For FIFO.
+            next: ?*Block, // For LIFO.
         };
 
         pub fn init(allocator: mem.Allocator, block_count: u32) !ResourcePool {
@@ -178,7 +177,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             }
             assert(blocks_allocated == block_count);
 
-            var blocks: FIFOType(Block) = .{
+            var blocks: LIFOType(Block) = .{
                 .name = "compaction_blocks",
                 .verify_push = false,
             };

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -177,10 +177,11 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             }
             assert(blocks_allocated == block_count);
 
-            var blocks: LIFOType(Block) = .{
-                .name = "compaction_blocks",
-                .verify_push = false,
-            };
+            var blocks = LIFOType(Block).init(
+                blocks_allocated,
+                "compaction_blocks",
+                false,
+            );
             for (blocks_backing_storage) |*block| blocks.push(block);
 
             return .{

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -43,7 +43,7 @@ const stdx = @import("../stdx.zig");
 const maybe = stdx.maybe;
 const vsr = @import("../vsr.zig");
 const trace = @import("../trace.zig");
-const LIFOType = @import("../lifo.zig").LIFOType;
+const StackType = @import("../stack.zig").StackType;
 const IOPSType = @import("../iops.zig").IOPSType;
 const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
@@ -86,7 +86,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         reads: IOPSType(BlockRead, constants.lsm_compaction_iops_read_max) = .{},
         writes: IOPSType(BlockWrite, constants.lsm_compaction_iops_write_max) = .{},
         cpus: IOPSType(CPU, 1) = .{},
-        blocks: LIFOType(Block),
+        blocks: StackType(Block),
         blocks_backing_storage: []Block,
 
         const ResourcePool = @This();
@@ -153,7 +153,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             // to the next index block.
             last_block_in_the_table: bool,
 
-            next: ?*Block, // For LIFO.
+            next: ?*Block, // For Stack.
         };
 
         pub fn init(allocator: mem.Allocator, block_count: u32) !ResourcePool {
@@ -177,7 +177,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             }
             assert(blocks_allocated == block_count);
 
-            var blocks = LIFOType(Block).init(.{
+            var blocks = StackType(Block).init(.{
                 .capacity = blocks_allocated,
                 .name = "compaction_blocks",
                 .verify_push = false,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -200,6 +200,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         pub fn reset(pool: *ResourcePool) void {
             pool.* = .{
                 .blocks = .{
+                    .count_max = pool.blocks.count_max,
                     .name = "compaction_blocks",
                     .verify_push = false,
                 },

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -4,7 +4,7 @@ comptime {
     _ = @import("ewah_benchmark.zig");
     _ = @import("ewah.zig");
     _ = @import("fifo.zig");
-    _ = @import("lifo.zig");
+    _ = @import("stack.zig");
     _ = @import("flags.zig");
     _ = @import("io.zig");
     _ = @import("list.zig");

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -4,6 +4,7 @@ comptime {
     _ = @import("ewah_benchmark.zig");
     _ = @import("ewah.zig");
     _ = @import("fifo.zig");
+    _ = @import("lifo.zig");
     _ = @import("flags.zig");
     _ = @import("io.zig");
     _ = @import("list.zig");


### PR DESCRIPTION
LIFO (List In/First Out) instead of FIFO (First In/First Out) causes better temporal locality for free `blocks`  in `lsm/compaction.zig`, reducing memory bandwidth consumption.

The absolute performance gain is marginal (~2%):
 
LIFO: load accepted = 321803 tx/s
FIFO: load accepted = 315314 tx/s

However, this change reduces the memory bandwidth consumption during the benchmark by up to 20% (see plot)
Note that the first few seconds of the benchmark memory is pre-allocated, and at around 10 seconds, the benchmark begins.

[memory_bw.pdf](https://github.com/user-attachments/files/19056136/memory_bw.pdf)
 
Command to measure memory bandwidth: 

AMD:  `AMDuProfPcm -m memory -q -a -d 1000 ./tigerbeetle/tigerbeetle benchmark --cache-grid=32GiB --file=/dev/nvme2n1 --query-count=0`