### PR TITLE
devhub: add `font-size-adjust`

### DIFF
--- a/src/devhub/style.css
+++ b/src/devhub/style.css
@@ -34,6 +34,7 @@ body {
     font-family: Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
+    font-size-adjust: 0.53;
 }
 
 a {

--- a/src/devhub/style.css
+++ b/src/devhub/style.css
@@ -31,7 +31,7 @@
 body {
     background-color: var(--gray-1);
     color: var(--gray-12);
-    font-family: Helvetica, Arial, sans-serif;
+    font-family: system-ui;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     font-size-adjust: 0.53;


### PR DESCRIPTION
Sans and monospaced text are the same size now! :)

Learned about this on https://matklad.github.io/2025/07/16/font-size-adjust.html