### PR TITLE
CFO: Retain checkouts + cache across iterations

### DIFF
--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -8,16 +8,21 @@ set -eu
 
 git --version
 
-if ! [ -d ./tigerbeetle ]
-then git clone https://github.com/tigerbeetle/tigerbeetle tigerbeetle
-fi
-
 while true
 do
+    # Drop the cache every ~24 hours.
+    if [ $((RANDOM % 24 )) -eq 0 ]
+    then rm -rf ./tigerbeetle
+    fi
+
     (
+        if ! [ -d ./tigerbeetle ]
+        then git clone https://github.com/tigerbeetle/tigerbeetle tigerbeetle
+        fi
+
         cd tigerbeetle
         git fetch
-        git checkout -f origin/main
+        git switch --discard-changes --detach origin/main
         ./zig/download.sh
         # `unshare --pid` ensures that, if the parent process dies, all children die as well.
         # `unshare --user` is needed to make `--pid` work without root.

--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -8,12 +8,16 @@ set -eu
 
 git --version
 
+if ! [ -d ./tigerbeetle ]
+then git clone https://github.com/tigerbeetle/tigerbeetle tigerbeetle
+fi
+
 while true
 do
-    rm -rf ./tigerbeetle
     (
-        git clone https://github.com/tigerbeetle/tigerbeetle tigerbeetle
         cd tigerbeetle
+        git fetch
+        git checkout -f origin/main
         ./zig/download.sh
         # `unshare --pid` ensures that, if the parent process dies, all children die as well.
         # `unshare --user` is needed to make `--pid` work without root.


### PR DESCRIPTION
Right now we force (each) CFO to recompile all fuzzers every iteration (so every ~hour) by deleting the working tree (which includes zig's binary cache).

This leads to a lot of extra compiling -- for the current PR's it is about 10 minutes for every 60 minutes of actual fuzzing. Since the branches don't change that often, this is unnecessary work -- we'd rather spend those 10 minutes fuzzing instead.

(When we are compiling, we aren't starting fuzzers, and compilation is only single-threaded, so the CFO machine spends that ~10 minutes very underutilized.)

Instead let's retain the cache and just garbage-collect it selectively when tasks are removed.

Note that this change requires updating the supervisor script.