### PR TITLE
cfo: use realtime to enforce budget & refresh timeouts

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -238,10 +238,10 @@ fn run_fuzzers(
     while (true) {
         const iteration_refresh = refresh_first or refresh_timer.read() >= refresh_ns;
         if (iteration_refresh) refresh_timer.reset();
-        refresh_first = false;
 
         const iteration_last = budget_timer.read() >= budget_ns;
-        const iteration_push = iteration_refresh or iteration_last;
+        const iteration_push = (iteration_refresh and !refresh_first) or iteration_last;
+        refresh_first = false;
 
         if (iteration_refresh) {
             try run_fuzzers_prepare_tasks(&tasks, shell, gh_token);


### PR DESCRIPTION
Currently, we use _ticks_ to enforce the budget timeout (the top-level timeout for the CFO) and refresh timeout (the timeout after which changes to main & PRs are pulled). The correctness of this approach rests on the assumption that each iteration of the CFO loop actually takes ~1 tick (0.5 seconds) 

This holds true in the happy path, where we run fuzzers using cached builds. However, we saw this assumption break when we recently upgraded to Zig 0.14.1 on `main`, but _not_ on `release`. Specifically, each iteration of the CFO loop started taking _much_ longer since the loop entailed _synchronous_ build failures for _all_ the fuzzers on the `release` branch (due to version mismatch). As a result, each loop started taking many minutes as opposed to half a second, and our logic to enforce timeouts broke down. 

To fix this, this PR uses real time to enforce the budget & refresh timeouts! 