### PR TITLE
client: eagerly deinitialize clients upon eviction

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -731,6 +731,10 @@ pub fn ContextType(
             // Now that the client is evicted, no more requests can be submitted to it and we can
             // safely deinitialize it. First, we stop the IO thread, which then deinitializes the
             // client before it exits (see `io_thread`).
+            //? batiati: Could we assign `reason` before calling `stop()`?
+            //? There's no practical reason, as the signal doesn't trigger the event
+            //? synchronously. However, making `stop()` the final action reads better.
+            //? resolved.
             self.eviction_reason = eviction.header.reason;
             self.signal.stop();
         }
@@ -886,6 +890,10 @@ pub fn ContextType(
 
             assert(self.submitted.pop() == null);
             assert(self.pending.pop() == null);
+            //? batiati: I think we could move the message_pool and IO deinit together
+            //? with the client deinit.
+            //? chaitanyabhandari: Ah yes, makes sense!
+            //? resolved.
 
             self.gpa.allocator().free(self.addresses_copy);
 

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -731,10 +731,6 @@ pub fn ContextType(
             // Now that the client is evicted, no more requests can be submitted to it and we can
             // safely deinitialize it. First, we stop the IO thread, which then deinitializes the
             // client before it exits (see `io_thread`).
-            //? batiati: Could we assign `reason` before calling `stop()`?
-            //? There's no practical reason, as the signal doesn't trigger the event
-            //? synchronously. However, making `stop()` the final action reads better.
-            //? resolved.
             self.eviction_reason = eviction.header.reason;
             self.signal.stop();
         }
@@ -890,10 +886,6 @@ pub fn ContextType(
 
             assert(self.submitted.pop() == null);
             assert(self.pending.pop() == null);
-            //? batiati: I think we could move the message_pool and IO deinit together
-            //? with the client deinit.
-            //? chaitanyabhandari: Ah yes, makes sense!
-            //? resolved.
 
             self.gpa.allocator().free(self.addresses_copy);
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -127,6 +127,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         /// Updated when the *client* is informed of the eviction.
         /// (Which may be some time after the client is actually evicted by the cluster.)
         client_eviction_reasons: []?vsr.Header.Eviction.Reason,
+        client_eviction_requests_cancelled: u32 = 0,
+
         client_id_permutation: IdPermutation,
 
         state_checker: StateChecker,
@@ -411,7 +413,13 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             cluster.storage_checker.deinit(cluster.allocator);
             cluster.state_checker.deinit();
             cluster.network.deinit();
-            for (cluster.clients) |*client| client.deinit(cluster.allocator);
+
+            for (cluster.clients, cluster.client_eviction_reasons) |*client, reason| {
+                if (reason == null) {
+                    client.deinit(cluster.allocator);
+                }
+            }
+
             for (cluster.client_pools) |*pool| pool.deinit(cluster.allocator);
             for (cluster.replicas, 0..) |*replica, i| {
                 switch (cluster.replica_health[i]) {
@@ -795,6 +803,12 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
             cluster.client_eviction_reasons[client_index] = eviction.header.reason;
             cluster.network.process_disable(.{ .client = client.id });
+
+            cluster.client_eviction_requests_cancelled +=
+                @intFromBool(client.request_inflight != null and
+                client.request_inflight.?.message.header.operation != .register);
+
+            client.deinit(cluster.allocator);
         }
 
         fn on_replica_event(replica: *const Replica, event: vsr.ReplicaEvent) void {


### PR DESCRIPTION
Currently, we ([against our own advice](https://github.com/tigerbeetle/tigerbeetle/blob/3a94cb28e5997a048458f1adb1fb366299b36803/src/vsr/client.zig#L137-L141)) don't deinitialize a client in our eviction callbacks. Instead, we wait for the application to _close_ the client, which invokes [deinit](https://github.com/tigerbeetle/tigerbeetle/blob/3a94cb28e5997a048458f1adb1fb366299b36803/src/clients/c/tb_client/context.zig#L825) and frees up all the client's resources. Therefore, an evicted client that isn't closed by the application doesn't close its outgoing connections to replicas. 

This could lead to a scenario (thanks to @sm2n 🚀) wherein:
* Replica R crashes and restarts
* Application creates a lot of clients
* Clients and the other replicas in the cluster all race to connect to R
* Clients end up hogging all the incoming connections on R, causing it to get locked out of the cluster! 

In this PR, we solve this by eagerly deinitializing evicted clients, so that the client closes its outgoing MessageBus connections to replicas. Consequently, replicas clean up the incoming connections from evicted clients, making up space for connections from other replicas & clients.

The following callbacks have been fixed:

* [client_eviction_callback](https://github.com/tigerbeetle/tigerbeetle/blob/3a94cb28e5997a048458f1adb1fb366299b36803/src/clients/c/tb_client/context.zig#L670-L686): Language Clients
*  [client_on_eviction](https://github.com/tigerbeetle/tigerbeetle/blob/3a94cb28e5997a048458f1adb1fb366299b36803/src/testing/cluster.zig#L784-L798): VOPR