### PR TITLE
ci: run fuzzers & vopr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
       - run: shellcheck ./zig/download.sh
       - run: ./zig/download.ps1 && ./zig/zig build ci -- smoke
 
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: shellcheck ./zig/download.sh
+      - run: ./zig/download.ps1 && ./zig/zig build ci -- fuzz
+
   test:
     strategy:
       matrix:


### PR DESCRIPTION
https://github.com/tigerbeetle/tigerbeetle/commit/1836a9231e64b6c89b32aec75cf8288c5626c3d2 removed the `./zig/zig build fuzz -- smoke` from the CI, but neither `./zig/zig build ci -- smoke` nor `./zig/zig build ci -- test` runs our fuzzers! 

This PR adds an explicit `fuzz` job to the CI, which invokes `./zig/zig build ci -- fuzz`. This would help detect regressions in the fuzzers and VOPR. 


