### PR TITLE
vsr: fix crash in primary_repair_pipeline

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7278,11 +7278,21 @@ pub fn ReplicaType(
                 return;
             }
 
+            if (self.journal.find_latest_headers_break_between(self.commit_max, self.op)) |range| {
+                log.debug("{}: repair_pipeline_read_callback: header break {}..{}", .{
+                    self.replica,
+                    range.op_min,
+                    range.op_max,
+                });
+                return;
+            }
+
             // We are in a state where we should be repairing the pipeline (cf. the end of repair).
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) == self.replica);
             assert(self.commit_stage == .idle);
             assert(self.commit_min == self.commit_max);
+            assert(self.valid_hash_chain_between(self.commit_max, self.op));
 
             // But we still need to check that we are reparing the right prepare.
             const op = self.primary_repair_pipeline_op() orelse {


### PR DESCRIPTION
The last step of the repair for prospective primary is pipeline repair (loading prepares from WAL on disk into pipeline in memory). It is tricky because, when WAL read finishes, the replica might no longer be a primary!

So `repair_pipeline_read_callback` starts with a bunch of checks to ensure that we still should be repairing pipeline. It misses one case, when there's a header break betwene commit_max and op.

Seed: ./zig/zig build  vopr -Drelease -- 16932172197309204889