### PR TITLE
VSR: Add end-to-end client request latency metric

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -387,6 +387,8 @@ pub fn AOFType(comptime IO: type) type {
                         .session = 0,
                         .request = 0,
                         .release = header.release,
+                        .previous_request_timestamp = 0,
+                        .previous_request_latency = 0,
                     };
 
                     self.client.raw_request(

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -387,7 +387,6 @@ pub fn AOFType(comptime IO: type) type {
                         .session = 0,
                         .request = 0,
                         .release = header.release,
-                        .previous_request_timestamp = 0,
                         .previous_request_latency = 0,
                     };
 

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -242,7 +242,7 @@ typedef struct tb_packet_t {
     uint16_t user_tag;
     uint8_t operation;
     uint8_t status;
-    uint8_t opaque[48];
+    uint8_t opaque[64];
 } tb_packet_t;
 
 typedef enum TB_OPERATION {

--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -242,7 +242,7 @@ typedef struct tb_packet_t {
     uint16_t user_tag;
     uint8_t operation;
     uint8_t status;
-    uint8_t opaque[32];
+    uint8_t opaque[48];
 } tb_packet_t;
 
 typedef enum TB_OPERATION {

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -512,7 +512,6 @@ pub fn ContextType(
             if (self.client.request_inflight == null) {
                 assert(self.pending.count() == 0);
                 packet.phase = .pending;
-                packet.multi_batch_time_real = self.client.time.realtime();
                 packet.multi_batch_time_monotonic = self.client.time.monotonic();
                 packet.multi_batch_count = 1;
                 packet.multi_batch_event_count = @intCast(batch.event_count);
@@ -571,7 +570,6 @@ pub fn ContextType(
 
             // Couldn't batch with existing packet so push to pending directly.
             packet.phase = .pending;
-            packet.multi_batch_time_real = self.client.time.realtime();
             packet.multi_batch_time_monotonic = self.client.time.monotonic();
             packet.multi_batch_count = 1;
             packet.multi_batch_event_count = @intCast(batch.event_count);
@@ -875,7 +873,6 @@ pub fn ContextType(
                 .user_tag = packet_extern.user_tag,
                 .status = .ok,
                 .link = .{},
-                .multi_batch_time_real = 0,
                 .multi_batch_time_monotonic = 0,
                 .multi_batch_next = null,
                 .multi_batch_tail = null,

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -206,7 +206,6 @@ pub fn ContextType(
         eviction_reason: ?vsr.Header.Eviction.Reason,
         thread: std.Thread,
 
-        previous_request_timestamp: ?i64 = null,
         previous_request_instant: ?stdx.Instant = null,
         previous_request_latency: ?stdx.Duration = null,
 
@@ -657,7 +656,6 @@ pub fn ContextType(
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @sizeOf(vsr.Header) + request_size,
-                .previous_request_timestamp = self.previous_request_timestamp orelse 0,
                 .previous_request_latency = @intCast(@min(
                     previous_request_latency.ns,
                     std.math.maxInt(u32),
@@ -665,11 +663,8 @@ pub fn ContextType(
             };
 
             assert((self.previous_request_instant == null) ==
-                (self.previous_request_timestamp == null));
-            assert((self.previous_request_instant == null) ==
                 (self.previous_request_latency == null));
             self.previous_request_instant = .{ .ns = packet_list.multi_batch_time_monotonic };
-            self.previous_request_timestamp = packet_list.multi_batch_time_real;
 
             packet_list.phase = .sent;
             self.client.raw_request(

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -513,6 +513,8 @@ pub fn ContextType(
             if (self.client.request_inflight == null) {
                 assert(self.pending.count() == 0);
                 packet.phase = .pending;
+                packet.multi_batch_time_real = self.client.time.realtime();
+                packet.multi_batch_time_monotonic = self.client.time.monotonic();
                 packet.multi_batch_count = 1;
                 packet.multi_batch_event_count = @intCast(batch.event_count);
                 packet.multi_batch_result_count_expected = @intCast(batch.result_count_expected);
@@ -570,6 +572,8 @@ pub fn ContextType(
 
             // Couldn't batch with existing packet so push to pending directly.
             packet.phase = .pending;
+            packet.multi_batch_time_real = self.client.time.realtime();
+            packet.multi_batch_time_monotonic = self.client.time.monotonic();
             packet.multi_batch_count = 1;
             packet.multi_batch_event_count = @intCast(batch.event_count);
             packet.multi_batch_result_count_expected = @intCast(batch.result_count_expected);
@@ -664,8 +668,8 @@ pub fn ContextType(
                 (self.previous_request_timestamp == null));
             assert((self.previous_request_instant == null) ==
                 (self.previous_request_latency == null));
-            self.previous_request_instant = self.client.time.monotonic_instant();
-            self.previous_request_timestamp = self.client.time.realtime();
+            self.previous_request_instant = .{ .ns = packet_list.multi_batch_time_monotonic };
+            self.previous_request_timestamp = packet_list.multi_batch_time_real;
 
             packet_list.phase = .sent;
             self.client.raw_request(
@@ -876,6 +880,8 @@ pub fn ContextType(
                 .user_tag = packet_extern.user_tag,
                 .status = .ok,
                 .link = .{},
+                .multi_batch_time_real = 0,
+                .multi_batch_time_monotonic = 0,
                 .multi_batch_next = null,
                 .multi_batch_tail = null,
                 .multi_batch_count = 0,

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -120,7 +120,6 @@ pub fn EchoClientType(
                 .command = .request,
                 .operation = .register,
                 .release = vsr.Release.minimum,
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 
@@ -160,7 +159,6 @@ pub fn EchoClientType(
                 .release = vsr.Release.minimum,
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @intCast(@sizeOf(Header) + events.len),
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -53,7 +53,6 @@ pub const Packet = extern struct {
 
     link: Queue.Link,
 
-    multi_batch_time_real: i64,
     multi_batch_time_monotonic: u64,
     multi_batch_next: ?*Packet,
     multi_batch_tail: ?*Packet,
@@ -61,7 +60,7 @@ pub const Packet = extern struct {
     multi_batch_event_count: u16,
     multi_batch_result_count_expected: u16,
     phase: Phase,
-    reserved: [17]u8 = .{0} ** 17,
+    reserved: [25]u8 = .{0} ** 25,
 
     pub fn cast(self: *Packet) *Extern {
         return @ptrCast(self);
@@ -84,7 +83,6 @@ pub const Packet = extern struct {
     pub inline fn assert_phase(packet: *const Packet, expected: Phase) void {
         assert(packet.phase == expected);
         assert(packet.data_size == 0 or packet.data != null);
-        assert((packet.multi_batch_time_real == 0) == (packet.multi_batch_time_monotonic == 0));
         assert(stdx.zeroed(&packet.reserved));
         maybe(packet.user_data == null);
         maybe(packet.user_tag == 0);
@@ -97,7 +95,6 @@ pub const Packet = extern struct {
                 assert(packet.multi_batch_count == 0);
                 assert(packet.multi_batch_event_count == 0);
                 assert(packet.multi_batch_result_count_expected == 0);
-                assert(packet.multi_batch_time_real == 0);
                 assert(packet.multi_batch_time_monotonic == 0);
             },
             .pending => {
@@ -108,7 +105,6 @@ pub const Packet = extern struct {
                 maybe(packet.multi_batch_event_count == 0);
                 maybe(packet.multi_batch_result_count_expected == 0);
                 maybe(packet.link.next == null);
-                assert(packet.multi_batch_time_real != 0);
                 assert(packet.multi_batch_time_monotonic != 0);
             },
             .batched => {
@@ -118,7 +114,6 @@ pub const Packet = extern struct {
                 assert(packet.multi_batch_event_count == 0);
                 assert(packet.multi_batch_result_count_expected == 0);
                 maybe(packet.multi_batch_next != null);
-                assert(packet.multi_batch_time_real == 0);
                 assert(packet.multi_batch_time_monotonic == 0);
             },
             .sent => {
@@ -128,7 +123,6 @@ pub const Packet = extern struct {
                 assert((packet.multi_batch_next == null) == (packet.multi_batch_tail == null));
                 maybe(packet.multi_batch_event_count == 0);
                 maybe(packet.multi_batch_result_count_expected == 0);
-                assert(packet.multi_batch_time_real != 0);
                 assert(packet.multi_batch_time_monotonic != 0);
             },
             .complete => {

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -122,7 +122,7 @@ pub const Packet = extern struct {
             },
             .complete => {
                 // The packet pointer isn't available after completed,
-                // it may be dealocated by the user;
+                // it may be deallocated by the user;
                 unreachable;
             },
         }

--- a/src/clients/c/tb_client/packet.zig
+++ b/src/clients/c/tb_client/packet.zig
@@ -27,7 +27,7 @@ pub const Packet = extern struct {
         user_tag: u16,
         operation: u8,
         status: Status,
-        @"opaque": [48]u8 = [_]u8{0} ** 48,
+        @"opaque": [64]u8 = [_]u8{0} ** 64,
 
         pub fn cast(self: *Extern) *Packet {
             return @ptrCast(self);
@@ -61,7 +61,7 @@ pub const Packet = extern struct {
     multi_batch_event_count: u16,
     multi_batch_result_count_expected: u16,
     phase: Phase,
-    reserved: u8 = 0,
+    reserved: [17]u8 = .{0} ** 17,
 
     pub fn cast(self: *Packet) *Extern {
         return @ptrCast(self);
@@ -85,7 +85,7 @@ pub const Packet = extern struct {
         assert(packet.phase == expected);
         assert(packet.data_size == 0 or packet.data != null);
         assert((packet.multi_batch_time_real == 0) == (packet.multi_batch_time_monotonic == 0));
-        assert(packet.reserved == 0);
+        assert(stdx.zeroed(&packet.reserved));
         maybe(packet.user_data == null);
         maybe(packet.user_tag == 0);
 

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1266,14 +1266,14 @@ internal unsafe struct TBClient
 [StructLayout(LayoutKind.Sequential, Size = SIZE)]
 internal unsafe struct TBPacket
 {
-    public const int SIZE = 72;
+    public const int SIZE = 88;
 
 
     [StructLayout(LayoutKind.Sequential, Size = OpaqueData.SIZE)]
     private unsafe struct OpaqueData
     {
-        public const int SIZE = 48;
-        private const int LENGTH = 48;
+        public const int SIZE = 64;
+        private const int LENGTH = 64;
 
         private fixed byte raw[LENGTH];
 

--- a/src/clients/dotnet/TigerBeetle/Bindings.cs
+++ b/src/clients/dotnet/TigerBeetle/Bindings.cs
@@ -1266,14 +1266,14 @@ internal unsafe struct TBClient
 [StructLayout(LayoutKind.Sequential, Size = SIZE)]
 internal unsafe struct TBPacket
 {
-    public const int SIZE = 56;
+    public const int SIZE = 72;
 
 
     [StructLayout(LayoutKind.Sequential, Size = OpaqueData.SIZE)]
     private unsafe struct OpaqueData
     {
-        public const int SIZE = 32;
-        private const int LENGTH = 32;
+        public const int SIZE = 48;
+        private const int LENGTH = 48;
 
         private fixed byte raw[LENGTH];
 

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -242,7 +242,7 @@ typedef struct tb_packet_t {
     uint16_t user_tag;
     uint8_t operation;
     uint8_t status;
-    uint8_t opaque[48];
+    uint8_t opaque[64];
 } tb_packet_t;
 
 typedef enum TB_OPERATION {

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -242,7 +242,7 @@ typedef struct tb_packet_t {
     uint16_t user_tag;
     uint8_t operation;
     uint8_t status;
-    uint8_t opaque[32];
+    uint8_t opaque[48];
 } tb_packet_t;
 
 typedef enum TB_OPERATION {

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -303,7 +303,7 @@ CPacket._fields_ = [ # noqa: SLF001
     ("user_tag", ctypes.c_uint16),
     ("operation", ctypes.c_uint8),
     ("status", ctypes.c_uint8),
-    ("opaque", ctypes.c_uint8 * 32),
+    ("opaque", ctypes.c_uint8 * 48),
 ]
 
 

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -303,7 +303,7 @@ CPacket._fields_ = [ # noqa: SLF001
     ("user_tag", ctypes.c_uint16),
     ("operation", ctypes.c_uint8),
     ("status", ctypes.c_uint8),
-    ("opaque", ctypes.c_uint8 * 48),
+    ("opaque", ctypes.c_uint8 * 64),
 ]
 
 

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -889,7 +889,7 @@ where
         user_tag: 0xABCD,
         operation: op,
         status: tbc::TB_PACKET_STATUS_TB_PACKET_OK,
-        opaque: [0; 48],
+        opaque: [0; 64],
     });
 
     (packet, rx)

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -889,7 +889,7 @@ where
         user_tag: 0xABCD,
         operation: op,
         status: tbc::TB_PACKET_STATUS_TB_PACKET_OK,
-        opaque: Default::default(),
+        opaque: [0; 48],
     });
 
     (packet, rx)

--- a/src/clients/rust/src/tb_client.rs
+++ b/src/clients/rust/src/tb_client.rs
@@ -242,7 +242,7 @@ pub struct tb_packet_t {
     pub user_tag: u16,
     pub operation: u8,
     pub status: u8,
-    pub opaque: [u8; 32],
+    pub opaque: [u8; 48],
 }
 
 pub type TB_OPERATION = u8;

--- a/src/clients/rust/src/tb_client.rs
+++ b/src/clients/rust/src/tb_client.rs
@@ -242,7 +242,7 @@ pub struct tb_packet_t {
     pub user_tag: u16,
     pub operation: u8,
     pub status: u8,
-    pub opaque: [u8; 48],
+    pub opaque: [u8; 64],
 }
 
 pub type TB_OPERATION = u8;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -877,7 +877,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, request_operation),
                 .size = @intCast(@sizeOf(vsr.Header) + request_body_size),
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -877,7 +877,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, request_operation),
                 .size = @intCast(@sizeOf(vsr.Header) + request_body_size),
-                .previous_request_latency = 0,
+                .previous_request_latency = cluster.prng.int(u32),
             };
 
             client.raw_request(

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -877,6 +877,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .command = .request,
                 .operation = vsr.Operation.from(StateMachine, request_operation),
                 .size = @intCast(@sizeOf(vsr.Header) + request_body_size),
+                .previous_request_timestamp = 0,
+                .previous_request_latency = 0,
             };
 
             client.raw_request(

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -102,7 +102,7 @@ const packet_count_max = stdx.div_ceil(
 comptime {
     // Sanity-check:
     assert(packet_count_max > 0);
-    assert(packet_count_max < 512);
+    assert(packet_count_max < 557);
 }
 
 pub const StatsD = struct {

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -274,7 +274,6 @@ pub fn ClientType(
                 .command = .request,
                 .operation = .register,
                 .release = self.release,
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 
@@ -333,7 +332,6 @@ pub fn ClientType(
                 .release = self.release,
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @intCast(@sizeOf(Header) + events.len),
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -17,11 +17,12 @@ const log = stdx.log.scoped(.client);
 pub fn ClientType(
     comptime StateMachine_: type,
     comptime MessageBus: type,
-    comptime Time: type,
+    comptime Time_: type,
 ) type {
     return struct {
         const Client = @This();
 
+        pub const Time = Time_;
         pub const StateMachine = StateMachine_;
         pub const Request = struct {
             pub const Callback = *const fn (
@@ -273,6 +274,8 @@ pub fn ClientType(
                 .command = .request,
                 .operation = .register,
                 .release = self.release,
+                .previous_request_timestamp = 0,
+                .previous_request_latency = 0,
             };
 
             std.mem.bytesAsValue(
@@ -330,6 +333,8 @@ pub fn ClientType(
                 .release = self.release,
                 .operation = vsr.Operation.from(StateMachine, operation),
                 .size = @intCast(@sizeOf(Header) + events.len),
+                .previous_request_timestamp = 0,
+                .previous_request_latency = 0,
             };
 
             stdx.copy_disjoint(.exact, u8, message.body_used(), events);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -553,14 +553,12 @@ pub const Header = extern struct {
         /// A client is allowed to have at most one request inflight at a time.
         request: u32,
         operation: Operation,
-        reserved_small: [11]u8 = [_]u8{0} ** 11,
-        /// Wall time when the client first began to construct the previous request's body.
-        previous_request_timestamp: i64,
+        previous_request_latency_padding: [3]u8 = [_]u8{0} ** 3,
         /// Nanosecond interval measuring the time between when the client first began to construct
         /// the previous request's body and the time that the client received the corresponding
         /// reply.
         previous_request_latency: u32,
-        reserved: [36]u8 = [_]u8{0} ** 36,
+        reserved: [52]u8 = [_]u8{0} ** 52,
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request);
@@ -624,9 +622,7 @@ pub const Header = extern struct {
                     // the check requires the StateMachine type.
                 },
             }
-            if (self.previous_request_latency != 0) {
-                if (self.previous_request_timestamp == 0) return "previous_request_timestamp == 0";
-            }
+            if (!stdx.zeroed(&self.previous_request_latency_padding)) return "padding != 0";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
             return null;
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6812,7 +6812,6 @@ pub fn ReplicaType(
                 request.message.header.client,
             });
             if (request.message.header.previous_request_latency != 0) {
-                assert(request.message.header.previous_request_timestamp != 0);
                 if (StateMachine.Operation == @import("../tigerbeetle.zig").Operation and
                     self.status == .normal)
                 {
@@ -10695,7 +10694,6 @@ pub fn ReplicaType(
                 .parent = 0,
                 .client = 0,
                 .session = 0,
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6811,6 +6811,24 @@ pub fn ReplicaType(
                 request.message.header.checksum,
                 request.message.header.client,
             });
+            if (request.message.header.previous_request_latency != 0) {
+                assert(request.message.header.previous_request_timestamp != 0);
+                if (StateMachine.Operation == @import("../tigerbeetle.zig").Operation and
+                    self.status == .normal)
+                {
+                    if (StateMachine.operation_from_vsr(
+                        request.message.header.operation,
+                    )) |operation| {
+                        self.trace.timing(
+                            .{ .client_request_round_trip = .{ .operation = operation } },
+                            @divFloor(
+                                request.message.header.previous_request_latency,
+                                std.time.ns_per_us,
+                            ),
+                        );
+                    }
+                }
+            }
 
             // Guard against the wall clock going backwards by taking the max with timestamps
             // issued:
@@ -10677,6 +10695,8 @@ pub fn ReplicaType(
                 .parent = 0,
                 .client = 0,
                 .session = 0,
+                .previous_request_timestamp = 0,
+                .previous_request_latency = 0,
             };
 
             request.header.set_checksum_body(request.body_used());

--- a/src/vsr/replica_reformat.zig
+++ b/src/vsr/replica_reformat.zig
@@ -120,7 +120,6 @@ pub fn ReplicaReformatType(
                 .release = reformat.client.release,
                 .operation = .noop,
                 .size = @sizeOf(vsr.Header),
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
 

--- a/src/vsr/replica_reformat.zig
+++ b/src/vsr/replica_reformat.zig
@@ -120,6 +120,8 @@ pub fn ReplicaReformatType(
                 .release = reformat.client.release,
                 .operation = .noop,
                 .size = @sizeOf(vsr.Header),
+                .previous_request_timestamp = 0,
+                .previous_request_latency = 0,
             };
 
             const user_data = @intFromPtr(reformat);

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1640,7 +1640,6 @@ test "Cluster: client: empty command=request operation=register body" {
                 .command = .request,
                 .operation = .register,
                 .release = client_release,
-                .previous_request_timestamp = 0,
                 .previous_request_latency = 0,
             };
             request_header.set_checksum_body(&.{}); // Note the absence of a `vsr.RegisterRequest`.

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1640,6 +1640,8 @@ test "Cluster: client: empty command=request operation=register body" {
                 .command = .request,
                 .operation = .register,
                 .release = client_release,
+                .previous_request_timestamp = 0,
+                .previous_request_latency = 0,
             };
             request_header.set_checksum_body(&.{}); // Note the absence of a `vsr.RegisterRequest`.
             request_header.set_checksum();


### PR DESCRIPTION
The client tracks both the instant and the wall clock time -- the client's instant is used for the duration, but is not meaningful at the replicas, so we use wall clock for the timestamp.

This _appears_ to add way more metrics "worst-case" packets than it reasonably should, but only because the worst-case calculation assumes that there are >140 different operations. (TODO!)

Currently the previous request timestamp is not used by the replica.

The latency begins from when the first event is added to the multi batch, even before the request is ever sent. That is, it includes the time that the request spends queued up on the client. The goal is to get an accurate representation of how much latency the application actually observes. Since `vsr.Client` isn't aware of queuing, this makes acquiring the timestamp/latency somewhat awkward. `client.raw_request()` receives a `*Message.Request`, which may have the timing fields already set by the `tb_client`. `client.request()` just sets the fields to `0`, since that function is not used by the language client.