### PR TITLE
ci: fix release_validate to run on release

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -20,7 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: release # Use the 'release' branch even if triggered by cron.
+          ref: release
+      # Run on the latest tag. The release branch is ahead of release tag over the weekend.
+      - run: |
+          TAG=$(gh release list --limit 1 | cut -f1)
+          git fetch origin $TAG && git switch -d FETCH_HEAD
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
It's important that release validation uses releases's own code. That used to be just the `release` branch, but, with two-phase releases, this is no longer true, so we need to check the tag specifically.