### PR TITLE
docs: fix broken link to VSR paper

### DIFF
--- a/docs/concepts/safety.md
+++ b/docs/concepts/safety.md
@@ -26,7 +26,7 @@ might fail catastrophically (e.g. due to a fire in the data center). Primary/bac
 ad-hoc failover can lose data due to split-brain.
 
 To avoid these pitfalls, TigerBeetle implements pioneering
-[Viewstamped Replication](https://pmg.csail.mit.edu/papers/vr-revisited.pdf) and consensus algorithm,
+[Viewstamped Replication](http://pmg.csail.mit.edu/papers/vr-revisited.pdf) and consensus algorithm,
 that guarantees correct, automatic failover. It's worth emphasizing that consensus proper needs only
 be engaged during actual failover. During the normal operation, the cost of consensus is just the
 cost of replication, which is further minimized because of

--- a/src/docs_website/src/file_checker.zig
+++ b/src/docs_website/src/file_checker.zig
@@ -142,6 +142,7 @@ fn read_file_cached(arena: std.mem.Allocator, dir: std.fs.Dir, path: []const u8)
 // These links don't work with https.
 const http_exceptions = std.StaticStringMap(void).initComptime(.{
     .{"http://www.bailis.org/blog/linearizability-versus-serializability/"},
+    .{"http://pmg.csail.mit.edu/papers/vr-revisited.pdf"},
 });
 
 // These links cause TLS errors with std.http.Client.


### PR DESCRIPTION
It's been a month and HTTPS hasn't been restored on the csail server (https://lobste.rs/s/oei5fj/jepsen_tigerbeetle_0_16_11#c_jdcqqi). Changing to HTTP.