### PR TITLE
rust client: Always build tb_client in release mode

### DIFF
--- a/src/clients/rust/build.rs
+++ b/src/clients/rust/build.rs
@@ -102,7 +102,7 @@ fn build_tigerbeetle(manifest_dir: &str) -> anyhow::Result<()> {
 
     for build_target in build_targets {
         let mut cmd = std::process::Command::new(&zig_compiler);
-        cmd.args(["build", build_target]);
+        cmd.args(["build", build_target, "-Drelease"]);
         let result = cmd.status()?;
 
         if !result.success() {


### PR DESCRIPTION
I considered passing the debug/release mode all the way to the zig build but it doesn't seem worth it.