### PR TITLE
ci: check release determinism and remove dependencies on `zip` & `unzip`

### DIFF
--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -57,7 +57,7 @@ const CLIArgs = union(enum) {
         \\
         \\  zig build scripts -- devhub --sha=<commit>
         \\
-        \\  zig build scripts -- release --run-number=<run> --sha=<commit>
+        \\  zig build scripts -- release --sha=<commit>
         \\
         \\Options:
         \\

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -114,18 +114,17 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         // Zig only guarantees release builds to be deterministic.
         if (std.mem.indexOf(u8, artifact, "-debug.zip") != null) continue;
 
-        // TODO(Zig): Determinism is broken on Windows:
-        // https://github.com/ziglang/zig/issues/9432
-        if (std.mem.indexOf(u8, artifact, "-windows.zip") != null) continue;
-
         const checksum_downloaded = try shell.exec_stdout("sha256sum {artifact}", .{
             .artifact = artifact,
         });
 
         shell.popd();
-        const checksum_built = try shell.exec_stdout("sha256sum zig-out/dist/tigerbeetle/{artifact}", .{
-            .artifact = artifact,
-        });
+        const checksum_built = try shell.exec_stdout(
+            "sha256sum zig-out/dist/tigerbeetle/{artifact}",
+            .{
+                .artifact = artifact,
+            },
+        );
         try shell.pushd_dir(tmp_dir.dir);
 
         // Slice the output to suppress the names.

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -138,7 +138,10 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         }
     }
 
-    try shell.exec("unzip tigerbeetle-x86_64-linux.zip", .{});
+    const zip_file = try std.fs.cwd().openFile("tigerbeetle-x86_64-linux.zip", .{});
+    defer zip_file.close();
+    try std.zip.extract(std.fs.cwd(), zip_file.seekableStream(), .{});
+
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);
     assert(std.mem.indexOf(u8, version, "ReleaseSafe") != null);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -142,7 +142,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         }
     }
 
-    try shell.zip_tigerbeetle_extract("tigerbeetle-x86_64-linux.zip");
+    try shell.unzip_executable("tigerbeetle-x86_64-linux.zip", "tigerbeetle");
 
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -137,7 +137,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         }
     }
 
-    try shell.extract_tigerbeetle_zip("tigerbeetle-x86_64-linux.zip");
+    try shell.zip_tigerbeetle_extract("tigerbeetle-x86_64-linux.zip");
 
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -137,9 +137,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         }
     }
 
-    const zip_file = try std.fs.cwd().openFile("tigerbeetle-x86_64-linux.zip", .{});
-    defer zip_file.close();
-    try std.zip.extract(std.fs.cwd(), zip_file.seekableStream(), .{});
+    try shell.extract_tigerbeetle_zip("tigerbeetle-x86_64-linux.zip");
 
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -129,7 +129,12 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
 
         // Slice the output to suppress the names.
         if (!std.mem.eql(u8, checksum_downloaded[0..64], checksum_built[0..64])) {
-            std.debug.panic("checksum mismatch - {s}: downloaded {s}, built {s}", .{
+            // Still run the code, but suppress failing until a release cycle has taken place.
+            std.log.info(
+                "deterministic builds still need a release cycle for validation to pass:",
+                .{},
+            );
+            std.log.info("checksum mismatch - {s}: downloaded {s}, built {s}", .{
                 artifact,
                 checksum_downloaded[0..64],
                 checksum_built[0..64],

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -105,49 +105,38 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         assert(shell.file_exists(artifact));
     }
 
-    // Enable this once deterministic zip generation has been merged in and released.
-    // const raw_run_number = stdx.cut(stdx.cut(tag, ".").?.suffix, ".").?.suffix;
+    const git_sha = try shell.exec_stdout("git rev-parse HEAD", .{});
+    try shell.exec_zig("build scripts -- release --build " ++
+        "--sha={git_sha} --language=zig", .{
+        .git_sha = git_sha,
+    });
+    for (artifacts) |artifact| {
+        // Zig only guarantees release builds to be deterministic.
+        if (std.mem.indexOf(u8, artifact, "-debug.zip") != null) continue;
 
-    // // The +188 comes from how release.zig calculates the version number.
-    // const run_number = try std.fmt.allocPrint(
-    //     shell.arena.allocator(),
-    //     "{}",
-    //     .{try std.fmt.parseInt(u32, raw_run_number, 10) + 188},
-    // );
+        // TODO(Zig): Determinism is broken on Windows:
+        // https://github.com/ziglang/zig/issues/9432
+        if (std.mem.indexOf(u8, artifact, "-windows.zip") != null) continue;
 
-    // const sha = try shell.exec_stdout("git rev-parse HEAD", .{});
-    // try shell.exec_zig("build scripts -- release --build  --run-number={run_number} " ++
-    //     "--sha={sha} --language=zig", .{
-    //     .run_number = run_number,
-    //     .sha = sha,
-    // });
-    // for (artifacts) |artifact| {
-    //     // Zig only guarantees release builds to be deterministic.
-    //     if (std.mem.indexOf(u8, artifact, "-debug.zip") != null) continue;
+        const checksum_downloaded = try shell.exec_stdout("sha256sum {artifact}", .{
+            .artifact = artifact,
+        });
 
-    //     // TODO(Zig): Determinism is broken on Windows:
-    //     // https://github.com/ziglang/zig/issues/9432
-    //     if (std.mem.indexOf(u8, artifact, "-windows.zip") != null) continue;
+        shell.popd();
+        const checksum_built = try shell.exec_stdout("sha256sum zig-out/dist/tigerbeetle/{artifact}", .{
+            .artifact = artifact,
+        });
+        try shell.pushd_dir(tmp_dir.dir);
 
-    //     const checksum_downloaded = try shell.exec_stdout("sha256sum {artifact}", .{
-    //         .artifact = artifact,
-    //     });
-
-    //     shell.popd();
-    //     const checksum_built = try shell.exec_stdout("sha256sum dist/tigerbeetle/{artifact}", .{
-    //         .artifact = artifact,
-    //     });
-    //     try shell.pushd_dir(tmp_dir.dir);
-
-    //     // Slice the output to suppress the names.
-    //     if (!std.mem.eql(u8, checksum_downloaded[0..64], checksum_built[0..64])) {
-    //         std.debug.panic("checksum mismatch - {s}: downloaded {s}, built {s}", .{
-    //             artifact,
-    //             checksum_downloaded[0..64],
-    //             checksum_built[0..64],
-    //         });
-    //     }
-    // }
+        // Slice the output to suppress the names.
+        if (!std.mem.eql(u8, checksum_downloaded[0..64], checksum_built[0..64])) {
+            std.debug.panic("checksum mismatch - {s}: downloaded {s}, built {s}", .{
+                artifact,
+                checksum_downloaded[0..64],
+                checksum_built[0..64],
+            });
+        }
+    }
 
     try shell.exec("unzip tigerbeetle-x86_64-linux.zip", .{});
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -136,7 +136,10 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     }
     try shell.project_root.deleteFile("tigerbeetle");
 
-    try shell.zip_tigerbeetle_extract("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip");
+    try shell.unzip_executable(
+        "zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip",
+        "tigerbeetle",
+    );
 
     const benchmark_result = try shell.exec_stdout(
         "./tigerbeetle benchmark --validate --checksum-performance",

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -136,7 +136,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     }
     try shell.project_root.deleteFile("tigerbeetle");
 
-    try shell.extract_tigerbeetle_zip("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip");
+    try shell.zip_tigerbeetle_extract("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip");
 
     const benchmark_result = try shell.exec_stdout(
         "./tigerbeetle benchmark --validate --checksum-performance",

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -135,7 +135,10 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         , .{ .sha = cli_args.sha });
     }
     try shell.project_root.deleteFile("tigerbeetle");
-    try shell.exec("unzip zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip", .{});
+
+    const zip_file = try std.fs.cwd().openFile("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip", .{});
+    defer zip_file.close();
+    try std.zip.extract(std.fs.cwd(), zip_file.seekableStream(), .{});
 
     const benchmark_result = try shell.exec_stdout(
         "./tigerbeetle benchmark --validate --checksum-performance",

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -136,9 +136,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     }
     try shell.project_root.deleteFile("tigerbeetle");
 
-    const zip_file = try std.fs.cwd().openFile("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip", .{});
-    defer zip_file.close();
-    try std.zip.extract(std.fs.cwd(), zip_file.seekableStream(), .{});
+    try shell.extract_tigerbeetle_zip("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip");
 
     const benchmark_result = try shell.exec_stdout(
         "./tigerbeetle benchmark --validate --checksum-performance",

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -586,9 +586,7 @@ fn publish(
             shell.project_root.deleteFile("tigerbeetle") catch {};
             defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
-            const zip_file = try std.fs.cwd().openFile("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip", .{});
-            defer zip_file.close();
-            try std.zip.extract(std.fs.cwd(), zip_file.seekableStream(), .{});
+            try shell.extract_tigerbeetle_zip("zig-out/dist/tigerbeetle/tigerbeetle-x86_64-linux.zip");
 
             const past_binary_contents = try shell.cwd.readFileAllocOptions(
                 shell.arena.allocator(),
@@ -890,10 +888,9 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
             // We need to unzip binaries from dist. For simplicity, don't bother with a temporary
             // directory.
             shell.project_root.deleteFile("tigerbeetle") catch {};
+
             const zip_path = "./zig-out/dist/tigerbeetle/tigerbeetle-" ++ triple ++ if (debug) "-debug" else "" ++ ".zip";
-            const zip_file = try std.fs.cwd().openFile(zip_path, .{});
-            defer zip_file.close();
-            try std.zip.extract(std.fs.cwd(), zip_file.seekableStream(), .{});
+            try shell.extract_tigerbeetle_zip(zip_path);
 
             try shell.project_root.rename(
                 "tigerbeetle",

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -17,6 +17,7 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
+const stdx = @import("stdx");
 const log = std.log;
 const assert = std.debug.assert;
 
@@ -255,11 +256,13 @@ fn build_tigerbeetle_target(
     );
     defer section.close();
 
-    const commit_timestamp_seconds: u64 = commit_timestamp_seconds: {
-        const timestamp = try shell.exec_stdout("git show -s --format=%ct {sha}", .{
+    const commit_date_time = commit_date_time: {
+        const timestamp_s = try shell.exec_stdout("git show -s --format=%ct {sha}", .{
             .sha = info.sha,
         });
-        break :commit_timestamp_seconds try std.fmt.parseInt(u64, timestamp, 10);
+        break :commit_date_time stdx.DateTimeUTC.from_timestamp_s(
+            try std.fmt.parseInt(u64, timestamp_s, 10),
+        );
     };
 
     // Build tigerbeetle binary for all OS/CPU combinations we support and copy the result to
@@ -312,7 +315,7 @@ fn build_tigerbeetle_target(
         zip_file,
         .{
             .executable_name = exe_name,
-            .executable_mtime_s = commit_timestamp_seconds,
+            .executable_mtime = commit_date_time,
             .max_size = multiversioning.multiversion_binary_size_max,
         },
     );

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -884,16 +884,18 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
         \\docker buildx create --use
     , .{});
 
-    inline for ([_]bool{ true, false }) |debug| {
+    for ([_]bool{ true, false }) |debug| {
         const triples = [_][]const u8{ "aarch64-linux", "x86_64-linux" };
         const docker_arches = [_][]const u8{ "arm64", "amd64" };
-        inline for (triples, docker_arches) |triple, docker_arch| {
+        for (triples, docker_arches) |triple, docker_arch| {
             // We need to unzip binaries from dist. For simplicity, don't bother with a temporary
             // directory.
             shell.project_root.deleteFile("tigerbeetle") catch {};
 
-            const zip_path = "./zig-out/dist/tigerbeetle/tigerbeetle-" ++
-                triple ++ if (debug) "-debug" else "" ++ ".zip";
+            const zip_path = try shell.fmt(
+                "./zig-out/dist/tigerbeetle/tigerbeetle-{s}-{s}.zip",
+                .{ triple, if (debug) "-debug" else "" },
+            );
             try shell.zip_tigerbeetle_extract(zip_path);
 
             try shell.project_root.rename(

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -944,10 +944,7 @@ pub fn unzip_executable(
     }
 }
 
-fn unix_to_dos_timestamp(epoch_s: u64) struct { time: u16, date: u16 } {
-    const date_time = stdx.DateTimeUTC.from_timestamp_ms(
-        epoch_s * std.time.ms_per_s,
-    );
+fn unix_to_dos_timestamp(date_time: stdx.DateTimeUTC) struct { time: u16, date: u16 } {
     assert(date_time.year >= 1980 and date_time.year <= 2107);
 
     const time: u16 =
@@ -968,7 +965,7 @@ pub fn zip_executable(
     zip_file: std.fs.File,
     input: struct {
         executable_name: []const u8,
-        executable_mtime_s: u64,
+        executable_mtime: stdx.DateTimeUTC,
         max_size: u64,
     },
 ) !void {
@@ -983,7 +980,7 @@ pub fn zip_executable(
     );
     defer shell.gpa.free(executable);
 
-    const executable_mtime_dos = unix_to_dos_timestamp(input.executable_mtime_s);
+    const executable_mtime_dos = unix_to_dos_timestamp(input.executable_mtime);
     const crc32 = std.hash.Crc32.hash(executable);
 
     const executable_deflated_buffer = try shell.gpa.alloc(u8, input.max_size);

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -926,7 +926,7 @@ pub fn iso8601_to_timestamp_seconds(shell: *Shell, datetime_iso8601: []const u8)
 }
 
 /// Extracts a TigerBeetle zip and ensures the output has correct permissions.
-pub fn extract_tigerbeetle_zip(shell: *Shell, relative_path: []const u8) !void {
+pub fn zip_tigerbeetle_extract(shell: *Shell, relative_path: []const u8) !void {
     assert(std.mem.indexOf(u8, relative_path, "tigerbeetle-") != null);
 
     const zip_file = try shell.cwd.openFile(relative_path, .{});
@@ -944,4 +944,113 @@ pub fn extract_tigerbeetle_zip(shell: *Shell, relative_path: []const u8) !void {
     if (builtin.os.tag != .windows) {
         try zip_extracted.chmod(0o755);
     }
+}
+
+fn unix_to_dos_timestamp(epoch_ns: i128) struct { time: u16, date: u16 } {
+    const date_time = stdx.DateTimeUTC.from_timestamp_ms(
+        @intCast(@divFloor(epoch_ns, std.time.ns_per_ms)),
+    );
+    assert(date_time.year >= 1980 and date_time.year <= 2107);
+
+    const seconds = @min(date_time.second, 59); // ZIP max is 58 (29*2)...
+
+    const time: u16 =
+        (@as(u16, date_time.hour) << 11) |
+        (@as(u16, date_time.minute) << 5) |
+        (@as(u16, seconds / 2));
+
+    const date: u16 =
+        ((@as(u16, date_time.year - 1980)) << 9) |
+        (@as(u16, date_time.month) << 5) |
+        (@as(u16, date_time.day));
+
+    return .{ .time = time, .date = date };
+}
+
+pub fn zip_tigerbeetle_create(
+    shell: *Shell,
+    zip_file: std.fs.File,
+    exe_path: []const u8,
+    max_size: u64,
+) !void {
+    var zip_file_writer = std.io.countingWriter(zip_file.writer());
+
+    const tigerbeetle = try shell.cwd.readFileAlloc(shell.arena.allocator(), exe_path, max_size);
+    const tigerbeetle_dos_mtime = unix_to_dos_timestamp((try shell.cwd.statFile(exe_path)).mtime);
+    const crc32 = std.hash.Crc32.hash(tigerbeetle);
+
+    const tigerbeetle_deflated = blk: {
+        var tigerbeetle_stream = std.io.fixedBufferStream(tigerbeetle);
+
+        const tigerbeetle_deflated_buffer = try shell.arena.allocator().alloc(u8, max_size);
+        var tigerbeetle_deflated_stream = std.io.fixedBufferStream(tigerbeetle_deflated_buffer);
+
+        try std.compress.flate.deflate.compress(
+            .raw,
+            tigerbeetle_stream.reader(),
+            tigerbeetle_deflated_stream.writer(),
+            .{ .level = .best },
+        );
+        assert(tigerbeetle_stream.pos == tigerbeetle.len);
+
+        break :blk tigerbeetle_deflated_stream.getWritten();
+    };
+
+    const zip_version_20 = 0x14;
+    const zip_unix = 0x0300;
+
+    const local_file_header: std.zip.LocalFileHeader = .{
+        .signature = std.zip.local_file_header_sig,
+        .version_needed_to_extract = zip_version_20,
+        .flags = .{ .encrypted = false, ._ = 0 },
+        .compression_method = .deflate,
+        .last_modification_time = tigerbeetle_dos_mtime.time,
+        .last_modification_date = tigerbeetle_dos_mtime.date,
+        .crc32 = crc32,
+        .compressed_size = @intCast(tigerbeetle_deflated.len),
+        .uncompressed_size = @intCast(tigerbeetle.len),
+        .filename_len = @intCast(exe_path.len),
+        .extra_len = 0,
+    };
+
+    try zip_file_writer.writer().writeStructEndian(local_file_header, .little);
+    try zip_file_writer.writer().writeAll(exe_path);
+    try zip_file_writer.writer().writeAll(tigerbeetle_deflated);
+
+    const central_directory_file_header: std.zip.CentralDirectoryFileHeader = .{
+        .signature = std.zip.central_file_header_sig,
+        .version_made_by = zip_unix | zip_version_20,
+        .version_needed_to_extract = zip_version_20,
+        .flags = .{ .encrypted = false, ._ = 0 },
+        .compression_method = .deflate,
+        .last_modification_time = tigerbeetle_dos_mtime.time,
+        .last_modification_date = tigerbeetle_dos_mtime.date,
+        .crc32 = crc32,
+        .compressed_size = @intCast(tigerbeetle_deflated.len),
+        .uncompressed_size = @intCast(tigerbeetle.len),
+        .filename_len = @intCast(exe_path.len),
+        .extra_len = 0,
+        .comment_len = 0,
+        .disk_number = 0,
+        .internal_file_attributes = 0,
+        .external_file_attributes = 0o0100755 << 16, // Regular file, executable.
+        .local_file_header_offset = 0,
+    };
+
+    const central_directory_offset = zip_file_writer.bytes_written;
+    try zip_file_writer.writer().writeStructEndian(central_directory_file_header, .little);
+    try zip_file_writer.writer().writeAll(exe_path);
+    const central_directory_end = zip_file_writer.bytes_written;
+
+    const end_record: std.zip.EndRecord = .{
+        .signature = std.zip.end_record_sig,
+        .disk_number = 0,
+        .central_directory_disk_number = 0,
+        .record_count_disk = 1,
+        .record_count_total = 1,
+        .central_directory_size = @intCast(central_directory_end - central_directory_offset),
+        .central_directory_offset = @intCast(central_directory_offset),
+        .comment_len = 0,
+    };
+    try zip_file_writer.writer().writeStructEndian(end_record, .little);
 }

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -952,12 +952,10 @@ fn unix_to_dos_timestamp(epoch_ns: i128) struct { time: u16, date: u16 } {
     );
     assert(date_time.year >= 1980 and date_time.year <= 2107);
 
-    const seconds = @min(date_time.second, 59); // ZIP max is 58 (29*2)...
-
     const time: u16 =
         (@as(u16, date_time.hour) << 11) |
         (@as(u16, date_time.minute) << 5) |
-        (@as(u16, seconds / 2));
+        (@as(u16, @divFloor(date_time.second, 2)));
 
     const date: u16 =
         ((@as(u16, date_time.year - 1980)) << 9) |

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -995,6 +995,10 @@ pub const DateTimeUTC = struct {
         return DateTimeUTC.from_timestamp_ms(@intCast(timestamp_ms));
     }
 
+    pub fn from_timestamp_s(timestamp_s: u64) DateTimeUTC {
+        return DateTimeUTC.from_timestamp_ms(timestamp_s * std.time.ms_per_s);
+    }
+
     pub fn from_timestamp_ms(timestamp_ms: u64) DateTimeUTC {
         const epoch_seconds = std.time.epoch.EpochSeconds{ .secs = @divTrunc(timestamp_ms, 1000) };
         const year_day = epoch_seconds.getEpochDay().calculateYearDay();


### PR DESCRIPTION
This has been there for ages, but not enabled! #2988 reminded me of it again.

In summary, rebuild the release zip when validating the release, to ensure the artifact's checksum matches the freshly built checksum.