### PR TITLE
inspect: Make 'inspect grid' open dbs with zero used blocks

### DIFF
--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -766,10 +766,22 @@ const Inspector = struct {
         );
         defer free_set.deinit(inspector.allocator);
 
+        const SliceOfAlignedWordSlice = []const []align(@alignOf(vsr.FreeSet.Word)) const u8;
+        const encoded_free_set_blocks_acquired: SliceOfAlignedWordSlice =
+            if (free_set_blocks_acquired_buffer.len != 0)
+            &.{free_set_blocks_acquired_buffer}
+        else
+            &.{};
+        const encoded_free_set_blocks_released: SliceOfAlignedWordSlice =
+            if (free_set_blocks_released_buffer.len != 0)
+            &.{free_set_blocks_released_buffer}
+        else
+            &.{};
+
         free_set.open(.{
             .encoded = .{
-                .blocks_acquired = &.{free_set_blocks_acquired_buffer},
-                .blocks_released = &.{free_set_blocks_released_buffer},
+                .blocks_acquired = encoded_free_set_blocks_acquired,
+                .blocks_released = encoded_free_set_blocks_released,
             },
             .free_set_block_addresses = .{
                 .blocks_acquired = free_set_blocks_acquired_addresses.items,


### PR DESCRIPTION
Currently `inspect grid` panics if opening a database in which no blocks have been acquired. The failure looks like:

```
$ bzig build run -- inspect grid ../0.1.bench.tb                                  
2025-04-24 18:52:11.960Z info(io): opening "0.1.bench.tb"...
thread 1697630 panic: reached unreachable code                                                                  
/home/brian/.homes/dev/zig/build/stage3/lib/zig/std/debug.zig:412:14: 0x121022d in assert (tigerbeetle)
    if (!ok) unreachable; // assertion failure
             ^                                                                                                  /home/brian/.homes/dev/tigerbeetle/src/vsr/free_set.zig:202:15: 0x130dce5 in open (tigerbeetle)
        assert((options.encoded.blocks_acquired.len == 0 and
              ^                                         
/home/brian/.homes/dev/tigerbeetle/src/tigerbeetle/inspect.zig:781:22: 0x130d56e in inspect_grid (tigerbeetle)
        free_set.open(.{                                
                     ^
/home/brian/.homes/dev/tigerbeetle/src/tigerbeetle/inspect.zig:101:43: 0x131d2c1 in main_inspect (tigerbeetle)
                try inspector.inspect_grid(stdout, args.superblock_copy);  
                                          ^

```

This is easy to reproduce on a fresh database.

This is due to an assertion in `FreeSet.open`:

```
        assert((options.encoded.blocks_acquired.len == 0 and                                                    
            options.encoded.blocks_released.len == 0) ==                                                        
            (options.free_set_block_addresses.blocks_acquired.len == 0 and                                      
            options.free_set_block_addresses.blocks_released.len == 0));  
```

I don't understand this assertion. Just removing it _seems_ to work, but maybe it is important. Instead I added some conditionals to the caller in `inspect` to pass the assertion by not passing in a slice of an empty slice for the blocks acquired/released.

The formatting is weird because that's the way I could get it to fit under 100 columns with the required type annotations.