### PR TITLE
devhub: only fetch the main branch

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -501,7 +501,7 @@ fn upload_results(
 
     _ = try shell.cwd.deleteTree("./devhubdb");
     try shell.exec(
-        \\git clone --depth 1
+        \\git clone --single-branch --depth 1
         \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb.git
         \\  devhubdb
     , .{
@@ -515,7 +515,7 @@ fn upload_results(
         var arena = std.heap.ArenaAllocator.init(gpa);
         defer arena.deinit();
 
-        try shell.exec("git fetch origin", .{});
+        try shell.exec("git fetch origin main", .{});
         try shell.exec("git reset --hard origin/main", .{});
 
         const max_size = 1024 * 1024;

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -178,7 +178,7 @@ fn get_measurement(
 fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
     const token = try shell.env_get("DEVHUBDB_PAT");
     try shell.exec(
-        \\git clone --depth 1
+        \\git clone --single-branch --depth 1
         \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb.git
         \\  devhubdb
     , .{
@@ -189,7 +189,7 @@ fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
     defer shell.popd();
 
     for (0..32) |_| {
-        try shell.exec("git fetch origin", .{});
+        try shell.exec("git fetch origin main", .{});
         try shell.exec("git reset --hard origin/main", .{});
 
         {


### PR DESCRIPTION
We periodically rotate git history, such that the main branch has a short history, but full history is preserved in a branch named rotate-$(date --iso). To make this useful, we need to make sure to only clone the main branch!