### PR TITLE
vsr: cleanup, handle message padding uniformly

### DIFF
--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -411,10 +411,10 @@ pub fn ClientRepliesType(comptime Storage: type) type {
                 const message = write.message;
                 _ = client_replies.write_queue.pop();
 
-                // Zero sector padding to ensure deterministic storage.
+                // Padding must be zero to ensure deterministic storage.
                 const size = message.header.size;
                 const size_ceil = vsr.sector_ceil(size);
-                @memset(message.buffer[size..size_ceil], 0);
+                assert(stdx.zeroed(message.buffer[size..size_ceil]));
 
                 client_replies.writing.set(write.slot.index);
                 client_replies.storage.write_sectors(


### PR DESCRIPTION
Message that is transferred as n bytes on the wire might take up to n + (sector_padding - 1) when written to disk, because disks are block devices operating on sector granularity.

For most messages we used to fix this in the message bus, but for replies the fix was applied right before writing it to disk.

Now, all the message types are handled uniformly by the Replica's `on_messages`, where we can also guarantee that message ref-count is zero, and so it is valid to mutate the underlying buffer.