### PR TITLE
aof: change flag from a bool to a path

### DIFF
--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -33,7 +33,7 @@ rm -f aof-test.tigerbeetle
 rm -f aof-test.tigerbeetle.aof
 
 ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 aof-test.tigerbeetle > aof.log 2>&1
-./tigerbeetle start --cache-grid=256MiB --addresses=3000 --aof=aof-test.tigerbeetle.aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
+./tigerbeetle start --cache-grid=256MiB --addresses=3000 --aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
 
 # Wait for replicas to start, listen and connect:
 sleep 1
@@ -55,12 +55,12 @@ rm -rf 1 2
 
 mkdir 1 && cd 1
 ../tigerbeetle-aof-recovery format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof=aof-test.tigerbeetle.aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
+../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof-file="aof-test.tigerbeetle.aof" --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
 cd ..
 
 mkdir 2 && cd 2
 ../tigerbeetle-aof-recovery format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof=aof-test.tigerbeetle.aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
+../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
 cd ..
 
 # mkdir 3 && cd 3

--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -33,7 +33,7 @@ rm -f aof-test.tigerbeetle
 rm -f aof-test.tigerbeetle.aof
 
 ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 aof-test.tigerbeetle > aof.log 2>&1
-./tigerbeetle start --cache-grid=256MiB --addresses=3000 --aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
+./tigerbeetle start --cache-grid=256MiB --addresses=3000 --aof=aof-test.tigerbeetle.aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
 
 # Wait for replicas to start, listen and connect:
 sleep 1
@@ -55,12 +55,12 @@ rm -rf 1 2
 
 mkdir 1 && cd 1
 ../tigerbeetle-aof-recovery format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
+../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof=aof-test.tigerbeetle.aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
 cd ..
 
 mkdir 2 && cd 2
 ../tigerbeetle-aof-recovery format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
+../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof=aof-test.tigerbeetle.aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
 cd ..
 
 # mkdir 3 && cd 3

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -127,7 +127,8 @@ pub fn AOFType(comptime IO: type) type {
 
         /// Create an AOF in the dir_fd when given a file name. dir_fd must be opened read write
         /// (except on Windows). This ensures everything (including the dir) is fsync'd
-        /// appropriately. Closing dir_fd is the responsibility of the caller.
+        /// appropriately. Closing dir_fd is the responsibility of the caller, which can be done
+        /// immediately after .init() finishes.
         pub fn init(
             io: *IO,
             options: struct {
@@ -136,6 +137,7 @@ pub fn AOFType(comptime IO: type) type {
             },
         ) !AOF {
             assert(!std.fs.path.isAbsolute(options.relative_path));
+            assert(std.mem.endsWith(u8, options.relative_path, ".aof"));
             assert(IO == @import("io.zig").IO);
 
             const dir = std.fs.Dir{

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1804,7 +1804,7 @@ test parse_elf {
 
 pub fn print_information(
     allocator: std.mem.Allocator,
-    exe_path: [:0]const u8,
+    exe_path: []const u8,
     output: std.io.AnyWriter,
 ) !void {
     var io = try IO.init(32, 0);

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -94,7 +94,7 @@ const CLIArgs = union(enum) {
         /// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple
         /// log consisting of logged requests. Much like a redis AOF with fsync=on.
         /// Enabling this will have performance implications.
-        aof: bool = false,
+        aof: ?[:0]const u8 = null,
     };
 
     const Version = struct {
@@ -494,7 +494,7 @@ pub const Command = union(enum) {
         experimental: bool,
         replicate_closed_loop: bool,
         replicate_star: bool,
-        aof: bool,
+        aof: ?[:0]const u8,
         path: [:0]const u8,
         log_debug: bool,
         statsd: ?std.net.Address,
@@ -912,6 +912,12 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
                 vsr.stdx.fmt_int_size_bin_exact(constants.block_size),
             },
         );
+    }
+
+    if (start.aof) |aof_path| {
+        if (!std.mem.endsWith(u8, aof_path, ".aof")) {
+            vsr.fatal(.cli, "AOF path must end with .aof: '{s}'", .{aof_path});
+        }
     }
 
     const lsm_forest_compaction_block_count: u32 =

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -37,7 +37,7 @@ const CLIArgs = union(enum) {
         log_debug: bool = false,
 
         positional: struct {
-            path: [:0]const u8,
+            path: []const u8,
         },
     };
 
@@ -50,7 +50,7 @@ const CLIArgs = union(enum) {
         log_debug: bool = false,
 
         positional: struct {
-            path: [:0]const u8,
+            path: []const u8,
         },
     };
 
@@ -60,7 +60,7 @@ const CLIArgs = union(enum) {
         cache_grid: ?flags.ByteSize = null,
         development: bool = false,
         positional: struct {
-            path: [:0]const u8,
+            path: []const u8,
         },
 
         // Everything below here is considered experimental, and requires `--experimental` to be
@@ -77,7 +77,7 @@ const CLIArgs = union(enum) {
         cache_transfers_pending: ?flags.ByteSize = null,
         memory_lsm_manifest: ?flags.ByteSize = null,
         memory_lsm_compaction: ?flags.ByteSize = null,
-        trace: ?[:0]const u8 = null,
+        trace: ?[]const u8 = null,
         log_debug: bool = false,
         timeout_prepare_ms: ?u64 = null,
         timeout_grid_repair_message_ms: ?u64 = null,
@@ -87,14 +87,14 @@ const CLIArgs = union(enum) {
         replicate_closed_loop: bool = false,
         replicate_star: bool = false,
 
-        statsd: ?[:0]const u8 = null,
+        statsd: ?[]const u8 = null,
 
         /// AOF (Append Only File) logs all transactions synchronously to disk before replying
         /// to the client. The logic behind this code has been kept as simple as possible -
         /// io_uring or kqueue aren't used, there aren't any fancy data structures. Just a simple
         /// log consisting of logged requests. Much like a redis AOF with fsync=on.
         /// Enabling this will have performance implications.
-        aof_file: ?[:0]const u8 = null,
+        aof_file: ?[]const u8 = null,
 
         /// Legacy AOF option. Mututally exclusive with aof_file, and will have the same effect as
         /// setting aof_file to '<data file path>.aof'.
@@ -146,7 +146,7 @@ const CLIArgs = union(enum) {
         id_order: Command.Benchmark.IdOrder = .sequential,
         clients: u32 = 1,
         statsd: ?[]const u8 = null,
-        trace: ?[:0]const u8 = null,
+        trace: ?[]const u8 = null,
         /// When set, don't delete the data file when the benchmark completes.
         file: ?[]const u8 = null,
         addresses: ?[]const u8 = null,
@@ -263,7 +263,7 @@ const CLIArgs = union(enum) {
     const Multiversion = struct {
         log_debug: bool = false,
         positional: struct {
-            path: [:0]const u8,
+            path: []const u8,
         },
     };
 
@@ -462,7 +462,7 @@ pub const Command = union(enum) {
         replica: u8,
         replica_count: u8,
         development: bool,
-        path: [:0]const u8,
+        path: []const u8,
         log_debug: bool,
     };
 
@@ -472,7 +472,7 @@ pub const Command = union(enum) {
         replica: u8,
         replica_count: u8,
         development: bool,
-        path: [:0]const u8,
+        path: []const u8,
         log_debug: bool,
     };
 
@@ -494,13 +494,13 @@ pub const Command = union(enum) {
         timeout_prepare_ticks: ?u64,
         timeout_grid_repair_message_ticks: ?u64,
         commit_stall_probability: ?Ratio,
-        trace: ?[:0]const u8,
+        trace: ?[]const u8,
         development: bool,
         experimental: bool,
         replicate_closed_loop: bool,
         replicate_star: bool,
         aof_file: ?Path,
-        path: [:0]const u8,
+        path: []const u8,
         log_debug: bool,
         statsd: ?std.net.Address,
     };
@@ -556,7 +556,7 @@ pub const Command = union(enum) {
         id_order: IdOrder,
         clients: u32,
         statsd: ?[]const u8,
-        trace: ?[:0]const u8,
+        trace: ?[]const u8,
         file: ?[]const u8,
         addresses: ?Addresses,
         seed: ?[]const u8,
@@ -596,7 +596,7 @@ pub const Command = union(enum) {
     };
 
     pub const Multiversion = struct {
-        path: [:0]const u8,
+        path: []const u8,
         log_debug: bool,
     };
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -756,7 +756,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         "development", "experimental",
     };
     inline for (std.meta.fields(@TypeOf(start))) |field| {
-        @setEvalBranchQuota(2_100);
+        @setEvalBranchQuota(2_200);
         const stable_field = comptime for (stable_args) |stable_arg| {
             assert(std.meta.fieldIndex(@TypeOf(start), stable_arg) != null);
             if (std.mem.eql(u8, field.name, stable_arg)) {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -345,14 +345,14 @@ const Command = struct {
         } });
         defer message_pool.deinit(allocator);
 
-        var aof: ?AOF = if (args.aof) |aof_path| blk: {
-            const aof_dir = std.fs.path.dirname(aof_path) orelse ".";
+        var aof: ?AOF = if (args.aof_file) |*aof_file| blk: {
+            const aof_dir = std.fs.path.dirname(aof_file.const_slice()) orelse ".";
             const aof_dir_fd = try IO.open_dir(aof_dir);
             defer std.posix.close(aof_dir_fd);
 
             break :blk try AOF.init(&command.io, .{
                 .dir_fd = aof_dir_fd,
-                .relative_path = std.fs.path.basename(aof_path),
+                .relative_path = std.fs.path.basename(aof_file.const_slice()),
             });
         } else null;
         defer if (aof != null) aof.?.close();

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -178,12 +178,12 @@ const Command = struct {
     io: IO,
     storage: Storage,
     self_exe_path: [:0]const u8,
-    data_file_path: [:0]const u8,
+    data_file_path: []const u8,
 
     fn init(
         command: *Command,
         allocator: mem.Allocator,
-        path: [:0]const u8,
+        path: []const u8,
         options: struct {
             must_create: bool,
             development: bool,


### PR DESCRIPTION
This allows specifying the absolute path of an AOF, and perhaps most interestingly allow for the AOF to be on a different drive to the data file.

~This should be called out in the release notes explicitly - while `--aof` is behind `--experimental`, this is a breaking CLI change.~

The change is fully backwards compatible.