### PR TITLE
VOPR: Don't print deinitialized packet

### DIFF
--- a/src/testing/packet_simulator.zig
+++ b/src/testing/packet_simulator.zig
@@ -419,7 +419,8 @@ pub fn PacketSimulatorType(comptime Packet: type) type {
             const queue_count = queue.count();
             if (queue_count + 1 > self.options.path_maximum_capacity) {
                 const link_packet = queue.remove_random(&self.prng).?;
-                self.packet_deinit(link_packet.packet);
+                defer self.packet_deinit(link_packet.packet);
+
                 log.warn("submit_packet: {} reached capacity, dropped packet: {}", .{
                     path,
                     if (@typeInfo(Packet) == .Pointer)


### PR DESCRIPTION
Note that this bug _only_ occurs if debug logging is enabled! (We should probably add a new task to the CFO so that it could catch this).

Stack trace:

```
General protection exception (no address available)
/var/home/djg/C/t/db/a/src/vsr/message_header.zig:148:21: 0x11ef017 in into_any (vopr)
        switch (self.command) {
                    ^
/var/home/djg/C/t/db/a/src/vsr/message_header.zig:248:30: 0x14b9690 in format__anon_32089 (vopr)
        switch (self.into_any()) {
                             ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/fmt.zig:494:32: 0x145a7d4 in formatType__anon_31163 (vopr)
        return try value.format(actual_fmt, options, writer);
                               ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/fmt.zig:185:23: 0x15969ec in format__anon_33171 (vopr)
        try formatType(
                      ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/io/Writer.zig:24:26: 0x154aa90 in print__anon_32892 (vopr)
    return std.fmt.format(self, format, args);
                         ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/io.zig:324:47: 0x14fab96 in log_override__anon_32412 (vopr)
            return @errorCast(self.any().print(format, args));
                                              ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/log.zig:125:22: 0x148dcf8 in log__anon_31567 (vopr)
    std.options.logFn(message_level, scope, format, args);
                     ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/log.zig:185:16: 0x13fa808 in warn__anon_30752 (vopr)
            log(.warn, scope, format, args);
               ^
/var/home/djg/C/t/db/a/src/testing/packet_simulator.zig:423:25: 0x13a1dc5 in submit_packet (vopr)
                log.warn("submit_packet: {} reached capacity, dropped packet: {}", .{
                        ^
/var/home/djg/C/t/db/a/src/testing/cluster/network.zig:237:47: 0x1375270 in send_message (vopr)
        network.packet_simulator.submit_packet(
                                              ^
/var/home/djg/C/t/db/a/src/testing/cluster/message_bus.zig:70:33: 0x13328f8 in send_message_to_replica (vopr)
        bus.network.send_message(message, .{
                                ^
/var/home/djg/C/t/db/a/src/vsr/replica.zig:8565:57: 0x12cf602 in send_message_to_replica_base (vopr)
                self.message_bus.send_message_to_replica(replica, message);
                                                        ^
/var/home/djg/C/t/db/a/src/vsr/replica.zig:8307:46: 0x12b763e in send_header_to_replica (vopr)
            self.send_message_to_replica_base(replica, message);
                                             ^
/var/home/djg/C/t/db/a/src/vsr/replica.zig:1573:40: 0x1265e26 in on_ping (vopr)
            self.send_header_to_replica(message.header.replica, @bitCast(Header.Pong{
                                       ^
/var/home/djg/C/t/db/a/src/vsr/replica.zig:1514:42: 0x1204272 in on_message (vopr)
                .ping => |m| self.on_ping(m),
                                         ^
/var/home/djg/C/t/db/a/src/vsr/replica.zig:1461:28: 0x11bc40b in on_message_from_bus (vopr)
            self.on_message(message);
                           ^
/var/home/djg/C/t/db/a/src/testing/cluster/network.zig:321:39: 0x117b607 in packet_deliver (vopr)
        target_bus.on_message_callback(target_bus, target_message);
                                      ^
/var/home/djg/C/t/db/a/src/testing/packet_simulator.zig:502:39: 0x13a1fad in packet_deliver (vopr)
            self.vtable.packet_deliver(self, packet, path);
                                      ^
/var/home/djg/C/t/db/a/src/testing/packet_simulator.zig:486:32: 0x1340ec9 in submit_packet_finish (vopr)
            self.packet_deliver(link_packet.packet, path);
                               ^
/var/home/djg/C/t/db/a/src/testing/packet_simulator.zig:367:50: 0x12e7849 in step (vopr)
                        self.submit_packet_finish(path, link_packet);
                                                 ^
/var/home/djg/C/t/db/a/src/testing/cluster/network.zig:113:45: 0x127b6df in step (vopr)
        return network.packet_simulator.step();
                                            ^
/var/home/djg/C/t/db/a/src/testing/cluster.zig:451:48: 0x1216a5f in tick (vopr)
                advanced = cluster.network.step() or advanced;
                                               ^
/var/home/djg/C/t/db/a/src/vopr.zig:815:31: 0x11dd0b9 in tick (vopr)
        simulator.cluster.tick();
                              ^
/var/home/djg/C/t/db/a/src/vopr.zig:245:23: 0x11d9c19 in main (vopr)
        simulator.tick();
                      ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/start.zig:524:37: 0x1178385 in posixCallMainAndExit (vopr)
            const result = root.main() catch |err| {
                                    ^
/var/home/djg/C/bin/zig-linux-x86_64-0.13.0/lib/std/start.zig:266:5: 0x1177ea1 in _start (vopr)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x1 in ??? (???)
Unwind information for `???:0x1` was not available, trace may be incomplete
```

Seed: ./zig/zig build vopr -- 1045452507385357793