### PR TITLE
git-review: add command to send review comments as a email

### DIFF
--- a/src/git-review.zig
+++ b/src/git-review.zig
@@ -353,7 +353,7 @@ const Review = struct {
                 // Extract '380' from
                 // @@ -379,0 +380,2 @@
                 _, const added = stdx.cut(line, " +").?;
-                const hunk_line_str, _ = stdx.cut(added, ",") orelse stdx.cut(added, " ").?;
+                const hunk_line_str, _ = stdx.cut(added, ",") orelse stdx.cut(added, " @@").?;
                 hunk_line = std.fmt.parseInt(u32, hunk_line_str, 10) catch unreachable;
             }
 


### PR DESCRIPTION
git-review email --recepient somebody@example.com` will parse the
current state of review and send a plain-text email to the specified
address. Currently, this is mostly just scaffolding. I confirmd that it
can, in fact, send an email, but there's a bunch of things yet to do to
make it fully useful:

- setup a review bot email account (I've been using my personal account
  for testing)
- actually call `git review send` in GHA
- add a gitdb to skip already emailed comments
- add nicer formatting for the actual mail

But I want to move one step at a time here, and the first step is
crafting of the relevant CURL command.