### PR TITLE
bus: pull-based message bus

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -388,11 +388,11 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             var connections_suspended = bus.connections_suspended;
             bus.connections_suspended.reset();
 
-            while (connections_suspended.pop()) |connecton| {
-                assert(connecton.recv_buffer != null);
-                assert(connecton.recv_buffer.?.advance_size >= @sizeOf(vsr.Header));
-                assert(connecton.recv_buffer.?.has_message());
-                connecton.call_on_messages(bus);
+            while (connections_suspended.pop()) |connection| {
+                assert(connection.recv_buffer != null);
+                assert(connection.recv_buffer.?.advance_size >= @sizeOf(vsr.Header));
+                assert(connection.recv_buffer.?.has_message());
+                connection.call_on_messages(bus);
             }
         }
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -382,6 +382,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             };
             assert(bus.resume_receive_submitted);
             bus.resume_receive_submitted = false;
+            maybe(bus.connections_suspended.empty());
 
             // Steal the queue to avoid an infinite loop.
             var connections_suspended = bus.connections_suspended;

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -22,6 +22,8 @@ pub const MessageBus = struct {
     process: Process,
 
     buffer: ?MessageBuffer,
+    suspended: bool = false,
+    resume_scheduled: bool = false,
     /// The callback to be called when a message is received.
     on_messages_callback: *const fn (message_bus: *MessageBus, buffer: *MessageBuffer) void,
 
@@ -68,6 +70,15 @@ pub const MessageBus = struct {
     /// - `MessageType(command)` for any `command`.
     pub fn unref(bus: *MessageBus, message: anytype) void {
         bus.pool.unref(message);
+    }
+
+    pub fn resume_needed(bus: *MessageBus) bool {
+        return bus.suspended;
+    }
+
+    pub fn resume_receive(bus: *MessageBus) void {
+        bus.suspended = false;
+        bus.resume_scheduled = true;
     }
 
     pub fn send_message_to_replica(bus: *MessageBus, replica: u8, message: *Message) void {

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -191,7 +191,8 @@ pub fn ClientType(
 
         pub fn on_messages(message_bus: *MessageBus, buffer: *MessageBuffer) void {
             const self: *Client = @fieldParentPtr("message_bus", message_bus);
-            while (buffer.consume_message(self.message_bus.pool)) |message| {
+            while (buffer.next_header()) |header| {
+                const message = buffer.consume_message(self.message_bus.pool, &header);
                 defer self.message_bus.unref(message);
 
                 if (message.header.cluster != self.cluster) {

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -199,8 +199,9 @@ pub fn ClientType(
                     buffer.invalidate(.header_cluster);
                     return;
                 }
-                self.on_message(message);
-                if (self.evicted) break;
+                if (!self.evicted) {
+                    self.on_message(message);
+                }
             }
         }
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2640,7 +2640,8 @@ const TestClientBus = struct {
 
     fn on_messages(message_bus: *Cluster.MessageBus, buffer: *MessageBuffer) void {
         const t: *TestClientBus = @fieldParentPtr("message_bus", message_bus);
-        while (buffer.consume_message(t.message_pool)) |message| {
+        while (buffer.next_header()) |header| {
+            const message = buffer.consume_message(t.message_pool, &header);
             defer t.message_pool.unref(message);
 
             assert(message.header.cluster == t.context.cluster.options.cluster_id);


### PR DESCRIPTION
**Note:** PR was substantially reworked & simplified, here's the new description:

Before this commit, replica had to process every message that the bus
throws at replica. Now, replica gains the ability to "suspend" certain
messages in bus' receive buffer, to return to them later.

This is used to:

* postpone prepare messages until there's a journal write available
* postpone block messages until there's a grid repair write available

If a message is suspended, the bus won't be recving into the socket,
propagating backpressure all the way up to the sending replica.

To ameliorate head-of-line blocking issues, backpressure applies to
specific commands. If there are _many_ messages in a particular buffer,
they all will be considered.

If a replica suspends a message, it must call bus.ready_to_receive at
some later point to guarantee that messages are delivered.

Old Description below (also available in a blog form here: https://matklad.github.io/2025/05/14/scalar-select-aniti-pattern.html): 

---

Before this comment, message bus invoked an on_message callback every
time a recv syscall returned enough bytes to form a valid message. Now,
messages need to be explicitly pulled out of the bus via receive_message
method.

  ## Background

Pulling events is in general a good pattern for asynchronous systems.
Imagine a generic evented system which works like:

    for message in incoming_messages:
        process(message)

Note that because `process` takes time, by the time it finishes and we
are ready to pull the next message from the pile, there might be _many_
messages in the pile already! And usually there are _some_ things to be
gained from exploiting the pile as a whole, rather than looking at it as
just a sequence of messages:

* You can prioritize, and select the more important messages out of the
  pile, even if they arrived later.
* You can coalesce and remove "duplicate" messages (e.g., taking only
  the latest state update).
* You can batch message processing. For example, processing all updates
  in one go and sending only a single change notification.

These points don't significantly apply to TigerBeetle, but there's one
issue that does apply, backpressure!

  ## Precarious Prepare Pileup

In the today's push-based setup, Replica's `on_message` is called
immediately upon receiving the message, and the replica might deal with
the message immediately. This is not always possible, the replica might
lack the required resources.

One very specific instance of this that we observed in real-world
deployments is message bus receiving a whole bunch of tiny prepares in
one go, lets say, 20 of them. When that happens, the bus calls
on_message 20 times in a row. But because we only have 8 IOPs in the
journal, most of the prepares are dropped on the floor, which creates
then causes extra repair and prepare traffic.

The behavior we want here is for the replica to _only_ pull a prepare
message out of the message bus when it has a spare IOP, and that's
exactly what's achieved here.

  ## Implementation

The core of the change is that MessageBus loses the `on_message`
callback, and instead gains a

  fn receive_message(bus: *Bus) ?*Message

instead. The replcia can now poll the bus when it is ready to process a
message. The fully general solution here would expose something like

    const MessageIterator = struct {
        fn peek(it: *const MessageIterator) ?*const Header,
        fn next_take(it: *MessageIterator) *Message,
        fn next_skip(it: *MessageIterator) *const Message,
    }

to allow the replica to inspect all available messages and receive them
selectively, but:

- I don't think we need to go _that_ far
- and, even if we need, it'll be a relatively uninteresting diff on top
  of the present commit.

So instead there's just `peek_message`, `receive_message`, which only
allow stalling the processing, rather than being selective. And we only
stall if we don't have a write IOP available, so the stalls should be
short, and I wouldn't worry about us delaying pings too much.

The interesting question is _when_ should the replica call
`bus.receive_message()`? How do we notify about readiness? The proposed
answer is "all the time". On every iteration of the event loop, before
we go into the kernel to sleep, we invoke

    fn idle(replica: *Replica) void

callback which then polls the bus.

The nice thing about this solution is that we avoid function pointes or
weird stacks: `replcia.idle()` is a _direct_ call, and we do it right
from main, there's nothing above us on the stack.

The not-so-nice thing is that this _seems_ inefficient. The previous
approach, with on_message callback, notified us precisely! We can
restore that by keeping the on_message callback, but then letting the
replica poll for the message from that callback. This would be an
incomplete solution! If the replica decides to postpone receiving a
prepare, it still needs to poll the bus later, when it is ready to
process the message. So the full solution here would be to pull from the
bus in the on_message callback, and _also_ in the `write_prepare` /
`write_block` callback. But that would create ugly backtraces, where
there's unrelated stuff above in the stack. To fix that, one option
would be just to set a `need_to_pull_message_bus` _flag_ in the
`write_prepare_callback`. And then, when we have nothing else on the
call-stack, we can check the flag and poll the bus. But then this
becomes equivalent to the idle solution!

This line of thinking convinced myself that the loop with `.idle` in
main is the right approach.

What I _don't_ like about this solution is that it make the VOPR event
loop even more complex, but, given that the production loop looks fine,
I am ok with that.
