### PR TITLE
VSR: Fix assert in commit stall

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4637,8 +4637,10 @@ pub fn ReplicaType(
                 }
                 break :commit_min_min min;
             };
-            assert(commit_min_min <= self.commit_min);
-            const commit_lag = self.commit_min - commit_min_min;
+            // An old primary may have committed ahead of us (the new primary), but not participated
+            // in the DVC quorum.
+            assert(commit_min_min <= self.commit_min + constants.pipeline_prepare_queue_max);
+            const commit_lag = self.commit_min -| commit_min_min;
 
             const stall_ms = ms: {
                 if (!pipeline_waiting) break :ms 0;


### PR DESCRIPTION
Fix invalid asserted from https://github.com/tigerbeetle/tigerbeetle/pull/3077.

1. R1 (view=1, primary): Commit op 168.
2. R0/R2 change to view=2. R1 joins after.
3. The new primary R2 receives an ack for op 168 from R1.

(The actual scenario in the VOPR seed is a bit more complicated than that but I think it still applies...)

Found by https://github.com/tigerbeetle/tigerbeetle/pull/2956 though it looks unrelated.

```
git switch -d 820cbd09772daf5c84ecc7f05c175d88bc86c8df && \
  ./zig/zig build -Drelease vopr -- 12995992096107620390
```