### PR TITLE
Initialize `IO` early

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -653,6 +653,7 @@ pub fn ReplType(comptime MessageBus: type) type {
 
         pub fn init(
             parent_allocator: std.mem.Allocator,
+            io: *IO,
             time: Time,
             options: struct {
                 addresses: []const std.net.Address,
@@ -674,12 +675,6 @@ pub fn ReplType(comptime MessageBus: type) type {
 
             message_pool.* = try MessagePool.init(allocator, .client);
             errdefer message_pool.deinit(allocator);
-
-            var io = try allocator.create(IO);
-            errdefer allocator.destroy(io);
-
-            io.* = try IO.init(32, 0);
-            errdefer io.deinit();
 
             const client_id = stdx.unique_u128();
             const client = try Client.init(
@@ -723,7 +718,6 @@ pub fn ReplType(comptime MessageBus: type) type {
             repl.static_allocator.transition_from_static_to_deinit();
 
             repl.client.deinit(allocator);
-            repl.io.deinit();
             repl.message_pool.deinit(allocator);
             allocator.destroy(repl.message_pool);
             repl.arguments.deinit(allocator);

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -22,7 +22,12 @@ const benchmark_load = @import("./benchmark_load.zig");
 
 const log = std.log;
 
-pub fn main(allocator: Allocator, time: vsr.time.Time, args: *const cli.Command.Benchmark) !void {
+pub fn main(
+    allocator: Allocator,
+    io: *vsr.io.IO,
+    time: vsr.time.Time,
+    args: *const cli.Command.Benchmark,
+) !void {
     // Note: we intentionally don't use a temporary directory for this data file, and instead just
     // put it into CWD, as performance of TigerBeetle very much depends on a specific file system.
     const data_file = args.file orelse data_file: {
@@ -83,7 +88,7 @@ pub fn main(allocator: Allocator, time: vsr.time.Time, args: *const cli.Command.
         addresses.const_slice()
     else
         &.{tigerbeetle_process.?.address};
-    try benchmark_load.main(allocator, time, addresses, args);
+    try benchmark_load.main(allocator, io, time, addresses, args);
 
     if (tigerbeetle_process) |*p| {
         const rusage = p.deinit();

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -36,6 +36,7 @@ const cli = @import("./cli.zig");
 
 pub fn main(
     allocator: std.mem.Allocator,
+    io: *IO,
     time: Time,
     addresses: []const std.net.Address,
     cli_args: *const cli.Command.Benchmark,
@@ -78,9 +79,6 @@ pub fn main(
 
     const cluster_id: u128 = 0;
 
-    var io = try IO.init(32, 0);
-    defer io.deinit();
-
     var message_pools = stdx.BoundedArrayType(MessagePool, constants.clients_max){};
     defer for (message_pools.slice()) |*message_pool| message_pool.deinit(allocator);
     for (0..cli_args.clients) |_| {
@@ -99,7 +97,7 @@ pub fn main(
             .replica_count = @intCast(addresses.len),
             .time = time,
             .message_pool = &message_pools.slice()[i],
-            .message_bus_options = .{ .configuration = addresses, .io = &io },
+            .message_bus_options = .{ .configuration = addresses, .io = io },
         }));
     }
 
@@ -157,7 +155,7 @@ pub fn main(
     });
 
     var benchmark = Benchmark{
-        .io = &io,
+        .io = io,
         .prng = &prng,
         .timer = try std.time.Timer.start(),
         .output = std.io.getStdOut().writer().any(),

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -99,7 +99,8 @@ pub fn main() !void {
         .start => |*args| {
             if (args.trace) |path| {
                 trace_file = std.fs.cwd().createFile(path, .{ .exclusive = true }) catch |err| {
-                    std.debug.panic("error creating trace file: {}", .{err});
+                    log.err("error creating trace file '{s}': {}", .{ path, err });
+                    return err;
                 };
             }
             if (args.statsd) |address| statsd_address = address;

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -71,18 +71,16 @@ pub fn main() !void {
 
     var command = cli.parse_args(&arg_iterator);
 
-    switch (command) {
-        .inspect => {},
-        .version => |*args| {
-            try Command.version(allocator, args.verbose);
-            return; // Exit early before initializing IO.
-        },
-        inline else => |*args| {
-            if (args.log_debug) {
-                log_level_runtime = .debug;
-            }
-        },
+    if (command == .version) {
+        try Command.version(allocator, command.version.verbose);
+        return; // Exit early before initializing IO.
     }
+
+    log_level_runtime = switch (command) {
+        .version => unreachable,
+        .inspect => .info,
+        inline else => |*args| if (args.log_debug) .debug else .info,
+    };
 
     // Try and init IO early, before a file has even been created, so if it fails (eg, io_uring
     // is not available) there won't be a dangling file.


### PR DESCRIPTION
...and use the same `io` in `repl`, `benchmark`, and `inspect`.

We also pull `Tracer` initialization into `main` and pass it down.