### PR TITLE
vsr: fix assertion

### DIFF
--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -833,8 +833,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             const buffer: []u8 = message.buffer[0..message_size];
 
             // Memory must not be owned by `journal.headers` as these may be modified concurrently:
-            assert(@intFromPtr(buffer.ptr) < @intFromPtr(journal.headers.ptr) or
-                @intFromPtr(buffer.ptr) > @intFromPtr(journal.headers.ptr) + headers_size);
+            assert(stdx.disjoint_slices(u8, vsr.Header.Prepare, buffer, journal.headers));
 
             journal.storage.read_sectors(
                 read_prepare_with_op_and_checksum_callback,


### PR DESCRIPTION
As written, the assertion has both false postives and false negatives.

False positive: it is OK if buffer.ptr == headers.ptr + headers_size, these just means that the two were allocated one after another.

False negative: it's not enough to check that buffer.ptr < headers.ptr, buffer's size needs to be taken into account.

Convieniently, we already have an stdx helper just for that!

Notably, false positive was triggered at https://github.com/tigerbeetle/tigerbeetle/pull/2883