### PR TITLE
test: introduce fixtures module 

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -120,12 +120,12 @@ const Environment = struct {
     fn init(env: *Environment, gpa: std.mem.Allocator, storage: *Storage) !void {
         env.storage = storage;
 
-        env.time_sim = fixtures.time(.{});
-        env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
+        env.time_sim = fixtures.init_time(.{});
+        env.trace = try fixtures.init_tracer(gpa, env.time_sim.time(), .{});
 
-        env.superblock = try fixtures.superblock(gpa, env.storage, .{});
+        env.superblock = try fixtures.init_superblock(gpa, env.storage, .{});
 
-        env.grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
+        env.grid = try fixtures.init_grid(gpa, &env.trace, &env.superblock, .{
             .blocks_released_prior_checkpoint_durability_max = Forest
                 .compaction_blocks_released_per_pipeline_max() +
                 Grid.free_set_checkpoints_blocks_max(constants.storage_size_limit_default),
@@ -178,7 +178,7 @@ const Environment = struct {
     }
 
     fn open(env: *Environment, gpa: std.mem.Allocator) !void {
-        fixtures.superblock_open(&env.superblock);
+        fixtures.open_superblock(&env.superblock);
 
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
@@ -1072,7 +1072,7 @@ pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     defer gpa.free(fuzz_ops);
 
     // Init mocked storage.
-    var storage = try fixtures.storage(gpa, .{
+    var storage = try fixtures.init_storage(gpa, .{
         .seed = prng.int(u64),
         .size = constants.storage_size_limit_default,
         .read_latency_min = .{ .ns = 0 },

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -95,7 +95,6 @@ const Environment = struct {
 
     const State = enum {
         init,
-        superblock_open,
         free_set_open,
         forest_init,
         forest_open,
@@ -155,7 +154,7 @@ const Environment = struct {
         try env.init(gpa, storage);
         defer env.deinit(gpa);
 
-        env.change_state(.init, .superblock_open);
+        env.change_state(.init, .free_set_open);
         try env.open(gpa);
         defer env.close(gpa);
 
@@ -179,8 +178,7 @@ const Environment = struct {
     }
 
     fn open(env: *Environment, gpa: std.mem.Allocator) !void {
-        env.superblock.open(superblock_open_callback, &env.superblock_context);
-        try env.tick_until_state_change(.superblock_open, .free_set_open);
+        fixtures.superblock_open(&env.superblock);
 
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
@@ -223,11 +221,6 @@ const Environment = struct {
 
     fn close(env: *Environment, gpa: std.mem.Allocator) void {
         env.forest.deinit(gpa);
-    }
-
-    fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
-        const env: *Environment = @fieldParentPtr("superblock_context", superblock_context);
-        env.change_state(.superblock_open, .free_set_open);
     }
 
     fn grid_open_callback(grid: *Grid) void {
@@ -660,7 +653,7 @@ const Environment = struct {
                 env.state = .init;
                 try env.init(gpa, env.storage);
 
-                env.change_state(.init, .superblock_open);
+                env.change_state(.init, .free_set_open);
                 try env.open(gpa);
 
                 // TODO: currently this checks that everything added to the LSM after checkpoint

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");
+const fixtures = @import("../testing/fixtures.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
@@ -126,13 +127,8 @@ const Environment = struct {
     fn init(env: *Environment, gpa: std.mem.Allocator, storage: *Storage) !void {
         env.storage = storage;
 
-        env.time_sim = TimeSim.init_simple();
-        env.trace = try Storage.Tracer.init(
-            gpa,
-            env.time_sim.time(),
-            .{ .replica = .{ .cluster = 0, .replica = replica } },
-            .{},
-        );
+        env.time_sim = fixtures.time(.{});
+        env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
 
         env.superblock = try SuperBlock.init(gpa, .{
             .storage = env.storage,

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -129,10 +129,7 @@ const Environment = struct {
         env.time_sim = fixtures.time(.{});
         env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
 
-        env.superblock = try SuperBlock.init(gpa, .{
-            .storage = env.storage,
-            .storage_size_limit = constants.storage_size_limit_default,
-        });
+        env.superblock = try fixtures.superblock(gpa, env.storage, .{});
 
         env.grid = try Grid.init(gpa, .{
             .superblock = &env.superblock,

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -70,10 +70,6 @@ const ScanParams = struct {
 };
 
 const Environment = struct {
-    const cluster = 32;
-    const replica = 4;
-    const replica_count = 6;
-
     const node_count = 1024;
     // This is the smallest size that set_associative_cache will allow us.
     const cache_entries_max = GrooveAccounts.ObjectsCache.Cache.value_count_max_multiple;
@@ -99,7 +95,6 @@ const Environment = struct {
 
     const State = enum {
         init,
-        superblock_format,
         superblock_open,
         free_set_open,
         forest_init,
@@ -164,16 +159,7 @@ const Environment = struct {
         try env.init(gpa, storage);
         defer env.deinit(gpa);
 
-        env.change_state(.init, .superblock_format);
-        env.superblock.format(superblock_format_callback, &env.superblock_context, .{
-            .cluster = cluster,
-            .release = vsr.Release.minimum,
-            .replica = replica,
-            .replica_count = replica_count,
-            .view = null,
-        });
-        try env.tick_until_state_change(.superblock_format, .superblock_open);
-
+        env.change_state(.init, .superblock_open);
         try env.open(gpa);
         defer env.close(gpa);
 
@@ -243,11 +229,6 @@ const Environment = struct {
         env.forest.deinit(gpa);
     }
 
-    fn superblock_format_callback(superblock_context: *SuperBlock.Context) void {
-        const env: *Environment = @fieldParentPtr("superblock_context", superblock_context);
-        env.change_state(.superblock_format, .superblock_open);
-    }
-
     fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
         const env: *Environment = @fieldParentPtr("superblock_context", superblock_context);
         env.change_state(.superblock_open, .free_set_open);
@@ -287,7 +268,7 @@ const Environment = struct {
 
         env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
             .header = header: {
-                var header = vsr.Header.Prepare.root(cluster);
+                var header = vsr.Header.Prepare.root(fixtures.cluster);
                 header.op = env.checkpoint_op.?;
                 header.set_checksum();
                 break :header header;
@@ -1111,6 +1092,8 @@ pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
         .write_latency_mean = fuzz.range_inclusive_ms(&prng, 0, io_latency_mean_ms),
     });
     defer storage.deinit(gpa);
+
+    try fixtures.storage_format(gpa, &storage, .{});
 
     try Environment.run(gpa, &storage, fuzz_ops);
 

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -126,11 +126,7 @@ const Environment = struct {
 
         env.superblock = try fixtures.superblock(gpa, env.storage, .{});
 
-        env.grid = try Grid.init(gpa, .{
-            .superblock = &env.superblock,
-            .trace = &env.trace,
-            .missing_blocks_max = 0,
-            .missing_tables_max = 0,
+        env.grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
             .blocks_released_prior_checkpoint_durability_max = Forest
                 .compaction_blocks_released_per_pipeline_max() +
                 Grid.free_set_checkpoints_blocks_max(constants.storage_size_limit_default),

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -14,6 +14,7 @@ const log = std.log.scoped(.fuzz_lsm_manifest_log);
 
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
+const fixtures = @import("../testing/fixtures.zig");
 const constants = @import("../constants.zig");
 const SuperBlock = @import("../vsr/superblock.zig").SuperBlockType(Storage);
 const TimeSim = @import("../testing/time.zig").TimeSim;
@@ -293,14 +294,14 @@ const Environment = struct {
         errdefer env.storage_verify.deinit(gpa);
 
         fields_initialized += 1;
-        env.time_sim = TimeSim.init_simple();
+        env.time_sim = fixtures.time(.{});
 
         fields_initialized += 1;
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .replica_test, .{});
+        env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
         errdefer env.trace.deinit(gpa);
 
         fields_initialized += 1;
-        env.trace_verify = try Storage.Tracer.init(gpa, env.time_sim.time(), .replica_test, .{});
+        env.trace_verify = try fixtures.tracer(gpa, env.time_sim.time(), .{});
         errdefer env.trace_verify.deinit(gpa);
 
         fields_initialized += 1;
@@ -562,12 +563,7 @@ const Environment = struct {
             test_storage.reset();
 
             test_trace.deinit(env.gpa);
-            test_trace.* = try Storage.Tracer.init(
-                env.gpa,
-                env.time_sim.time(),
-                .replica_test,
-                .{},
-            );
+            test_trace.* = try fixtures.tracer(env.gpa, env.time_sim.time(), .{});
 
             // Reset the state so that the manifest log (and dependencies) can be reused.
             // Do not "defer deinit()" because these are cleaned up by Env.deinit().

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -74,9 +74,7 @@ fn run_fuzz(
 
     {
         fixtures.open_superblock(&env.superblock);
-
-        env.open_grid();
-        env.wait(&env.manifest_log);
+        fixtures.open_grid(&env.grid);
 
         // The first checkpoint is trivially durable.
         env.grid.free_set.mark_checkpoint_durable();
@@ -369,17 +367,6 @@ const Environment = struct {
         while (env.pending > 0) {
             manifest_log.superblock.storage.run();
         }
-    }
-
-    fn open_grid(env: *Environment) void {
-        assert(env.pending == 0);
-        env.pending += 1;
-        env.grid.open(open_grid_callback);
-    }
-
-    fn open_grid_callback(grid: *Grid) void {
-        const env: *Environment = @fieldParentPtr("grid", grid);
-        env.pending -= 1;
     }
 
     fn open(env: *Environment) void {

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -304,17 +304,11 @@ const Environment = struct {
         errdefer env.trace_verify.deinit(gpa);
 
         fields_initialized += 1;
-        env.superblock = try SuperBlock.init(gpa, .{
-            .storage = &env.storage,
-            .storage_size_limit = storage_options.size,
-        });
+        env.superblock = try fixtures.superblock(gpa, &env.storage, .{});
         errdefer env.superblock.deinit(gpa);
 
         fields_initialized += 1;
-        env.superblock_verify = try SuperBlock.init(gpa, .{
-            .storage = &env.storage_verify,
-            .storage_size_limit = storage_options.size,
-        });
+        env.superblock_verify = try fixtures.superblock(gpa, &env.storage_verify, .{});
         errdefer env.superblock_verify.deinit(gpa);
 
         fields_initialized += 1;
@@ -567,13 +561,7 @@ const Environment = struct {
             // Reset the state so that the manifest log (and dependencies) can be reused.
             // Do not "defer deinit()" because these are cleaned up by Env.deinit().
             test_superblock.deinit(env.gpa);
-            test_superblock.* = try SuperBlock.init(
-                env.gpa,
-                .{
-                    .storage = test_storage,
-                    .storage_size_limit = constants.storage_size_limit_default,
-                },
-            );
+            test_superblock.* = try fixtures.superblock(env.gpa, &env.storage, .{});
 
             test_grid.deinit(env.gpa);
             test_grid.* = try Grid.init(env.gpa, .{

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -59,7 +59,7 @@ fn run_fuzz(
     prng: *stdx.PRNG,
     events: []const ManifestEvent,
 ) !void {
-    const storage_options: fixtures.StorageOptions = .{
+    const storage_options: Storage.Options = .{
         .seed = prng.int(u64),
         .size = constants.storage_size_limit_default,
         .read_latency_min = .{ .ns = 10 * std.time.ns_per_ms },
@@ -271,7 +271,7 @@ const Environment = struct {
     fn init(
         env: *Environment, // In-place construction for stable addresses.
         gpa: std.mem.Allocator,
-        storage_options: fixtures.StorageOptions,
+        storage_options: Storage.Options,
     ) !void {
         comptime var fields_initialized = 0;
 

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -314,11 +314,7 @@ const Environment = struct {
         env.superblock_context = undefined;
 
         fields_initialized += 1;
-        env.grid = try Grid.init(gpa, .{
-            .superblock = &env.superblock,
-            .trace = &env.trace,
-            .missing_blocks_max = 0,
-            .missing_tables_max = 0,
+        env.grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
             // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
             // FreeSet.blocks_released_prior_checkpoint_durability.
             .blocks_released_prior_checkpoint_durability_max = Grid
@@ -327,13 +323,7 @@ const Environment = struct {
         errdefer env.grid.deinit(gpa);
 
         fields_initialized += 1;
-        env.grid_verify = try Grid.init(gpa, .{
-            .superblock = &env.superblock_verify,
-            .trace = &env.trace_verify,
-            .missing_blocks_max = 0,
-            .missing_tables_max = 0,
-            .blocks_released_prior_checkpoint_durability_max = 0,
-        });
+        env.grid_verify = try fixtures.grid(gpa, &env.trace_verify, &env.superblock_verify, .{});
         errdefer env.grid_verify.deinit(gpa);
 
         fields_initialized += 1;

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -320,7 +320,8 @@ const Environment = struct {
         errdefer env.grid.deinit(gpa);
 
         fields_initialized += 1;
-        env.grid_verify = try fixtures.init_grid(gpa, &env.trace_verify, &env.superblock_verify, .{});
+        env.grid_verify =
+            try fixtures.init_grid(gpa, &env.trace_verify, &env.superblock_verify, .{});
         errdefer env.grid_verify.deinit(gpa);
 
         fields_initialized += 1;

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -471,7 +471,6 @@ const Environment = struct {
 
     const State = enum {
         init,
-        superblock_open,
         free_set_open,
         forest_init,
         forest_open,
@@ -564,7 +563,7 @@ const Environment = struct {
         try env.init(gpa, storage, prng);
         defer env.deinit(gpa);
 
-        env.change_state(.init, .superblock_open);
+        env.change_state(.init, .free_set_open);
 
         try env.open(gpa);
         defer env.close(gpa);
@@ -781,8 +780,7 @@ const Environment = struct {
     }
 
     fn open(env: *Environment, gpa: std.mem.Allocator) !void {
-        env.superblock.open(superblock_open_callback, &env.superblock_context);
-        try env.tick_until_state_change(.superblock_open, .free_set_open);
+        fixtures.superblock_open(&env.superblock);
 
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
@@ -865,11 +863,6 @@ const Environment = struct {
 
             env.checkpoint_op = null;
         }
-    }
-
-    fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
-        const env: *Environment = @fieldParentPtr("superblock_context", superblock_context);
-        env.change_state(.superblock_open, .free_set_open);
     }
 
     fn grid_open_callback(grid: *Grid) void {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -525,11 +525,7 @@ const Environment = struct {
 
             .superblock = try fixtures.superblock(gpa, env.storage, .{}),
 
-            .grid = try Grid.init(gpa, .{
-                .superblock = &env.superblock,
-                .trace = &env.trace,
-                .missing_blocks_max = 0,
-                .missing_tables_max = 0,
+            .grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
                 // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
                 // FreeSet.blocks_released_prior_checkpoint_durability.
                 .blocks_released_prior_checkpoint_durability_max = Grid

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const maybe = stdx.maybe;
 
 const constants = @import("../constants.zig");
+const fixtures = @import("../testing/fixtures.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
@@ -515,8 +516,8 @@ const Environment = struct {
         storage: *Storage,
         prng: *stdx.PRNG,
     ) !void {
-        env.time_sim = TimeSim.init_simple();
-        env.trace = try Storage.Tracer.init(gpa, env.time_sim.time(), .replica_test, .{});
+        env.time_sim = fixtures.time(.{});
+        env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
         errdefer env.trace.deinit(gpa);
 
         env.* = .{

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -940,18 +940,10 @@ pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
     // Init mocked storage.
-    var storage = try Storage.init(
-        gpa,
-        constants.storage_size_limit_default,
-        Storage.Options{
-            .seed = prng.int(u64),
-            .read_latency_min = .{ .ns = 0 },
-            .read_latency_mean = .{ .ns = 0 },
-            .write_latency_min = .{ .ns = 0 },
-            .write_latency_mean = .{ .ns = 0 },
-            .crash_fault_probability = Ratio.zero(),
-        },
-    );
+    var storage = try fixtures.storage(gpa, .{
+        .seed = prng.int(u64),
+        .size = constants.storage_size_limit_default,
+    });
     defer storage.deinit(gpa);
 
     const commits_max: u32 = @intCast(

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -861,11 +861,6 @@ const Environment = struct {
         }
     }
 
-    fn grid_open_callback(grid: *Grid) void {
-        const env: *Environment = @fieldParentPtr("grid", grid);
-        env.change_state(.free_set_open, .forest_init);
-    }
-
     fn forest_open_callback(forest: *Forest) void {
         const env: *Environment = @fieldParentPtr("forest", forest);
         env.change_state(.forest_open, .fuzzing);

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -527,10 +527,7 @@ const Environment = struct {
             .time_sim = env.time_sim,
             .trace = env.trace,
 
-            .superblock = try SuperBlock.init(gpa, .{
-                .storage = env.storage,
-                .storage_size_limit = constants.storage_size_limit_default,
-            }),
+            .superblock = try fixtures.superblock(gpa, env.storag, .{}),
 
             .grid = try Grid.init(gpa, .{
                 .superblock = &env.superblock,
@@ -939,7 +936,6 @@ const Environment = struct {
 pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
-    // Init mocked storage.
     var storage = try fixtures.storage(gpa, .{
         .seed = prng.int(u64),
         .size = constants.storage_size_limit_default,

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -511,8 +511,8 @@ const Environment = struct {
         storage: *Storage,
         prng: *stdx.PRNG,
     ) !void {
-        env.time_sim = fixtures.time(.{});
-        env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
+        env.time_sim = fixtures.init_time(.{});
+        env.trace = try fixtures.init_tracer(gpa, env.time_sim.time(), .{});
         errdefer env.trace.deinit(gpa);
 
         env.* = .{
@@ -522,9 +522,9 @@ const Environment = struct {
             .time_sim = env.time_sim,
             .trace = env.trace,
 
-            .superblock = try fixtures.superblock(gpa, env.storage, .{}),
+            .superblock = try fixtures.init_superblock(gpa, env.storage, .{}),
 
-            .grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
+            .grid = try fixtures.init_grid(gpa, &env.trace, &env.superblock, .{
                 // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
                 // FreeSet.blocks_released_prior_checkpoint_durability.
                 .blocks_released_prior_checkpoint_durability_max = Grid
@@ -780,7 +780,7 @@ const Environment = struct {
     }
 
     fn open(env: *Environment, gpa: std.mem.Allocator) !void {
-        fixtures.superblock_open(&env.superblock);
+        fixtures.open_superblock(&env.superblock);
 
         env.grid.open(grid_open_callback);
         try env.tick_until_state_change(.free_set_open, .forest_init);
@@ -908,7 +908,7 @@ const Environment = struct {
 pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
-    var storage = try fixtures.storage(gpa, .{
+    var storage = try fixtures.init_storage(gpa, .{
         .seed = prng.int(u64),
         .size = constants.storage_size_limit_default,
     });

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -158,14 +158,14 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.state = .init;
             env.storage = storage;
 
-            env.time_sim = fixtures.time(.{});
-            env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
+            env.time_sim = fixtures.init_time(.{});
+            env.trace = try fixtures.init_tracer(gpa, env.time_sim.time(), .{});
             defer env.trace.deinit(gpa);
 
-            env.superblock = try fixtures.superblock(gpa, env.storage, .{});
+            env.superblock = try fixtures.init_superblock(gpa, env.storage, .{});
             defer env.superblock.deinit(gpa);
 
-            env.grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
+            env.grid = try fixtures.init_grid(gpa, &env.trace, &env.superblock, .{
                 // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
                 // FreeSet.blocks_released_prior_checkpoint_durability.
                 .blocks_released_prior_checkpoint_durability_max = Grid
@@ -233,7 +233,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             fuzz_ops: []const FuzzOp,
         ) !void {
             env.change_state(.init, .free_set_open);
-            fixtures.superblock_open(&env.superblock);
+            fixtures.open_superblock(&env.superblock);
 
             env.grid.open(grid_open_callback);
 
@@ -906,7 +906,7 @@ pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     const fuzz_ops = try generate_fuzz_ops(gpa, &prng, fuzz_op_count);
     defer gpa.free(fuzz_ops);
 
-    var storage = try fixtures.storage(gpa, .{
+    var storage = try fixtures.init_storage(gpa, .{
         .size = constants.storage_size_limit_default,
         .seed = prng.int(u64),
         .read_latency_min = .{ .ns = 0 },

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -114,7 +114,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         const State = enum {
             init,
-            free_set_open,
             tree_init,
             manifest_log_open,
             fuzzing,
@@ -232,13 +231,10 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             gpa: std.mem.Allocator,
             fuzz_ops: []const FuzzOp,
         ) !void {
-            env.change_state(.init, .free_set_open);
             fixtures.open_superblock(&env.superblock);
+            fixtures.open_grid(&env.grid);
 
-            env.grid.open(grid_open_callback);
-
-            env.tick_until_state_change(.free_set_open, .tree_init);
-
+            env.change_state(.init, .tree_init);
             // The first checkpoint is trivially durable.
             env.grid.free_set.mark_checkpoint_durable();
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -117,7 +117,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         const State = enum {
             init,
-            superblock_open,
             free_set_open,
             tree_init,
             manifest_log_open,
@@ -236,10 +235,9 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             gpa: std.mem.Allocator,
             fuzz_ops: []const FuzzOp,
         ) !void {
-            env.change_state(.init, .superblock_open);
-            env.superblock.open(superblock_open_callback, &env.superblock_context);
+            env.change_state(.init, .free_set_open);
+            fixtures.superblock_open(&env.superblock);
 
-            env.tick_until_state_change(.superblock_open, .free_set_open);
             env.grid.open(grid_open_callback);
 
             env.tick_until_state_change(.free_set_open, .tree_init);
@@ -264,11 +262,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.tree.open_complete();
 
             try env.apply(gpa, fuzz_ops);
-        }
-
-        fn superblock_open_callback(superblock_context: *SuperBlock.Context) void {
-            const env: *Environment = @fieldParentPtr("superblock_context", superblock_context);
-            env.change_state(.superblock_open, .free_set_open);
         }
 
         fn grid_open_callback(grid: *Grid) void {

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -257,11 +257,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             try env.apply(gpa, fuzz_ops);
         }
 
-        fn grid_open_callback(grid: *Grid) void {
-            const env: *Environment = @fieldParentPtr("grid", grid);
-            env.change_state(.free_set_open, .tree_init);
-        }
-
         fn manifest_log_open_event(
             manifest_log: *ManifestLog,
             table: *const schema.ManifestNode.TableInfo,

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 
 const stdx = @import("../stdx.zig");
 const constants = @import("../constants.zig");
+const fixtures = @import("../testing/fixtures.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const vsr = @import("../vsr.zig");
 const schema = @import("schema.zig");
@@ -162,13 +163,8 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.state = .init;
             env.storage = storage;
 
-            env.time_sim = TimeSim.init_simple();
-            env.trace = try Storage.Tracer.init(
-                gpa,
-                env.time_sim.time(),
-                .{ .replica = .{ .cluster = 0, .replica = replica } },
-                .{},
-            );
+            env.time_sim = fixtures.time(.{});
+            env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
             defer env.trace.deinit(gpa);
 
             env.superblock = try SuperBlock.init(gpa, .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -167,10 +167,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.trace = try fixtures.tracer(gpa, env.time_sim.time(), .{});
             defer env.trace.deinit(gpa);
 
-            env.superblock = try SuperBlock.init(gpa, .{
-                .storage = env.storage,
-                .storage_size_limit = constants.storage_size_limit_default,
-            });
+            env.superblock = try fixtures.superblock(gpa, env.storage, .{});
             defer env.superblock.deinit(gpa);
 
             env.grid = try Grid.init(gpa, .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -86,9 +86,6 @@ const value_count_max = constants.lsm_compaction_ops * commit_entries_max;
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 const table_count_max = @import("tree.zig").table_count_max;
 
-const cluster = 32;
-const replica = 4;
-const replica_count = 6;
 const node_count = 1024;
 const scan_results_max = 4096;
 const events_max = 10_000_000;
@@ -410,7 +407,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             const checkpoint_op = op - constants.lsm_compaction_ops;
             env.superblock.checkpoint(superblock_checkpoint_callback, &env.superblock_context, .{
                 .header = header: {
-                    var header = vsr.Header.Prepare.root(cluster);
+                    var header = vsr.Header.Prepare.root(fixtures.cluster);
                     header.op = checkpoint_op;
                     header.set_checksum();
                     break :header header;

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -169,11 +169,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.superblock = try fixtures.superblock(gpa, env.storage, .{});
             defer env.superblock.deinit(gpa);
 
-            env.grid = try Grid.init(gpa, .{
-                .superblock = &env.superblock,
-                .trace = &env.trace,
-                .missing_blocks_max = 0,
-                .missing_tables_max = 0,
+            env.grid = try fixtures.grid(gpa, &env.trace, &env.superblock, .{
                 // Grid.mark_checkpoint_not_durable releases the FreeSet checkpoints blocks into
                 // FreeSet.blocks_released_prior_checkpoint_durability.
                 .blocks_released_prior_checkpoint_durability_max = Grid

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5100,8 +5100,7 @@ pub const TestContext = struct {
         ctx.trace = try fixtures.tracer(allocator, ctx.time_sim.time(), .{});
         errdefer ctx.trace.deinit(allocator);
 
-        ctx.superblock = try SuperBlock.init(allocator, .{
-            .storage = &ctx.storage,
+        ctx.superblock = try fixtures.superblock(allocator, &ctx.storage, .{
             .storage_size_limit = data_file_size_min,
         });
         errdefer ctx.superblock.deinit(allocator);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5092,17 +5092,9 @@ pub const TestContext = struct {
     busy: bool,
 
     pub fn init(ctx: *TestContext, allocator: mem.Allocator) !void {
-        ctx.storage = try Storage.init(
-            allocator,
-            4096,
-            .{
-                .read_latency_min = .{ .ns = 0 },
-                .read_latency_mean = .{ .ns = 0 },
-                .write_latency_min = .{ .ns = 0 },
-                .write_latency_mean = .{ .ns = 0 },
-            },
-        );
+        ctx.storage = try fixtures.storage(allocator, .{ .size = 4096 });
         errdefer ctx.storage.deinit(allocator);
+
         ctx.time_sim = fixtures.time(.{});
 
         ctx.trace = try fixtures.tracer(allocator, ctx.time_sim.time(), .{});

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5092,15 +5092,15 @@ pub const TestContext = struct {
     busy: bool,
 
     pub fn init(ctx: *TestContext, allocator: mem.Allocator) !void {
-        ctx.storage = try fixtures.storage(allocator, .{ .size = 4096 });
+        ctx.storage = try fixtures.init_storage(allocator, .{ .size = 4096 });
         errdefer ctx.storage.deinit(allocator);
 
-        ctx.time_sim = fixtures.time(.{});
+        ctx.time_sim = fixtures.init_time(.{});
 
-        ctx.trace = try fixtures.tracer(allocator, ctx.time_sim.time(), .{});
+        ctx.trace = try fixtures.init_tracer(allocator, ctx.time_sim.time(), .{});
         errdefer ctx.trace.deinit(allocator);
 
-        ctx.superblock = try fixtures.superblock(allocator, &ctx.storage, .{
+        ctx.superblock = try fixtures.init_superblock(allocator, &ctx.storage, .{
             .storage_size_limit = data_file_size_min,
         });
         errdefer ctx.superblock.deinit(allocator);
@@ -5109,7 +5109,7 @@ pub const TestContext = struct {
         ctx.superblock.opened = true;
         ctx.superblock.working.vsr_state.checkpoint.header.op = 0;
 
-        ctx.grid = try fixtures.grid(allocator, &ctx.trace, &ctx.superblock, .{});
+        ctx.grid = try fixtures.init_grid(allocator, &ctx.trace, &ctx.superblock, .{});
         errdefer ctx.grid.deinit(allocator);
 
         try ctx.state_machine.init(allocator, &ctx.grid, .{

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5109,13 +5109,7 @@ pub const TestContext = struct {
         ctx.superblock.opened = true;
         ctx.superblock.working.vsr_state.checkpoint.header.op = 0;
 
-        ctx.grid = try Grid.init(allocator, .{
-            .superblock = &ctx.superblock,
-            .trace = &ctx.trace,
-            .missing_blocks_max = 0,
-            .missing_tables_max = 0,
-            .blocks_released_prior_checkpoint_durability_max = 0,
-        });
+        ctx.grid = try fixtures.grid(allocator, &ctx.trace, &ctx.superblock, .{});
         errdefer ctx.grid.deinit(allocator);
 
         try ctx.state_machine.init(allocator, &ctx.grid, .{

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5071,6 +5071,8 @@ pub const TestContext = struct {
     const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
     const SuperBlock = @import("vsr/superblock.zig").SuperBlockType(Storage);
     const Grid = @import("vsr/grid.zig").GridType(Storage);
+    const fixtures = @import("testing/fixtures.zig");
+
     pub const StateMachine = StateMachineType(Storage, .{
         .release = vsr.Release.minimum,
         // Overestimate the batch size because the test never compacts.
@@ -5101,9 +5103,9 @@ pub const TestContext = struct {
             },
         );
         errdefer ctx.storage.deinit(allocator);
-        ctx.time_sim = TimeSim.init_simple();
+        ctx.time_sim = fixtures.time(.{});
 
-        ctx.trace = try Tracer.init(allocator, ctx.time_sim.time(), .replica_test, .{});
+        ctx.trace = try fixtures.tracer(allocator, ctx.time_sim.time(), .{});
         errdefer ctx.trace.deinit(allocator);
 
         ctx.superblock = try SuperBlock.init(allocator, .{

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -7,6 +7,7 @@ const constants = @import("constants.zig");
 const IO = @import("testing/io.zig").IO;
 const Tracer = vsr.trace.Tracer;
 const Storage = @import("storage.zig").StorageType(IO);
+const fixtures = @import("testing/fixtures.zig");
 const fuzz = @import("testing/fuzz.zig");
 const ratio = stdx.PRNG.ratio;
 
@@ -78,7 +79,7 @@ pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
             .larger_than_logical_sector_read_fault_probability = ratio(10, 100),
         });
 
-        var tracer = try Tracer.init(gpa, time, .replica_test, .{});
+        var tracer = try fixtures.init_tracer(gpa, time, .{});
         defer tracer.deinit(gpa);
 
         var storage = try Storage.init(&io, &tracer, 0);

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -5,7 +5,6 @@ const vsr = @import("vsr.zig");
 const stdx = vsr.stdx;
 const constants = @import("constants.zig");
 const IO = @import("testing/io.zig").IO;
-const Tracer = vsr.trace.Tracer;
 const Storage = @import("storage.zig").StorageType(IO);
 const fixtures = @import("testing/fixtures.zig");
 const fuzz = @import("testing/fuzz.zig");

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -226,11 +226,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 storage_options.replica_index = @intCast(replica_index);
                 storage_options.fault_atlas = storage_fault_atlas;
                 storage_options.grid_checker = grid_checker;
-                storage.* = try Storage.init(
-                    allocator,
-                    options.cluster.storage_size_limit,
-                    storage_options,
-                );
+                storage.* = try Storage.init(allocator, storage_options);
                 // Disable most faults at startup,
                 // so that the replicas don't get stuck recovering_head.
                 storage.faulty =
@@ -854,11 +850,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             const storage = &cluster.storages[replica_index];
             const storage_options = storage.options;
             storage.deinit(cluster.allocator);
-            storage.* = try Storage.init(
-                cluster.allocator,
-                cluster.options.storage_size_limit,
-                storage_options,
-            );
+            storage.* = try Storage.init(cluster.allocator, storage_options);
 
             const client_index = cluster.options.client_count + cluster.reformat_count;
             cluster.reformat_count += 1;

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -145,8 +145,8 @@ pub fn open_superblock(superblock: *SuperBlock) void {
 
         fn callback(superblock_context: *SuperBlock.Context) void {
             const self: *@This() = @fieldParentPtr("superblock_context", superblock_context);
-            assert(!self.pending);
-            self.pending = true;
+            assert(self.pending);
+            self.pending = false;
         }
     };
     var context: Context = .{};
@@ -168,6 +168,7 @@ pub fn open_grid(grid: *Grid) void {
 
     const Context = struct {
         pending: bool = false,
+        // NB: This lacks in elegance and robustness, but is good enough for testing.
         var global: @This() = .{};
         fn callback(_: *Grid) void {
             assert(@This().global.pending);

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -65,7 +65,7 @@ pub fn init_storage(gpa: std.mem.Allocator, options: Storage.Options) !Storage {
 pub fn storage_format(
     gpa: std.mem.Allocator,
     storage: *Storage,
-    format_options: struct {
+    options: struct {
         cluster: u128 = cluster,
         replica: u8 = replica,
         replica_count: u8 = replica_count,
@@ -90,10 +90,10 @@ pub fn storage_format(
     var context: Context = .{};
 
     superblock.format(Context.callback, &context.superblock_context, .{
-        .cluster = format_options.cluster,
-        .replica = format_options.replica,
-        .replica_count = format_options.replica_count,
-        .release = format_options.release,
+        .cluster = options.cluster,
+        .replica = options.replica,
+        .replica_count = options.replica_count,
+        .release = options.release,
         .view = null,
     });
     for (0..1_000) |_| {

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -32,6 +32,7 @@ const Tracer = @import("../trace.zig").Tracer;
 const Storage = @import("./storage.zig").Storage;
 const ClusterFaultAtlas = @import("./storage.zig").ClusterFaultAtlas;
 const SuperBlock = vsr.SuperBlockType(Storage);
+const Grid = vsr.GridType(Storage);
 
 const TimeSim = @import("./time.zig").TimeSim;
 
@@ -147,5 +148,20 @@ pub fn superblock(gpa: std.mem.Allocator, s: *Storage, options: struct {
     return try SuperBlock.init(gpa, .{
         .storage = s,
         .storage_size_limit = options.storage_size_limit orelse s.size,
+    });
+}
+
+pub fn grid(gpa: std.mem.Allocator, trace: *Tracer, sb: *SuperBlock, options: struct {
+    missing_blocks_max: u64 = 0,
+    missing_tables_max: u64 = 0,
+    blocks_released_prior_checkpoint_durability_max: u64 = 0,
+}) !Grid {
+    return try Grid.init(gpa, .{
+        .superblock = sb,
+        .trace = trace,
+        .missing_blocks_max = options.missing_blocks_max,
+        .missing_tables_max = options.missing_tables_max,
+        .blocks_released_prior_checkpoint_durability_max = //
+        options.blocks_released_prior_checkpoint_durability_max,
     });
 }

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -1,16 +1,14 @@
-//! Convenient constors for TigerBeetle components, for fuzzing and testing.
+//! Convenient constructs for TigerBeetle components, for fuzzing and testing.
 //!
-//! Consider Storage. In the actual database, there is only single call to Storage.init.
-//! However, Storage is needed for most of our tests and fuzzers. If the init call is repeated
+//! Consider the Grid. In the actual database, there is only single call to Grid.init.
+//! However, Grid is needed for most of our tests and fuzzers. If the init call is repeated
 //! in every fuzzer, changing Storage creation flow becomes hard. To solve this, all fuzzers create
-//! Storage through this file, such that we have one production and one test call to Storage.init.
+//! Grid through this file, such that we have one production and one test call to Grid.init.
 //!
 //! Design:
 //!
-//! - All fuctions take struct options as a last argument, even if it starts out as empty.
+//! - All functions take struct options as a last argument, even if it starts out as empty.
 //!   All call-sites pass at least .{}, which makes adding new options cheap.
-//! - Options should be spelled-out in this file, rather re-using StorageOptions and the like, to
-//!   help the reader see the full API at a glance.
 //! - Most options should have defaults. This is intentional deviation from TigerStyle, as, for
 //!   tests, we gain a useful property: all options that are set are meaningful for a particular
 //!   test.
@@ -64,41 +62,8 @@ pub fn init_tracer(gpa: std.mem.Allocator, init: Time, options: struct {
     return Tracer.init(gpa, init, options.process_id, .{ .writer = options.writer });
 }
 
-pub const StorageOptions = struct {
-    size: u32,
-
-    seed: u64 = 0,
-
-    read_latency_min: Duration = .{ .ns = 0 },
-    read_latency_mean: Duration = .{ .ns = 0 },
-
-    write_latency_min: Duration = .{ .ns = 0 },
-    write_latency_mean: Duration = .{ .ns = 0 },
-
-    read_fault_probability: Ratio = .zero(),
-    write_fault_probability: Ratio = .zero(),
-    write_misdirect_probability: Ratio = .zero(),
-    crash_fault_probability: Ratio = .zero(),
-
-    fault_atlas: ?*const ClusterFaultAtlas = null,
-};
-
-pub fn init_storage(
-    gpa: std.mem.Allocator,
-    options: StorageOptions,
-) !Storage {
-    return try Storage.init(gpa, options.size, .{
-        .seed = options.seed,
-        .read_latency_min = options.read_latency_min,
-        .read_latency_mean = options.read_latency_mean,
-        .write_latency_min = options.write_latency_min,
-        .write_latency_mean = options.write_latency_mean,
-        // Faults makes sense only in the cluster.
-        .read_fault_probability = .zero(),
-        .write_fault_probability = .zero(),
-        .write_misdirect_probability = .zero(),
-        .crash_fault_probability = .zero(),
-    });
+pub fn init_storage(gpa: std.mem.Allocator, options: Storage.Options) !Storage {
+    return try Storage.init(gpa, options);
 }
 
 pub fn storage_format(

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -38,6 +38,7 @@ const TimeSim = @import("./time.zig").TimeSim;
 
 pub const cluster: u128 = 0;
 pub const replica: u8 = 0;
+pub const replica_count: u8 = 6;
 
 pub fn time(options: struct {
     resolution: u64 = constants.tick_ms * std.time.ns_per_ms,
@@ -106,7 +107,7 @@ pub fn storage_format(
     format_options: struct {
         cluster: u128 = cluster,
         replica: u8 = replica,
-        replica_count: u8 = constants.replicas_max,
+        replica_count: u8 = replica_count,
         release: vsr.Release = vsr.Release.minimum,
     },
 ) !void {

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -1,0 +1,50 @@
+//! Convenient constors for TigerBeetle components, for fuzzing and testing.
+//!
+//! Consider Storage. In the actual database, there is only single call to Storage.init.
+//! However, Storage is needed for most of our tests and fuzzers. If the init call is repeated
+//! in every fuzzer, changing Storage creation flow becomes hard. To solve this, all fuzzers create
+//! Storage through this file, such that we have one production and one test call to Storage.init.
+//!
+//! Design:
+//!
+//! - All fuctions take struct options as a last argument, even if it starts out as empty.
+//!   All call-sites pass at least .{}, which makes adding new options cheap.
+//! - Options should be spelled-out in this file, rather re-using StorageOptions and the like, to
+//!   help the reader see the full API at a glance.
+//! - Most options should have defaults. This is intentional deviation from TigerStyle, as, for
+//!   tests, we gain a useful property: all options that are set are meaningful for a particular
+//!   test.
+//! - It could be convenient to export types themselves, in addition to constructors, but we avoid
+//!   introducing two ways to import something.
+const std = @import("std");
+const constants = @import("../constants.zig");
+
+const Time = @import("../time.zig").Time;
+const OffsetType = @import("./time.zig").OffsetType;
+const Tracer = @import("../trace.zig").Tracer;
+
+const TimeSim = @import("./time.zig").TimeSim;
+
+pub fn time(options: struct {
+    resolution: u64 = constants.tick_ms * std.time.ns_per_ms,
+    offset_type: OffsetType = .linear,
+    offset_coefficient_A: i64 = 0,
+    offset_coefficient_B: i64 = 0,
+    offset_coefficient_C: u32 = 0,
+}) TimeSim {
+    const result: TimeSim = .{
+        .resolution = options.resolution,
+        .offset_type = options.offset_type,
+        .offset_coefficient_A = options.offset_coefficient_A,
+        .offset_coefficient_B = options.offset_coefficient_B,
+        .offset_coefficient_C = options.offset_coefficient_C,
+    };
+    return result;
+}
+
+pub fn tracer(gpa: std.mem.Allocator, t: Time, options: struct {
+    writer: ?std.io.AnyWriter = null,
+    process_id: Tracer.ProcessID = .{ .replica = .{ .cluster = 0, .replica = 0 } },
+}) !Tracer {
+    return Tracer.init(gpa, t, options.process_id, .{ .writer = options.writer });
+}

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -17,18 +17,14 @@
 //! - It could be convenient to export types themselves, in addition to constructors, but we avoid
 //!   introducing two ways to import something.
 const std = @import("std");
-const stdx = @import("../stdx.zig");
 const vsr = @import("../vsr.zig");
 const constants = @import("../constants.zig");
 const assert = std.debug.assert;
-const Ratio = stdx.PRNG.Ratio;
-const Duration = stdx.Duration;
 
 const Time = @import("../time.zig").Time;
 const OffsetType = @import("./time.zig").OffsetType;
 const Tracer = @import("../trace.zig").Tracer;
 const Storage = @import("./storage.zig").Storage;
-const ClusterFaultAtlas = @import("./storage.zig").ClusterFaultAtlas;
 const SuperBlock = vsr.SuperBlockType(Storage);
 const Grid = vsr.GridType(Storage);
 

--- a/src/testing/time.zig
+++ b/src/testing/time.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const stdx = @import("../stdx.zig");
-const constants = @import("../constants.zig");
 const Time = @import("../time.zig").Time;
 
 pub const OffsetType = enum {
@@ -45,15 +44,6 @@ pub const TimeSim = struct {
                 .realtime = realtime,
                 .tick = tick,
             },
-        };
-    }
-
-    pub fn init_simple() TimeSim {
-        return .{
-            .resolution = constants.tick_ms * std.time.ns_per_ms,
-            .offset_type = .linear,
-            .offset_coefficient_A = 0,
-            .offset_coefficient_B = 0,
         };
     }
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -237,7 +237,7 @@ fn tidy_long_line(file: SourceFile) !?u32 {
 
                 // trace.zig's JSON snapshot test.
                 if (std.mem.endsWith(u8, file.path, "trace.zig") and
-                    std.mem.startsWith(u8, string_value, "{\"pid\":0,\"tid\":")) continue;
+                    std.mem.startsWith(u8, string_value, "{\"pid\":1,\"tid\":")) continue;
 
                 // AMQP encoder snapshot test.
                 if (std.mem.endsWith(u8, file.path, "cdc/amqp/protocol.zig") and

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -445,9 +445,9 @@ test "trace json" {
     var trace_buffer: std.ArrayListUnmanaged(u8) = .empty;
     defer trace_buffer.deinit(gpa);
 
-    var time_sim = fixtures.time(.{});
+    var time_sim = fixtures.init_time(.{});
 
-    var trace = try fixtures.tracer(gpa, time_sim.time(), .{
+    var trace = try fixtures.init_tracer(gpa, time_sim.time(), .{
         .writer = trace_buffer.writer(gpa).any(),
         .process_id = .unknown,
     });
@@ -483,8 +483,8 @@ test "trace json" {
 test "timing overflow" {
     const gpa = std.testing.allocator;
 
-    var time_sim = fixtures.time(.{});
-    var trace = try fixtures.tracer(gpa, time_sim.time(), .{});
+    var time_sim = fixtures.init_time(.{});
+    var trace = try fixtures.init_tracer(gpa, time_sim.time(), .{});
     defer trace.deinit(gpa);
 
     trace.set_replica(.{ .cluster = 0, .replica = 0 });

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -442,6 +442,7 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
     const read_latency_min = range_inclusive_ms(prng, 0, 30);
     const write_latency_min = range_inclusive_ms(prng, 0, 30);
     const storage_options: Cluster.Storage.Options = .{
+        .size = cluster_options.storage_size_limit,
         .seed = prng.int(u64),
         .read_latency_min = read_latency_min,
         .read_latency_mean = range_inclusive_ms(prng, read_latency_min, 100),
@@ -561,6 +562,7 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {
     };
 
     const storage_options: Cluster.Storage.Options = .{
+        .size = cluster_options.storage_size_limit,
         .seed = prng.int(u64),
         .read_latency_min = .{ .ns = 0 },
         .read_latency_mean = .{ .ns = 0 },

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -224,7 +224,7 @@ test "format" {
     const replica = 1;
     const replica_count = 1;
 
-    var storage = try fixtures.storage(allocator, .{ .size = data_file_size_min });
+    var storage = try fixtures.init_storage(allocator, .{ .size = data_file_size_min });
     defer storage.deinit(allocator);
 
     try format(Storage, allocator, .{

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -218,21 +218,13 @@ fn ReplicaFormatType(comptime Storage: type) type {
 test "format" {
     const data_file_size_min = @import("./superblock.zig").data_file_size_min;
     const Storage = @import("../testing/storage.zig").Storage;
+    const fixtures = @import("../testing/fixtures.zig");
     const allocator = std.testing.allocator;
     const cluster = 0;
     const replica = 1;
     const replica_count = 1;
 
-    var storage = try Storage.init(
-        allocator,
-        data_file_size_min,
-        .{
-            .read_latency_min = .{ .ns = 0 },
-            .read_latency_mean = .{ .ns = 0 },
-            .write_latency_min = .{ .ns = 0 },
-            .write_latency_mean = .{ .ns = 0 },
-        },
-    );
+    var storage = try fixtures.storage(allocator, .{ .size = data_file_size_min });
     defer storage.deinit(allocator);
 
     try format(Storage, allocator, .{

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1983,6 +1983,7 @@ const TestContext = struct {
         const log_level_original = std.testing.log_level;
         std.testing.log_level = log_level;
         var prng = stdx.PRNG.from_seed(options.seed);
+        const storage_size_limit = vsr.sector_floor(128 * 1024 * 1024);
 
         const cluster = try Cluster.init(allocator, .{
             .cluster = .{
@@ -1990,7 +1991,7 @@ const TestContext = struct {
                 .replica_count = options.replica_count,
                 .standby_count = options.standby_count,
                 .client_count = options.client_count,
-                .storage_size_limit = vsr.sector_floor(128 * 1024 * 1024),
+                .storage_size_limit = storage_size_limit,
                 .seed = prng.int(u64),
                 .releases = &releases,
                 .client_release = options.client_release,
@@ -2013,6 +2014,7 @@ const TestContext = struct {
                 .recorded_count_max = 16,
             },
             .storage = .{
+                .size = storage_size_limit,
                 .read_latency_min = .{ .ns = 10 * std.time.ns_per_ms },
                 .read_latency_mean = .{ .ns = 50 * std.time.ns_per_ms },
                 .write_latency_min = .{ .ns = 10 * std.time.ns_per_ms },

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -144,7 +144,6 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
     while (env.pending.count() > 0) env.superblock.storage.run();
 
     env.open();
-    while (env.pending.count() > 0) env.superblock.storage.run();
 
     try env.verify();
     assert(env.pending.count() == 0);
@@ -320,15 +319,7 @@ const Environment = struct {
 
     fn open(env: *Environment) void {
         assert(env.pending.count() == 0);
-        env.pending.insert(.open);
-        env.superblock.open(open_callback, &env.context_open);
-    }
-
-    fn open_callback(context: *SuperBlock.Context) void {
-        const env: *Environment = @fieldParentPtr("context_open", context);
-        assert(env.pending.contains(.open));
-        env.pending.remove(.open);
-
+        fixtures.superblock_open(env.superblock);
         assert(env.superblock.working.sequence == 1);
         assert(env.superblock.working.vsr_state.replica_id == env.members[replica]);
         assert(env.superblock.working.vsr_state.replica_count == replica_count);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -24,6 +24,7 @@ const SuperBlockHeader = @import("superblock.zig").SuperBlockHeader;
 const SuperBlockType = @import("superblock.zig").SuperBlockType;
 const Caller = @import("superblock.zig").Caller;
 const SuperBlock = SuperBlockType(Storage);
+const fixtures = @import("../testing/fixtures.zig");
 const fuzz = @import("../testing/fuzz.zig");
 const stdx = @import("../stdx.zig");
 const ratio = stdx.PRNG.ratio;
@@ -51,9 +52,9 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
     });
     defer storage_fault_atlas.deinit(gpa);
 
-    const storage_options: Storage.Options = .{
-        .replica_index = 0,
+    const storage_options: fixtures.StorageOptions = .{
         .seed = prng.int(u64),
+        .size = superblock_zone_size,
         // SuperBlock's IO is all serial, so latencies never reorder reads/writes.
         .read_latency_min = .{ .ns = 0 },
         .read_latency_mean = .{ .ns = 0 },
@@ -76,10 +77,10 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
         .fault_atlas = &storage_fault_atlas,
     };
 
-    var storage = try Storage.init(gpa, superblock_zone_size, storage_options);
+    var storage = try fixtures.storage(gpa, storage_options);
     defer storage.deinit(gpa);
 
-    var storage_verify = try Storage.init(gpa, superblock_zone_size, storage_options);
+    var storage_verify = try fixtures.storage(gpa, storage_options);
     defer storage_verify.deinit(gpa);
 
     var superblock = try SuperBlock.init(gpa, .{

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -83,14 +83,12 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
     var storage_verify = try fixtures.storage(gpa, storage_options);
     defer storage_verify.deinit(gpa);
 
-    var superblock = try SuperBlock.init(gpa, .{
-        .storage = &storage,
+    var superblock = try fixtures.superblock(gpa, &storage, .{
         .storage_size_limit = constants.storage_size_limit_default,
     });
     defer superblock.deinit(gpa);
 
-    var superblock_verify = try SuperBlock.init(gpa, .{
-        .storage = &storage_verify,
+    var superblock_verify = try fixtures.superblock(gpa, &storage_verify, .{
         .storage_size_limit = constants.storage_size_limit_default,
     });
     defer superblock_verify.deinit(gpa);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -77,18 +77,18 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
         .fault_atlas = &storage_fault_atlas,
     };
 
-    var storage = try fixtures.storage(gpa, storage_options);
+    var storage = try fixtures.init_storage(gpa, storage_options);
     defer storage.deinit(gpa);
 
-    var storage_verify = try fixtures.storage(gpa, storage_options);
+    var storage_verify = try fixtures.init_storage(gpa, storage_options);
     defer storage_verify.deinit(gpa);
 
-    var superblock = try fixtures.superblock(gpa, &storage, .{
+    var superblock = try fixtures.init_superblock(gpa, &storage, .{
         .storage_size_limit = constants.storage_size_limit_default,
     });
     defer superblock.deinit(gpa);
 
-    var superblock_verify = try fixtures.superblock(gpa, &storage_verify, .{
+    var superblock_verify = try fixtures.init_superblock(gpa, &storage_verify, .{
         .storage_size_limit = constants.storage_size_limit_default,
     });
     defer superblock_verify.deinit(gpa);
@@ -319,7 +319,7 @@ const Environment = struct {
 
     fn open(env: *Environment) void {
         assert(env.pending.count() == 0);
-        fixtures.superblock_open(env.superblock);
+        fixtures.open_superblock(env.superblock);
         assert(env.superblock.working.sequence == 1);
         assert(env.superblock.working.vsr_state.replica_id == env.members[replica]);
         assert(env.superblock.working.vsr_state.replica_count == replica_count);

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -52,7 +52,7 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
     });
     defer storage_fault_atlas.deinit(gpa);
 
-    const storage_options: fixtures.StorageOptions = .{
+    const storage_options: Storage.Options = .{
         .seed = prng.int(u64),
         .size = superblock_zone_size,
         // SuperBlock's IO is all serial, so latencies never reorder reads/writes.
@@ -74,6 +74,7 @@ fn run_fuzz(gpa: std.mem.Allocator, seed: u64, transitions_count_total: usize) !
             prng.range_inclusive(u64, 50, 100),
             100,
         ),
+        .replica_index = fixtures.replica,
         .fault_atlas = &storage_fault_atlas,
     };
 

--- a/src/vsr/superblock_fuzz.zig
+++ b/src/vsr/superblock_fuzz.zig
@@ -29,9 +29,9 @@ const fuzz = @import("../testing/fuzz.zig");
 const stdx = @import("../stdx.zig");
 const ratio = stdx.PRNG.ratio;
 
-const cluster = 0;
-const replica = 0;
-const replica_count = 6;
+const cluster = fixtures.cluster;
+const replica = fixtures.replica;
+const replica_count = fixtures.replica_count;
 
 pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
     // Total calls to checkpoint() + view_change().


### PR DESCRIPTION
We have a lot of code duplciation in fuzzers when creating storage,
grid, superblock, tracer, etc. This is bad, as it makes refactoring
construcotrs unnecessary painful (unnecessary, because typically there's
only _producion_ call-site, all duplicates come from fuzzers).

The idea is that everything should be create through fixtures module, so
that there's just a single consturciton call, shared for all fuzzer.
Crucially, the fixtures can _default_ most of the arguments, and
otherwise adapt the API, to insulate callers from changes.