### PR TITLE
vsr: quicker request protocol

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -192,6 +192,13 @@ pub fn main() !void {
     var simulator = try Simulator.init(allocator, &prng, options);
     defer simulator.deinit(allocator);
 
+    // Warm-up the cluster before performance testing to get past the initial view change.
+    if (cli_args.performance) {
+        simulator.options.request_probability = ratio(0, 100);
+        for (0..500) |_| simulator.tick();
+        simulator.options.request_probability = options.request_probability;
+    }
+
     for (0..simulator.cluster.clients.len) |client_index| {
         simulator.cluster.register(client_index);
     }

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -452,9 +452,9 @@ pub fn ClientType(
                     pong.header.view,
                 });
                 self.view = pong.header.view;
-                // Even if there is a requst in flight, don't try to retransmit it immediately after
-                // a view change. Instead, ride the on_request_timeout normally  to reduce the size
-                // of thundering heard.
+                // Even if there is a request in flight, don't try to retransmit it immediately
+                // after a view change. Instead, ride the on_request_timeout normally to reduce the
+                // size of thundering herd.
                 maybe(self.request_inflight != null);
             }
 
@@ -764,7 +764,6 @@ pub fn ClientType(
             assert(!self.request_timeout.ticking);
             self.request_timeout.start();
 
-            // Otherwise we know the view and send directly to the primary.
             self.send_message_to_replica(
                 @as(u8, @intCast(self.view % self.replica_count)),
                 message.base(),

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -661,7 +661,7 @@ pub fn ClientType(
                 .client = self.id,
                 .ping_timestamp_monotonic = self.time.monotonic(),
             };
-            assert(self.request_timeout.attempts > 0);
+
             const next_backup: u32 =
                 (self.view + self.request_timeout.attempts) % self.replica_count;
             self.send_header_to_replica(@as(u8, @intCast(next_backup)), ping.frame_const());

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -201,7 +201,8 @@ pub const Header = extern struct {
     } {
         switch (self.into_any()) {
             .reserved => unreachable,
-            // These messages cannot always identify the peer as they may be forwarded:
+            // TODO: replicas used to forward requests. They no longer do, and can always return
+            // request.client starting with the next release.
             .request => |request| {
                 switch (request.operation) {
                     // However, we do not forward the first .register request sent by a client:

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5525,8 +5525,8 @@ pub fn ReplicaType(
             // should send evictions.
             if (self.backup()) {
                 // Clients only send requests to the primary. Either the client's view is outdated,
-                // or a message was misdirected. Intentinonally don't try to forward the message to
-                // the primary, to avoid amplyfying the network load.
+                // or a message was misdirected. Intentionally don't try to forward the message to
+                // the primary, to avoid amplifying the network load.
                 log.debug("{}: on_request: ignoring (backup view={} header.view={})", .{
                     self.replica,
                     self.view,


### PR DESCRIPTION
Old protocol:

- client round-robins the target replica during retries
- replica forwards a request to the primary _if_ the message is from the
  earlier view
- if the request is from the same view, it is dropped

This really doesn't work at all --- if a single message is dropped or
delayed, the client has to go through the entire ring unitl it re-sends
back to the primary.

New protocol:

- client always sends a message to a replica it thinks to be the primary.
- on retry, client sends a round-robin ping message to learn if a view
  change happened.
- backups never forward requests

Things intentionally omitted:

- When a client receives a pong and advances its view, it _does not_
  reset the on_request timeout. This is to spread out the thundering
  heard after a view change, when the cluster might have a backlog of
  prepares.
- Replicas never forward a request, as that is prone to amplify
  bandwidth when the cluster isn't fully healthy.
- Replicas _do not_ respond with a pong to a request with a wrong view.
  Because the client always sends request to the primary, and the
  primary might be down, it _has_ to send a ping to someone else, and
  it's that replica's job to inform the client about the view.
- The original `.register` request is not broadcast, and follows the same logic.
  This is a bit unintelligent, as client's initial view might be wrong,
  and broadcasting feels better. However, I am not sure our on_request
  timeout is set correctly: in local VOPR testing with very fast
  storage, somewhat faulty networks, and multiple clients, the clients
  often do useless retries, which lead to "request already
  queued/preparing" on the primary. I will look into the timeout
  separately, and, for now, use the same logic for .register as for all
  other messages, as that's just simpler.

Results for `./zig/zig build vopr -- --performance 92` with one client and 10% packet loss:

```
Before:

Messages:
ping                     10650   5.20MiB
pong                     9574    2.34MiB
commit                   3615    903.75KiB
prepare                  1563    578.34KiB
prepare_ok               1428    357.00KiB
request                  561     202.00KiB
reply                    280     106.84KiB
request_prepare          228     57.00KiB
request_headers          157     39.25KiB
headers                  139     501.00KiB
ping_client              66      16.50KiB
pong_client              59      14.75KiB
request_start_view       51      12.75KiB
start_view               51      138.50KiB
do_view_change           25      12.50KiB
total                    28447   10.41MiB

          PASSED (35075 ticks)
```

```
After:

Messages:
ping                     3210    1.57MiB
pong                     2890    722.50KiB
prepare                  1682    727.20KiB
prepare_ok               1518    379.50KiB
commit                   1140    285.00KiB
request                  348     153.91KiB
reply                    302     134.94KiB
request_prepare          273     68.25KiB
request_headers          164     41.00KiB
headers                  151     552.75KiB
ping_client              109     27.25KiB
pong_client              99      24.75KiB
start_view               38      101.50KiB
request_start_view       36      9.00KiB
do_view_change           25      12.50KiB
total                    11985   4.73MiB

          PASSED (10296 ticks)
```

Note how both the number of ticks, and the number of requests goes down,
as expected.

Six clients and no packet loss:

```
Before:

Messages:
prepare                  1390    617.47KiB
prepare_ok               1299    324.75KiB
ping                     630     315.00KiB
pong                     630     157.50KiB
request                  276     123.63KiB
commit                   275     68.75KiB
reply                    262     110.00KiB
request_headers          62      15.50KiB
headers                  60      190.25KiB
request_prepare          32      8.00KiB
do_view_change           30      15.00KiB
start_view               5       7.50KiB
total                    4951    1.91MiB

          PASSED (1652 ticks)
```

```
After:

Messages:
prepare                  1425    634.95KiB
prepare_ok               1420    355.00KiB
ping                     660     330.00KiB
pong                     660     165.00KiB
request                  309     141.88KiB
commit                   290     72.50KiB
reply                    277     112.72KiB
request_headers          71      17.75KiB
headers                  71      242.75KiB
ping_client              47      11.75KiB
pong_client              46      11.50KiB
do_view_change           30      15.00KiB
request_prepare          26      6.50KiB
start_view               5       7.50KiB
total                    5337    2.07MiB

          PASSED (1783 ticks)
```

I don't understand why we get more requests in this scenario, but my gut
feeling is that something's off with our on_request timeout, as we do get some
retries even in the perfect network with fast disk!

```
λ rg 'on_request: ignoring' log.vopr
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 0: on_request: ignoring (backup view=1 header.view=0)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already queued)
[debug] (replica): 1: on_request: ignoring (pipeline full)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (pipeline full)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already queued)
[debug] (replica): 1: on_request: ignoring (pipeline full)
[debug] (replica): 1: on_request: ignoring (already queued)
[debug] (replica): 1: on_request: ignoring (pipeline full)
[debug] (replica): 1: on_request: ignoring (already queued)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (pipeline full)
[debug] (replica): 1: on_request: ignoring (already preparing)
[debug] (replica): 1: on_request: ignoring (already preparing)
```

I think this is what happening --- before, we finished the test without sending a single ping_client. After, we do send a ping_client on retry, and that lowers the rtt in the on_request timeout, and we start retrying more. 