### PR TITLE
scripts: Better error on empty readme template sections

### DIFF
--- a/src/scripts/client_readmes.zig
+++ b/src/scripts/client_readmes.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const assert = std.debug.assert;
+const log = std.log;
 
 const stdx = @import("../stdx.zig");
 const Shell = @import("../shell.zig");
@@ -573,7 +574,11 @@ const Context = struct {
             text = section_cut.suffix;
 
             var section = section_cut.prefix;
-            section = section[0..std.mem.lastIndexOfScalar(u8, section, '\n').?];
+            const newline_index = std.mem.lastIndexOfScalar(u8, section, '\n') orelse {
+                log.warn("empty section fragment: {s}", .{section_name});
+                @panic("empty section fragement");
+            };
+            section = section[0..newline_index];
 
             var indent_min: usize = std.math.maxInt(usize);
             var lines = std.mem.splitScalar(u8, section, '\n');


### PR DESCRIPTION
When adding the Rust client CI, I got stuck for a long time setting up the README template, where I initially created empty code sections to be copied into the readme.

For reference, every client has sample projects, and some of that content is copied into the client readme. I initially began the rust client sample by writing this:

```rust
// section:imports

fn main() {
    // endsection:imports
    todo!();                                                                                                                                             
    // section:client
    // endsection:client 
```

But empty sections are not allowed, producing an obscure assertion failure. This change makes the error more explicit when sections are empty by printing a explanatory warning and then panicking.

Hopefully this will make it easier for the next person who adds a client.