### PR TITLE
fuzz: fix stack probing to not actually _use_ all the stack

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -88,7 +88,7 @@ pub fn main() !void {
 //
 // If you are from the future, consider removing this and seeing if the issue reproduces. Chances
 // are a kernel upgrade can fix it? The CFO kernel at the time of writing is 6.1.0-25-amd64.
-fn probe_stack(comptime size: usize) void {
+noinline fn probe_stack(comptime size: usize) void {
     var big: [size]u8 = undefined;
     touch(&big);
     assert(big[0] == 92 and big[size - 1] == 92);


### PR DESCRIPTION
https://github.com/tigerbeetle/tigerbeetle/pull/2999 added eager stack probing to our fuzz runs. The probing worked correctly in the sense that it did allocate 3 MiBs of stack and touched it.

What didn't work though, was that the probe itself was inlined, and so the stack  space was release only after return from main. That is, we didn't just _probe_ the stack, but actually used all of it!

This of course is visible in the original godbolt: https://godbolt.org/z/Ez9r69rW6

Marking the function as noinline achieves the desired result where we just touch the stack, and then give it back to the actual fuzzing code.