### PR TITLE
vsr: bump default journal write iops

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -110,7 +110,7 @@ const ConfigProcess = struct {
     tcp_nodelay: bool = true,
     direct_io: bool,
     journal_iops_read_max: usize = 8,
-    journal_iops_write_max: usize = 8,
+    journal_iops_write_max: usize = 16,
     client_replies_iops_read_max: usize = 1,
     client_replies_iops_write_max: usize = 2,
     client_request_completion_warn_ms: u64 = 200,


### PR DESCRIPTION
This is a work-around for a design issue in our message bus, where it pushes messages onto replica without flow control, and can overwhelm the journal, leading to dropped prepares.