### PR TITLE
docs: update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tigerbeetle
 
-*TigerBeetle is the financial transactions database designed for mission critical safety and performance to power the next 30 years of [OLTP](https://docs.tigerbeetle.com/about/oltp).*
+*TigerBeetle is the financial transactions database designed for mission critical safety and performance to power the next 30 years of [OLTP](https://docs.tigerbeetle.com/concepts/oltp).*
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * [Redesigning OLTP for a New Order of Magnitude (QCon SF)](https://www.infoq.com/presentations/redesign-oltp/)
   talk with a deeper dive into TigerBeetle’s local storage engine and global consensus protocol.
 * [TIGER_STYLE.md](./docs/TIGER_STYLE.md), the engineering methodology behind TigerBeetle.
-* [Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg), say hello!
+* [Slack](https://slack.tigerbeetle.com/join), say hello!
 
 ## Start
 

--- a/docs/coding/financial-accounting.md
+++ b/docs/coding/financial-accounting.md
@@ -190,7 +190,7 @@ determines whether the given type of account is increased with a debit or a cred
 Have questions about debits and credits, TigerBeetle's data model, how to design your application on
 top of it, or anything else?
 
-Come join our [Community Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg) and ask any and all questions
+Come join our [Community Slack](https://slack.tigerbeetle.com/join) and ask any and all questions
 you might have!
 
 ### Dedicated Consultation

--- a/docs/internals/HACKING.md
+++ b/docs/internals/HACKING.md
@@ -143,7 +143,7 @@ Developer-oriented documentation is at
 
 ## Getting In Touch
 
-Say hello in our [Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg)!
+Say hello in our [Slack](https://slack.tigerbeetle.com/join)!
 
 ## Pull Requests
 

--- a/docs/start.md
+++ b/docs/start.md
@@ -171,7 +171,7 @@ follow:
 
 - [Monthly Newsletter](https://mailchi.mp/8e9fa0f36056/subscribe-to-tigerbeetle) covers everything
   of importance that happened with TigerBeetle. It is a changelog director's cut!
-- [Slack](https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg) is the place to hang out with users and developers
+- [Slack](https://slack.tigerbeetle.com/join) is the place to hang out with users and developers
   of TigerBeetle. We try to answer every question.
 - [YouTube](https://www.youtube.com/@tigerbeetledb) channel has most of the talks about TigerBeetle,
   as well as talks from the Systems Distributed conference. We also stream on

--- a/src/docs_website/src/html/page.html
+++ b/src/docs_website/src/html/page.html
@@ -87,7 +87,7 @@
         </picture>
         <p>
           Still haven't found what you're looking for?<br>
-          <a href="https://join.slack.com/t/tigerbeetle/shared_invite/zt-2zja1sjtx-hUwPqHCo7_nqy6jItyYZKg">Ask the TigerBeetle Slack Community.</a>
+          <a href="https://slack.tigerbeetle.com/join">Ask the TigerBeetle Slack Community.</a>
         </p>
       </div>
       <nav class="side">

--- a/src/docs_website/src/redirects.zig
+++ b/src/docs_website/src/redirects.zig
@@ -10,6 +10,7 @@ const Redirect = struct {
         .{ .old = "quick-start/", .new = "start/" },
         .{ .old = "about/", .new = "concepts/" },
         .{ .old = "about/vopr", .new = "concepts/safety" },
+        .{ .old = "about/oltp", .new = "concepts/oltp" },
     };
 };
 


### PR DESCRIPTION
Replace all instances of the shared invite with our centrally maintained redirect.