### PR TITLE
Add basic monitoring docs and track request timings

### DIFF
--- a/docs/operating/README.md
+++ b/docs/operating/README.md
@@ -8,6 +8,7 @@ in the harshest conditions, there's certainly a preferred way to handle one!
 - [Hardware](./hardware.md) specifies the host requirements.
 - [Cluster](./cluster.md) specifies the overall cluster requirements and recommendations.
 - [Deploying](./deploying/) spells out deployment process and its variations.
+- [Monitoring](./monitoring.md) details how to monitor a TigerBeetle cluster.
 - [Upgrading](./upgrading.md) explains how to move to a newer TigerBeetle version without downtime.
 - [Recovering](./recovering.md) explains how to repair the cluster when a replica is permanently
   lost.

--- a/docs/operating/monitoring.md
+++ b/docs/operating/monitoring.md
@@ -1,8 +1,7 @@
 # Monitoring
 
-TigerBeetle supports emitting metrics via StatsD, with
-[DogStatsD extensions](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell?tab=metrics)
-for tags.
+TigerBeetle supports emitting metrics via StatsD, and uses the
+[DogStatsD format for tags.](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell?tab=metrics)
 
 This requires a StatsD compatible agent running locally. The Datadog Agent works out of the
 box with its default configuration, as does Telegraf's [statsd plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/README.md),
@@ -14,7 +13,9 @@ You can enable emitting metrics by adding the following CLI flags to each replic
 ```
 --experimental --statsd=127.0.0.1:8125
 ```
-(the `--statsd=` only accepts IP addresses at present.)
+
+The `--statsd` argument must be specified as an `IP:Port` address (IPv4 or IPv6).  DNS names are not
+currently supported.
 
 All TigerBeetle metrics are namespaced under `tb.` and are tagged with `cluster` (the cluster ID
 specified at format time) and `replica` (the replica index). Specific metrics might have additional

--- a/docs/operating/monitoring.md
+++ b/docs/operating/monitoring.md
@@ -1,0 +1,67 @@
+# Monitoring
+
+TigerBeetle supports emitting metrics via StatsD, with
+[DogStatsD extensions](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell?tab=metrics)
+for tags.
+
+This requires a StatsD compatible agent running locally. The Datadog Agent works out of the
+box with its default configuration, as does Telegraf's [statsd plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/README.md),
+with `datadog_extensions` enabled.
+
+You can enable emitting metrics by adding the following CLI flags to each replica, depending on your
+[deployment method](./deploying/):
+
+```
+--experimental --statsd=127.0.0.1:8125
+```
+(the `--statsd=` only accepts IP addresses at present.)
+
+All TigerBeetle metrics are namespaced under `tb.` and are tagged with `cluster` (the cluster ID
+specified at format time) and `replica` (the replica index). Specific metrics might have additional
+tags - you can see a full list of metrics and cardinality by running `tigerbeetle inspect metrics`.
+
+## Specific Metrics
+
+### Overall status
+The `replica_status` metric corresponds to the overall status of the replica. If it's anything other
+than 0, it should be alerted on as it indicates a non-normal status. The full values are:
+
+| Value | Status          | Explanation                                                                                                                                    |
+|-------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0     | normal          | The replica is functioning normally.                                                                                                           |
+| 1     | view_change     | The replica is doing a view change.                                                                                                            |
+| 2     | recovering      | The replica is recovering. Usually, this will be present on startup before immediately transitioning to normal.                                |
+| 3     | recovering_head | The replica's persistent state is corrupted, and it can't participate in consensus. It will try and recover from the remainder of the cluster. |
+
+### State sync status
+The `replica_sync_stage` metric corresponds to the state sync stage. If this is anything other than
+`0`, the replica is undergoing state sync and should be alerted on.
+
+### Operations timing
+The `replica_request` timing metric can help inform how long requests are taking. This is tagged
+with the operation type (e.g., `create_accounts`) and is the closest measure of how long a request
+takes end to end, from the replica's point of view.
+
+It's recommended to additionally add metrics around your TigerBeetle client code, to measure the
+full request latency, including things like network delay which aren't captured here.
+
+### Cache monitoring and sizing
+The `grid_cache_hits` and `grid_cache_misses` metrics can help inform if your grid cache
+(`--cache-grid`) is sized too small for your workload.
+
+## System Monitoring
+In addition to TigerBeetle's own metrics, it's recommended to monitor and alert on a few additional
+system level metrics. These are:
+
+* Disk space used, on the path that has the TigerBeetle data file.
+* NTP clock sync status.
+* Memory utilization: once started, TigerBeetle will use a fixed amount of memory and not change. A
+  change in memory utilization can indicate a problem with other processes on the server.
+* CPU utilization: TigerBeetle will use at most a single core at present. CPU utilization exceeding
+  a single core can indicate a problem with other processes on the server.
+
+While a specific alerting threshold is hard to define for the following, they are useful to monitor
+to help diagnose problems:
+
+* Network bandwidth utilization.
+* Disk bandwidth utilization.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -763,14 +763,12 @@ pub const StateMachineConfig = struct {
     release: vsr.Release,
     message_body_size_max: comptime_int,
     lsm_compaction_ops: comptime_int,
-    vsr_operations_reserved: u8,
 };
 
 pub const state_machine_config = StateMachineConfig{
     .release = config.process.release,
     .message_body_size_max = message_body_size_max,
     .lsm_compaction_ops = lsm_compaction_ops,
-    .vsr_operations_reserved = vsr_operations_reserved,
 };
 
 /// TigerBeetle uses asserts proactively, unless they severely degrade performance. For production,

--- a/src/docs_website/styles/config/vocabularies/docs/accept.txt
+++ b/src/docs_website/styles/config/vocabularies/docs/accept.txt
@@ -56,6 +56,7 @@ create_accounts
 create_transfer
 create_transfers
 credit_account_id
+Datadog
 datastack
 Dconfig
 Dcpu
@@ -190,6 +191,7 @@ myscript
 nack
 nacks
 namespace
+namespaced
 namespaces
 Nearline
 networkd
@@ -250,6 +252,7 @@ realised
 realtime
 rebalances
 rebase
+recovering_head
 Recurse
 Redpanda
 refactorings
@@ -321,6 +324,7 @@ tbid
 tbtest
 tdaly
 teardown
+Telegraf
 tenatus
 tensorush
 threadpools
@@ -355,6 +359,7 @@ userspace
 usize
 utcnow
 versión
+view_change
 Viewstamped
 virtualized
 Vitesse

--- a/src/iops.zig
+++ b/src/iops.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 const stdx = @import("./stdx.zig");
 const assert = std.debug.assert;
 
-/// Take a u8 to limit to 256 items max (2^8 = 256)
-pub fn IOPSType(comptime T: type, comptime size: u8) type {
+/// `size` is further bounded by the maximum the underlying BitSetType supports.
+pub fn IOPSType(comptime T: type, comptime size: u16) type {
     const Map = stdx.BitSetType(size);
 
     return struct {

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -92,34 +92,6 @@ pub const tree_ids = struct {
     };
 };
 
-// Looking to make backwards incompatible changes here? Make sure to check release.zig for
-// `release_triple_client_min`.
-pub const Operation_ = enum(u8) {
-    /// Operations exported by TigerBeetle:
-    pulse = global_constants.vsr_operations_reserved + 0,
-
-    // Deprecated operations not encoded as multi-batch:
-    deprecated_create_accounts = global_constants.vsr_operations_reserved + 1,
-    deprecated_create_transfers = global_constants.vsr_operations_reserved + 2,
-    deprecated_lookup_accounts = global_constants.vsr_operations_reserved + 3,
-    deprecated_lookup_transfers = global_constants.vsr_operations_reserved + 4,
-    deprecated_get_account_transfers = global_constants.vsr_operations_reserved + 5,
-    deprecated_get_account_balances = global_constants.vsr_operations_reserved + 6,
-    deprecated_query_accounts = global_constants.vsr_operations_reserved + 7,
-    deprecated_query_transfers = global_constants.vsr_operations_reserved + 8,
-
-    get_change_events = config.vsr_operations_reserved + 9,
-
-    create_accounts = global_constants.vsr_operations_reserved + 10,
-    create_transfers = global_constants.vsr_operations_reserved + 11,
-    lookup_accounts = global_constants.vsr_operations_reserved + 12,
-    lookup_transfers = global_constants.vsr_operations_reserved + 13,
-    get_account_transfers = global_constants.vsr_operations_reserved + 14,
-    get_account_balances = global_constants.vsr_operations_reserved + 15,
-    query_accounts = global_constants.vsr_operations_reserved + 16,
-    query_transfers = global_constants.vsr_operations_reserved + 17,
-};
-
 pub fn StateMachineType(
     comptime Storage: type,
     comptime config: global_constants.StateMachineConfig,
@@ -131,7 +103,7 @@ pub fn StateMachineType(
     return struct {
         const StateMachine = @This();
         const Grid = @import("vsr/grid.zig").GridType(Storage);
-        pub const Operation = Operation_;
+        pub const Operation = tb.Operation;
 
         pub const constants = struct {
             pub const message_body_size_max = config.message_body_size_max;

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -92,17 +92,46 @@ pub const tree_ids = struct {
     };
 };
 
+// Looking to make backwards incompatible changes here? Make sure to check release.zig for
+// `release_triple_client_min`.
+pub const Operation_ = enum(u8) {
+    /// Operations exported by TigerBeetle:
+    pulse = global_constants.vsr_operations_reserved + 0,
+
+    // Deprecated operations not encoded as multi-batch:
+    deprecated_create_accounts = global_constants.vsr_operations_reserved + 1,
+    deprecated_create_transfers = global_constants.vsr_operations_reserved + 2,
+    deprecated_lookup_accounts = global_constants.vsr_operations_reserved + 3,
+    deprecated_lookup_transfers = global_constants.vsr_operations_reserved + 4,
+    deprecated_get_account_transfers = global_constants.vsr_operations_reserved + 5,
+    deprecated_get_account_balances = global_constants.vsr_operations_reserved + 6,
+    deprecated_query_accounts = global_constants.vsr_operations_reserved + 7,
+    deprecated_query_transfers = global_constants.vsr_operations_reserved + 8,
+
+    get_change_events = config.vsr_operations_reserved + 9,
+
+    create_accounts = global_constants.vsr_operations_reserved + 10,
+    create_transfers = global_constants.vsr_operations_reserved + 11,
+    lookup_accounts = global_constants.vsr_operations_reserved + 12,
+    lookup_transfers = global_constants.vsr_operations_reserved + 13,
+    get_account_transfers = global_constants.vsr_operations_reserved + 14,
+    get_account_balances = global_constants.vsr_operations_reserved + 15,
+    query_accounts = global_constants.vsr_operations_reserved + 16,
+    query_transfers = global_constants.vsr_operations_reserved + 17,
+};
+
 pub fn StateMachineType(
     comptime Storage: type,
     comptime config: global_constants.StateMachineConfig,
 ) type {
     assert(config.message_body_size_max > 0);
     assert(config.lsm_compaction_ops > 0);
-    assert(config.vsr_operations_reserved > 0);
+    assert(global_constants.vsr_operations_reserved > 0);
 
     return struct {
         const StateMachine = @This();
         const Grid = @import("vsr/grid.zig").GridType(Storage);
+        pub const Operation = Operation_;
 
         pub const constants = struct {
             pub const message_body_size_max = config.message_body_size_max;
@@ -438,34 +467,6 @@ pub fn StateMachineType(
         );
 
         const AccountEventsScanLookup = AccountEventsScanLookupType(AccountEventsGroove, Storage);
-
-        // Looking to make backwards incompatible changes here? Make sure to check release.zig for
-        // `release_triple_client_min`.
-        pub const Operation = enum(u8) {
-            /// Operations exported by TigerBeetle:
-            pulse = config.vsr_operations_reserved + 0,
-
-            // Deprecated operations not encoded as multi-batch:
-            deprecated_create_accounts = config.vsr_operations_reserved + 1,
-            deprecated_create_transfers = config.vsr_operations_reserved + 2,
-            deprecated_lookup_accounts = config.vsr_operations_reserved + 3,
-            deprecated_lookup_transfers = config.vsr_operations_reserved + 4,
-            deprecated_get_account_transfers = config.vsr_operations_reserved + 5,
-            deprecated_get_account_balances = config.vsr_operations_reserved + 6,
-            deprecated_query_accounts = config.vsr_operations_reserved + 7,
-            deprecated_query_transfers = config.vsr_operations_reserved + 8,
-
-            get_change_events = config.vsr_operations_reserved + 9,
-
-            create_accounts = config.vsr_operations_reserved + 10,
-            create_transfers = config.vsr_operations_reserved + 11,
-            lookup_accounts = config.vsr_operations_reserved + 12,
-            lookup_transfers = config.vsr_operations_reserved + 13,
-            get_account_transfers = config.vsr_operations_reserved + 14,
-            get_account_balances = config.vsr_operations_reserved + 15,
-            query_accounts = config.vsr_operations_reserved + 16,
-            query_transfers = config.vsr_operations_reserved + 17,
-        };
 
         pub fn operation_from_vsr(operation: vsr.Operation) ?Operation {
             if (operation == .pulse) return .pulse;
@@ -4918,7 +4919,6 @@ pub const TestContext = struct {
         // Overestimate the batch size because the test never compacts.
         .message_body_size_max = TestContext.message_body_size_max,
         .lsm_compaction_ops = global_constants.lsm_compaction_ops,
-        .vsr_operations_reserved = 128,
     });
     const AccountEvent = StateMachine.AccountEvent;
     pub const message_body_size_max = 64 * @max(@sizeOf(Account), @sizeOf(Transfer));
@@ -7709,7 +7709,6 @@ test "StateMachine: batch_elements_max" {
         .release = vsr.Release.minimum,
         .message_body_size_max = message_body_size_max,
         .lsm_compaction_ops = global_constants.lsm_compaction_ops,
-        .vsr_operations_reserved = global_constants.vsr_operations_reserved,
     });
 
     // No multi-batch encode.

--- a/src/stdx/bit_set.zig
+++ b/src/stdx/bit_set.zig
@@ -2,15 +2,15 @@ const stdx = @import("../stdx.zig");
 const std = @import("std");
 const assert = std.debug.assert;
 
-/// Take a u8 to limit to 255 items max (2^8 - 1 = 255).
-/// Use dynamic bitset for larger sizes.
-pub fn BitSetType(comptime with_capacity: u8) type {
+/// Takes a u16, but the maximum size is bounded by the Word selection below.
+/// Use a dynamic bitset for larger sizes.
+pub fn BitSetType(comptime with_capacity: u16) type {
     return struct {
         // While mathematically 0 and 1 are symmetric, we intentionally bias the API to use zeros
         // default, as zero-initialization reduces binary size.
         bits: Word = 0,
 
-        pub const Word = for (.{ u8, u16, u32, u64, u128, u256 }) |w| {
+        pub const Word = for (.{ u8, u16, u32, u64, u128, u256, u512 }) |w| {
             if (@bitSizeOf(w) >= with_capacity) break w;
         } else unreachable;
 
@@ -89,7 +89,7 @@ pub fn BitSetType(comptime with_capacity: u8) type {
 
 test BitSetType {
     var prng = stdx.PRNG.from_seed(92);
-    inline for (.{ 0, 1, 8, 32, 65, 255 }) |N| {
+    inline for (.{ 0, 1, 8, 32, 65, 255, 256, 512 }) |N| {
         const BitSet = BitSetType(N);
 
         var set: BitSet = .{};

--- a/src/stdx/bit_set.zig
+++ b/src/stdx/bit_set.zig
@@ -2,15 +2,16 @@ const stdx = @import("../stdx.zig");
 const std = @import("std");
 const assert = std.debug.assert;
 
-/// Takes a u16, but the maximum size is bounded by the Word selection below.
 /// Use a dynamic bitset for larger sizes.
-pub fn BitSetType(comptime with_capacity: u16) type {
+pub fn BitSetType(comptime with_capacity: u9) type {
+    assert(with_capacity <= 256);
+
     return struct {
         // While mathematically 0 and 1 are symmetric, we intentionally bias the API to use zeros
         // default, as zero-initialization reduces binary size.
         bits: Word = 0,
 
-        pub const Word = for (.{ u8, u16, u32, u64, u128, u256, u512 }) |w| {
+        pub const Word = for (.{ u8, u16, u32, u64, u128, u256 }) |w| {
             if (@bitSizeOf(w) >= with_capacity) break w;
         } else unreachable;
 
@@ -89,7 +90,7 @@ pub fn BitSetType(comptime with_capacity: u16) type {
 
 test BitSetType {
     var prng = stdx.PRNG.from_seed(92);
-    inline for (.{ 0, 1, 8, 32, 65, 255, 256, 512 }) |N| {
+    inline for (.{ 0, 1, 8, 32, 65, 255, 256 }) |N| {
         const BitSet = BitSetType(N);
 
         var set: BitSet = .{};

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -18,7 +18,7 @@ pub fn StateMachineType(
         pub const Workload = WorkloadType(StateMachine);
 
         pub const Operation = enum(u8) {
-            echo = config.vsr_operations_reserved + 0,
+            echo = global_constants.vsr_operations_reserved + 0,
         };
 
         pub fn operation_from_vsr(operation: vsr.Operation) ?Operation {

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 const stdx = @import("stdx.zig");
+const constants = @import("constants.zig");
 
 pub const Account = extern struct {
     id: u128,
@@ -628,6 +629,34 @@ pub const ChangeEventsFilter = extern struct {
         assert(stdx.no_padding(ChangeEventsFilter));
         assert(@sizeOf(ChangeEventsFilter) == 64);
     }
+};
+
+// Looking to make backwards incompatible changes here? Make sure to check release.zig for
+// `release_triple_client_min`.
+pub const Operation = enum(u8) {
+    /// Operations exported by TigerBeetle:
+    pulse = constants.vsr_operations_reserved + 0,
+
+    // Deprecated operations not encoded as multi-batch:
+    deprecated_create_accounts = constants.vsr_operations_reserved + 1,
+    deprecated_create_transfers = constants.vsr_operations_reserved + 2,
+    deprecated_lookup_accounts = constants.vsr_operations_reserved + 3,
+    deprecated_lookup_transfers = constants.vsr_operations_reserved + 4,
+    deprecated_get_account_transfers = constants.vsr_operations_reserved + 5,
+    deprecated_get_account_balances = constants.vsr_operations_reserved + 6,
+    deprecated_query_accounts = constants.vsr_operations_reserved + 7,
+    deprecated_query_transfers = constants.vsr_operations_reserved + 8,
+
+    get_change_events = constants.vsr_operations_reserved + 9,
+
+    create_accounts = constants.vsr_operations_reserved + 10,
+    create_transfers = constants.vsr_operations_reserved + 11,
+    lookup_accounts = constants.vsr_operations_reserved + 12,
+    lookup_transfers = constants.vsr_operations_reserved + 13,
+    get_account_transfers = constants.vsr_operations_reserved + 14,
+    get_account_balances = constants.vsr_operations_reserved + 15,
+    query_accounts = constants.vsr_operations_reserved + 16,
+    query_transfers = constants.vsr_operations_reserved + 17,
 };
 
 comptime {

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -417,8 +417,8 @@ test "trace json" {
     try snap(@src(),
         \\[
         \\{"pid":0,"tid":0,"ph":"B","ts":0,"cat":"replica_commit","name":"replica_commit  stage=idle","args":{"stage":"idle","op":123}},
-        \\{"pid":0,"tid":5,"ph":"B","ts":10000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
-        \\{"pid":0,"tid":5,"ph":"E","ts":20000},
+        \\{"pid":0,"tid":7,"ph":"B","ts":10000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
+        \\{"pid":0,"tid":7,"ph":"E","ts":20000},
         \\{"pid":0,"tid":0,"ph":"E","ts":60000},
         \\
     ).diff(trace_buffer.items);

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -360,7 +360,7 @@ pub fn TracerType(comptime Time: type) type {
         // values.
         //
         // This matches the default behavior of the `g` and `c` statsd types respectively.
-        fn timing(tracer: *Tracer, event_timing: EventTiming, duration_us: u64) void {
+        pub fn timing(tracer: *Tracer, event_timing: EventTiming, duration_us: u64) void {
             const timing_slot = event_timing.slot();
 
             if (tracer.events_timing[timing_slot]) |*event_timing_existing| {
@@ -417,8 +417,8 @@ test "trace json" {
     try snap(@src(),
         \\[
         \\{"pid":0,"tid":0,"ph":"B","ts":0,"cat":"replica_commit","name":"replica_commit  stage=idle","args":{"stage":"idle","op":123}},
-        \\{"pid":0,"tid":4,"ph":"B","ts":10000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
-        \\{"pid":0,"tid":4,"ph":"E","ts":20000},
+        \\{"pid":0,"tid":5,"ph":"B","ts":10000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
+        \\{"pid":0,"tid":5,"ph":"E","ts":20000},
         \\{"pid":0,"tid":0,"ph":"E","ts":60000},
         \\
     ).diff(trace_buffer.items);

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -4,7 +4,7 @@ const assert = std.debug.assert;
 const constants = @import("../constants.zig");
 
 const CommitStage = @import("../vsr/replica.zig").CommitStage;
-const Operation = @import("../state_machine.zig").Operation_;
+const Operation = @import("../tigerbeetle.zig").Operation;
 
 const TreeEnum = tree_enum: {
     const tree_ids = @import("../state_machine.zig").tree_ids;
@@ -68,6 +68,8 @@ pub const Event = union(enum) {
     replica_aof_write: struct { op: usize },
     replica_sync_table: struct { index: usize },
     replica_request: struct { operation: Operation },
+    replica_request_execute: struct { operation: Operation },
+    replica_request_local: struct { operation: Operation },
 
     compact_beat: struct { tree: TreeEnum, level_b: u8 },
     compact_beat_merge: struct { tree: TreeEnum, level_b: u8 },
@@ -135,6 +137,8 @@ pub const EventTiming = union(Event.Tag) {
     replica_aof_write,
     replica_sync_table,
     replica_request: struct { operation: Operation },
+    replica_request_execute: struct { operation: Operation },
+    replica_request_local: struct { operation: Operation },
 
     compact_beat: struct { tree: TreeEnum },
     compact_beat_merge: struct { tree: TreeEnum },
@@ -158,6 +162,8 @@ pub const EventTiming = union(Event.Tag) {
         .replica_aof_write = 1,
         .replica_sync_table = 1,
         .replica_request = enum_max(Operation),
+        .replica_request_execute = enum_max(Operation),
+        .replica_request_local = enum_max(Operation),
         .compact_beat = enum_max(TreeEnum),
         .compact_beat_merge = enum_max(TreeEnum),
         .compact_manifest = 1,
@@ -208,7 +214,10 @@ pub const EventTiming = union(Event.Tag) {
                 return slot_bases.get(event.*) + @as(u32, @intCast(stage));
             },
             // Single payload: Operation
-            inline .replica_request => |data| {
+            inline .replica_request,
+            .replica_request_execute,
+            .replica_request_local,
+            => |data| {
                 const operation = @intFromEnum(data.operation);
                 assert(operation < slot_limits.get(event.*));
 
@@ -271,6 +280,8 @@ pub const EventTracing = union(Event.Tag) {
     replica_aof_write,
     replica_sync_table: struct { index: usize },
     replica_request,
+    replica_request_execute,
+    replica_request_local,
 
     compact_beat,
     compact_beat_merge,
@@ -294,6 +305,8 @@ pub const EventTracing = union(Event.Tag) {
         .replica_aof_write = 1,
         .replica_sync_table = constants.grid_missing_tables_max,
         .replica_request = 1,
+        .replica_request_execute = 1,
+        .replica_request_local = 1,
         .compact_beat = 1,
         .compact_beat_merge = 1,
         .compact_manifest = 1,
@@ -554,6 +567,12 @@ test "EventTiming slot doesn't have collisions" {
             .replica_aof_write => .replica_aof_write,
             .replica_sync_table => .replica_sync_table,
             .replica_request => .{ .replica_request = .{ .operation = g.enum_value(Operation) } },
+            .replica_request_execute => .{ .replica_request_execute = .{
+                .operation = g.enum_value(Operation),
+            } },
+            .replica_request_local => .{ .replica_request_local = .{
+                .operation = g.enum_value(Operation),
+            } },
             .compact_beat => .{ .compact_beat = .{
                 .tree = g.enum_value(TreeEnum),
             } },

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 const constants = @import("../constants.zig");
 
 const CommitStage = @import("../vsr/replica.zig").CommitStage;
+const Operation = @import("../state_machine.zig").Operation_;
 
 const TreeEnum = tree_enum: {
     const tree_ids = @import("../state_machine.zig").tree_ids;
@@ -66,6 +67,7 @@ pub const Event = union(enum) {
     replica_commit: struct { stage: CommitStage.Tag, op: ?usize = null },
     replica_aof_write: struct { op: usize },
     replica_sync_table: struct { index: usize },
+    replica_request: struct { operation: Operation },
 
     compact_beat: struct { tree: TreeEnum, level_b: u8 },
     compact_beat_merge: struct { tree: TreeEnum, level_b: u8 },
@@ -132,6 +134,7 @@ pub const EventTiming = union(Event.Tag) {
     replica_commit: struct { stage: CommitStage.Tag },
     replica_aof_write,
     replica_sync_table,
+    replica_request: struct { operation: Operation },
 
     compact_beat: struct { tree: TreeEnum },
     compact_beat_merge: struct { tree: TreeEnum },
@@ -154,6 +157,7 @@ pub const EventTiming = union(Event.Tag) {
         .replica_commit = enum_max(CommitStage.Tag),
         .replica_aof_write = 1,
         .replica_sync_table = 1,
+        .replica_request = enum_max(Operation),
         .compact_beat = enum_max(TreeEnum),
         .compact_beat_merge = enum_max(TreeEnum),
         .compact_manifest = 1,
@@ -202,6 +206,13 @@ pub const EventTiming = union(Event.Tag) {
                 assert(stage < slot_limits.get(event.*));
 
                 return slot_bases.get(event.*) + @as(u32, @intCast(stage));
+            },
+            // Single payload: Operation
+            inline .replica_request => |data| {
+                const operation = @intFromEnum(data.operation);
+                assert(operation < slot_limits.get(event.*));
+
+                return slot_bases.get(event.*) + @as(u32, @intCast(operation));
             },
             // Single payload: TreeEnum
             inline .compact_mutable,
@@ -259,6 +270,7 @@ pub const EventTracing = union(Event.Tag) {
     replica_commit,
     replica_aof_write,
     replica_sync_table: struct { index: usize },
+    replica_request,
 
     compact_beat,
     compact_beat_merge,
@@ -281,6 +293,7 @@ pub const EventTracing = union(Event.Tag) {
         .replica_commit = 1,
         .replica_aof_write = 1,
         .replica_sync_table = constants.grid_missing_tables_max,
+        .replica_request = 1,
         .compact_beat = 1,
         .compact_beat_merge = 1,
         .compact_manifest = 1,
@@ -540,6 +553,7 @@ test "EventTiming slot doesn't have collisions" {
             .replica_commit => .{ .replica_commit = .{ .stage = g.enum_value(CommitStage.Tag) } },
             .replica_aof_write => .replica_aof_write,
             .replica_sync_table => .replica_sync_table,
+            .replica_request => .{ .replica_request = .{ .operation = g.enum_value(Operation) } },
             .compact_beat => .{ .compact_beat = .{
                 .tree = g.enum_value(TreeEnum),
             } },

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -4,7 +4,6 @@ const stdx = @import("../stdx.zig");
 const assert = std.debug.assert;
 
 const IO = @import("../io.zig").IO;
-const IOPSType = @import("../iops.zig").IOPSType;
 
 const EventMetric = @import("event.zig").EventMetric;
 const EventMetricAggregate = @import("event.zig").EventMetricAggregate;
@@ -119,7 +118,8 @@ pub const StatsD = struct {
     },
 
     send_buffer: *[packet_count_max * packet_size_max]u8,
-    send_completions: IOPSType(IO.Completion, packet_count_max) = .{},
+    send_completions: [packet_count_max]IO.Completion = undefined,
+    send_in_flight_count: u32 = 0,
 
     /// Creates a statsd instance, which will send UDP packets via the IO instance provided.
     pub fn init_udp(
@@ -191,10 +191,12 @@ pub const StatsD = struct {
         //
         // Keep it as a log, rather than assert, to avoid the common pitfall of metrics killing
         // the whole system.
-        if (self.send_completions.executing() != 0) {
+        //
+        // This is also a load-bearing check: see send_callback().
+        if (self.send_in_flight_count != 0) {
             log.err("{}: {} / {} packets still in flight; skipping emit", .{
                 self.replica,
-                self.send_completions.executing(),
+                self.send_in_flight_count,
                 packet_count_max,
             });
             return error.Busy;
@@ -264,11 +266,13 @@ pub const StatsD = struct {
 
         var send_offset: u32 = 0;
         for (send_sizes.const_slice()) |send_size| {
-            const completion = self.send_completions.acquire() orelse {
+            if (self.send_in_flight_count >= self.send_completions.len) {
                 // This shouldn't ever happen, but don't allow metrics to kill the system.
                 log.err("{}: insufficient packets to emit any metrics", .{self.replica});
                 return;
-            };
+            }
+            const completion = &self.send_completions[self.send_in_flight_count];
+            self.send_in_flight_count += 1;
             self.emit_buffer(completion, self.send_buffer[send_offset..][0..send_size]);
             send_offset += send_size;
         }
@@ -300,7 +304,11 @@ pub const StatsD = struct {
             assert(self.implementation == .udp);
             self.implementation.udp.send_callback_error_count += 1;
         };
-        self.send_completions.release(completion);
+
+        // Completions can be returned in any order: this is _only_ safe because their emitting is
+        // guarded on `self.send_in_flight_count != 0`.
+        self.send_in_flight_count -= 1;
+        completion.* = undefined;
     }
 };
 

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -103,7 +103,7 @@ const packet_count_max = stdx.div_ceil(
 comptime {
     // Sanity-check:
     assert(packet_count_max > 0);
-    assert(packet_count_max < 256);
+    assert(packet_count_max < 512);
 }
 
 pub const StatsD = struct {

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -574,9 +574,10 @@ pub fn ClientType(
                 std.time.ns_per_ms,
             );
             if (request_completion_time_ms > constants.client_request_completion_warn_ms) {
-                log.warn("{}: on_reply: slow request, request={} size={} {s} time={}ms", .{
+                log.warn("{}: on_reply: slow request, request={} op={} size={} {s} time={}ms", .{
                     self.id,
                     inflight.message.header.request,
+                    reply.header.op,
                     inflight.message.header.size,
                     inflight.message.header.operation.tag_name(StateMachine),
                     request_completion_time_ms,


### PR DESCRIPTION
This PR adds some basic documentation on monitoring (including things like what you should look out for at a system level), and adds a new metric: `replica_request` which currently corresponds to the `commit_dispatch: slow request` messages.

~Originally, the plan was to make `replica_request` be end-to-end - so things like a view change would show as a latency spike. However, this is complicated by the fact that the header's prepare timestamp is set by `primary_pipeline_prepare`, which will underestimate latency significantly.~

`replica_request` is now as end-to-end as it can be; it's based off the message timestamp, which happens as soon as replica sees a message. However, this is subject to a bit of measurement error: if a message comes in while CPU compaction is running, it'll exclude that time, but if it comes in before it'll include it. This causes a divergence from what the client sees, because the client sees a reply before compaction starts.

Additionally, `replica_request_local` is tracked which is the local timer (exact same values as the log messages) and `replica_request_execute` which is the end-to-end timing until the execute stage, at which point the reply is sent to the client.