### PR TITLE
vsr: implement request throttling for grid repair

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -74,14 +74,6 @@ comptime {
     assert(vsr_checkpoint_ops % lsm_compaction_ops == 0);
 }
 
-pub const vsr_repair_message_budget_max = replicas_max * 2;
-pub const vsr_repair_message_budget_refill = @divFloor(vsr_repair_message_budget_max, 2);
-
-comptime {
-    assert(vsr_repair_message_budget_max > 0);
-    assert(vsr_repair_message_budget_refill > 0);
-}
-
 /// The maximum number of clients allowed per cluster, where each client has a unique 128-bit ID.
 /// This impacts the amount of memory allocated at initialization by the server.
 /// This determines the size of the VR client table used to cache replies to clients by client ID.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1687,6 +1687,41 @@ pub const Snapshot = struct {
     }
 };
 
+pub const Budget = struct {
+    capacity: u32,
+    available: u32,
+    refill_max: u32,
+
+    pub fn init(options: struct {
+        capacity: u32,
+        refill_max: u32,
+    }) Budget {
+        assert(options.refill_max <= options.capacity);
+        return Budget{
+            .capacity = options.capacity,
+            .available = options.capacity,
+            .refill_max = options.refill_max,
+        };
+    }
+
+    pub fn spend(budget: *Budget, amount: u32) bool {
+        assert(budget.capacity > 0);
+        assert(budget.available <= budget.capacity);
+        assert(amount > 0);
+
+        if (budget.available < amount) return false;
+        budget.available -= amount;
+        return true;
+    }
+
+    pub fn refill(budget: *Budget, amount: u32) void {
+        assert(amount <= budget.refill_max);
+        assert(budget.available <= budget.capacity);
+
+        budget.available = @min((budget.available + amount), budget.capacity);
+    }
+};
+
 pub fn block_count_max(storage_size_limit: u64) usize {
     const shard_count_limit: usize = @intCast(@divFloor(
         storage_size_limit - superblock.data_file_size_min,


### PR DESCRIPTION
Currently, we don't throttle grid repair requests. Specifically, we send a `request_blocks` message requesting _4 blocks_ (at max), every time we repair a block! This can lead to a situation where a syncing replica overwhelms other replicas with `request_blocks` messages, leading to a lot of dropped messages. This wastes network bandwidth and also impedes other replicas' progress, since other important messages (like _prepare/commit_) get dropped.

This PR implements a budgeting logic for grid repair requests, such that each replica has *at most 2 `request_blocks`* messages in flight to another replica. This is merely an approximation that is loosely enforced by randomizing the remote replica we choose for repair, instead of strictly by ensuring that there is *exactly* two inflight repair message to a specific replica.

It also fixes the budgeting logic for WAL repair. For WAL repair as well, intend to have *at most 2 `request_headers`/`request_prepares`* requests in fight to another replica. However, we set the budget to `vsr_repair_message_budget_max = replicas_max * 2`, which is agnostic of the number of replicas in the cluster! In a smaller cluster, this would lead to each replica having a budget of >2 requests. So, now, the budget is parametrized by the number of replicas in the cluster:
```C
            self.repair_messages_budget_journal_max =
                2 * (replica_count - @intFromBool(!self.standby()));
``` 

---


To evaluate the efficacy of the budgeting logic, we run an experiment with a 3-replica cluster spun up on a single machine. We run `./tigerbeetle benchmark` with only R1 and R2 up, and start R0 after the cluster advances its checkpoint. We let R0 state sync while the benchmark is issuing `get_account_transfers` queries to the cluster.

#### Main

Sync took ~8 minutes. _1060 & 1022 instances of dropped commands from R1 & R2, and 1022 & 1011 instances of dropped _block_ commands_. 
```C
2025-05-16 13:28:45.063Z info(replica): 0: sync: ops=0..991
2025-05-16 13:36:33.993Z info(replica): 0: sync_enqueue_tables: all tables synced (commit=0..991)
```

#### After this PR

Sync took ~9 minutes, and _56 & 32 instances of dropped from R1 & R2_:

```C
2025-05-15 20:46:00.461Z info(replica): 0: sync: ops=0..991
2025-05-15 20:54:48.298Z info(replica): 0: sync_enqueue_tables: all tables synced (commit=0..991)
```