### PR TITLE
vopr: fix false positive after pull-based message bus

### DIFF
--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -52,6 +52,7 @@ pub const MessageBus = struct {
     pub fn deinit(bus: *MessageBus, _: std.mem.Allocator) void {
         bus.buffer.?.deinit(bus.pool);
         bus.buffer = null;
+        bus.resume_scheduled = false;
         // NB: Network keeps a reference to a message bus even when a replica is de-initialized,
         // so we don't assign bus.* to undefined here.
     }


### PR DESCRIPTION
We can crash in network.zig in

            if (bus.resume_scheduled) {
                bus.resume_scheduled = false;
                bus.on_messages_callback(bus, &bus.buffer.?);
                if (bus.buffer.?.has_message()) {
                    bus.suspended = true;
                }
                advanced = true;
            }

if the replica crashes after scheduling a resume.

Discovered on ac7a96f

Seed: ./zig/zig build vopr -- 10734304986262340864