### PR TITLE
git-review: add a smoke test

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,3 @@
+# Review Summary
+
+ Use this for review cover letter, if needed, or to leave review-wide comments.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,3 +1,0 @@
-# Review Summary
-
- Use this for review cover letter, if needed, or to leave review-wide comments.

--- a/src/git-review.zig
+++ b/src/git-review.zig
@@ -122,9 +122,8 @@ fn review_status(shell: *Shell) !enum { resolved, unresolved } {
         return error.NoReview;
     }
 
-    const diff_review = try shell.exec_stdout("git diff HEAD~ HEAD", .{});
-    const stats = try parse_diff(diff_review);
-    const unresolved = stats.comments_total - stats.comments_resolved;
+    const diff_review = try shell.exec_stdout("git diff --unified=0 HEAD~ HEAD", .{});
+    const review = try Review.parse(shell.arena.allocator(), diff_review);
 
     const merge_base = try shell.exec_stdout("git merge-base origin/main HEAD~", .{});
     const all_commits = try shell.exec_stdout("git log --format=%H {merge_base}..HEAD~", .{
@@ -159,10 +158,9 @@ fn review_status(shell: *Shell) !enum { resolved, unresolved } {
         }
     }
 
-    log.info("comments:   {}", .{stats.comments_total});
-    log.info("unresolved: {}", .{unresolved});
+    try std.io.getStdErr().writer().print("{}", .{review});
 
-    return if (unresolved == 0) .resolved else .unresolved;
+    return if (review.unresolved_count == 0) .resolved else .unresolved;
 }
 
 fn review_new(shell: *Shell) !void {
@@ -196,56 +194,171 @@ fn review_lgtm(shell: *Shell) !void {
     try shell.exec("git push --force-with-lease", .{});
 }
 
-const ParseDiffResult = struct {
-    comments_total: u32,
-    comments_resolved: u32,
-};
+const Review = struct {
+    comments: []const Comment,
+    resolved_count: u32,
+    unresolved_count: u32,
 
-fn parse_diff(diff: []const u8) !ParseDiffResult {
-    var result: ParseDiffResult = .{
-        .comments_total = 0,
-        .comments_resolved = 0,
+    const Comment = struct {
+        location: Location,
+        snippet: []const u8,
+        resolved: bool,
     };
-    var file_name: []const u8 = "";
-    var line_iterator = std.mem.tokenizeScalar(u8, diff, '\n');
-    var comment_start: ?u32 = null;
-    var line_index: u32 = 0;
-    while (line_iterator.next()) |line| {
-        defer line_index += 1;
 
-        if (stdx.cut_prefix(line, "diff --git a/")) |suffix| {
-            _, file_name = stdx.cut(suffix, " ").?;
-            continue;
+    const Location = struct {
+        file: []const u8,
+        line: u32, // 1-based display number.
+
+        pub fn format(
+            location: Location,
+            comptime fmt: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = fmt;
+            _ = options;
+            try writer.print("{s}:{d}", .{ location.file, location.line });
         }
-        assert(file_name.len > 0);
-        if (std.mem.eql(u8, file_name, "b/REVIEW.md")) continue;
-        errdefer log.err("invalid review in '{s}':\n{s}", .{ file_name, line });
+    };
 
-        if (std.mem.startsWith(u8, line, "- ")) {
-            return error.InvalidDiff;
-        }
+    pub fn parse(arena: std.mem.Allocator, diff: []const u8) !Review {
+        var comments: std.ArrayListUnmanaged(Comment) = .{};
+        var unresolved_count: u32 = 0;
+        var resolved_count: u32 = 0;
 
-        if (stdx.cut_prefix(line, "+")) |line_added| {
-            if (std.mem.startsWith(u8, line_added, "++")) continue;
-            const comment = std.mem.trimLeft(u8, line_added, " ");
-            if (!std.mem.startsWith(u8, comment, "//?")) {
+        var file_name: []const u8 = "";
+        var hunk_line: ?u32 = null;
+        var line_iterator = std.mem.tokenizeScalar(u8, diff, '\n');
+        var in_comment = false;
+        while (line_iterator.next()) |line| {
+            if (stdx.cut_prefix(line, "diff --git a/")) |suffix| {
+                _, file_name = stdx.cut(suffix, " b/").?;
+                hunk_line = null;
+                continue;
+            }
+            assert(file_name.len > 0);
+            if (std.mem.eql(u8, file_name, "REVIEW.md")) continue;
+            errdefer log.err("invalid review in '{s}':\n{s}", .{ file_name, line });
+
+            if (std.mem.startsWith(u8, line, "@@")) {
+                // Extract '380' from
+                // @@ -379,0 +380,2 @@
+                _, const added = stdx.cut(line, " +").?;
+                const hunk_line_str, _ = stdx.cut(added, ",").?;
+                hunk_line = std.fmt.parseInt(u32, hunk_line_str, 10) catch unreachable;
+            }
+
+            if (std.mem.startsWith(u8, line, "- ")) {
                 return error.InvalidDiff;
             }
 
-            if (comment_start == null) {
-                comment_start = line_index;
-                result.comments_total += 1;
-            } else {
-                if (std.mem.eql(u8, comment, "//? resolved.")) {
-                    assert(comment_start != null);
-                    comment_start = null;
-                    result.comments_resolved += 1;
+            if (stdx.cut_prefix(line, "+")) |line_added| {
+                if (std.mem.startsWith(u8, line_added, "++")) continue;
+                assert(hunk_line != null);
+
+                const comment = std.mem.trimLeft(u8, line_added, " ");
+                if (!std.mem.startsWith(u8, comment, "//?")) {
+                    return error.InvalidDiff;
                 }
+
+                if (!in_comment) {
+                    in_comment = true;
+                    try comments.append(arena, .{
+                        .location = .{
+                            .file = file_name,
+                            .line = hunk_line.?,
+                        },
+                        .snippet = stdx.cut_prefix(comment, "//?").?,
+                        .resolved = false,
+                    });
+                    unresolved_count += 1;
+                } else {
+                    if (std.mem.eql(u8, comment, "//? resolved.")) {
+                        assert(comments.items.len > 0);
+                        assert(!comments.items[comments.items.len - 1].resolved);
+                        comments.items[comments.items.len - 1].resolved = true;
+                        in_comment = false;
+                        unresolved_count -= 1;
+                        resolved_count += 1;
+                    }
+                }
+            } else {
+                in_comment = false;
             }
+        }
+
+        return .{
+            .comments = comments.items,
+            .resolved_count = resolved_count,
+            .unresolved_count = unresolved_count,
+        };
+    }
+
+    pub fn format(
+        review: Review,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+        for (review.comments) |comment| {
+            if (!comment.resolved) {
+                try writer.print("{s}: {s}\n", .{ comment.location, comment.snippet });
+            }
+        }
+        if (review.unresolved_count > 0) {
+            try writer.print("\n{d} resolved {d} unresolved", .{
+                review.resolved_count,
+                review.unresolved_count,
+            });
         } else {
-            comment_start = null;
+            try writer.print("{d} resolved", .{review.resolved_count});
         }
     }
-    assert(result.comments_total >= result.comments_resolved);
-    return result;
+};
+
+const Snap = @import("./testing/snaptest.zig").Snap;
+const snap = Snap.snap;
+
+test Review {
+    const diff =
+        \\diff --git a/REVIEW.md b/REVIEW.md
+        \\new file mode 100644
+        \\index 000000000..6b5e74701
+        \\--- /dev/null
+        \\+++ b/REVIEW.md
+        \\@@ -0,0 +1,3 @@
+        \\+# Review Summary
+        \\+
+        \\+(Work in progress review so far.)
+        \\diff --git a/src/vsr/message_header.zig b/src/vsr/message_header.zig
+        \\index b2b176e5f..fd7d420c1 100644
+        \\--- a/src/vsr/message_header.zig
+        \\+++ b/src/vsr/message_header.zig
+        \\@@ -379,0 +380,2 @@ pub const Header = extern struct {
+        \\+        //? dj: Positioning the field here is nice for alignment, but makes the upgrade
+        \\+        //? more complicated than if we just appended the field after release_count.
+        \\+        //? matklad: I want to fix this in a follow up!
+        \\+        //? resolved.
+        \\@@ -427,0 +432,2 @@ pub fn op_next_hop(routing: *const Routing, op: u64) NextHop {
+        \\+        //? dj: What do you think of referring to this as a replica_position,
+        \\+        //? since replica_index is also what `routing.replica` is.
+        \\
+    ;
+    try test_review_case(diff, snap(@src(),
+        \\src/vsr/message_header.zig:432:  dj: What do you think of referring to this as a replica_position,
+        \\
+        \\1 resolved 1 unresolved
+    ));
+}
+
+fn test_review_case(diff: []const u8, want: Snap) !void {
+    var arena_instance = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_instance.deinit();
+
+    const arena = arena_instance.allocator();
+
+    const review = try Review.parse(arena, diff);
+    try want.diff_fmt("{}", .{review});
 }

--- a/src/git-review.zig
+++ b/src/git-review.zig
@@ -308,12 +308,12 @@ const Review = struct {
             }
         }
         if (review.unresolved_count > 0) {
-            try writer.print("\n{d} resolved {d} unresolved", .{
+            try writer.print("\n{d} resolved {d} unresolved\n", .{
                 review.resolved_count,
                 review.unresolved_count,
             });
         } else {
-            try writer.print("{d} resolved", .{review.resolved_count});
+            try writer.print("{d} resolved\n", .{review.resolved_count});
         }
     }
 };
@@ -350,6 +350,7 @@ test Review {
         \\src/vsr/message_header.zig:432:  dj: What do you think of referring to this as a replica_position,
         \\
         \\1 resolved 1 unresolved
+        \\
     ));
 }
 

--- a/src/git-review.zig
+++ b/src/git-review.zig
@@ -121,16 +121,7 @@ fn review_status(shell: *Shell) !enum { resolved, unresolved } {
         log.info("no review", .{});
         return error.NoReview;
     }
-    //? batiati: What if the reviewer isn't careful engough to keep the comments at 100 columns maximum?
-    //? To avoid breaking the CI checks, we could either skip \\? from tidy, or include the tidy
-    //? step in `git-review status`.
-    //?
-    //? matklad: I think we should keep review comments under 100 columns to make them readable. If
-    //? anything, I'd _reduce_ the maximum allowed width for all comments, as, for prose, you want
-    //? about 60 characters per line, not 100 for code. But that's too complicated for little gain,
-    //? so I'd stay with 100! No super strong feelings here! (FYI, I use stkb.rewrap VS Code plugin
-    //? to reflow comments).
-    //? resolved.
+
     const diff_review = try shell.exec_stdout("git diff --unified=0 HEAD~ HEAD", .{});
     const review = try Review.parse(shell.arena.allocator(), diff_review);
 
@@ -266,21 +257,6 @@ const Review = struct {
                 assert(hunk_line != null);
 
                 const comment = std.mem.trimLeft(u8, line_added, " ");
-                //? batiati: Should we allow empty lines?
-                //? For example a line break between the author's code and the reviewer comment.
-                //?
-                //? matklad: That's an open design question! The current design is that _every_ line
-                //? of review comment is marked with '//?', so that you can do a very simple line-by
-                //? line parsing, very much inspired by Zig's `\\` syntax. An alternative is to do
-                //? "block parsing": say that a review comment starts with a special marker, like
-                //? '// CR', and continues until the first non- comment line. I am actually leaning
-                //? towards that design, as it would make it easier to reflow comments to make them
-                //? fit under 100 columns. I'll let it simmer for a bit, as first I want to add a
-                //? helper which would allow to modify code "in-place" during review, and than,
-                //? using this helper, split review commit into comments part and changes part.
-                //? After I do that (with some tests), I'll probably switch to more complicated to
-                //? parse, but easier to use format for review comments.
-                //? resolved.
                 if (!std.mem.startsWith(u8, comment, "//?")) {
                     return error.InvalidDiff;
                 }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -9,6 +9,11 @@ comptime {
     _ = @import("io.zig");
     _ = @import("list.zig");
     _ = @import("shell.zig");
+    _ = @import("storage.zig");
+    _ = @import("tidy.zig");
+    _ = @import("time.zig");
+    _ = @import("git-review.zig");
+
     _ = @import("stdx.zig");
     _ = @import("stdx/aegis.zig");
     _ = @import("stdx/bit_set.zig");
@@ -17,9 +22,7 @@ comptime {
     _ = @import("stdx/ring_buffer.zig");
     _ = @import("stdx/sort_test.zig");
     _ = @import("stdx/zipfian.zig");
-    _ = @import("storage.zig");
-    _ = @import("tidy.zig");
-    _ = @import("time.zig");
+
     _ = @import("trace.zig");
     _ = @import("trace/event.zig");
     _ = @import("trace/statsd.zig");


### PR DESCRIPTION
Let's get a bit more serious here and start writing tests!

Also, let's print all pending comments using gcc file:line: message format, so that you can use you editor to jump to a particular unresolved review comment. This is an improvemnt over just `git show HEAD`, as that doesn't make distinctin between resolved and unresolved comments.