### PR TITLE
LSM: Make object cache optional.

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -168,9 +168,9 @@ pub fn GrooveType(
     ///     Whether Groove should store objectless `id`s to prevent their reuse.
     ///     Should be `true` only if the object contains an `id` field.
     ///
-    /// - object_cache: bool:
+    /// - objects_cache: bool:
     ///     Whether Groove should have an ObjectCache.
-    ///     Should be `false` only if both `prefetch_entries_for_update_max` and 
+    ///     Should be `false` only if both `prefetch_entries_for_update_max` and
     ///     `prefetch_entries_for_read_max` are set to 0.
     comptime groove_options: anytype,
 ) type {
@@ -336,7 +336,7 @@ pub fn GrooveType(
 
     const has_scan = index_fields.len > 0;
 
-    const has_objects_cache = groove_options.object_cache;
+    const has_objects_cache = groove_options.objects_cache;
 
     // Verify groove index count:
     const indexes_count_actual = std.meta.fields(_IndexTrees).len;
@@ -563,7 +563,7 @@ pub fn GrooveType(
         /// keeping table_mutable as an array, and simplifying the compaction path
         /// is faster than trying to amortize and save memory.
         ///
-        /// Invariant: if there is an object_cache then if something is in the mutable or immutable 
+        /// Invariant: if there is an object_cache then if something is in the mutable or immutable
         /// table, it _must_ exist in our object cache.
         objects_cache: if (has_objects_cache) ObjectsCache else void,
 
@@ -611,9 +611,9 @@ pub fn GrooveType(
                 true => blk: {
                     break :blk try ObjectsCache.init(allocator, .{
                         .cache_value_count_max = options.cache_entries_max,
-                        // In the worst case, each stash must be able to store 
-                        // batch_value_count_limit per beat (to contain either TableMutable or 
-                        // TableImmutable) as well as the maximum number of prefetches a bar may 
+                        // In the worst case, each stash must be able to store
+                        // batch_value_count_limit per beat (to contain either TableMutable or
+                        // TableImmutable) as well as the maximum number of prefetches a bar may
                         // perform, excluding prefetches already accounted
                         // for by batch_value_count_limit.
                         .stash_value_count_max = constants.lsm_compaction_ops *
@@ -622,8 +622,7 @@ pub fn GrooveType(
 
                         // Scopes are limited to a single beat, so the maximum number of entries in
                         // a single scope is batch_value_count_limit (total – not per beat).
-                        .scope_value_count_max = 
-                            options.tree_options_object.batch_value_count_limit,
+                        .scope_value_count_max = options.tree_options_object.batch_value_count_limit,
 
                         .name = ObjectTree.tree_name(),
                     });
@@ -1426,11 +1425,10 @@ pub fn GrooveType(
 
             // Compact the objects_cache on the last beat of the bar, just like the trees do to
             // their mutable tables.
-            if (has_objects_cache){
+            if (has_objects_cache) {
                 const compaction_beat = op % constants.lsm_compaction_ops;
                 if (compaction_beat == constants.lsm_compaction_ops - 1) {
                     groove.objects_cache.compact();
-
                 }
             }
         }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -561,7 +561,7 @@ pub fn GrooveType(
         /// keeping table_mutable as an array, and simplifying the compaction path
         /// is faster than trying to amortize and save memory.
         ///
-        /// Invariant: if there is an objects_cache then if something is in the mutable or immutable
+        /// Invariant: if there is an objects_cache then if something is in the mutable
         /// table, it _must_ exist in our object cache.
         /// Otherwise, the ObjectsCache is of type void.
         objects_cache: ObjectsCache,

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -167,6 +167,11 @@ pub fn GrooveType(
     /// - orphaned_ids: bool:
     ///     Whether Groove should store objectless `id`s to prevent their reuse.
     ///     Should be `true` only if the object contains an `id` field.
+    ///
+    /// - object_cache: bool:
+    ///     Whether Groove should have an ObjectCache.
+    ///     Should be `false` only if both `prefetch_entries_for_update_max` and 
+    ///     `prefetch_entries_for_read_max` are set to 0.
     comptime groove_options: anytype,
 ) type {
     @setEvalBranchQuota(64_000);
@@ -330,6 +335,8 @@ pub fn GrooveType(
     });
 
     const has_scan = index_fields.len > 0;
+
+    const has_objects_cache = groove_options.object_cache;
 
     // Verify groove index count:
     const indexes_count_actual = std.meta.fields(_IndexTrees).len;
@@ -556,9 +563,9 @@ pub fn GrooveType(
         /// keeping table_mutable as an array, and simplifying the compaction path
         /// is faster than trying to amortize and save memory.
         ///
-        /// Invariant: if something is in the mutable or immutable table, it _must_ exist in our
-        /// object cache.
-        objects_cache: ObjectsCache,
+        /// Invariant: if there is an object_cache then if something is in the mutable or immutable 
+        /// table, it _must_ exist in our object cache.
+        objects_cache: if (has_objects_cache) ObjectsCache else void,
 
         timestamps: if (has_id) TimestampSet else void,
 
@@ -595,29 +602,42 @@ pub fn GrooveType(
                 .ids = undefined,
                 .indexes = undefined,
                 .prefetch_keys = undefined,
-                .objects_cache = undefined,
+                .objects_cache = if (has_objects_cache) undefined else {},
                 .timestamps = undefined,
                 .scan_builder = undefined,
             };
 
-            groove.objects_cache = try ObjectsCache.init(allocator, .{
-                .cache_value_count_max = options.cache_entries_max,
+            groove.objects_cache = switch (has_objects_cache) {
+                true => blk: {
+                    break :blk try ObjectsCache.init(allocator, .{
+                        .cache_value_count_max = options.cache_entries_max,
+                        // In the worst case, each stash must be able to store 
+                        // batch_value_count_limit per beat (to contain either TableMutable or 
+                        // TableImmutable) as well as the maximum number of prefetches a bar may 
+                        // perform, excluding prefetches already accounted
+                        // for by batch_value_count_limit.
+                        .stash_value_count_max = constants.lsm_compaction_ops *
+                            (options.tree_options_object.batch_value_count_limit +
+                            options.prefetch_entries_for_read_max),
 
-                // In the worst case, each stash must be able to store batch_value_count_limit per
-                // beat (to contain either TableMutable or TableImmutable) as well as the maximum
-                // number of prefetches a bar may perform, excluding prefetches already accounted
-                // for by batch_value_count_limit.
-                .stash_value_count_max = constants.lsm_compaction_ops *
-                    (options.tree_options_object.batch_value_count_limit +
-                    options.prefetch_entries_for_read_max),
+                        // Scopes are limited to a single beat, so the maximum number of entries in
+                        // a single scope is batch_value_count_limit (total – not per beat).
+                        .scope_value_count_max = 
+                            options.tree_options_object.batch_value_count_limit,
 
-                // Scopes are limited to a single beat, so the maximum number of entries in a
-                // single scope is batch_value_count_limit (total – not per beat).
-                .scope_value_count_max = options.tree_options_object.batch_value_count_limit,
+                        .name = ObjectTree.tree_name(),
+                    });
+                },
+                false => {
+                    // If there are no modifications or point lookups on the Groove then
+                    // no `objects_cache` is needed.
+                    assert(options.prefetch_entries_for_read_max == 0);
+                    assert(options.prefetch_entries_for_update_max == 0);
+                    {}
+                },
+            };
 
-                .name = ObjectTree.tree_name(),
-            });
-            errdefer groove.objects_cache.deinit(allocator);
+            errdefer if (has_objects_cache) groove.objects_cache.deinit(allocator);
 
             // Initialize the object LSM tree.
             try groove.objects.init(
@@ -697,8 +717,8 @@ pub fn GrooveType(
             if (has_id) groove.ids.deinit(allocator);
 
             groove.prefetch_keys.deinit(allocator);
-            groove.objects_cache.deinit(allocator);
 
+            if (has_objects_cache) groove.objects_cache.deinit(allocator);
             if (has_id) groove.timestamps.deinit(allocator);
             if (has_scan) groove.scan_builder.deinit(allocator);
 
@@ -713,7 +733,8 @@ pub fn GrooveType(
             if (has_id) groove.ids.reset();
 
             groove.prefetch_keys.clearRetainingCapacity();
-            groove.objects_cache.reset();
+
+            if (has_objects_cache) groove.objects_cache.reset();
 
             if (has_id) groove.timestamps.reset();
             if (has_scan) groove.scan_builder.reset();
@@ -1216,9 +1237,11 @@ pub fn GrooveType(
         pub fn insert(groove: *Groove, object: *const Object) void {
             assert(object.timestamp >= TimestampRange.timestamp_min);
             assert(object.timestamp <= TimestampRange.timestamp_max);
-            assert(!groove.objects_cache.has(@field(object, primary_field)));
 
-            groove.objects_cache.upsert(object);
+            if (has_objects_cache) {
+                assert(!groove.objects_cache.has(@field(object, primary_field)));
+                groove.objects_cache.upsert(object);
+            }
 
             if (has_id) {
                 groove.ids.put(&IdTreeValue{ .id = object.id, .timestamp = object.timestamp });
@@ -1247,7 +1270,7 @@ pub fn GrooveType(
             const old = values.old;
             const new = values.new;
 
-            if (constants.verify) {
+            if (has_objects_cache) {
                 const old_from_cache = groove.objects_cache.get(@field(old, primary_field)).?;
                 assert(stdx.equal_bytes(Object, old_from_cache, old));
             }
@@ -1300,7 +1323,10 @@ pub fn GrooveType(
             // We diff the old and new objects, but the old object will be a pointer into the
             // objects_cache. If we upsert first, there's a high chance old.* == new.* (always,
             // unless old comes from the stash) and no secondary indexes will be updated!
-            groove.objects_cache.upsert(new);
+
+            if (has_objects_cache) {
+                groove.objects_cache.upsert(new);
+            }
             groove.objects.put(new);
         }
 
@@ -1365,7 +1391,7 @@ pub fn GrooveType(
         }
 
         pub fn scope_open(groove: *Groove) void {
-            groove.objects_cache.scope_open();
+            if (has_objects_cache) groove.objects_cache.scope_open();
 
             if (has_id) {
                 groove.ids.scope_open();
@@ -1378,7 +1404,7 @@ pub fn GrooveType(
         }
 
         pub fn scope_close(groove: *Groove, mode: ScopeCloseMode) void {
-            groove.objects_cache.scope_close(mode);
+            if (has_objects_cache) groove.objects_cache.scope_close(mode);
 
             if (has_id) {
                 groove.ids.scope_close(mode);
@@ -1400,9 +1426,12 @@ pub fn GrooveType(
 
             // Compact the objects_cache on the last beat of the bar, just like the trees do to
             // their mutable tables.
-            const compaction_beat = op % constants.lsm_compaction_ops;
-            if (compaction_beat == constants.lsm_compaction_ops - 1) {
-                groove.objects_cache.compact();
+            if (has_objects_cache){
+                const compaction_beat = op % constants.lsm_compaction_ops;
+                if (compaction_beat == constants.lsm_compaction_ops - 1) {
+                    groove.objects_cache.compact();
+
+                }
             }
         }
 

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -106,6 +106,7 @@ const ThingsGroove = GrooveType(
         .optional = &[_][]const u8{},
         .derived = .{},
         .orphaned_ids = false,
+        .object_cache = true,
     },
 );
 

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -106,7 +106,7 @@ const ThingsGroove = GrooveType(
         .optional = &[_][]const u8{},
         .derived = .{},
         .orphaned_ids = false,
-        .object_cache = true,
+        .objects_cache = true,
     },
 );
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -165,6 +165,7 @@ pub fn StateMachineType(
                     }.closed,
                 },
                 .orphaned_ids = false,
+                .object_cache = true,
             },
         );
 
@@ -206,6 +207,7 @@ pub fn StateMachineType(
                     }.closing,
                 },
                 .orphaned_ids = true,
+                .object_cache = true,
             },
         );
 
@@ -225,6 +227,7 @@ pub fn StateMachineType(
                 },
                 .derived = .{},
                 .orphaned_ids = false,
+                .object_cache = true,
             },
         );
 
@@ -349,6 +352,7 @@ pub fn StateMachineType(
                     }.prunable,
                 },
                 .orphaned_ids = false,
+                .object_cache = false,
             },
         );
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -165,7 +165,7 @@ pub fn StateMachineType(
                     }.closed,
                 },
                 .orphaned_ids = false,
-                .object_cache = true,
+                .objects_cache = true,
             },
         );
 
@@ -207,7 +207,7 @@ pub fn StateMachineType(
                     }.closing,
                 },
                 .orphaned_ids = true,
-                .object_cache = true,
+                .objects_cache = true,
             },
         );
 
@@ -227,7 +227,7 @@ pub fn StateMachineType(
                 },
                 .derived = .{},
                 .orphaned_ids = false,
-                .object_cache = true,
+                .objects_cache = true,
             },
         );
 
@@ -352,7 +352,7 @@ pub fn StateMachineType(
                     }.prunable,
                 },
                 .orphaned_ids = false,
-                .object_cache = false,
+                .objects_cache = false,
             },
         );
 

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -64,7 +64,7 @@ pub fn StateMachineType(
                 .optional = &[_][]const u8{},
                 .derived = .{},
                 .orphaned_ids = false,
-                .object_cache = true,
+                .objects_cache = true,
             },
         );
 

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -64,6 +64,7 @@ pub fn StateMachineType(
                 .optional = &[_][]const u8{},
                 .derived = .{},
                 .orphaned_ids = false,
+                .object_cache = true,
             },
         );
 


### PR DESCRIPTION
This update makes the `objects_cache` optional within the `Groove`. 
Previously, the `objects_cache` was always maintained, even in scenarios where it was not  used. 
For example, the `AccountEvents` Groove is append-only and is currently accessed only via scans, making the cache unnecessary. Specifically, this is the case if  `prefetch_entries_for_read_max` and `prefetch_entries_for_update_max` are both 0.
We avoid doing unnecessary work by disabling the cache when it isn’t required.

This change gives us roughly 10% overall performance:

Before: load accepted = 328302 tx/s
After:    load accepted = 355223 tx/s 