### PR TITLE
[Fix] AccountFilter and QueryFilter timestamp range

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1158,7 +1158,7 @@ public class IntegrationTests
             {
                 AccountId = accounts[1].Id,
                 TimestampMin = 1,
-                TimestampMax = ulong.MaxValue - 1,
+                TimestampMax = 0,
                 Limit = 254,
                 Flags = AccountFilterFlags.Credits | AccountFilterFlags.Reversed
             };
@@ -1341,7 +1341,7 @@ public class IntegrationTests
             filter = new AccountFilter
             {
                 AccountId = accounts[0].Id,
-                TimestampMin = ulong.MaxValue - 1,
+                TimestampMin = 2,
                 TimestampMax = 1,
                 Limit = 254,
                 Flags = AccountFilterFlags.Credits | AccountFilterFlags.Debits,

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -1530,6 +1530,7 @@ public class IntegrationTest {
             }
         }
 
+
         {
             // Querying transfers where:
             // `credit_account_id=$account2Id
@@ -1537,7 +1538,7 @@ public class IntegrationTest {
             final var filter = new AccountFilter();
             filter.setAccountId(account2Id);
             filter.setTimestampMin(1);
-            filter.setTimestampMax(-2L); // -2L == ulong max - 1
+            filter.setTimestampMax(0);
             filter.setLimit(254);
             filter.setDebits(false);
             filter.setCredits(true);
@@ -1722,8 +1723,36 @@ public class IntegrationTest {
             // Invalid timestamp min > max:
             final var filter = new AccountFilter();
             filter.setAccountId(account2Id);
-            filter.setTimestampMin(-2L); // -2L == ulong max - 1
+            filter.setTimestampMin(2);
             filter.setTimestampMax(1);
+            filter.setLimit(254);
+            filter.setDebits(true);
+            filter.setCredits(true);
+            filter.setReversed(false);
+            assertTrue(client.getAccountTransfersAsync(filter).get().getLength() == 0);
+            assertTrue(client.getAccountBalancesAsync(filter).get().getLength() == 0);
+        }
+
+        {
+            // Invalid negative timestamp_min:
+            final var filter = new AccountFilter();
+            filter.setAccountId(account2Id);
+            filter.setTimestampMin(-123123130);
+            filter.setTimestampMax(0);
+            filter.setLimit(254);
+            filter.setDebits(true);
+            filter.setCredits(true);
+            filter.setReversed(false);
+            assertTrue(client.getAccountTransfersAsync(filter).get().getLength() == 0);
+            assertTrue(client.getAccountBalancesAsync(filter).get().getLength() == 0);
+        }
+
+        {
+            // Invalid negative timestamp_max:
+            final var filter = new AccountFilter();
+            filter.setAccountId(account2Id);
+            filter.setTimestampMin(0);
+            filter.setTimestampMax(-123123130);
             filter.setLimit(254);
             filter.setDebits(true);
             filter.setCredits(true);
@@ -2120,6 +2149,27 @@ public class IntegrationTest {
             assertTrue(client.queryAccountsAsync(filter).get().getLength() == 0);
             assertTrue(client.queryTransfersAsync(filter).get().getLength() == 0);
         }
+
+        {
+            // Invalid negative timestamp_min:
+            final var filter = new QueryFilter();
+            filter.setTimestampMin(-123123130);
+            filter.setTimestampMax(0);
+            filter.setLimit(254);
+            assertTrue(client.queryAccountsAsync(filter).get().getLength() == 0);
+            assertTrue(client.queryTransfersAsync(filter).get().getLength() == 0);
+        }
+
+        {
+            // Invalid negative timestamp_max:
+            final var filter = new QueryFilter();
+            filter.setTimestampMin(0);
+            filter.setTimestampMax(-123123130);
+            filter.setLimit(254);
+            assertTrue(client.queryAccountsAsync(filter).get().getLength() == 0);
+            assertTrue(client.queryTransfersAsync(filter).get().getLength() == 0);
+        }
+
     }
 
     @Test

--- a/src/lsm/timestamp_range.zig
+++ b/src/lsm/timestamp_range.zig
@@ -32,4 +32,9 @@ pub const TimestampRange = struct {
             .max = final,
         };
     }
+
+    pub inline fn valid(timestamp: u64) bool {
+        return timestamp >= timestamp_min and
+            timestamp <= timestamp_max;
+    }
 };

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1314,8 +1314,8 @@ pub fn StateMachineType(
 
             const filter_valid =
                 filter.account_id != 0 and filter.account_id != std.math.maxInt(u128) and
-                filter.timestamp_min != std.math.maxInt(u64) and
-                filter.timestamp_max != std.math.maxInt(u64) and
+                (filter.timestamp_min == 0 or TimestampRange.valid(filter.timestamp_min)) and
+                (filter.timestamp_max == 0 or TimestampRange.valid(filter.timestamp_max)) and
                 (filter.timestamp_max == 0 or filter.timestamp_min <= filter.timestamp_max) and
                 filter.limit != 0 and
                 (filter.flags.credits or filter.flags.debits) and
@@ -1595,8 +1595,8 @@ pub fn StateMachineType(
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
 
             const filter_valid =
-                filter.timestamp_min != std.math.maxInt(u64) and
-                filter.timestamp_max != std.math.maxInt(u64) and
+                (filter.timestamp_min == 0 or TimestampRange.valid(filter.timestamp_min)) and
+                (filter.timestamp_max == 0 or TimestampRange.valid(filter.timestamp_max)) and
                 (filter.timestamp_max == 0 or filter.timestamp_min <= filter.timestamp_max) and
                 filter.limit != 0 and
                 filter.flags.padding == 0 and


### PR DESCRIPTION
Improper validation of timestamps from query filters (`get_account_{transfers,balances}` and `query_{accounts,transfers}`) could cause the replica to crash if a value greater than a `u63` was provided. (The last bit of the timestamp is reserved for the tombstone flag.)