### PR TITLE
Remove anonymous structs

### DIFF
--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -30,7 +30,7 @@ const jni_version = jni.jni_version_10;
 
 const global_allocator = std.heap.c_allocator;
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .debug,
     .logFn = tb.exports.Logging.application_logger,
 };

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -20,7 +20,7 @@ const Operation = StateMachine.Operation;
 const constants = vsr.constants;
 const stdx = vsr.stdx;
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .debug,
     .logFn = tb_client.exports.Logging.application_logger,
 };

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -304,10 +304,10 @@ test "ewah encode→decode cycle" {
     var prng = stdx.PRNG.from_seed(123);
 
     inline for (.{ u8, u16, u32, u64, usize }) |Word| {
+        const Context = fuzz.ContextType(Word);
         for ([_]usize{ 1, 2, 4, 5, 8, 16, 17, 32 }) |chunk_count| {
             var decoded: [4096]Word = undefined;
-
-            const fuzz_options = .{
+            const fuzz_options: Context.TestOptions = .{
                 .encode_chunk_words_count = @divFloor(decoded.len, chunk_count),
                 .decode_chunk_words_count = @divFloor(decoded.len, chunk_count),
             };

--- a/src/ewah_fuzz.zig
+++ b/src/ewah_fuzz.zig
@@ -87,7 +87,7 @@ fn generate_bits(prng: *stdx.PRNG, data: []u8, bits_set_total: usize) void {
     }
 }
 
-fn ContextType(comptime Word: type) type {
+pub fn ContextType(comptime Word: type) type {
     return struct {
         const Context = @This();
         const Codec = ewah.ewah(Word);
@@ -117,7 +117,7 @@ fn ContextType(comptime Word: type) type {
             allocator.free(context.encoded_actual);
         }
 
-        const TestOptions = struct {
+        pub const TestOptions = struct {
             encode_chunk_words_count: usize,
             decode_chunk_words_count: usize,
         };

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -13,7 +13,7 @@ comptime {
     assert(constants.storage_size_limit_max == tigerbeetle_config.process.storage_size_limit_max);
 }
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .info,
     .log_scope_levels = &[_]std.log.ScopeLevel{
         .{ .scope = .superblock_quorums, .level = .err },

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -246,7 +246,7 @@ pub const IO = struct {
         comptime callback: anytype,
         completion: *Completion,
         comptime operation_tag: std.meta.Tag(Operation),
-        operation_data: anytype,
+        operation_data: std.meta.TagPayload(Operation, operation_tag),
         comptime OperationImpl: type,
     ) void {
         const onCompleteFn = struct {

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -246,7 +246,7 @@ pub const IO = struct {
         comptime callback: anytype,
         completion: *Completion,
         comptime op_tag: std.meta.Tag(Completion.Operation),
-        op_data: anytype,
+        op_data: std.meta.TagPayload(Completion.Operation, op_tag),
         comptime OperationImpl: type,
     ) void {
         const Callback = struct {

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -86,7 +86,7 @@ pub fn binary_search_values_upsert_index(
             inline for (0..cache_lines_per_value) |i| {
                 // Locality = 0 means no temporal locality. That is, the data can be immediately
                 // dropped from the cache after it is accessed.
-                const options = .{
+                const options: std.builtin.PrefetchOptions = .{
                     .rw = .read,
                     .locality = 0,
                     .cache = .data,

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -59,7 +59,7 @@ fn run_fuzz(
     prng: *stdx.PRNG,
     events: []const ManifestEvent,
 ) !void {
-    const storage_options = .{
+    const storage_options: Storage.Options = .{
         .seed = prng.int(u64),
         .read_latency_min = 1,
         .read_latency_mean = 1 + prng.int_inclusive(u64, 40),

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -887,7 +887,7 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
     });
     defer storage_fault_atlas.deinit(allocator);
 
-    const storage_options = .{
+    const storage_options: Storage.Options = .{
         .seed = prng.int(u64),
         .replica_index = 0,
         .read_latency_min = 0,

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -132,7 +132,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 .client => @as(u64, @truncate(process_id.client)),
             };
 
-            const process = switch (process_type) {
+            const process: std.meta.FieldType(MessageBus, .process) = switch (process_type) {
                 .replica => blk: {
                     const tcp = try init_tcp(options.io, options.configuration[process_id.replica]);
                     break :blk .{

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -687,7 +687,7 @@ pub const Multiversion = struct {
         };
         errdefer posix.close(target_fd);
 
-        const args_envp = switch (builtin.target.os.tag) {
+        const args_envp: ArgsEnvp = switch (builtin.target.os.tag) {
             .linux, .macos => blk: {
                 // We can pass through our env as-is to exec. We have to manipulate the types
                 // here somewhat: they're cast in start.zig and we can't access `argc_argv_ptr`

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -32,7 +32,7 @@ pub fn log_fn(
     stdx.log_with_timestamp(message_level, scope, format, args);
 }
 
-pub const std_options = .{ .logFn = log_fn };
+pub const std_options: std.Options = .{ .logFn = log_fn };
 
 const CLIArgs = union(enum) {
     cfo: cfo.CLIArgs,

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -111,7 +111,12 @@ const transfer_templates = table: {
     const Result = accounting_auditor.CreateTransferResultSet;
     const result = Result.init;
 
-    const two_phase_ok = .{
+    const InitValues = std.enums.EnumFieldStruct(
+        tb.CreateTransferResult.Ordered,
+        bool,
+        false,
+    );
+    const two_phase_ok: InitValues = .{
         .ok = true,
         .pending_transfer_already_posted = true,
         .pending_transfer_already_voided = true,

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -80,7 +80,7 @@ pub const IO = struct {
         comptime callback: anytype,
         completion: *Completion,
         comptime operation_tag: std.meta.Tag(Operation),
-        operation_data: anytype,
+        operation_data: std.meta.TagPayload(Operation, operation_tag),
         comptime OperationImpl: type,
     ) void {
         const on_complete_fn = struct {

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -339,7 +339,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             while (from < self.process_count()) : (from += 1) {
                 var to: u8 = 0;
                 while (to < self.process_count()) : (to += 1) {
-                    const path = .{ .source = from, .target = to };
+                    const path: Path = .{ .source = from, .target = to };
                     const enabled =
                         from >= self.options.node_count or
                         to >= self.options.node_count or
@@ -378,7 +378,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             while (from < self.process_count()) : (from += 1) {
                 var to: u8 = 0;
                 while (to < self.process_count()) : (to += 1) {
-                    const path = .{ .source = from, .target = to };
+                    const path: Path = .{ .source = from, .target = to };
                     if (self.is_clogged(path)) continue;
 
                     const queue = &self.links[self.path_index(path)].queue;

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -434,7 +434,7 @@ fn tidy_long_functions(
         const function_body_first_token = tree.firstToken(@intCast(function_body_node));
         const function_body_last_token = tree.lastToken(@intCast(function_body_node));
 
-        const innermost_function = .{
+        const innermost_function: Function = .{
             .fn_decl_line = tree.tokenLocation(0, function_decl_first_token).line,
             .first_token_location = tree.tokenLocation(0, function_body_first_token),
             .last_token_location = tree.tokenLocation(0, function_body_last_token),

--- a/src/tigerbeetle/libtb_client.zig
+++ b/src/tigerbeetle/libtb_client.zig
@@ -2,11 +2,12 @@
 //! Used by language clients that rely on the shared or static library exposed by `tb_client.h`.
 //! For an idiomatic Zig API, use `vsr.tb_client` directly instead.
 const builtin = @import("builtin");
+const std = @import("std");
 
 pub const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .debug,
     .logFn = exports.Logging.application_logger,
 };

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -45,7 +45,7 @@ pub fn log_runtime(
     }
 }
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     // The comptime log_level. This needs to be debug - otherwise messages are compiled out.
     // The runtime filtering is handled by log_level_runtime.
     .log_level = .debug,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -48,7 +48,7 @@ const releases = [_]Release{
 pub const output = std.log.scoped(.cluster);
 const log = std.log.scoped(.simulator);
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     // The -vopr-log=<full|short> build option selects two logging modes.
     // In "short" mode, only state transitions are printed (see `Cluster.log_replica`).
     // "full" mode is the usual logging according to the level.

--- a/src/vortex.zig
+++ b/src/vortex.zig
@@ -19,7 +19,7 @@ const assert = std.debug.assert;
 
 const log = std.log.scoped(.vortex);
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .info,
     .logFn = stdx.log_with_timestamp,
 };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1651,7 +1651,7 @@ pub fn ReplicaType(
                     return;
                 };
 
-            const request = .{
+            const request: Request = .{
                 .message = message.ref(),
                 .realtime = realtime,
             };

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -14,6 +14,7 @@ const Message = @import("../message_pool.zig").MessagePool.Message;
 const marks = @import("../testing/marks.zig");
 const StateMachineType = @import("../testing/state_machine.zig").StateMachineType;
 const Cluster = @import("../testing/cluster.zig").ClusterType(StateMachineType);
+const Release = @import("../testing/cluster.zig").Release;
 const LinkFilter = @import("../testing/cluster/network.zig").LinkFilter;
 const Network = @import("../testing/cluster/network.zig").Network;
 const ratio = stdx.PRNG.ratio;
@@ -34,7 +35,7 @@ const checkpoint_2_prepare_ok_max = checkpoint_2_trigger + constants.pipeline_pr
 
 const log_level = std.log.Level.err;
 
-const releases = .{
+const releases = [_]Release{
     .{
         .release = vsr.Release.from(.{ .major = 0, .minor = 0, .patch = 10 }),
         .release_client_min = vsr.Release.from(.{ .major = 0, .minor = 0, .patch = 10 }),

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -53,7 +53,7 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
     });
     defer storage_fault_atlas.deinit(allocator);
 
-    const storage_options = .{
+    const storage_options: Storage.Options = .{
         .replica_index = 0,
         .seed = prng.int(u64),
         // SuperBlock's IO is all serial, so latencies never reorder reads/writes.


### PR DESCRIPTION
In preparation for Zig 0.14.0
Ref https://ziglang.org/download/0.14.0/release-notes.html#Remove-Anonymous-Struct-Types-Unify-Tuples