### PR TITLE
VOPR: Swarm test different replication configurations

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -89,6 +89,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             releases: []const Release,
             client_release: vsr.Release,
             state_machine: StateMachine.Options,
+            replicate_options: Replica.ReplicateOptions = .{},
         };
 
         pub const Callbacks = struct {
@@ -714,6 +715,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     .release_execute = replica_release_execute_soon,
                     .release_execute_context = null,
                     .test_context = cluster,
+                    .replicate_options = cluster.options.replicate_options,
                 },
             );
             assert(replica.cluster == cluster.options.cluster_id);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -407,6 +407,10 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
                 .cache_entries_transfers_pending = if (prng.boolean()) 256 else 0,
             },
         },
+        .replicate_options = .{
+            .closed_loop = prng.chance(ratio(1, 5)),
+            .star = prng.chance(ratio(1, 5)),
+        },
     };
 
     const network_options: Cluster.NetworkOptions = .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -152,7 +152,7 @@ pub fn ReplicaType(
         const ForestTableIterator = ForestTableIteratorType(Forest);
         const Tracer = Storage.Tracer;
 
-        const ReplicateOptions = struct {
+        pub const ReplicateOptions = struct {
             closed_loop: bool = false,
             star: bool = false,
         };


### PR DESCRIPTION
These flags are "Highly experimental options that will be removed in a future release" -- but until they are removed, let's make sure the vopr covers them.