### PR TITLE
stdx: de-genericify Queue

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -26,10 +26,10 @@ pub const IO = struct {
 
     /// Operations not yet submitted to the kernel and waiting on available space in the
     /// submission queue.
-    unqueued: QueueType(Completion) = .{ .name = "io_unqueued" },
+    unqueued: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_unqueued" }),
 
     /// Completions that are ready to have their callbacks run.
-    completed: QueueType(Completion) = .{ .name = "io_completed" },
+    completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
 
     // TODO Track these as metrics:
     ios_queued: u32 = 0,
@@ -382,7 +382,7 @@ pub const IO = struct {
     pub const Completion = struct {
         io: *IO,
         result: i32 = undefined,
-        next: ?*Completion = null,
+        link: QueueType(Completion).Link = .{},
         operation: Operation,
         context: ?*anyopaque,
         callback: *const fn (

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -8,7 +8,7 @@ const QueueLink = extern struct {
 };
 
 /// An intrusive first in/first out linked list.
-/// The element type T must have a field called "next" of type ?*T
+/// The element type T must have a field called "link" of type QueueType(T).Link.
 pub fn QueueType(comptime T: type) type {
     return struct {
         any: QueueAny,

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -3,109 +3,203 @@ const assert = std.debug.assert;
 
 const constants = @import("./constants.zig");
 
+const QueueLink = extern struct {
+    next: ?*QueueLink = null,
+};
+
 /// An intrusive first in/first out linked list.
 /// The element type T must have a field called "next" of type ?*T
 pub fn QueueType(comptime T: type) type {
     return struct {
+        any: QueueAny,
+
+        pub const Link = QueueLink;
         const Queue = @This();
 
-        in: ?*T = null,
-        out: ?*T = null,
-        count: u64 = 0,
-
-        // This should only be null if you're sure we'll never want to monitor `count`.
-        name: ?[]const u8,
-
-        // If the number of elements is large, the constants.verify check in push() can be too
-        // expensive. Allow the user to gate it. Could also be a comptime param?
-        verify_push: bool = true,
-
-        pub fn push(self: *Queue, elem: *T) void {
-            if (constants.verify and self.verify_push) assert(!self.contains(elem));
-
-            assert(elem.next == null);
-            if (self.in) |in| {
-                in.next = elem;
-                self.in = elem;
-            } else {
-                assert(self.out == null);
-                self.in = elem;
-                self.out = elem;
-            }
-            self.count += 1;
+        pub inline fn init(options: struct {
+            name: ?[]const u8,
+            verify_push: bool = true,
+        }) Queue {
+            return .{ .any = .{
+                .name = options.name,
+                .verify_push = options.verify_push,
+            } };
         }
 
-        pub fn pop(self: *Queue) ?*T {
-            const ret = self.out orelse return null;
-            self.out = ret.next;
-            ret.next = null;
-            if (self.in == ret) self.in = null;
-            self.count -= 1;
-            return ret;
+        pub inline fn push(self: *Queue, link: *T) void {
+            self.any.push(&link.link);
         }
 
-        pub fn peek_last(self: Queue) ?*T {
-            return self.in;
+        pub inline fn pop(self: *Queue) ?*T {
+            const link = self.any.pop() orelse return null;
+            return @alignCast(@fieldParentPtr("link", link));
         }
 
-        pub fn peek(self: Queue) ?*T {
-            return self.out;
+        pub inline fn peek_last(self: *const Queue) ?*T {
+            const link = self.any.peek_last() orelse return null;
+            return @alignCast(@fieldParentPtr("link", link));
         }
 
-        pub fn empty(self: Queue) bool {
-            return self.peek() == null;
+        pub inline fn peek(self: *const Queue) ?*T {
+            const link = self.any.peek() orelse return null;
+            return @alignCast(@fieldParentPtr("link", link));
+        }
+
+        pub fn count(self: *const Queue) u64 {
+            return self.any.count;
+        }
+
+        pub inline fn empty(self: *const Queue) bool {
+            return self.any.empty();
         }
 
         /// Returns whether the linked list contains the given *exact element* (pointer comparison).
-        pub fn contains(self: *const Queue, elem_needle: *const T) bool {
-            var iterator = self.peek();
-            while (iterator) |elem| : (iterator = elem.next) {
-                if (elem == elem_needle) return true;
-            }
-            return false;
+        pub inline fn contains(self: *const Queue, elem_needle: *const T) bool {
+            return self.any.contains(&elem_needle.link);
         }
 
         /// Remove an element from the Queue. Asserts that the element is
         /// in the Queue. This operation is O(N), if this is done often you
         /// probably want a different data structure.
-        pub fn remove(self: *Queue, to_remove: *T) void {
-            if (to_remove == self.out) {
-                _ = self.pop();
-                return;
-            }
-            var it = self.out;
-            while (it) |elem| : (it = elem.next) {
-                if (to_remove == elem.next) {
-                    if (to_remove == self.in) self.in = elem;
-                    elem.next = to_remove.next;
-                    to_remove.next = null;
-                    self.count -= 1;
-                    break;
-                }
-            } else unreachable;
+        pub inline fn remove(self: *Queue, to_remove: *T) void {
+            self.any.remove(&to_remove.link);
         }
 
-        pub fn reset(self: *Queue) void {
-            self.* = .{ .name = self.name };
+        pub inline fn reset(self: *Queue) void {
+            self.any.reset();
         }
+
+        pub inline fn iterate(self: *const Queue) Iterator {
+            return .{ .any = self.any.iterate() };
+        }
+
+        pub const Iterator = struct {
+            any: QueueAny.Iterator,
+
+            pub inline fn next(iterator: *@This()) ?*T {
+                const link = iterator.any.next() orelse return null;
+                return @alignCast(@fieldParentPtr("link", link));
+            }
+        };
     };
 }
+
+// Non-generic implementation for smaller binary and faster compile times.
+const QueueAny = struct {
+    in: ?*QueueLink = null,
+    out: ?*QueueLink = null,
+    count: u64 = 0,
+
+    // This should only be null if you're sure we'll never want to monitor `count`.
+    name: ?[]const u8,
+
+    // If the number of elements is large, the constants.verify check in push() can be too
+    // expensive. Allow the user to gate it. Could also be a comptime param?
+    verify_push: bool = true,
+
+    pub fn push(self: *QueueAny, link: *QueueLink) void {
+        if (constants.verify and self.verify_push) assert(!self.contains(link));
+
+        assert(link.next == null);
+        if (self.in) |in| {
+            in.next = link;
+            self.in = link;
+        } else {
+            assert(self.out == null);
+            self.in = link;
+            self.out = link;
+        }
+        self.count += 1;
+    }
+
+    pub fn pop(self: *QueueAny) ?*QueueLink {
+        const result = self.out orelse return null;
+        self.out = result.next;
+        result.next = null;
+        if (self.in == result) self.in = null;
+        self.count -= 1;
+        return result;
+    }
+
+    pub fn peek_last(self: *const QueueAny) ?*QueueLink {
+        return self.in;
+    }
+
+    pub fn peek(self: *const QueueAny) ?*QueueLink {
+        return self.out;
+    }
+
+    pub fn empty(self: *const QueueAny) bool {
+        return self.peek() == null;
+    }
+
+    pub fn contains(self: *const QueueAny, needle: *const QueueLink) bool {
+        var iterator = self.peek();
+        while (iterator) |link| : (iterator = link.next) {
+            if (link == needle) return true;
+        }
+        return false;
+    }
+
+    pub fn remove(self: *QueueAny, to_remove: *QueueLink) void {
+        if (to_remove == self.out) {
+            _ = self.pop();
+            return;
+        }
+        var it = self.out;
+        while (it) |link| : (it = link.next) {
+            if (to_remove == link.next) {
+                if (to_remove == self.in) self.in = link;
+                link.next = to_remove.next;
+                to_remove.next = null;
+                self.count -= 1;
+                break;
+            }
+        } else unreachable;
+    }
+
+    pub fn reset(self: *QueueAny) void {
+        self.* = .{
+            .name = self.name,
+            .verify_push = self.verify_push,
+        };
+    }
+
+    pub fn iterate(self: *const QueueAny) Iterator {
+        return .{
+            .head = self.out,
+        };
+    }
+
+    const Iterator = struct {
+        head: ?*QueueLink,
+
+        fn next(iterator: *Iterator) ?*QueueLink {
+            const head = iterator.head orelse return null;
+            iterator.head = head.next;
+            return head;
+        }
+    };
+};
 
 test "Queue: push/pop/peek/remove/empty" {
     const testing = @import("std").testing;
 
-    const Foo = struct { next: ?*@This() = null };
+    const Item = struct { link: QueueType(@This()).Link = .{} };
 
-    var one: Foo = .{};
-    var two: Foo = .{};
-    var three: Foo = .{};
+    var one: Item = .{};
+    var two: Item = .{};
+    var three: Item = .{};
 
-    var fifo: QueueType(Foo) = .{ .name = null };
+    var fifo = QueueType(Item).init(.{
+        .name = null,
+        .verify_push = true,
+    });
     try testing.expect(fifo.empty());
 
     fifo.push(&one);
     try testing.expect(!fifo.empty());
-    try testing.expectEqual(@as(?*Foo, &one), fifo.peek());
+    try testing.expectEqual(@as(?*Item, &one), fifo.peek());
     try testing.expect(fifo.contains(&one));
     try testing.expect(!fifo.contains(&two));
     try testing.expect(!fifo.contains(&three));
@@ -113,16 +207,16 @@ test "Queue: push/pop/peek/remove/empty" {
     fifo.push(&two);
     fifo.push(&three);
     try testing.expect(!fifo.empty());
-    try testing.expectEqual(@as(?*Foo, &one), fifo.peek());
+    try testing.expectEqual(@as(?*Item, &one), fifo.peek());
     try testing.expect(fifo.contains(&one));
     try testing.expect(fifo.contains(&two));
     try testing.expect(fifo.contains(&three));
 
     fifo.remove(&one);
     try testing.expect(!fifo.empty());
-    try testing.expectEqual(@as(?*Foo, &two), fifo.pop());
-    try testing.expectEqual(@as(?*Foo, &three), fifo.pop());
-    try testing.expectEqual(@as(?*Foo, null), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &two), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &three), fifo.pop());
+    try testing.expectEqual(@as(?*Item, null), fifo.pop());
     try testing.expect(fifo.empty());
     try testing.expect(!fifo.contains(&one));
     try testing.expect(!fifo.contains(&two));
@@ -133,9 +227,9 @@ test "Queue: push/pop/peek/remove/empty" {
     fifo.push(&three);
     fifo.remove(&two);
     try testing.expect(!fifo.empty());
-    try testing.expectEqual(@as(?*Foo, &one), fifo.pop());
-    try testing.expectEqual(@as(?*Foo, &three), fifo.pop());
-    try testing.expectEqual(@as(?*Foo, null), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &one), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &three), fifo.pop());
+    try testing.expectEqual(@as(?*Item, null), fifo.pop());
     try testing.expect(fifo.empty());
 
     fifo.push(&one);
@@ -143,20 +237,20 @@ test "Queue: push/pop/peek/remove/empty" {
     fifo.push(&three);
     fifo.remove(&three);
     try testing.expect(!fifo.empty());
-    try testing.expectEqual(@as(?*Foo, &one), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &one), fifo.pop());
     try testing.expect(!fifo.empty());
-    try testing.expectEqual(@as(?*Foo, &two), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &two), fifo.pop());
     try testing.expect(fifo.empty());
-    try testing.expectEqual(@as(?*Foo, null), fifo.pop());
+    try testing.expectEqual(@as(?*Item, null), fifo.pop());
     try testing.expect(fifo.empty());
 
     fifo.push(&one);
     fifo.push(&two);
     fifo.remove(&two);
     fifo.push(&three);
-    try testing.expectEqual(@as(?*Foo, &one), fifo.pop());
-    try testing.expectEqual(@as(?*Foo, &three), fifo.pop());
-    try testing.expectEqual(@as(?*Foo, null), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &one), fifo.pop());
+    try testing.expectEqual(@as(?*Item, &three), fifo.pop());
+    try testing.expectEqual(@as(?*Item, null), fifo.pop());
     try testing.expect(fifo.empty());
 }
 
@@ -166,7 +260,7 @@ test "Queue: fuzz" {
 
     const Item = struct {
         value: u64,
-        next: ?*@This(),
+        link: QueueType(@This()).Link,
     };
     const Queue = QueueType(Item);
     const Model = stdx.RingBufferType(u64, .slice);
@@ -177,9 +271,9 @@ test "Queue: fuzz" {
     for (0..100) |_| {
         const N = 1000;
 
-        var queue: Queue = .{
+        var queue = Queue.init(.{
             .name = "fuzz",
-        };
+        });
         var model = try Model.init(gpa, N);
         defer model.deinit(gpa);
 
@@ -189,8 +283,8 @@ test "Queue: fuzz" {
 
         var items = try gpa.alloc(Item, N);
         defer gpa.free(items);
-        for (items) |*item| {
-            item.* = .{ .value = prng.int(u64), .next = null };
+        for (items, 0..) |*item, value| {
+            item.* = .{ .value = value, .link = .{} };
         }
 
         var free: std.ArrayListUnmanaged(usize) = .{};
@@ -201,10 +295,14 @@ test "Queue: fuzz" {
             free.appendAssumeCapacity(index);
         }
 
-        const weights = fuzz.random_enum_weights(&prng, std.meta.DeclEnum(Queue));
+        const Declarations = fuzz.DeclEnumExcludingType(
+            Queue,
+            &.{ .Link, .Iterator, .init, .count, .empty },
+        );
+        const weights = fuzz.random_enum_weights(&prng, Declarations);
 
         for (0..N) |_| {
-            switch (prng.enum_weighted(std.meta.DeclEnum(Queue), weights)) {
+            switch (prng.enum_weighted(Declarations, weights)) {
                 .push => {
                     if (free.items.len > 0) {
                         const index = free.swapRemove(prng.index(free.items));
@@ -240,9 +338,6 @@ test "Queue: fuzz" {
                         assert(queue.peek_last() == null);
                     }
                 },
-                .empty => {
-                    assert(model.empty() == queue.empty());
-                },
                 .contains => {
                     const item = &items[prng.index(items)];
 
@@ -275,8 +370,20 @@ test "Queue: fuzz" {
                     model.clear();
                     queue.reset();
                 },
+                .iterate => {
+                    var queue_iterator = queue.iterate();
+                    var model_iterator = model.iterator();
+
+                    while (queue_iterator.next()) |queue_item| {
+                        const model_item = model_iterator.next().?;
+                        assert(queue_item.value == model_item);
+                    }
+                    assert(model_iterator.next() == null);
+                    assert(queue_iterator.next() == null);
+                },
             }
-            assert(queue.count == model.count);
+            assert(queue.count() == model.count);
+            assert(queue.empty() == model.empty());
         }
     }
 }

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -64,6 +64,7 @@ pub fn StackType(comptime T: type) type {
     };
 }
 
+// Non-generic implementation for smaller binary and faster compile times.
 const StackAny = struct {
     head: ?*StackLink = null,
 

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -9,7 +9,7 @@ pub const StackLink = extern struct {
 };
 
 /// An intrusive last in/first out linked list (LIFO).
-/// The element type T must have a field called "next" of type ?*T.
+/// The element type T must have a field called "next" of type StackType(T).Link.
 pub fn StackType(comptime T: type) type {
     return struct {
         any: StackAny,

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -80,7 +80,7 @@ pub fn StorageType(comptime IO: type, comptime _Tracer: type) type {
         };
 
         pub const NextTick = struct {
-            next: ?*NextTick = null,
+            link: QueueType(NextTick).Link = .{},
             source: NextTickSource,
             callback: *const fn (next_tick: *NextTick) void,
         };
@@ -92,7 +92,9 @@ pub fn StorageType(comptime IO: type, comptime _Tracer: type) type {
         io: *IO,
         fd: IO.fd_t,
 
-        next_tick_queue: QueueType(NextTick) = .{ .name = "storage_next_tick" },
+        next_tick_queue: QueueType(NextTick) = QueueType(NextTick).init(.{
+            .name = "storage_next_tick",
+        }),
         next_tick_completion_scheduled: bool = false,
         next_tick_completion: IO.Completion = undefined,
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -965,7 +965,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                         replica.grid.free_set.count_acquired()
                     else
                         null,
-                    .grid_blocks_global = replica.grid.read_global_queue.count,
+                    .grid_blocks_global = replica.grid.read_global_queue.count(),
                     .grid_blocks_repair = replica.grid.blocks_missing.faulty_blocks.count(),
                 }) catch unreachable;
 

--- a/src/testing/fuzz.zig
+++ b/src/testing/fuzz.zig
@@ -88,6 +88,29 @@ pub fn parse_seed(bytes: []const u8) u64 {
     };
 }
 
+// Like `std.meta.DeclEnum`, but allows excluding specific things. Feed the result into
+// random_enum_weights for swarm testing public API of a data structure.
+pub fn DeclEnumExcludingType(T: type, exclude: []const std.meta.DeclEnum(T)) type {
+    const base = @typeInfo(std.meta.DeclEnum(T)).Enum;
+    var fields_filtered: [base.fields.len - exclude.len]std.builtin.Type.EnumField = undefined;
+    var i: usize = 0;
+    next_field: for (base.fields) |field| {
+        for (exclude) |excluded| {
+            if (std.mem.eql(u8, field.name, @tagName(excluded))) continue :next_field;
+        }
+        fields_filtered[i] = field;
+        i += 1;
+    }
+    assert(i == fields_filtered.len);
+
+    return @Type(.{ .Enum = .{
+        .tag_type = base.tag_type,
+        .fields = &fields_filtered,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+}
+
 /// A queue for tracking work to be executed at a particular tick.
 pub fn ReadyQueueType(T: type) type {
     return struct {

--- a/src/testing/fuzz.zig
+++ b/src/testing/fuzz.zig
@@ -92,6 +92,8 @@ pub fn parse_seed(bytes: []const u8) u64 {
 // random_enum_weights for swarm testing public API of a data structure.
 pub fn DeclEnumExcludingType(T: type, exclude: []const std.meta.DeclEnum(T)) type {
     const base = @typeInfo(std.meta.DeclEnum(T)).Enum;
+    assert(exclude.len > 0); // Use plain std.meta.DeclEnum.
+    assert(exclude.len < base.fields.len);
     var fields_filtered: [base.fields.len - exclude.len]std.builtin.Type.EnumField = undefined;
     var i: usize = 0;
     next_field: for (base.fields) |field| {

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -129,7 +129,7 @@ pub const Storage = struct {
     };
 
     pub const NextTick = struct {
-        next: ?*NextTick = null,
+        link: QueueType(NextTick).Link = .{},
         source: NextTickSource,
         callback: *const fn (next_tick: *NextTick) void,
     };
@@ -194,7 +194,9 @@ pub const Storage = struct {
     writes: ReadyQueueType(*Storage.Write),
 
     ticks: u64 = 0,
-    next_tick_queue: QueueType(NextTick) = .{ .name = "storage_next_tick" },
+    next_tick_queue: QueueType(NextTick) = QueueType(NextTick).init(.{
+        .name = "storage_next_tick",
+    }),
 
     pub fn init(allocator: mem.Allocator, size: u64, options: Storage.Options) !Storage {
         assert(size <= constants.storage_size_limit_max);
@@ -253,7 +255,7 @@ pub const Storage = struct {
         log.debug("Reset: {} pending reads, {} pending writes, {} pending next_ticks", .{
             storage.reads.count(),
             storage.writes.count(),
-            storage.next_tick_queue.count,
+            storage.next_tick_queue.count(),
         });
         for (storage.writes.slice()) |write| {
             if (!storage.prng.chance(storage.options.crash_fault_probability)) continue;

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1083,8 +1083,8 @@ pub const Simulator = struct {
 
             const storage = &simulator.cluster.storages[replica.replica];
 
-            var fault_iterator = replica.grid.read_global_queue.peek();
-            while (fault_iterator) |faulty_read| : (fault_iterator = faulty_read.next) {
+            var fault_iterator = replica.grid.read_global_queue.iterate();
+            while (fault_iterator.next()) |faulty_read| {
                 const v = try blocks_missing.getOrPut(.{
                     .address = faulty_read.address,
                     .checksum = faulty_read.checksum,

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -69,7 +69,7 @@ pub const GridBlocksMissing = struct {
         /// When non-null, the table is awaiting data blocks.
         /// This count includes the index block.
         table_blocks_total: ?u32 = null,
-        /// "next" belongs to the `faulty_tables`/`faulty_tables_free` FIFOs.
+        /// For `faulty_tables`/`faulty_tables_free` queues.
         link: QueueType(RepairTable).Link = .{},
     };
 

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -70,7 +70,7 @@ pub const GridBlocksMissing = struct {
         /// This count includes the index block.
         table_blocks_total: ?u32 = null,
         /// "next" belongs to the `faulty_tables`/`faulty_tables_free` FIFOs.
-        next: ?*RepairTable = null,
+        link: QueueType(RepairTable).Link = .{},
     };
 
     pub const Options = struct {
@@ -100,8 +100,12 @@ pub const GridBlocksMissing = struct {
 
     /// Invariants:
     /// - For every index address in faulty_tables: ¬free_set.is_free(address).
-    faulty_tables: QueueType(RepairTable) = .{ .name = "grid_missing_blocks_tables" },
-    faulty_tables_free: QueueType(RepairTable) = .{ .name = "grid_missing_blocks_tables_free" },
+    faulty_tables: QueueType(RepairTable) = QueueType(RepairTable).init(.{
+        .name = "grid_missing_blocks_tables",
+    }),
+    faulty_tables_free: QueueType(RepairTable) = QueueType(RepairTable).init(.{
+        .name = "grid_missing_blocks_tables_free",
+    }),
 
     checkpoint_durable: ?struct {
         /// The number of faulty_blocks with state=aborting.
@@ -186,7 +190,7 @@ pub const GridBlocksMissing = struct {
 
     /// Count the number of *non-table* block repairs available.
     pub fn enqueue_blocks_available(queue: *const GridBlocksMissing) usize {
-        assert(queue.faulty_tables.count <= queue.options.tables_max);
+        assert(queue.faulty_tables.count() <= queue.options.tables_max);
         assert(queue.faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         assert(queue.enqueued_blocks_table <=
@@ -202,7 +206,7 @@ pub const GridBlocksMissing = struct {
     /// Queue a faulty block to request from the cluster and repair.
     pub fn enqueue_block(queue: *GridBlocksMissing, address: u64, checksum: u128) void {
         assert(queue.enqueue_blocks_available() > 0);
-        assert(queue.faulty_tables.count <= queue.options.tables_max);
+        assert(queue.faulty_tables.count() <= queue.options.tables_max);
         assert(queue.faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
 
@@ -217,14 +221,14 @@ pub const GridBlocksMissing = struct {
         address: u64,
         checksum: u128,
     ) enum { insert, duplicate } {
-        assert(queue.faulty_tables.count < queue.options.tables_max);
+        assert(queue.faulty_tables.count() < queue.options.tables_max);
         assert(queue.faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         assert(table_bitset.capacity() == constants.lsm_table_data_blocks_max);
         assert(table_bitset.count() == 0);
 
-        var tables = queue.faulty_tables.peek();
-        while (tables) |queue_table| : (tables = queue_table.next) {
+        var tables = queue.faulty_tables.iterate();
+        while (tables.next()) |queue_table| {
             assert(queue_table != table);
             assert(queue_table.data_blocks_received != table_bitset);
 
@@ -261,7 +265,7 @@ pub const GridBlocksMissing = struct {
         replace: *FaultyBlock,
         duplicate,
     } {
-        assert(queue.faulty_tables.count <= queue.options.tables_max);
+        assert(queue.faulty_tables.count() <= queue.options.tables_max);
         assert(queue.faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
 
@@ -482,7 +486,9 @@ pub const GridBlocksMissing = struct {
             }
         }
 
-        var tables: QueueType(RepairTable) = .{ .name = queue.faulty_tables.name };
+        var tables: QueueType(RepairTable) = QueueType(RepairTable).init(.{
+            .name = queue.faulty_tables.any.name,
+        });
         while (queue.faulty_tables.pop()) |table| {
             assert(!free_set.is_free(table.index_address));
 

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -78,7 +78,7 @@ pub fn GridScrubberType(comptime Forest: type) type {
             /// Whether the read is ready to be released.
             done: bool,
 
-            /// "next" belongs to the FIFOs.
+            /// For `reads_busy`/`reads_done` queues.
             link: QueueType(Read).Link = .{},
         };
 

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -79,7 +79,7 @@ pub fn GridScrubberType(comptime Forest: type) type {
             done: bool,
 
             /// "next" belongs to the FIFOs.
-            next: ?*Read = null,
+            link: QueueType(Read).Link = .{},
         };
 
         superblock: *SuperBlock,
@@ -89,9 +89,9 @@ pub fn GridScrubberType(comptime Forest: type) type {
         reads: IOPSType(Read, constants.grid_scrubber_reads_max) = .{},
 
         /// A list of reads that are in progress.
-        reads_busy: QueueType(Read) = .{ .name = "grid_scrubber_reads_busy" },
+        reads_busy: QueueType(Read) = QueueType(Read).init(.{ .name = "grid_scrubber_reads_busy" }),
         /// A list of reads that are ready to be released.
-        reads_done: QueueType(Read) = .{ .name = "grid_scrubber_reads_done" },
+        reads_done: QueueType(Read) = QueueType(Read).init(.{ .name = "grid_scrubber_reads_done" }),
 
         /// Track the progress through the grid.
         ///
@@ -209,8 +209,8 @@ pub fn GridScrubberType(comptime Forest: type) type {
 
         pub fn cancel(scrubber: *GridScrubber) void {
             for ([_]QueueType(Read){ scrubber.reads_busy, scrubber.reads_done }) |reads_fifo| {
-                var reads_iterator = reads_fifo.peek();
-                while (reads_iterator) |read| : (reads_iterator = read.next) {
+                var reads_iterator = reads_fifo.iterate();
+                while (reads_iterator.next()) |read| {
                     read.status = .canceled;
                 }
             }
@@ -230,8 +230,8 @@ pub fn GridScrubberType(comptime Forest: type) type {
             assert(scrubber.forest.grid.callback == .none);
 
             for ([_]QueueType(Read){ scrubber.reads_busy, scrubber.reads_done }) |reads_fifo| {
-                var reads_iterator = reads_fifo.peek();
-                while (reads_iterator) |read| : (reads_iterator = read.next) {
+                var reads_iterator = reads_fifo.iterate();
+                while (reads_iterator.next()) |read| {
                     if (read.status == .repair) {
                         assert(!scrubber.forest.grid.free_set.is_free(read.read.address));
                         // Use `to_be_freed_at_checkpoint_durability` instead of `is_released`;
@@ -264,9 +264,9 @@ pub fn GridScrubberType(comptime Forest: type) type {
         pub fn read_next(scrubber: *GridScrubber) bool {
             assert(scrubber.superblock.opened);
             assert(scrubber.forest.grid.callback != .cancel);
-            assert(scrubber.reads_busy.count + scrubber.reads_done.count ==
+            assert(scrubber.reads_busy.count() + scrubber.reads_done.count() ==
                 scrubber.reads.executing());
-            defer assert(scrubber.reads_busy.count + scrubber.reads_done.count ==
+            defer assert(scrubber.reads_busy.count() + scrubber.reads_done.count() ==
                 scrubber.reads.executing());
 
             if (scrubber.reads.available() == 0) return false;
@@ -360,9 +360,9 @@ pub fn GridScrubberType(comptime Forest: type) type {
         }
 
         pub fn read_fault(scrubber: *GridScrubber) ?BlockId {
-            assert(scrubber.reads_busy.count + scrubber.reads_done.count ==
+            assert(scrubber.reads_busy.count() + scrubber.reads_done.count() ==
                 scrubber.reads.executing());
-            defer assert(scrubber.reads_busy.count + scrubber.reads_done.count ==
+            defer assert(scrubber.reads_busy.count() + scrubber.reads_done.count() ==
                 scrubber.reads.executing());
 
             while (scrubber.reads_done.pop()) |read| {
@@ -671,7 +671,7 @@ fn ManifestBlockIteratorType(comptime ManifestLog: type) type {
 // - There are only 3 (quorum_replication) copies of each sector.
 // - Scrub randomization is ignored.
 // - The simulated fault rate is much greater than a real disk's. (See `sector_faults_per_year`).
-// - Reads, writes, and repairs due to other workloads (besides the scrubber) are not modelled.
+// - Reads, writes, and repairs due to other workloads (besides the scrubber) are not modeled.
 // - All blocks are always full (512KiB).
 //
 // ¹: To mitigate the risk of correlated errors in production, replicas could use different SSD
@@ -683,7 +683,7 @@ fn ManifestBlockIteratorType(comptime ManifestLog: type) type {
 //   (https://www.usenix.org/system/files/fast21-han.pdf)
 // - "Flash Reliability in Production: The Expected and the Unexpected"
 //   (https://www.usenix.org/system/files/conference/fast16/fast16-papers-schroeder.pdf)
-// That being said, for the purposes of modelling scrubbing, it is a decent approximation because
+// That being said, for the purposes of modeling scrubbing, it is a decent approximation because
 // blocks are large relative to sectors. (Additionally, blocks that are written together are often
 // scrubbed together).
 test "GridScrubber cycle interval" {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2994,7 +2994,7 @@ pub fn ReplicaType(
             maybe(message.header.protocol < vsr.Version);
 
             if (self.grid.callback == .cancel) {
-                assert(self.grid.read_global_queue.count == 0);
+                assert(self.grid.read_global_queue.empty());
 
                 log.debug("{}: on_block: ignoring; grid is canceling (address={} checksum={})", .{
                     self.replica,


### PR DESCRIPTION
We recently did this for a Stack, let's apply the same trick to Queue, for the same reason: smaller binary&faster compile times.

Binary size for aarch64 is reduced from 3 641 672 to 3 639 688, shaving off two KiBs!