### PR TITLE
ci: don't rely on default token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+permissions: {}
 
 concurrency:
   group: core-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+permissions: {}
 
 on:
   workflow_dispatch: # Manual triggering to re-run a release with a different run_number

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -1,4 +1,5 @@
 name: "Release (validate)"
+permissions: {}
 
 on:
   workflow_dispatch: # Manual triggering for debugging


### PR DESCRIPTION
As per TigerStyle,

> Explicitly pass options to library functions at the call site, instead
> of relying on the defaults.

This applies quadruply to automation permissions!