### PR TITLE
stdx: refine BoundedArrayType API

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -588,13 +588,13 @@ fn build_multiversion_body(shell: *Shell, options: struct {
             break :blk offset;
         };
 
-        releases.append_assume_capacity(past_release);
-        checksums.append_assume_capacity(past_checksum);
-        offsets.append_assume_capacity(offset);
-        sizes.append_assume_capacity(past_size);
-        flags_.append_assume_capacity(past_flag);
-        git_commits.append_assume_capacity(past_commit);
-        release_client_mins.append_assume_capacity(past_release_client_min);
+        releases.push(past_release);
+        checksums.push(past_checksum);
+        offsets.push(offset);
+        sizes.push(past_size);
+        flags_.push(past_flag);
+        git_commits.push(past_commit);
+        release_client_mins.push(past_release_client_min);
     }
 
     const old_current_release_offset = blk: {
@@ -616,13 +616,13 @@ fn build_multiversion_body(shell: *Shell, options: struct {
 
     // All of these are in ascending order, so the old current release goes last:
 
-    releases.append_assume_capacity(old_current_release);
-    checksums.append_assume_capacity(header.current_checksum);
-    offsets.append_assume_capacity(old_current_release_offset);
-    sizes.append_assume_capacity(old_current_release_size);
-    flags_.append_assume_capacity(old_current_release_flags);
-    git_commits.append_assume_capacity(header.current_git_commit);
-    release_client_mins.append_assume_capacity(header.current_release_client_min);
+    releases.push(old_current_release);
+    checksums.push(header.current_checksum);
+    offsets.push(old_current_release_offset);
+    sizes.push(old_current_release_size);
+    flags_.push(old_current_release_flags);
+    git_commits.push(header.current_git_commit);
+    release_client_mins.push(header.current_release_client_min);
     try unpacked.append(old_current_release_output_name);
 
     const body_file = try shell.cwd.createFile(options.output, .{ .exclusive = true });

--- a/src/clients/c/tb_client/signal_fuzz.zig
+++ b/src/clients/c/tb_client/signal_fuzz.zig
@@ -43,8 +43,8 @@ pub fn main(_: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
         const threads_max = prng.range_inclusive(u32, 1, threads_limit);
         var threads: Threads = .{};
         for (0..threads_max) |_| {
-            const thread: *std.Thread = threads.add_one_assume_capacity();
-            thread.* = try std.Thread.spawn(.{}, notify, .{&context});
+            const thread = try std.Thread.spawn(.{}, notify, .{&context});
+            threads.push(thread);
         }
 
         while (context.signal.status() != .stopped) {

--- a/src/list.zig
+++ b/src/list.zig
@@ -197,7 +197,7 @@ test "DoublyLinkedList fuzz" {
                 const node = &nodes[node_free];
 
                 list.push(node);
-                list_model.append_assume_capacity(node.id);
+                list_model.push(node.id);
                 nodes_free.unset(node.id);
             },
             .pop => {

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -710,7 +710,7 @@ pub fn CompactionType(
                 const snapshot_max = snapshot_max_for_table_input(compaction.op_min);
                 assert(compaction.table_info_a.?.disk.table_info.snapshot_max >= snapshot_max);
 
-                compaction.manifest_entries.append_assume_capacity(.{
+                compaction.manifest_entries.push(.{
                     .operation = .move_to_level_b,
                     .table = compaction.table_info_a.?.disk.table_info.*,
                 });
@@ -1841,7 +1841,7 @@ pub fn CompactionType(
             assert(compaction.table_builder.state == .no_blocks);
             compaction.table_builder_index_block = null;
 
-            compaction.manifest_entries.append_assume_capacity(.{
+            compaction.manifest_entries.push(.{
                 .operation = .insert_to_level_b,
                 .table = table,
             });

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -612,8 +612,8 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                             }
 
                             switch (direction) {
-                                .descending => range.tables.insert_assume_capacity(0, table_next),
-                                .ascending => range.tables.append_assume_capacity(table_next),
+                                .descending => range.tables.insert_at(0, table_next),
+                                .ascending => range.tables.push(table_next),
                             }
                         } else {
                             break :inner;

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -743,7 +743,7 @@ pub fn ManifestLevelType(
                         .table_info = table,
                         .generation = level.generation,
                     };
-                    range.tables.append_assume_capacity(table_info_reference);
+                    range.tables.push(table_info_reference);
                 } else {
                     return null;
                 }
@@ -997,11 +997,11 @@ pub fn TestContextType(
         fn create_snapshot(context: *TestContext) !void {
             if (context.snapshots.full()) return;
 
-            context.snapshots.append_assume_capacity(context.take_snapshot());
+            context.snapshots.push(context.take_snapshot());
 
-            const tables = context.snapshot_tables.add_one_assume_capacity();
-            tables.* = std.ArrayList(TableInfo).init(testing.allocator);
+            var tables = std.ArrayList(TableInfo).init(testing.allocator);
             try tables.insertSlice(0, context.reference.items);
+            context.snapshot_tables.push(tables);
         }
 
         fn drop_snapshot(context: *TestContext) !void {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -200,7 +200,7 @@ const QuerySpec = struct {
                 .merge => |merge| {
                     print_operator = false;
                     try writer.print("(", .{});
-                    stack.append_assume_capacity(merge);
+                    stack.push(merge);
                 },
             }
 
@@ -241,7 +241,7 @@ const QuerySpec = struct {
                     },
                 },
             };
-            matches.append_assume_capacity(match);
+            matches.push(match);
         }
         return matches.get(matches.count() - 1);
     }
@@ -310,22 +310,19 @@ const QuerySpecFuzzer = struct {
         var query: Query = .{};
         if (field_max == 1) {
             // Single field queries must have just one part.
-            query.append_assume_capacity(.{
-                .field = self.generate_query_field(),
-            });
-
+            query.push(.{ .field = self.generate_query_field() });
             return query;
         }
 
         // Multi field queries must start with a merge.
         var stack: stdx.BoundedArrayType(MergeStack, query_scans_max - 1) = .{};
-        stack.append_assume_capacity(.{
+        stack.push(.{
             .index = 0,
             .operand_count = 0,
             .fields_remain = field_max,
         });
 
-        query.append_assume_capacity(.{
+        query.push(.{
             .merge = .{
                 .operator = self.prng.enum_uniform(QueryOperator),
                 .operand_count = 0,
@@ -396,7 +393,7 @@ const QuerySpecFuzzer = struct {
                         stack.truncate(stack.count() - 1);
                     }
 
-                    stack.append_assume_capacity(.{
+                    stack.push(.{
                         .index = query.count(),
                         .operand_count = 0,
                         .fields_remain = merge_field_remain,
@@ -411,7 +408,7 @@ const QuerySpecFuzzer = struct {
                 },
             };
 
-            query.append_assume_capacity(query_part);
+            query.push(query_part);
         }
 
         assert(stack.count() == 0);
@@ -763,7 +760,7 @@ const Environment = struct {
                             query_spec.direction,
                         ),
                     };
-                    stack.append_assume_capacity(scan);
+                    stack.push(scan);
                 },
                 .merge => |merge| {
                     assert(merge.operand_count > 1);
@@ -776,7 +773,7 @@ const Environment = struct {
                     };
 
                     stack.truncate(stack.count() - merge.operand_count);
-                    stack.append_assume_capacity(scan);
+                    stack.push(scan);
                 },
             }
         }

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -180,7 +180,7 @@ fn ScanMergeType(
 
                 // Mark this scan as `assigned`, so it can't be used to compose other merges.
                 scan.assigned = true;
-                self.streams.append_assume_capacity(.{ .scan = scan });
+                self.streams.push(.{ .scan = scan });
             }
 
             return self;

--- a/src/message_buffer.zig
+++ b/src/message_buffer.zig
@@ -419,7 +419,7 @@ test "MessageBuffer fuzz" {
                 std.mem.asBytes(&header),
             );
             total_size += header.size;
-            headers.append_assume_capacity(header.frame_const().*);
+            headers.push(header.frame_const().*);
         }
 
         if (fault) {

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -439,14 +439,14 @@ pub const MultiversionHeader = extern struct {
         var release_list: ReleaseList = .{};
 
         for (0..self.past.count) |i| {
-            release_list.append_assume_capacity(Release{ .value = self.past.releases[i] });
+            release_list.push(Release{ .value = self.past.releases[i] });
             if (from_release.value < self.past.releases[i]) {
                 if (self.past.flags[i].visit) {
                     break;
                 }
             }
         } else {
-            release_list.append_assume_capacity(Release{ .value = self.current_release });
+            release_list.push(Release{ .value = self.current_release });
         }
 
         // These asserts should be impossible to reach barring a bug; they're checked in verify()
@@ -517,10 +517,10 @@ test "MultiversionHeader.advertisable" {
         var git_commits: ListGitCommit = .{};
 
         for (t.releases) |_| {
-            checksums.append_assume_capacity(0);
-            offsets.append_assume_capacity(@intCast(offsets.count()));
-            sizes.append_assume_capacity(1);
-            git_commits.append_assume_capacity("00000000000000000000".*);
+            checksums.push(0);
+            offsets.push(@intCast(offsets.count()));
+            sizes.push(1);
+            git_commits.push("00000000000000000000".*);
         }
 
         const past_releases = MultiversionHeader.PastReleases.init(@intCast(t.releases.len), .{
@@ -549,7 +549,7 @@ test "MultiversionHeader.advertisable" {
         const advertisable = header.advertisable(Release{ .value = t.from });
         var expected: ReleaseList = .{};
         for (t.expected) |release| {
-            expected.append_assume_capacity(Release{ .value = release });
+            expected.push(Release{ .value = release });
         }
         try std.testing.expectEqualSlices(
             Release,
@@ -781,7 +781,7 @@ pub const Multiversion = struct {
             // If there's been an error starting up multiversioning, don't disable it, but
             // advertise only the current version in memory.
             self.releases_bundled.clear();
-            self.releases_bundled.append_assume_capacity(constants.config.process.release);
+            self.releases_bundled.push(constants.config.process.release);
 
             return self.stage.err;
         }
@@ -1106,7 +1106,7 @@ pub const Multiversion = struct {
         // Since target_fd points to a memfd on Linux, this is functionally a memcpy. On other
         // platforms, it's blocking IO - which is acceptable for development.
         self.releases_bundled.clear();
-        self.releases_bundled.append_slice_assume_capacity(advertisable.const_slice());
+        self.releases_bundled.push_slice(advertisable.const_slice());
 
         // While these look like blocking IO operations, on a memfd they're memory manipulation.
         // TODO: Would panic'ing be a better option? On Linux, these should never fail. On other
@@ -1880,7 +1880,7 @@ pub fn print_information(
         {
             var release_list: ReleaseList = .{};
             for (@field(header.past, field)[0..header.past.count]) |release| {
-                release_list.append_assume_capacity(Release{ .value = release });
+                release_list.push(Release{ .value = release });
             }
 
             try output.print("multiversioning.header.past.{s}={any}\n", .{

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -226,7 +226,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                             });
                         }
 
-                        repl.buffer.insert_assume_capacity(buffer_index, character);
+                        repl.buffer.insert_at(buffer_index, character);
                         buffer_index += 1;
                     },
                     .backspace => if (buffer_index > 0) {
@@ -361,9 +361,9 @@ pub fn ReplType(comptime MessageBus: type) type {
                         // Re-fill the buffer with prefix, current match and suffix. Set the
                         // buffer index where the current selected match ends.
                         repl.buffer.clear();
-                        repl.buffer.append_slice_assume_capacity(repl.completion.prefix.slice());
-                        repl.buffer.append_slice_assume_capacity(current_completion);
-                        repl.buffer.append_slice_assume_capacity(repl.completion.suffix.slice());
+                        repl.buffer.push_slice(repl.completion.prefix.slice());
+                        repl.buffer.push_slice(current_completion);
+                        repl.buffer.push_slice(repl.completion.suffix.slice());
                         buffer_index = repl.buffer.count() - repl.completion.suffix.count();
                     },
                     .left, .ctrlb => if (buffer_index > 0) {
@@ -409,14 +409,12 @@ pub fn ReplType(comptime MessageBus: type) type {
 
                         if (history_index == repl.history.count) {
                             repl.buffer_outside_history.clear();
-                            repl.buffer_outside_history.append_slice_assume_capacity(
-                                repl.buffer.const_slice(),
-                            );
+                            repl.buffer_outside_history.push_slice(repl.buffer.const_slice());
                         }
                         history_index = history_index_next;
 
                         repl.buffer.clear();
-                        repl.buffer.append_slice_assume_capacity(buffer_next);
+                        repl.buffer.push_slice(buffer_next);
                         buffer_index = repl.buffer.count();
                     },
                     .down, .ctrln => if (history_index < repl.history.count) {
@@ -453,7 +451,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                         });
 
                         repl.buffer.clear();
-                        repl.buffer.append_slice_assume_capacity(buffer_next);
+                        repl.buffer.push_slice(buffer_next);
                         buffer_index = repl.buffer.count();
                     },
                     .altf, .ctrlright => {

--- a/src/repl/completion.zig
+++ b/src/repl/completion.zig
@@ -60,14 +60,14 @@ pub const Completion = struct {
         }
 
         self.prefix.clear();
-        self.prefix.append_slice_assume_capacity(buffer[0..query_start_index]);
+        self.prefix.push_slice(buffer[0..query_start_index]);
 
         self.suffix.clear();
-        self.suffix.append_slice_assume_capacity(buffer[buffer_index..]);
+        self.suffix.push_slice(buffer[buffer_index..]);
 
         if (self.matches.count == 0) {
             self.query.clear();
-            self.query.append_slice_assume_capacity(buffer[query_start_index..buffer_index]);
+            self.query.push_slice(buffer[query_start_index..buffer_index]);
 
             try self.get_completions(self.query.const_slice());
         }

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -804,18 +804,18 @@ fn run_fuzzers_start_fuzzer(shell: *Shell, options: struct {
     // - build time is excluded from overall runtime,
     // - the exit status of the fuzzer process can be inspected, to determine if OOM happened.
     args.clear();
-    args.append_slice_assume_capacity(&.{ "./zig/zig", "build", "-Drelease" });
-    args.append_slice_assume_capacity(switch (options.fuzzer) {
+    args.push_slice(&.{ "./zig/zig", "build", "-Drelease" });
+    args.push_slice(switch (options.fuzzer) {
         inline else => |f| comptime f.args_run(),
     });
     var seed_buffer: [32]u8 = undefined;
-    args.append_assume_capacity(stdx.array_print(32, &seed_buffer, "{d}", .{options.seed}));
+    args.push(stdx.array_print(32, &seed_buffer, "{d}", .{options.seed}));
     const command = try std.mem.join(shell.arena.allocator(), " ", args.const_slice());
 
     const exe = exe: {
         args.clear();
-        args.append_slice_assume_capacity(&.{ "build", "-Drelease", "-Dprint-exe" });
-        args.append_slice_assume_capacity(switch (options.fuzzer) {
+        args.push_slice(&.{ "build", "-Drelease", "-Dprint-exe" });
+        args.push_slice(switch (options.fuzzer) {
             inline else => |f| comptime f.args_build(),
         });
         break :exe shell.exec_stdout("{zig} {args}", .{

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1932,7 +1932,7 @@ pub fn StateMachineType(
 
             // Adding the condition for `debit_account_id = $account_id`.
             if (filter.flags.debits) {
-                scan_conditions.append_assume_capacity(scan_builder.scan_prefix(
+                scan_conditions.push(scan_builder.scan_prefix(
                     .debit_account_id,
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
                     snapshot_latest,
@@ -1944,7 +1944,7 @@ pub fn StateMachineType(
 
             // Adding the condition for `credit_account_id = $account_id`.
             if (filter.flags.credits) {
-                scan_conditions.append_assume_capacity(scan_builder.scan_prefix(
+                scan_conditions.push(scan_builder.scan_prefix(
                     .credit_account_id,
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
                     snapshot_latest,
@@ -1960,7 +1960,7 @@ pub fn StateMachineType(
                     // Creating an union `OR` with the `debit_account_id` and `credit_account_id`.
                     const accounts_merge = scan_builder.merge_union(scan_conditions.const_slice());
                     scan_conditions.clear();
-                    scan_conditions.append_assume_capacity(accounts_merge);
+                    scan_conditions.push(accounts_merge);
                 },
                 else => unreachable,
             }
@@ -1971,7 +1971,7 @@ pub fn StateMachineType(
             }) |filter_field| {
                 const filter_value = @field(filter, @tagName(filter_field));
                 if (filter_value != 0) {
-                    scan_conditions.append_assume_capacity(scan_builder.scan_prefix(
+                    scan_conditions.push(scan_builder.scan_prefix(
                         filter_field,
                         self.forest.scan_buffer_pool.acquire_assume_capacity(),
                         snapshot_latest,
@@ -2251,7 +2251,7 @@ pub fn StateMachineType(
             var scan_conditions: stdx.BoundedArrayType(*Groove.ScanBuilder.Scan, indexes.len) = .{};
             inline for (indexes) |index| {
                 if (@field(filter, @tagName(index)) != 0) {
-                    scan_conditions.append_assume_capacity(groove.scan_builder.scan_prefix(
+                    scan_conditions.push(groove.scan_builder.scan_prefix(
                         std.enums.nameCast(std.meta.FieldEnum(Groove.IndexTrees), index),
                         self.forest.scan_buffer_pool.acquire_assume_capacity(),
                         snapshot_latest,

--- a/src/stdx/bounded_array.zig
+++ b/src/stdx/bounded_array.zig
@@ -27,7 +27,7 @@ pub fn BoundedArrayType(comptime T: type, comptime buffer_capacity: usize) type 
         /// Returns count of elements in this BoundedArray in the specified integer types,
         /// checking at compile time that it indeed can represent the length.
         pub inline fn count_as(array: *const BoundedArray, comptime Int: type) Int {
-            comptime assert(@TypeOf(array.inner.len) != comptime_int);
+            comptime assert(buffer_capacity <= std.math.maxInt(Int));
             return @intCast(array.inner.len);
         }
 
@@ -59,30 +59,24 @@ pub fn BoundedArrayType(comptime T: type, comptime buffer_capacity: usize) type 
             try array.inner.resize(len);
         }
 
-        pub inline fn add_one_assume_capacity(array: *BoundedArray) *T {
-            return array.inner.addOneAssumeCapacity();
-        }
+        pub fn insert_at(array: *BoundedArray, index: usize, item: T) void {
+            assert(!array.full());
+            assert(index <= array.inner.len);
 
-        pub fn insert_assume_capacity(self: *BoundedArray, index: usize, item: T) void {
-            assert(self.inner.len < buffer_capacity);
-            assert(index <= self.inner.len);
+            array.inner.len += 1;
 
-            self.inner.len += 1;
-
-            var slice_ = self.slice();
+            var slice_ = array.slice();
             stdx.copy_right(.exact, T, slice_[index + 1 ..], slice_[index .. slice_.len - 1]);
             slice_[index] = item;
         }
 
-        pub fn append(array: *BoundedArray, item: T) error{Overflow}!void {
-            return array.inner.append(item);
-        }
-
-        pub inline fn append_assume_capacity(array: *BoundedArray, item: T) void {
+        pub fn push(array: *BoundedArray, item: T) void {
+            assert(!array.full());
             array.inner.appendAssumeCapacity(item);
         }
 
-        pub inline fn append_slice_assume_capacity(array: *BoundedArray, items: []const T) void {
+        pub fn push_slice(array: *BoundedArray, items: []const T) void {
+            assert(array.count() + items.len <= array.capacity());
             array.inner.appendSliceAssumeCapacity(items);
         }
 
@@ -117,7 +111,7 @@ pub fn BoundedArrayType(comptime T: type, comptime buffer_capacity: usize) type 
     };
 }
 
-test "BoundedArray.insert_assume_capacity" {
+test "BoundedArray.insert_at" {
     const items_max = 32;
     const BoundedArrayU64 = BoundedArrayType(u64, items_max);
 
@@ -125,14 +119,14 @@ test "BoundedArray.insert_assume_capacity" {
     for (0..items_max) |len| {
         var list_base = BoundedArrayU64{};
         for (0..len) |i| {
-            list_base.append_assume_capacity(i);
+            list_base.push(i);
         }
 
         // Test an insert at every possible position (including an append).
         for (0..list_base.count() + 1) |i| {
             var list = list_base;
 
-            list.insert_assume_capacity(i, 12345);
+            list.insert_at(i, 12345);
 
             // Verify the result:
 

--- a/src/stdx/zipfian.zig
+++ b/src/stdx/zipfian.zig
@@ -300,7 +300,7 @@ pub const ZipfianShuffled = struct {
         while (index < end_index) : (index += 1) {
             if (self.hot_items.count() < hot_items_count_max) {
                 const pos_actual = prng.int_inclusive(u64, self.hot_items.count());
-                self.hot_items.insert_assume_capacity(pos_actual, index);
+                self.hot_items.insert_at(pos_actual, index);
             } else {
                 // NB: I believe this is biased as to which new items become hot items,
                 // but it probably doesn't matter for our purposes.
@@ -308,7 +308,7 @@ pub const ZipfianShuffled = struct {
                 if (pos_init < hot_items_count_max) {
                     self.hot_items.truncate(hot_items_count_max - 1);
                     const pos_actual = prng.int_inclusive(u64, self.hot_items.count());
-                    self.hot_items.insert_assume_capacity(pos_actual, index);
+                    self.hot_items.insert_at(pos_actual, index);
                 }
             }
         }

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -438,9 +438,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 errdefer for (replicas[0..replica_index]) |*r| r.deinit(allocator);
 
                 cluster.releases_bundled[replica_index].clear();
-                cluster.releases_bundled[replica_index].append_assume_capacity(
-                    options.cluster.releases[0].release,
-                );
+                cluster.releases_bundled[replica_index].push(options.cluster.releases[0].release);
 
                 // Nonces are incremented on restart, so spread them out across 128 bit space
                 // to avoid collisions.

--- a/src/testing/table.zig
+++ b/src/testing/table.zig
@@ -14,7 +14,7 @@ pub fn parse(comptime Row: type, table_string: []const u8) stdx.BoundedArrayType
 
         var columns = std.mem.tokenizeScalar(u8, row_string, ' ');
         const row = parse_data(Row, &columns);
-        rows.append_assume_capacity(row);
+        rows.push(row);
 
         // Ignore trailing line comment.
         if (columns.next()) |last| assert(std.mem.eql(u8, last, "//"));

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -762,20 +762,11 @@ const Replica = struct {
         );
 
         var argv: stdx.BoundedArrayType([]const u8, 16) = .{};
-        argv.append_slice_assume_capacity(&.{
-            self.executable_path,
-            "start",
-        });
+        argv.push_slice(&.{ self.executable_path, "start" });
         if (self.log_debug) {
-            argv.append_slice_assume_capacity(&.{
-                "--log-debug",
-                "--experimental",
-            });
+            argv.push_slice(&.{ "--log-debug", "--experimental" });
         }
-        argv.append_slice_assume_capacity(&.{
-            addresses_arg,
-            self.datafile,
-        });
+        argv.push_slice(&.{ addresses_arg, self.datafile });
 
         self.process = try LoggedProcess.spawn(self.allocator, argv.const_slice(), .{});
     }

--- a/src/testing/vortex/workload.zig
+++ b/src/testing/vortex/workload.zig
@@ -225,7 +225,7 @@ fn reconcile(result: Result, command: *const Command, model: *Model) !void {
                     continue;
                 }
 
-                successful_transfer_ids.append_assume_capacity(transfer.id);
+                successful_transfer_ids.push(transfer.id);
 
                 if (transfer.flags.pending) {
                     try testing.expect(!model.pending_transfers.contains(transfer.id));

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -382,7 +382,7 @@ fn tidy_dead_declarations(
 }
 
 /// As we trim our functions, make sure to update this constant; tidy will error if you do not.
-const function_line_count_max = 413; // fn check in state_machine.zig
+const function_line_count_max = 411; // fn check in state_machine.zig
 
 fn tidy_long_functions(
     file: SourceFile,
@@ -477,7 +477,7 @@ fn tidy_long_functions(
             last_function.is_innermost = false;
         }
 
-        function_stack.append_assume_capacity(innermost_function);
+        function_stack.push(innermost_function);
     }
 
     if (function_stack.count() > 0) {

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -84,7 +84,7 @@ pub fn main(
     var message_pools = stdx.BoundedArrayType(MessagePool, constants.clients_max){};
     defer for (message_pools.slice()) |*message_pool| message_pool.deinit(allocator);
     for (0..cli_args.clients) |_| {
-        message_pools.append_assume_capacity(try MessagePool.init(allocator, .client));
+        message_pools.push(try MessagePool.init(allocator, .client));
     }
 
     std.log.info("Benchmark running against {any}", .{addresses});
@@ -93,7 +93,7 @@ pub fn main(
     defer for (clients.slice()) |*client| client.deinit(allocator);
 
     for (0..cli_args.clients) |i| {
-        clients.append_assume_capacity(try Client.init(allocator, .{
+        clients.push(try Client.init(allocator, .{
             .id = stdx.unique_u128(),
             .cluster = cluster_id,
             .replica_count = @intCast(addresses.len),

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -933,8 +933,8 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         if (aof_file.capacity() < start.positional.path.len + 4) {
             vsr.fatal(.cli, "data file path is too long for --aof. use --aof-file", .{});
         }
-        aof_file.append_slice_assume_capacity(start.positional.path);
-        aof_file.append_slice_assume_capacity(".aof");
+        aof_file.push_slice(start.positional.path);
+        aof_file.push_slice(".aof");
 
         std.log.warn(
             "--aof is deprecated. consider switching to '--aof-file={s}'",
@@ -951,7 +951,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         if (aof_file.capacity() < start.positional.path.len) {
             vsr.fatal(.cli, "--aof-file path is too long", .{});
         }
-        aof_file.append_slice_assume_capacity(start_aof_file);
+        aof_file.push_slice(start_aof_file);
 
         break :blk aof_file;
     } else null;

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -418,7 +418,7 @@ const Command = struct {
         if (multiversion != null) multiversion.?.open_sync() catch {};
 
         var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .{};
-        releases_bundled_baseline.append_assume_capacity(constants.config.process.release);
+        releases_bundled_baseline.push(constants.config.process.release);
 
         const releases_bundled = if (multiversion != null)
             &multiversion.?.releases_bundled

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1635,7 +1635,7 @@ pub const Simulator = struct {
         const replica_releases_count = simulator.replica_releases[replica_index];
         var release_list = vsr.ReleaseList{};
         for (0..replica_releases_count) |i| {
-            release_list.append_assume_capacity(releases[i].release);
+            release_list.push(releases[i].release);
         }
         return release_list;
     }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1495,20 +1495,20 @@ const ViewChangeHeadersArray = struct {
     ) void {
         headers.command = command;
         headers.array.clear();
-        for (slice) |*header| headers.array.append_assume_capacity(header.*);
+        for (slice) |*header| headers.array.push(header.*);
         headers.verify();
     }
 
     pub fn append(headers: *ViewChangeHeadersArray, header: *const Header.Prepare) void {
         // We don't do comprehensive validation here — assume that verify() will be called
         // after any series of appends.
-        headers.array.append_assume_capacity(header.*);
+        headers.array.push(header.*);
     }
 
     pub fn append_blank(headers: *ViewChangeHeadersArray, op: u64) void {
         assert(headers.command == .do_view_change);
         assert(headers.array.count() > 0);
-        headers.array.append_assume_capacity(Headers.dvc_blank(op));
+        headers.array.push(Headers.dvc_blank(op));
     }
 };
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -483,7 +483,7 @@ pub fn ClientType(
                 var round_trip_times_ns = stdx.BoundedArrayType(u64, constants.replicas_max){};
                 for (self.replica_round_trip_times_ns) |round_trip_time_ns| {
                     if (round_trip_time_ns) |rtt_ns| {
-                        round_trip_times_ns.append_assume_capacity(rtt_ns);
+                        round_trip_times_ns.push(rtt_ns);
                     }
                 }
                 std.mem.sort(u64, round_trip_times_ns.slice(), {}, std.sort.asc(u64));

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -364,7 +364,7 @@ pub fn round_trip_time_median_ns(self: *const Clock) ?u64 {
     for (self.window.sources, 0..) |source, replica_index| {
         if (self.replica != replica_index) {
             if (source) |sampled| {
-                one_way_delays.append_assume_capacity(sampled.one_way_delay);
+                one_way_delays.push(sampled.one_way_delay);
             }
         }
     }

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1480,7 +1480,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                         assert(!journal.prepare_inhabited[index]);
 
                         if (torn_slots.count() < constants.journal_iops_write_max) {
-                            torn_slots.append_assume_capacity(slot);
+                            torn_slots.push(slot);
                         } else {
                             log.warn("{}: torn_prepares: not truncating, found >{} " ++
                                 "torn prepares!", .{

--- a/src/vsr/multi_batch.zig
+++ b/src/vsr/multi_batch.zig
@@ -690,7 +690,7 @@ const TestRunner = struct {
             @memset(std.mem.bytesAsSlice(u16, slice[0..bytes_written]), @intCast(index));
             encoder.add(bytes_written);
 
-            expected.append_assume_capacity(elements_count);
+            expected.push(elements_count);
         }
         const bytes_written = encoder.finish();
         try testing.expect(encoder.batch_count == options.batch_count);

--- a/src/vsr/multi_batch_fuzz.zig
+++ b/src/vsr/multi_batch_fuzz.zig
@@ -115,7 +115,7 @@ fn run_fuzz(options: struct {
 
         encoder.add(batch_size);
         expect_payload_size += batch_size;
-        batches.append_assume_capacity(batch_element_count);
+        batches.push(batch_element_count);
         expect_trailer_size = trailer_size_next;
     }
     assert(batches.count() > 0);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1776,7 +1776,7 @@ pub fn ReplicaType(
 
                     for (releases) |release| {
                         if (release.value > self.release.value) {
-                            upgrade_targets.*.?.releases.append_assume_capacity(release);
+                            upgrade_targets.*.?.releases.push(release);
                         }
                     }
                 }
@@ -11051,7 +11051,7 @@ const DVCQuorum = struct {
                 assert(message.header.command == .do_view_change);
                 assert(message.header.replica == replica);
 
-                array.append_assume_capacity(message);
+                array.push(message);
             }
         }
         return array;
@@ -11066,7 +11066,7 @@ const DVCQuorum = struct {
         const dvcs = DVCQuorum.dvcs_all(dvc_quorum);
         for (dvcs.const_slice()) |message| {
             if (message.header.log_view == log_view) {
-                array.append_assume_capacity(message);
+                array.push(message);
             }
         }
         return array;
@@ -11080,7 +11080,7 @@ const DVCQuorum = struct {
             assert(message.header.log_view <= log_view_max_);
 
             if (message.header.log_view < log_view_max_) {
-                array.append_assume_capacity(message);
+                array.push(message);
             }
         }
         return array;

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2065,7 +2065,7 @@ const TestContext = struct {
     pub fn replica(t: *TestContext, selector: ProcessSelector) TestReplicas {
         const replica_processes = t.processes(selector);
         var replica_indexes = stdx.BoundedArrayType(u8, constants.members_max){};
-        for (replica_processes.const_slice()) |p| replica_indexes.append_assume_capacity(p.replica);
+        for (replica_processes.const_slice()) |p| replica_indexes.push(p.replica);
         return TestReplicas{
             .context = t,
             .cluster = t.cluster,
@@ -2084,7 +2084,7 @@ const TestContext = struct {
         assert(index + count <= t.cluster.options.client_count);
 
         var client_indexes = stdx.BoundedArrayType(usize, constants.clients_max){};
-        for (index..index + count) |i| client_indexes.append_assume_capacity(i);
+        for (index..index + count) |i| client_indexes.push(i);
         return TestClients{
             .context = t,
             .cluster = t.cluster,
@@ -2145,45 +2145,45 @@ const TestContext = struct {
 
         var array = ProcessList{};
         switch (selector) {
-            .R0 => array.append_assume_capacity(.{ .replica = 0 }),
-            .R1 => array.append_assume_capacity(.{ .replica = 1 }),
-            .R2 => array.append_assume_capacity(.{ .replica = 2 }),
-            .R3 => array.append_assume_capacity(.{ .replica = 3 }),
-            .R4 => array.append_assume_capacity(.{ .replica = 4 }),
-            .R5 => array.append_assume_capacity(.{ .replica = 5 }),
-            .S0 => array.append_assume_capacity(.{ .replica = replica_count + 0 }),
-            .S1 => array.append_assume_capacity(.{ .replica = replica_count + 1 }),
-            .S2 => array.append_assume_capacity(.{ .replica = replica_count + 2 }),
-            .S3 => array.append_assume_capacity(.{ .replica = replica_count + 3 }),
-            .S4 => array.append_assume_capacity(.{ .replica = replica_count + 4 }),
-            .S5 => array.append_assume_capacity(.{ .replica = replica_count + 5 }),
+            .R0 => array.push(.{ .replica = 0 }),
+            .R1 => array.push(.{ .replica = 1 }),
+            .R2 => array.push(.{ .replica = 2 }),
+            .R3 => array.push(.{ .replica = 3 }),
+            .R4 => array.push(.{ .replica = 4 }),
+            .R5 => array.push(.{ .replica = 5 }),
+            .S0 => array.push(.{ .replica = replica_count + 0 }),
+            .S1 => array.push(.{ .replica = replica_count + 1 }),
+            .S2 => array.push(.{ .replica = replica_count + 2 }),
+            .S3 => array.push(.{ .replica = replica_count + 3 }),
+            .S4 => array.push(.{ .replica = replica_count + 4 }),
+            .S5 => array.push(.{ .replica = replica_count + 5 }),
             .A0 => array
-                .append_assume_capacity(.{ .replica = @intCast((view + 0) % replica_count) }),
+                .push(.{ .replica = @intCast((view + 0) % replica_count) }),
             .B1 => array
-                .append_assume_capacity(.{ .replica = @intCast((view + 1) % replica_count) }),
+                .push(.{ .replica = @intCast((view + 1) % replica_count) }),
             .B2 => array
-                .append_assume_capacity(.{ .replica = @intCast((view + 2) % replica_count) }),
+                .push(.{ .replica = @intCast((view + 2) % replica_count) }),
             .B3 => array
-                .append_assume_capacity(.{ .replica = @intCast((view + 3) % replica_count) }),
+                .push(.{ .replica = @intCast((view + 3) % replica_count) }),
             .B4 => array
-                .append_assume_capacity(.{ .replica = @intCast((view + 4) % replica_count) }),
+                .push(.{ .replica = @intCast((view + 4) % replica_count) }),
             .B5 => array
-                .append_assume_capacity(.{ .replica = @intCast((view + 5) % replica_count) }),
-            .C0 => array.append_assume_capacity(.{ .client = t.cluster.clients[0].?.id }),
+                .push(.{ .replica = @intCast((view + 5) % replica_count) }),
+            .C0 => array.push(.{ .client = t.cluster.clients[0].?.id }),
             .__, .R_, .S_, .C_ => {
                 if (selector == .__ or selector == .R_) {
                     for (t.cluster.replicas[0..replica_count], 0..) |_, i| {
-                        array.append_assume_capacity(.{ .replica = @intCast(i) });
+                        array.push(.{ .replica = @intCast(i) });
                     }
                 }
                 if (selector == .__ or selector == .S_) {
                     for (t.cluster.replicas[replica_count..], 0..) |_, i| {
-                        array.append_assume_capacity(.{ .replica = @intCast(replica_count + i) });
+                        array.push(.{ .replica = @intCast(replica_count + i) });
                     }
                 }
                 if (selector == .__ or selector == .C_) {
                     for (t.cluster.clients) |*client| {
-                        array.append_assume_capacity(.{ .client = client.*.?.id });
+                        array.push(.{ .client = client.*.?.id });
                     }
                 }
             },
@@ -2232,7 +2232,7 @@ const TestReplicas = struct {
     pub fn open_upgrade(t: *const TestReplicas, releases_bundled_patch: []const u8) !void {
         var releases_bundled = vsr.ReleaseList{};
         for (releases_bundled_patch) |patch| {
-            releases_bundled.append_assume_capacity(vsr.Release.from(.{
+            releases_bundled.push(vsr.Release.from(.{
                 .major = 0,
                 .minor = 0,
                 .patch = patch,
@@ -2552,10 +2552,10 @@ const TestReplicas = struct {
             const process_a = Process{ .replica = a };
             for (peers.const_slice()) |process_b| {
                 if (direction == .bidirectional or direction == .outgoing) {
-                    paths.append_assume_capacity(.{ .source = process_a, .target = process_b });
+                    paths.push(.{ .source = process_a, .target = process_b });
                 }
                 if (direction == .bidirectional or direction == .incoming) {
-                    paths.append_assume_capacity(.{ .source = process_b, .target = process_a });
+                    paths.push(.{ .source = process_b, .target = process_a });
                 }
             }
         }

--- a/src/vsr/routing.zig
+++ b/src/vsr/routing.zig
@@ -256,7 +256,7 @@ fn route_valid(routing: *const Routing, route: Route) bool {
 fn route_view_default(view: u32, replica_count: u8) Route {
     var route: Route = .{};
     for (0..replica_count) |replica| {
-        route.append_assume_capacity(@intCast(replica));
+        route.push(@intCast(replica));
     }
 
     // Rotate primary to the midpoint;
@@ -272,7 +272,7 @@ fn route_view_default(view: u32, replica_count: u8) Route {
 fn route_random(prng: *stdx.PRNG, view: u32, replica_count: u8) Route {
     var route: Route = .{};
     for (0..replica_count) |replica| {
-        route.append_assume_capacity(@intCast(replica));
+        route.push(@intCast(replica));
     }
     prng.shuffle(u8, route.slice());
 
@@ -312,14 +312,14 @@ test route_encode {
 
         while (!g.done()) {
             var pool: stdx.BoundedArrayType(u8, constants.replicas_max) = .{};
-            for (0..replica_count) |i| pool.append_assume_capacity(@intCast(i));
+            for (0..replica_count) |i| pool.push(@intCast(i));
 
             var route: stdx.BoundedArrayType(u8, constants.replicas_max) = .{};
             assert(route.count() == 0);
             assert(pool.count() == replica_count);
             for (0..replica_count) |_| {
                 const index = g.index(pool.const_slice());
-                route.append_assume_capacity(pool.get(index));
+                route.push(pool.get(index));
                 _ = pool.ordered_remove(index);
             }
             assert(route.count() == replica_count);
@@ -348,7 +348,7 @@ pub fn route_decode(routing: *const Routing, code: u64) ?Route {
         const byte: u64 = (code >> shift) & 0xFF;
         if (index < routing.replica_count) {
             if (byte < routing.replica_count) {
-                route.append_assume_capacity(@intCast(byte));
+                route.push(@intCast(byte));
             } else {
                 return null;
             }
@@ -433,10 +433,10 @@ pub fn op_next_hop(routing: *const Routing, op: u64) NextHop {
         const replica_position = std.mem.indexOfScalar(u8, route.const_slice(), routing.replica).?;
 
         if (replica_position <= primary_position and replica_position > 0) {
-            result.append_assume_capacity(route.const_slice()[replica_position - 1]);
+            result.push(route.const_slice()[replica_position - 1]);
         }
         if (replica_position >= primary_position and replica_position < routing.replica_count - 1) {
-            result.append_assume_capacity(route.const_slice()[replica_position + 1]);
+            result.push(route.const_slice()[replica_position + 1]);
         }
 
         assert(result.count() <= 2);
@@ -445,13 +445,13 @@ pub fn op_next_hop(routing: *const Routing, op: u64) NextHop {
         if (routing.standby_count > 0) {
             if (replica_position == 0) {
                 const first_standby = routing.replica_count;
-                result.append_assume_capacity(first_standby);
+                result.push(first_standby);
             }
         }
     } else {
         // Standby replication uses static ring topology.
         if (routing.replica + 1 < routing.replica_count + routing.standby_count) {
-            result.append_assume_capacity(routing.replica + 1);
+            result.push(routing.replica + 1);
         }
     }
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -296,7 +296,7 @@ const Environment = struct {
         });
 
         var vsr_headers = vsr.Headers.Array{};
-        vsr_headers.append_assume_capacity(vsr.Header.Prepare.root(cluster));
+        vsr_headers.push(vsr.Header.Prepare.root(cluster));
 
         assert(env.sequence_states.items.len == 0);
         try env.sequence_states.append(undefined); // skip sequence=0
@@ -364,7 +364,7 @@ const Environment = struct {
         });
         vsr_head.set_checksum_body(&.{});
         vsr_head.set_checksum();
-        vsr_headers.append_assume_capacity(vsr_head);
+        vsr_headers.push(vsr_head);
 
         assert(env.sequence_states.items.len == env.superblock.staging.sequence + 1);
         try env.sequence_states.append(.{


### PR DESCRIPTION
Rename append_assume_capacity to push, to be shorter and consistent with Queue&Stack.

Also make it return `?void`, so that the caller has to `.?` explicitly, signaling a pre-condition here.

I am a bit torn on void+callee assert over void?+caller .?, but I prefer either to `assume_capacity`, and doing from caller to callee is the easier future move.