### PR TITLE
docs: Add syntax highlighting to code snippets

### DIFF
--- a/docs/operating/deploying/docker.md
+++ b/docs/operating/deploying/docker.md
@@ -54,7 +54,7 @@ Note that the data file stores which replica in the cluster the file belongs to.
 
 Then, create a docker-compose.yml file:
 
-```docker-compose
+```yaml
 version: "3.7"
 
 ##

--- a/docs/operating/deploying/systemd.md
+++ b/docs/operating/deploying/systemd.md
@@ -5,7 +5,7 @@ systemd. The unit is configured to start a single-node cluster, so you may need 
 other cluster configurations.
 
 ### **tigerbeetle.service**
-```
+```toml
 [Unit]
 Description=TigerBeetle Replica
 Documentation=https://docs.tigerbeetle.com/
@@ -64,7 +64,7 @@ Here's how to do that:
    This will bring you to an editor with instructions.
 3. Add your overrides.
    Example:
-   ```
+   ```toml
    [Service]
    Environment=TIGERBEETLE_CACHE_GRID_SIZE=4GiB
    Environment=TIGERBEETLE_ADDRESSES=0.0.0.0:3001


### PR DESCRIPTION
I read your [blog post](https://tigerbeetle.com/blog/2025-02-27-why-we-designed-tigerbeetles-docs-from-scratch/) about the redesign of the docs and started playing around with it :) 

I noticed that the toml code snippets in https://docs.tigerbeetle.com/operating/deploying/systemd/ and the docker-compose (yaml) snippet in https://docs.tigerbeetle.com/operating/deploying/docker/ do not have syntax highlighting.

This is how the look like with the annotations:

<img width="949" alt="yaml" src="https://github.com/user-attachments/assets/c9b6c8cd-9982-4656-b5bd-8fdcb16d7394" />

<img width="949" alt="toml" src="https://github.com/user-attachments/assets/63daf73a-6115-499d-9239-4ba15dd2cb42" />
