### PR TITLE
Typed python client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/setup-python@v4
         with: { python-version: "${{ matrix.language_version }}" }
       - if: matrix.language == 'python'
-        run: pip install build hatch pytest
+        run: pip install build hatch pytest mypy
 
       - run: ./zig/download.ps1 && ./zig/zig build ci -- ${{ matrix.language }}
 

--- a/src/clients/python/ci.zig
+++ b/src/clients/python/ci.zig
@@ -68,6 +68,9 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
         try shell.exec("python3 main.py", .{});
     }
+
+    // We are checking type annotations of the entire package.
+    try shell.exec("python3 -m mypy . --strict", .{});
 }
 
 pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {

--- a/src/clients/python/pyproject.toml
+++ b/src/clients/python/pyproject.toml
@@ -37,3 +37,10 @@ artifacts = ["*.so", "*.dylib", "*.dll"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.mypy]
+strict = true
+exclude = [
+    "samples/",
+    "tests/",
+]

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -205,7 +205,7 @@ fn emit_struct_ctypes(
     buffer.print(
         \\class C{[type_name]s}(ctypes.Structure):
         \\    @classmethod
-        \\    def from_param(cls, obj):
+        \\    def from_param(cls, obj: Any) -> Self:
         \\
     , .{
         .type_name = c_name,
@@ -248,7 +248,7 @@ fn emit_struct_ctypes(
     if (generate_ctypes_to_python) {
         buffer.print(
             \\
-            \\    def to_python(self):
+            \\    def to_python(self) -> {[type_name]s}:
             \\        return {[type_name]s}(
             \\
         , .{
@@ -313,9 +313,16 @@ fn emit_struct_dataclass(
             });
 
             if (field_type_info == .@"struct" and field_type_info.@"struct".layout == .@"packed") {
+                // Flags:
                 buffer.print("{s}.NONE\n", .{python_type});
             } else {
-                buffer.print("0\n", .{});
+                if (field_type_info == .@"enum") {
+                    // Enums - the only ones exposed by the client call `.0` as `.OK`:
+                    buffer.print("{s}.OK\n", .{python_type});
+                } else {
+                    // Simple integer types:
+                    buffer.print("0\n", .{});
+                }
             }
         }
     }
@@ -351,9 +358,10 @@ fn emit_method(
     else
         event_name(operation);
 
+    // NB: _submit is loosely annotated, the operations define interfaces for the Python developer.
     buffer.print(
         \\    {[prefix_fn]s}def {[fn_name]s}(self, {[event_name]s}: {[event_type]s}) -> {[result_type]s}:
-        \\        return {[prefix_call]s}self._submit(
+        \\        return {[prefix_call]s}self._submit(  # type: ignore[no-any-return]
         \\            Operation.{[uppercase_name]s},
         \\            {[event_name_or_list]s},
         \\            {[event_type_c]s},
@@ -394,10 +402,21 @@ pub fn main() !void {
         \\
         \\import ctypes
         \\import enum
+        \\import sys
+        \\from dataclasses import dataclass
         \\from collections.abc import Callable # noqa: TCH003
         \\from typing import Any
+        \\if sys.version_info >= (3, 11):
+        \\    from typing import Self
+        \\else:
+        \\    from typing_extensions import Self
         \\
-        \\from .lib import c_uint128, dataclass, tbclient, validate_uint
+        \\from .lib import c_uint128, tbclient, validate_uint
+        \\
+        \\# Use slots=True if the version of Python is new enough (3.10+) to support it.
+        \\if sys.version_info >= (3, 10):
+        \\    # mypy: ignore assignment (3.10+) and unused-ignore (pre 3.10)
+        \\    dataclass = dataclass(slots=True) # type: ignore[assignment, unused-ignore]
         \\
         \\
         \\
@@ -519,7 +538,7 @@ pub fn main() !void {
         \\tb_client_register_log_callback = tbclient.tb_client_register_log_callback
         \\tb_client_register_log_callback.restype = RegisterLogCallbackStatus
         \\# Need to pass in None to clear - ctypes will error if argtypes is set.
-        \\#tb_client_register_log_callback.argtypes = [LogHandler, ctypes.c_bool]
+        \\# tb_client_register_log_callback.argtypes = [LogHandler, ctypes.c_bool]
         \\
         \\
         \\
@@ -528,6 +547,8 @@ pub fn main() !void {
     inline for (.{ true, false }) |is_async| {
         const prefix_class = if (is_async) "Async" else "";
 
+        // This is annotated loosely, the operations calling it will contain their
+        // own annotations so the interface is clear to Python as well.
         buffer.print(
             \\class {s}StateMachineMixin:
             \\    _submit: Callable[[Operation, Any, Any, Any], Any]

--- a/src/clients/python/src/tigerbeetle/__init__.py
+++ b/src/clients/python/src/tigerbeetle/__init__.py
@@ -1,3 +1,39 @@
 from .bindings import * # noqa
 from .client import ClientAsync, ClientSync, id, amount_max, configure_logging # noqa
 from .lib import IntegerOverflowError, NativeError
+
+# Explicitly declare public exports:
+__all__ = [
+    # from .client:
+    "ClientAsync",
+    "ClientSync",
+    "id",
+    "amount_max",
+    "configure_logging",
+    # from .lib:
+    "IntegerOverflowError",
+    "NativeError",
+    # from .bindings - everything treated as public:
+    "Operation",
+    "PacketStatus",
+    "InitStatus",
+    "ClientStatus",
+    "LogLevel",
+    "RegisterLogCallbackStatus",
+    "AccountFlags",
+    "TransferFlags",
+    "AccountFilterFlags",
+    "QueryFilterFlags",
+    "CreateAccountResult",
+    "CreateTransferResult",
+    "Account",
+    "Transfer",
+    "CreateAccountsResult",
+    "CreateTransfersResult",
+    "AccountFilter",
+    "AccountBalance",
+    "QueryFilter",
+    "InitParameters",
+    "AsyncStateMachineMixin",
+    "StateMachineMixin",
+]

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -6,10 +6,21 @@ from __future__ import annotations
 
 import ctypes
 import enum
+import sys
+from dataclasses import dataclass
 from collections.abc import Callable # noqa: TCH003
 from typing import Any
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
-from .lib import c_uint128, dataclass, tbclient, validate_uint
+from .lib import c_uint128, tbclient, validate_uint
+
+# Use slots=True if the version of Python is new enough (3.10+) to support it.
+if sys.version_info >= (3, 10):
+    # mypy: ignore assignment (3.10+) and unused-ignore (pre 3.10)
+    dataclass = dataclass(slots=True) # type: ignore[assignment, unused-ignore]
 
 
 class Operation(enum.IntEnum):
@@ -236,13 +247,13 @@ class Transfer:
 @dataclass
 class CreateAccountsResult:
     index: int = 0
-    result: CreateAccountResult = 0
+    result: CreateAccountResult = CreateAccountResult.OK
 
 
 @dataclass
 class CreateTransfersResult:
     index: int = 0
-    result: CreateTransferResult = 0
+    result: CreateTransferResult = CreateTransferResult.OK
 
 
 @dataclass
@@ -282,7 +293,7 @@ class QueryFilter:
 
 class CPacket(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=32, name="data_size", number=obj.data_size)
         validate_uint(bits=16, name="user_tag", number=obj.user_tag)
         validate_uint(bits=8, name="operation", number=obj.operation)
@@ -309,7 +320,7 @@ CPacket._fields_ = [ # noqa: SLF001
 
 class CClient(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         return cls(
             opaque=obj.opaque,
         )
@@ -321,7 +332,7 @@ CClient._fields_ = [ # noqa: SLF001
 
 class CAccount(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=128, name="id", number=obj.id)
         validate_uint(bits=128, name="debits_pending", number=obj.debits_pending)
         validate_uint(bits=128, name="debits_posted", number=obj.debits_posted)
@@ -349,7 +360,7 @@ class CAccount(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> Account:
         return Account(
             id=self.id.to_python(),
             debits_pending=self.debits_pending.to_python(),
@@ -384,7 +395,7 @@ CAccount._fields_ = [ # noqa: SLF001
 
 class CTransfer(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=128, name="id", number=obj.id)
         validate_uint(bits=128, name="debit_account_id", number=obj.debit_account_id)
         validate_uint(bits=128, name="credit_account_id", number=obj.credit_account_id)
@@ -414,7 +425,7 @@ class CTransfer(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> Transfer:
         return Transfer(
             id=self.id.to_python(),
             debit_account_id=self.debit_account_id.to_python(),
@@ -450,7 +461,7 @@ CTransfer._fields_ = [ # noqa: SLF001
 
 class CCreateAccountsResult(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=32, name="index", number=obj.index)
         return cls(
             index=obj.index,
@@ -458,7 +469,7 @@ class CCreateAccountsResult(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> CreateAccountsResult:
         return CreateAccountsResult(
             index=self.index,
             result=CreateAccountResult(self.result),
@@ -472,7 +483,7 @@ CCreateAccountsResult._fields_ = [ # noqa: SLF001
 
 class CCreateTransfersResult(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=32, name="index", number=obj.index)
         return cls(
             index=obj.index,
@@ -480,7 +491,7 @@ class CCreateTransfersResult(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> CreateTransfersResult:
         return CreateTransfersResult(
             index=self.index,
             result=CreateTransferResult(self.result),
@@ -494,7 +505,7 @@ CCreateTransfersResult._fields_ = [ # noqa: SLF001
 
 class CAccountFilter(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=128, name="account_id", number=obj.account_id)
         validate_uint(bits=128, name="user_data_128", number=obj.user_data_128)
         validate_uint(bits=64, name="user_data_64", number=obj.user_data_64)
@@ -516,7 +527,7 @@ class CAccountFilter(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> AccountFilter:
         return AccountFilter(
             account_id=self.account_id.to_python(),
             user_data_128=self.user_data_128.to_python(),
@@ -545,7 +556,7 @@ CAccountFilter._fields_ = [ # noqa: SLF001
 
 class CAccountBalance(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=128, name="debits_pending", number=obj.debits_pending)
         validate_uint(bits=128, name="debits_posted", number=obj.debits_posted)
         validate_uint(bits=128, name="credits_pending", number=obj.credits_pending)
@@ -560,7 +571,7 @@ class CAccountBalance(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> AccountBalance:
         return AccountBalance(
             debits_pending=self.debits_pending.to_python(),
             debits_posted=self.debits_posted.to_python(),
@@ -581,7 +592,7 @@ CAccountBalance._fields_ = [ # noqa: SLF001
 
 class CQueryFilter(ctypes.Structure):
     @classmethod
-    def from_param(cls, obj):
+    def from_param(cls, obj: Any) -> Self:
         validate_uint(bits=128, name="user_data_128", number=obj.user_data_128)
         validate_uint(bits=64, name="user_data_64", number=obj.user_data_64)
         validate_uint(bits=32, name="user_data_32", number=obj.user_data_32)
@@ -603,7 +614,7 @@ class CQueryFilter(ctypes.Structure):
         )
 
 
-    def to_python(self):
+    def to_python(self) -> QueryFilter:
         return QueryFilter(
             user_data_128=self.user_data_128.to_python(),
             user_data_64=self.user_data_64,
@@ -678,13 +689,13 @@ tb_client_submit.argtypes = [ctypes.POINTER(CClient), ctypes.POINTER(CPacket)]
 tb_client_register_log_callback = tbclient.tb_client_register_log_callback
 tb_client_register_log_callback.restype = RegisterLogCallbackStatus
 # Need to pass in None to clear - ctypes will error if argtypes is set.
-#tb_client_register_log_callback.argtypes = [LogHandler, ctypes.c_bool]
+# tb_client_register_log_callback.argtypes = [LogHandler, ctypes.c_bool]
 
 
 class AsyncStateMachineMixin:
     _submit: Callable[[Operation, Any, Any, Any], Any]
     async def create_accounts(self, accounts: list[Account]) -> list[CreateAccountsResult]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.CREATE_ACCOUNTS,
             accounts,
             CAccount,
@@ -692,7 +703,7 @@ class AsyncStateMachineMixin:
         )
 
     async def create_transfers(self, transfers: list[Transfer]) -> list[CreateTransfersResult]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.CREATE_TRANSFERS,
             transfers,
             CTransfer,
@@ -700,7 +711,7 @@ class AsyncStateMachineMixin:
         )
 
     async def lookup_accounts(self, accounts: list[int]) -> list[Account]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.LOOKUP_ACCOUNTS,
             accounts,
             c_uint128,
@@ -708,7 +719,7 @@ class AsyncStateMachineMixin:
         )
 
     async def lookup_transfers(self, transfers: list[int]) -> list[Transfer]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.LOOKUP_TRANSFERS,
             transfers,
             c_uint128,
@@ -716,7 +727,7 @@ class AsyncStateMachineMixin:
         )
 
     async def get_account_transfers(self, filter: AccountFilter) -> list[Transfer]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.GET_ACCOUNT_TRANSFERS,
             [filter],
             CAccountFilter,
@@ -724,7 +735,7 @@ class AsyncStateMachineMixin:
         )
 
     async def get_account_balances(self, filter: AccountFilter) -> list[AccountBalance]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.GET_ACCOUNT_BALANCES,
             [filter],
             CAccountFilter,
@@ -732,7 +743,7 @@ class AsyncStateMachineMixin:
         )
 
     async def query_accounts(self, query_filter: QueryFilter) -> list[Account]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.QUERY_ACCOUNTS,
             [query_filter],
             CQueryFilter,
@@ -740,7 +751,7 @@ class AsyncStateMachineMixin:
         )
 
     async def query_transfers(self, query_filter: QueryFilter) -> list[Transfer]:
-        return await self._submit(
+        return await self._submit(  # type: ignore[no-any-return]
             Operation.QUERY_TRANSFERS,
             [query_filter],
             CQueryFilter,
@@ -752,7 +763,7 @@ class AsyncStateMachineMixin:
 class StateMachineMixin:
     _submit: Callable[[Operation, Any, Any, Any], Any]
     def create_accounts(self, accounts: list[Account]) -> list[CreateAccountsResult]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.CREATE_ACCOUNTS,
             accounts,
             CAccount,
@@ -760,7 +771,7 @@ class StateMachineMixin:
         )
 
     def create_transfers(self, transfers: list[Transfer]) -> list[CreateTransfersResult]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.CREATE_TRANSFERS,
             transfers,
             CTransfer,
@@ -768,7 +779,7 @@ class StateMachineMixin:
         )
 
     def lookup_accounts(self, accounts: list[int]) -> list[Account]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.LOOKUP_ACCOUNTS,
             accounts,
             c_uint128,
@@ -776,7 +787,7 @@ class StateMachineMixin:
         )
 
     def lookup_transfers(self, transfers: list[int]) -> list[Transfer]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.LOOKUP_TRANSFERS,
             transfers,
             c_uint128,
@@ -784,7 +795,7 @@ class StateMachineMixin:
         )
 
     def get_account_transfers(self, filter: AccountFilter) -> list[Transfer]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.GET_ACCOUNT_TRANSFERS,
             [filter],
             CAccountFilter,
@@ -792,7 +803,7 @@ class StateMachineMixin:
         )
 
     def get_account_balances(self, filter: AccountFilter) -> list[AccountBalance]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.GET_ACCOUNT_BALANCES,
             [filter],
             CAccountFilter,
@@ -800,7 +811,7 @@ class StateMachineMixin:
         )
 
     def query_accounts(self, query_filter: QueryFilter) -> list[Account]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.QUERY_ACCOUNTS,
             [query_filter],
             CQueryFilter,
@@ -808,7 +819,7 @@ class StateMachineMixin:
         )
 
     def query_transfers(self, query_filter: QueryFilter) -> list[Transfer]:
-        return self._submit(
+        return self._submit(  # type: ignore[no-any-return]
             Operation.QUERY_TRANSFERS,
             [query_filter],
             CQueryFilter,

--- a/src/clients/python/src/tigerbeetle/client.py
+++ b/src/clients/python/src/tigerbeetle/client.py
@@ -4,11 +4,16 @@ import asyncio
 import ctypes
 import logging
 import os
+import sys
 import threading
 import time
 from collections.abc import Callable  # noqa: TCH003
 from dataclasses import dataclass
 from typing import Any
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from . import bindings
 from .lib import tb_assert, c_uint128
@@ -17,11 +22,11 @@ logger = logging.getLogger("tigerbeetle")
 
 
 class AtomicInteger:
-    def __init__(self, value=0):
+    def __init__(self, value: int = 0) -> None:
         self._value = value
         self._lock = threading.Lock()
 
-    def increment(self):
+    def increment(self) -> int:
         with self._lock:
             self._value += 1
             return self._value
@@ -45,30 +50,43 @@ class InflightPacket:
     operation: bindings.Operation
     c_event_type: Any
     c_result_type: Any
-    on_completion: Callable | None
+    on_completion: Callable[[Self], None] | None
     on_completion_context: CompletionContextSync | CompletionContextAsync | None
 
+class _IDGenerator:
+    """
+    Generator for Universally Unique and Sortable Identifiers as a 128-bit integers, based on ULIDs.
+
+    Keeps a monotonically increasing millisecond timestamp between calls to `.generate()`.
+    """
+    def __init__(self) -> None:
+        self._time_ms_last = time.time_ns() // (1000 * 1000)
+
+    def generate(self) -> int:
+        time_ms = time.time_ns() // (1000 * 1000)
+
+        # Ensure time_ms monotonically increases.
+        if time_ms <= self._time_ms_last:
+            time_ms = self._time_ms_last
+        else:
+            self._time_ms_last = time_ms
+
+        randomness = os.urandom(10)
+
+        return int.from_bytes(
+            time_ms.to_bytes(6, "big") + randomness,
+            "big",
+        )
+
+# Module-level singleton instance.
+_id_generator = _IDGenerator()
 
 
 def id() -> int:
     """
     Generates a Universally Unique and Sortable Identifier as a 128-bit integer. Based on ULIDs.
     """
-    time_ms = time.time_ns() // (1000 * 1000)
-
-    # Ensure time_ms monotonically increases.
-    time_ms_last = getattr(id, "_time_ms_last", 0)
-    if time_ms <= time_ms_last:
-        time_ms = time_ms_last
-    else:
-        id._time_ms_last = time_ms
-
-    randomness = os.urandom(10)
-
-    return int.from_bytes(
-        time_ms.to_bytes(6, "big") + randomness,
-        "big",
-    )
+    return _id_generator.generate()
 
 
 amount_max = (2 ** 128) - 1
@@ -137,15 +155,15 @@ class Client:
             c_event_type=c_event_type,
             c_result_type=c_result_type)
 
-    def close(self):
+    def close(self) -> None:
         bindings.tb_client_deinit(ctypes.byref(self._client))
         tb_assert(self._client is not None)
         tb_assert(len(self._inflight_packets) == 0)
         del Client._clients[self._client_key]
 
     @staticmethod
-    @bindings.OnCompletion
-    def _c_on_completion(completion_ctx, packet, timestamp, bytes_ptr, len_):
+    @bindings.OnCompletion  # type: ignore[misc]
+    def _c_on_completion(completion_ctx: int, packet: Any, timestamp: int, bytes_ptr: Any, len_: int) -> None:
         """
         Invoked in a separate thread
         """
@@ -156,7 +174,9 @@ class Client:
 
         if packet[0].status != bindings.PacketStatus.OK.value:
             inflight_packet.response = PacketError(repr(bindings.PacketStatus(packet[0].status)))
-            tb_assert(inflight_packet.on_completion is not None)
+            if inflight_packet.on_completion is None:
+                # Can't use tb_assert here, as mypy complains later that it might be None.
+                raise TypeError("inflight_packet.on_completion not set")
             inflight_packet.on_completion(inflight_packet)
             return
 
@@ -174,22 +194,27 @@ class Client:
 
         inflight_packet.response = results
 
-        tb_assert(inflight_packet.on_completion is not None)
+        if inflight_packet.on_completion is None:
+            # Can't use tb_assert here, as mypy complains later that it might be None.
+            raise TypeError("inflight_packet.on_completion not set")
+
         inflight_packet.on_completion(inflight_packet)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.close()
 
 
 class ClientSync(Client, bindings.StateMachineMixin):
-    def _on_completion(self, inflight_packet):
+    def _on_completion(self, inflight_packet: InflightPacket) -> None:
+        if not isinstance(inflight_packet.on_completion_context, CompletionContextSync):
+            raise TypeError(repr(inflight_packet.on_completion_context))
         inflight_packet.on_completion_context.event.set()
 
     def _submit(self, operation: bindings.Operation, operations: list[Any],
-                c_event_type: Any, c_result_type: Any):
+                c_event_type: Any, c_result_type: Any) -> Any:
         inflight_packet = self._acquire_packet(operation, operations, c_event_type, c_result_type)
         self._inflight_packets[inflight_packet.packet.user_data] = inflight_packet
 
@@ -212,22 +237,26 @@ class ClientSync(Client, bindings.StateMachineMixin):
 
 
 class ClientAsync(Client, bindings.AsyncStateMachineMixin):
-    def _on_completion(self, inflight_packet):
+    def _on_completion(self, inflight_packet: InflightPacket) -> None:
         """
         Called by Client._c_on_completion, which itself is called from a different thread. Use
         `call_soon_threadsafe` to return to the thread of the event loop the request was invoked
         from, so _trigger_event() can trigger the async event and allow the client to progress.
         """
+        if not isinstance(inflight_packet.on_completion_context, CompletionContextAsync):
+            raise TypeError(repr(inflight_packet.on_completion_context))
         inflight_packet.on_completion_context.loop.call_soon_threadsafe(
             self._trigger_event,
             inflight_packet
         )
 
-    def _trigger_event(self, inflight_packet):
+    def _trigger_event(self, inflight_packet:InflightPacket) -> None:
+        if not isinstance(inflight_packet.on_completion_context, CompletionContextAsync):
+            raise TypeError(repr(inflight_packet.on_completion_context))
         inflight_packet.on_completion_context.event.set()
 
     async def _submit(self, operation: bindings.Operation, operations: Any,
-                      c_event_type: Any, c_result_type: Any):
+                      c_event_type: Any, c_result_type: Any) -> Any:
         inflight_packet = self._acquire_packet(operation, operations, c_event_type, c_result_type)
         self._inflight_packets[inflight_packet.packet.user_data] = inflight_packet
 
@@ -252,8 +281,8 @@ class ClientAsync(Client, bindings.AsyncStateMachineMixin):
         return inflight_packet.response
 
 
-@bindings.LogHandler
-def log_handler(level_zig, message_ptr, message_len):
+@bindings.LogHandler  # type: ignore[misc]
+def log_handler(level_zig: bindings.LogLevel, message_ptr: Any, message_len: int) -> None:
     level_python = {
         bindings.LogLevel.ERR: logging.ERROR,
         bindings.LogLevel.WARN: logging.WARNING,
@@ -265,10 +294,15 @@ def log_handler(level_zig, message_ptr, message_len):
 tb_assert(bindings.tb_client_register_log_callback(log_handler, True) ==
     bindings.RegisterLogCallbackStatus.SUCCESS)
 
-def configure_logging(*, debug, log_handler=log_handler):
+
+def configure_logging(
+    *,
+    debug: bool,
+    handler: Callable[[bindings.LogLevel, Any, int], None] = log_handler,
+) -> None:
     # First disable the existing log handler, before enabling the new one.
     tb_assert(bindings.tb_client_register_log_callback(None, debug) ==
         bindings.RegisterLogCallbackStatus.SUCCESS)
 
-    tb_assert(bindings.tb_client_register_log_callback(log_handler, debug) ==
+    tb_assert(bindings.tb_client_register_log_callback(handler, debug) ==
         bindings.RegisterLogCallbackStatus.SUCCESS)

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -1389,3 +1389,15 @@ def test_uint128(client):
         capture_output=True
     )
     assert json.loads(repl_output.stdout) == expected_repl_response
+
+
+def test_ids_random():
+    """IDs are different from repeated invocations of the function."""
+    samples = [tb.id() for _ in range(10_000)]
+    assert len(samples) == len(set(samples))
+
+def test_ids_sortable():
+    """IDs are expected to be sortable, with at least 1 millisecond between calls."""
+    id1 = tb.id()
+    time.sleep(0.001)
+    assert tb.id() > id1

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -771,6 +771,7 @@ test "tidy extensions" {
         .{"src/scripts/cfo_supervisor.sh"},
         .{".github/ci/test_aof.sh"},
         .{"src/clients/python/pyproject.toml"},
+        .{"src/clients/python/src/tigerbeetle/py.typed"},
         .{"src/clients/rust/Cargo.lock"},
     });
 


### PR DESCRIPTION
# summary 

Type annotations for the python client, for #3007. The client code is now passing `mypy` in "strict" mode.


# details

Updated the hand-written python client code, and the zig code generating the client bindings as well. Both are type annotated now, with backwards compatibility up to Python 3.7. I've also added `mypy` to `src/clients/python/ci.zig` so need to continue passing this when running the CI.

# questions

## CI running on commits
I've edited the github actions settings so the CI is ran on my own branches. How to correctly set this up so it's running on all my commits without this making it into the upstream for you?

## enum defaults in dataclasses

The bindings include dataclasses with `IntEnum` attributes. These are created with default 0, but the type checker realises this is looser than the `IntEnum` class defined. I've noticed that for all enums exposed, 0 is `.OK` so I've used that - this would break if you write/expose other enums where 0 is not `OK`. **What do you want/recommend?**
- inspect the enum and find what 0 corresponds to and print that? (how to do this in Zig?)
- don't add a default
the latter I'd only do for enums, sine for flags, and general numbers 0 seems to typically mean NONE/no-filtering.

see https://github.com/stenczelt/tigerbeetle/blob/6b909ae1e02194f96c4e027dc74da4d75930ddc3/src/clients/python/python_bindings.zig#L320-L325

and 

https://github.com/stenczelt/tigerbeetle/blob/6b909ae1e02194f96c4e027dc74da4d75930ddc3/src/clients/python/src/tigerbeetle/bindings.py#L246-L249

## ~decorators~

~I've removed a few decorators, e.g. from the log handler, which to my understanding was not actually doing anything. The tests still passed. Please check if you agree with this, or let me know if there is some behaviour expected under the hood that I've not noticed (also let's add a test for these if so).~



