### PR TITLE
use double-entry accounting for allocations

### DIFF
--- a/src/counting_allocator.zig
+++ b/src/counting_allocator.zig
@@ -4,7 +4,8 @@ const Alignment = std.mem.Alignment;
 const CountingAllocator = @This();
 
 parent_allocator: std.mem.Allocator,
-size: usize = 0,
+alloc_size: u64 = 0,
+free_size: u64 = 0,
 
 pub fn init(parent_allocator: std.mem.Allocator) CountingAllocator {
     return .{ .parent_allocator = parent_allocator };
@@ -26,22 +27,39 @@ pub fn allocator(self: *CountingAllocator) std.mem.Allocator {
     };
 }
 
+pub fn live_size(self: *CountingAllocator) u64 {
+    return self.alloc_size - self.free_size;
+}
+
 fn alloc(ctx: *anyopaque, len: usize, ptr_align: Alignment, ret_addr: usize) ?[*]u8 {
     const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
-    self.size += len;
+    self.alloc_size += len;
     return self.parent_allocator.rawAlloc(len, ptr_align, ret_addr);
 }
 
 fn resize(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_addr: usize) bool {
     const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
-    self.size = (self.size - buf.len) + new_len;
-    return self.parent_allocator.rawResize(buf, buf_align, new_len, ret_addr);
+
+    if (self.parent_allocator.rawResize(buf, buf_align, new_len, ret_addr)) {
+        if (new_len > buf.len) {
+            self.alloc_size += new_len - buf.len;
+        } else {
+            self.free_size += buf.len - new_len;
+        }
+        return true;
+    } else {
+        return false;
+    }
 }
 
 fn remap(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
     const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
     if (self.parent_allocator.rawRemap(buf, buf_align, new_len, ret_addr)) |remapped| {
-        self.size = (self.size - buf.len) + new_len;
+        if (new_len > buf.len) {
+            self.alloc_size += new_len - buf.len;
+        } else {
+            self.free_size += buf.len - new_len;
+        }
         return remapped;
     }
     return null;
@@ -49,6 +67,6 @@ fn remap(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_a
 
 fn free(ctx: *anyopaque, buf: []u8, buf_align: Alignment, ret_addr: usize) void {
     const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
-    self.size -= buf.len;
+    self.free_size += buf.len;
     return self.parent_allocator.rawFree(buf, buf_align, ret_addr);
 }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -543,7 +543,7 @@ const Command = struct {
         // the nearest page by `std.heap.page_allocator`.
         log.info("{}: Allocated {}MiB during replica init", .{
             replica.replica,
-            @divFloor(counting_allocator.size, 1024 * 1024),
+            @divFloor(counting_allocator.live_size(), 1024 * 1024),
         });
         log.info("{}: Grid cache: {}MiB, LSM-tree manifests: {}MiB", .{
             replica.replica,
@@ -608,7 +608,9 @@ const Command = struct {
             // potentially introducing undetectable disk corruption into memory.
             // This is a best-effort attempt and not a hard rule as it may not cover all memory edge
             // case. So warn on error to notify the operator to adjust conditions if possible.
-            stdx.memory_lock_allocated(.{ .allocated_size = counting_allocator.size }) catch {
+            stdx.memory_lock_allocated(.{
+                .allocated_size = counting_allocator.live_size(),
+            }) catch {
                 log.warn(
                     "If this is a production replica, consider either " ++
                         "running the replica with CAP_IPC_LOCK privilege, " ++


### PR DESCRIPTION
I did this to check the hypothesis that we do _reallocations_ during init, but we actually don't (we free zero bytes!). Still, given that the code is already there, let's keep it at higher resolution!