### PR TITLE
Test/StorageChecker: Verify replies earlier

### DIFF
--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -312,12 +312,19 @@ pub const StorageChecker = struct {
             } else {
                 assert(client_session.header.command == .reply);
 
+                assert(client_session.header.size >= @sizeOf(vsr.Header));
                 if (client_session.header.size == @sizeOf(vsr.Header)) {
                     // ClientReplies won't store this entry.
                 } else {
-                    checksum.add(superblock.storage.area_memory(
+                    const reply = superblock.storage.area_memory(
                         .{ .client_replies = .{ .slot = slot } },
-                    )[0..vsr.sector_ceil(client_session.header.size)]);
+                    )[0..vsr.sector_ceil(client_session.header.size)];
+
+                    const reply_header =
+                        std.mem.bytesAsValue(vsr.Header, reply[0..@sizeOf(vsr.Header)]);
+
+                    assert(reply_header.checksum == client_session.header.checksum);
+                    checksum.add(reply);
                 }
             }
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -9924,7 +9924,7 @@ pub fn ReplicaType(
             self.client_sessions.reset();
 
             if (self.aof) |aof| aof.sync();
-            // Faulty bits will be set in sync_content().
+            // Faulty bits will be set in client_sessions_open_callback().
             while (self.client_replies.faulty.first_set()) |slot| {
                 self.client_replies.faulty.unset(slot);
             }


### PR DESCRIPTION
If this new assert fails, then we would already detect that later (e.g. at checkpoint) via a `StorageChecker` area mismatch. But this earlier assertion is easier to debug.
