### PR TITLE
chore(docker): update alpine to 3.21

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -904,7 +904,7 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
         try shell.exec_options(
             .{
                 .stdin_slice =
-                \\FROM alpine:3.19
+                \\FROM alpine:latest
                 \\RUN apk add --no-cache tini
                 \\ARG TARGETARCH
                 \\COPY tigerbeetle-${TARGETARCH} /tigerbeetle


### PR DESCRIPTION
### Updated
- Update Docker base image alpine 3.19 to 3.21