### PR TITLE
tidy: fix off by one

### DIFF
--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -39,7 +39,7 @@ test "tidy" {
     // to read the files once.
     for (paths) |path| {
         const bytes_read = (try std.fs.cwd().readFile(path, buffer)).len;
-        if (bytes_read == buffer.len - 1) return error.FileTooLong;
+        if (bytes_read >= buffer.len - 1) return error.FileTooLong;
         buffer[bytes_read] = 0;
 
         const source_file = SourceFile{ .path = path, .text = buffer[0..bytes_read :0] };


### PR DESCRIPTION
bytes_read is a count, not an index, we don't neeed -1 there.

Found on the stream: https://www.youtube.com/live/Lvp3Le7R3OM?feature=shared&t=3375