### PR TITLE
vsr: remove dead code

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3411,12 +3411,8 @@ pub fn ReplicaType(
                     }
                 }
 
-                if (self.primary_pipeline_pending()) |prepare_pending| {
-                    if (prepare_pending == prepare) {
-                        self.prepare_timeout.backoff(&self.prng);
-                    } else {
-                        self.prepare_timeout.reset();
-                    }
+                if (self.primary_pipeline_pending()) |_| {
+                    self.prepare_timeout.reset();
                 } else {
                     self.prepare_timeout.stop();
 


### PR DESCRIPTION
Due to

    prepare.ok_from_all_replicas.count() >= self.quorum_replication)

and

    if (prepare_pipelined.ok_from_all_replicas.count() >= self.quorum_replication) {
        prepare_pipelined.ok_quorum_received = true;
    }

checks that dominate the code in question, prepare can't be pending anymore, so `==` is tautologically false.

I changed the code to what it does (reset), rather that to what it intended to do (backoff), because reset seems more appropriate here, as we did in fact make progress.

See also #2813