### PR TITLE
stdx: teach snaptest to hex & zon

### DIFF
--- a/src/cdc/amqp/protocol.zig
+++ b/src/cdc/amqp/protocol.zig
@@ -1013,8 +1013,8 @@ test "amqp: frame and header" {
         encoder.write_method_header(.{ .class = 1, .method = 10 });
         encoder.finish_frame(.method);
         try snap(@src(),
-            \\[1,0,0,0,0,0,4,0,1,0,10,206]
-        ).diff_json(buffer[0..encoder.index], .{ .emit_strings_as_arrays = true });
+            \\01 00 00 00 00 00 04 00  01 00 0a ce
+        ).diff_hex(buffer[0..encoder.index]);
     }
 
     {
@@ -1030,8 +1030,9 @@ test "amqp: frame and header" {
         encoder.finish_header(0);
 
         try snap(@src(),
-            \\[1,0,0,0,0,0,4,0,10,0,100,206,2,0,1,0,0,0,12,0,10,0,0,0,0,0,0,0,0,0,0,206]
-        ).diff_json(buffer[0..encoder.index], .{ .emit_strings_as_arrays = true });
+            \\01 00 00 00 00 00 04 00  0a 00 64 ce 02 00 01 00
+            \\00 00 0c 00 0a 00 00 00  00 00 00 00 00 00 00 ce
+        ).diff_hex(buffer[0..encoder.index]);
     }
 
     {
@@ -1051,8 +1052,10 @@ test "amqp: frame and header" {
         encoder.finish_frame(.body);
 
         try snap(@src(),
-            \\[1,0,0,0,0,0,4,0,100,3,232,206,2,0,1,0,0,0,12,0,100,0,0,0,0,0,0,0,0,0,4,206,3,0,1,0,0,0,4,98,111,100,121,206]
-        ).diff_json(buffer[0..encoder.index], .{ .emit_strings_as_arrays = true });
+            \\01 00 00 00 00 00 04 00  64 03 e8 ce 02 00 01 00
+            \\00 00 0c 00 64 00 00 00  00 00 00 00 00 00 04 ce
+            \\03 00 01 00 00 00 04 62  6f 64 79 ce
+        ).diff_hex(buffer[0..encoder.index]);
     }
 }
 

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -785,22 +785,22 @@ test "shell: expand_argv" {
             defer argv.deinit();
 
             try expand_argv(&argv, cmd, args);
-            try want.diff_json(argv.slice(), .{});
+            try want.diff_zon(argv.slice());
         }
     };
 
     try T.check("zig version", .{}, snap(@src(),
-        \\["zig","version"]
+        \\.{ "zig", "version" }
     ));
     try T.check("  zig  version  ", .{}, snap(@src(),
-        \\["zig","version"]
+        \\.{ "zig", "version" }
     ));
 
     try T.check(
         "zig {version}",
         .{ .version = @as([]const u8, "version") },
         snap(@src(),
-            \\["zig","version"]
+            \\.{ "zig", "version" }
         ),
     );
 
@@ -808,7 +808,11 @@ test "shell: expand_argv" {
         "zig {version}",
         .{ .version = @as([]const []const u8, &.{ "version", "--verbose" }) },
         snap(@src(),
-            \\["zig","version","--verbose"]
+            \\.{
+            \\    "zig",
+            \\    "version",
+            \\    "--verbose",
+            \\}
         ),
     );
 
@@ -816,14 +820,24 @@ test "shell: expand_argv" {
         "git fetch origin refs/pull/{pr}/head",
         .{ .pr = 92 },
         snap(@src(),
-            \\["git","fetch","origin","refs/pull/92/head"]
+            \\.{
+            \\    "git",
+            \\    "fetch",
+            \\    "origin",
+            \\    "refs/pull/92/head",
+            \\}
         ),
     );
     try T.check(
         "gh pr checkout {pr}",
         .{ .pr = @as(u32, 92) },
         snap(@src(),
-            \\["gh","pr","checkout","92"]
+            \\.{
+            \\    "gh",
+            \\    "pr",
+            \\    "checkout",
+            \\    "92",
+            \\}
         ),
     );
 }

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1179,7 +1179,6 @@ test "ByteSize.parse_flag_value" {
 }
 
 comptime {
-    _ = @import("stdx.zig");
     _ = @import("aegis.zig");
     _ = @import("bit_set.zig");
     _ = @import("bounded_array.zig");
@@ -1187,5 +1186,7 @@ comptime {
     _ = @import("prng.zig");
     _ = @import("ring_buffer.zig");
     _ = @import("sort_test.zig");
+    _ = @import("stdx.zig");
+    _ = @import("testing/snaptest.zig");
     _ = @import("zipfian.zig");
 }

--- a/src/stdx/testing/snaptest.zig
+++ b/src/stdx/testing/snaptest.zig
@@ -150,6 +150,14 @@ pub const Snap = struct {
         try snapshot.diff(got.items);
     }
 
+    pub fn diff_hex(snapshot: *const Snap, value: []const u8) !void {
+        var buffer: std.ArrayListUnmanaged(u8) = .empty;
+        defer buffer.deinit(std.testing.allocator);
+
+        try hexdump(value, buffer.writer(std.testing.allocator).any());
+        try snapshot.diff(buffer.items);
+    }
+
     // Compare the snapshot with a given string.
     pub fn diff(snapshot: *const Snap, got: []const u8) !void {
         if (equal_excluding_ignored(got, snapshot.text)) return;
@@ -330,4 +338,23 @@ fn get_indent(line: []const u8) []const u8 {
         if (c != ' ') return line[0..i];
     }
     return line;
+}
+
+fn hexdump(bytes: []const u8, writer: std.io.AnyWriter) !void {
+    for (bytes, 0..) |byte, index| {
+        if (index > 0) {
+            const space = if (index % 16 == 0) "\n" else if (index % 8 == 0) "  " else " ";
+            try writer.writeAll(space);
+        }
+        try writer.print("{x:02}", .{byte});
+    }
+}
+
+test hexdump {
+    const snap = Snap.snap_fn("./src/stdx");
+
+    try snap(@src(),
+        \\68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 01 02
+        \\03 fd fe ff
+    ).diff_hex("hello, world\n" ++ .{ 0, 1, 2, 3, 253, 254, 255 });
 }

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -239,10 +239,6 @@ fn tidy_long_line(file: SourceFile) !?u32 {
                 if (std.mem.endsWith(u8, file.path, "trace.zig") and
                     std.mem.startsWith(u8, string_value, "{\"pid\":1,\"tid\":")) continue;
 
-                // AMQP encoder snapshot test.
-                if (std.mem.endsWith(u8, file.path, "cdc/amqp/protocol.zig") and
-                    std.mem.startsWith(u8, string_value, "[1,0,0")) continue;
-
                 // AMQP JSON snapshot test.
                 if (std.mem.endsWith(u8, file.path, "cdc/runner.zig") and
                     std.mem.startsWith(u8, string_value, "{\"timestamp\":")) continue;


### PR DESCRIPTION
My primary goal was to replace `diff_json` with `diff_zon`, but I realized that `diff_hex` is also a useful utility!