### PR TITLE
cfo: start time wrongly recorded as a duration instead of timestamp

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -318,8 +318,9 @@ fn run_fuzzers(
                     }
                 };
 
+                const seed_timestamp_start_ns = fuzzer.seed.seed_timestamp_start;
                 const seed_duration_ns =
-                    @as(u64, @intCast(std.time.nanoTimestamp())) - fuzzer.seed.seed_timestamp_start;
+                    @as(u64, @intCast(std.time.nanoTimestamp())) - seed_timestamp_start_ns;
                 const seed_expired = !fuzzer_done and seed_duration_ns > timeout_ns;
 
                 if (fuzzer_done or seed_expired or iteration_last) {
@@ -345,7 +346,7 @@ fn run_fuzzers(
                         seed_record.ok = std.meta.eql(term, .{ .Exited = 0 });
                         // Convert seed_timestamp_start to seconds as `devhub.js` relies on it.
                         seed_record.seed_timestamp_start = @divFloor(
-                            seed_duration_ns,
+                            seed_timestamp_start_ns,
                             std.time.ns_per_s,
                         );
                         seed_record.seed_timestamp_end = @intCast(std.time.timestamp());


### PR DESCRIPTION
Turns out https://github.com/tigerbeetle/tigerbeetle/pull/3074 introduced a bug wherein `seed_timestamp_start` is being emitted as a _duration in seconds_ as opposed to _timestamp in seconds_, leading to incoherent results in [DevHubDB](https://github.com/tigerbeetle/devhubdb/blob/main/fuzzing/data.json) like the below:
```
  {
    "commit_timestamp": 1751839646,
    "commit_sha": "6a6e39e68d2aea5683a3ddf2091042fd45e4ba16",
    "fuzzer": "lsm_cache_map",
    "ok": true,
    "count": 1,
    "seed_timestamp_start": 1,
    "seed_timestamp_end": 1752066602,
    "seed": 4217018858006524443,
    "command": "./zig/zig build -Drelease fuzz -- lsm_cache_map 4217018858006524443",
    "branch": "https://github.com/tigerbeetle/tigerbeetle/tree/release"
  },
```

Unfortunately, I _think_ we'd have to clean out bad data data from DevHubDB, since its leading to _correct counts but wrong durations_ in the UI:

<img width="1657" alt="Screenshot 2025-07-09 at 8 18 37 AM" src="https://github.com/user-attachments/assets/332a6ee1-f3dc-49fb-bd20-af7b071cec33" />
