### PR TITLE
vsr: fix reset of prepare_timeout

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1932,7 +1932,8 @@ pub fn ReplicaType(
             assert(self.primary_abdicate_timeout.ticking);
             assert(!self.primary_abdicating);
             if (self.primary_pipeline_pending()) |prepare_pending| {
-                if (prepare_pending == prepare) {
+                assert(prepare != prepare_pending);
+                if (prepare.message.header.op < prepare_pending.message.header.op) {
                     self.prepare_timeout.reset();
                 }
             } else {


### PR DESCRIPTION
If we receive a preapre_ok, this prepare_ok completes prepare_quorum, and it is the earliest pending prepare, we logically move onto the next prepare from the pipeline, and want to reset the preapre_tmeout.

The previous code tried to do this, but failed: we set `prepare.ok_quorum_received = true;` before this if, so our prepare is no longer pending and `if (prepare_pending == prepare)` is tautologically false.

Fix this by checking whether the pendin prepare is ahead of us instead.

The previous code lead to a pathalogical behavior when, if a busy cluster's pipeline is full, the timeout was never rest.

This improves performance of a local benchmark for a 6-replica cluster with one replica down and 4 clients from `200 batches in 41.31 s` to `200 batches in 11.81 s`