### PR TITLE
vsr: remove cluster from MessageBus

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -39,7 +39,6 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
         pool: *MessagePool,
         io: *IO,
 
-        cluster: u128,
         configuration: []const std.net.Address,
 
         process: switch (process_type) {
@@ -97,11 +96,9 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             clients_limit: ?usize = null,
         };
 
-        /// Initialize the MessageBus for the given cluster, configuration and
-        /// replica/client process.
+        /// Initialize the MessageBus for the given configuration and replica/client process.
         pub fn init(
             allocator: mem.Allocator,
-            cluster: u128,
             process_id: ProcessID,
             message_pool: *MessagePool,
             on_messages_callback: *const fn (message_bus: *MessageBus, buffer: *MessageBuffer) void,
@@ -160,7 +157,6 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
             var bus: MessageBus = .{
                 .pool = message_pool,
                 .io = options.io,
-                .cluster = cluster,
                 .configuration = options.configuration,
                 .process = process,
                 .id = switch (process_id) {

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -18,7 +18,6 @@ pub const MessageBus = struct {
     network: *Network,
     pool: *MessagePool,
 
-    cluster: u128,
     process: Process,
 
     buffer: ?MessageBuffer,
@@ -33,7 +32,6 @@ pub const MessageBus = struct {
 
     pub fn init(
         _: std.mem.Allocator,
-        cluster: u128,
         process: Process,
         message_pool: *MessagePool,
         on_messages_callback: *const fn (message_bus: *MessageBus, buffer: *MessageBuffer) void,
@@ -42,7 +40,6 @@ pub const MessageBus = struct {
         return MessageBus{
             .network = options.network,
             .pool = message_pool,
-            .cluster = cluster,
             .process = process,
             .buffer = MessageBuffer.init(message_pool),
             .on_messages_callback = on_messages_callback,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -150,7 +150,6 @@ pub fn ClientType(
 
             var message_bus = try MessageBus.init(
                 allocator,
-                options.cluster,
                 .{ .client = options.id },
                 options.message_pool,
                 Client.on_messages,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1236,7 +1236,6 @@ pub fn ReplicaType(
             // faulting in.
             self.message_bus = try MessageBus.init(
                 allocator,
-                options.cluster,
                 .{ .replica = options.replica_index },
                 options.message_pool,
                 Replica.on_messages_from_bus,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2698,7 +2698,6 @@ const TestClientBus = struct {
             .message_pool = message_pool,
             .message_bus = try MessageBus.init(
                 allocator,
-                context.cluster.options.cluster_id,
                 .{ .client = client_id },
                 message_pool,
                 on_messages,


### PR DESCRIPTION
As a part of MessageBuffer work, now its the entity that pulls out of message bus who is responsible for validating cluster.