### PR TITLE
vsr: Add 'slow request' to common warning

### DIFF
--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -556,9 +556,9 @@ pub fn ClientType(
             if (request_completion_time_ms > constants.client_request_completion_warn_ms) {
                 log.warn("{}: on_reply: slow request, request={} size={} {s} time={}ms", .{
                     self.id,
-                    reply.header.request,
-                    reply.header.size,
-                    reply.header.operation.tag_name(StateMachine),
+                    inflight.message.header.request,
+                    inflight.message.header.size,
+                    inflight.message.header.operation.tag_name(StateMachine),
                     request_completion_time_ms,
                 });
             }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4671,7 +4671,7 @@ pub fn ReplicaType(
                 std.time.ns_per_ms,
             );
             if (commit_completion_time_ms > constants.client_request_completion_warn_ms) {
-                log.warn("{}: commit_dispatch: request={} size={} {s} time={}ms", .{
+                log.warn("{}: commit_dispatch: slow request, request={} size={} {s} time={}ms", .{
                     self.replica,
                     self.commit_prepare.?.header.request,
                     self.commit_prepare.?.header.size,


### PR DESCRIPTION
My machine routinely has slow requests and this triggers two warnings the purpose of which are not clear.

I previously clarified the one in client.zig: https://github.com/tigerbeetle/tigerbeetle/pull/2723

But seemingly didn't notice another one in replica.zig.

This does the same thing to the warning in that file.

After that my benchmark runs look like:

```
2025-03-10 19:36:04.963Z warning(client): 198731929798949074270782392735490584945: on_reply: slow request, request=16 size=256 create_transfers time=203ms
2025-03-10 19:36:05.087Z warning(replica): 0: commit_dispatch: slow request, request=16 size=1048576 create_transfers time=219ms
2025-03-10 19:36:05.333Z warning(replica): 0: commit_dispatch: slow request, request=17 size=1048576 create_transfers time=217ms
2025-03-10 19:36:05.580Z warning(replica): 0: commit_dispatch: slow request, request=18 size=1048576 create_transfers time=227ms
2025-03-10 19:36:05.697Z warning(client): 198731929798949074270782392735490584945: on_reply: slow request, request=19 size=256 create_transfers time=206ms
```
