### PR TITLE
vsr: remove suprious resume in client_replies

### DIFF
--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -242,11 +242,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             const destination_replica = read.destination_replica;
 
             client_replies.reads.release(read);
-
-            defer {
-                client_replies.message_pool.unref(message);
-                client_replies.write_reply_next();
-            }
+            defer client_replies.message_pool.unref(message);
 
             const callback = callback_or_null orelse {
                 log.debug("{}: read_reply: already resolved (client={} reply={})", .{


### PR DESCRIPTION
As far as I can tell, there's no specific reason to resume writing after read completes: read and writes race, when writing, we only check that the slot is not being written to.