### PR TITLE
replica: track aof checkpoint time

### DIFF
--- a/src/trace.zig
+++ b/src/trace.zig
@@ -431,8 +431,8 @@ test "trace json" {
     try snap(@src(),
         \\[
         \\{"pid":0,"tid":0,"ph":"B","ts":0,"cat":"replica_commit","name":"replica_commit  stage=idle","args":{"stage":"idle","op":123}},
-        \\{"pid":0,"tid":7,"ph":"B","ts":10000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
-        \\{"pid":0,"tid":7,"ph":"E","ts":30000},
+        \\{"pid":0,"tid":8,"ph":"B","ts":10000,"cat":"compact_beat","name":"compact_beat  tree=Account.id","args":{"tree":"Account.id","level_b":1}},
+        \\{"pid":0,"tid":8,"ph":"E","ts":30000},
         \\{"pid":0,"tid":0,"ph":"E","ts":60000},
         \\
     ).diff(trace_buffer.items);

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -69,6 +69,7 @@ fn enum_max(EnumOrUnion: type) u8 {
 pub const Event = union(enum) {
     replica_commit: struct { stage: CommitStage.Tag, op: ?usize = null },
     replica_aof_write: struct { op: usize },
+    replica_aof_checkpoint,
     replica_sync_table: struct { index: usize },
     replica_request: struct { operation: Operation },
     replica_request_execute: struct { operation: Operation },
@@ -140,6 +141,7 @@ pub const Event = union(enum) {
 pub const EventTiming = union(Event.Tag) {
     replica_commit: struct { stage: CommitStage.Tag },
     replica_aof_write,
+    replica_aof_checkpoint,
     replica_sync_table,
     replica_request: struct { operation: Operation },
     replica_request_execute: struct { operation: Operation },
@@ -167,6 +169,7 @@ pub const EventTiming = union(Event.Tag) {
     pub const slot_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = enum_max(CommitStage.Tag),
         .replica_aof_write = 1,
+        .replica_aof_checkpoint = 1,
         .replica_sync_table = 1,
         .replica_request = enum_max(Operation),
         .replica_request_execute = enum_max(Operation),
@@ -287,6 +290,7 @@ pub const EventTiming = union(Event.Tag) {
 pub const EventTracing = union(Event.Tag) {
     replica_commit,
     replica_aof_write,
+    replica_aof_checkpoint,
     replica_sync_table: struct { index: usize },
     replica_request,
     replica_request_execute,
@@ -314,6 +318,7 @@ pub const EventTracing = union(Event.Tag) {
     pub const stack_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = 1,
         .replica_aof_write = 1,
+        .replica_aof_checkpoint = 1,
         .replica_sync_table = constants.grid_missing_tables_max,
         .replica_request = 1,
         .replica_request_execute = 1,
@@ -592,6 +597,7 @@ test "EventTiming slot doesn't have collisions" {
         const event: EventTiming = switch (g.enum_value(Event.Tag)) {
             .replica_commit => .{ .replica_commit = .{ .stage = g.enum_value(CommitStage.Tag) } },
             .replica_aof_write => .replica_aof_write,
+            .replica_aof_checkpoint => .replica_aof_checkpoint,
             .replica_sync_table => .replica_sync_table,
             .replica_request => .{ .replica_request = .{ .operation = g.enum_value(Operation) } },
             .replica_request_execute => .{ .replica_request_execute = .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4711,6 +4711,8 @@ pub fn ReplicaType(
                 self.send_commit();
             }
             if (self.aof) |aof| {
+                self.trace.start(.replica_aof_checkpoint);
+
                 aof.checkpoint(self, commit_checkpoint_data_aof_callback);
             } else {
                 self.commit_checkpoint_data_callback_join(.aof);
@@ -4729,6 +4731,7 @@ pub fn ReplicaType(
         fn commit_checkpoint_data_aof_callback(replica: *anyopaque) void {
             const self: *Replica = @alignCast(@ptrCast(replica));
             assert(self.commit_stage == .checkpoint_data);
+            self.trace.stop(.replica_aof_checkpoint);
             self.commit_checkpoint_data_callback_join(.aof);
         }
 


### PR DESCRIPTION
AOF "checkpoints" calls fsync from io_uring or similar; to ensure the data is persisted. A good time to measure! Especially if with #3055 the AOF is on a different device.