### PR TITLE
vsr: track requested prepares so they're repaired once per timeout

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1084,6 +1084,8 @@ pub fn ReplicaType(
                     .refill_max = repair_messages_budget_journal_refill,
                 },
             );
+            errdefer self.repair_messages_budget_journal.deinit(allocator);
+
             assert(self.repair_messages_budget_journal.available ==
                 self.repair_messages_budget_journal.capacity);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10525,21 +10525,19 @@ pub fn ReplicaType(
                         });
                     }
 
-                    if (self.repair_messages_budget_journal.decrement(.{
-                        .start_view = header.view,
-                    })) {
-                        log.debug("{}: jump_view: requesting start_view message", .{self.replica});
-                        self.send_header_to_replica(
-                            self.primary_index(header.view),
-                            @bitCast(Header.RequestStartView{
-                                .command = .request_start_view,
-                                .cluster = self.cluster,
-                                .replica = self.replica,
-                                .view = header.view,
-                                .nonce = self.nonce,
-                            }),
-                        );
-                    }
+                    // TODO Debounce and decouple this from `on_message()` by moving into `tick()`:
+                    // (Using request_start_view_message_timeout).
+                    log.debug("{}: jump_view: requesting start_view message", .{self.replica});
+                    self.send_header_to_replica(
+                        self.primary_index(header.view),
+                        @bitCast(Header.RequestStartView{
+                            .command = .request_start_view,
+                            .cluster = self.cluster,
+                            .replica = self.replica,
+                            .view = header.view,
+                            .nonce = self.nonce,
+                        }),
+                    );
                 },
                 .view_change => {
                     assert(self.status == .normal or self.status == .view_change);


### PR DESCRIPTION
We maintain an invariant during WAL repair wherein we only send `request_prepare` for a missing prepare _at most once_ between repair timeouts. We do this by maintaining the _largest_ op # that has been requested, and this op # is reset at repair timeout. However, this is not the best way to enforce this invariant as a reordered network message could cause a larger op to be requested _before_ a smaller op. Consequently, the smaller op would only be requested after the repair timeout is triggered (~100ms), which degrades repair performance. 

This PR implements a different way to enforce this invariant, which ensures that each missing prepare is requested _exactly once_ between repair timeouts (provided the cluster is receiving traffic). Specifically, we maintain the set of inflight ops (which guards against duplicate `request_prepares`), and iterate through all the ops every time `repair` is invoked, to ensure the aforementioned scenario does not occur. 