### PR TITLE
rust client: Fix ABI assertions

### DIFF
--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -303,20 +303,12 @@ fn assert_abi_compatibility() {
         std::mem::align_of::<tbc::tb_account_t>()
     );
     assert_eq!(
-        std::mem::size_of::<Account>(),
-        std::mem::size_of::<tbc::tb_account_t>()
+        std::mem::size_of::<AccountFlags>(),
+        std::mem::size_of::<tbc::TB_ACCOUNT_FLAGS>()
     );
     assert_eq!(
-        std::mem::align_of::<Account>(),
-        std::mem::align_of::<tbc::tb_account_t>()
-    );
-    assert_eq!(
-        std::mem::size_of::<Transfer>(),
-        std::mem::size_of::<tbc::tb_transfer_t>()
-    );
-    assert_eq!(
-        std::mem::align_of::<Transfer>(),
-        std::mem::align_of::<tbc::tb_transfer_t>()
+        std::mem::align_of::<AccountFlags>(),
+        std::mem::align_of::<tbc::TB_ACCOUNT_FLAGS>()
     );
     assert_eq!(
         std::mem::size_of::<Transfer>(),
@@ -325,6 +317,14 @@ fn assert_abi_compatibility() {
     assert_eq!(
         std::mem::align_of::<Transfer>(),
         std::mem::align_of::<tbc::tb_transfer_t>()
+    );
+    assert_eq!(
+        std::mem::size_of::<TransferFlags>(),
+        std::mem::size_of::<tbc::TB_TRANSFER_FLAGS>()
+    );
+    assert_eq!(
+        std::mem::align_of::<TransferFlags>(),
+        std::mem::align_of::<tbc::TB_TRANSFER_FLAGS>()
     );
     assert_eq!(
         std::mem::size_of::<AccountFilter>(),
@@ -333,6 +333,14 @@ fn assert_abi_compatibility() {
     assert_eq!(
         std::mem::align_of::<AccountFilter>(),
         std::mem::align_of::<tbc::tb_account_filter_t>()
+    );
+    assert_eq!(
+        std::mem::size_of::<AccountFilterFlags>(),
+        std::mem::size_of::<tbc::TB_ACCOUNT_FILTER_FLAGS>()
+    );
+    assert_eq!(
+        std::mem::align_of::<AccountFilterFlags>(),
+        std::mem::align_of::<tbc::TB_ACCOUNT_FILTER_FLAGS>()
     );
     assert_eq!(
         std::mem::size_of::<AccountBalance>(),
@@ -349,6 +357,14 @@ fn assert_abi_compatibility() {
     assert_eq!(
         std::mem::align_of::<QueryFilter>(),
         std::mem::align_of::<tbc::tb_query_filter_t>()
+    );
+    assert_eq!(
+        std::mem::size_of::<QueryFilterFlags>(),
+        std::mem::size_of::<tbc::TB_QUERY_FILTER_FLAGS>()
+    );
+    assert_eq!(
+        std::mem::align_of::<QueryFilterFlags>(),
+        std::mem::align_of::<tbc::TB_QUERY_FILTER_FLAGS>()
     );
 }
 


### PR DESCRIPTION
Fix duplicate and missing checks. It must have been late when I wrote this function.