### PR TITLE
LSM: Skip full sort if incremental sorted runs are monotonic and prepare for k-way merge by tracking sorted runs.

### DIFF
--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -237,8 +237,9 @@ pub fn TableMemoryType(comptime Table: type) type {
             var source_index: u32 = offset;
             var target_index: u32 = offset;
             while (source_index < source_count) {
-                const value = values[source_index];
-                values[target_index] = value;
+                if (source_index != target_index) {
+                    values[target_index] = values[source_index];
+                }
 
                 // If we're at the end of the source, there is no next value, so the next value
                 // can't be equal.


### PR DESCRIPTION

This PR prepares for the k-way merge by tracking the sorted runs we produce on every beat. 

To simplify the review of the final k-way merge, this PR introduces tracking of sorted runs. Additionally, it includes an orthogonal optimization enabled by this tracking:

We already produce sorted runs incrementally with sort_suffix. With this PR, we now remember each sorted run's starting and ending indices. By checking the boundaries of these sorted runs, we can determine if they are strictly monotonically increasing. For example, if the end of the first sorted run is smaller than the beginning of the second, we can confirm that the entire table is sorted and skip the final sort.

Example:
```
[1, 2, 3   5, 6, 7]
^            ^ 
|              Second sorted run 
First sorted run
```

While the benchmark improvement is meager (~ 2%), this PR is a first step toward implementing the k-way merge, as tracking the sorted runs is required for that algorithm.

Benchmark baseline: 351437 tx/s
Benchmark this pr:   357342 tx/s 