### PR TITLE
vopr: fix two-orders-of-magnitude error in probabilities

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -237,18 +237,18 @@ pub fn main() !void {
         .cluster = cluster_options,
         .workload = workload_options,
         // TODO Swarm testing: Test long+few crashes and short+many crashes separately.
-        .replica_crash_probability = ratio(2, 100_000),
+        .replica_crash_probability = ratio(2, 10_000_000),
         .replica_crash_stability = prng.int_inclusive(u32, 1_000),
-        .replica_restart_probability = ratio(2, 10_000),
+        .replica_restart_probability = ratio(2, 1_000_000),
         .replica_restart_stability = prng.int_inclusive(u32, 1_000),
 
-        .replica_pause_probability = ratio(8, 100_000),
+        .replica_pause_probability = ratio(8, 10_000_000),
         .replica_pause_stability = prng.int_inclusive(u32, 1_000),
-        .replica_unpause_probability = ratio(8, 1_000),
+        .replica_unpause_probability = ratio(8, 1_000_000),
         .replica_unpause_stability = prng.int_inclusive(u32, 1_000),
 
-        .replica_release_advance_probability = ratio(1, 10_000),
-        .replica_release_catchup_probability = ratio(1, 1_000),
+        .replica_release_advance_probability = ratio(1, 1_000_000),
+        .replica_release_catchup_probability = ratio(1, 100_000),
 
         .requests_max = constants.journal_slot_count * 3,
         .request_probability = ratio(


### PR DESCRIPTION
The PRNG PR, #2798, introduced a bug, where a probability like `0.00002` was converted to `ratio(2, 100_000)`. Such probabilites were being fed into `chance_f64` function, which treated them as persentange. That is, the probability was not `0.00002`, but rather `0.00002%`, a hundred times more rare!

Add the zeroes back! replica_unpause_probability gets one extra zero, which was genuinely typo'ed out in #2798.

With the current probabilities, the cluster exhausts AOF.