### PR TITLE
docs: sync navigation when using the close button and some style fixes

### DIFF
--- a/src/docs_website/assets/js/search.js
+++ b/src/docs_website/assets/js/search.js
@@ -42,7 +42,6 @@ document.addEventListener("keydown", event => {
         } else {
           closeSearch();
           searchPreviewUsed = false;
-          document.querySelector("article").focus();
         }
         event.preventDefault();
       }
@@ -58,10 +57,7 @@ searchInput.addEventListener("blur", () => {
 });
 searchInput.addEventListener("input", onSearchInput);
 searchClearButton.addEventListener("click", () => {
-  searchInput.value = "";
-  onSearchInput();
-  if (searchInput !== document.activeElement) searchHotkey.style.display = "block";
-  removeTextHighlight(content);
+  closeSearch();
   searchPreviewUsed = false;
 });
 
@@ -323,6 +319,7 @@ function closeSearch() {
   removeTextHighlight(content);
   syncSideNavWithLocation();
   if (sidenavWasCollapsed) document.body.classList.add("sidenav-collapsed");
+  document.querySelector("article").focus();
 }
 
 function highlightText(term, container) {

--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -749,11 +749,13 @@ article {
       }
     }
 
-    a>code {
+    a>code,
+    a>strong {
       color: var(--primary-10);
     }
 
-    a:visited>code {
+    a:visited>code,
+    a:visited>strong {
       color: var(--visited-link);
     }
 

--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -898,6 +898,24 @@ article {
       }
     }
 
+    blockquote {
+      font-style: italic;
+      padding: 0 0 0 24px;
+      position: relative;
+    }
+    
+    blockquote::before {
+      background-color: var(--primary-10);
+      border-radius: 2px;
+      content: "";
+      display: block;
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 4px;
+    }
+
     img {
       max-width: 100%;
     }


### PR DESCRIPTION
* Synchronizes the sidebar navigation with the current page when the search is closed via its close button
* `<strong>` links were styled black instead of using the link color
* Add a style for `<blockquote>`:
<img width="870" alt="image" src="https://github.com/user-attachments/assets/0f9504d1-2502-4a63-a971-5651e5199285" />
