### PR TITLE
Update correcting-transfers.md example

### DIFF
--- a/docs/coding/recipes/correcting-transfers.md
+++ b/docs/coding/recipes/correcting-transfers.md
@@ -35,7 +35,7 @@ Two specific recommendations for correcting transfers are:
 
 ### Example
 
-Let's say you had a couple of transfers, from account `A` to accounts `Y` and `Z`:
+Let's say you had a couple of transfers, from account `A` to accounts `X` and `Y`:
 
 | Ledger | Debit Account | Credit Account | Amount | `code` | `user_data_128` | `flags.linked` |
 | -----: | ------------: | -------------: | -----: | -----: | --------------: | -------------: |


### PR DESCRIPTION
## Description
The transfers are happening from account `A` to accounts `X` and `Y`.
But in the explanation it says to accounts `Y` and `Z`
<img width="847" alt="Screenshot 2025-03-27 at 2 11 45 PM" src="https://github.com/user-attachments/assets/b41d36c6-18e8-456b-b4a6-c512b9468f38" />

## Changes Proposed 

Corrected Example wordings in correcting-transfers.md 

- Let's say you had a couple of transfers, from account A to accounts X and Y: