### PR TITLE
VOPR: Fix false positive uncommitted header mismatch

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -935,9 +935,8 @@ pub const Simulator = struct {
             }
         }
 
-        if (core_recovering == 0) return false;
-
         const quorums = vsr.quorums(simulator.options.cluster.replica_count);
+        assert(quorums.view_change <= core_replicas);
         return quorums.view_change > core_replicas - core_recovering;
     }
 

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1327,7 +1327,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             for (journal.headers, 0..) |*header_untrusted, index| {
                 const slot = Slot{ .index = index };
                 if (header_ok(replica.cluster, slot, header_untrusted)) |header| {
-                    var view_range = view_change_headers.view_for_op(header.op, log_view);
+                    const view_range = view_change_headers.view_for_op(header.op, log_view);
                     assert(view_range.max <= log_view);
 
                     if (header.operation != .reserved and !view_range.contains(header.view)) {


### PR DESCRIPTION
## Bug

The (false-liveness) bug was originally found by CFO on a [PR](https://github.com/tigerbeetle/tigerbeetle/pull/3050#issuecomment-3042339827) but is unrelated to that change.

<details>
<summary>Stack trace</summary>

```
thread 53690 panic: reached unreachable code
/var/home/djg/C/bin/zig-x86_64-linux-0.14.1/lib/std/debug.zig:550:14: 0x1186c5d in assert (vopr)
    if (!ok) unreachable; // assertion failure
             ^
/var/home/djg/C/t/db/main/src/vopr.zig:1031:35: 0x12745b2 in core_missing_prepare (vopr)
                            assert(header_existing.view == header.view);
                                  ^
/var/home/djg/C/t/db/main/src/vopr.zig:834:54: 0x1273576 in cluster_recoverable (vopr)
        } else if (try simulator.core_missing_prepare(gpa)) |op| {
                                                     ^
/var/home/djg/C/t/db/main/src/vopr.zig:291:46: 0x1278ffe in main (vopr)
        if (try simulator.cluster_recoverable(gpa)) {
                                             ^
/var/home/djg/C/bin/zig-x86_64-linux-0.14.1/lib/std/start.zig:660:37: 0x121bf0a in posixCallMainAndExit (vopr)
            const result = root.main() catch |err| {
                                    ^
/var/home/djg/C/bin/zig-x86_64-linux-0.14.1/lib/std/start.zig:271:5: 0x121babd in _start (vopr)
    asm volatile (switch (native_arch) {
    ^
```

</details>

In `core_missing_prepare` we panic because we find two different versions of an uncommitted header (different views, same op) on replicas with the same `log_view`.

The core is (correctly) stuck unable to complete a view change (`quorum received, awaiting repair`):

```
[warn] (replica): 1: on_do_view_change: view=574 quorum received, awaiting repair
[debug] (replica): 1: on_do_view_change: dvc: replica=0 log_view=77 op=43 commit_min=19 checkpoint=19
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=43 checksum=90858606581083681804798268180609722043 nack=true present=false type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=42 checksum=25207739721414724739579623433639362773 nack=true present=false type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=41 checksum=230786532201043377860257200482069569495 nack=true present=false type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=40 checksum=111268384401053384633480741479385479397 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=0 op=39 checksum=165766723500108855116616181420408158704 nack=true present=false type=valid
[debug] (replica): 1: on_do_view_change: dvc: replica=1 log_view=77 op=44 commit_min=19 checkpoint=19
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=44 checksum=174260420033076603560095846963316969188 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=43 checksum=0 nack=false present=false type=blank
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=42 checksum=25207739721414724739579623433639362773 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=41 checksum=230786532201043377860257200482069569495 nack=false present=true type=valid
[debug] (replica): 1: on_do_view_change: dvc: header: replica=1 op=40 checksum=111268384401053384633480741479385479397 nack=false present=true type=valid
```

When the VOPR checks `core_missing_prepare`, we assemble a list of the uncommitted headers, but find a mismatch:

```zig
if (replica.journal.header_with_op(op)) |header| {
    if (uncommitted_headers[op % pipeline_max]) |header_existing| {
        assert(header_existing.op == header.op);
        assert(header_existing.view == header.view); // <-- PANIC!
        assert(header_existing.checksum == header.checksum);
    } else {
        uncommitted_headers[op % pipeline_max] = header.*;
    }
}
```

The uncommitted headers are pulled from the journals of the core replicas (`replica.journal.header_with_op`).
What happens in this seed is:

1. Replica 1: In view 76, prepare ops 42A and 43A as primary.
2. Replica 1: Join view 77, truncating 43A.
3. Replica 1: Write a reserved header to slot 43's redundant header.
4. Replica 1: Prepare op 44B.
5. Replica 1: Crash. Restart.
6. Replica 1: Slot 43 is recovered as case `@G → fix`. Even though 43A doesn't belong in this view, that will be resolved by header repair... or it would be, if the core could complete a view change.

## Fix

In `core_missing_prepare`, use the superblock's view headers when the replica is view changing.

### Fix (Alternate)

I considered instead solving this in `Journal.recover_slots`:

```zig
if (replica.superblock.working.vsr_state.log_view <
    replica.superblock.working.vsr_state.view)
{
    for (view_change_headers.slice) |*view_change_header| {
        if (journal.header_with_op(view_change_header.op)) |header| {
            if (vsr.Headers.dvc_header_type(view_change_header) == .blank) {
                assert(header.view < log_view);
                log.warn("{}: recover_slots: drop header due to blank " ++
                    "view={} op={} checksum={}", .{
                    journal.replica,
                    header.view,
                    header.op,
                    header.checksum,
                });
                journal.remove_entry(journal.slot_for_op(view_change_header.op));
            }
        }
    }
}
```

In one sense this makes sense, as it causes the recovered journal to more closely resemble the journal prior to the crash.

However, the journal state is not actually an issue -- header repair can handle it just fine.

---

(The seed reproduces on commit `a91e4e11199eb34807a8ae209ec5f6cc39aa0e82`.)

Seed: ./zig/zig build -Drelease vopr -- 17521837034643442761