### PR TITLE
devhub: Show VOPR count for the release

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -112,6 +112,8 @@ async function main_seeds() {
       !open_pull_requests.has(pull_request_number(record))
     ) {
       include = false;
+    } else if (record.fuzzer === "canary" && !is_main(record)) {
+      include = false;
     } else {
       include = (!record.ok || pull_request_number(record) !== undefined) &&
         !fuzzers_with_failures.has(record.branch + record.fuzzer);

--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -114,6 +114,8 @@ async function main_seeds() {
       include = false;
     } else if (record.fuzzer === "canary" && !is_main(record)) {
       include = false;
+    } else if (record.fuzzer === "vopr" && is_release(record)) {
+      include = true;
     } else {
       include = (!record.ok || pull_request_number(record) !== undefined) &&
         !fuzzers_with_failures.has(record.branch + record.fuzzer);

--- a/src/docs_website/build.zig
+++ b/src/docs_website/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const assert = std.debug.assert;
 const Website = @import("src/website.zig").Website;
 const docs = @import("src/docs.zig");
 const redirects = @import("src/redirects.zig");
@@ -24,6 +25,7 @@ pub fn build(b: *std.Build) !void {
     const vale_bin = get_vale_bin(b) orelse return;
 
     const check_spelling = std.Build.Step.Run.create(b, "run vale");
+    hide_stderr(check_spelling);
     check_spelling.addFileArg(vale_bin);
     const md_files = b.run(&.{ "git", "ls-files", "../../**/*.md" });
     var md_files_iter = std.mem.tokenizeScalar(u8, md_files, '\n');
@@ -125,4 +127,27 @@ fn get_vale_bin(b: *std.Build) ?std.Build.LazyPath {
     } else {
         return null;
     }
+}
+
+// Hide step's stderr unless it fails. Sadly, this requires overriding Build.Step.Run make function.
+fn hide_stderr(run: *std.Build.Step.Run) void {
+    const b = run.step.owner;
+
+    run.addCheck(.{ .expect_term = .{ .Exited = 0 } });
+    run.has_side_effects = true;
+
+    const override = struct {
+        var global_map: std.AutoHashMapUnmanaged(usize, std.Build.Step.MakeFn) = .{};
+
+        fn make(step: *std.Build.Step, options: std.Build.Step.MakeOptions) anyerror!void {
+            const original = global_map.get(@intFromPtr(step)).?;
+            try original(step, options);
+            assert(step.result_error_msgs.items.len == 0);
+            step.result_stderr = "";
+        }
+    };
+
+    const original = run.step.makeFn;
+    override.global_map.put(b.allocator, @intFromPtr(&run.step), original) catch @panic("OOM");
+    run.step.makeFn = &override.make;
 }

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1672,22 +1672,10 @@ test "cfo: SeedRecord.merge" {
             \\    "commit_sha": "1111111111111111111111111111111111111111",
             \\    "fuzzer": "ewah",
             \\    "ok": true,
-            \\    "count": 4,
+            \\    "count": 6,
             \\    "seed_timestamp_start": 1,
             \\    "seed_timestamp_end": 1,
             \\    "seed": 3,
-            \\    "command": "fuzz ewah",
-            \\    "branch": "main"
-            \\  },
-            \\  {
-            \\    "commit_timestamp": 1,
-            \\    "commit_sha": "1111111111111111111111111111111111111111",
-            \\    "fuzzer": "ewah",
-            \\    "ok": true,
-            \\    "count": 2,
-            \\    "seed_timestamp_start": 1,
-            \\    "seed_timestamp_end": 1,
-            \\    "seed": 1,
             \\    "command": "fuzz ewah",
             \\    "branch": "main"
             \\  }

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1088,26 +1088,26 @@ const SeedRecord = struct {
             }
             seed_previous = record.seed;
 
-            seed_count += 1;
-            if (seed_count <= options.seed_count_max) {
-                try result.append(record);
-            } else {
-                if (record.ok) {
-                    // Merge counts with the first ok record for this fuzzer/commit, to make it
-                    // easy for the front-end to show the total count by displaying just the first
-                    // record
-                    var last_ok_index = result.items.len;
-                    while (last_ok_index > 0 and
-                        result.items[last_ok_index - 1].ok and
-                        std.mem.eql(u8, result.items[last_ok_index - 1].fuzzer, record.fuzzer) and
-                        std.meta.eql(result.items[last_ok_index - 1].commit_sha, record.commit_sha))
-                    {
-                        last_ok_index -= 1;
-                    }
-                    if (last_ok_index != result.items.len) {
-                        result.items[last_ok_index].count += record.count;
-                    }
+            if (record.ok) {
+                // Merge counts with the first ok record for this fuzzer/commit, to make it easy for
+                // the front-end to show the total count by displaying just the first record.
+                var last_ok_index = result.items.len;
+                while (last_ok_index > 0 and
+                    result.items[last_ok_index - 1].ok and
+                    std.mem.eql(u8, result.items[last_ok_index - 1].fuzzer, record.fuzzer) and
+                    std.meta.eql(result.items[last_ok_index - 1].commit_sha, record.commit_sha))
+                {
+                    last_ok_index -= 1;
                 }
+                if (last_ok_index != result.items.len) {
+                    result.items[last_ok_index].count += record.count;
+                    continue;
+                }
+            }
+
+            if (seed_count < options.seed_count_max) {
+                try result.append(record);
+                seed_count += 1;
             }
         }
 


### PR DESCRIPTION
* Show canary only for the main branch
* Show successful VOPR count on release branch
* CFO: merge all successful seeds per fuzzer and commit
* docs: don't print successful spellcheck result using `hide_stderr`