### PR TITLE
test: speed up fuzz smoke tests

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -263,7 +263,6 @@ pub fn build(b: *std.Build) !void {
     const scripts = build_scripts(b, build_steps.scripts, .{
         .vsr_options = vsr_options,
         .target = target,
-        .mode = mode,
     });
 
     // zig build vortex
@@ -1065,14 +1064,13 @@ fn build_scripts(
     options: struct {
         vsr_options: *std.Build.Step.Options,
         target: std.Build.ResolvedTarget,
-        mode: std.builtin.OptimizeMode,
     },
 ) *std.Build.Step.Compile {
     const scripts = b.addExecutable(.{
         .name = "scripts",
         .root_source_file = b.path("src/scripts.zig"),
         .target = options.target,
-        .optimize = options.mode,
+        .optimize = .Debug,
     });
     scripts.root_module.addOptions("vsr_options", options.vsr_options);
     const scripts_run = b.addRunArtifact(scripts);

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -86,18 +86,18 @@ fn main_smoke(gpa: std.mem.Allocator) !void {
             .lsm_manifest_log => 2_000,
             .lsm_scan => 100,
             .lsm_tree => 400,
-            .vsr_free_set => 10_000,
-            .vsr_superblock => 3,
             .state_machine => 10_000,
+            .storage => 1_000,
+            .vsr_free_set => 10_000,
+            .vsr_multi_batch => 128,
+            .vsr_superblock => 3,
 
             inline .ewah,
             .lsm_segmented_array,
             .lsm_manifest_level,
             .vsr_journal_format,
             .vsr_superblock_quorums,
-            .storage,
             .signal,
-            .vsr_multi_batch,
             => null,
         };
 
@@ -107,7 +107,7 @@ fn main_smoke(gpa: std.mem.Allocator) !void {
             .events_max = events_max,
         });
         const fuzz_duration = timer_single.lap();
-        if (fuzz_duration > 60 * std.time.ns_per_s) {
+        if (fuzz_duration > 10 * std.time.ns_per_s) {
             log.err("fuzzer too slow for the smoke mode: " ++ @tagName(fuzzer) ++ " {}", .{
                 std.fmt.fmtDuration(fuzz_duration),
             });


### PR DESCRIPTION
Smoke testing fuzzers is one of the biggest contributor to our `zig
build ci` pre-submit check, so it makes sense to optimize that a bit:

    λ ./zig/zig build ci --summary all
    ✔ 0 errors, 0 warnings and 0 suggestions in 99 files.
    Build Summary: 18/18 steps succeeded
    ci success
    ├─ test:fmt success 18s MaxRSS:99M
    ├─ check success 9s MaxRSS:174M
    ├─ run /Users/matklad/p/tb/work/zig/zig success 16s MaxRSS:114M
    ├─ test success 3m MaxRSS:3G
    ├─ clients:c:sample success 9s MaxRSS:357M
    ├─ run scripts success 200ms MaxRSS:4M
    │  └─ zig build-exe scripts Debug aarch64-macos success 14s MaxRSS:800M
    │     └─ options success
    ├─ fuzz -- smoke success 1m MaxRSS:2G
    ├─ vopr -Dvopr-state-machine=testing -Drelease -- https://github.com/tigerbeetle/tigerbeetle/commit/ca04bfcd5c7d0cd54ddef14cf2904407d2fd4056 success 28s MaxRSS:2G
    ├─ vopr -Dvopr-state-machine=accounting -Drelease -- https://github.com/tigerbeetle/tigerbeetle/commit/ca04bfcd5c7d0cd54ddef14cf2904407d2fd4056 success 32s MaxRSS:2G
    ├─ clients:dotnet success 9s MaxRSS:289M
    ├─ clients:go success 15s MaxRSS:354M
    ├─ clients:rust success 8s MaxRSS:286M
    ├─ clients:java success 15s MaxRSS:365M
    ├─ clients:node success 15s MaxRSS:369M
    └─ clients:python success 9s MaxRSS:371M

It doesn't make sense to burn so much wall-clock time for something that
basically checks that the code compiles.