### PR TITLE
Move `Tracer` initialization into `main`

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -130,7 +130,7 @@ const Environment = struct {
         env.trace = try Storage.Tracer.init(
             gpa,
             env.time_sim.time(),
-            .{ .replica = .{ .cluster = 0, .replica_index = replica } },
+            .{ .replica = .{ .cluster = 0, .replica = replica } },
             .{},
         );
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -127,7 +127,12 @@ const Environment = struct {
         env.storage = storage;
 
         env.time_sim = TimeSim.init_simple();
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), 0, replica, .{});
+        env.trace = try Storage.Tracer.init(
+            gpa,
+            env.time_sim.time(),
+            .{ .replica = .{ .cluster = 0, .replica_index = replica } },
+            .{},
+        );
 
         env.superblock = try SuperBlock.init(gpa, .{
             .storage = env.storage,

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -296,11 +296,11 @@ const Environment = struct {
         env.time_sim = TimeSim.init_simple();
 
         fields_initialized += 1;
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), 0, 0, .{});
+        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .unknown, .{});
         errdefer env.trace.deinit(gpa);
 
         fields_initialized += 1;
-        env.trace_verify = try Storage.Tracer.init(gpa, env.time_sim.time(), 0, 0, .{});
+        env.trace_verify = try Storage.Tracer.init(gpa, env.time_sim.time(), .unknown, .{});
         errdefer env.trace_verify.deinit(gpa);
 
         fields_initialized += 1;
@@ -562,7 +562,7 @@ const Environment = struct {
             test_storage.reset();
 
             test_trace.deinit(env.gpa);
-            test_trace.* = try Storage.Tracer.init(env.gpa, env.time_sim.time(), 0, 0, .{});
+            test_trace.* = try Storage.Tracer.init(env.gpa, env.time_sim.time(), .unknown, .{});
 
             // Reset the state so that the manifest log (and dependencies) can be reused.
             // Do not "defer deinit()" because these are cleaned up by Env.deinit().

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -296,11 +296,11 @@ const Environment = struct {
         env.time_sim = TimeSim.init_simple();
 
         fields_initialized += 1;
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .unknown, .{});
+        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .replica_test, .{});
         errdefer env.trace.deinit(gpa);
 
         fields_initialized += 1;
-        env.trace_verify = try Storage.Tracer.init(gpa, env.time_sim.time(), .unknown, .{});
+        env.trace_verify = try Storage.Tracer.init(gpa, env.time_sim.time(), .replica_test, .{});
         errdefer env.trace_verify.deinit(gpa);
 
         fields_initialized += 1;
@@ -562,7 +562,12 @@ const Environment = struct {
             test_storage.reset();
 
             test_trace.deinit(env.gpa);
-            test_trace.* = try Storage.Tracer.init(env.gpa, env.time_sim.time(), .unknown, .{});
+            test_trace.* = try Storage.Tracer.init(
+                env.gpa,
+                env.time_sim.time(),
+                .replica_test,
+                .{},
+            );
 
             // Reset the state so that the manifest log (and dependencies) can be reused.
             // Do not "defer deinit()" because these are cleaned up by Env.deinit().

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -516,7 +516,7 @@ const Environment = struct {
         prng: *stdx.PRNG,
     ) !void {
         env.time_sim = TimeSim.init_simple();
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), 0, 0, .{});
+        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .unknown, .{});
         errdefer env.trace.deinit(gpa);
 
         env.* = .{

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -516,7 +516,7 @@ const Environment = struct {
         prng: *stdx.PRNG,
     ) !void {
         env.time_sim = TimeSim.init_simple();
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .unknown, .{});
+        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .replica_test, .{});
         errdefer env.trace.deinit(gpa);
 
         env.* = .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -165,7 +165,12 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.storage = storage;
 
             env.time_sim = TimeSim.init_simple();
-            env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), 0, replica, .{});
+            env.trace = try Storage.Tracer.init(
+                gpa,
+                env.time_sim.time(),
+                .{ .replica = .{ .cluster = 0, .replica_index = replica } },
+                .{},
+            );
             defer env.trace.deinit(gpa);
 
             env.superblock = try SuperBlock.init(gpa, .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -168,7 +168,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.trace = try Storage.Tracer.init(
                 gpa,
                 env.time_sim.time(),
-                .{ .replica = .{ .cluster = 0, .replica_index = replica } },
+                .{ .replica = .{ .cluster = 0, .replica = replica } },
                 .{},
             );
             defer env.trace.deinit(gpa);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5103,7 +5103,7 @@ pub const TestContext = struct {
         errdefer ctx.storage.deinit(allocator);
         ctx.time_sim = TimeSim.init_simple();
 
-        ctx.trace = try Tracer.init(allocator, ctx.time_sim.time(), .unknown, .{});
+        ctx.trace = try Tracer.init(allocator, ctx.time_sim.time(), .replica_test, .{});
         errdefer ctx.trace.deinit(allocator);
 
         ctx.superblock = try SuperBlock.init(allocator, .{

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5103,7 +5103,7 @@ pub const TestContext = struct {
         errdefer ctx.storage.deinit(allocator);
         ctx.time_sim = TimeSim.init_simple();
 
-        ctx.trace = try Tracer.init(allocator, ctx.time_sim.time(), 0, 0, .{});
+        ctx.trace = try Tracer.init(allocator, ctx.time_sim.time(), .unknown, .{});
         errdefer ctx.trace.deinit(allocator);
 
         ctx.superblock = try SuperBlock.init(allocator, .{

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -714,6 +714,18 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 }
             } else unreachable;
 
+            // Re-initialize the trace to get a clean state.
+            cluster.replica_tracers[replica_index].deinit(cluster.allocator);
+            cluster.replica_tracers[replica_index] = try Tracer.init(
+                cluster.allocator,
+                cluster.replica_times[replica_index].time(),
+                .{ .replica = .{
+                    .cluster = cluster.replicas[replica_index].cluster,
+                    .replica = @intCast(replica_index),
+                } },
+                .{},
+            );
+
             cluster.releases_bundled[replica_index] = options.releases_bundled.*;
             cluster.aofs[replica_index].reset();
             cluster.aof_ios[replica_index].reset();

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -269,12 +269,14 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             errdefer allocator.free(replica_tracers);
 
             for (replica_tracers, 0..) |*tracer, replica_index| {
+                errdefer for (replica_tracers[0..replica_index]) |*t| t.deinit(allocator);
                 const time = replica_times[replica_index].time();
                 tracer.* = try Tracer.init(allocator, time, .{ .replica = .{
                     .cluster = options.cluster.cluster_id,
                     .replica_index = @intCast(replica_index),
                 } }, .{});
             }
+            errdefer for (replica_tracers) |*tracer| tracer.deinit(allocator);
 
             const replicas = try allocator.alloc(Replica, node_count);
             errdefer allocator.free(replicas);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -273,7 +273,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 const time = replica_times[replica_index].time();
                 tracer.* = try Tracer.init(allocator, time, .{ .replica = .{
                     .cluster = options.cluster.cluster_id,
-                    .replica_index = @intCast(replica_index),
+                    .replica = @intCast(replica_index),
                 } }, .{});
             }
             errdefer for (replica_tracers) |*tracer| tracer.deinit(allocator);

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -237,7 +237,7 @@ fn tidy_long_line(file: SourceFile) !?u32 {
 
                 // trace.zig's JSON snapshot test.
                 if (std.mem.endsWith(u8, file.path, "trace.zig") and
-                    std.mem.startsWith(u8, string_value, "{\"pid\":0,\"tid\":")) continue;
+                    std.mem.startsWith(u8, string_value, "{\"pid\":_,\"tid\":")) continue;
 
                 // AMQP encoder snapshot test.
                 if (std.mem.endsWith(u8, file.path, "cdc/amqp/protocol.zig") and

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -237,7 +237,7 @@ fn tidy_long_line(file: SourceFile) !?u32 {
 
                 // trace.zig's JSON snapshot test.
                 if (std.mem.endsWith(u8, file.path, "trace.zig") and
-                    std.mem.startsWith(u8, string_value, "{\"pid\":_,\"tid\":")) continue;
+                    std.mem.startsWith(u8, string_value, "{\"pid\":0,\"tid\":")) continue;
 
                 // AMQP encoder snapshot test.
                 if (std.mem.endsWith(u8, file.path, "cdc/amqp/protocol.zig") and

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -450,9 +450,8 @@ const start_defaults_development = StartDefaults{
 const lsm_compaction_block_count_min = StateMachine.Forest.Options.compaction_block_count_min;
 const lsm_compaction_block_memory_min = lsm_compaction_block_count_min * constants.block_size;
 
-/// While CLIArgs store raw arguments as passed on the command line, Command ensures that
-/// arguments are properly validated and desugared (e.g, sizes converted to counts where
-///  appropriate).
+/// While CLIArgs store raw arguments as passed on the command line, Command ensures that arguments
+/// are properly validated and desugared (e.g, sizes converted to counts where appropriate).
 pub const Command = union(enum) {
     const Addresses = stdx.BoundedArrayType(std.net.Address, constants.members_max);
     const Path = stdx.BoundedArrayType(u8, std.fs.max_path_bytes);

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -150,6 +150,13 @@ pub const ProcessID = union(enum) {
             .replica => |replica| try writer.print("{d}", .{replica.replica}),
         };
     }
+
+    pub fn json(self: ProcessID) u8 {
+        return switch (self) {
+            .unknown => 0,
+            .replica => |replica| replica.replica,
+        };
+    }
 };
 
 pub const Options = struct {
@@ -284,7 +291,7 @@ pub fn start(tracer: *Tracer, event: Event) void {
         "\"name\":\"{[category]s} {[event_tracing]} {[event_timing]}\"," ++
         "\"args\":{[args]s}" ++
         "}},\n", .{
-        .process_id = tracer.process_id,
+        .process_id = tracer.process_id.json(),
         .thread_id = event_tracing.stack(),
         .category = @tagName(event),
         .event = 'B',
@@ -367,7 +374,7 @@ fn write_stop(tracer: *Tracer, stack: u32, time_elapsed: stdx.Duration) void {
             "\"ts\":{[timestamp]}" ++
             "}},\n",
         .{
-            .process_id = tracer.process_id,
+            .process_id = tracer.process_id.json(),
             .thread_id = stack,
             .event = 'E',
             .timestamp = time_elapsed.us(),

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -136,7 +136,7 @@ pub const ProcessID = union(enum) {
     },
 
     pub fn format(
-        self: @This(),
+        self: ProcessID,
         comptime fmt: []const u8,
         options: std.fmt.FormatOptions,
         writer: anytype,
@@ -220,7 +220,7 @@ pub fn deinit(tracer: *Tracer, allocator: std.mem.Allocator) void {
 
 /// We learn the cluster id and replica index after opening the datafile.
 pub fn set_replica(tracer: *Tracer, options: struct { cluster: u128, replica: u8 }) void {
-    const process_id = ProcessID{ .replica = .{
+    const process_id: ProcessID = .{ .replica = .{
         .cluster = options.cluster,
         .replica_index = options.replica,
     } };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -596,7 +596,7 @@ pub fn ReplicaType(
         /// Simulator hooks.
         event_callback: ?*const fn (replica: *const Replica, event: ReplicaEvent) void = null,
 
-        trace: Tracer,
+        trace: *Tracer,
         trace_emit_timeout: Timeout,
 
         aof: ?*AOF,
@@ -614,7 +614,7 @@ pub fn ReplicaType(
             aof: ?*AOF,
             state_machine_options: StateMachine.Options,
             message_bus_options: MessageBus.Options,
-            tracer_options: Tracer.Options = .{},
+            tracer: *Tracer,
             grid_cache_blocks_count: u32 = Grid.Cache.value_count_max_multiple,
             release: vsr.Release,
             release_client_min: vsr.Release,
@@ -678,14 +678,11 @@ pub fn ReplicaType(
                 return error.NoAddress;
             }
 
-            self.trace = try Tracer.init(
-                allocator,
-                options.time,
-                self.superblock.working.cluster,
-                replica,
-                options.tracer_options,
-            );
-            errdefer if (!initialized) self.trace.deinit(allocator);
+            self.trace = options.tracer;
+            self.trace.set_replica(.{
+                .cluster = self.superblock.working.cluster,
+                .replica = replica,
+            });
 
             // Initialize the replica:
             try self.init(allocator, .{
@@ -1208,7 +1205,7 @@ pub fn ReplicaType(
 
             self.grid = try Grid.init(allocator, .{
                 .superblock = &self.superblock,
-                .trace = &self.trace,
+                .trace = self.trace,
                 .cache_blocks_count = options.grid_cache_blocks_count,
                 .missing_blocks_max = constants.grid_missing_blocks_max,
                 .missing_tables_max = constants.grid_missing_tables_max,
@@ -1415,7 +1412,7 @@ pub fn ReplicaType(
                 .aof = options.aof,
                 .replicate_options = options.replicate_options,
             };
-            options.storage.set_tracer(&self.trace);
+            options.storage.set_tracer(self.trace);
             self.routing.view_change(self.view);
 
             log.debug("{}: init: replica_count={} quorum_view_change={} quorum_replication={} " ++
@@ -1434,7 +1431,6 @@ pub fn ReplicaType(
         pub fn deinit(self: *Replica, allocator: Allocator) void {
             self.static_allocator.transition_from_static_to_deinit();
 
-            self.trace.deinit(allocator);
             self.grid_scrubber.deinit(allocator);
             self.client_replies.deinit();
             self.client_sessions_checkpoint.deinit(allocator);


### PR DESCRIPTION
This change moves the initialization of `Tracer` from `Replica.open` to `main.Command.start`. And in src/testing/cluster.zig `Cluster.init` now initializes traces for each replica.

Once the cluster id and replica index are read from the datafile, the tracer is updated via `Tracer.set_replica`.

The goal is to make tracer more generally available for logging purposes.