### PR TITLE
devhub: add lewisdaly to the release rotation

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -35,6 +35,7 @@ function main_release_rotation() {
       "cb22",
       "chaitanyabhandari",
       "fabioarnold",
+      "lewisdaly",
       "matklad",
       "sentientwaffle",
     ];


### PR DESCRIPTION
<img width="213" alt="image" src="https://github.com/user-attachments/assets/573d144b-4b37-4965-a43a-c0b93737b15d" />

This week's release has been handled so this should be perfect timing.