### PR TITLE
stdx: de-genericify Stack

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -179,7 +179,6 @@ pub fn ResourcePoolType(comptime Grid: type) type {
 
             var blocks = StackType(Block).init(.{
                 .capacity = blocks_allocated,
-                .name = "compaction_blocks",
                 .verify_push = false,
             });
             for (blocks_backing_storage) |*block| blocks.push(block);
@@ -201,7 +200,6 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             pool.* = .{
                 .blocks = StackType(Block).init(.{
                     .capacity = pool.blocks.capacity(),
-                    .name = "compaction_blocks",
                     .verify_push = false,
                 }),
                 .blocks_backing_storage = pool.blocks_backing_storage,

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -4,93 +4,136 @@ const assert = std.debug.assert;
 
 const constants = @import("./constants.zig");
 
-/// An intrusive last in/first out linked list (Stack).
+pub const StackLink = struct {
+    next: ?*StackLink = null,
+};
+
+/// An intrusive last in/first out linked list (LIFO).
 /// The element type T must have a field called "next" of type ?*T.
 pub fn StackType(comptime T: type) type {
     return struct {
+        any: StackAny,
+
+        pub const Link = StackLink;
         const Stack = @This();
 
-        head: ?*T = null,
-
-        count: u64 = 0,
-        count_max: u64,
-
-        // This should only be null if you're sure we'll never want to monitor `count`.
-        name: ?[]const u8,
-
-        // If the number of elements is large, the constants.verify check in push() can be too
-        // expensive. Allow the user to gate it.
-        verify_push: bool,
-
-        pub fn init(options: struct {
-            capacity: u64,
+        pub inline fn init(options: struct {
+            capacity: u32,
             verify_push: bool,
             name: ?[]const u8,
         }) Stack {
-            return Stack{
+            return .{ .any = .{
                 .name = options.name,
-                .count_max = options.capacity,
+                .capacity = options.capacity,
                 .verify_push = options.verify_push,
-            };
+            } };
+        }
+
+        pub inline fn count(self: *Stack) u64 {
+            return self.any.count;
+        }
+
+        pub inline fn capacity(self: *Stack) u64 {
+            return self.any.capacity;
         }
 
         /// Pushes a new node to the first position of the Stack.
-        pub fn push(self: *Stack, node: *T) void {
-            if (constants.verify and self.verify_push) assert(!self.contains(node));
-
-            assert((self.count == 0) == (self.head == null));
-            assert(node.next == null);
-            assert(self.count < self.count_max);
-
-            // Insert the new element at the head.
-            node.next = self.head;
-            self.head = node;
-            self.count += 1;
+        pub inline fn push(self: *Stack, node: *T) void {
+            self.any.push(&node.link);
         }
 
         /// Returns the first element of the Stack list, and removes it.
-        pub fn pop(self: *Stack) ?*T {
-            assert((self.count == 0) == (self.head == null));
-
-            const node = self.head orelse return null;
-            self.head = node.next;
-            node.next = null;
-            self.count -= 1;
-            return node;
+        pub inline fn pop(self: *Stack) ?*T {
+            const link = self.any.pop() orelse return null;
+            return @fieldParentPtr("link", link);
         }
 
         /// Returns the first element of the Stack list, but does not remove it.
-        pub fn peek(self: Stack) ?*T {
-            return self.head;
+        pub inline fn peek(self: *const Stack) ?*T {
+            const link = self.any.peek() orelse return null;
+            return @fieldParentPtr("link", link);
         }
 
         /// Checks if the Stack is empty.
-        pub fn empty(self: Stack) bool {
-            assert((self.count == 0) == (self.head == null));
-            return self.head == null;
+        pub inline fn empty(self: *const Stack) bool {
+            return self.any.empty();
         }
 
         /// Returns whether the linked list contains the given *exact element* (pointer comparison).
-        fn contains(self: *const Stack, needle: *const T) bool {
-            assert(self.count <= self.count_max);
-            var next = self.head;
-            for (0..self.count + 1) |_| {
-                const node = next orelse return false;
-                if (node == needle) return true;
-                next = node.next;
-            } else unreachable;
+        inline fn contains(self: *const Stack, needle: *const T) bool {
+            return self.any.contains(&needle.link);
         }
 
         /// Resets the state.
-        pub fn reset(self: *Stack) void {
-            self.* = .{
-                .name = self.name,
-                .count_max = self.count_max,
-                .verify_push = self.verify_push,
-            };
+        pub inline fn reset(self: *Stack) void {
+            self.any.reset();
         }
     };
 }
+
+const StackAny = struct {
+    head: ?*StackLink = null,
+
+    count: u32 = 0,
+    capacity: u32,
+
+    // This should only be null if you're sure we'll never want to monitor `count`.
+    name: ?[]const u8,
+
+    // If the number of elements is large, the constants.verify check in push() can be too
+    // expensive. Allow the user to gate it.
+    verify_push: bool,
+
+    fn push(self: *StackAny, link: *StackLink) void {
+        if (constants.verify and self.verify_push) assert(!self.contains(link));
+
+        assert((self.count == 0) == (self.head == null));
+        assert(link.next == null);
+        assert(self.count < self.capacity);
+
+        // Insert the new element at the head.
+        link.next = self.head;
+        self.head = link;
+        self.count += 1;
+    }
+
+    fn pop(self: *StackAny) ?*StackLink {
+        assert((self.count == 0) == (self.head == null));
+
+        const link = self.head orelse return null;
+        self.head = link.next;
+        link.next = null;
+        self.count -= 1;
+        return link;
+    }
+
+    fn peek(self: *const StackAny) ?*StackLink {
+        return self.head;
+    }
+
+    fn empty(self: *const StackAny) bool {
+        assert((self.count == 0) == (self.head == null));
+        return self.head == null;
+    }
+
+    fn contains(self: *const StackAny, needle: *const StackLink) bool {
+        assert(self.count <= self.capacity);
+        var next = self.head;
+        for (0..self.count + 1) |_| {
+            const link = next orelse return false;
+            if (link == needle) return true;
+            next = link.next;
+        } else unreachable;
+    }
+
+    fn reset(self: *StackAny) void {
+        self.* = .{
+            .name = self.name,
+            .capacity = self.capacity,
+            .verify_push = self.verify_push,
+        };
+    }
+};
 
 test "Stack: fuzz" {
     // Fuzzy test to compare behavior of Stack against std.ArrayList (reference model).
@@ -100,13 +143,13 @@ test "Stack: fuzz" {
 
     var prng = stdx.PRNG.from_seed(0);
 
-    const Node = struct {
+    const Item = struct {
         id: u32,
-        next: ?*@This() = null,
+        link: StackType(@This()).Link,
     };
-    const Stack = StackType(Node);
+    const Stack = StackType(Item);
 
-    const node_count_max = 1024;
+    const item_count_max = 1024;
     const events_max = 1 << 10;
 
     const Event = enum { push, pop };
@@ -116,53 +159,53 @@ test "Stack: fuzz" {
     };
 
     // Allocate a pool of nodes.
-    var nodes = try allocator.alloc(Node, node_count_max);
-    defer allocator.free(nodes);
-    for (nodes, 0..) |*node, i| {
-        node.* = Node{ .id = @intCast(i), .next = null };
+    var items = try allocator.alloc(Item, item_count_max);
+    defer allocator.free(items);
+    for (items, 0..) |*item, i| {
+        item.* = Item{ .id = @intCast(i), .link = .{} };
     }
 
     // A bit set that tracks which nodes are available.
-    var nodes_free = try std.DynamicBitSetUnmanaged.initFull(allocator, node_count_max);
-    defer nodes_free.deinit(allocator);
+    var items_free = try std.DynamicBitSetUnmanaged.initFull(allocator, item_count_max);
+    defer items_free.deinit(allocator);
 
     var stack = Stack.init(.{
-        .capacity = node_count_max,
+        .capacity = item_count_max,
         .name = "fuzz",
         .verify_push = true,
     });
 
     // Reference model: a dynamic array of node IDs in Stack order (last is the top).
-    var model = try std.ArrayList(u32).initCapacity(allocator, node_count_max);
+    var model = try std.ArrayList(u32).initCapacity(allocator, item_count_max);
     defer model.deinit();
 
     // Run a sequence of randomized events.
     for (0..events_max) |_| {
-        assert(model.items.len <= node_count_max);
-        assert(model.items.len == stack.count);
+        assert(model.items.len <= item_count_max);
+        assert(model.items.len == stack.count());
         assert(model.items.len == 0 or !stack.empty());
 
         const event = prng.enum_weighted(Event, event_weights);
         switch (event) {
             .push => {
                 // Only push if a free node is available.
-                const free_index = nodes_free.findFirstSet() orelse continue;
-                const node = &nodes[free_index];
-                stack.push(node);
-                try model.append(node.id);
-                nodes_free.unset(node.id);
+                const free_index = items_free.findFirstSet() orelse continue;
+                const item = &items[free_index];
+                stack.push(item);
+                try model.append(item.id);
+                items_free.unset(item.id);
             },
             .pop => {
-                if (stack.pop()) |node| {
+                if (stack.pop()) |item| {
                     // The reference model should have the same node at the top.
-                    const id = node.id;
+                    const id = item.id;
                     const expected = model.pop();
                     assert(id == expected);
-                    nodes_free.set(id);
+                    items_free.set(id);
                 } else {
                     assert(model.items.len == 0);
                     assert(stack.empty());
-                    assert(stack.count == 0);
+                    assert(stack.count() == 0);
                     assert(stack.peek() == null);
                 }
             },
@@ -175,33 +218,33 @@ test "Stack: fuzz" {
             try model.append(top_ref);
         } else {
             assert(stack.empty());
-            assert(stack.count == 0);
+            assert(stack.count() == 0);
             assert(stack.peek() == null);
         }
     }
 
     // Finally, empty the Stack and ensure our reference model agrees.
-    while (stack.pop()) |node| {
-        const id = node.id;
+    while (stack.pop()) |item| {
+        const id = item.id;
         const expected = model.pop();
         assert(id == expected);
-        nodes_free.set(id);
+        items_free.set(id);
     }
     assert(model.items.len == 0);
     assert(stack.empty());
-    assert(stack.count == 0);
+    assert(stack.count() == 0);
     assert(stack.peek() == null);
 }
 
 test "Stack: push/pop/peek/empty" {
     const testing = @import("std").testing;
-    const Foo = struct { next: ?*@This() = null };
+    const Item = struct { link: StackLink = .{} };
 
-    var one: Foo = .{};
-    var two: Foo = .{};
-    var three: Foo = .{};
+    var one: Item = .{};
+    var two: Item = .{};
+    var three: Item = .{};
 
-    var stack: StackType(Foo) = StackType(Foo).init(.{
+    var stack: StackType(Item) = StackType(Item).init(.{
         .capacity = 3,
         .name = "fuzz",
         .verify_push = true,
@@ -212,7 +255,7 @@ test "Stack: push/pop/peek/empty" {
     // Push one element and verify
     stack.push(&one);
     try testing.expect(!stack.empty());
-    try testing.expectEqual(@as(?*Foo, &one), stack.peek());
+    try testing.expectEqual(@as(?*Item, &one), stack.peek());
     try testing.expect(stack.contains(&one));
     try testing.expect(!stack.contains(&two));
     try testing.expect(!stack.contains(&three));
@@ -221,15 +264,15 @@ test "Stack: push/pop/peek/empty" {
     stack.push(&two);
     stack.push(&three);
     try testing.expect(!stack.empty());
-    try testing.expectEqual(@as(?*Foo, &three), stack.peek());
+    try testing.expectEqual(@as(?*Item, &three), stack.peek());
     try testing.expect(stack.contains(&one));
     try testing.expect(stack.contains(&two));
     try testing.expect(stack.contains(&three));
 
     // Pop elements and check Stack order
-    try testing.expectEqual(@as(?*Foo, &three), stack.pop());
-    try testing.expectEqual(@as(?*Foo, &two), stack.pop());
-    try testing.expectEqual(@as(?*Foo, &one), stack.pop());
+    try testing.expectEqual(@as(?*Item, &three), stack.pop());
+    try testing.expectEqual(@as(?*Item, &two), stack.pop());
+    try testing.expectEqual(@as(?*Item, &one), stack.pop());
     try testing.expect(stack.empty());
-    try testing.expectEqual(@as(?*Foo, null), stack.pop());
+    try testing.expectEqual(@as(?*Item, null), stack.pop());
 }

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -4,7 +4,7 @@ const assert = std.debug.assert;
 
 const constants = @import("./constants.zig");
 
-pub const StackLink = struct {
+pub const StackLink = extern struct {
     next: ?*StackLink = null,
 };
 
@@ -27,11 +27,11 @@ pub fn StackType(comptime T: type) type {
             } };
         }
 
-        pub inline fn count(self: *Stack) u64 {
+        pub inline fn count(self: *Stack) u32 {
             return self.any.count;
         }
 
-        pub inline fn capacity(self: *Stack) u64 {
+        pub inline fn capacity(self: *Stack) u32 {
             return self.any.capacity;
         }
 

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -61,11 +61,6 @@ pub fn StackType(comptime T: type) type {
         inline fn contains(self: *const Stack, needle: *const T) bool {
             return self.any.contains(&needle.link);
         }
-
-        /// Resets the state.
-        pub inline fn reset(self: *Stack) void {
-            self.any.reset();
-        }
     };
 }
 
@@ -119,13 +114,6 @@ const StackAny = struct {
             if (link == needle) return true;
             next = link.next;
         } else unreachable;
-    }
-
-    fn reset(self: *StackAny) void {
-        self.* = .{
-            .capacity = self.capacity,
-            .verify_push = self.verify_push,
-        };
     }
 };
 

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -20,10 +20,8 @@ pub fn StackType(comptime T: type) type {
         pub inline fn init(options: struct {
             capacity: u32,
             verify_push: bool,
-            name: ?[]const u8,
         }) Stack {
             return .{ .any = .{
-                .name = options.name,
                 .capacity = options.capacity,
                 .verify_push = options.verify_push,
             } };
@@ -77,9 +75,6 @@ const StackAny = struct {
     count: u32 = 0,
     capacity: u32,
 
-    // This should only be null if you're sure we'll never want to monitor `count`.
-    name: ?[]const u8,
-
     // If the number of elements is large, the constants.verify check in push() can be too
     // expensive. Allow the user to gate it.
     verify_push: bool,
@@ -128,7 +123,6 @@ const StackAny = struct {
 
     fn reset(self: *StackAny) void {
         self.* = .{
-            .name = self.name,
             .capacity = self.capacity,
             .verify_push = self.verify_push,
         };
@@ -171,7 +165,6 @@ test "Stack: fuzz" {
 
     var stack = Stack.init(.{
         .capacity = item_count_max,
-        .name = "fuzz",
         .verify_push = true,
     });
 
@@ -246,7 +239,6 @@ test "Stack: push/pop/peek/empty" {
 
     var stack: StackType(Item) = StackType(Item).init(.{
         .capacity = 3,
-        .name = "fuzz",
         .verify_push = true,
     });
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -563,13 +563,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             cluster.log_replica(.crash, replica_index);
 
             // Ensure that none of the replica's messages leaked when it was deinitialized.
-            var messages_in_pool: usize = 0;
             const message_bus = cluster.network.get_message_bus(.{ .replica = replica_index });
-            {
-                var it = message_bus.pool.free_list;
-                while (it) |message| : (it = message.next) messages_in_pool += 1;
-            }
-            assert(messages_in_pool == message_bus.pool.messages_max);
+            assert(message_bus.pool.free_list.count() == message_bus.pool.messages_max);
         }
 
         fn replica_enable(cluster: *Cluster, replica_index: u8) void {

--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -78,15 +78,14 @@ pub const Network = struct {
         // - replica → client paths
         // - client → replica paths
         // but not client→client paths; clients never message one another.
-        const node_count = @as(usize, options.node_count);
-        const client_count = @as(usize, options.client_count);
-        const path_count = node_count * (node_count - 1) + 2 * node_count * client_count;
+        const node_count: u32 = options.node_count;
+        const client_count: u32 = options.client_count;
+        const path_count: u32 = node_count * (node_count - 1) + 2 * node_count * client_count;
         const message_pool = try MessagePool.init_capacity(
             allocator,
             // +1 so we can allocate an extra packet when all packet queues are at capacity,
             // so that `PacketSimulator.submit_packet` can choose which packet to drop.
-            1 + @as(usize, options.path_maximum_capacity) * path_count +
-                options.recorded_count_max,
+            1 + options.path_maximum_capacity * path_count + options.recorded_count_max,
         );
         errdefer message_pool.deinit(allocator);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1337,7 +1337,7 @@ pub fn ReplicaType(
             }
 
             if (self.loopback_queue) |loopback_message| {
-                assert(loopback_message.next == null);
+                assert(loopback_message.link.next == null);
                 self.message_bus.unref(loopback_message);
                 self.loopback_queue = null;
             }
@@ -5320,7 +5320,7 @@ pub fn ReplicaType(
 
                 assert(!self.standby());
 
-                assert(message.next == null);
+                assert(message.link.next == null);
                 self.loopback_queue = null;
                 assert(message.header.replica == self.replica);
                 self.on_message(message);


### PR DESCRIPTION
Move most of the code out of generic Stack into non-generic StackAny.

In terms of machine code, while before `.next` field pointed to `T`, now `.next` points to `.next` directly, which means things need not to be generic.

I keept the wrapping `StackType` just for some type safety. An alternative design would be to just have `StackAny`, but then at the call site you'll be able to pop a node of a wrong type.

See also https://github.com/ziglang/zig/commit/1639fcea43549853f1fded32aa1d711d21771e1c and hat tip to https://www.openmymind.net/Zigs-New-LinkedList-API/ for brining this to my attention.