### PR TITLE
style: naming things

### DIFF
--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -295,6 +295,10 @@ Beyond these rules:
   then line up nicely when `latency_ms_min` is added, as well as group all variables that relate to
   latency.
 
+- Infuse names with meaning. For example, `allocator: Allocator` is a good, if boring name,
+  but `gpa: Allocator` and `arena: Allocator` are excellent. They inform the reader whether
+  `deinit` should be called explicitly.
+
 - When choosing related names, try hard to find names with the same number of characters so that
   related variables all line up in the source. For example, as arguments to a memcpy function,
   `source` and `target` are better than `src` and `dest` because they have the second-order effect
@@ -312,6 +316,22 @@ Beyond these rules:
 - _Order_ matters for readability (even if it doesn't affect semantics). On the first read, a file
   is read top-down, so put important things near the top. The `main` function goes first.
 
+  The same goes for `structs`, the order is fields then types then methods:
+
+  ```zig
+  time: Time,
+  process_id: ProcessID,
+
+  const ProcessID = struct { cluster: u128, replica: u8 };
+  const Tracer = @This(); // This alias concludes the types section.
+
+  pub fn init(gpa: std.mem.Alocator, time: Time) !Tracer {
+      ...
+  }
+  ```
+
+  If a nested type is complex, make it a top-level struct.
+
   At the same time, not everything has a single right order. When in doubt, consider sorting
   alphabetically, taking advantage of big-endian naming.
 
@@ -326,6 +346,13 @@ Beyond these rules:
   `replica.preparing`. The former can be used directly as a section header in a document or
   conversation, whereas the latter must be clarified. Noun names compose more clearly for derived
   identifiers, e.g. `config.pipeline_max`.
+
+- Zig has named arguments through the `options: struct` pattern. Use it when arguments can be
+  mixed up. A function taking two `u64` must use an options struct. If an argument can be `null`,
+  it should be named so that the meaning of `null` literal at the call site is clear.
+
+  Because dependencies like an allocator or a tracer are singletons with unique types, they should
+  be threaded through constructors positionally, from the most general to the most specific.
 
 - **Write descriptive commit messages** that inform and delight the reader, because your commit
   messages are being read.


### PR DESCRIPTION
Some conventions I've picked up recently  which I think would be good. We don't fully follow the suggestions as written, but I think we should

For gpa/arena, I was recently confused by the file-reading code in `diff`:

```zig
        const file_text = try std.fs.cwd().readFileAlloc(
            allocator,
            file_path_relative,
            1024 * 1024,
        );
        var file_text_updated = try std.ArrayList(u8).initCapacity(allocator, file_text.len);
```

Is this a leak? No, because the allocator is actually `arena`! Plus, `gpa: Allocator` is shorter and less repetitive than `allocator: Allocator`

For structs order, this is mostly about bringing fields to the top. We often have nested types, and they make harder to access at a glance what the struct actually does. E.g, here are the first 10 lines of `ClientRepliesType`:

```zig
    return struct {
        const ClientReplies = @This();

        const Read = struct {
            client_replies: *ClientReplies,
            completion: Storage.Read,
            callback: ?*const fn (
                client_replies: *ClientReplies,
                reply_header: *const vsr.Header.Reply,
                reply: ?*Message.Reply,
```

This seems much less useful than the suggested alternative of

```zig
    return struct {
        storage: *Storage,
        message_pool: *MessagePool,
        replica: u8,

        reads: IOPSType(Read, constants.client_replies_iops_read_max) = .{},
        writes: IOPSType(Write, constants.client_replies_iops_write_max) = .{},

        /// Track which slots have a write currently in progress.
        writing: stdx.BitSetType(constants.clients_max) = .{},
        /// Track which slots hold a corrupt reply, or are otherwise missing the reply

```

It _is_ a bit counter-intuitive that we use `Read` type before we declare it, but that's leaser wevil than hiding the data in the middle of the struct imo! Zig does allow order-independent declarations, so we might use them!

For named arguments, I think `size` in TestStorage should be in options:

```
pub fn init(allocator: mem.Allocator, size: u64, options: Storage.Options) !Storage {
```

At the call site, `, 4096` is much less readable than `.size = 4096`. Note that it shouldn't be optional, just named!

In contrast, for the grid, I think we want to change this

```zig
pub fn init(allocator: mem.Allocator, options: struct {
    superblock: *SuperBlock,
    trace: *Storage.Tracer,
    cache_blocks_count: u64 = Cache.value_count_max_multiple,
    missing_blocks_max: usize,
    missing_tables_max: usize,
    blocks_released_prior_checkpoint_durability_max: usize,
}) !Grid {
```

to

```zig
pub fn init(gpa: mem.Allocator, trace: *Trace, superblock: *SuperBlock, options: struct {
    cache_blocks_count: u64 = Cache.value_count_max_multiple,
    missing_blocks_max: usize,
    missing_tables_max: usize,
    blocks_released_prior_checkpoint_durability_max: usize,
}) !Grid {
```

This is the weakest suggestion of all, and I can't really motivate it positively, it but it just makes sense to me that we want to separate dependencies which we just have to pass, from parameters that _actually_ affect how the grid works. That's the key: you may choose `missing_blocks_max`, it's a real parameter of a grid. But you don't get to chose the superblock, it is what it is, you'll probably get it from _your_ caller.