### PR TITLE
fuzz: remove global allocator

### DIFF
--- a/src/clients/c/tb_client/signal_fuzz.zig
+++ b/src/clients/c/tb_client/signal_fuzz.zig
@@ -24,7 +24,7 @@ const Context = struct {
     stop_request: Atomic = Atomic.init(.none),
 };
 
-pub fn main(args: fuzz.FuzzArgs) !void {
+pub fn main(_: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(args.seed);
     const events_max = args.events_max orelse 100;
 

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -4,7 +4,6 @@ const assert = std.debug.assert;
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
 const fuzz = @import("../testing/fuzz.zig");
-const allocator = fuzz.allocator;
 
 const TestTable = @import("cache_map.zig").TestTable;
 const TestCacheMap = @import("cache_map.zig").TestCacheMap;
@@ -36,12 +35,12 @@ const Environment = struct {
     cache_map: TestCacheMap,
     model: Model,
 
-    pub fn init(options: TestCacheMap.Options) !Environment {
-        var cache_map = try TestCacheMap.init(allocator, options);
-        errdefer cache_map.deinit(allocator);
+    pub fn init(gpa: std.mem.Allocator, options: TestCacheMap.Options) !Environment {
+        var cache_map = try TestCacheMap.init(gpa, options);
+        errdefer cache_map.deinit(gpa);
 
-        var model = Model.init();
-        errdefer model.deinit();
+        var model = Model.init(gpa);
+        errdefer model.deinit(gpa);
 
         return Environment{
             .cache_map = cache_map,
@@ -49,9 +48,9 @@ const Environment = struct {
         };
     }
 
-    pub fn deinit(self: *Environment) void {
+    pub fn deinit(self: *Environment, gpa: std.mem.Allocator) void {
         self.model.deinit();
-        self.cache_map.deinit(allocator);
+        self.cache_map.deinit(gpa);
     }
 
     pub fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
@@ -203,10 +202,10 @@ const Model = struct {
     scope_active: bool = false,
     compacts: u32 = 0,
 
-    fn init() Model {
+    fn init(gpa: std.mem.Allocator) Model {
         return .{
-            .map = Map.init(allocator),
-            .undo_log = UndoLog.init(allocator),
+            .map = Map.init(gpa),
+            .undo_log = UndoLog.init(gpa),
         };
     }
 
@@ -288,11 +287,15 @@ fn random_id(prng: *stdx.PRNG, comptime Int: type) Int {
     return fuzz.random_int_exponential(prng, Int, avg_int);
 }
 
-pub fn generate_fuzz_ops(prng: *stdx.PRNG, fuzz_op_count: usize) ![]const FuzzOp {
+pub fn generate_fuzz_ops(
+    gpa: std.mem.Allocator,
+    prng: *stdx.PRNG,
+    fuzz_op_count: usize,
+) ![]const FuzzOp {
     log.info("fuzz_op_count = {}", .{fuzz_op_count});
 
-    const fuzz_ops = try allocator.alloc(FuzzOp, fuzz_op_count);
-    errdefer allocator.free(fuzz_ops);
+    const fuzz_ops = try gpa.alloc(FuzzOp, fuzz_op_count);
+    errdefer gpa.free(fuzz_ops);
 
     const fuzz_op_weights = stdx.PRNG.EnumWeightsType(FuzzOpTag){
         // Always do puts, and always more puts than removes.
@@ -389,7 +392,7 @@ pub fn generate_fuzz_ops(prng: *stdx.PRNG, fuzz_op_count: usize) ![]const FuzzOp
     return fuzz_ops;
 }
 
-pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
+pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
     const fuzz_op_count = @min(
@@ -397,8 +400,8 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
         fuzz.random_int_exponential(&prng, usize, 1E8),
     );
 
-    const fuzz_ops = try generate_fuzz_ops(&prng, fuzz_op_count);
-    defer allocator.free(fuzz_ops);
+    const fuzz_ops = try generate_fuzz_ops(gpa, &prng, fuzz_op_count);
+    defer gpa.free(fuzz_ops);
 
     // Running the same fuzz with and without cache enabled.
     inline for (&.{ TestCacheMap.Cache.value_count_max_multiple, 0 }) |cache_value_count_max| {
@@ -409,8 +412,8 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
             .name = "fuzz map",
         };
 
-        var env = try Environment.init(options);
-        defer env.deinit();
+        var env = try Environment.init(gpa, options);
+        defer env.deinit(gpa);
 
         try env.apply(fuzz_ops);
         env.verify();

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -7,7 +7,6 @@ const constants = @import("../constants.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
-const allocator = fuzz.allocator;
 const ratio = stdx.PRNG.ratio;
 
 const log = std.log.scoped(.lsm_forest_fuzz);
@@ -122,17 +121,17 @@ const Environment = struct {
     ticks_remaining: usize,
     scan_lookup_buffer: []tb.Account,
 
-    fn init(env: *Environment, storage: *Storage) !void {
+    fn init(env: *Environment, gpa: std.mem.Allocator, storage: *Storage) !void {
         env.storage = storage;
 
-        env.trace = try vsr.trace.Tracer.init(allocator, 0, replica, .{});
+        env.trace = try vsr.trace.Tracer.init(gpa, 0, replica, .{});
 
-        env.superblock = try SuperBlock.init(allocator, .{
+        env.superblock = try SuperBlock.init(gpa, .{
             .storage = env.storage,
             .storage_size_limit = constants.storage_size_limit_default,
         });
 
-        env.grid = try Grid.init(allocator, .{
+        env.grid = try Grid.init(gpa, .{
             .superblock = &env.superblock,
             .trace = &env.trace,
             .missing_blocks_max = 0,
@@ -142,7 +141,7 @@ const Environment = struct {
                 Grid.free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
         });
 
-        env.scan_lookup_buffer = try allocator.alloc(
+        env.scan_lookup_buffer = try gpa.alloc(
             tb.Account,
             StateMachine.constants.batch_max.create_accounts,
         );
@@ -152,18 +151,18 @@ const Environment = struct {
         env.ticks_remaining = std.math.maxInt(usize);
     }
 
-    fn deinit(env: *Environment) void {
-        env.superblock.deinit(allocator);
-        env.grid.deinit(allocator);
-        env.trace.deinit(allocator);
-        allocator.free(env.scan_lookup_buffer);
+    fn deinit(env: *Environment, gpa: std.mem.Allocator) void {
+        env.superblock.deinit(gpa);
+        env.grid.deinit(gpa);
+        env.trace.deinit(gpa);
+        gpa.free(env.scan_lookup_buffer);
     }
 
-    pub fn run(storage: *Storage, fuzz_ops: []const FuzzOp) !void {
+    pub fn run(gpa: std.mem.Allocator, storage: *Storage, fuzz_ops: []const FuzzOp) !void {
         var env: Environment = undefined;
         env.state = .init;
-        try env.init(storage);
-        defer env.deinit();
+        try env.init(gpa, storage);
+        defer env.deinit(gpa);
 
         env.change_state(.init, .superblock_format);
         env.superblock.format(superblock_format_callback, &env.superblock_context, .{
@@ -174,10 +173,10 @@ const Environment = struct {
         });
         try env.tick_until_state_change(.superblock_format, .superblock_open);
 
-        try env.open();
-        defer env.close();
+        try env.open(gpa);
+        defer env.close(gpa);
 
-        try env.apply(fuzz_ops);
+        try env.apply(gpa, fuzz_ops);
     }
 
     fn change_state(env: *Environment, current_state: State, next_state: State) void {
@@ -196,14 +195,14 @@ const Environment = struct {
         assert(env.state == next_state);
     }
 
-    fn open(env: *Environment) !void {
+    fn open(env: *Environment, gpa: std.mem.Allocator) !void {
         env.superblock.open(superblock_open_callback, &env.superblock_context);
         try env.tick_until_state_change(.superblock_open, .free_set_open);
 
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
 
-        try env.forest.init(allocator, &env.grid, .{
+        try env.forest.init(gpa, &env.grid, .{
             // TODO Test that the same sequence of events applied to forests with different
             // compaction_blocks result in identical grids.
             .compaction_block_count = Forest.Options.compaction_block_count_min,
@@ -239,8 +238,8 @@ const Environment = struct {
         }
     }
 
-    fn close(env: *Environment) void {
-        env.forest.deinit(allocator);
+    fn close(env: *Environment, gpa: std.mem.Allocator) void {
+        env.forest.deinit(gpa);
     }
 
     fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
@@ -545,13 +544,13 @@ const Environment = struct {
         // Represents in-memory state:
         log: Log,
 
-        pub fn init() Model {
+        pub fn init(gpa: std.mem.Allocator) Model {
             return .{
                 .checkpointed = .{
-                    .objects = Map.init(allocator),
-                    .timestamps = Set.init(allocator),
+                    .objects = Map.init(gpa),
+                    .timestamps = Set.init(gpa),
                 },
-                .log = Log.init(allocator),
+                .log = Log.init(gpa),
             };
         }
 
@@ -621,8 +620,8 @@ const Environment = struct {
         }
     };
 
-    fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
-        var model = Model.init();
+    fn apply(env: *Environment, gpa: std.mem.Allocator, fuzz_ops: []const FuzzOp) !void {
+        var model = Model.init(gpa);
         defer model.deinit();
 
         for (fuzz_ops, 0..) |fuzz_op, fuzz_op_index| {
@@ -648,13 +647,13 @@ const Environment = struct {
             });
 
             // Apply fuzz_op to the forest and the model.
-            try env.apply_op(fuzz_op, &model);
+            try env.apply_op(gpa, fuzz_op, &model);
         }
 
         log.debug("Applied all ops", .{});
     }
 
-    fn apply_op(env: *Environment, fuzz_op: FuzzOp, model: *Model) !void {
+    fn apply_op(env: *Environment, gpa: std.mem.Allocator, fuzz_op: FuzzOp, model: *Model) !void {
         switch (fuzz_op.modifier) {
             .normal => {
                 env.ticks_remaining = std.math.maxInt(usize);
@@ -676,15 +675,15 @@ const Environment = struct {
                 env.ticks_remaining = std.math.maxInt(usize);
 
                 env.storage.log_pending_io();
-                env.close();
-                env.deinit();
+                env.close(gpa);
+                env.deinit(gpa);
                 env.storage.reset();
 
                 env.state = .init;
-                try env.init(env.storage);
+                try env.init(gpa, env.storage);
 
                 env.change_state(.init, .superblock_open);
-                try env.open();
+                try env.open(gpa);
 
                 // TODO: currently this checks that everything added to the LSM after checkpoint
                 // resets to the last checkpoint on crash by looking through what's been added
@@ -854,16 +853,20 @@ const Environment = struct {
     }
 };
 
-pub fn run_fuzz_ops(storage_options: Storage.Options, fuzz_ops: []const FuzzOp) !void {
+pub fn run_fuzz_ops(
+    gpa: std.mem.Allocator,
+    storage_options: Storage.Options,
+    fuzz_ops: []const FuzzOp,
+) !void {
     // Init mocked storage.
     var storage = try Storage.init(
-        allocator,
+        gpa,
         constants.storage_size_limit_default,
         storage_options,
     );
-    defer storage.deinit(allocator);
+    defer storage.deinit(gpa);
 
-    try Environment.run(&storage, fuzz_ops);
+    try Environment.run(gpa, &storage, fuzz_ops);
 }
 
 fn random_id(prng: *stdx.PRNG, comptime Int: type) Int {
@@ -877,11 +880,15 @@ fn random_id(prng: *stdx.PRNG, comptime Int: type) Int {
     return fuzz.random_int_exponential(prng, Int, avg_int);
 }
 
-pub fn generate_fuzz_ops(prng: *stdx.PRNG, fuzz_op_count: usize) ![]const FuzzOp {
+pub fn generate_fuzz_ops(
+    gpa: std.mem.Allocator,
+    prng: *stdx.PRNG,
+    fuzz_op_count: usize,
+) ![]const FuzzOp {
     log.info("fuzz_op_count = {}", .{fuzz_op_count});
 
-    const fuzz_ops = try allocator.alloc(FuzzOp, fuzz_op_count);
-    errdefer allocator.free(fuzz_ops);
+    const fuzz_ops = try gpa.alloc(FuzzOp, fuzz_op_count);
+    errdefer gpa.free(fuzz_ops);
 
     const action_weights = stdx.PRNG.EnumWeightsType(FuzzOpActionTag){
         // Maybe compact more often than forced to by `puts_since_compact`.
@@ -906,7 +913,7 @@ pub fn generate_fuzz_ops(prng: *stdx.PRNG, fuzz_op_count: usize) ![]const FuzzOp
 
     log.info("puts_since_compact_max = {}", .{Environment.puts_since_compact_max});
 
-    var id_to_account = std.hash_map.AutoHashMap(u128, Account).init(allocator);
+    var id_to_account = std.hash_map.AutoHashMap(u128, Account).init(gpa);
     defer id_to_account.deinit();
 
     var op: u64 = 1;
@@ -1097,7 +1104,7 @@ fn generate_put_account(
 
 const io_latency_mean = 20;
 
-pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
+pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
     const fuzz_op_count = @min(
@@ -1105,10 +1112,10 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
         fuzz.random_int_exponential(&prng, usize, 1E6),
     );
 
-    const fuzz_ops = try generate_fuzz_ops(&prng, fuzz_op_count);
-    defer allocator.free(fuzz_ops);
+    const fuzz_ops = try generate_fuzz_ops(gpa, &prng, fuzz_op_count);
+    defer gpa.free(fuzz_ops);
 
-    try run_fuzz_ops(Storage.Options{
+    try run_fuzz_ops(gpa, Storage.Options{
         .seed = prng.int(u64),
         .read_latency_min = 0,
         .read_latency_mean = 0 + fuzz.random_int_exponential(&prng, u64, io_latency_mean),

--- a/src/lsm/segmented_array_fuzz.zig
+++ b/src/lsm/segmented_array_fuzz.zig
@@ -1,7 +1,7 @@
+const std = @import("std");
 const fuzz = @import("../testing/fuzz.zig");
 const segmented_array = @import("segmented_array.zig");
 
-pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
-    const allocator = fuzz.allocator;
-    try segmented_array.run_fuzz(allocator, fuzz_args.seed, .{ .verify = true });
+pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
+    try segmented_array.run_fuzz(gpa, fuzz_args.seed, .{ .verify = true });
 }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -7,7 +7,6 @@ const constants = @import("../constants.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const vsr = @import("../vsr.zig");
 const schema = @import("schema.zig");
-const allocator = fuzz.allocator;
 const ratio = stdx.PRNG.ratio;
 
 const log = std.log.scoped(.lsm_tree_fuzz);
@@ -152,21 +151,26 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         pool: ResourcePool,
 
-        pub fn run(storage: *Storage, block_count: u32, fuzz_ops: []const FuzzOp) !void {
+        pub fn run(
+            gpa: std.mem.Allocator,
+            storage: *Storage,
+            block_count: u32,
+            fuzz_ops: []const FuzzOp,
+        ) !void {
             var env: Environment = undefined;
             env.state = .init;
             env.storage = storage;
 
-            env.trace = try vsr.trace.Tracer.init(allocator, 0, replica, .{});
-            defer env.trace.deinit(allocator);
+            env.trace = try vsr.trace.Tracer.init(gpa, 0, replica, .{});
+            defer env.trace.deinit(gpa);
 
-            env.superblock = try SuperBlock.init(allocator, .{
+            env.superblock = try SuperBlock.init(gpa, .{
                 .storage = env.storage,
                 .storage_size_limit = constants.storage_size_limit_default,
             });
-            defer env.superblock.deinit(allocator);
+            defer env.superblock.deinit(gpa);
 
-            env.grid = try Grid.init(allocator, .{
+            env.grid = try Grid.init(gpa, .{
                 .superblock = &env.superblock,
                 .trace = &env.trace,
                 .missing_blocks_max = 0,
@@ -176,10 +180,10 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 .blocks_released_prior_checkpoint_durability_max = Grid
                     .free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
             });
-            defer env.grid.deinit(allocator);
+            defer env.grid.deinit(gpa);
 
             try env.manifest_log.init(
-                allocator,
+                gpa,
                 &env.grid,
                 &ManifestLogPace.init(.{
                     .tree_count = 1,
@@ -187,28 +191,28 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     .compact_extra_blocks = constants.lsm_manifest_compact_extra_blocks,
                 }),
             );
-            defer env.manifest_log.deinit(allocator);
+            defer env.manifest_log.deinit(gpa);
 
-            try env.node_pool.init(allocator, node_count);
-            defer env.node_pool.deinit(allocator);
+            try env.node_pool.init(gpa, node_count);
+            defer env.node_pool.deinit(gpa);
 
             env.tree = undefined;
             env.lookup_value = null;
 
-            try env.scan_buffer.init(allocator, .{ .index = 0 });
-            defer env.scan_buffer.deinit(allocator);
+            try env.scan_buffer.init(gpa, .{ .index = 0 });
+            defer env.scan_buffer.deinit(gpa);
 
-            env.scan_results = try allocator.alloc(Value, scan_results_max);
+            env.scan_results = try gpa.alloc(Value, scan_results_max);
             env.scan_results_count = 0;
-            defer allocator.free(env.scan_results);
+            defer gpa.free(env.scan_results);
 
-            env.scan_results_model = try allocator.alloc(Value, scan_results_max);
-            defer allocator.free(env.scan_results_model);
+            env.scan_results_model = try gpa.alloc(Value, scan_results_max);
+            defer gpa.free(env.scan_results_model);
 
-            env.pool = try ResourcePool.init(allocator, block_count);
-            defer env.pool.deinit(allocator);
+            env.pool = try ResourcePool.init(gpa, block_count);
+            defer env.pool.deinit(gpa);
 
-            try env.open_then_apply(fuzz_ops);
+            try env.open_then_apply(gpa, fuzz_ops);
         }
 
         fn change_state(env: *Environment, current_state: State, next_state: State) void {
@@ -232,7 +236,11 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             assert(env.state == next_state);
         }
 
-        pub fn open_then_apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
+        pub fn open_then_apply(
+            env: *Environment,
+            gpa: std.mem.Allocator,
+            fuzz_ops: []const FuzzOp,
+        ) !void {
             env.change_state(.init, .superblock_format);
             env.superblock.format(superblock_format_callback, &env.superblock_context, .{
                 .cluster = cluster,
@@ -252,13 +260,13 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             // The first checkpoint is trivially durable.
             env.grid.free_set.mark_checkpoint_durable();
 
-            try env.tree.init(allocator, &env.node_pool, &env.grid, .{
+            try env.tree.init(gpa, &env.node_pool, &env.grid, .{
                 .id = 1,
                 .name = "Key.Value",
             }, .{
                 .batch_value_count_limit = commit_entries_max,
             });
-            defer env.tree.deinit(allocator);
+            defer env.tree.deinit(gpa);
 
             env.change_state(.tree_init, .manifest_log_open);
 
@@ -268,7 +276,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.tick_until_state_change(.manifest_log_open, .fuzzing);
             env.tree.open_complete();
 
-            try env.apply(fuzz_ops);
+            try env.apply(gpa, fuzz_ops);
         }
 
         fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
@@ -501,10 +509,10 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.scan_tree, .fuzzing);
         }
 
-        pub fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
+        pub fn apply(env: *Environment, gpa: std.mem.Allocator, fuzz_ops: []const FuzzOp) !void {
             var model: Model = undefined;
-            try model.init(table_usage);
-            defer model.deinit();
+            try model.init(gpa, table_usage);
+            defer model.deinit(gpa);
 
             var value_count: u64 = 0;
             for (fuzz_ops, 0..) |fuzz_op, fuzz_op_index| {
@@ -651,7 +659,7 @@ const Model = struct {
     node_pool: NodePool,
     array: Array,
 
-    fn init(model: *Model, table_usage: TableUsage) !void {
+    fn init(model: *Model, gpa: std.mem.Allocator, table_usage: TableUsage) !void {
         model.* = .{
             .table_usage = table_usage,
 
@@ -664,16 +672,16 @@ const Model = struct {
             NodePool.node_size,
         );
 
-        try model.node_pool.init(allocator, model_node_count);
-        errdefer model.node_pool.deinit(allocator);
+        try model.node_pool.init(gpa, model_node_count);
+        errdefer model.node_pool.deinit(gpa);
 
-        model.array = try Array.init(allocator);
-        errdefer model.array.deinit(allocator, &model.node_pool);
+        model.array = try Array.init(gpa);
+        errdefer model.array.deinit(gpa, &model.node_pool);
     }
 
-    fn deinit(model: *Model) void {
-        model.array.deinit(allocator, &model.node_pool);
-        model.node_pool.deinit(allocator);
+    fn deinit(model: *Model, gpa: std.mem.Allocator) void {
+        model.array.deinit(gpa, &model.node_pool);
+        model.node_pool.deinit(gpa);
         model.* = undefined;
     }
 
@@ -773,11 +781,15 @@ fn random_id(prng: *stdx.PRNG, comptime Int: type) Int {
     return fuzz.random_int_exponential(prng, Int, avg_int);
 }
 
-pub fn generate_fuzz_ops(prng: *stdx.PRNG, fuzz_op_count: usize) ![]const FuzzOp {
+pub fn generate_fuzz_ops(
+    gpa: std.mem.Allocator,
+    prng: *stdx.PRNG,
+    fuzz_op_count: usize,
+) ![]const FuzzOp {
     log.info("fuzz_op_count = {}", .{fuzz_op_count});
 
-    const fuzz_ops = try allocator.alloc(FuzzOp, fuzz_op_count);
-    errdefer allocator.free(fuzz_ops);
+    const fuzz_ops = try gpa.alloc(FuzzOp, fuzz_op_count);
+    errdefer gpa.free(fuzz_ops);
 
     const fuzz_op_weights = stdx.PRNG.EnumWeightsType(FuzzOpTag){
         // Maybe compact more often than forced to by `puts_since_compact`.
@@ -872,20 +884,20 @@ fn generate_compact(
     } };
 }
 
-pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
+pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
     const table_usage = prng.enum_uniform(TableUsage);
     log.info("table_usage={}", .{table_usage});
 
-    var storage_fault_atlas = try ClusterFaultAtlas.init(allocator, 3, &prng, .{
+    var storage_fault_atlas = try ClusterFaultAtlas.init(gpa, 3, &prng, .{
         .faulty_superblock = false,
         .faulty_wal_headers = false,
         .faulty_wal_prepares = false,
         .faulty_client_replies = false,
         .faulty_grid = true,
     });
-    defer storage_fault_atlas.deinit(allocator);
+    defer storage_fault_atlas.deinit(gpa);
 
     const storage_options: Storage.Options = .{
         .seed = prng.int(u64),
@@ -912,20 +924,20 @@ pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
         fuzz.random_int_exponential(&prng, usize, 1E6),
     );
 
-    const fuzz_ops = try generate_fuzz_ops(&prng, fuzz_op_count);
-    defer allocator.free(fuzz_ops);
+    const fuzz_ops = try generate_fuzz_ops(gpa, &prng, fuzz_op_count);
+    defer gpa.free(fuzz_ops);
 
     // Init mocked storage.
     var storage = try Storage.init(
-        allocator,
+        gpa,
         constants.storage_size_limit_default,
         storage_options,
     );
-    defer storage.deinit(allocator);
+    defer storage.deinit(gpa);
 
     switch (table_usage) {
         inline else => |usage| {
-            try EnvironmentType(usage).run(&storage, block_count, fuzz_ops);
+            try EnvironmentType(usage).run(gpa, &storage, block_count, fuzz_ops);
         },
     }
 

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -9,7 +9,7 @@ const Storage = @import("storage.zig").StorageType(IO);
 const fuzz = @import("testing/fuzz.zig");
 const ratio = stdx.PRNG.ratio;
 
-pub fn main(args: fuzz.FuzzArgs) !void {
+pub fn main(_: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
     const zones: []const vsr.Zone = &.{
         .superblock,
         .wal_headers,

--- a/src/testing/fuzz.zig
+++ b/src/testing/fuzz.zig
@@ -5,11 +5,6 @@ const stdx = @import("../stdx.zig");
 const assert = std.debug.assert;
 const PRNG = stdx.PRNG;
 
-// Use our own allocator in the global scope instead of testing.allocator
-// as the latter now @compileError()'s if referenced outside a `test` block.
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-pub const allocator = gpa.allocator();
-
 /// Returns an integer of type `T` with an exponential distribution of rate `avg`.
 /// Note: If you specify a very high rate then `std.math.maxInt(T)` may be over-represented.
 pub fn random_int_exponential(prng: *stdx.PRNG, comptime T: type, avg: T) T {

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -2593,7 +2593,7 @@ pub fn format_wal_headers(cluster: u128, offset_logical: u64, target: []u8) usiz
 
 test "format_wal_headers" {
     const fuzz = @import("./journal_format_fuzz.zig");
-    try fuzz.fuzz_format_wal_headers(constants.sector_size);
+    try fuzz.fuzz_format_wal_headers(std.testing.allocator, constants.sector_size);
 }
 
 /// Format part of a new WAL's Zone.wal_prepares, writing to `target`.
@@ -2640,5 +2640,5 @@ pub fn format_wal_prepares(cluster: u128, offset_logical: u64, target: []u8) usi
 
 test "format_wal_prepares" {
     const fuzz = @import("./journal_format_fuzz.zig");
-    try fuzz.fuzz_format_wal_prepares(256 * 1024);
+    try fuzz.fuzz_format_wal_prepares(std.testing.allocator, 256 * 1024);
 }

--- a/src/vsr/superblock_quorums_fuzz.zig
+++ b/src/vsr/superblock_quorums_fuzz.zig
@@ -13,7 +13,7 @@ const fuzz = @import("../testing/fuzz.zig");
 const superblock_quorums = @import("superblock_quorums.zig");
 const QuorumsType = superblock_quorums.QuorumsType;
 
-pub fn main(fuzz_args: fuzz.FuzzArgs) !void {
+pub fn main(_: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
     // TODO When there is a top-level fuzz.zig main(), split these fuzzers into two different


### PR DESCRIPTION
There's no reason for us to use a global allocator during fuzzing. Let's align this more with TigerStyle and pass the allocator explicitly: it's not really any more code, but it makes it clear where the allocation can happen, and where we are violating "allocate only during startup" rule, which is not _critical_ for fuzzing, but helps non-the-less!