### PR TITLE
tigerbeetle: disable upgrades with --addresses=0

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -453,6 +453,11 @@ const Command = struct {
                 break :blk null;
             }
 
+            if (args.addresses_zero) {
+                log.info("multiversioning: upgrades disabled due to --addresses=0", .{});
+                break :blk null;
+            }
+
             break :blk try vsr.multiversioning.Multiversion.init(
                 allocator,
                 io,


### PR DESCRIPTION
With addresses zero, after restart the replica would bind to a different port, which doesn't make sense. We _could_ perhaps try to reuse the port between replica incarnations, but that doesn't seem worth the hassle.

Not that what _actually_ would happen if you try to do upgbrade with addressses=0 before this PR is that the reincarnation of a  replica would get an error in

```
try stdout.writer().print("{}\n", .{port_actual});
stdout.close();
```

on a `print` call, because the _first_ incarnation would have closed fd=0.

The error by itself it _fine_, but it will cause `replica.deinit`, which would then _panic_ due to storage.next_tick still runnnig. That is _also_ a bug, but not the one I intend to fix here :0)