### PR TITLE
benchmark: print only key latencies

### DIFF
--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -944,7 +944,7 @@ fn print_percentiles_histogram(
             if (sum >= histogram_percentile) break bucket_index;
         } else histogram_buckets.len;
 
-        stdout.print("{s} latency p{} = {} ms{s}\n", .{
+        stdout.print("{s} latency p{: <3} = {} ms{s}\n", .{
             label,
             percentile,
             latency,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -933,7 +933,7 @@ fn print_percentiles_histogram(
     var histogram_total: u64 = 0;
     for (histogram_buckets) |bucket| histogram_total += bucket;
 
-    const percentiles = [_]u64{ 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100 };
+    const percentiles = [_]u64{ 1, 50, 99, 100 };
     for (percentiles) |percentile| {
         const histogram_percentile: usize = @divTrunc(histogram_total * percentile, 100);
 


### PR DESCRIPTION
Latency histogram is the key output of the benchmark, and is something
directly processed by humans. It's worth investing into increasing
signal to noise ratio here, and to print _less_ data, such that the data
that are printed become more valuable. p1, p50, p99 and p100 feel like
the key numbers for us.

New output format:

    13 batches in 0.33 s
    transfer batch size = 8189 txs
    transfer batch delay = 0 us
    load accepted = 301887 tx/s
    batch latency p1   = 0 ms
    batch latency p50  = 22 ms
    batch latency p99  = 32 ms
    batch latency p100 = 42 ms