### PR TITLE
ewah: fix decoding bigger free set into smaller

### DIFF
--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -35,7 +35,7 @@ pub fn ewah(comptime Word: type) type {
         pub const MarkerUniformCount = std.meta.Int(.unsigned, word_bits / 2 - 1); // Word=u64 → u31
         pub const MarkerLiteralCount = std.meta.Int(.unsigned, word_bits / 2); // Word=u64 → u32
 
-        const Marker = packed struct(Word) {
+        pub const Marker = packed struct(Word) {
             // Whether the uniform word is all 0s or all 1s.
             uniform_bit: u1,
             // 31-bit number of uniform words following the marker.
@@ -173,6 +173,8 @@ pub fn ewah(comptime Word: type) type {
             /// be copied.
             literal_word_count: usize = 0,
 
+            trailing_zero_runs_count: usize = 0,
+
             /// Returns the number of bytes written to `target_chunk` by this invocation.
             pub fn encode_chunk(encoder: *Encoder, target_chunk: []align(@alignOf(Word)) u8) usize {
                 const source_words = encoder.source_words;
@@ -257,6 +259,13 @@ pub fn ewah(comptime Word: type) type {
                     target_index += literal_word_count_chunk;
 
                     encoder.literal_word_count = literal_word_count - literal_word_count_chunk;
+
+                    if (uniform_bit == 0 and literal_word_count == 0) {
+                        assert(uniform_word_count > 0);
+                        encoder.trailing_zero_runs_count += 1;
+                    } else {
+                        encoder.trailing_zero_runs_count = 0;
+                    }
                 }
                 assert(source_index <= source_words.len);
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -140,8 +140,7 @@ const Environment = struct {
             .missing_blocks_max = 0,
             .missing_tables_max = 0,
             .blocks_released_prior_checkpoint_durability_max = Forest
-                .compaction_blocks_released_per_pipeline_max() +
-                Grid.free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
+                .compaction_blocks_released_per_pipeline_max(),
         });
 
         env.scan_lookup_buffer = try gpa.alloc(

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -328,8 +328,7 @@ const Environment = struct {
             .missing_tables_max = 0,
             // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
             // FreeSet.blocks_released_prior_checkpoint_durability.
-            .blocks_released_prior_checkpoint_durability_max = Grid
-                .free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
+            .blocks_released_prior_checkpoint_durability_max = 0,
         });
         errdefer env.grid.deinit(gpa);
 

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -541,8 +541,7 @@ const Environment = struct {
                 .missing_tables_max = 0,
                 // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
                 // FreeSet.blocks_released_prior_checkpoint_durability.
-                .blocks_released_prior_checkpoint_durability_max = Grid
-                    .free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
+                .blocks_released_prior_checkpoint_durability_max = 0,
             }),
             .forest = undefined,
             .model = .{},

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -181,8 +181,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 .missing_tables_max = 0,
                 // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
                 // FreeSet.blocks_released_prior_checkpoint_durability.
-                .blocks_released_prior_checkpoint_durability_max = Grid
-                    .free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
+                .blocks_released_prior_checkpoint_durability_max = 0,
             });
             defer env.grid.deinit(gpa);
 

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -74,7 +74,7 @@ pub const StorageChecker = struct {
         var free_set = try vsr.FreeSet.init(
             allocator,
             .{
-                .blocks_count = Storage.grid_blocks_max,
+                .grid_size_limit = Storage.grid_blocks_max * constants.block_size,
                 .blocks_released_prior_checkpoint_durability_max = 0,
             },
         );

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -83,7 +83,7 @@ pub const StorageChecker = struct {
         var client_sessions = try vsr.ClientSessions.init(allocator);
         errdefer client_sessions.deinit(allocator);
 
-        const free_set_size = vsr.FreeSet.encode_size_max(Storage.grid_blocks_max);
+        const free_set_size = free_set.encode_size_max();
 
         const free_set_blocks_acquired_encoded =
             try allocator.alignedAlloc(u8, @alignOf(u64), free_set_size);

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -234,11 +234,13 @@ fn inspect_constants(output: std.io.AnyWriter) !void {
                 CheckpointTrailer.block_count_for_trailer_size(vsr.ClientSessions.encode_size)),
             std.hash_map.default_max_load_percentage,
         );
+
+        const blocks_count_storage_limit = vsr.block_count_max(datafile_size);
+        const blocks_count_free_set = vsr.FreeSet.block_count_max(blocks_count_storage_limit);
+
         try output.print("{:.2}\n", .{std.fmt.fmtIntSizeBin(
-            // HashMap of block addresses.
-            hashmap_entries * @sizeOf(u64) +
-                // Two bitsets with bit per block.
-                2 * stdx.div_ceil(vsr.block_count_max(datafile_size), 8),
+            // HashMap of block addresses plus two bitsets with bit per block.
+            hashmap_entries * @sizeOf(u64) + 2 * stdx.div_ceil(blocks_count_free_set, 8),
         )});
     }
 }

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -24,8 +24,6 @@ const SuperBlockQuorums = vsr.superblock.Quorums;
 const StateMachine = @import("main.zig").StateMachine;
 const BlockPtr = vsr.grid.BlockPtr;
 const BlockPtrConst = vsr.grid.BlockPtrConst;
-const CheckpointTrailer = vsr.CheckpointTrailerType(Storage);
-const Grid = vsr.GridType(Storage);
 const allocate_block = vsr.grid.allocate_block;
 const is_composite_key = vsr.lsm.composite_key.is_composite_key;
 
@@ -227,20 +225,27 @@ fn inspect_constants(output: std.io.AnyWriter) !void {
     });
 
     {
+        const grid_size_limit = datafile_size - vsr.superblock.data_file_size_min;
+        const blocks_count = vsr.FreeSet.block_count_max(grid_size_limit);
+        const ewah = vsr.ewah(vsr.FreeSet.Word);
+
+        // 2x since both `blocks_acquired` and `blocks_released` are encoded.
+        const free_set_encoded_blocks_max = 2 *
+            vsr.checkpoint_trailer.block_count_for_trailer_size(ewah.encode_size_max(blocks_count));
+
+        const client_sessions_encoded_blocks_max =
+            vsr.checkpoint_trailer.block_count_for_trailer_size(vsr.ClientSessions.encode_size);
+
         try print_header(output, 0, "free_set");
         const hashmap_entries = stdx.div_ceil(
             100 * (StateMachine.Forest.compaction_blocks_released_per_pipeline_max() +
-                Grid.free_set_checkpoints_blocks_max(datafile_size) +
-                CheckpointTrailer.block_count_for_trailer_size(vsr.ClientSessions.encode_size)),
+                free_set_encoded_blocks_max + client_sessions_encoded_blocks_max),
             std.hash_map.default_max_load_percentage,
         );
 
-        const blocks_count_storage_limit = vsr.block_count_max(datafile_size);
-        const blocks_count_free_set = vsr.FreeSet.block_count_max(blocks_count_storage_limit);
-
         try output.print("{:.2}\n", .{std.fmt.fmtIntSizeBin(
             // HashMap of block addresses plus two bitsets with bit per block.
-            hashmap_entries * @sizeOf(u64) + 2 * stdx.div_ceil(blocks_count_free_set, 8),
+            hashmap_entries * @sizeOf(u64) + 2 * stdx.div_ceil(blocks_count, 8),
         )});
     }
 }
@@ -818,13 +823,12 @@ const Inspector = struct {
         // This is not exact, but is an overestimate:
         const grid_blocks_max =
             @divFloor(constants.storage_size_limit_max, constants.block_size);
-        const free_set_block_addresses_count = free_set_blocks_acquired_addresses.items.len +
-            free_set_blocks_released_addresses.items.len;
+
         var free_set = try vsr.FreeSet.init(
             inspector.allocator,
             .{
-                .blocks_count = grid_blocks_max,
-                .blocks_released_prior_checkpoint_durability_max = free_set_block_addresses_count,
+                .grid_size_limit = grid_blocks_max * constants.block_size,
+                .blocks_released_prior_checkpoint_durability_max = 0,
             },
         );
         defer free_set.deinit(inspector.allocator);

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1748,14 +1748,3 @@ pub const Budget = struct {
         budget.available = @min((budget.available + amount), budget.capacity);
     }
 };
-<<<<<<< HEAD
-
-pub fn block_count_max(storage_size_limit: u64) usize {
-    const shard_count_limit: usize = @intCast(@divFloor(
-        storage_size_limit - superblock.data_file_size_min,
-        constants.block_size * FreeSet.shard_bits,
-    ));
-    return shard_count_limit * FreeSet.shard_bits;
-}
-=======
->>>>>>> f6d5ccc7f (free_set: refactor overloaded usage of blocks_count_max)

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -41,6 +41,8 @@ pub const testing = .{
     .IdPermutation = @import("testing/id.zig").IdPermutation,
     .parse_seed = @import("testing/fuzz.zig").parse_seed,
 };
+pub const ewah = @import("ewah.zig").ewah;
+pub const checkpoint_trailer = @import("vsr/checkpoint_trailer.zig");
 
 pub const multi_batch = @import("vsr/multi_batch.zig");
 
@@ -1746,6 +1748,7 @@ pub const Budget = struct {
         budget.available = @min((budget.available + amount), budget.capacity);
     }
 };
+<<<<<<< HEAD
 
 pub fn block_count_max(storage_size_limit: u64) usize {
     const shard_count_limit: usize = @intCast(@divFloor(
@@ -1754,3 +1757,5 @@ pub fn block_count_max(storage_size_limit: u64) usize {
     ));
     return shard_count_limit * FreeSet.shard_bits;
 }
+=======
+>>>>>>> f6d5ccc7f (free_set: refactor overloaded usage of blocks_count_max)

--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -13,6 +13,31 @@ const constants = @import("../constants.zig");
 const FreeSet = @import("./free_set.zig").FreeSet;
 const BlockType = schema.BlockType;
 
+// Body of the block which holds encoded trailer data.
+// All chunks except for possibly the last one are full.
+const chunk_size_max = constants.block_size - @sizeOf(vsr.Header);
+
+// Chunk describes a slice of encoded trailer that goes into nth block on disk.
+const Chunk = struct {
+    fn size(options: struct {
+        block_index: u32,
+        block_count: u32,
+        trailer_size: u64,
+    }) u32 {
+        assert(options.block_count > 0);
+        assert(options.block_count == stdx.div_ceil(options.trailer_size, chunk_size_max));
+        assert(options.block_index < options.block_count);
+
+        const last_block = options.block_index == options.block_count - 1;
+        const chunk_size: u32 = if (last_block)
+            @intCast(options.trailer_size - (options.block_count - 1) * chunk_size_max)
+        else
+            chunk_size_max;
+
+        return chunk_size;
+    }
+};
+
 /// CheckpointTrailer is the persistent representation of the free set and client sessions.
 /// It defines the layout of the free set and client sessions as stored in the grid between
 /// checkpoints.
@@ -35,31 +60,6 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
 
     return struct {
         const CheckpointTrailer = @This();
-
-        // Body of the block which holds encoded trailer data.
-        // All chunks except for possibly the last one are full.
-        const chunk_size_max = constants.block_size - @sizeOf(vsr.Header);
-
-        // Chunk describes a slice of encoded trailer that goes into nth block on disk.
-        const Chunk = struct {
-            fn size(options: struct {
-                block_index: u32,
-                block_count: u32,
-                trailer_size: u64,
-            }) u32 {
-                assert(options.block_count > 0);
-                assert(options.block_count == stdx.div_ceil(options.trailer_size, chunk_size_max));
-                assert(options.block_index < options.block_count);
-
-                const last_block = options.block_index == options.block_count - 1;
-                const chunk_size: u32 = if (last_block)
-                    @intCast(options.trailer_size - (options.block_count - 1) * chunk_size_max)
-                else
-                    chunk_size_max;
-
-                return chunk_size;
-            }
-        };
 
         // Reference to the grid is late-initialized in `open`, because the free set is part of
         // the grid, which doesn't have access to a stable grid pointer. It is set to null by
@@ -163,10 +163,6 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
 
         pub fn block_count(trailer: *const CheckpointTrailer) u32 {
             return block_count_for_trailer_size(trailer.size);
-        }
-
-        pub fn block_count_for_trailer_size(trailer_size: u64) u32 {
-            return @intCast(stdx.div_ceil(trailer_size, chunk_size_max));
         }
 
         /// Each returned chunk has `chunk.len == chunk_size_max`.
@@ -451,6 +447,10 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
             callback(trailer);
         }
     };
+}
+
+pub fn block_count_for_trailer_size(trailer_size: u64) u32 {
+    return @intCast(stdx.div_ceil(trailer_size, chunk_size_max));
 }
 
 pub const TrailerType = enum {

--- a/src/vsr/free_set.zig
+++ b/src/vsr/free_set.zig
@@ -622,11 +622,7 @@ pub const FreeSet = struct {
     }
 
     /// Decodes the compressed bitset chunks in `source_chunks` into `target_bitset`.
-<<<<<<< HEAD
     /// Panics if the `source_chunks` encoding is invalid.
-=======
-    /// Panic if the `source_chunks` encoding is invalid.
->>>>>>> f6d5ccc7f (free_set: refactor overloaded usage of blocks_count_max)
     fn decode(
         set: *FreeSet,
         target_bitset: FreeSet.BitsetKind,
@@ -1119,10 +1115,18 @@ fn expect_free_set_equal(a: FreeSet, b: FreeSet) !void {
     try expect_bit_set_equal(a.blocks_acquired, b.blocks_acquired);
     try expect_bit_set_equal(a.blocks_released, b.blocks_released);
     try expect_bit_set_equal(a.index, b.index);
+
     try std.testing.expectEqual(
+        a.blocks_released_prior_checkpoint_durability.count(),
+        b.blocks_released_prior_checkpoint_durability.count(),
+    );
+
+    for (
         a.blocks_released_prior_checkpoint_durability.keys(),
         b.blocks_released_prior_checkpoint_durability.keys(),
-    );
+    ) |address_a, address_b| {
+        assert(address_a == address_b);
+    }
 }
 
 fn expect_bit_set_equal(a: DynamicBitSetUnmanaged, b: DynamicBitSetUnmanaged) !void {

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -220,7 +220,7 @@ pub fn GridType(comptime Storage: type) type {
             blocks_released_prior_checkpoint_durability_max: usize,
         }) !Grid {
             var free_set = try FreeSet.init(allocator, .{
-                .blocks_count = vsr.block_count_max(options.superblock.storage_size_limit),
+                .grid_size_limit = options.superblock.grid_size_limit(),
                 .blocks_released_prior_checkpoint_durability_max = options
                     .blocks_released_prior_checkpoint_durability_max,
             });
@@ -1325,16 +1325,6 @@ pub fn GridType(comptime Storage: type) type {
                 );
                 return request_faults_count + request_repairs_count;
             }
-        }
-
-        pub fn free_set_checkpoints_blocks_max(storage_size_limit: u64) usize {
-            const ewah = @import("../ewah.zig").ewah(FreeSet.Word);
-
-            const blocks_count_storage_limit = vsr.block_count_max(storage_size_limit);
-            const blocks_count_free_set = FreeSet.block_count_max(blocks_count_storage_limit);
-
-            const free_set_encoded_size = ewah.encode_size_max(blocks_count_free_set);
-            return 2 * CheckpointTrailer.block_count_for_trailer_size(free_set_encoded_size);
         }
 
         fn block_offset(address: u64) u64 {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1214,8 +1214,7 @@ pub fn ReplicaType(
                 .missing_tables_max = constants.grid_missing_tables_max,
                 .blocks_released_prior_checkpoint_durability_max = Forest
                     .compaction_blocks_released_per_pipeline_max() +
-                    Grid.free_set_checkpoints_blocks_max(self.superblock.storage_size_limit) +
-                    CheckpointTrailer.block_count_for_trailer_size(ClientSessions.encode_size),
+                    vsr.checkpoint_trailer.block_count_for_trailer_size(ClientSessions.encode_size),
             });
             errdefer self.grid.deinit(allocator);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4968,7 +4968,7 @@ pub fn ReplicaType(
                 if (self.grid.free_set.highest_address_acquired()) |address| {
                     assert(address > 0);
                     assert(self.grid.free_set_checkpoint_blocks_acquired.size > 0);
-                    assert(self.grid.free_set_checkpoint_blocks_released.size > 0);
+                    maybe(self.grid.free_set_checkpoint_blocks_released.size == 0);
 
                     storage_size += address * constants.block_size;
                 } else {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1150,6 +1150,10 @@ pub fn SuperBlockType(comptime Storage: type) type {
             superblock.acquire(context);
         }
 
+        pub fn grid_size_limit(superblock: *const SuperBlock) usize {
+            return superblock.storage_size_limit - data_file_size_min;
+        }
+
         pub fn updating(superblock: *const SuperBlock, caller: Caller) bool {
             assert(superblock.opened);
 


### PR DESCRIPTION
Currently, our `--limit-storage` configuration is broken -- it can be increased but not decreased. This is because our EWAH decoder does not allow decoding a bigger free-set into a smaller free-set, even if there are no set bits in the bigger free set past the smaller free set's capacity!

 This PR changes our EWAH decoder to optimistically continue even if the target buffer is exhausted, _iff_ the data that is being decoded is all 0s. If the decoder encounters a 1 bit that can't be accommodated in the target buffer (could be in a literal word, or a uniform word), it now throws `error.TargetTooSmall`. At the FreeSet level, decoding the encoded free-set simply panics if the target buffer is too small, since this would be a bug and should have been caught by: https://github.com/tigerbeetle/tigerbeetle/blob/86b85ab60395dedec8b1c47df062cb2b840c9413/src/vsr/superblock.zig#L1504-L1517


After this change, for a data file which is `16253.5MiB` in size and  that is populated using the _default_ --limit-storage (16 TiB), we can start up TB using as little as `16254MiB` (although there isn't much utility as reservations would fail soon after)!

```C
./tigerbeetle start --addresses=3001 --limit-storage=16253MiB --experimental data.tigerbeetle // Doesn't work, too small

2025-07-17 18:25:44.369Z error(vsr): data file too large size=17043030016 > limit=16077815808, restart the replica increasing '--limit-storage'

./tigerbeetle start --addresses=3001 --limit-storage=16254MiB --experimental data.tigerbeetle // Works
````