### PR TITLE
AOF: Fix `unflushed` assertion

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -290,9 +290,15 @@ pub const AOF = struct {
         self.state.writing.unflushed += 1;
     }
 
+    pub fn sync(self: *AOF) void {
+        assert(self.state == .writing);
+        assert(self.state.writing.unflushed <= constants.journal_slot_count);
+        self.state.writing.unflushed = 0;
+    }
+
     pub fn checkpoint(self: *AOF, replica: *anyopaque, callback: *const fn (*anyopaque) void) void {
         assert(self.state == .writing);
-        assert(self.state.writing.unflushed < constants.journal_slot_count);
+        assert(self.state.writing.unflushed <= constants.journal_slot_count);
 
         self.state = .{
             .checkpoint = .{

--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -39,6 +39,7 @@ pub const AOF = struct {
     validation_target: *AOFEntry,
     last_checksum: ?u128 = null,
     validation_checksums: std.AutoHashMap(u128, void) = undefined,
+    unflushed: u32 = 0,
 
     pub fn init(allocator: std.mem.Allocator) !AOF {
         const memory = try allocator.alignedAlloc(u8, constants.sector_size, backing_size);
@@ -60,6 +61,10 @@ pub const AOF = struct {
         allocator.free(self.backing_store);
         allocator.destroy(self.validation_target);
         self.validation_checksums.deinit();
+    }
+
+    pub fn reset(self: *AOF) void {
+        self.unflushed = 0;
     }
 
     pub fn validate(self: *AOF, last_checksum: ?u128) !void {
@@ -108,6 +113,9 @@ pub const AOF = struct {
     }
 
     pub fn write(self: *AOF, message: *const Message.Prepare) !void {
+        assert(self.unflushed < constants.journal_slot_count);
+        self.unflushed += 1;
+
         var entry: AOFEntry align(16) = undefined;
         entry.from_message(
             message,
@@ -128,7 +136,8 @@ pub const AOF = struct {
     }
 
     pub fn checkpoint(self: *AOF, replica: *anyopaque, callback: *const fn (*anyopaque) void) void {
-        _ = self;
+        assert(self.unflushed < constants.journal_slot_count);
+        self.unflushed = 0;
         callback(replica);
     }
 

--- a/src/testing/aof.zig
+++ b/src/testing/aof.zig
@@ -135,8 +135,13 @@ pub const AOF = struct {
         log.debug("wrote {} bytes, {} used / {}", .{ size_disk, self.index, backing_size });
     }
 
+    pub fn sync(self: *AOF) void {
+        assert(self.unflushed <= constants.journal_slot_count);
+        self.unflushed = 0;
+    }
+
     pub fn checkpoint(self: *AOF, replica: *anyopaque, callback: *const fn (*anyopaque) void) void {
-        assert(self.unflushed < constants.journal_slot_count);
+        assert(self.unflushed <= constants.journal_slot_count);
         self.unflushed = 0;
         callback(replica);
     }

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -599,6 +599,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             } else unreachable;
 
             cluster.releases_bundled[replica_index] = options.releases_bundled.*;
+            cluster.aofs[replica_index].reset();
 
             var replica = &cluster.replicas[replica_index];
             try replica.open(

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9571,6 +9571,8 @@ pub fn ReplicaType(
 
             self.client_sessions_checkpoint.reset();
             self.client_sessions.reset();
+
+            if (self.aof) |aof| aof.sync();
             // Faulty bits will be set in sync_content().
             while (self.client_replies.faulty.first_set()) |slot| {
                 self.client_replies.faulty.unset(slot);


### PR DESCRIPTION
Note that the full fix for this is probably to make the two AOF implementation share code more. But in the interest of getting this fix into next week's release, this is a more minimal change.