### PR TITLE
Support CDC processing for transactions created before 0.16.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Released: 2025-06-27
 
   Swarm test different replication configurations in VOPR.
 
+- [#3053](https://github.com/tigerbeetle/tigerbeetle/pull/3053)
+
+  Supports CDC processing for transfers created by versions earlier than `0.16.29`.
+  Fixes a liveness bug that would crash the replicar if a CDC query encountered objects
+  created with a schema before [#2507](https://github.com/tigerbeetle/tigerbeetle/pull/2507).
+
 ### Features
 
 - [#3038](https://github.com/tigerbeetle/tigerbeetle/pull/3038)
@@ -27,11 +33,19 @@ Released: 2025-06-27
 
   Support `--clients` alongside `--transfer-batch-delay-us` in `tigerbeetle benchmark`.
 
+- [#3056](https://github.com/tigerbeetle/tigerbeetle/pull/3056)
+
+  The command `tigerbeetle inspect constants` prints VSR queue sizes.
+
 ### Internals
 
 - [#3045](https://github.com/tigerbeetle/tigerbeetle/pull/3045)
 
   Define timeouts in terms of `tick_ms`.
+
+- [#3042](https://github.com/tigerbeetle/tigerbeetle/pull/3042)
+
+  Disable "hint" argument for mmap call, which was observed to cause stack overflow.
 
 ### TigerTracks 🎧
 

--- a/docs/operating/cdc.md
+++ b/docs/operating/cdc.md
@@ -169,7 +169,7 @@ The CDC job requires TigerBeetle cluster version `0.16.43` or greater.
 
 The same [upgrade planning](./upgrading.md#planning-for-upgrades) recommended for clients applies
 to the CDC job. The CDC job version must not be newer than the cluster version, as it will fail
-with an error message if it is.
+with an error message if so.
 
 Any transactions _originally_ created by TigerBeetle versions before `0.16.29` have the following
 limitations for CDC processing:

--- a/docs/operating/cdc.md
+++ b/docs/operating/cdc.md
@@ -162,3 +162,21 @@ However, during crash recovery, the CDC job may replay unacknowledged messages t
 been already delivered to consumers.
 
 It is the consumer's responsibility to perform **idempotency checks** when processing messages.
+
+## Upgrading
+
+The CDC job requires TigerBeetle cluster version `0.16.43` or greater.
+
+The same [upgrade planning](./upgrading.md#planning-for-upgrades) recommended for clients applies
+to the CDC job. The CDC job version must not be newer than the cluster version, as it will fail
+with an error message if it is.
+
+Any transactions _originally_ created by TigerBeetle versions before `0.16.29` have the following
+limitations for CDC processing:
+
+- Events of type `two_phase_expired` are **not** supported.
+- Only transfers where both the debit and credit accounts have the
+  [`flags.history`](../reference/account.md#flagshistory) enabled are visible to CDC.
+
+Transactions committed after version `0.16.29` are fully compatible with CDC and do not require
+the `history` flag.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -422,6 +422,21 @@ pub fn StateMachineType(
                     assert(stdx.no_padding(Former));
                     assert(@sizeOf(Former) == @sizeOf(AccountEvent));
                     assert(@alignOf(Former) == @alignOf(AccountEvent));
+
+                    // Asserting the fields are identical.
+                    for (std.meta.fields(Former)) |field_former| {
+                        if (std.mem.eql(u8, field_former.name, "reserved")) continue;
+                        const field = std.meta.fields(AccountEvent)[
+                            std.meta.fieldIndex(
+                                AccountEvent,
+                                field_former.name,
+                            ).?
+                        ];
+                        assert(field_former.type == field.type);
+                        assert(field_former.alignment == field.alignment);
+                        assert(@offsetOf(AccountEvent, field_former.name) ==
+                            @offsetOf(Former, field_former.name));
+                    }
                 }
             };
 


### PR DESCRIPTION
- Be aware of the AccountEvent schema during GetChangeEvents.
- Skip legacy events recorded without the history flags (not enough balance information for CDC).
- Fix the debit/credit account flags to reflect the time of the event (for closing transfers).
- Rename missing ChangeEvents* occurrences.
- Docs