### PR TITLE
ci: run fuzzers with smaller stacks 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1019,6 +1019,7 @@ fn build_vopr(
         // When running without a SEED, default to release.
         .optimize = if (b.args == null) .ReleaseSafe else options.mode,
     });
+    vopr.stack_size = 4 * MiB;
     vopr.root_module.addOptions("vsr_options", options.vsr_options);
     vopr.root_module.addOptions("vsr_vopr_options", vopr_options);
     // Ensure that we get stack traces even in release builds.
@@ -1049,6 +1050,7 @@ fn build_fuzz(
         .target = options.target,
         .optimize = options.mode,
     });
+    fuzz_exe.stack_size = 4 * MiB;
     fuzz_exe.root_module.addOptions("vsr_options", options.vsr_options);
     fuzz_exe.root_module.omit_frame_pointer = false;
     steps.fuzz_build.dependOn(print_or_install(b, fuzz_exe, options.print_exe));
@@ -2039,3 +2041,5 @@ fn fetch(b: *std.Build, options: struct {
     }
     return result;
 }
+
+const MiB = 1024 * 1024;


### PR DESCRIPTION
Two changes here:

* Set stack size for vopr and fuzz to 4*MiB. Zig's default stack size is
  16*MiB, but we want to make sure that we have ample free space. Given
  that we don't have a billion of dependencies, and that recursion is
  banned by TigerStyle, our stack size should be pretty shallow.

* Eagerly fault-in the stack on startup for fuzzers, to, ahem, scare out
  the ghosts out of our CFO machines:
  https://ziggit.dev/t/stack-probe-puzzle/10291/1

  This _is_ a work-around, but, based on the fact that it _only_ affects
  forest_fuzz which does a lot of allocation and de-allocation, I do
  think there isn't any issue with our code, and, given that the root
  cause hasn't reveal itself after 3 days of investigation, it seems
  better to just table this for now.