### PR TITLE
vsr: prepare repair optimizations

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1792,7 +1792,12 @@ pub fn ReplicaType(
                 self.advance_commit_max(message.header.commit, @src());
                 assert(self.commit_max >= message.header.commit);
             }
-            defer if (self.backup()) self.commit_journal();
+            defer {
+                if (self.backup()) {
+                    self.commit_journal();
+                    self.repair();
+                }
+            }
 
             if (message.header.op > self.commit_min + 2 * constants.pipeline_prepare_queue_max) {
                 log.warn("{}: on_prepare: lagging behind the cluster prepare.op={} " ++

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1279,7 +1279,7 @@ pub fn ReplicaType(
                 .repair_timeout = Timeout{
                     .name = "repair_timeout",
                     .id = replica_index,
-                    .after = 50,
+                    .after = 10,
                 },
                 .repair_sync_timeout = Timeout{
                     .name = "repair_sync_timeout",

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -118,6 +118,12 @@ test "Cluster: recovery: WAL prepare corruption (R=3, corrupt root)" {
 
     try c.request(1, 1);
     try expectEqual(t.replica(.R_).commit(), 1);
+
+    const r0 = t.replica(.R0);
+    const r0_storage = &t.cluster.storages[r0.replicas.get(0)];
+    const fault_offset = vsr.Zone.wal_prepares.offset(0);
+    const fault_sector = @divExact(fault_offset, constants.sector_size);
+    try expect(!r0_storage.faults.isSet(fault_sector));
 }
 
 test "Cluster: recovery: WAL prepare corruption (R=3, corrupt checkpoint…head)" {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -121,9 +121,7 @@ test "Cluster: recovery: WAL prepare corruption (R=3, corrupt root)" {
 
     const r0 = t.replica(.R0);
     const r0_storage = &t.cluster.storages[r0.replicas.get(0)];
-    const fault_offset = vsr.Zone.wal_prepares.offset(0);
-    const fault_sector = @divExact(fault_offset, constants.sector_size);
-    try expect(!r0_storage.faults.isSet(fault_sector));
+    try expect(!r0_storage.area_faulty(.{ .wal_prepares = .{ .slot = 0 } }));
 }
 
 test "Cluster: recovery: WAL prepare corruption (R=3, corrupt checkpoint…head)" {


### PR DESCRIPTION
Best reviewed per commit! This PR implements various improvement to prepare repair.

**_First, it improves detection latency for a missing prepare._**

Currently, we only detect and attempt to repair prepares at repair timeout (which is 500ms), or if we are _already_ repairing the WAL (`self.repair` is invoked only when when we are already in the repair process). This can be disastrous in a loaded cluster, because even if a _single_ prepare is missed, we only detect it at repair timeout. This delayed detection also stalls the commit progress, exacerbating the lag on an already lagging replica.

We now invoke `self.repair` from some _non repair_ paths as well, to speed up the detection of missing prepares. Specifically, we now invoke `self.repair` during `on_prepare`, to pace repair with the rate on incoming prepares in the cluster.

Also, reduce `repair_timeout` from 500ms → 100ms.

**_Second, it improves throughput of repair._**

Our repair process maintains a repair budget to ensure a lagging replica doesn't flood the network with repair messages. However, while currently _decrement_ the repair budget every time we send a repair message (like `request_headers`, `request_prepares`), we only _replenish_ the repair budget at repair timeout. This is a bug that impacts repair throughput, because if a replica exhausts its repair budget, it must wait for ~500ms for it to get replenished.

The fix is simple, we increment the budget every time we receive a `header` or `prepare` that we _actually_ repair from (to avoid handling duplicate messages). 

**_Third, we now cycle through the missing prepares, instead of requesting for the same ones over and over again._**

_During_ a repair timeout interval, we now iterate through the missing prepares and ensure we only send a `request_prepare` for a missing prepare _once_. At repair timeout, we cycle around and start iterating from the beginning again!