### PR TITLE
node client: Fix for Node v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '21'    }
           - { os: 'ubuntu-latest',  language: 'node',    language_version: '18.x'  }
           - { os: 'ubuntu-latest',  language: 'node',    language_version: '20.x'  }
+          - { os: 'ubuntu-latest',  language: 'node',    language_version: '24.x'  }
 
           # Support Python 3.7 explicitly, even though it's EOL.
           - { os: 'ubuntu-22.04',  language: 'python',  language_version: '3.7'    }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '11'    }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '21'    }
           - { os: 'ubuntu-latest',  language: 'node',    language_version: '18.x'  }
-          - { os: 'ubuntu-latest',  language: 'node',    language_version: '20.x'  }
           - { os: 'ubuntu-latest',  language: 'node',    language_version: '24.x'  }
 
           # Support Python 3.7 explicitly, even though it's EOL.

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -165,7 +165,11 @@ export function id(): bigint {
     timestamp = idLastTimestamp
   } else {
     idLastTimestamp = timestamp
-    randomFillSync(idLastBuffer)
+    // NB: in Node 24 (24.0.2) randomFillSync appears to not accept a DataView,
+    // contrary to its documentation and previous behavior. As workaround
+    // we turn the DataView it into a typed array buffer and fill that.
+    const array = new Uint8Array(idLastBuffer.buffer, idLastBuffer.byteOffset, idLastBuffer.byteLength);
+    randomFillSync(array)
   }
 
   // Increment the u80 in idLastBuffer using carry arithmetic on u32s (as JS doesn't have fast u64).

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -149,7 +149,14 @@ export function createClient (args: ClientInitArgs): Client {
 }
 
 let idLastTimestamp = 0;
-let idLastBuffer = new DataView(new ArrayBuffer(16));
+
+// These are two references to the same buffer.
+// We only need the `Uint8Array` because in Node 24, but not earlier, `crypto.randomFillSync`
+// rejects `DataView` typed arguments.
+const idLastBuffer = new DataView(new ArrayBuffer(16));
+const idLastBufferArray = new Uint8Array(
+    idLastBuffer.buffer, idLastBuffer.byteOffset, idLastBuffer.byteLength
+);
 
 /**
  * Generates a Universally Unique and Sortable Identifier as a u128 bigint.
@@ -165,11 +172,7 @@ export function id(): bigint {
     timestamp = idLastTimestamp
   } else {
     idLastTimestamp = timestamp
-    // NB: in Node 24 (24.0.2) randomFillSync appears to not accept a DataView,
-    // contrary to its documentation and previous behavior. As workaround
-    // we turn the DataView it into a typed array buffer and fill that.
-    const array = new Uint8Array(idLastBuffer.buffer, idLastBuffer.byteOffset, idLastBuffer.byteLength);
-    randomFillSync(array)
+    randomFillSync(idLastBufferArray)
   }
 
   // Increment the u80 in idLastBuffer using carry arithmetic on u32s (as JS doesn't have fast u64).


### PR DESCRIPTION
It appears that the node client doesn't work on Node v24 (the latest, released in May), with the tests failing with the following:

```
$ node dist/test
id() monotonically increasing: FAILED
operator: undefined
stack: TypeError [ERR_INVALID_ARG_TYPE]: The "buf" argument must be an instance of ArrayBuffer or ArrayBufferView. Received an instance of DataView
    at randomFillSync (node:internal/crypto/random:120:11)
    at id (/home/brian/.homes/dev/tigerbeetle/src/clients/node/dist/index.js:105:42)
    at Object.fn (/home/brian/.homes/dev/tigerbeetle/src/clients/node/dist/test.js:56:31)
    at async main (/home/brian/.homes/dev/tigerbeetle/src/clients/node/dist/test.js:1243:13)
```

What is happening is that the `randomFillSync` function is rejecting the type of the `DataView` argument passed into it, which we use to generate ids.

It _appears_ that in node 24 `randomFillSync` no longer accepts a `DataView` argument, even though the docs indicate it does. It's almost unbelievable - I can find no reference to this backwards-incompatible change, but I have tested it locally with prior versions of Node.

This PR first adds CI for node 24 to confirm the test failure. Then I'll add the patch to fix the failure.