### PR TITLE
stdx: vendor bitset

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -148,7 +148,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         }
 
         // There are no gaps in the tree ids.
-        assert(tree_infos_set.count() == tree_infos.len);
+        assert(tree_infos_set.full());
 
         break :tree_infos tree_infos_sorted;
     };

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -138,10 +138,10 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         for (tree_infos) |tree_info| tree_id_min = @min(tree_id_min, tree_info.tree_id);
 
         var tree_infos_sorted: [tree_infos.len]TreeInfo = undefined;
-        var tree_infos_set = std.StaticBitSet(tree_infos.len).initEmpty();
+        var tree_infos_set: stdx.BitSetType(tree_infos.len) = .{};
         for (tree_infos) |tree_info| {
             const tree_index = tree_info.tree_id - tree_id_min;
-            assert(!tree_infos_set.isSet(tree_index));
+            assert(!tree_infos_set.is_set(tree_index));
 
             tree_infos_sorted[tree_index] = tree_info;
             tree_infos_set.set(tree_index);

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -693,7 +693,7 @@ fn expand_argv(argv: *Argv, comptime cmd: []const u8, cmd_args: anytype) !void {
     comptime var concat_right: bool = false;
 
     const arg_count = std.meta.fields(@TypeOf(cmd_args)).len;
-    comptime var args_used = std.StaticBitSet(arg_count).initEmpty();
+    comptime var args_used: stdx.BitSetType(arg_count) = .{};
     comptime assert(std.mem.indexOfScalar(u8, cmd, '\'') == null); // Quoting isn't supported yet.
     comptime assert(std.mem.indexOfScalar(u8, cmd, '"') == null);
     inline while (pos < cmd.len) {

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -6,6 +6,7 @@ const assert = std.debug.assert;
 
 pub const BoundedArrayType = @import("./stdx/bounded_array.zig").BoundedArrayType;
 pub const RingBufferType = @import("./stdx/ring_buffer.zig").RingBufferType;
+pub const BitSetType = @import("./stdx/bit_set.zig").BitSetType;
 pub const ZipfianGenerator = @import("./stdx/zipfian.zig").ZipfianGenerator;
 pub const ZipfianShuffled = @import("./stdx/zipfian.zig").ZipfianShuffled;
 

--- a/src/stdx/bit_set.zig
+++ b/src/stdx/bit_set.zig
@@ -7,7 +7,7 @@ const assert = std.debug.assert;
 pub fn BitSetType(comptime with_capacity: u8) type {
     return struct {
         // While mathematicaly 0 and 1 are symmetric, we intentionally bias the API to use zeros
-        // default, as zero-initalization requces binary size.
+        // default, as zero-initialization reduces binary size.
         bits: Word = 0,
 
         pub const Word = for (.{ u8, u16, u32, u64, u128, u256 }) |w| {
@@ -129,8 +129,8 @@ test BitSetType {
                 .unset => {
                     if (N > 0) {
                         const bit = prng.int_inclusive(usize, N - 1);
-                        set.set(bit);
-                        model.set(bit);
+                        set.unset(bit);
+                        model.unset(bit);
                     }
                 },
                 .set_value => {

--- a/src/stdx/bit_set.zig
+++ b/src/stdx/bit_set.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+/// Take a u8 to limit to 256 items max (2^8 = 256).
+/// Use dynamic bitset for larger sizes.
+pub fn BitSetType(comptime with_capacity: u8) type {
+    return struct {
+        // While mathematicaly 0 and 1 are symmetric, we intentionally bias the API to use zeros
+        // default, as zero-initalization requces binary size.
+        bits: Word = 0,
+
+        pub const Word = for (.{ u8, u16, u32, u64, u128, u256 }) |w| {
+            if (@bitSizeOf(w) >= with_capacity) break w;
+        } else unreachable;
+
+        const BitSet = @This();
+
+        pub fn is_set(bit_set: BitSet, index: usize) bool {
+            assert(index < bit_set.capacity());
+            return bit_set.bits & bit(index) != 0;
+        }
+
+        pub fn count(bit_set: BitSet) usize {
+            return @popCount(bit_set.bits);
+        }
+
+        pub inline fn capacity(_: BitSet) usize {
+            return with_capacity;
+        }
+        pub fn first_set(bit_set: BitSet) ?usize {
+            if (bit_set.bits == 0) return null;
+            return @ctz(bit_set.bits);
+        }
+
+        pub fn first_unset(bit_set: BitSet) ?usize {
+            const result = @ctz(~bit_set.bits);
+            return if (result < bit_set.capacity()) result else null;
+        }
+
+        pub fn set(bit_set: *BitSet, index: usize) void {
+            assert(index < bit_set.capacity());
+            bit_set.bits |= bit(index);
+        }
+
+        pub fn unset(bit_set: *BitSet, index: usize) void {
+            assert(index < bit_set.capacity());
+            bit_set.bits &= ~bit(index);
+        }
+
+        pub fn set_value(bit_set: *BitSet, index: usize, value: bool) void {
+            if (value) {
+                bit_set.set(index);
+            } else {
+                bit_set.unset(index);
+            }
+        }
+
+        fn bit(index: usize) Word {
+            assert(index < with_capacity);
+            return @as(Word, 1) << @intCast(index);
+        }
+
+        pub fn iterate(bit_set: BitSet) Iterator {
+            return .{ .bits_remain = bit_set.bits };
+        }
+
+        pub const Iterator = struct {
+            bits_remain: Word,
+
+            pub fn next(it: *@This()) ?usize {
+                const result = @ctz(it.bits_remain);
+                if (result >= with_capacity) return null;
+                it.bits_remain &= it.bits_remain - 1;
+                return result;
+            }
+        };
+    };
+}

--- a/src/stdx/bit_set.zig
+++ b/src/stdx/bit_set.zig
@@ -27,6 +27,15 @@ pub fn BitSetType(comptime with_capacity: u8) type {
         pub inline fn capacity(_: BitSet) usize {
             return with_capacity;
         }
+
+        pub fn full(bit_set: BitSet) bool {
+            return bit_set.count() == bit_set.capacity();
+        }
+
+        pub fn empty(bit_set: BitSet) bool {
+            return bit_set.bits == 0;
+        }
+
         pub fn first_set(bit_set: BitSet) ?usize {
             if (bit_set.bits == 0) return null;
             return @ctz(bit_set.bits);

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -15,6 +15,7 @@
 //! - remove dynamic-dispatch idirection (a minor bonus).
 
 const std = @import("std");
+const stdx = @import("../stdx.zig");
 const assert = std.debug.assert;
 const math = std.math;
 const Snap = @import("../testing/snaptest.zig").Snap;
@@ -130,7 +131,7 @@ test fill {
     for (0..size_max + 1) |size| {
         // Check that the entire buffer is filled, by filling it over a couple of times
         // and checking that each byte is non-zero at least once.
-        var non_zero = std.StaticBitSet(size_max).initEmpty();
+        var non_zero: stdx.BitSetType(size_max) = .{};
         for (0..3) |_| {
             const buffer = buffer_max[0..size];
             @memset(buffer, 0);
@@ -140,7 +141,7 @@ test fill {
                 if (byte != 0) non_zero.set(i);
             }
         }
-        for (0..size) |i| assert(non_zero.isSet(i));
+        for (0..size) |i| assert(non_zero.is_set(i));
     }
 
     try snap(@src(),

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -56,7 +56,7 @@ pub const Network = struct {
     ///
     /// At the moment, we require core members to have direct bidirectional connectivity, but this
     /// could be relaxed in the future to indirect connectivity.
-    pub const Core = std.StaticBitSet(constants.members_max);
+    pub const Core = stdx.BitSetType(constants.members_max);
 
     allocator: std.mem.Allocator,
 
@@ -141,9 +141,9 @@ pub const Network = struct {
         network.packet_simulator.options.partition_probability = ratio(0, 100);
         network.packet_simulator.options.unpartition_probability = ratio(0, 100);
 
-        var it_source = core.iterator(.{});
+        var it_source = core.iterate();
         while (it_source.next()) |replica_source| {
-            var it_target = core.iterator(.{});
+            var it_target = core.iterate();
             while (it_target.next()) |replica_target| {
                 if (replica_target != replica_source) {
                     const path = Path{

--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -4,17 +4,18 @@ const mem = std.mem;
 
 const constants = @import("../../constants.zig");
 const vsr = @import("../../vsr.zig");
+const stdx = @import("../../stdx.zig");
 
 const message_pool = @import("../../message_pool.zig");
 const MessagePool = message_pool.MessagePool;
 const Message = MessagePool.Message;
 
-const ReplicaSet = std.StaticBitSet(constants.members_max);
+const ReplicaSet = stdx.BitSetType(constants.members_max);
 const Commits = std.ArrayList(struct {
     header: vsr.Header.Prepare,
     // null for operation=root and operation=upgrade
     release: ?vsr.Release,
-    replicas: ReplicaSet = ReplicaSet.initEmpty(),
+    replicas: ReplicaSet = .{},
 });
 
 const ReplicaHead = struct {
@@ -53,7 +54,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
             var commits = Commits.init(allocator);
             errdefer commits.deinit();
 
-            var commit_replicas = ReplicaSet.initEmpty();
+            var commit_replicas: ReplicaSet = .{};
             for (options.replicas, 0..) |_, i| commit_replicas.set(i);
             try commits.append(.{
                 .header = root_prepare,

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -1024,7 +1024,7 @@ pub const ClusterFaultAtlas = struct {
         faulty_grid: bool,
     };
 
-    const ReplicaSet = std.StaticBitSet(constants.replicas_max);
+    const ReplicaSet = stdx.BitSetType(constants.replicas_max);
     const headers_per_sector = @divExact(constants.sector_size, @sizeOf(vsr.Header));
     const members_max = constants.members_max;
 
@@ -1090,7 +1090,7 @@ pub const ClusterFaultAtlas = struct {
             if (!faulty) continue;
 
             for (0..chunks[0].bit_length) |chunk| {
-                var replicas = ReplicaSet.initEmpty();
+                var replicas: ReplicaSet = .{};
                 while (replicas.count() < faults_max) {
                     const replica_index = prng.int_inclusive(u8, replica_count - 1);
                     if (chunks[replica_index].count() + 1 <

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -126,6 +126,10 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
         return "use stdx.BoundedArrayType instead of std version";
     }
 
+    if (std.mem.indexOf(u8, source, "Static" ++ "BitSet") != null) {
+        return "use stdx.BitSetType instead of std version";
+    }
+
     if (std.mem.indexOf(u8, source, "std.time." ++ "Duration") != null) {
         return "use stdx.Duration instead of std veresion";
     }

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -187,13 +187,13 @@ pub const CreateAccountResult = enum(u32) {
 
     comptime {
         const values = std.enums.values(CreateAccountResult);
-        const BitSet = std.StaticBitSet(values.len);
-        var set = BitSet.initEmpty();
+        const BitSet = stdx.BitSetType(values.len);
+        var set: BitSet = .{};
         for (0..values.len) |index| {
             const result: CreateAccountResult = @enumFromInt(index);
             stdx.maybe(result == values[index]);
 
-            assert(!set.isSet(index));
+            assert(!set.is_set(index));
             set.set(index);
         }
 
@@ -385,13 +385,13 @@ pub const CreateTransferResult = enum(u32) {
 
     comptime {
         const values = std.enums.values(CreateTransferResult);
-        const BitSet = std.StaticBitSet(values.len);
-        var set = BitSet.initEmpty();
+        const BitSet = stdx.BitSetType(values.len);
+        var set: BitSet = .{};
         for (0..values.len) |index| {
             const result: CreateTransferResult = @enumFromInt(index);
             stdx.maybe(result == values[index]);
 
-            assert(!set.isSet(index));
+            assert(!set.is_set(index));
             set.set(index);
         }
 

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -199,7 +199,7 @@ pub const CreateAccountResult = enum(u32) {
 
         // It's a non-ordered enum, we need to ensure
         // there are no gaps in the numbering of the values.
-        assert(set.count() == set.capacity());
+        assert(set.full());
     }
 };
 
@@ -397,7 +397,7 @@ pub const CreateTransferResult = enum(u32) {
 
         // It's a non-ordered enum, we need to ensure
         // there are no gaps in the numbering of the values.
-        assert(set.count() == set.capacity());
+        assert(set.full());
     }
 
     /// TODO(zig): CreateTransferResult is ordered by precedence, but it crashes

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -293,7 +293,7 @@ const Benchmark = struct {
     pub fn run(b: *Benchmark, stage: Stage) !void {
         assert(b.stage == .idle);
         assert(b.clients.len > 0);
-        assert(b.clients_busy.count() == 0);
+        assert(b.clients_busy.empty());
         assert(stdx.zeroed(std.mem.sliceAsBytes(b.request_latency_histogram)));
         assert(b.request_index == 0);
         assert(b.account_index == 0);
@@ -325,7 +325,7 @@ const Benchmark = struct {
 
     fn run_finish(b: *Benchmark) void {
         assert(b.stage != .idle);
-        assert(b.clients_busy.count() == 0);
+        assert(b.clients_busy.empty());
 
         b.stage = .idle;
         b.request_index = 0;
@@ -355,7 +355,7 @@ const Benchmark = struct {
         assert(b.clients_busy.is_set(context.client_index));
 
         b.clients_busy.unset(context.client_index);
-        if (b.clients_busy.count() == 0) b.run_finish();
+        if (b.clients_busy.empty()) b.run_finish();
     }
 
     fn create_accounts(b: *Benchmark, client_index: u32) void {
@@ -364,7 +364,7 @@ const Benchmark = struct {
         assert(b.account_batch_size > 0);
 
         if (b.account_index >= b.account_count) {
-            if (b.clients_busy.count() == 0) b.run_finish();
+            if (b.clients_busy.empty()) b.run_finish();
         } else {
             const accounts_count = @min(b.account_count, b.account_batch_size);
             const accounts_bytes = &b.client_requests[client_index];
@@ -390,7 +390,7 @@ const Benchmark = struct {
         assert(b.transfer_batch_size > 0);
 
         if (b.transfer_index >= b.transfer_count) {
-            if (b.clients_busy.count() == 0) b.create_transfers_finish();
+            if (b.clients_busy.empty()) b.create_transfers_finish();
         } else {
             const transfers_count = @min(b.transfer_count, b.transfer_batch_size);
             const transfers_bytes = &b.client_requests[client_index];
@@ -451,7 +451,7 @@ const Benchmark = struct {
         assert(!b.clients_busy.is_set(client_index));
 
         if (b.query_index >= b.query_count) {
-            if (b.clients_busy.count() == 0) b.get_account_transfers_finish();
+            if (b.clients_busy.empty()) b.get_account_transfers_finish();
             return;
         }
         b.query_index += 1;
@@ -510,7 +510,7 @@ const Benchmark = struct {
         assert(!b.clients_busy.is_set(client_index));
 
         if (b.account_index >= b.account_count) {
-            if (b.clients_busy.count() == 0) b.validate_accounts_finish();
+            if (b.clients_busy.empty()) b.validate_accounts_finish();
         } else {
             const account_count = @min(b.account_count, b.account_batch_size);
             const account_ids =
@@ -562,7 +562,7 @@ const Benchmark = struct {
         assert(!b.clients_busy.is_set(client_index));
 
         if (b.transfer_index >= b.transfer_count) {
-            if (b.clients_busy.count() == 0) b.validate_transfers_finish();
+            if (b.clients_busy.empty()) b.validate_transfers_finish();
         } else {
             const transfer_count = @min(b.transfer_count, b.transfer_batch_size);
             const transfer_ids =

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -268,8 +268,7 @@ const Benchmark = struct {
     print_batch_timings: bool,
 
     // State:
-    clients_busy: std.StaticBitSet(constants.clients_max) =
-        std.StaticBitSet(constants.clients_max).initEmpty(),
+    clients_busy: stdx.BitSetType(constants.clients_max) = .{},
     clients_request_ns: [constants.clients_max]u64 = .{undefined} ** constants.clients_max,
     client_requests: []align(constants.sector_size) [constants.message_body_size_max]u8,
     client_replies: []align(constants.sector_size) [constants.message_body_size_max]u8,
@@ -338,7 +337,7 @@ const Benchmark = struct {
 
     fn register(b: *Benchmark, client_index: usize) void {
         assert(b.stage == .register);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
 
         b.clients_busy.set(client_index);
         b.clients[client_index].register(register_callback, @bitCast(RequestContext{
@@ -353,7 +352,7 @@ const Benchmark = struct {
         const context: RequestContext = @bitCast(user_data);
         const b: *Benchmark = context.benchmark;
         assert(b.stage == .register);
-        assert(b.clients_busy.isSet(context.client_index));
+        assert(b.clients_busy.is_set(context.client_index));
 
         b.clients_busy.unset(context.client_index);
         if (b.clients_busy.count() == 0) b.run_finish();
@@ -361,7 +360,7 @@ const Benchmark = struct {
 
     fn create_accounts(b: *Benchmark, client_index: u32) void {
         assert(b.stage == .create_accounts);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
         assert(b.account_batch_size > 0);
 
         if (b.account_index >= b.account_count) {
@@ -387,7 +386,7 @@ const Benchmark = struct {
 
     fn create_transfers(b: *Benchmark, client_index: u32) void {
         assert(b.stage == .create_transfers);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
         assert(b.transfer_batch_size > 0);
 
         if (b.transfer_index >= b.transfer_count) {
@@ -449,7 +448,7 @@ const Benchmark = struct {
 
     fn get_account_transfers(b: *Benchmark, client_index: u32) void {
         assert(b.stage == .get_account_transfers);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
 
         if (b.query_index >= b.query_count) {
             if (b.clients_busy.count() == 0) b.get_account_transfers_finish();
@@ -508,7 +507,7 @@ const Benchmark = struct {
 
     fn validate_accounts(b: *Benchmark, client_index: u32) void {
         assert(b.stage == .validate_accounts);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
 
         if (b.account_index >= b.account_count) {
             if (b.clients_busy.count() == 0) b.validate_accounts_finish();
@@ -560,7 +559,7 @@ const Benchmark = struct {
 
     fn validate_transfers(b: *Benchmark, client_index: u32) void {
         assert(b.stage == .validate_transfers);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
 
         if (b.transfer_index >= b.transfer_count) {
             if (b.clients_busy.count() == 0) b.validate_transfers_finish();
@@ -635,7 +634,7 @@ const Benchmark = struct {
     ) void {
         assert(b.stage != .idle);
         assert(b.clients_busy.count() < b.clients.len);
-        assert(!b.clients_busy.isSet(client_index));
+        assert(!b.clients_busy.is_set(client_index));
 
         b.clients_busy.set(client_index);
         b.clients_request_ns[client_index] = b.timer.read();
@@ -662,7 +661,7 @@ const Benchmark = struct {
         const context: RequestContext = @bitCast(user_data);
         const client = context.client_index;
         const b: *Benchmark = context.benchmark;
-        assert(b.clients_busy.isSet(client));
+        assert(b.clients_busy.is_set(client));
         assert(b.stage != .idle);
         assert(timestamp > 0);
 

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -411,13 +411,13 @@ const Inspector = struct {
 
             var label_buffer: [128]u8 = undefined;
             for (group_by.groups()) |group| {
-                const header_index = group.findFirstSet().?;
+                const header_index = group.first_set().?;
                 const header = &inspector.superblock_headers[header_index];
                 const header_mark: u8 = if (header_valid[header_index]) '|' else 'X';
 
                 var label_stream = std.io.fixedBufferStream(&label_buffer);
                 for (0..constants.superblock_copies) |j| {
-                    try label_stream.writer().writeByte(if (group.isSet(j)) header_mark else '_');
+                    try label_stream.writer().writeByte(if (group.is_set(j)) header_mark else '_');
                 }
                 try label_stream.writer().writeByte(' ');
                 try label_stream.writer().writeAll(field.name);
@@ -473,14 +473,14 @@ const Inspector = struct {
 
             var label_buffer: [64]u8 = undefined;
             for (group_by.groups()) |group| {
-                const header = header_pair[group.findFirstSet().?];
+                const header = header_pair[group.first_set().?];
                 const header_valid = header.valid_checksum() and
-                    (!group.isSet(1) or wal_prepare_body_valid);
+                    (!group.is_set(1) or wal_prepare_body_valid);
 
                 const mark: u8 = if (header_valid) '|' else 'X';
                 var label_stream = std.io.fixedBufferStream(&label_buffer);
-                try label_stream.writer().writeByte(if (group.isSet(0)) mark else '_');
-                try label_stream.writer().writeByte(if (group.isSet(1)) mark else '_');
+                try label_stream.writer().writeByte(if (group.is_set(0)) mark else '_');
+                try label_stream.writer().writeByte(if (group.is_set(1)) mark else '_');
                 try label_stream.writer().print("{:_>4}: ", .{slot});
 
                 try print_struct(output, label_stream.getWritten(), &.{
@@ -532,10 +532,10 @@ const Inspector = struct {
 
         var label_buffer: [2]u8 = undefined;
         for (group_by.groups()) |group| {
-            const header = copies[group.findFirstSet().?];
+            const header = copies[group.first_set().?];
             const header_mark: u8 = if (header.valid_checksum()) '|' else 'X';
-            label_buffer[0] = if (group.isSet(0)) header_mark else '_';
-            label_buffer[1] = if (group.isSet(1)) header_mark else '_';
+            label_buffer[0] = if (group.is_set(0)) header_mark else '_';
+            label_buffer[1] = if (group.is_set(1)) header_mark else '_';
 
             try print_struct(output, &label_buffer, header);
         }
@@ -580,14 +580,14 @@ const Inspector = struct {
             try output.print("{:_>2}     session={}\n", .{ slot, session });
 
             for (group_by.groups()) |group| {
-                const header_index = group.findFirstSet().?;
+                const header_index = group.first_set().?;
                 const header = copies[header_index];
                 const header_mark: u8 = if (header.valid_checksum()) '|' else 'X';
 
                 var label_stream = std.io.fixedBufferStream(&label_buffer);
                 try label_stream.writer().print("{:_>2}: ", .{slot});
-                try label_stream.writer().writeByte(if (group.isSet(0)) header_mark else '_');
-                try label_stream.writer().writeByte(if (group.isSet(1)) header_mark else '_');
+                try label_stream.writer().writeByte(if (group.is_set(0)) header_mark else '_');
+                try label_stream.writer().writeByte(if (group.is_set(1)) header_mark else '_');
                 try label_stream.writer().writeAll(" header");
                 try print_struct(output, label_stream.getWritten(), header);
             }
@@ -634,10 +634,10 @@ const Inspector = struct {
 
         var label_buffer: [2]u8 = undefined;
         for (group_by.groups()) |group| {
-            const header = copies[group.findFirstSet().?];
+            const header = copies[group.first_set().?];
             const header_mark: u8 = if (header.valid_checksum()) '|' else 'X';
-            label_buffer[0] = if (group.isSet(0)) header_mark else '_';
-            label_buffer[1] = if (group.isSet(1)) header_mark else '_';
+            label_buffer[0] = if (group.is_set(0)) header_mark else '_';
+            label_buffer[1] = if (group.is_set(1)) header_mark else '_';
 
             try print_struct(output, &label_buffer, header);
         }
@@ -958,7 +958,7 @@ const Inspector = struct {
             var quorums = SuperBlockQuorums{};
             const quorum = try quorums.working(&copies, .open);
             if (!quorum.valid) return error.SuperBlockQuorumInvalid;
-            return inspector.superblock_headers[quorum.copies.findFirstSet().?];
+            return inspector.superblock_headers[quorum.copies.first_set().?];
         }
     }
 
@@ -1481,7 +1481,7 @@ fn print_table_info(
 fn GroupByType(comptime count_max: usize) type {
     return struct {
         const GroupBy = @This();
-        const BitSet = std.StaticBitSet(count_max);
+        const BitSet = stdx.BitSetType(count_max);
 
         count: usize = 0,
         checksums: [count_max]?u128 = [_]?u128{null} ** count_max,
@@ -1500,11 +1500,11 @@ fn GroupByType(comptime count_max: usize) type {
 
             var distinct: usize = 0;
             for (&group_by.checksums, 0..) |checksum_a, a| {
-                var matches = BitSet.initEmpty();
+                var matches: BitSet = .{};
                 for (&group_by.checksums, 0..) |checksum_b, b| {
-                    matches.setValue(b, checksum_a.? == checksum_b.?);
+                    matches.set_value(b, checksum_a.? == checksum_b.?);
                 }
-                if (matches.findFirstSet().? == a) {
+                if (matches.first_set().? == a) {
                     group_by.matches[distinct] = matches;
                     distinct += 1;
                 }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -11,11 +11,12 @@ comptime {
     _ = @import("shell.zig");
     _ = @import("stdx.zig");
     _ = @import("stdx/aegis.zig");
+    _ = @import("stdx/bit_set.zig");
     _ = @import("stdx/bounded_array.zig");
+    _ = @import("stdx/prng.zig");
     _ = @import("stdx/ring_buffer.zig");
     _ = @import("stdx/sort_test.zig");
     _ = @import("stdx/zipfian.zig");
-    _ = @import("stdx/prng.zig");
     _ = @import("storage.zig");
     _ = @import("tidy.zig");
     _ = @import("trace.zig");

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -232,7 +232,7 @@ pub fn main() !void {
         // are repaired. After this, all we must be left with are correlated faults.
         {
             var replica: u8 = 0;
-            var core: Core = Core.initEmpty();
+            var core: Core = .{};
             while (replica < simulator.options.cluster.replica_count) : (replica += 1) {
                 core.set(replica);
             }
@@ -277,7 +277,7 @@ pub fn main() !void {
 
         if (simulator.pending()) |reason| {
             if (try simulator.cluster_recoverable(allocator)) {
-                log.info("no liveness, final cluster state (core={b}):", .{simulator.core.mask});
+                log.info("no liveness, final cluster state (core={b}):", .{simulator.core.bits});
                 simulator.cluster.log_cluster();
                 log.err("you can reproduce this failure with seed={}", .{seed});
                 fatal(.liveness, "no state convergence: {s}", .{reason});
@@ -286,7 +286,7 @@ pub fn main() !void {
             const commits = simulator.cluster.state_checker.commits.items;
             const last_checksum = commits[commits.len - 1].header.checksum;
             for (simulator.cluster.aofs, 0..) |*aof, replica_index| {
-                if (simulator.core.isSet(replica_index)) {
+                if (simulator.core.is_set(replica_index)) {
                     try aof.validate(last_checksum);
                 } else {
                     try aof.validate(null);
@@ -604,7 +604,7 @@ pub const Simulator = struct {
     reply_op_next: u64 = 1, // Skip the root op.
 
     /// Fully-connected subgraph of replicas for liveness checking.
-    core: Core = Core.initEmpty(),
+    core: Core = .{},
 
     /// Total number of requests sent, including those that have not been delivered.
     /// Does not include `register` messages.
@@ -697,7 +697,7 @@ pub const Simulator = struct {
         // Even though there are no client requests in progress, the cluster may be upgrading.
         const release_max = simulator.core_release_max();
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.is_set(replica.replica)) {
                 // (If down, the replica is waiting to be upgraded.)
                 maybe(simulator.cluster.replica_health[replica.replica] == .down);
 
@@ -706,7 +706,7 @@ pub const Simulator = struct {
         }
 
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.is_set(replica.replica)) {
                 if (!simulator.cluster.state_checker.replica_convergence(replica.replica)) {
                     return "pending replica convergence";
                 }
@@ -718,7 +718,7 @@ pub const Simulator = struct {
         // Check whether the replica is still repairing prepares/tables/replies.
         const commit_max: u64 = simulator.cluster.state_checker.commits.items.len - 1;
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.is_set(replica.replica)) {
                 for (replica.op_checkpoint() + 1..commit_max + 1) |op| {
                     const header = simulator.cluster.state_checker.header_with_op(op);
                     if (!replica.journal.has_prepare(&header)) return "pending journal";
@@ -733,7 +733,7 @@ pub const Simulator = struct {
         // Expect that all core replicas have arrived at an identical (non-divergent) checkpoint.
         var checkpoint_id: ?u128 = null;
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.is_set(replica.replica)) {
                 const replica_checkpoint_id = replica.superblock.working.checkpoint_id();
                 if (checkpoint_id) |id| {
                     assert(checkpoint_id == id);
@@ -784,13 +784,13 @@ pub const Simulator = struct {
     /// See https://tigerbeetle.com/blog/2023-07-06-simulation-testing-for-liveness for broader
     /// context.
     pub fn transition_to_liveness_mode(simulator: *Simulator, core: Core) void {
-        log.debug("transition_to_liveness_mode: core={b}", .{core.mask});
+        log.debug("transition_to_liveness_mode: core={b}", .{core.bits});
         assert(simulator.core.count() == 0);
         defer assert(simulator.core.count() > 0);
 
         simulator.core = core;
 
-        var it = core.iterator(.{});
+        var it = core.iterate();
         while (it.next()) |replica_index| {
             const fault = false;
             if (simulator.cluster.replica_health[replica_index] == .down) {
@@ -826,11 +826,11 @@ pub const Simulator = struct {
         for (simulator.cluster.replicas) |*replica| {
             if (simulator.cluster.replica_health[replica.replica] == .up and
                 replica.status == .normal and replica.primary() and
-                !simulator.core.isSet(replica.replica))
+                !simulator.core.is_set(replica.replica))
             {
                 // `replica` considers itself a primary, check that at least part of the core thinks
                 // so as well.
-                var it = simulator.core.iterator(.{});
+                var it = simulator.core.iterate();
                 while (it.next()) |replica_core_index| {
                     if (simulator.cluster.replicas[replica_core_index].view == replica.view) {
                         return true;
@@ -849,7 +849,7 @@ pub const Simulator = struct {
         var core_replicas: u8 = 0;
         var core_recovering_head: u8 = 0;
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica) and !replica.standby()) {
+            if (simulator.core.is_set(replica.replica) and !replica.standby()) {
                 core_replicas += 1;
                 core_recovering_head += @intFromBool(replica.status == .recovering_head);
             }
@@ -866,7 +866,7 @@ pub const Simulator = struct {
         comptime Replica: type,
         replica: *const Replica,
     ) bool {
-        if (!simulator.core.isSet(replica.replica)) return false;
+        if (!simulator.core.is_set(replica.replica)) return false;
         if (replica.standby()) return false;
         switch (replica.status) {
             .normal => return true,
@@ -934,7 +934,7 @@ pub const Simulator = struct {
             }
         }
 
-        const ReplicaSet = std.StaticBitSet(constants.replicas_max);
+        const ReplicaSet = stdx.BitSetType(constants.replicas_max);
         var replicas_missing_ops = try allocator.alloc(
             ReplicaSet,
             cluster_op_head - cluster_op_repair_min + 1,
@@ -942,7 +942,7 @@ pub const Simulator = struct {
         errdefer allocator.free(replicas_missing_ops);
 
         for (replicas_missing_ops, cluster_op_repair_min..) |*replicas_missing_op, op| {
-            replicas_missing_op.* = ReplicaSet.initEmpty();
+            replicas_missing_op.* = .{};
             const header = blk: {
                 if (op > cluster_commit_max) {
                     const uncommitted_header = uncommitted_headers[op % pipeline_max].?;
@@ -955,7 +955,7 @@ pub const Simulator = struct {
             for (simulator.cluster.replicas) |replica| {
                 // Replicas should be able to repair using any other replica in the core.
                 if (replica.standby()) continue;
-                if (!simulator.core.isSet(replica.replica) or
+                if (!simulator.core.is_set(replica.replica) or
                     !replica.journal.has_prepare(&header))
                 {
                     replicas_missing_op.set(replica.replica);
@@ -1015,7 +1015,7 @@ pub const Simulator = struct {
     ) error{OutOfMemory}!?usize {
         assert(simulator.core.count() > 0);
 
-        const FaultyReplicas = std.StaticBitSet(constants.members_max);
+        const FaultyReplicas = stdx.BitSetType(constants.members_max);
         var blocks_missing = std.AutoArrayHashMap(
             struct { address: u64, checksum: u128 },
             FaultyReplicas,
@@ -1024,7 +1024,7 @@ pub const Simulator = struct {
 
         // Find all blocks that any replica in the core is missing.
         for (simulator.cluster.replicas) |replica| {
-            if (!simulator.core.isSet(replica.replica)) continue;
+            if (!simulator.core.is_set(replica.replica)) continue;
 
             const storage = &simulator.cluster.storages[replica.replica];
 
@@ -1035,7 +1035,7 @@ pub const Simulator = struct {
                     .checksum = faulty_read.checksum,
                 });
 
-                if (!v.found_existing) v.value_ptr.* = FaultyReplicas.initEmpty();
+                if (!v.found_existing) v.value_ptr.* = .{};
                 v.value_ptr.set(replica.replica);
 
                 log.debug("{}: core_missing_blocks: " ++
@@ -1054,7 +1054,7 @@ pub const Simulator = struct {
                     .checksum = fault.value_ptr.checksum,
                 });
 
-                if (!v.found_existing) v.value_ptr.* = FaultyReplicas.initEmpty();
+                if (!v.found_existing) v.value_ptr.* = .{};
                 v.value_ptr.set(replica.replica);
 
                 log.debug("{}: core_missing_blocks: " ++
@@ -1079,9 +1079,9 @@ pub const Simulator = struct {
                 // A replica might actually have the block that it is requesting, but not know.
                 // This can occur after state sync: if we compact and create a table, but then skip
                 // over that table via state sync, we will try to sync the table anyway.
-                if (faulty_replicas.isSet(replica.replica)) continue;
+                if (faulty_replicas.is_set(replica.replica)) continue;
 
-                if (!simulator.core.isSet(replica.replica)) continue;
+                if (!simulator.core.is_set(replica.replica)) continue;
                 if (replica.standby()) continue;
                 if (storage.area_faulty(.{
                     .grid = .{ .address = block_missing.address },
@@ -1131,7 +1131,7 @@ pub const Simulator = struct {
                 const storage_replies = storage.client_replies();
                 const storage_reply = storage_replies[reply_slot];
 
-                if (simulator.core.isSet(replica.replica) and !replica.standby()) {
+                if (simulator.core.is_set(replica.replica) and !replica.standby()) {
                     if (storage_reply.header.checksum == reply.checksum and
                         !storage.area_faulty(.{ .client_replies = .{ .slot = reply_slot } }))
                     {
@@ -1149,7 +1149,7 @@ pub const Simulator = struct {
 
         var release_max: vsr.Release = vsr.Release.zero;
         for (simulator.cluster.replicas) |*replica| {
-            if (simulator.core.isSet(replica.replica)) {
+            if (simulator.core.is_set(replica.replica)) {
                 release_max = release_max.max(replica.release);
                 if (replica.upgrade_release) |release| {
                     release_max = release_max.max(release);
@@ -1360,7 +1360,7 @@ pub const Simulator = struct {
         const restart_upgrade =
             simulator.replica_releases[replica.replica] <
             simulator.replica_releases_limit and
-            (simulator.core.isSet(replica.replica) or
+            (simulator.core.is_set(replica.replica) or
             simulator.prng.chance(simulator.options.replica_release_catchup_probability));
         if (restart_upgrade) simulator.replica_upgrade(replica.replica);
 
@@ -1541,7 +1541,7 @@ fn random_core(prng: *stdx.PRNG, replica_count: u8, standby_count: u8) Core {
     const replica_core_count = prng.range_inclusive(u8, quorum_view_change, replica_count);
     const standby_core_count = prng.range_inclusive(u8, 0, standby_count);
 
-    var result: Core = Core.initEmpty();
+    var result: Core = .{};
 
     var combination = stdx.PRNG.Combination.init(.{
         .total = replica_count,

--- a/src/vsr/client_sessions.zig
+++ b/src/vsr/client_sessions.zig
@@ -40,12 +40,12 @@ pub const ClientSessions = struct {
     /// Values are indexes into `entries`.
     const EntriesByClient = std.AutoHashMapUnmanaged(u128, usize);
 
-    const EntriesFree = std.StaticBitSet(constants.clients_max);
+    const EntriesPresent = stdx.BitSetType(constants.clients_max);
 
     /// Free entries are zeroed, both in `entries` and on-disk.
     entries: []Entry,
     entries_by_client: EntriesByClient,
-    entries_free: EntriesFree = EntriesFree.initFull(),
+    entries_present: EntriesPresent = .{},
 
     pub fn init(allocator: mem.Allocator) !ClientSessions {
         var entries_by_client: EntriesByClient = .{};
@@ -72,7 +72,7 @@ pub const ClientSessions = struct {
     pub fn reset(client_sessions: *ClientSessions) void {
         @memset(client_sessions.entries, std.mem.zeroes(Entry));
         client_sessions.entries_by_client.clearRetainingCapacity();
-        client_sessions.entries_free = EntriesFree.initFull();
+        client_sessions.entries_present = .{};
     }
 
     /// Size of the buffer needed to encode the client sessions on disk.
@@ -136,7 +136,7 @@ pub const ClientSessions = struct {
         source: []align(@alignOf(vsr.Header)) const u8,
     ) void {
         assert(client_sessions.count() == 0);
-        assert(client_sessions.entries_free.count() == constants.clients_max);
+        assert(client_sessions.entries_present.count() == 0);
         for (client_sessions.entries) |*entry| {
             assert(entry.session == 0);
             assert(stdx.zeroed(std.mem.asBytes(&entry.header)));
@@ -174,7 +174,7 @@ pub const ClientSessions = struct {
                 assert(header.commit >= session);
 
                 client_sessions.entries_by_client.putAssumeCapacityNoClobber(header.client, i);
-                client_sessions.entries_free.unset(i);
+                client_sessions.entries_present.set(i);
                 client_sessions.entries[i] = .{
                     .session = session,
                     .header = header.*,
@@ -182,8 +182,9 @@ pub const ClientSessions = struct {
             }
         }
 
-        assert(constants.clients_max - client_sessions.entries_free.count() ==
-            client_sessions.entries_by_client.count());
+        assert(
+            client_sessions.entries_present.count() == client_sessions.entries_by_client.count(),
+        );
     }
 
     pub fn count(client_sessions: *const ClientSessions) usize {
@@ -238,7 +239,7 @@ pub const ClientSessions = struct {
         const entry_gop = client_sessions.entries_by_client.getOrPutAssumeCapacity(client);
         if (entry_gop.found_existing) {
             const entry_index = entry_gop.value_ptr.*;
-            assert(!client_sessions.entries_free.isSet(entry_index));
+            assert(client_sessions.entries_present.is_set(entry_index));
 
             const existing = &client_sessions.entries[entry_index];
             assert(existing.session == session);
@@ -249,8 +250,8 @@ pub const ClientSessions = struct {
             existing.header = header.*;
             return ReplySlot{ .index = entry_index };
         } else {
-            const entry_index = client_sessions.entries_free.findFirstSet().?;
-            client_sessions.entries_free.unset(entry_index);
+            const entry_index = client_sessions.entries_present.first_unset().?;
+            client_sessions.entries_present.set(entry_index);
 
             const e = &client_sessions.entries[entry_index];
             assert(e.session == 0);
@@ -272,7 +273,7 @@ pub const ClientSessions = struct {
     /// This ensures that we will always pick the entry with the oldest commit number.
     /// We also check that a client has only one entry in the hash map (or it's buggy).
     pub fn evictee(client_sessions: *const ClientSessions) u128 {
-        assert(client_sessions.entries_free.count() == 0);
+        assert(client_sessions.entries_present.count() == constants.clients_max);
         assert(client_sessions.count() == constants.clients_max);
 
         var evictee_: ?*const vsr.Header.Reply = null;
@@ -302,8 +303,8 @@ pub const ClientSessions = struct {
     pub fn remove(client_sessions: *ClientSessions, client: u128) void {
         const entry_index = client_sessions.entries_by_client.fetchRemove(client).?.value;
 
-        assert(!client_sessions.entries_free.isSet(entry_index));
-        client_sessions.entries_free.set(entry_index);
+        assert(client_sessions.entries_present.is_set(entry_index));
+        client_sessions.entries_present.unset(entry_index);
 
         assert(client_sessions.entries[entry_index].header.client == client);
         client_sessions.entries[entry_index] = std.mem.zeroes(Entry);
@@ -321,9 +322,9 @@ pub const ClientSessions = struct {
 
                 const entry = &it.client_sessions.entries[it.index];
                 if (entry.session == 0) {
-                    assert(it.client_sessions.entries_free.isSet(it.index));
+                    assert(!it.client_sessions.entries_present.is_set(it.index));
                 } else {
-                    assert(!it.client_sessions.entries_free.isSet(it.index));
+                    assert(it.client_sessions.entries_present.is_set(it.index));
                     return entry;
                 }
             }

--- a/src/vsr/client_sessions.zig
+++ b/src/vsr/client_sessions.zig
@@ -136,7 +136,7 @@ pub const ClientSessions = struct {
         source: []align(@alignOf(vsr.Header)) const u8,
     ) void {
         assert(client_sessions.count() == 0);
-        assert(client_sessions.entries_present.count() == 0);
+        assert(client_sessions.entries_present.empty());
         for (client_sessions.entries) |*entry| {
             assert(entry.session == 0);
             assert(stdx.zeroed(std.mem.asBytes(&entry.header)));
@@ -273,7 +273,7 @@ pub const ClientSessions = struct {
     /// This ensures that we will always pick the entry with the oldest commit number.
     /// We also check that a client has only one entry in the hash map (or it's buggy).
     pub fn evictee(client_sessions: *const ClientSessions) u128 {
-        assert(client_sessions.entries_present.count() == constants.clients_max);
+        assert(client_sessions.entries_present.full());
         assert(client_sessions.count() == constants.clients_max);
 
         var evictee_: ?*const vsr.Header.Reply = null;

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -240,7 +240,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             constants.journal_iops_write_max
         ][constants.sector_size]u8,
 
-        /// A set bit indicates a chunk of redundant headers that have a read has been issued.
+        /// A set bit indicates a chunk of redundant headers for which a read has been issued.
         header_chunks_requested: HeaderChunks = .{},
         /// A set bit indicates a chunk of redundant headers that has been recovered.
         header_chunks_recovered: HeaderChunks = .{},

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -956,8 +956,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(journal.faulty.count == slot_count);
             assert(journal.reads.executing() == 0);
             assert(journal.writes.executing() == 0);
-            assert(journal.header_chunks_requested.count() == 0);
-            assert(journal.header_chunks_recovered.count() == 0);
+            assert(journal.header_chunks_requested.empty());
+            assert(journal.header_chunks_recovered.empty());
 
             journal.status = .{ .recovering = callback };
             log.debug("{}: recover: recovering", .{journal.replica});
@@ -965,7 +965,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             var available: usize = journal.reads.available();
             while (available > 0) : (available -= 1) journal.recover_headers();
 
-            assert(journal.header_chunks_recovered.count() == 0);
+            assert(journal.header_chunks_recovered.empty());
             assert(journal.header_chunks_requested.count() == journal.reads.executing());
         }
 
@@ -977,9 +977,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                 journal.header_chunks_recovered.count() <= journal.header_chunks_requested.count(),
             );
 
-            if (journal.header_chunks_recovered.count() ==
-                journal.header_chunks_recovered.capacity())
-            {
+            if (journal.header_chunks_recovered.full()) {
                 log.debug("{}: recover_headers: complete", .{journal.replica});
                 journal.recover_prepares();
                 return;
@@ -1667,9 +1665,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(journal.dirty.count <= slot_count);
             assert(journal.faulty.count <= slot_count);
             assert(journal.faulty.count == journal.dirty.count);
-            assert(journal.header_chunks_requested.count() == 0);
-            assert(journal.header_chunks_recovered.count() ==
-                journal.header_chunks_recovered.capacity());
+            assert(journal.header_chunks_requested.full());
+            assert(journal.header_chunks_recovered.full());
 
             const replica: *Replica = @alignCast(@fieldParentPtr("journal", journal));
             const callback = journal.status.recovering;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -904,7 +904,7 @@ pub fn ReplicaType(
             assert(self.syncing == .idle);
             assert(self.sync_tables == null);
             assert(self.grid_repair_tables.executing() == 0);
-            assert(self.client_sessions.entries_present.count() == 0);
+            assert(self.client_sessions.entries_present.empty());
             assert(std.meta.eql(
                 self.client_sessions_checkpoint.checkpoint_reference(),
                 self.superblock.working.client_sessions_reference(),
@@ -927,7 +927,7 @@ pub fn ReplicaType(
             }
 
             if (self.superblock.working.vsr_state.sync_op_max > 0) {
-                maybe(self.client_replies.writing.count() > 0);
+                maybe(!self.client_replies.writing.empty());
                 for (0..constants.clients_max) |entry_slot| {
                     const slot_faulty = self.client_replies.faulty.is_set(entry_slot);
                     const slot_free = !self.client_sessions.entries_present.is_set(entry_slot);
@@ -2169,7 +2169,7 @@ pub fn ReplicaType(
             });
 
             self.transition_to_view_change_status(self.view + 1);
-            assert(self.start_view_change_from_all_replicas.count() == 0);
+            assert(self.start_view_change_from_all_replicas.empty());
         }
 
         /// DVC serves two purposes:
@@ -3300,7 +3300,7 @@ pub fn ReplicaType(
 
         fn on_start_view_change_window_timeout(self: *Replica) void {
             assert(self.status == .normal or self.status == .view_change);
-            assert(self.start_view_change_from_all_replicas.count() > 0);
+            assert(!self.start_view_change_from_all_replicas.empty());
             assert(!self.solo());
             self.start_view_change_window_timeout.stop();
 
@@ -7761,7 +7761,7 @@ pub fn ReplicaType(
             }
 
             counter.* = quorum_counter_null;
-            assert(counter.count() == 0);
+            assert(counter.empty());
 
             var replica: usize = 0;
             while (replica < self.replica_count) : (replica += 1) {
@@ -8919,7 +8919,7 @@ pub fn ReplicaType(
                 while (pipeline_prepares.next()) |prepare| {
                     assert(self.journal.has_header(prepare.message.header));
                     assert(!prepare.ok_quorum_received);
-                    assert(prepare.ok_from_all_replicas.count() == 0);
+                    assert(prepare.ok_from_all_replicas.empty());
 
                     log.debug("{}: start_view_as_the_new_primary: pipeline " ++
                         "(op={} checksum={x} parent={x})", .{

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -102,7 +102,7 @@ pub fn QuorumsType(comptime options: Options) type {
             std.mem.sort(Quorum, quorums.slice(), {}, sort_priority_descending);
 
             for (quorums.slice()) |quorum| {
-                if (quorum.copies.count() == options.superblock_copies) {
+                if (quorum.copies.full()) {
                     log.debug("quorum: checksum={x} parent={x} sequence={} count={} valid={}", .{
                         quorum.header.checksum,
                         quorum.header.parent,

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -21,7 +21,7 @@ pub fn QuorumsType(comptime options: Options) type {
             valid: bool = false,
             /// Track which copies are a member of the quorum.
             /// Used to ignore duplicate copies of a header when determining a quorum.
-            copies: QuorumCount = QuorumCount.initEmpty(),
+            copies: QuorumCount = .{},
             /// An integer value indicates the copy index found in the corresponding slot.
             /// A `null` value indicates that the copy is invalid or not a member of the working
             /// quorum. All copies belong to the same (valid, working) quorum.
@@ -33,7 +33,7 @@ pub fn QuorumsType(comptime options: Options) type {
             }
         };
 
-        pub const QuorumCount = std.StaticBitSet(options.superblock_copies);
+        pub const QuorumCount = stdx.BitSetType(options.superblock_copies);
 
         pub const Error = error{
             Fork,
@@ -254,7 +254,7 @@ pub fn QuorumsType(comptime options: Options) type {
                 // that is, the copy is in the correct slot, and its copy index is simply corrupt.
                 quorum.slots[slot] = @intCast(slot);
                 quorum.copies.set(slot);
-            } else if (quorum.copies.isSet(copy.copy)) {
+            } else if (quorum.copies.is_set(copy.copy)) {
                 // Ignore the duplicate copy.
             } else {
                 quorum.slots[slot] = @intCast(copy.copy);
@@ -337,13 +337,13 @@ pub fn QuorumsType(comptime options: Options) type {
                 }
 
                 // Set bits indicate that the corresponding copy was found at least once.
-                var copies_any = QuorumCount.initEmpty();
+                var copies_any: QuorumCount = .{};
                 // Set bits indicate that the corresponding copy was found more than once.
-                var copies_duplicate = QuorumCount.initEmpty();
+                var copies_duplicate: QuorumCount = .{};
 
                 for (iterator.slots) |slot| {
                     if (slot) |copy| {
-                        if (copies_any.isSet(copy)) copies_duplicate.set(copy);
+                        if (copies_any.is_set(copy)) copies_duplicate.set(copy);
                         copies_any.set(copy);
                     }
                 }
@@ -356,10 +356,10 @@ pub fn QuorumsType(comptime options: Options) type {
                 var b: ?u8 = null;
                 var c: ?u8 = null;
                 for (iterator.slots, 0..) |slot, i| {
-                    if (slot == null and !copies_any.isSet(i)) a = @intCast(i);
-                    if (slot == null and copies_any.isSet(i)) b = @intCast(i);
+                    if (slot == null and !copies_any.is_set(i)) a = @intCast(i);
+                    if (slot == null and copies_any.is_set(i)) b = @intCast(i);
                     if (slot) |slot_copy| {
-                        if (slot_copy != i and copies_duplicate.isSet(slot_copy)) c = @intCast(i);
+                        if (slot_copy != i and copies_duplicate.is_set(slot_copy)) c = @intCast(i);
                     }
                 }
 

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -314,14 +314,14 @@ pub fn fuzz_quorum_repairs(
     // Generate a random valid 2/4 quorum.
     // 1 bits indicate valid headers.
     // 0 bits indicate invalid headers.
-    var valid = std.bit_set.IntegerBitSet(superblock_copies).initEmpty();
+    var valid: stdx.BitSetType(superblock_copies) = .{};
     while (valid.count() < Quorums.Threshold.open.count() or prng.boolean()) {
         valid.set(prng.int_inclusive(usize, superblock_copies - 1));
     }
 
     var working_headers: [superblock_copies]SuperBlockHeader = undefined;
     for (&working_headers, 0..) |*header, i| {
-        header.* = if (valid.isSet(i)) headers_valid[i] else header_invalid;
+        header.* = if (valid.is_set(i)) headers_valid[i] else header_invalid;
     }
     prng.shuffle(SuperBlockHeader, &working_headers);
     var repair_headers = working_headers;
@@ -346,7 +346,7 @@ pub fn fuzz_quorum_repairs(
 
     // At the end of all repairs, we expect to have every copy of the superblock.
     // They do not need to be in their home slot.
-    var copies = Quorums.QuorumCount.initEmpty();
+    var copies: Quorums.QuorumCount = .{};
     for (repair_headers) |repair_header| {
         assert(repair_header.checksum == working_quorum.header.checksum);
         copies.set(repair_header.copy);


### PR DESCRIPTION
Vendor another type from stdx to std! The standard motivation applies:
we want to insualte us from std API chunrn, reduce the risk of
"meaningless" (to us) changes subtly breaking the sematics we rely on,
and align APIs with TIGER_STYLE.

The extra specific motivation in this case is that stdlib type provides
both `initFull` and `initEmpty` symmetrically, but `initFull` is a
binary size footgun --- you must include the entire bitset into the text
section of Elf binary! The `initEmpty` works by `memset`, rather than
`memcpy`, at runtime. And, although symmetrict, std only provides
`findFirstSet`, not `findFirstUnset`, which forces us to use initFull at
times.

This change reducess the release binary size on Linux by 38KiB.

Additionally, there are a couple of "nice to have" changes:

- std version comptime dispatches between a small integer-backed bitset,
  and a large array-backed one. We instead _assert_ that the bitset is
  reasonably small (if it isn't, you should use DynamicBitset, to avoid
  specializing on length).
- I decided to avoid odd-sized integers (eg, `u3`) as a backign integer
  for the bitset, to make sure we rely on simpler compiler machinery.
- It feels like we sometimes used a "flipped" bitset just to gain
  `findFirstSet`, now we rely on the natural empty semantics more often.
- I removed some extra API surface, like bidirectional iteration over
  set/unset. We _might_ end up adding it back later, but my hunch is
  that a minimal API would be enough.