### PR TITLE
ci: run fuzzers as part of `zig build ci -- test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,6 @@ jobs:
       - run: shellcheck ./zig/download.sh
       - run: ./zig/download.ps1 && ./zig/zig build ci -- smoke
 
-  fuzz:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: shellcheck ./zig/download.sh
-      - run: ./zig/download.ps1 && ./zig/zig build ci -- fuzz
-
   test:
     strategy:
       matrix:

--- a/build.zig
+++ b/build.zig
@@ -447,6 +447,7 @@ fn build_ci(
     }
     if (default or mode == .@"test") {
         build_ci_step(b, step_ci, .{"test"});
+        build_ci_step(b, step_ci, .{ "fuzz", "--", "smoke" });
         build_ci_step(b, step_ci, .{"clients:c:sample"});
         build_ci_script(b, step_ci, options.scripts, &.{"--help"});
     }


### PR DESCRIPTION
In https://github.com/tigerbeetle/tigerbeetle/pull/2997, we added a separate CI job to run fuzzers. To reduce # of entrypoints,  this PR removes that separate job and runs fuzzers as part of `zig build ci -- test`. 