### PR TITLE
Improve explanation of asset scale

### DIFF
--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -95,8 +95,6 @@ to avoid loss of precision due to floating-point approximations.
 When the multiplier is a power of 10 (e.g. `10 ^ n`), then the exponent `n` is referred to as an
 _asset scale_. For example, representing USD in cents uses an asset scale of `2`.
 
-The 128-bit representation defines the precision, but not the scale.
-
 #### Examples
 
 - In USD, `$1` = `100` cents. Using an asset scale of `2`,
@@ -104,19 +102,16 @@ The 128-bit representation defines the precision, but not the scale.
   - The fractional amount `$123.00` is represented as the integer `12300`.
   - The fractional amount `$123.45` is represented as the integer `12345`.
 
-- In JPY, `¥1` = `1` yen. Using an asset scale of `0`;
+- In JPY, `¥1` = `1` yen. Using an asset scale of `0`,
   - The fractional amount `¥123` is represented as the integer `123`.
 
-- In KWD, `د.ك 1` = `1000` fils. Using an asset scale of `3`;
+- In KWD, `د.ك 1` = `1000` fils. Using an asset scale of `3`,
   - The fractional amount `0.450 د.ك` is represented as the integer `450`.
   - The fractional amount `123.000 د.ك` is represented as the integer `123000`.
   - The fractional amount `123.450 د.ك` is represented as the integer `123450`.
 
 The other direction works as well. If the smallest useful unit of an asset is `10,000,000` units,
 then it can be scaled down to the integer `1` using an asset scale of `-7`.
-
-Asset scale cannot be used to represent non-decimal denominations such as Malagasy ariary (MGA) or
-Mauritanian ouguiya (MRU). These currencies have subdivisions worth one fifth of the base unit.
 
 ### ⚠️ Asset Scales Cannot Be Easily Changed
 

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -107,7 +107,7 @@ The 128-bit representation defines the precision, but not the scale.
 - In JPY, `¥‎1` = `1` yen. Using an asset scale of `0`;
   - The fractional amount `¥‎123` is represented as the integer `123`.
 
-- In IQD, `1 د.ع` = `1000` fils. Using an asset scale of `3`;
+- In IQD, `1 IQD` = `1000` fils. Using an asset scale of `3`;
   - The fractional amount `0.450 د.ع` is represented as the integer `450`.
   - The fractional amount `123.000 د.ع` is represented as the integer `123000`.
   - The fractional amount `123.450 د.ع` is represented as the integer `123450`.

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -99,15 +99,15 @@ The 128-bit representation defines the precision, but not the scale.
 
 #### Examples
 
-- In USD, `$1` = `100` cents. So for example,
+- In USD, `$1` = `100` cents. Using an asset scale of `2`;
   - The fractional amount `$0.45` is represented as the integer `45`.
   - The fractional amount `$123.00` is represented as the integer `12300`.
   - The fractional amount `$123.45` is represented as the integer `12345`.
 
-- In JPY, `¥‎1` = `1` yen. So for example,
+- In JPY, `¥‎1` = `1` yen. Using an asset scale of `0`;
   - The fractional amount `¥‎123` is represented as the integer `123`.
 
-- In IQD, `1 د.ع` = `1000` fils. So for example,
+- In IQD, `1 د.ع` = `1000` fils. Using an asset scale of `3`;
   - The fractional amount `0.450 د.ع` is represented as the integer `450`.
   - The fractional amount `123.000 د.ع` is represented as the integer `123000`.
   - The fractional amount `123.450 د.ع` is represented as the integer `123450`.

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -105,13 +105,12 @@ The 128-bit representation defines the precision, but not the scale.
   - The fractional amount `$123.45` is represented as the integer `12345`.
 
 - In JPY, `¥‎1` = `1` yen. So for example,
-  - The fractional amount `¥‎123.00` is represented as the integer `123`.
-  - The fractional amount `¥‎123.45` is represented as the integer `123`.
+  - The fractional amount `¥‎123` is represented as the integer `123`.
 
 - In IQD, `1 د.ع` = `1000` fils. So for example,
-  - The fractional amount `0.45 د.ع` is represented as the integer `450`.
-  - The fractional amount `123.00 د.ع` is represented as the integer `123000`.
-  - The fractional amount `123.45 د.ع` is represented as the integer `123450`.
+  - The fractional amount `0.450 د.ع` is represented as the integer `450`.
+  - The fractional amount `123.000 د.ع` is represented as the integer `123000`.
+  - The fractional amount `123.450 د.ع` is represented as the integer `123450`.
 
 The other direction works as well. If the smallest useful unit of an asset is `10,000,000` units,
 then it can be scaled down to the integer `1` using an asset scale of `-7`.

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -107,10 +107,10 @@ The 128-bit representation defines the precision, but not the scale.
 - In JPY, `¥‎1` = `1` yen. Using an asset scale of `0`;
   - The fractional amount `¥‎123` is represented as the integer `123`.
 
-- In IQD, `1 IQD` = `1000` fils. Using an asset scale of `3`;
-  - The fractional amount `0.450 د.ع` is represented as the integer `450`.
-  - The fractional amount `123.000 د.ع` is represented as the integer `123000`.
-  - The fractional amount `123.450 د.ع` is represented as the integer `123450`.
+- In KWD, `د.ك 1` = `1000` fils. Using an asset scale of `3`;
+  - The fractional amount `0.450 د.ك` is represented as the integer `450`.
+  - The fractional amount `123.000 د.ك` is represented as the integer `123000`.
+  - The fractional amount `123.450 د.ك` is represented as the integer `123450`.
 
 The other direction works as well. If the smallest useful unit of an asset is `10,000,000` units,
 then it can be scaled down to the integer `1` using an asset scale of `-7`.

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -104,8 +104,8 @@ The 128-bit representation defines the precision, but not the scale.
   - The fractional amount `$123.00` is represented as the integer `12300`.
   - The fractional amount `$123.45` is represented as the integer `12345`.
 
-- In JPY, `¥‎1` = `1` yen. Using an asset scale of `0`;
-  - The fractional amount `¥‎123` is represented as the integer `123`.
+- In JPY, `¥1` = `1` yen. Using an asset scale of `0`;
+  - The fractional amount `¥123` is represented as the integer `123`.
 
 - In KWD, `د.ك 1` = `1000` fils. Using an asset scale of `3`;
   - The fractional amount `0.450 د.ك` is represented as the integer `450`.
@@ -116,7 +116,7 @@ The other direction works as well. If the smallest useful unit of an asset is `1
 then it can be scaled down to the integer `1` using an asset scale of `-7`.
 
 Asset scale cannot be used to represent non-decimal denominations such as Malagasy ariary (MGA) or
-Mauritanian ouguiya (MRU).
+Mauritanian ouguiya (MRU). These currencies have subdivisions worth one fifth of the base unit.
 
 ### ⚠️ Asset Scales Cannot Be Easily Changed
 

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -95,6 +95,8 @@ to avoid loss of precision due to floating-point approximations.
 When the multiplier is a power of 10 (e.g. `10 ^ n`), then the exponent `n` is referred to as an
 _asset scale_. For example, representing USD in cents uses an asset scale of `2`.
 
+The 128-bit representation defines the precision, but not the scale.
+
 #### Examples
 
 - In USD, `$1` = `100` cents. So for example,
@@ -102,12 +104,20 @@ _asset scale_. For example, representing USD in cents uses an asset scale of `2`
   - The fractional amount `$123.00` is represented as the integer `12300`.
   - The fractional amount `$123.45` is represented as the integer `12345`.
 
-### Oversized Amounts
+- In JPY, `¥‎1` = `1` yen. So for example,
+  - The fractional amount `¥‎123.00` is represented as the integer `123`.
+  - The fractional amount `¥‎123.45` is represented as the integer `123`.
 
-The other direction works as well. If the smallest useful unit of a currency is `10,000,000` units,
-then it can be scaled down to the integer `1`.
+- In IQD, `1 د.ع` = `1000` fils. So for example,
+  - The fractional amount `0.45 د.ع` is represented as the integer `450`.
+  - The fractional amount `123.00 د.ع` is represented as the integer `123000`.
+  - The fractional amount `123.45 د.ع` is represented as the integer `123450`.
 
-The 128-bit representation defines the precision, but not the scale.
+The other direction works as well. If the smallest useful unit of an asset is `10,000,000` units,
+then it can be scaled down to the integer `1` using an asset scale of `-7`.
+
+Asset scale cannot be used to represent non-decimal denominations such as Malagasy ariary (MGA) or
+Mauritanian ouguiya (MRU).
 
 ### ⚠️ Asset Scales Cannot Be Easily Changed
 

--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -99,7 +99,7 @@ The 128-bit representation defines the precision, but not the scale.
 
 #### Examples
 
-- In USD, `$1` = `100` cents. Using an asset scale of `2`;
+- In USD, `$1` = `100` cents. Using an asset scale of `2`,
   - The fractional amount `$0.45` is represented as the integer `45`.
   - The fractional amount `$123.00` is represented as the integer `12300`.
   - The fractional amount `$123.45` is represented as the integer `12345`.


### PR DESCRIPTION
Including examples highlighting contrasting assets scales and what asset scale would achieve 10, 000, 000:1 (-7)

I found the explanation of "other direction" confusing:

> The other direction works as well. If the smallest useful unit of a currency is `10,000,000` units, then it can be scaled down to the integer `1`.