### PR TITLE
ci: block merging based on devhub pipeline result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
   core-pipeline:
     if: always() && github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    needs: [smoke, test_alpine, test_ubuntu, test_aof, test_windows, test_macos, clients]
+    needs: [smoke, test_alpine, test_ubuntu, test_aof, test_windows, test_macos, clients, devhub]
     steps:
       - if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0


### PR DESCRIPTION
Fixes that #2840 got merged, even though the devhub check was failing.

(I'll fix that shortly too, just want to ensure that this works!)