### PR TITLE
ci: limit fuzzer processes to 20GiB of RAM

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -58,6 +58,7 @@ const CLIArgs = struct {
 };
 
 pub fn main() !void {
+    fuzz.limit_ram();
     probe_stack(3 * MiB);
 
     var gpa_allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -11,6 +11,7 @@ const constants = @import("constants.zig");
 const flags = @import("./flags.zig");
 const schema = @import("lsm/schema.zig");
 const vsr = @import("vsr.zig");
+const fuzz = @import("./testing/fuzz.zig");
 const Header = vsr.Header;
 
 const vsr_vopr_options = @import("vsr_vopr_options");
@@ -84,6 +85,7 @@ const CLIArgs = struct {
 pub fn main() !void {
     // This must be initialized at runtime as stderr is not comptime known on e.g. Windows.
     log_buffer.unbuffered_writer = std.io.getStdErr().writer();
+    fuzz.limit_ram();
 
     var gpa_instance: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer {


### PR DESCRIPTION
This is done in-process, rather than in cfo_supervisor via unsare, because in-process limiting is actually better! The reason why we need unsare is that we can't really reliably wait for children to finish, and _have_ to do that from the outside!