### PR TITLE
vsr: fix VOPR false positive on release upgrade

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8626,6 +8626,14 @@ pub fn ReplicaType(
                     if (checkpoint.header.op == self.op_checkpoint()) {
                         self.sync_superblock_update_finish();
                         assert(self.syncing == .idle);
+                        if (self.release.value <
+                            self.superblock.working.vsr_state.checkpoint.release.value)
+                        {
+                            // sync_superblock_update_finish triggered `release_transition`,
+                            // short-circuite for VOPR.
+                            assert(Forest.Storage == TestStorage);
+                            return;
+                        }
                     }
                 },
                 else => {},


### PR DESCRIPTION
This fails in VOPR with `assert(storage.status != .resetting);` when inside `superblock.view_change`. What happens here is that state sync triggeres release_execute, but then replica daisy-chains a second superblock update

if (update_dvc or update_sv or update_checkpoint) self.view_durable_update();

This only happens in VOPR, where `release_execute` isn't actually noreturn. Propagate the return in this case.

I think we previously didn't hit this simply because we weren't asserting that repilcas do nothing after a release_execute.

Seed: ./zig/zig build vopr -Drelease -- --lite 12202402584754975833