### PR TITLE
Trace: Add replica_messages_{in,out} counters

### DIFF
--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -22,7 +22,7 @@ const TreeEnum = tree_enum: {
     }
 
     break :tree_enum @Type(.{ .Enum = .{
-        .tag_type = u64,
+        .tag_type = u32,
         .fields = tree_fields,
         .decls = &.{},
         .is_exhaustive = true,
@@ -214,10 +214,10 @@ pub const EventTiming = union(Event.Tag) {
         switch (event.*) {
             // Single payload: CommitStage.Tag
             inline .replica_commit => |data| {
-                const stage = @intFromEnum(data.stage);
+                const stage: u32 = @intFromEnum(data.stage);
                 assert(stage < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(stage));
+                return slot_bases.get(event.*) + stage;
             },
             // Single payload: Operation
             inline .replica_request,
@@ -225,10 +225,10 @@ pub const EventTiming = union(Event.Tag) {
             .replica_request_local,
             .client_request_round_trip,
             => |data| {
-                const operation = @intFromEnum(data.operation);
+                const operation: u32 = @intFromEnum(data.operation);
                 assert(operation < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(operation));
+                return slot_bases.get(event.*) + operation;
             },
             // Single payload: TreeEnum
             inline .compact_mutable,
@@ -237,24 +237,24 @@ pub const EventTiming = union(Event.Tag) {
             .lookup_worker,
             .scan_tree,
             => |data| {
-                const tree_id = @intFromEnum(data.tree);
+                const tree_id: u32 = @intFromEnum(data.tree);
                 assert(tree_id < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(tree_id));
+                return slot_bases.get(event.*) + tree_id;
             },
             inline .compact_beat, .compact_beat_merge => |data| {
-                const tree_id = @intFromEnum(data.tree);
+                const tree_id: u32 = @intFromEnum(data.tree);
                 const offset = tree_id;
                 assert(offset < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(offset));
+                return slot_bases.get(event.*) + offset;
             },
             inline .scan_tree_level => |data| {
-                const tree_id = @intFromEnum(data.tree);
+                const tree_id: u32 = @intFromEnum(data.tree);
                 const offset = tree_id;
                 assert(offset < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(offset));
+                return slot_bases.get(event.*) + offset;
             },
             inline else => |data, event_tag| {
                 comptime assert(@TypeOf(data) == void);
@@ -481,18 +481,18 @@ pub const EventMetric = union(enum) {
     pub fn slot(event: *const EventMetric) u32 {
         switch (event.*) {
             inline .table_count_visible, .table_count_visible_max => |data| {
-                const tree_id = @intFromEnum(data.tree);
+                const tree_id: u32 = @intFromEnum(data.tree);
                 const offset = tree_id;
                 assert(offset < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(offset));
+                return slot_bases.get(event.*) + offset;
             },
             inline .replica_messages_in, .replica_messages_out => |data| {
-                const command = @intFromEnum(data.command);
+                const command: u32 = @intFromEnum(data.command);
                 const offset = command;
                 assert(offset < slot_limits.get(event.*));
 
-                return slot_bases.get(event.*) + @as(u32, @intCast(offset));
+                return slot_bases.get(event.*) + offset;
             },
             else => {
                 return slot_bases.get(event.*);

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -102,7 +102,7 @@ const packet_count_max = stdx.div_ceil(
 comptime {
     // Sanity-check:
     assert(packet_count_max > 0);
-    assert(packet_count_max < 557);
+    assert(packet_count_max < 564);
 }
 
 pub const StatsD = struct {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1606,6 +1606,7 @@ pub fn ReplicaType(
                 @tagName(self.status),
                 message.header,
             });
+            self.trace.count(.{ .replica_messages_in = .{ .command = message.header.command } }, 1);
 
             if (message.header.invalid()) |reason| {
                 log.warn("{}: on_message: invalid (command={}, {s})", .{
@@ -8595,6 +8596,9 @@ pub fn ReplicaType(
                     });
                 },
             }
+            self.trace.count(.{ .replica_messages_out = .{
+                .command = message.header.command,
+            } }, 1);
 
             if (message.header.invalid()) |reason| {
                 log.warn("{}: send_message_to_replica: invalid ({s})", .{ self.replica, reason });

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1555,6 +1555,9 @@ pub fn ReplicaType(
                     assert(request_header.client != 0 or constants.aof_recovery);
                 }
 
+                self.trace.count(.{ .replica_messages_in = .{
+                    .command = message.header.command,
+                } }, 1);
                 self.on_message(message);
             }
 
@@ -1606,7 +1609,6 @@ pub fn ReplicaType(
                 @tagName(self.status),
                 message.header,
             });
-            self.trace.count(.{ .replica_messages_in = .{ .command = message.header.command } }, 1);
 
             if (message.header.invalid()) |reason| {
                 log.warn("{}: on_message: invalid (command={}, {s})", .{


### PR DESCRIPTION
Both counters are segmented by `Command`.