### PR TITLE
zig: build ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: shellcheck ./zig/download.sh
-      - run: ./zig/download.sh
-      - run: ./zig/zig fmt --check .
-      - run: ./zig/zig build check
-      - run: ./zig/zig build scripts -- ci --build-docs
+      - run: ./zig/download.ps1 && ./zig/zig build ci -- smoke
+
+  test:
+    strategy:
+      matrix:
+        include:
+          - { os: 'ubuntu-latest' }
+          - { os: 'ubuntu-latest-arm64' }
+          - { os: 'windows-latest' }
+          - { os: 'macos-latest' }
+          - { os: 'macos-13' }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: git config --global core.autocrlf false
+      - if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-latest-arm64'
+        run: | # Allow unshare for vortex.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2147483647 } # Fetch full history for tidy.
+      - run: ./zig/download.ps1 && ./zig/zig build ci -- test
 
   test_alpine:
     runs-on: ubuntu-latest
@@ -36,71 +53,15 @@ jobs:
       # https://github.com/actions/checkout/issues/1169
       - run: git config --system --add safe.directory '*'
       - uses: actions/checkout@v4
-        # Fetch the entire history of the commit in question for tidy.
-        with:
-          fetch-depth: 2147483647
-      - run: ./zig/download.sh
-      - run: ./zig/zig build test
-
-  test_ubuntu:
-    strategy:
-      matrix:
-        include:
-          - { os: 'ubuntu-latest' }
-          - { os: 'ubuntu-latest-arm64' }
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2147483647
-      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
-      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      - run: ./zig/download.sh
-      - run: ./zig/zig build test
-      - run: ./zig/zig build clients:c:sample -Drelease
-      - run: ./zig/zig build fuzz -- smoke
-      # Run simulator once for each state machine, using commit hash as a random, but also deterministic
-      # seed.
-      - run: ./zig/zig build vopr -Dvopr-state-machine=accounting -Drelease -- ${{ github.sha }}
-      - run: ./zig/zig build vopr -Dvopr-state-machine=testing    -Drelease -- ${{ github.sha }}
+        with: { fetch-depth: 2147483647 }
+      - run: ./zig/download.ps1 && ./zig/zig build ci -- test
 
   test_aof:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2147483647
-      - run: ./zig/download.sh
-      - run: ./.github/ci/test_aof.sh
-
-  test_windows:
-    runs-on: windows-latest
-    steps:
-      - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2147483647
-      - run: .\zig\download.bat
-      - run: .\zig\zig build test
-      - run: .\zig\zig build clients:c:sample
-
-  test_macos:
-    strategy:
-      matrix:
-        include:
-          - { os: 'macos-latest' }
-          - { os: 'macos-13' }
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2147483647
-      - run: ./zig/download.sh
-      - run: ./zig/zig build test
-      - run: ./zig/zig build clients:c:sample -Drelease
-
+        with: { fetch-depth: 2147483647 }
+      - run: ./zig/download.ps1 && ./zig/zig build ci -- aof
 
   clients:
     strategy:
@@ -149,34 +110,27 @@ jobs:
 
       - if: matrix.language == 'dotnet'
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.language_version }}
+        with: { dotnet-version: "${{ matrix.language_version }}" }
 
       - if: matrix.language == 'go'
         uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.language_version }}
+        with: { go-version: "${{ matrix.language_version }}" }
 
       - if: matrix.language == 'java'
         uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.language_version }}
-          distribution: 'temurin'
+        with: { java-version: "${{ matrix.language_version }}", distribution: 'temurin' }
 
       - if: matrix.language == 'node'
         uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.language_version }}
+        with: { node-version: "${{ matrix.language_version }}" }
 
       - if: matrix.language == 'python'
         uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.language_version }}
+        with: { python-version: "${{ matrix.language_version }}" }
       - if: matrix.language == 'python'
         run: pip install build hatch pytest
 
-      - run: ./zig/download.${{ matrix.os == 'windows-latest' && 'bat' || 'sh' }}
-      - run: ./zig/zig build scripts -- ci --language=${{ matrix.language }}
+      - run: ./zig/download.ps1 && ./zig/zig build ci -- ${{ matrix.language }}
 
   devhub:
     runs-on: ubuntu-22.04
@@ -187,35 +141,34 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2147483647
+        with: { fetch-depth: 2147483647 }
       - run: sudo apt-get update && sudo apt-get install -y kcov
-      - run: ./zig/download.sh
+      - run: ./zig/download.ps1
 
       # Dummy devhub run - checks that all the devhub tests pass in CI. They are run again, in main
       # once merged. Kcov is skipped to avoid adding to the pipeline time.
-      - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }} --skip-kcov
-        if: github.ref != 'refs/heads/main'
+      - if: github.ref != 'refs/heads/main'
+        run: sudo -E ./zig/zig build ci -- devhub-dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Not providing DEVHUBDB_PAT and NYRKIO_TOKEN stops devhub from uploading its results, but
           # it still runs everything.
 
       # Run under sudo to enable memory locking for accurate RSS stats.
-      - run: sudo -E ./zig/zig build scripts -- devhub --sha=${{ github.sha }}
-        if: github.ref == 'refs/heads/main'
+      - if: github.ref == 'refs/heads/main'
+        run: sudo -E ./zig/zig build ci -- devhub
         env:
           DEVHUBDB_PAT: ${{ secrets.DEVHUBDB_PAT }}
           NYRKIO_TOKEN: ${{ secrets.NYRKIO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/main'
-        with:
-          path: ./src/devhub
+      - if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with: { path: ./src/devhub }
 
-      - uses: actions/deploy-pages@v4
-        if: github.ref == 'refs/heads/main'
+      - if: github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v4
+
 
   # Work around GitHub considering Skipped jobs success for "Require status checks before merging"
   # See also:
@@ -225,7 +178,7 @@ jobs:
   core-pipeline:
     if: always() && github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    needs: [smoke, test_alpine, test_ubuntu, test_aof, test_windows, test_macos, clients, devhub]
+    needs: [smoke, test, test_alpine, test_aof, clients, devhub]
     steps:
       - if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0
@@ -253,7 +206,7 @@ jobs:
           ANTITHESIS_DOCKER_USER: ${{ secrets.ANTITHESIS_DOCKER_USER }}
           ANTITHESIS_DOCKER_PASS: ${{ secrets.ANTITHESIS_DOCKER_PASS }}
       - name: Download Zig
-        run: ./zig/download.sh
+        run: ./zig/download.ps1
       - name: Build and push
         run: |
           ./zig/zig build scripts -- antithesis \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,6 @@ jobs:
         with: { fetch-depth: 2147483647 } # Fetch full history for tidy.
       - run: ./zig/download.ps1 && ./zig/zig build ci -- test
 
-  test_alpine:
-    runs-on: ubuntu-latest
-    container:
-      image: alpine
-      # Docker restricts io_uring by default, running unconfined then.
-      options: --security-opt seccomp=unconfined
-    steps:
-      - run: apk add -U git github-cli iproute2-tc
-      # https://github.com/actions/checkout/issues/1169
-      - run: git config --system --add safe.directory '*'
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 2147483647 }
-      - run: ./zig/download.ps1 && ./zig/zig build ci -- test
-
   test_aof:
     runs-on: ubuntu-latest
     steps:
@@ -178,7 +164,7 @@ jobs:
   core-pipeline:
     if: always() && github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    needs: [smoke, test, test_alpine, test_aof, clients, devhub]
+    needs: [smoke, test, test_aof, clients, devhub]
     steps:
       - if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0

--- a/build.zig
+++ b/build.zig
@@ -80,6 +80,7 @@ pub fn build(b: *std.Build) !void {
         .fuzz = b.step("fuzz", "Run non-VOPR fuzzers"),
         .fuzz_build = b.step("fuzz:build", "Build non-VOPR fuzzers"),
         .run = b.step("run", "Run TigerBeetle"),
+        .ci = b.step("ci", "Run the full suite of CI checks"),
         .scripts = b.step("scripts", "Free form automation scripts"),
         .vortex = b.step("vortex", "Full system tests with pluggable client drivers"),
         .@"test" = b.step("test", "Run all tests"),
@@ -258,7 +259,7 @@ pub fn build(b: *std.Build) !void {
     });
 
     // zig build scripts -- ci --language=java
-    build_scripts(b, build_steps.scripts, .{
+    const scripts = build_scripts(b, build_steps.scripts, .{
         .vsr_options = vsr_options,
         .target = target,
         .mode = mode,
@@ -322,6 +323,12 @@ pub fn build(b: *std.Build) !void {
         nested_build.setCwd(b.path("./src/docs_website/"));
         break :blk &nested_build.step;
     });
+
+    // zig build ci
+    build_ci(b, build_steps.ci, .{
+        .scripts = scripts,
+        .git_commit = build_options.git_commit,
+    });
 }
 
 fn build_vsr_module(b: *std.Build, options: struct {
@@ -357,6 +364,147 @@ fn build_vsr_module(b: *std.Build, options: struct {
     vsr_module.addOptions("vsr_options", vsr_options);
 
     return .{ vsr_options, vsr_module };
+}
+
+/// This is what is called by CI infrastructure, but you can also use it locally. In particular,
+///
+///     ./zig/zig build ci
+///
+/// is useful to run locally to get a set of somewhat comprehensive checks without needing many
+/// external dependencies.
+///
+/// Various CI machines pass filters to select a subset of checks:
+///
+///     ./zig/zig build ci -- all
+fn build_ci(
+    b: *std.Build,
+    step_ci: *std.Build.Step,
+    options: struct {
+        scripts: *std.Build.Step.Compile,
+        git_commit: []const u8,
+    },
+) void {
+    const CIMode = enum {
+        smoke, // Quickly check formatting and such.
+        @"test", // Main test suite, excluding VOPR and clients.
+        fuzz, // Smoke tests for fuzzers and VOPR.
+        aof, // Dedicated test for AOF, which is somewhat slow to run.
+
+        clients, // Tests for all language clients below.
+        dotnet,
+        go,
+        java,
+        node,
+        python,
+
+        devhub, // Things that run on known-good commit on main branch after merge.
+        @"devhub-dry-run",
+        default, // smoke + test + building Zig parts of clients.
+        all,
+    };
+
+    const mode: CIMode = if (b.args) |args| mode: {
+        if (args.len != 1) {
+            step_ci.dependOn(&FailStep.add(b, "invalid CIMode").step);
+            return;
+        }
+        if (std.meta.stringToEnum(CIMode, args[0])) |m| {
+            break :mode m;
+        } else {
+            step_ci.dependOn(&FailStep.add(b, "invalid CIMode").step);
+            return;
+        }
+    } else .default;
+
+    const all = mode == .all;
+    const default = all or mode == .default;
+
+    if (default or mode == .smoke) {
+        build_ci_step(b, step_ci, .{"test:fmt"});
+        build_ci_step(b, step_ci, .{"check"});
+
+        const build_docs = b.addSystemCommand(&.{ b.graph.zig_exe, "build" });
+        build_docs.has_side_effects = true;
+        build_docs.cwd = b.path("./src/docs_website");
+        step_ci.dependOn(&build_docs.step);
+    }
+    if (default or mode == .@"test") {
+        build_ci_step(b, step_ci, .{"test"});
+        build_ci_step(b, step_ci, .{"clients:c:sample"});
+    }
+    if (default or mode == .fuzz) {
+        build_ci_step(b, step_ci, .{ "fuzz", "--", "smoke" });
+        inline for (.{ "testing", "accounting" }) |state_machine| {
+            build_ci_step(b, step_ci, .{
+                "vopr",
+                "-Dvopr-state-machine=" ++ state_machine,
+                "-Drelease",
+                "--",
+                options.git_commit,
+            });
+        }
+    }
+    if (all or mode == .aof) {
+        const aof = b.addSystemCommand(&.{"./.github/ci/test_aof.sh"});
+        build_ci_check_status(aof);
+        step_ci.dependOn(&aof.step);
+    }
+    inline for (&.{ CIMode.dotnet, .go, .java, .node, .python }) |language| {
+        if (default or mode == .clients or mode == language) {
+            build_ci_step(b, step_ci, .{"clients:" ++ @tagName(language)});
+        }
+        if (all or mode == .clients or mode == language) {
+            build_ci_script(b, step_ci, options.scripts, &.{
+                "ci",
+                "--language=" ++ @tagName(language),
+            });
+        }
+    }
+    if (all or mode == .@"devhub-dry-run") {
+        build_ci_script(b, step_ci, options.scripts, &.{
+            "devhub",
+            b.fmt("--sha={s}", .{options.git_commit}),
+            "--skip-kcov",
+        });
+    }
+    if (mode == .devhub) {
+        build_ci_script(b, step_ci, options.scripts, &.{
+            "devhub",
+            b.fmt("--sha={s}", .{options.git_commit}),
+        });
+    }
+}
+
+fn build_ci_step(
+    b: *std.Build,
+    step_ci: *std.Build.Step,
+    command: anytype,
+) void {
+    const argv = .{ b.graph.zig_exe, "build" } ++ command;
+    const system_command = b.addSystemCommand(&argv);
+    build_ci_check_status(system_command);
+    step_ci.dependOn(&system_command.step);
+}
+
+fn build_ci_script(
+    b: *std.Build,
+    step_ci: *std.Build.Step,
+    scripts: *std.Build.Step.Compile,
+    argv: []const []const u8,
+) void {
+    const run_artifact = b.addRunArtifact(scripts);
+    run_artifact.addArgs(argv);
+    run_artifact.setEnvironmentVariable("ZIG_EXE", b.graph.zig_exe);
+    build_ci_check_status(run_artifact);
+    step_ci.dependOn(&run_artifact.step);
+}
+
+fn build_ci_check_status(step: *std.Build.Step.Run) void {
+    // NB: The purpose here is not to check status (Zig does that automatically), but rather to
+    // prevent inheriting stdio, which causes everything to execute sequentially due to stdio lock!
+    step.stdio = .{ .check = .{} };
+    step.addCheck(.{ .expect_term = .{ .Exited = 0 } });
+    step.has_side_effects = true;
 }
 
 // Run a tigerbeetle build without running codegen and waiting for llvm
@@ -886,7 +1034,7 @@ fn build_scripts(
         target: std.Build.ResolvedTarget,
         mode: std.builtin.OptimizeMode,
     },
-) void {
+) *std.Build.Step.Compile {
     const scripts = b.addExecutable(.{
         .name = "scripts",
         .root_source_file = b.path("src/scripts.zig"),
@@ -898,6 +1046,8 @@ fn build_scripts(
     scripts_run.setEnvironmentVariable("ZIG_EXE", b.graph.zig_exe);
     if (b.args) |args| scripts_run.addArgs(args);
     step_scripts.dependOn(&scripts_run.step);
+
+    return scripts;
 }
 
 fn build_vortex(

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -16,6 +16,7 @@ comptime {
 pub const std_options: std.Options = .{
     .log_level = .info,
     .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .storage, .level = .err },
         .{ .scope = .superblock_quorums, .level = .err },
         .{ .scope = .state_machine, .level = .err },
     },

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -25,14 +25,11 @@ const LanguageCI = .{
 pub const CLIArgs = struct {
     language: ?Language = null,
     validate_release: bool = false,
-    build_docs: bool = false,
 };
 
 pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     if (cli_args.validate_release) {
         try validate_release(shell, gpa, cli_args.language);
-    } else if (cli_args.build_docs) {
-        try build_docs(shell);
     } else {
         try generate_readmes(shell, gpa, cli_args.language);
         try run_tests(shell, gpa, cli_args.language);
@@ -65,13 +62,6 @@ fn run_tests(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?Languag
             }
         }
     }
-}
-
-fn build_docs(shell: *Shell) !void {
-    try shell.pushd("./src/docs_website");
-    defer shell.popd();
-
-    try shell.exec_zig("build", .{});
 }
 
 fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?Language) !void {

--- a/zig/.gitignore
+++ b/zig/.gitignore
@@ -1,3 +1,4 @@
 *
 !download.bat
+!download.ps1
 !download.sh

--- a/zig/download.ps1
+++ b/zig/download.ps1
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo `# <#`
+./zig/download.sh
+exit
+#> > $null
+./zig/download.bat


### PR DESCRIPTION
Every time I subimt a PR, I fail either `zig fmt`, `zig build check`, or `zig build tidy`. I of course remember which one failed, and run that locally before the next PR. Sadly, I can remeber running two commands at most, and it is always the third one that fails!

So, let's introduce `zig build ci` which runs a reasonable set of checks.