### PR TITLE
vopr: allow fast writes

### DIFF
--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -48,7 +48,7 @@ pub const Signal = struct {
     }
 
     /// Requests to stop listening for notifications.
-    /// The caller must continue processing `IO.tick()` until `state() == .stopped`.
+    /// The caller must continue processing `IO.run()` until `state() == .stopped`.
     /// Safe to call from multiple threads.
     pub fn stop(self: *Signal) void {
         const listening = self.listening.swap(false, .release);
@@ -180,11 +180,11 @@ test "signal" {
             const thread = try std.Thread.spawn(.{}, Context.notify, .{&self});
 
             // Wait for the number of events to complete.
-            while (self.count < events_count) try self.io.tick();
+            while (self.count < events_count) try self.io.run();
 
             // Begin shutdown and keep ticking until it's completed.
             self.signal.stop();
-            while (self.signal.status() != .stopped) try self.io.tick();
+            while (self.signal.status() != .stopped) try self.io.run();
             thread.join();
 
             // Notify after shutdown should be ignored.

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -37,7 +37,7 @@ pub const IO = struct {
     }
 
     /// Pass all queued submissions to the kernel and peek for completions.
-    pub fn tick(self: *IO) !void {
+    pub fn run(self: *IO) !void {
         return self.flush(false);
     }
 

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -87,7 +87,7 @@ pub const IO = struct {
     }
 
     /// Pass all queued submissions to the kernel and peek for completions.
-    pub fn tick(self: *IO) !void {
+    pub fn run(self: *IO) !void {
         assert(self.cancel_status != .done);
 
         // We assume that all timeouts submitted by `run_for_ns()` will be reaped by `run_for_ns()`

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -42,7 +42,7 @@ pub const IO = struct {
         os.windows.WSACleanup() catch unreachable;
     }
 
-    pub fn tick(self: *IO) !void {
+    pub fn run(self: *IO) !void {
         return self.flush(.non_blocking);
     }
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -191,7 +191,7 @@ const Environment = struct {
 
             if (env.ticks_remaining == 0) return error.OutOfTicks;
             env.ticks_remaining -= 1;
-            env.storage.tick();
+            env.storage.run();
         }
         assert(env.state == next_state);
     }
@@ -366,7 +366,7 @@ const Environment = struct {
         while (!context.finished) {
             if (env.ticks_remaining == 0) return error.OutOfTicks;
             env.ticks_remaining -= 1;
-            env.storage.tick();
+            env.storage.run();
         }
     }
 
@@ -400,7 +400,7 @@ const Environment = struct {
         while (!context.finished) {
             if (env.ticks_remaining == 0) return error.OutOfTicks;
             env.ticks_remaining -= 1;
-            env.storage.tick();
+            env.storage.run();
         }
     }
 
@@ -505,7 +505,7 @@ const Environment = struct {
                 while (self.result == null) {
                     if (env.ticks_remaining == 0) return error.OutOfTicks;
                     env.ticks_remaining -= 1;
-                    env.storage.tick();
+                    env.storage.run();
                 }
 
                 return self.result.?;

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -382,7 +382,7 @@ const Environment = struct {
 
     fn wait(env: *Environment, manifest_log: *ManifestLog) void {
         while (env.pending > 0) {
-            manifest_log.superblock.storage.tick();
+            manifest_log.superblock.storage.run();
         }
     }
 

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -781,7 +781,7 @@ const Environment = struct {
 
             if (env.ticks_remaining == 0) return error.OutOfTicks;
             env.ticks_remaining -= 1;
-            env.storage.tick();
+            env.storage.run();
         }
         assert(env.state == next_state);
     }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -227,7 +227,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             const safety_counter = 10_000_000;
             for (0..safety_counter) |_| {
                 if (env.state != current_state) break;
-                env.storage.tick();
+                env.storage.run();
             } else unreachable;
             assert(env.state == next_state);
         }

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -771,7 +771,7 @@ pub const Multiversion = struct {
         assert(self.stage != .init);
 
         while (self.stage != .ready and self.stage != .err) {
-            self.io.tick() catch |e| {
+            self.io.run() catch |e| {
                 assert(self.stage != .ready);
                 self.stage = .{ .err = e };
             };

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -3805,7 +3805,7 @@ const TestContext = struct {
             operation,
             input,
         );
-        while (context.busy) context.storage.tick();
+        while (context.busy) context.storage.run();
 
         return context.state_machine.commit(
             0,

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -107,8 +107,8 @@ pub fn StorageType(comptime IO: type) type {
             storage.fd = IO.INVALID_FILE;
         }
 
-        pub fn tick(storage: *Storage) void {
-            storage.io.tick() catch |err| {
+        pub fn run(storage: *Storage) void {
+            storage.io.run() catch |err| {
                 log.warn("tick: {}", .{err});
                 std.debug.panic("io.tick(): {}", .{err});
             };

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -89,7 +89,7 @@ pub fn main(args: fuzz.FuzzArgs) !void {
                 0,
             );
 
-            storage.tick();
+            storage.run();
         }
 
         for (zones) |zone| {
@@ -142,7 +142,7 @@ pub fn main(args: fuzz.FuzzArgs) !void {
                     sector_offset,
                 );
 
-                storage.tick();
+                storage.run();
             }
         }
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -859,6 +859,11 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 },
                 .sync_stage_changed => switch (replica.syncing) {
                     .idle => cluster.log_replica(.sync, replica.replica),
+                    .updating_checkpoint => {
+                        cluster.state_checker.check_state(replica.replica) catch |err| {
+                            fatal(.correctness, "state checker error: {}", .{err});
+                        };
+                    },
                     else => {},
                 },
                 .client_evicted => |client_id| cluster.cluster_on_eviction(client_id),

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -125,6 +125,10 @@ pub const Network = struct {
         network.message_pool.deinit(network.allocator);
     }
 
+    pub fn step(network: *Network) bool {
+        return network.packet_simulator.step();
+    }
+
     pub fn tick(network: *Network) void {
         network.packet_simulator.tick();
     }

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -45,7 +45,7 @@ pub const IO = struct {
     }
 
     /// Pass all queued submissions to the kernel and peek for completions.
-    pub fn tick(io: *IO) !void {
+    pub fn run(io: *IO) !void {
         while (io.completed.pop()) |completion| {
             completion.callback(io, completion);
         }

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -352,6 +352,40 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             }
         }
 
+        pub fn step(self: *PacketSimulator) bool {
+            const ReadyPacket = struct { path: Path, link_packet: LinkPacket };
+            var packets: [32]ReadyPacket = undefined;
+            var packet_count: u32 = 0;
+            defer for (packets[0..packet_count]) |ready| {
+                ready.link_packet.packet.deinit();
+            };
+
+            for (0..self.process_count()) |from| {
+                for (0..self.process_count()) |to| {
+                    const path: Path = .{ .source = @intCast(from), .target = @intCast(to) };
+                    if (self.is_clogged(path)) continue;
+
+                    const queue = &self.links[self.path_index(path)].queue;
+                    while (queue.peek()) |*head| {
+                        if (head.expiry > self.ticks) break;
+                        if (packet_count == packets.len) break;
+
+                        const link_packet = queue.remove();
+                        packets[packet_count] = .{ .path = path, .link_packet = link_packet };
+                        packet_count += 1;
+                    }
+                }
+            }
+            if (packet_count == 0) return false;
+
+            self.prng.shuffle(ReadyPacket, packets[0..packet_count]);
+            for (packets[0..packet_count]) |ready| {
+                self.submit_packet_finish(ready.path, ready.link_packet);
+            }
+
+            return true;
+        }
+
         pub fn tick(self: *PacketSimulator) void {
             self.ticks += 1;
 
@@ -374,55 +408,16 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
                 }
             }
 
-            var from: u8 = 0;
-            while (from < self.process_count()) : (from += 1) {
-                var to: u8 = 0;
-                while (to < self.process_count()) : (to += 1) {
-                    const path: Path = .{ .source = from, .target = to };
-                    if (self.is_clogged(path)) continue;
-
-                    const queue = &self.links[self.path_index(path)].queue;
-                    while (queue.peek()) |*link_packet| {
-                        if (link_packet.expiry > self.ticks) break;
-
-                        _ = queue.remove();
-                        defer link_packet.packet.deinit();
-
-                        if (self.links[self.path_index(path)].should_drop(&link_packet.packet)) {
-                            log.warn(
-                                "dropped packet (different partitions): from={} to={}",
-                                .{ from, to },
-                            );
-                            continue;
-                        }
-
-                        if (self.should_drop()) {
-                            log.warn("dropped packet from={} to={}", .{ from, to });
-                            continue;
-                        }
-
-                        if (self.should_replay()) {
-                            self.submit_packet(
-                                link_packet.packet.clone(),
-                                link_packet.callback,
-                                path,
-                            );
-                            log.debug("replayed packet from={} to={}", .{ from, to });
-                        }
-
-                        log.debug("delivering packet from={} to={}", .{ from, to });
-                        link_packet.callback(link_packet.packet, path);
-                    }
-
-                    const reverse_path: Path = .{ .source = to, .target = from };
-
-                    if (self.should_clog(reverse_path)) {
+            for (0..self.process_count()) |from| {
+                for (0..self.process_count()) |to| {
+                    const path: Path = .{ .source = @intCast(from), .target = @intCast(to) };
+                    if (self.should_clog(path)) {
                         const ticks = fuzz.random_int_exponential(
                             &self.prng,
                             u64,
                             self.options.path_clog_duration_mean,
                         );
-                        self.clog_for(reverse_path, ticks);
+                        self.clog_for(path, ticks);
                     }
                 }
             }
@@ -460,6 +455,34 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
                     .path = path,
                 };
             }
+        }
+
+        fn submit_packet_finish(self: *PacketSimulator, path: Path, link_packet: LinkPacket) void {
+            assert(link_packet.expiry <= self.ticks);
+            if (self.links[self.path_index(path)].should_drop(&link_packet.packet)) {
+                log.warn(
+                    "dropped packet (different partitions): from={} to={}",
+                    .{ path.source, path.target },
+                );
+                return;
+            }
+
+            if (self.should_drop()) {
+                log.warn("dropped packet from={} to={}", .{ path.source, path.target });
+                return;
+            }
+
+            if (self.should_replay()) {
+                self.submit_packet(
+                    link_packet.packet.clone(),
+                    link_packet.callback,
+                    path,
+                );
+                log.debug("replayed packet from={} to={}", .{ path.source, path.target });
+            }
+
+            log.debug("delivering packet from={} to={}", .{ path.source, path.target });
+            link_packet.callback(link_packet.packet, path);
         }
     };
 }

--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -356,9 +356,6 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             const ReadyPacket = struct { path: Path, link_packet: LinkPacket };
             var packets: [32]ReadyPacket = undefined;
             var packet_count: u32 = 0;
-            defer for (packets[0..packet_count]) |ready| {
-                ready.link_packet.packet.deinit();
-            };
 
             for (0..self.process_count()) |from| {
                 for (0..self.process_count()) |to| {
@@ -381,6 +378,7 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             self.prng.shuffle(ReadyPacket, packets[0..packet_count]);
             for (packets[0..packet_count]) |ready| {
                 self.submit_packet_finish(ready.path, ready.link_packet);
+                ready.link_packet.packet.deinit();
             }
 
             return true;

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -382,8 +382,12 @@ pub const Storage = struct {
         return true;
     }
 
+    pub fn run(storage: *Storage) void {
+        while (storage.step()) {}
+        storage.tick();
+    }
+
     pub fn tick(storage: *Storage) void {
-        while (storage.progress()) {}
         storage.ticks += 1;
     }
 

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -362,12 +362,14 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
         .unpartition_stability = prng.int_inclusive(u32, 20),
     };
 
+    const read_latency_min = prng.range_inclusive(u16, 0, 3);
+    const write_latency_min = prng.range_inclusive(u16, 0, 3);
     const storage_options = .{
         .seed = prng.int(u64),
-        .read_latency_min = prng.range_inclusive(u16, 0, 3),
-        .read_latency_mean = prng.range_inclusive(u16, 3, 10),
-        .write_latency_min = prng.range_inclusive(u16, 0, 3),
-        .write_latency_mean = prng.range_inclusive(u16, 3, 100),
+        .read_latency_min = read_latency_min,
+        .read_latency_mean = prng.range_inclusive(u16, read_latency_min, 10),
+        .write_latency_min = write_latency_min,
+        .write_latency_mean = prng.range_inclusive(u16, write_latency_min, 100),
         .read_fault_probability = ratio(prng.range_inclusive(u8, 0, 10), 100),
         .write_fault_probability = ratio(prng.range_inclusive(u8, 0, 10), 100),
         .write_misdirect_probability = ratio(prng.range_inclusive(u8, 0, 10), 100),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -631,7 +631,7 @@ pub fn ReplicaType(
             // Open the superblock:
             self.opened = false;
             self.superblock.open(superblock_open_callback, &self.superblock_context);
-            while (!self.opened) self.superblock.storage.tick();
+            while (!self.opened) self.superblock.storage.run();
             self.superblock.working.vsr_state.assert_internally_consistent();
 
             const replica_id = self.superblock.working.vsr_state.replica_id;
@@ -699,7 +699,7 @@ pub fn ReplicaType(
 
             self.opened = false;
             self.journal.recover(journal_recover_callback);
-            while (!self.opened) self.superblock.storage.tick();
+            while (!self.opened) self.superblock.storage.run();
 
             // Abort if all slots are faulty, since something is very wrong.
             if (self.journal.faulty.count == constants.journal_slot_count) return error.WALInvalid;

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -37,7 +37,7 @@ pub fn format(
     );
 
     replica_format.formatting = true;
-    while (replica_format.formatting) storage.tick();
+    while (replica_format.formatting) storage.run();
 }
 
 fn ReplicaFormatType(comptime Storage: type) type {
@@ -101,7 +101,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                     wal_offset,
                 );
                 self.formatting = true;
-                while (self.formatting) storage.tick();
+                while (self.formatting) storage.run();
                 wal_offset += size;
             }
             // There are no prepares left to write.
@@ -130,7 +130,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                     wal_offset,
                 );
                 self.formatting = true;
-                while (self.formatting) storage.tick();
+                while (self.formatting) storage.run();
                 wal_offset += size;
             }
             // There are no headers left to write.
@@ -159,7 +159,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                     slot * constants.message_size_max,
                 );
                 self.formatting = true;
-                while (self.formatting) storage.tick();
+                while (self.formatting) storage.run();
             }
         }
 
@@ -191,7 +191,7 @@ fn ReplicaFormatType(comptime Storage: type) type {
                     0,
                 );
                 self.formatting = true;
-                while (self.formatting) storage.tick();
+                while (self.formatting) storage.run();
             }
         }
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -144,10 +144,10 @@ fn run_fuzz(allocator: std.mem.Allocator, seed: u64, transitions_count_total: us
     };
 
     try env.format();
-    while (env.pending.count() > 0) env.superblock.storage.tick();
+    while (env.pending.count() > 0) env.superblock.storage.run();
 
     env.open();
-    while (env.pending.count() > 0) env.superblock.storage.tick();
+    while (env.pending.count() > 0) env.superblock.storage.run();
 
     try env.verify();
     assert(env.pending.count() == 0);
@@ -224,7 +224,7 @@ const Environment = struct {
         assert(env.pending.contains(.view_change) == env.superblock.updating(.view_change));
 
         const write = env.superblock.storage.writes.peek();
-        env.superblock.storage.tick();
+        env.superblock.storage.run();
 
         if (write) |w| {
             if (w.done_at_tick <= env.superblock.storage.ticks) try env.verify();
@@ -246,7 +246,7 @@ const Environment = struct {
         env.superblock_verify.open(verify_callback, &env.context_verify);
 
         env.pending_verify = true;
-        while (env.pending_verify) env.superblock_verify.storage.tick();
+        while (env.pending_verify) env.superblock_verify.storage.run();
 
         assert(env.superblock_verify.working.checksum == env.superblock.working.checksum or
             env.superblock_verify.working.checksum == env.superblock.staging.checksum);


### PR DESCRIPTION
In the current VOPR config, the minimum mean storage latency is 3 ticks,
which is 30 ms, which is just ridiculous. We generally expect almost all
IOPs to complete faster than in a single tick.

To model "faster than a tick" realistically, I change the simulator to
drain storage&network IO "within" each tick. As there could be multiple
immediately ready IOPs, the simulator randomizes the order in which
completions are invoked.
