### PR TITLE
cfo: also fuzz the release branch

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -25,10 +25,9 @@
 //!
 //! Note that the budget/refresh timers do not count time spent cloning or compiling code.
 //!
-//! It is important that the caller (systemd typically) arranges for CFO to be a process group
-//! leader. It is not possible to reliably wait for (grand) children with POSIX, so its on the
-//! call-site to cleanup any run-away subprocesses. See `./cfo_supervisor.sh` for one way to
-//! arrange that.
+//! It is important that the caller arranges for CFO's descendants to be reaped when CFO exits.
+//! It is not possible to reliably wait for (grand) children with POSIX, so its on the call-site to
+//! cleanup any run-away subprocesses. See `./cfo_supervisor.sh` for one way to arrange that.
 //!
 //! Every `args.refresh_minutes`, and at the end of the fuzzing loop:
 //! 1. CFO collects a list of seeds (some of which are failing),


### PR DESCRIPTION
Add `release` branch to CFO. The split of time between main/prs/release is 40:40:20. 

The idea here is that we'll push the `release` branch on Friday, give the weekend for fuzzing, and then run the actual release workflow off the release branch on Monday. 

Isn't it wasteful to continue fuzzing already released code between Monday and next Friday? I think not --- we _might_ have a bug slipping into release somehow, so I'd be more comfortable if we don't just blindly trust our development testing infrastructure, but also continuously test whatever we are releasing at the moment. 