### PR TITLE
inspect: compaction/checkpoint/journal slot count

### DIFF
--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -156,6 +156,15 @@ fn inspect_constants(output: std.io.AnyWriter) !void {
     });
     try output.print("\n", .{});
 
+    try output.print("LSM:\n", .{});
+    try print_header(output, 0, "compaction_ops");
+    try output.print("{}\n", .{constants.lsm_compaction_ops});
+    try print_header(output, 0, "checkpoint_ops");
+    try output.print("{}\n", .{constants.vsr_checkpoint_ops});
+    try print_header(output, 0, "journal_slot_count");
+    try output.print("{}\n", .{constants.journal_slot_count});
+    try output.print("\n", .{});
+
     try output.print("Data File Layout:\n", .{});
     inline for (comptime std.enums.values(vsr.Zone)) |zone| {
         try print_header(output, 0, @tagName(zone));


### PR DESCRIPTION
```
λ ./zig/zig build run -- inspect constants
VSR:
prepare_queue                   8
request_queue                   57
prepare_cache                   65

LSM:
compaction_ops                  32
checkpoint_ops                  960
journal_slot_count              1024
```

I filed journal_slot_count under `lsm` rather than `vsr` to rhyme with compaction/checkpoint ops, although technically it's more about vsr than lsm. 