### PR TITLE
clients: remove dependency on libc from the C client

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -917,7 +917,6 @@ fn build_vortex(
         .target = options.target,
         .optimize = options.mode,
     });
-    tb_client.linkLibC();
     tb_client.pie = true;
     tb_client.bundle_compiler_rt = true;
     tb_client.root_module.addImport("vsr", options.vsr_module);
@@ -935,7 +934,6 @@ fn build_vortex(
     });
 
     vortex.root_module.omit_frame_pointer = false;
-    vortex.linkLibC();
     vortex.linkLibrary(tb_client);
     vortex.addIncludePath(options.tb_client_header.dirname());
     vortex.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1017,7 +1015,6 @@ fn build_go_client(
             .target = resolved_target,
             .optimize = options.mode,
         });
-        lib.linkLibC();
         lib.pie = true;
         lib.bundle_compiler_rt = true;
         lib.root_module.stack_protector = false;
@@ -1123,7 +1120,6 @@ fn build_dotnet_client(
             .target = resolved_target,
             .optimize = options.mode,
         });
-        lib.linkLibC();
 
         if (resolved_target.result.os.tag == .windows) {
             lib.linkSystemLibrary("ws2_32");
@@ -1277,7 +1273,6 @@ fn build_python_client(
             .target = resolved_target,
             .optimize = options.mode,
         });
-        shared_lib.linkLibC();
 
         if (resolved_target.result.os.tag == .windows) {
             shared_lib.linkSystemLibrary("ws2_32");
@@ -1336,8 +1331,6 @@ fn build_c_client(
         static_lib.pie = true;
 
         for ([_]*std.Build.Step.Compile{ shared_lib, static_lib }) |lib| {
-            lib.linkLibC();
-
             if (resolved_target.result.os.tag == .windows) {
                 lib.linkSystemLibrary("ws2_32");
                 lib.linkSystemLibrary("advapi32");
@@ -1371,7 +1364,6 @@ fn build_clients_c_sample(
         .target = options.target,
         .optimize = options.mode,
     });
-    static_lib.linkLibC();
     static_lib.pie = true;
     static_lib.bundle_compiler_rt = true;
     static_lib.root_module.addImport("vsr", options.vsr_module);

--- a/src/clients/c/tb_client_exports.zig
+++ b/src/clients/c/tb_client_exports.zig
@@ -5,6 +5,10 @@ const vsr = @import("../../vsr.zig");
 const tb = vsr.tb_client;
 const stdx = vsr.stdx;
 
+var global_allocator: std.heap.GeneralPurposeAllocator(.{
+    .thread_safe = true,
+}) = .{};
+
 pub const tb_packet_t = tb.Packet;
 pub const tb_packet_status = tb.PacketStatus;
 
@@ -108,7 +112,7 @@ pub fn init(
     };
 
     tb.init(
-        std.heap.c_allocator,
+        global_allocator.allocator(),
         tb_client_out.cast(),
         cluster_id,
         addresses,
@@ -135,9 +139,8 @@ pub fn init_echo(
 
         break :blk cluster_id;
     };
-
     tb.init_echo(
-        std.heap.c_allocator,
+        global_allocator.allocator(),
         tb_client_out.cast(),
         cluster_id,
         addresses,

--- a/src/tigerbeetle/libtb_client.zig
+++ b/src/tigerbeetle/libtb_client.zig
@@ -1,7 +1,6 @@
 //! Entry point for exporting the `tb_client` library.
 //! Used by language clients that rely on the shared or static library exposed by `tb_client.h`.
 //! For an idiomatic Zig API, use `vsr.tb_client` directly instead.
-const builtin = @import("builtin");
 const std = @import("std");
 
 pub const vsr = @import("vsr");
@@ -13,10 +12,6 @@ pub const std_options: std.Options = .{
 };
 
 comptime {
-    if (!builtin.link_libc) {
-        @compileError("Must be built with libc to export tb_client symbols.");
-    }
-
     @export(exports.init, .{ .name = "tb_client_init", .linkage = .strong });
     @export(exports.init_echo, .{ .name = "tb_client_init_echo", .linkage = .strong });
     @export(exports.submit, .{ .name = "tb_client_submit", .linkage = .strong });


### PR DESCRIPTION
We only need libc for an allocator, and, given that we don't allocate after startup, we don't need a good alocator, anything would do!

So let's just use GPA!

We could further improve this by using per-client allocator with leak checking, but let's do things step-by-step, my primary goal here is reducing dimensionality via removing dependency on external code (libc).