### PR TITLE
vopr: search for correlated faults after safety mode

### DIFF
--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -65,12 +65,6 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             errdefer allocator.free(replica_head_max);
             for (replica_head_max) |*head| head.* = .{ .view = 0, .op = 0 };
 
-            const pipeline_max = constants.pipeline_prepare_queue_max;
-            var uncommitted_headers: [pipeline_max]vsr.Header.Prepare = undefined;
-            for (0..pipeline_max) |slot| {
-                uncommitted_headers[slot] = vsr.Header.Prepare.reserve(options.cluster_id, slot);
-            }
-
             return StateChecker{
                 .node_count = @intCast(options.replicas.len),
                 .replica_count = options.replica_count,
@@ -260,7 +254,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             }
         }
 
-        pub fn committed_header_with_op(state_checker: *StateChecker, op: u64) vsr.Header.Prepare {
+        pub fn header_with_op(state_checker: *StateChecker, op: u64) vsr.Header.Prepare {
             assert(op < state_checker.commits.items.len);
             const commit = &state_checker.commits.items[op];
             assert(commit.header.op == op);

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -65,6 +65,12 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             errdefer allocator.free(replica_head_max);
             for (replica_head_max) |*head| head.* = .{ .view = 0, .op = 0 };
 
+            const pipeline_max = constants.pipeline_prepare_queue_max;
+            var uncommitted_headers: [pipeline_max]vsr.Header.Prepare = undefined;
+            for (0..pipeline_max) |slot| {
+                uncommitted_headers[slot] = vsr.Header.Prepare.reserve(options.cluster_id, slot);
+            }
+
             return StateChecker{
                 .node_count = @intCast(options.replicas.len),
                 .replica_count = options.replica_count,

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -260,7 +260,8 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             }
         }
 
-        pub fn header_with_op(state_checker: *StateChecker, op: u64) vsr.Header.Prepare {
+        pub fn committed_header_with_op(state_checker: *StateChecker, op: u64) vsr.Header.Prepare {
+            assert(op < state_checker.commits.items.len);
             const commit = &state_checker.commits.items[op];
             assert(commit.header.op == op);
             assert(commit.replicas.count() > 0);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -657,6 +657,12 @@ pub const Simulator = struct {
             if (simulator.cluster.replica_health[replica_index] == .down) {
                 simulator.replica_restart(@intCast(replica_index), fault);
             }
+
+            const replica_health = simulator.cluster.replica_health[replica_index];
+            if (replica_health == .up and replica_health.up.paused) {
+                simulator.cluster.replica_unpause(@intCast(replica_index));
+            }
+
             simulator.cluster.storages[replica_index].transition_to_liveness_mode();
         }
 

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -846,8 +846,8 @@ pub const Simulator = struct {
         // Check whether any of the uncommitted headers is corrupted on more than a nack
         // quorum of replicas. If so, the cluster cannot initiate repair or commit (see the
         // awaiting_repair and complete_invalid cases in the DVCQuorum).
-        if (cluster_commit_max < cluster_op_head) {
-            for (cluster_commit_max + 1..cluster_op_head + 1) |op| {
+        if (cluster_commit_max <= cluster_op_head) {
+            for (cluster_commit_max..cluster_op_head + 1) |op| {
                 if (replicas_missing_ops[op - cluster_op_repair_min]
                     .count() >= vsr.quorums(replica_count).nack_prepare)
                 {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6268,7 +6268,7 @@ pub fn ReplicaType(
         }
 
         /// Returns the op that will be `op_checkpoint` after the next checkpoint.
-        fn op_checkpoint_next(self: *const Replica) u64 {
+        pub fn op_checkpoint_next(self: *const Replica) u64 {
             assert(vsr.Checkpoint.valid(self.op_checkpoint()));
             assert(self.op_checkpoint() <= self.commit_min);
             assert(self.op_checkpoint() <= self.op or


### PR DESCRIPTION
This PR solves the following two VOPR failures:

#### ./zig/zig build -Drelease vopr -- 9161948212551073841

In this one, an uncommitted prepare is missing on more than a nack quorum of replicas (it is corrupted on R2, was never replicated to R0, and R1 goes into recovering_head state). Specifically, the cluster ends up getting stuck during view change, and all replicas continuously `on_do_view_change: view=22334 quorum received, awaiting repair`.

This is detected as a liveness failure at the end of safety mode, after which we expect replicas to reply to all requests and upgrade to the latest available release. We expect this because we are very careful about the parts of the grid & WAL where we inject corruptions, and we also take special measures to avoid more than a view change quorum of replicas to go into recovering_head status. Future work (https://github.com/tigerbeetle/tigerbeetle/pull/2708) will get rid of all of this logic that cautiously does storage fault injection.

For now, we roll out part of https://github.com/tigerbeetle/tigerbeetle/pull/2708, specifically the logic that tries to detect correlated faults at the end of safety mode as well (similar to how we do at the end of liveness mode). This would help shake off such false positives, where we accidentally end up injecting more faults than we should during safety mode.  Also, we add logic to the StateChecker to track uncommitted headers, so we can check for their existence in the VOPR.

#### ./zig/zig build -Drelease vopr -- 13232551907466493063

We end up violating one of our invariants at the end of liveness mode here -- a grid block that can be repaired (is present on the core) should be repaired.

Specifically, a replica that is supposed to help out with a block keeps emitting `on_request_blocks: ignoring remaining blocks; busy`. This happened because _no asynchronous callbacks were being invoked_, causing all grid repair read IOPs to get stuck. The ultimate root cause was that paused replicas weren't being unpaused while transitioning to liveness mode, leading to storage not being ticked! 
