### PR TITLE
IO/Linux: Handle ECANCELED error for send()

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -704,6 +704,7 @@ pub const IO = struct {
                                 .OPNOTSUPP => error.OperationNotSupported,
                                 .PIPE => error.BrokenPipe,
                                 .TIMEDOUT => error.ConnectionTimedOut,
+                                .CANCELED => error.Canceled,
                                 else => |errno| stdx.unexpected_errno("send", errno),
                             };
                             break :blk err;
@@ -1126,6 +1127,7 @@ pub const IO = struct {
         BrokenPipe,
         ConnectionTimedOut,
         ConnectionRefused,
+        Canceled,
     } || posix.UnexpectedError;
 
     pub fn send(


### PR DESCRIPTION
This was hit by antithesis. I _think_ what triggers it is a `message_bus.terminate() -> posix.shutdown()` call concurrent with `send()`.

```
2025-06-12 21:32:10.521Z error(stdx): unexpected errno: send: code=125 name=CANCELED
2025-06-12 21:32:10.521Z warning(message_bus): 1: on_send: to=message_bus.MessageBusType(.client).Connection.Peer{ .replica = 0 } error.Unexpected
```