### PR TITLE
io: allow open_read_only on locked data files

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -894,7 +894,16 @@ pub const IO = struct {
         // Obtain an advisory exclusive lock that works only if all processes actually use flock().
         // LOCK_NB means that we want to fail the lock without waiting if another process has it.
         posix.flock(fd, posix.LOCK.EX | posix.LOCK.NB) catch |err| switch (err) {
-            error.WouldBlock => @panic("another process holds the data file lock"),
+            error.WouldBlock => {
+                if (method == .open_read_only) {
+                    log.warn(
+                        "another process holds the data file lock - results may be inconsistent",
+                        .{},
+                    );
+                } else {
+                    @panic("another process holds the data file lock");
+                }
+            },
             else => return err,
         };
 

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1277,7 +1277,16 @@ pub const IO = struct {
         // Obtain an advisory exclusive lock
         // even when we haven't given shared access to other processes.
         fs_lock(handle, size) catch |err| switch (err) {
-            error.WouldBlock => @panic("another process holds the data file lock"),
+            error.WouldBlock => {
+                if (method == .open_read_only) {
+                    log.warn(
+                        "another process holds the data file lock - results may be inconsistent",
+                        .{},
+                    );
+                } else {
+                    @panic("another process holds the data file lock");
+                }
+            },
             else => return err,
         };
 


### PR DESCRIPTION
This allows `tigerbeetle inspect` to be run on open data files, which can be particularly useful for some adhoc DR solutions, or getting an idea of what's going on on a running cluster without needing to shut it down first.