### PR TITLE
stdx: rename Instant/Duration.nanoseconds to ns

### DIFF
--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -923,35 +923,35 @@ pub fn array_print(
 }
 
 pub const Instant = struct {
-    base_ns: u64,
+    ns: u64,
 
     pub fn duration_since(now: Instant, earlier: Instant) Duration {
-        assert(now.base_ns >= earlier.base_ns);
-        const elapsed_ns = now.base_ns - earlier.base_ns;
-        return .{ .nanoseconds = elapsed_ns };
+        assert(now.ns >= earlier.ns);
+        const elapsed_ns = now.ns - earlier.ns;
+        return .{ .ns = elapsed_ns };
     }
 };
 
 pub const Duration = struct {
-    nanoseconds: u64,
+    ns: u64,
 
     pub fn microseconds(duration: Duration) u64 {
-        return @divFloor(duration.nanoseconds, std.time.ns_per_us);
+        return @divFloor(duration.ns, std.time.ns_per_us);
     }
 
     pub fn milliseconds(duration: Duration) u64 {
-        return @divFloor(duration.nanoseconds, std.time.ns_per_ms);
+        return @divFloor(duration.ns, std.time.ns_per_ms);
     }
 };
 
 test "Instant/Duration" {
-    const instant_1: Instant = .{ .base_ns = 100 * std.time.ns_per_day };
-    const instant_2: Instant = .{ .base_ns = 100 * std.time.ns_per_day + std.time.ns_per_s };
-    assert(instant_1.duration_since(instant_1).nanoseconds == 0);
-    assert(instant_2.duration_since(instant_1).nanoseconds == std.time.ns_per_s);
+    const instant_1: Instant = .{ .ns = 100 * std.time.ns_per_day };
+    const instant_2: Instant = .{ .ns = 100 * std.time.ns_per_day + std.time.ns_per_s };
+    assert(instant_1.duration_since(instant_1).ns == 0);
+    assert(instant_2.duration_since(instant_1).ns == std.time.ns_per_s);
 
     const duration = instant_2.duration_since(instant_1);
-    assert(duration.nanoseconds == 1_000_000_000);
+    assert(duration.ns == 1_000_000_000);
     assert(duration.microseconds() == 1_000_000);
     assert(duration.milliseconds() == 1_000);
 }

--- a/src/testing/time.zig
+++ b/src/testing/time.zig
@@ -51,7 +51,7 @@ pub const Time = struct {
     }
 
     pub fn monotonic_instant(self: *Time) Instant {
-        return .{ .base_ns = self.monotonic() };
+        return .{ .ns = self.monotonic() };
     }
 
     pub fn realtime(self: *Time) i64 {

--- a/src/time.zig
+++ b/src/time.zig
@@ -38,7 +38,7 @@ pub const Time = struct {
     }
 
     pub fn monotonic_instant(self: *Time) Instant {
-        return Instant{ .base_ns = self.monotonic() };
+        return Instant{ .ns = self.monotonic() };
     }
 
     fn monotonic_windows() u64 {
@@ -154,6 +154,6 @@ test "Time monotonic smoke" {
     var time: Time = .{};
     const instant_1 = time.monotonic_instant();
     const instant_2 = time.monotonic_instant();
-    assert(instant_1.duration_since(instant_1).nanoseconds == 0);
-    assert(instant_2.duration_since(instant_1).nanoseconds >= 0);
+    assert(instant_1.duration_since(instant_1).ns == 0);
+    assert(instant_2.duration_since(instant_1).ns >= 0);
 }

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -283,11 +283,11 @@ pub fn TracerType(comptime Time: type) type {
                 @tagName(event),
                 event_tracing,
                 event_timing,
-                if (event_duration.nanoseconds < us_log_threshold_ns)
+                if (event_duration.ns < us_log_threshold_ns)
                     event_duration.microseconds()
                 else
                     event_duration.milliseconds(),
-                if (event_duration.nanoseconds < us_log_threshold_ns) "us" else "ms",
+                if (event_duration.ns < us_log_threshold_ns) "us" else "ms",
             });
 
             tracer.timing(event_timing, event_duration.microseconds());


### PR DESCRIPTION
We usually avoid abbreviation, but I think it makes sense to bend the rule here:

* ns is not an abbreviation, it's a word in its own right!
* From the context (Instant/Duration), its pretty unambigious what this means.
* At the call-site, if you need any kind of arithmetic of Durations, `.nanoseconds` makes the code way too wide (we don't have such call sites now, but I'll need them for #2880 