### PR TITLE
docs: disable `tex_math_dollars` extension

### DIFF
--- a/src/docs_website/src/docs.zig
+++ b/src/docs_website/src/docs.zig
@@ -174,7 +174,7 @@ fn run_pandoc(
 ) std.Build.LazyPath {
     const pandoc_step = std.Build.Step.Run.create(b, "run pandoc");
     pandoc_step.addFileArg(pandoc_bin);
-    pandoc_step.addArgs(&.{ "--from", "gfm+smart", "--to", "html5" });
+    pandoc_step.addArgs(&.{ "--from", "gfm+smart-tex_math_dollars", "--to", "html5" });
     pandoc_step.addPrefixedFileArg("--lua-filter=", b.path("pandoc/markdown-links.lua"));
     pandoc_step.addPrefixedFileArg("--lua-filter=", b.path("pandoc/anchor-links.lua"));
     pandoc_step.addPrefixedFileArg("--lua-filter=", b.path("pandoc/table-wrapper.lua"));


### PR DESCRIPTION
Having an expression like `$... ...$` with no spaces next to the dollar signs would trigger the mathjax extension for inline math expressions. For example, this is falsely triggered on https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/coding/financial-accounting.md by:
> is your balance $100 or -$100?

This change disables the responsible Pandoc extension.

I double checked our docs for usages of `$` and it's only used for currency and shell variables.