### PR TITLE
stdx: modernize stdx.cut API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -482,6 +482,8 @@ fn build_ci_step(
 ) void {
     const argv = .{ b.graph.zig_exe, "build" } ++ command;
     const system_command = b.addSystemCommand(&argv);
+    const name = std.mem.join(b.allocator, " ", &command) catch @panic("OOM");
+    system_command.setName(name);
     hide_stderr(system_command);
     step_ci.dependOn(&system_command.step);
 }

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -107,7 +107,7 @@ pub fn main() !void {
 fn extract_function_name(define: []const u8, buf: []u8) ?[]const u8 {
     if (!std.mem.endsWith(u8, define, "{")) return null;
 
-    const mangled_name = (stdx.cut(define, "@") orelse return null).suffix;
+    _, const mangled_name = stdx.cut(define, "@") orelse return null;
     var buf_count: usize = 0;
     var level: u32 = 0;
     for (mangled_name) |c| {
@@ -138,7 +138,7 @@ test "extract_function_name" {
 
 /// Parses out the size argument of an memcpy call.
 fn extract_memcpy_size(memcpy_call: []const u8) ?u32 {
-    const call_args = (stdx.cut(memcpy_call, "(") orelse return null).suffix;
+    _, const call_args = stdx.cut(memcpy_call, "(") orelse return null;
     var level: u32 = 0;
     var arg_count: u32 = 0;
 
@@ -156,9 +156,9 @@ fn extract_memcpy_size(memcpy_call: []const u8) ?u32 {
         }
     } else return null;
 
-    const size_arg = (stdx.cut(args_after_size, ",") orelse return null).prefix;
+    const size_arg, _ = stdx.cut(args_after_size, ",") orelse return null;
 
-    const size_value = (stdx.cut(size_arg, " ") orelse return null).suffix;
+    _, const size_value = stdx.cut(size_arg, " ") orelse return null;
 
     // Runtime-known memcpy size, assume that's OK.
     if (std.mem.startsWith(u8, size_value, "%")) return 0;

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -619,8 +619,8 @@ fn run_fuzzers_prepare_tasks(tasks: *Tasks, shell: *Shell, gh_token: ?[]const u8
             var pr_fuzzers_count: u32 = 0;
             for (std.enums.values(Fuzzer)) |fuzzer| {
                 const labeled = for (pr.labels) |label| {
-                    if (stdx.cut(label.name, "fuzz ")) |cut| {
-                        if (std.mem.eql(u8, cut.suffix, @tagName(fuzzer))) {
+                    if (stdx.cut_prefix(label.name, "fuzz ")) |suffix| {
+                        if (std.mem.eql(u8, suffix, @tagName(fuzzer))) {
                             break true;
                         }
                     }

--- a/src/scripts/changelog.zig
+++ b/src/scripts/changelog.zig
@@ -138,19 +138,15 @@ fn format_changelog_cut_single_merge(merges_left: *[]const u8) !?struct {
     //
     //    Client: add ULID helper functions
 
-    var cut = stdx.cut(merges_left.*, "Merge pull request #") orelse return null;
-    merges_left.* = cut.suffix;
+    _, merges_left.* = stdx.cut(merges_left.*, "Merge pull request #") orelse return null;
 
-    cut = stdx.cut(merges_left.*, " from ") orelse return error.ParseMergeLog;
-    const pr = try std.fmt.parseInt(u16, cut.prefix, 10);
-    merges_left.* = cut.suffix;
+    const pr_string, merges_left.* = stdx.cut(merges_left.*, " from ") orelse
+        return error.ParseMergeLog;
+    const pr = try std.fmt.parseInt(u16, pr_string, 10);
 
-    cut = stdx.cut(merges_left.*, "\n    \n    ") orelse return error.ParseMergeLog;
-    merges_left.* = cut.suffix;
+    _, merges_left.* = stdx.cut(merges_left.*, "\n    \n    ") orelse return error.ParseMergeLog;
 
-    cut = stdx.cut(merges_left.*, "\n") orelse return error.ParseMergeLog;
-    const summary = cut.prefix;
-    merges_left.* = cut.suffix;
+    const summary, merges_left.* = stdx.cut(merges_left.*, "\n") orelse return error.ParseMergeLog;
 
     return .{ .pr = pr, .summary = summary };
 }
@@ -214,7 +210,7 @@ pub const ChangelogIterator = struct {
         assert(std.mem.endsWith(u8, text_full, "\n"));
         assert(!std.mem.endsWith(u8, text_full, "\n\n"));
 
-        const first_line, var body = stdx.cut(text_full, "\n").?.unpack();
+        const first_line, var body = stdx.cut(text_full, "\n").?;
         const release = if (std.mem.eql(u8, first_line, "## TigerBeetle (unreleased)"))
             null
         else
@@ -222,7 +218,7 @@ pub const ChangelogIterator = struct {
                 @panic("invalid changelog");
 
         body = stdx.cut_prefix(body, "\nReleased:").?;
-        _, body = stdx.cut(body, "\n").?.unpack();
+        _, body = stdx.cut(body, "\n").?;
         return .{ .release = release, .text_full = text_full, .text_body = body };
     }
 };

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -75,7 +75,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         "gh release --repo tigerbeetle/tigerbeetle list --limit 1",
         .{},
     );
-    const tag = stdx.cut(release_info, "\t").?.prefix;
+    const tag, _ = stdx.cut(release_info, "\t").?;
     log.info("validating release {s}", .{tag});
 
     try shell.exec(

--- a/src/scripts/client_readmes.zig
+++ b/src/scripts/client_readmes.zig
@@ -110,7 +110,7 @@ fn readme_root(ctx: *Context) !void {
                 "Then create `{s}` and copy this into it:\n\n",
                 .{ctx.docs.project_file_name},
             );
-            const project_file_language = stdx.cut(ctx.docs.project_file_name, ".").?.suffix;
+            _, const project_file_language = stdx.cut(ctx.docs.project_file_name, ".").?;
             ctx.code(project_file_language, ctx.docs.project_file);
         }
 
@@ -565,14 +565,11 @@ const Context = struct {
         const section_end =
             ctx.shell.fmt("endsection:{s}\n", .{section_name}) catch @panic("OOM");
 
-        var text = ctx.walkthrough;
+        var rest = ctx.walkthrough;
         for (0..10) |_| {
-            text = (stdx.cut(text, section_start) orelse break).suffix;
+            _, rest = stdx.cut(rest, section_start) orelse break;
 
-            const section_cut = stdx.cut(text, section_end).?;
-            text = section_cut.suffix;
-
-            var section = section_cut.prefix;
+            var section, rest = stdx.cut(rest, section_end).?;
             section = section[0..std.mem.lastIndexOfScalar(u8, section, '\n').?];
 
             var indent_min: usize = std.math.maxInt(usize);

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -255,27 +255,15 @@ test bytes_as_slice {
     );
 }
 
-const Cut = struct {
-    prefix: []const u8,
-    suffix: []const u8,
-
-    pub fn unpack(self: Cut) struct { []const u8, []const u8 } {
-        return .{ self.prefix, self.suffix };
-    }
-};
-
 /// Splits the `haystack` around the first occurrence of `needle`, returning parts before and after.
 ///
 /// This is a Zig version of Go's `string.Cut` / Rust's `str::split_once`. Cut turns out to be a
 /// surprisingly versatile primitive for ad-hoc string processing. Often `std.mem.indexOf` and
 /// `std.mem.split` can be replaced with a shorter and clearer code using  `cut`.
-pub fn cut(haystack: []const u8, needle: []const u8) ?Cut {
+pub fn cut(haystack: []const u8, needle: []const u8) ?struct { []const u8, []const u8 } {
     const index = std.mem.indexOf(u8, haystack, needle) orelse return null;
 
-    return Cut{
-        .prefix = haystack[0..index],
-        .suffix = haystack[index + needle.len ..],
-    };
+    return .{ haystack[0..index], haystack[index + needle.len ..] };
 }
 
 pub fn cut_prefix(haystack: []const u8, needle: []const u8) ?[]const u8 {

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -44,11 +44,12 @@ pub const Ratio = struct {
     }
 
     pub fn parse_flag_value(value: []const u8) union(enum) { ok: Ratio, err: []const u8 } {
-        const cut = stdx.cut(value, "/") orelse
+        const numerator_string, const denominator_string = stdx.cut(value, "/") orelse
             return .{ .err = "expected 'a/b' ratio, but found:" };
-        const numerator = std.fmt.parseInt(u64, cut.prefix, 16) catch
+
+        const numerator = std.fmt.parseInt(u64, numerator_string, 16) catch
             return .{ .err = "invalid numerator:" };
-        const denominator = std.fmt.parseInt(u64, cut.suffix, 16) catch
+        const denominator = std.fmt.parseInt(u64, denominator_string, 16) catch
             return .{ .err = "invalid denominator:" };
         if (numerator > denominator) {
             return .{ .err = "ratio greater than 1:" };


### PR DESCRIPTION
Cut predates tuple unpacking in Zig, so it can be simplifed away now.