### PR TITLE
ci: Add windows runner for rust client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
 
           - { os: 'windows-latest', language: 'dotnet',  language_version: '8.0.x' }
           - { os: 'windows-latest', language: 'go',      language_version: '1.21'  }
+          - { os: 'windows-latest', language: 'rust',    language_version: '1.84'  }
           - { os: 'windows-latest', language: 'java',    language_version: '11'    }
           - { os: 'windows-latest', language: 'java',    language_version: '21'    }
           - { os: 'windows-latest', language: 'node',    language_version: '18.x'  }

--- a/src/clients/rust/build.rs
+++ b/src/clients/rust/build.rs
@@ -38,6 +38,7 @@ fn main() -> anyhow::Result<()> {
     if unix {
         println!("cargo:rerun-if-changed={libdir}/lib{libname}.a");
     } else if windows {
+        println!("cargo:rustc-link-lib=advapi32");
         println!("cargo:rerun-if-changed={libdir}/{libname}.lib");
     } else {
         todo!();

--- a/src/clients/rust/build.rs
+++ b/src/clients/rust/build.rs
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
         ("x86_64", "linux", "gnu") => "x86_64-linux-gnu.2.27",
         ("x86_64", "linux", "musl") => "x86_64-linux-musl",
         ("x86_64", "macos", "") => "x86_64-macos",
-        ("x86_64", "windows", "") => "x86_64-windows",
+        ("x86_64", "windows", "msvc") => "x86_64-windows",
         _ => todo!(),
     };
 


### PR DESCRIPTION
In the original PR I only set up the linux runner. This adds windows. I don't add mac or ARM because their machines are limited, but also don't expect any problems there.