### PR TITLE
stdx: commit to disallowing quoting

### DIFF
--- a/src/shell.zig
+++ b/src/shell.zig
@@ -692,7 +692,7 @@ fn expand_argv(argv: *Argv, comptime cmd: []const u8, cmd_args: anytype) !void {
 
     const arg_count = std.meta.fields(@TypeOf(cmd_args)).len;
     comptime var args_used: stdx.BitSetType(arg_count) = .{};
-    comptime assert(std.mem.indexOfScalar(u8, cmd, '\'') == null); // Quoting isn't supported yet.
+    comptime assert(std.mem.indexOfScalar(u8, cmd, '\'') == null); // Intentionally unsupported.
     comptime assert(std.mem.indexOfScalar(u8, cmd, '"') == null);
     inline while (pos < cmd.len) {
         inline while (pos < cmd.len and (cmd[pos] == ' ' or cmd[pos] == '\n')) {


### PR DESCRIPTION
Originally this was a TODO, as I wanted to allow things like

    shell.exec("git switch 'my cool branch with spaces'", .{})

I tried implementing this yesterday, and realized that this is a feature we'd be better without. The principal problem is that the quotes are hard to match visually. Consider

    shell exec("git switch ' '{branch}'with 'spaces' in it'", .{...})

While it is possible to give a reasonable and unambiguous interpretation of what this means, this is really hard to parse at a glance for a human! One can imagine restricting to a single pair of quotes, or requiring spaces on the outside, but not on the inside of the quotes, or some such, but, really, at this point moving the entire thing into a `{binding}` feels much simpler.

So, let's not do this! Interesting people from the future can learn the motivation in git blame.