### PR TITLE
vsr: call hook into vopr while sending message to client

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1158,19 +1158,6 @@ pub const Simulator = struct {
     pub fn core_missing_reply(simulator: *const Simulator) ?vsr.Header.Reply {
         assert(simulator.core.count() > 0);
 
-        var replies_latest = [_]?vsr.Header.Reply{null} ** constants.clients_max;
-        for (simulator.cluster.replicas) |replica| {
-            for (replica.client_sessions.entries, 0..) |entry, entry_slot| {
-                if (entry.session != 0) {
-                    if (replies_latest[entry_slot] == null or
-                        replies_latest[entry_slot].?.op < entry.header.op)
-                    {
-                        replies_latest[entry_slot] = entry.header;
-                    }
-                }
-            }
-        }
-
         for (simulator.cluster.state_checker.client_replies.values()) |reply| {
             const reply_in_core = reply_in_core: for (simulator.cluster.replicas) |replica| {
                 const storage = &simulator.cluster.storages[replica.replica];

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8115,6 +8115,11 @@ pub fn ReplicaType(
             assert(reply.header.command == .reply);
             assert(reply.header.view <= self.view);
             assert(reply.header.client != 0);
+            defer {
+                if (self.event_callback) |hook| {
+                    hook(self, .{ .message_sent = reply.base() });
+                }
+            }
 
             // If the request committed in a different view than the one it was originally prepared
             // in, we must inform the client about this newer view before we send it a reply.


### PR DESCRIPTION
In 5de082c227b4ebb72aa11945a132004cb0bc5e26, we added new logic to track replies based on when they are externalized from replica to client. Turns out this new logic was not being exercised at all, since we only call the hook into the VOPR when messages are sent to other replicas, not when they are sent to the client!

Fix it by calling the hook when messages are sent to the client, this would lead to reply messages getting appropriately tracked.

Seed: ./zig/zig build -Drelease vopr -Dvopr-state-machine=testing -- 10711934386281284252