### PR TITLE
[git-review] Fix the line number parser.

### DIFF
--- a/src/git-review.zig
+++ b/src/git-review.zig
@@ -317,7 +317,11 @@ const Review = struct {
                 // Extract '380' from
                 // @@ -379,0 +380,2 @@
                 _, const added = stdx.cut(line, " +").?;
-                const hunk_line_str, _ = stdx.cut(added, ",").?;
+                const hunk_line_str, _ = stdx.cut(added, ",") orelse
+                    // The number of lines may not be shown:
+                    // @@ -379,0 +380 @@
+                    stdx.cut(added, " @@").?;
+
                 hunk_line = std.fmt.parseInt(u32, hunk_line_str, 10) catch unreachable;
             }
 


### PR DESCRIPTION
The number of lines may not be shown if it's 1.