### PR TITLE
Set socket options for peer connections.

### DIFF
--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -7,7 +7,7 @@ const assert = std.debug.assert;
 
 const is_linux = builtin.target.os.tag == .linux;
 
-pub const ListenOptions = struct {
+pub const SocketOptions = struct {
     rcvbuf: c_int,
     sndbuf: c_int,
     keepalive: ?struct {
@@ -17,6 +17,9 @@ pub const ListenOptions = struct {
     },
     user_timeout_ms: c_int,
     nodelay: bool,
+};
+
+pub const ListenOptions = struct {
     backlog: u31,
 };
 
@@ -25,62 +28,7 @@ pub fn listen(
     address: std.net.Address,
     options: ListenOptions,
 ) !std.net.Address {
-    const set = struct {
-        fn set(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
-            try posix.setsockopt(_fd, level, option, &std.mem.toBytes(value));
-        }
-    }.set;
-
-    if (options.rcvbuf > 0) rcvbuf: {
-        if (is_linux) {
-            // Requires CAP_NET_ADMIN privilege (settle for SO_RCVBUF in case of an EPERM):
-            if (set(fd, posix.SOL.SOCKET, posix.SO.RCVBUFFORCE, options.rcvbuf)) |_| {
-                break :rcvbuf;
-            } else |err| switch (err) {
-                error.PermissionDenied => {},
-                else => |e| return e,
-            }
-        }
-        try set(fd, posix.SOL.SOCKET, posix.SO.RCVBUF, options.rcvbuf);
-    }
-
-    if (options.sndbuf > 0) sndbuf: {
-        if (is_linux) {
-            // Requires CAP_NET_ADMIN privilege (settle for SO_SNDBUF in case of an EPERM):
-            if (set(fd, posix.SOL.SOCKET, posix.SO.SNDBUFFORCE, options.sndbuf)) |_| {
-                break :sndbuf;
-            } else |err| switch (err) {
-                error.PermissionDenied => {},
-                else => |e| return e,
-            }
-        }
-        try set(fd, posix.SOL.SOCKET, posix.SO.SNDBUF, options.sndbuf);
-    }
-
-    if (options.keepalive) |keepalive| {
-        try set(fd, posix.SOL.SOCKET, posix.SO.KEEPALIVE, 1);
-        if (is_linux) {
-            try set(fd, posix.IPPROTO.TCP, posix.TCP.KEEPIDLE, keepalive.keepidle);
-            try set(fd, posix.IPPROTO.TCP, posix.TCP.KEEPINTVL, keepalive.keepintvl);
-            try set(fd, posix.IPPROTO.TCP, posix.TCP.KEEPCNT, keepalive.keepcnt);
-        }
-    }
-
-    if (options.user_timeout_ms > 0) {
-        if (is_linux) {
-            const timeout_ms = options.user_timeout_ms;
-            try set(fd, posix.IPPROTO.TCP, posix.TCP.USER_TIMEOUT, timeout_ms);
-        }
-    }
-
-    // Set tcp no-delay
-    if (options.nodelay) {
-        if (is_linux) {
-            try set(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, 1);
-        }
-    }
-
-    try set(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, 1);
+    try setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, 1);
     try posix.bind(fd, &address.any, address.getOsSockLen());
 
     // Resolve port 0 to an actual port picked by the OS.
@@ -93,4 +41,62 @@ pub fn listen(
     try posix.listen(fd, options.backlog);
 
     return address_resolved;
+}
+
+pub fn socket_options(
+    fd: posix.socket_t,
+    options: SocketOptions,
+) !void {
+    if (options.rcvbuf > 0) rcvbuf: {
+        if (is_linux) {
+            // Requires CAP_NET_ADMIN privilege (settle for SO_RCVBUF in case of an EPERM):
+            if (setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVBUFFORCE, options.rcvbuf)) |_| {
+                break :rcvbuf;
+            } else |err| switch (err) {
+                error.PermissionDenied => {},
+                else => |e| return e,
+            }
+        }
+        try setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVBUF, options.rcvbuf);
+    }
+
+    if (options.sndbuf > 0) sndbuf: {
+        if (is_linux) {
+            // Requires CAP_NET_ADMIN privilege (settle for SO_SNDBUF in case of an EPERM):
+            if (setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDBUFFORCE, options.sndbuf)) |_| {
+                break :sndbuf;
+            } else |err| switch (err) {
+                error.PermissionDenied => {},
+                else => |e| return e,
+            }
+        }
+        try setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDBUF, options.sndbuf);
+    }
+
+    if (options.keepalive) |keepalive| {
+        try setsockopt(fd, posix.SOL.SOCKET, posix.SO.KEEPALIVE, 1);
+        if (is_linux) {
+            try setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.KEEPIDLE, keepalive.keepidle);
+            try setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.KEEPINTVL, keepalive.keepintvl);
+            try setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.KEEPCNT, keepalive.keepcnt);
+        }
+    }
+
+    if (options.user_timeout_ms > 0) {
+        if (is_linux) {
+            const timeout_ms = options.user_timeout_ms;
+            try setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.USER_TIMEOUT, timeout_ms);
+        }
+    }
+
+    // Set tcp no-delay
+    if (options.nodelay) {
+        if (is_linux) {
+            try setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, 1);
+        }
+    }
+}
+
+fn setsockopt(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
+    try posix.setsockopt(_fd, level, option, &std.mem.toBytes(value));
 }

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -8,15 +8,15 @@ const assert = std.debug.assert;
 const is_linux = builtin.target.os.tag == .linux;
 
 pub const TCPOptions = struct {
-    rcvbuf: c_int = 0,
-    sndbuf: c_int = 0,
+    rcvbuf: c_int,
+    sndbuf: c_int,
     keepalive: ?struct {
         keepidle: c_int,
         keepintvl: c_int,
         keepcnt: c_int,
-    } = null,
-    user_timeout_ms: c_int = 0,
-    nodelay: bool = false,
+    },
+    user_timeout_ms: c_int,
+    nodelay: bool,
 };
 
 pub const ListenOptions = struct {
@@ -100,6 +100,6 @@ pub fn tcp_options(
     }
 }
 
-pub fn setsockopt(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
-    try posix.setsockopt(_fd, level, option, &std.mem.toBytes(value));
+pub fn setsockopt(fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
+    try posix.setsockopt(fd, level, option, &std.mem.toBytes(value));
 }

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -8,15 +8,15 @@ const assert = std.debug.assert;
 const is_linux = builtin.target.os.tag == .linux;
 
 pub const TCPOptions = struct {
-    rcvbuf: c_int,
-    sndbuf: c_int,
+    rcvbuf: c_int = 0,
+    sndbuf: c_int = 0,
     keepalive: ?struct {
         keepidle: c_int,
         keepintvl: c_int,
         keepcnt: c_int,
-    },
-    user_timeout_ms: c_int,
-    nodelay: bool,
+    } = null,
+    user_timeout_ms: c_int = 0,
+    nodelay: bool = false,
 };
 
 pub const ListenOptions = struct {
@@ -43,6 +43,9 @@ pub fn listen(
     return address_resolved;
 }
 
+/// Sets the socket options.
+/// Although some options are generic at the socket level,
+/// these settings are intended only for TCP sockets.
 pub fn tcp_options(
     fd: posix.socket_t,
     options: TCPOptions,

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -7,7 +7,7 @@ const assert = std.debug.assert;
 
 const is_linux = builtin.target.os.tag == .linux;
 
-pub const SocketOptions = struct {
+pub const TCPOptions = struct {
     rcvbuf: c_int,
     sndbuf: c_int,
     keepalive: ?struct {
@@ -43,9 +43,9 @@ pub fn listen(
     return address_resolved;
 }
 
-pub fn socket_options(
+pub fn tcp_options(
     fd: posix.socket_t,
-    options: SocketOptions,
+    options: TCPOptions,
 ) !void {
     if (options.rcvbuf > 0) rcvbuf: {
         if (is_linux) {
@@ -97,6 +97,6 @@ pub fn socket_options(
     }
 }
 
-fn setsockopt(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
+pub fn setsockopt(_fd: posix.socket_t, level: i32, option: u32, value: c_int) !void {
     try posix.setsockopt(_fd, level, option, &std.mem.toBytes(value));
 }

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -807,6 +807,14 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
+    pub fn socket_options(
+        _: *IO,
+        fd: socket_t,
+        options: common.SocketOptions,
+    ) !void {
+        try common.socket_options(fd, options);
+    }
+
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {
         return posix.shutdown(socket, how);
     }

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -13,6 +13,8 @@ const buffer_limit = @import("../io.zig").buffer_limit;
 const DirectIO = @import("../io.zig").DirectIO;
 
 pub const IO = struct {
+    pub const TCPOptions = common.TCPOptions;
+
     kq: fd_t,
     event_id: Event = 0,
     time: Time = .{},
@@ -775,8 +777,8 @@ pub const IO = struct {
     pub const socket_t = posix.socket_t;
     pub const INVALID_SOCKET = -1;
 
-    /// Creates a socket that can be used for async operations with the IO instance.
-    pub fn open_socket_tcp(self: *IO, family: u32, options: common.TCPOptions) !socket_t {
+    /// Creates a TCP socket that can be used for async operations with the IO instance.
+    pub fn open_socket_tcp(self: *IO, family: u32, options: TCPOptions) !socket_t {
         const fd = try self.open_socket(
             family,
             posix.SOCK.STREAM | posix.SOCK.NONBLOCK,
@@ -788,7 +790,7 @@ pub const IO = struct {
         return fd;
     }
 
-    /// Creates a socket that can be used for async operations with the IO instance.
+    /// Creates a UDP socket that can be used for async operations with the IO instance.
     pub fn open_socket_udp(self: *IO, family: u32) !socket_t {
         return try self.open_socket(
             family,

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -784,7 +784,7 @@ pub const IO = struct {
         _ = try posix.fcntl(fd, posix.F.SETFD, posix.FD_CLOEXEC);
 
         // darwin doesn't support posix.MSG_NOSIGNAL, but instead a socket option to avoid SIGPIPE.
-        try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.NOSIGPIPE, &mem.toBytes(@as(c_int, 1)));
+        try common.setsockopt(fd, posix.SOL.SOCKET, posix.SO.NOSIGPIPE, 1);
 
         return fd;
     }
@@ -807,12 +807,15 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
-    pub fn socket_options(
+    /// Sets the socket options.
+    /// Although some options are generic at the socket level,
+    /// these settings are intended only for TCP sockets.
+    pub fn tcp_options(
         _: *IO,
         fd: socket_t,
-        options: common.SocketOptions,
+        options: common.TCPOptions,
     ) !void {
-        try common.socket_options(fd, options);
+        try common.tcp_options(fd, options);
     }
 
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1478,6 +1478,14 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
+    pub fn socket_options(
+        _: *IO,
+        fd: socket_t,
+        options: common.SocketOptions,
+    ) !void {
+        try common.socket_options(fd, options);
+    }
+
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {
         return posix.shutdown(socket, how);
     }

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1478,12 +1478,15 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
-    pub fn socket_options(
+    /// Sets the socket options.
+    /// Although some options are generic at the socket level,
+    /// these settings are intended only for TCP sockets.
+    pub fn tcp_options(
         _: *IO,
         fd: socket_t,
-        options: common.SocketOptions,
+        options: common.TCPOptions,
     ) !void {
-        try common.socket_options(fd, options);
+        try common.tcp_options(fd, options);
     }
 
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -19,6 +19,7 @@ const parse_dirty_semver = stdx.parse_dirty_semver;
 const maybe = stdx.maybe;
 
 pub const IO = struct {
+    pub const TCPOptions = common.TCPOptions;
     const CompletionList = DoublyLinkedListType(Completion, .awaiting_back, .awaiting_next);
 
     ring: IO_Uring,
@@ -1454,8 +1455,8 @@ pub const IO = struct {
     pub const socket_t = posix.socket_t;
     pub const INVALID_SOCKET = -1;
 
-    /// Creates a UDP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_tcp(self: *IO, family: u32, options: common.TCPOptions) !socket_t {
+    /// Creates a TCP socket that can be used for async operations with the IO instance.
+    pub fn open_socket_tcp(self: *IO, family: u32, options: TCPOptions) !socket_t {
         const fd = try posix.socket(
             family,
             posix.SOCK.STREAM | posix.SOCK.CLOEXEC,

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -8,6 +8,14 @@ const assert = std.debug.assert;
 const Time = @import("../time.zig").Time;
 const IO = @import("../io.zig").IO;
 
+pub const tcp_options: IO.TCPOptions = .{
+    .rcvbuf = 0,
+    .sndbuf = 0,
+    .keepalive = null,
+    .user_timeout_ms = 0,
+    .nodelay = false,
+};
+
 test "open/write/read/close/statx" {
     try struct {
         const Context = @This();
@@ -164,10 +172,10 @@ test "accept/connect/send/receive" {
             const address = try std.net.Address.parseIp4("127.0.0.1", 0);
             const kernel_backlog = 1;
 
-            const server = try io.open_socket_tcp(address.any.family, .{});
+            const server = try io.open_socket_tcp(address.any.family, tcp_options);
             defer io.close_socket(server);
 
-            const client = try io.open_socket_tcp(address.any.family, .{});
+            const client = try io.open_socket_tcp(address.any.family, tcp_options);
             defer io.close_socket(client);
 
             try posix.setsockopt(
@@ -450,7 +458,7 @@ test "tick to wait" {
             const address = try std.net.Address.parseIp4("127.0.0.1", 0);
             const kernel_backlog = 1;
 
-            const server = try self.io.open_socket_tcp(address.any.family, .{});
+            const server = try self.io.open_socket_tcp(address.any.family, tcp_options);
             defer self.io.close_socket(server);
 
             try posix.setsockopt(
@@ -466,7 +474,7 @@ test "tick to wait" {
             var client_address_len = client_address.getOsSockLen();
             try posix.getsockname(server, &client_address.any, &client_address_len);
 
-            const client = try self.io.open_socket_tcp(client_address.any.family, .{});
+            const client = try self.io.open_socket_tcp(client_address.any.family, tcp_options);
             defer self.io.close_socket(client);
 
             // Start the accept
@@ -645,7 +653,7 @@ test "pipe data over socket" {
             };
             defer self.io.deinit();
 
-            self.server.fd = try self.io.open_socket_tcp(posix.AF.INET, .{});
+            self.server.fd = try self.io.open_socket_tcp(posix.AF.INET, tcp_options);
             defer self.io.close_socket(self.server.fd);
 
             const address = try std.net.Address.parseIp4("127.0.0.1", 0);
@@ -671,7 +679,7 @@ test "pipe data over socket" {
                 self.server.fd,
             );
 
-            self.tx.socket.fd = try self.io.open_socket_tcp(posix.AF.INET, .{});
+            self.tx.socket.fd = try self.io.open_socket_tcp(posix.AF.INET, tcp_options);
             defer self.io.close_socket(self.tx.socket.fd);
 
             self.io.connect(

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -164,18 +164,10 @@ test "accept/connect/send/receive" {
             const address = try std.net.Address.parseIp4("127.0.0.1", 0);
             const kernel_backlog = 1;
 
-            const server = try io.open_socket(
-                address.any.family,
-                posix.SOCK.STREAM,
-                posix.IPPROTO.TCP,
-            );
+            const server = try io.open_socket_tcp(address.any.family, .{});
             defer io.close_socket(server);
 
-            const client = try io.open_socket(
-                address.any.family,
-                posix.SOCK.STREAM,
-                posix.IPPROTO.TCP,
-            );
+            const client = try io.open_socket_tcp(address.any.family, .{});
             defer io.close_socket(client);
 
             try posix.setsockopt(
@@ -458,8 +450,7 @@ test "tick to wait" {
             const address = try std.net.Address.parseIp4("127.0.0.1", 0);
             const kernel_backlog = 1;
 
-            const server =
-                try self.io.open_socket(address.any.family, posix.SOCK.STREAM, posix.IPPROTO.TCP);
+            const server = try self.io.open_socket_tcp(address.any.family, .{});
             defer self.io.close_socket(server);
 
             try posix.setsockopt(
@@ -475,11 +466,7 @@ test "tick to wait" {
             var client_address_len = client_address.getOsSockLen();
             try posix.getsockname(server, &client_address.any, &client_address_len);
 
-            const client = try self.io.open_socket(
-                client_address.any.family,
-                posix.SOCK.STREAM,
-                posix.IPPROTO.TCP,
-            );
+            const client = try self.io.open_socket_tcp(client_address.any.family, .{});
             defer self.io.close_socket(client);
 
             // Start the accept
@@ -658,11 +645,7 @@ test "pipe data over socket" {
             };
             defer self.io.deinit();
 
-            self.server.fd = try self.io.open_socket(
-                posix.AF.INET,
-                posix.SOCK.STREAM,
-                posix.IPPROTO.TCP,
-            );
+            self.server.fd = try self.io.open_socket_tcp(posix.AF.INET, .{});
             defer self.io.close_socket(self.server.fd);
 
             const address = try std.net.Address.parseIp4("127.0.0.1", 0);
@@ -688,11 +671,7 @@ test "pipe data over socket" {
                 self.server.fd,
             );
 
-            self.tx.socket.fd = try self.io.open_socket(
-                posix.AF.INET,
-                posix.SOCK.STREAM,
-                posix.IPPROTO.TCP,
-            );
+            self.tx.socket.fd = try self.io.open_socket_tcp(posix.AF.INET, .{});
             defer self.io.close_socket(self.tx.socket.fd);
 
             self.io.connect(

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -12,6 +12,8 @@ const buffer_limit = @import("../io.zig").buffer_limit;
 const DirectIO = @import("../io.zig").DirectIO;
 
 pub const IO = struct {
+    pub const TCPOptions = common.TCPOptions;
+
     iocp: os.windows.HANDLE,
     timer: Time = .{},
     io_pending: usize = 0,
@@ -1088,7 +1090,7 @@ pub const IO = struct {
     pub const INVALID_SOCKET = os.windows.ws2_32.INVALID_SOCKET;
 
     /// Creates a TCP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_tcp(self: *IO, family: u32, options: common.TCPOptions) !socket_t {
+    pub fn open_socket_tcp(self: *IO, family: u32, options: TCPOptions) !socket_t {
         const socket = try self.open_socket(
             @bitCast(family),
             posix.SOCK.STREAM,

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1139,12 +1139,15 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
-    pub fn socket_options(
+    /// Sets the socket options.
+    /// Although some options are generic at the socket level,
+    /// these settings are intended only for TCP sockets.
+    pub fn tcp_options(
         _: *IO,
         fd: socket_t,
-        options: common.SocketOptions,
+        options: common.TCPOptions,
     ) !void {
-        try common.socket_options(fd, options);
+        try common.tcp_options(fd, options);
     }
 
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1139,6 +1139,14 @@ pub const IO = struct {
         return common.listen(fd, address, options);
     }
 
+    pub fn socket_options(
+        _: *IO,
+        fd: socket_t,
+        options: common.SocketOptions,
+    ) !void {
+        try common.socket_options(fd, options);
+    }
+
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {
         return posix.shutdown(socket, how);
     }

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -444,9 +444,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 assert(connection.state == .free);
                 assert(connection.fd == IO.INVALID_SOCKET);
 
-                // The first replica's network address family determines the
-                // family for all other replicas:
-                const family = bus.configuration[0].any.family;
+                const family = bus.configuration[replica].any.family;
                 connection.fd = init_tcp(bus.io, family) catch return;
                 connection.peer = .{ .replica = replica };
                 connection.state = .connecting;

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -297,7 +297,7 @@ const Connection = struct {
 
         const remote_fd = connection.io.open_socket_tcp(
             connection.remote_address.?.any.family,
-            .{},
+            tcp_options,
         ) catch |err| {
             log.warn("couldn't open socket for remote ({d},{d}): {}", .{
                 connection.replica_index,
@@ -462,6 +462,14 @@ const Proxy = struct {
     }
 };
 
+pub const tcp_options: IO.TCPOptions = .{
+    .rcvbuf = 0,
+    .sndbuf = 0,
+    .keepalive = null,
+    .user_timeout_ms = 0,
+    .nodelay = false,
+};
+
 pub const Network = struct {
     io: *IO,
     prng: *stdx.PRNG,
@@ -495,7 +503,7 @@ pub const Network = struct {
         };
 
         for (address_mappings, proxies, 0..) |mapping, *proxy, replica_index| {
-            const listen_fd = try io.open_socket_tcp(mapping.origin.any.family, .{});
+            const listen_fd = try io.open_socket_tcp(mapping.origin.any.family, tcp_options);
             errdefer io.close_socket(listen_fd);
 
             proxy.io = io;

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -295,10 +295,9 @@ const Connection = struct {
         };
         connection.origin_fd = fd;
 
-        const remote_fd = connection.io.open_socket(
+        const remote_fd = connection.io.open_socket_tcp(
             connection.remote_address.?.any.family,
-            std.posix.SOCK.STREAM,
-            std.posix.IPPROTO.TCP,
+            .{},
         ) catch |err| {
             log.warn("couldn't open socket for remote ({d},{d}): {}", .{
                 connection.replica_index,
@@ -496,11 +495,7 @@ pub const Network = struct {
         };
 
         for (address_mappings, proxies, 0..) |mapping, *proxy, replica_index| {
-            const listen_fd = try io.open_socket(
-                mapping.origin.any.family,
-                std.posix.SOCK.STREAM,
-                std.posix.IPPROTO.TCP,
-            );
+            const listen_fd = try io.open_socket_tcp(mapping.origin.any.family, .{});
             errdefer io.close_socket(listen_fd);
 
             proxy.io = io;

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -129,11 +129,7 @@ pub const StatsD = struct {
         io: *IO,
         address: std.net.Address,
     ) !StatsD {
-        const socket = try io.open_socket(
-            address.any.family,
-            std.posix.SOCK.DGRAM,
-            std.posix.IPPROTO.UDP,
-        );
+        const socket = try io.open_socket_udp(address.any.family);
         errdefer io.close_socket(socket);
 
         const send_buffer = try allocator.create([packet_count_max * packet_size_max]u8);


### PR DESCRIPTION
Socket options such as keepalive, timeout, no_delay, and send/receive buffer size were previously set only during `listen()`, leaving clients and replica-to-replica sockets with default OS parameters.