### PR TITLE
back off ping timeout on missing pongs

### DIFF
--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -645,7 +645,6 @@ pub fn ClientType(
                 .ping_timestamp_monotonic = self.time.monotonic(),
             };
 
-            // TODO If we haven't received a pong from a replica since our last ping, then back off.
             self.send_header_to_replicas(ping.frame_const());
         }
 


### PR DESCRIPTION
Track whether a pong response was received after a ping request. If not, the client backs off the ping timeout instead of resetting it, reducing unnecessary network pressure and timeout resets.

Closes a TODO in a source code.