### PR TITLE
CLI: "inspect metrics"

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -263,6 +263,14 @@ test "benchmark/inspect smoke" {
     );
 
     inline for (.{
+        "{tigerbeetle} inspect constants",
+        "{tigerbeetle} inspect metrics",
+    }) |command| {
+        log.debug("{s}", .{command});
+        try shell.exec(command, .{ .tigerbeetle = tigerbeetle });
+    }
+
+    inline for (.{
         "{tigerbeetle} inspect superblock              {path}",
         "{tigerbeetle} inspect wal --slot=0            {path}",
         "{tigerbeetle} inspect replies                 {path}",

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -141,6 +141,7 @@ const CLIArgs = union(enum) {
     // Experimental: the interface is subject to change.
     const Inspect = union(enum) {
         constants,
+        metrics,
         superblock: struct {
             positional: struct { path: []const u8 },
         },
@@ -176,6 +177,8 @@ const CLIArgs = union(enum) {
             \\
             \\  tigerbeetle inspect constants
             \\
+            \\  tigerbeetle inspect metrics
+            \\
             \\  tigerbeetle inspect superblock <path>
             \\
             \\  tigerbeetle inspect wal [--slot=<slot>] <path>
@@ -198,6 +201,9 @@ const CLIArgs = union(enum) {
             \\
             \\  constants
             \\        Print most important compile-time parameters.
+            \\
+            \\  metrics
+            \\        List metrics and their cardinalities.
             \\
             \\  superblock
             \\        Inspect the superblock header copies.
@@ -488,6 +494,7 @@ pub const Command = union(enum) {
 
     pub const Inspect = union(enum) {
         constants,
+        metrics,
         data_file: DataFile,
 
         pub const DataFile = struct {
@@ -912,6 +919,7 @@ fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
 fn parse_args_inspect(inspect: CLIArgs.Inspect) Command.Inspect {
     const path = switch (inspect) {
         .constants => return .constants,
+        .metrics => return .metrics,
         inline else => |args| args.positional.path,
     };
 
@@ -919,6 +927,7 @@ fn parse_args_inspect(inspect: CLIArgs.Inspect) Command.Inspect {
         .path = path,
         .query = switch (inspect) {
             .constants => unreachable,
+            .metrics => unreachable,
             .superblock => .superblock,
             .wal => |args| .{ .wal = .{ .slot = args.slot } },
             .replies => |args| .{ .replies = .{

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -103,12 +103,12 @@ const constants = @import("constants.zig");
 const stdx = @import("stdx.zig");
 const IO = @import("io.zig").IO;
 const StatsD = @import("trace/statsd.zig").StatsD;
-const Event = @import("trace/event.zig").Event;
-const EventMetric = @import("trace/event.zig").EventMetric;
-const EventTracing = @import("trace/event.zig").EventTracing;
-const EventTiming = @import("trace/event.zig").EventTiming;
-const EventTimingAggregate = @import("trace/event.zig").EventTimingAggregate;
-const EventMetricAggregate = @import("trace/event.zig").EventMetricAggregate;
+pub const Event = @import("trace/event.zig").Event;
+pub const EventMetric = @import("trace/event.zig").EventMetric;
+pub const EventTracing = @import("trace/event.zig").EventTracing;
+pub const EventTiming = @import("trace/event.zig").EventTiming;
+pub const EventTimingAggregate = @import("trace/event.zig").EventTimingAggregate;
+pub const EventMetricAggregate = @import("trace/event.zig").EventMetricAggregate;
 
 const trace_span_size_max = 1024;
 


### PR DESCRIPTION
- Add `tigerbeetle inspect metrics` to help keep track of metric cardinality.
- Add metric cardinality to devhub.

Example output:

```
$ ./tigerbeetle inspect metrics
2025-03-19 15:18:12.106Z info(inspect): Format: [metric type]: [metric name]([metric tags])=[metric cardinality]
2025-03-19 15:18:12.106Z info(inspect): Total stats per replica: 1220
2025-03-19 15:18:12.106Z info(inspect): (All metrics are tagged with the replica, so the cluster has 6x as many metrics.)
gauge: table_count_visible(tree)=34
gauge: table_count_visible_max(tree)=34
timing: replica_commit(stage)=40
timing: replica_aof_write()=4
timing: replica_sync_table()=4
timing: compact_beat(tree)=136
timing: compact_beat_merge(tree)=136
timing: compact_manifest()=4
timing: compact_mutable(tree)=136
timing: compact_mutable_suffix(tree)=136
timing: lookup(tree)=136
timing: lookup_worker(tree)=136
timing: scan_tree(tree)=136
timing: scan_tree_level(tree)=136
timing: grid_read()=4
timing: grid_write()=4
timing: metrics_emit()=4
```