### PR TITLE
vsr: allow sending non-zero view in RequestPrepare

### DIFF
--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1185,7 +1185,7 @@ pub const Header = extern struct {
         cluster: u128,
         size: u32 = @sizeOf(Header),
         epoch: u32 = 0,
-        view: u32 = 0, // Always 0.
+        view: u32,
         release: vsr.Release = vsr.Release.zero, // Always 0.
         protocol: u16 = vsr.Version,
         command: Command,
@@ -1203,7 +1203,6 @@ pub const Header = extern struct {
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
             if (self.release.value != 0) return "release != 0";
             if (self.prepare_checksum_padding != 0) return "prepare_checksum_padding != 0";
-            if (self.view != 0) return "view == 0";
             if (!stdx.zeroed(&self.reserved)) return "reserved != 0";
             return null;
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7986,6 +7986,7 @@ pub fn ReplicaType(
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .prepare_op = op,
+                .view = 0,
                 .prepare_checksum = checksum,
             };
 


### PR DESCRIPTION
In preparation for the repair optimizations in https://github.com/tigerbeetle/tigerbeetle/pull/3123, allow sending non-zero view in a RequestPrepare message. This is required to ensure repair compatibility during upgrades. 