### PR TITLE
vopr: re-do tickless VOPR

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -649,7 +649,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 maybe(replica.release.value < release.value);
             }
 
-            cluster.storages[replica.replica].reset_soon();
+            cluster.storages[replica.replica].reset();
             cluster.replica_upgrades[replica.replica] = release;
         }
 

--- a/src/testing/fuzz.zig
+++ b/src/testing/fuzz.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const stdx = @import("../stdx.zig");
 const assert = std.debug.assert;
 const PRNG = stdx.PRNG;
+const ratio = stdx.PRNG.ratio;
 
 /// Returns an integer of type `T` with an exponential distribution of rate `avg`.
 /// Note: If you specify a very high rate then `std.math.maxInt(T)` may be over-represented.
@@ -70,5 +71,110 @@ pub fn parse_seed(bytes: []const u8) u64 {
     return std.fmt.parseUnsigned(u64, bytes, 10) catch |err| switch (err) {
         error.Overflow => @panic("seed exceeds a 64-bit unsigned integer"),
         error.InvalidCharacter => @panic("seed contains an invalid character"),
+    };
+}
+
+/// A queue for tracking work to be executed at a particular tick.
+pub fn ReadyQueueType(T: type) type {
+    return struct {
+        queue: Queue,
+
+        const Queue = std.PriorityQueue(T, void, order_by_ready_at);
+        fn order_by_ready_at(_: void, lhs: T, rhs: T) std.math.Order {
+            return std.math.order(lhs.ready_at_tick, rhs.ready_at_tick);
+        }
+
+        const ReadyQueue = @This();
+
+        pub fn init(gpa_allocator: std.mem.Allocator, capacity: usize) !ReadyQueue {
+            var result: ReadyQueue = .{
+                .queue = Queue.init(gpa_allocator, {}),
+            };
+            try result.queue.ensureTotalCapacity(capacity);
+            return result;
+        }
+
+        pub fn deinit(ready: *ReadyQueue, _: std.mem.Allocator) void {
+            ready.queue.deinit();
+            ready.* = undefined;
+        }
+
+        pub fn reset(ready: *ReadyQueue) void {
+            ready.queue.items.len = 0;
+        }
+
+        pub fn add(ready: *ReadyQueue, item: T) void {
+            assert(ready.queue.count() < ready.queue.capacity());
+            ready.queue.add(item) catch |err| switch (err) {
+                error.OutOfMemory => unreachable,
+            };
+        }
+
+        pub fn remove_ready(ready: *ReadyQueue, prng: *stdx.PRNG, tick: u64) ?T {
+            const top = ready.queue.peek() orelse return null;
+            if (top.ready_at_tick > tick) return null;
+
+            const root = ready.pick_random_ready(prng, tick, 0);
+            assert(root.count > 0);
+            assert(root.pick < ready.queue.items.len);
+
+            const result = ready.queue.removeIndex(root.pick);
+            assert(result.ready_at_tick <= tick);
+            return result;
+        }
+
+        pub fn remove_random(ready: *ReadyQueue, prng: *stdx.PRNG) ?T {
+            if (ready.count() == 0) return null;
+            const index = prng.index(ready.queue.items);
+            return ready.queue.removeIndex(index);
+        }
+
+        // All items in the queue, in an unspecified order.
+        pub fn slice(ready: *ReadyQueue) []T {
+            return ready.queue.items;
+        }
+
+        // All items in the queue, in an unspecified order.
+        pub fn const_slice(ready: *const ReadyQueue) []const T {
+            return ready.queue.items;
+        }
+
+        pub fn count(ready: *ReadyQueue) usize {
+            return ready.queue.items.len;
+        }
+
+        // For a subtree rooted at index, return the total number of items in the subtree as
+        // well as an index of a randomly uniformly drawn ready item.
+        //
+        // The implementation relies on a particular layout of std.PriorityQueue, and might require
+        // vendoring it in the future.
+        const SubtreePick = struct { pick: usize, count: usize };
+        fn pick_random_ready(
+            ready: *const ReadyQueue,
+            prng: *stdx.PRNG,
+            tick: u64,
+            index: usize,
+        ) SubtreePick {
+            if (index >= ready.queue.items.len or ready.queue.items[index].ready_at_tick > tick) {
+                return .{
+                    .pick = undefined,
+                    .count = 0,
+                };
+            }
+            assert(ready.queue.items[index].ready_at_tick <= tick);
+
+            // Reservoir-ish sampling: replace our pick from the one from subtree, with probability
+            // proportional to subtree's size.
+            var result: SubtreePick = .{ .pick = index, .count = 1 };
+            inline for (.{ index * 2 + 1, index * 2 + 2 }) |index_child| {
+                const subtree = ready.pick_random_ready(prng, tick, index_child);
+                if (prng.chance(ratio(subtree.count, result.count + subtree.count))) {
+                    result.pick = subtree.pick;
+                }
+                result.count += subtree.count;
+            }
+
+            return result;
+        }
     };
 }

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -221,12 +221,10 @@ const Environment = struct {
         assert(!env.pending_verify);
         assert(env.pending.contains(.view_change) == env.superblock.updating(.view_change));
 
-        const write = env.superblock.storage.writes.peek();
-        env.superblock.storage.run();
-
-        if (write) |w| {
-            if (w.done_at_tick <= env.superblock.storage.ticks) try env.verify();
+        while (env.superblock.storage.step()) {
+            try env.verify();
         }
+        env.superblock.storage.tick();
     }
 
     /// Verify that the superblock will recover safely if the replica crashes immediately after


### PR DESCRIPTION
This is a second take at https://github.com/tigerbeetle/tigerbeetle/pull/2823. The idea is the same: with many IOPs
ready at any given tick, we want to randomize the order in which IOPs
are executed.

The implementation is different --- rather than collecting a list of
ready IOPS and shuflling it, I add a helper function to pick a random
IOP directly off the queue. This keeps the queue as the real source of
truth about pending operations.

The "source of truth property" is important:

* For upgrades, where we clear the queue and expect that that removes
  all operations.
* For packet simulator, where we size message pool accoring to the size
  of the queue.