### PR TITLE
zig: simplify the idiom for creating comptime lists

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -29,36 +29,33 @@ const compaction_input_tables_max = @import("compaction.zig").compaction_tables_
 pub const table_count_max = @import("tree.zig").table_count_max;
 
 pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
-    var groove_fields: []const std.builtin.Type.StructField = &.{};
-    var groove_options_fields: []const std.builtin.Type.StructField = &.{};
+    const groove_count = std.meta.fields(@TypeOf(groove_cfg)).len;
+    var groove_fields: [groove_count]std.builtin.Type.StructField = undefined;
+    var groove_options_fields: [groove_count]std.builtin.Type.StructField = undefined;
 
-    for (std.meta.fields(@TypeOf(groove_cfg))) |field| {
+    for (std.meta.fields(@TypeOf(groove_cfg)), 0..) |field, i| {
         const Groove = @field(groove_cfg, field.name);
-        groove_fields = groove_fields ++ [_]std.builtin.Type.StructField{
-            .{
-                .name = field.name,
-                .type = Groove,
-                .default_value = null,
-                .is_comptime = false,
-                .alignment = @alignOf(Groove),
-            },
+        groove_fields[i] = .{
+            .name = field.name,
+            .type = Groove,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(Groove),
         };
 
-        groove_options_fields = groove_options_fields ++ [_]std.builtin.Type.StructField{
-            .{
-                .name = field.name,
-                .type = Groove.Options,
-                .default_value = null,
-                .is_comptime = false,
-                .alignment = @alignOf(Groove),
-            },
+        groove_options_fields[i] = .{
+            .name = field.name,
+            .type = Groove.Options,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(Groove),
         };
     }
 
     const _Grooves = @Type(.{
         .Struct = .{
             .layout = .auto,
-            .fields = groove_fields,
+            .fields = &groove_fields,
             .decls = &.{},
             .is_tuple = false,
         },
@@ -67,7 +64,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
     const _GroovesOptions = @Type(.{
         .Struct = .{
             .layout = .auto,
-            .fields = groove_options_fields,
+            .fields = &groove_options_fields,
             .decls = &.{},
             .is_tuple = false,
         },
@@ -157,16 +154,16 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
     };
 
     const _TreeID = comptime tree_id: {
-        var fields: []const std.builtin.Type.EnumField = &.{};
-        for (_tree_infos) |tree_info| {
-            fields = fields ++ [1]std.builtin.Type.EnumField{.{
+        var fields: [_tree_infos.len]std.builtin.Type.EnumField = undefined;
+        for (_tree_infos, 0..) |tree_info, i| {
+            fields[i] = .{
                 .name = @ptrCast(tree_info.tree_name),
                 .value = tree_info.tree_id,
-            }};
+            };
         }
         break :tree_id @Type(.{ .Enum = .{
             .tag_type = u16,
-            .fields = fields,
+            .fields = &fields,
             .decls = &.{},
             .is_exhaustive = true,
         } });

--- a/src/lsm/forest_table_iterator.zig
+++ b/src/lsm/forest_table_iterator.zig
@@ -31,20 +31,20 @@ pub fn ForestTableIteratorType(comptime Forest: type) type {
     const TreeTableIterators = iterator: {
         const StructField = std.builtin.Type.StructField;
 
-        var fields: []const StructField = &[_]StructField{};
-        for (Forest.tree_infos) |tree_info| {
-            fields = fields ++ &[_]StructField{.{
+        var fields: [Forest.tree_infos.len]StructField = undefined;
+        for (Forest.tree_infos, 0..) |tree_info, i| {
+            fields[i] = .{
                 .name = @ptrCast(tree_info.tree_name),
                 .type = TreeTableIteratorType(tree_info.Tree),
                 .default_value = null,
                 .is_comptime = false,
                 .alignment = @alignOf(TreeTableIteratorType(tree_info.Tree)),
-            }};
+            };
         }
 
         break :iterator @Type(.{ .Struct = .{
             .layout = .auto,
-            .fields = fields,
+            .fields = &fields,
             .decls = &.{},
             .is_tuple = false,
         } });

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -259,17 +259,15 @@ pub fn GrooveType(
         };
     }
 
-    comptime var index_options_fields: []const std.builtin.Type.StructField = &.{};
-    for (index_fields) |index_field| {
+    comptime var index_options_fields: [index_fields.len]std.builtin.Type.StructField = undefined;
+    for (index_fields, 0..) |index_field, i| {
         const IndexTree = index_field.type;
-        index_options_fields = index_options_fields ++ [_]std.builtin.Type.StructField{
-            .{
-                .name = index_field.name,
-                .type = IndexTree.Options,
-                .default_value = null,
-                .is_comptime = false,
-                .alignment = @alignOf(IndexTree.Options),
-            },
+        index_options_fields[i] = .{
+            .name = index_field.name,
+            .type = IndexTree.Options,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(IndexTree.Options),
         };
     }
 
@@ -325,7 +323,7 @@ pub fn GrooveType(
     const _IndexTreeOptions = @Type(.{
         .Struct = .{
             .layout = .auto,
-            .fields = index_options_fields,
+            .fields = &index_options_fields,
             .decls = &.{},
             .is_tuple = false,
         },

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -6504,63 +6504,63 @@ test "StateMachine: input_valid" {
     };
 
     const events = comptime events: {
-        var array: []const Event = &.{};
-        for (std.enums.values(TestContext.StateMachine.Operation)) |operation| {
-            array = switch (operation) {
-                .pulse, .get_events => array ++ [_]Event{.{
+        var array: [std.enums.values(TestContext.StateMachine.Operation).len]Event = undefined;
+        for (std.enums.values(TestContext.StateMachine.Operation), 0..) |operation, i| {
+            array[i] = switch (operation) {
+                .pulse, .get_events => .{
                     .operation = operation,
                     .min = 0,
                     .max = 0,
                     .size = 0,
-                }},
-                .create_accounts => array ++ [_]Event{.{
+                },
+                .create_accounts => .{
                     .operation = operation,
                     .min = 0,
                     .max = @divExact(TestContext.message_body_size_max, @sizeOf(Account)),
                     .size = @sizeOf(Account),
-                }},
-                .create_transfers => array ++ [_]Event{.{
+                },
+                .create_transfers => .{
                     .operation = operation,
                     .min = 0,
                     .max = @divExact(TestContext.message_body_size_max, @sizeOf(Transfer)),
                     .size = @sizeOf(Transfer),
-                }},
-                .lookup_accounts => array ++ [_]Event{.{
+                },
+                .lookup_accounts => .{
                     .operation = operation,
                     .min = 0,
                     .max = @divExact(TestContext.message_body_size_max, @sizeOf(Account)),
                     .size = @sizeOf(u128),
-                }},
-                .lookup_transfers => array ++ [_]Event{.{
+                },
+                .lookup_transfers => .{
                     .operation = operation,
                     .min = 0,
                     .max = @divExact(TestContext.message_body_size_max, @sizeOf(Transfer)),
                     .size = @sizeOf(u128),
-                }},
-                .get_account_transfers => array ++ [_]Event{.{
+                },
+                .get_account_transfers => .{
                     .operation = operation,
                     .min = 1,
                     .max = 1,
                     .size = @sizeOf(AccountFilter),
-                }},
-                .get_account_balances => array ++ [_]Event{.{
+                },
+                .get_account_balances => .{
                     .operation = operation,
                     .min = 1,
                     .max = 1,
                     .size = @sizeOf(AccountFilter),
-                }},
-                .query_accounts => array ++ [_]Event{.{
+                },
+                .query_accounts => .{
                     .operation = operation,
                     .min = 1,
                     .max = 1,
                     .size = @sizeOf(QueryFilter),
-                }},
-                .query_transfers => array ++ [_]Event{.{
+                },
+                .query_transfers => .{
                     .operation = operation,
                     .min = 1,
                     .max = 1,
                     .size = @sizeOf(QueryFilter),
-                }},
+                },
             };
         }
         break :events array;

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -732,18 +732,18 @@ pub fn EnumUnionType(
 ) type {
     const UnionField = std.builtin.Type.UnionField;
 
-    var fields: []const UnionField = &[_]UnionField{};
-    for (std.enums.values(Enum)) |enum_variant| {
-        fields = fields ++ &[_]UnionField{.{
+    var fields: [std.enums.values(Enum).len]UnionField = undefined;
+    for (std.enums.values(Enum), 0..) |enum_variant, i| {
+        fields[i] = .{
             .name = @tagName(enum_variant),
             .type = TypeForVariant(enum_variant),
             .alignment = @alignOf(TypeForVariant(enum_variant)),
-        }};
+        };
     }
 
     return @Type(.{ .Union = .{
         .layout = .auto,
-        .fields = fields,
+        .fields = &fields,
         .decls = &.{},
         .tag_type = Enum,
     } });


### PR DESCRIPTION
`++` is awkward to use when you want to add only a single element. But if you know the length up-front, you don't need `++`, you can assign array elements directly!