### PR TITLE
vopr: simplify time handling

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -367,6 +367,7 @@ const Command = struct {
 
         const trace_writer = if (trace_file) |file| file.writer() else null;
 
+        var time: Time = .{};
         var replica: Replica = undefined;
         replica.open(allocator, .{
             .node_count = args.addresses.count_as(u8),
@@ -381,7 +382,7 @@ const Command = struct {
             .aof = if (aof != null) &aof.? else null,
             .message_pool = &message_pool,
             .nonce = nonce,
-            .time = .{},
+            .time = &time,
             .timeout_prepare_ticks = args.timeout_prepare_ticks,
             .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
             .state_machine_options = .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -258,7 +258,7 @@ pub fn ReplicaType(
         /// Presently, it is used to detect outdated start view messages in recovering head status.
         nonce: Nonce,
 
-        time: Time,
+        time: *Time,
 
         /// A distributed fault-tolerant clock for lower and upper bounds on the primary's wall
         /// clock:
@@ -578,7 +578,7 @@ pub fn ReplicaType(
             storage: *Storage,
             message_pool: *MessagePool,
             nonce: Nonce,
-            time: Time,
+            time: *Time,
             aof: ?*AOF,
             state_machine_options: StateMachine.Options,
             message_bus_options: MessageBus.Options,
@@ -1001,7 +1001,7 @@ pub fn ReplicaType(
             replica_index: u8,
             pipeline_requests_limit: u32,
             nonce: Nonce,
-            time: Time,
+            time: *Time,
             storage: *Storage,
             aof: ?*AOF,
             message_pool: *MessagePool,
@@ -1078,7 +1078,7 @@ pub fn ReplicaType(
             //   - a standby clock tracks active replicas and the standby itself.
             self.clock = try Clock.init(
                 allocator,
-                &self.time,
+                self.time,
                 if (replica_index < replica_count) .{
                     .replica_count = replica_count,
                     .replica = replica_index,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -258,8 +258,6 @@ pub fn ReplicaType(
         /// Presently, it is used to detect outdated start view messages in recovering head status.
         nonce: Nonce,
 
-        time: *Time,
-
         /// A distributed fault-tolerant clock for lower and upper bounds on the primary's wall
         /// clock:
         clock: Clock,
@@ -1066,8 +1064,6 @@ pub fn ReplicaType(
             assert(request_size_limit <= constants.message_size_max);
             assert(request_size_limit > @sizeOf(Header));
 
-            self.time = options.time;
-
             // The clock is special-cased for standbys. We want to balance two concerns:
             //   - standby clock should never affect cluster time,
             //   - standby should have up-to-date clock, such that it can quickly join the cluster
@@ -1078,7 +1074,7 @@ pub fn ReplicaType(
             //   - a standby clock tracks active replicas and the standby itself.
             self.clock = try Clock.init(
                 allocator,
-                self.time,
+                options.time,
                 if (replica_index < replica_count) .{
                     .replica_count = replica_count,
                     .replica = replica_index,
@@ -1187,9 +1183,6 @@ pub fn ReplicaType(
                 .release_execute = options.release_execute,
                 .release_execute_context = options.release_execute_context,
                 .nonce = options.nonce,
-                // Copy the (already-initialized) time back, to avoid regressing the monotonic
-                // clock guard.
-                .time = self.time,
                 .clock = self.clock,
                 .journal = self.journal,
                 .client_sessions = client_sessions,


### PR DESCRIPTION
I don't see a strong reason why Replica must own the time. Injecting it as a pointer feels simpler.