### PR TITLE
vopr: increase timeout for post safety mode convergence

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -247,6 +247,9 @@ pub fn main() !void {
     // without split-brain.
     var tick_total: u64 = 0;
     var tick: u64 = 0;
+    var requests_done: bool = false;
+    var upgrades_done: bool = false;
+
     while (tick < cli_args.ticks_max_requests) : (tick += 1) {
         const requests_replied_old = simulator.requests_replied;
         simulator.tick();
@@ -254,8 +257,8 @@ pub fn main() !void {
         if (simulator.requests_replied > requests_replied_old) {
             tick = 0;
         }
-        const requests_done = simulator.requests_replied == simulator.options.requests_max;
-        const upgrades_done =
+        requests_done = simulator.requests_replied == simulator.options.requests_max;
+        upgrades_done =
             for (simulator.cluster.replicas, simulator.cluster.replica_health) |*replica, health| {
                 if (health != .up) continue;
                 const release_latest = releases[simulator.replica_releases_limit - 1].release;
@@ -265,50 +268,31 @@ pub fn main() !void {
             } else false;
 
         if (requests_done and upgrades_done) break;
-    } else {
-        if (cli_args.lite) return;
-
-        // Safety mode ran out of ticks without completing its requests, so now we check whether it
-        // was correct to do so.
-        //
-        // Heal current network partitions, disable future process, storage, and network faults
-        // on all replicas. Run this fully-connected core of replicas for 600_000 ticks, which
-        // should enough to ensure all faulty grid blocks, headers, or prepares that can be repaired
-        // are repaired. After this, all we must be left with are correlated faults.
-        {
-            var replica: u8 = 0;
-            var core: Core = .{};
-            while (replica < simulator.options.cluster.replica_count) : (replica += 1) {
-                core.set(replica);
-            }
-
-            simulator.transition_to_liveness_mode(core);
-
-            tick = 0;
-            while (tick < 600_000) : (tick += 1) simulator.tick();
-        }
-
-        log.info(
-            "no liveness, final cluster state (requests_max={} requests_replied={}):",
-            .{ simulator.options.requests_max, simulator.requests_replied },
-        );
-        simulator.cluster.log_cluster();
-        if (try simulator.cluster_recoverable(gpa)) {
-            log.err("you can reproduce this failure with seed={}", .{seed});
-            fatal(.liveness, "unable to complete requests_committed_max before ticks_max", .{});
-        } else return;
     }
 
     if (cli_args.lite or cli_args.performance) {
         // Don't care about convergence.
     } else {
-        // Liveness: a core set of replicas is up and fully connected. The rest of replicas might be
-        // crashed or partitioned permanently. The core should converge to the same state.
-        const core = random_core(
-            simulator.prng,
-            simulator.options.cluster.replica_count,
-            simulator.options.cluster.standby_count,
-        );
+        const core = if (requests_done and upgrades_done)
+            // Liveness: a core set of replicas is up and fully connected. The rest of the replicas
+            // might be crashed or partitioned permanently. The core should converge to the same
+            // state.
+            random_core(
+                simulator.prng,
+                simulator.options.cluster.replica_count,
+                simulator.options.cluster.standby_count,
+            )
+        else
+            // Safety mode ran out of ticks without completing its requests, so now we check whether
+            // it was correct to do so.
+            //
+            // Run a fully-connected core of replicas to repair all faulty grid blocks, headers, and
+            // prepares that can be repaired. Thereafter, only correlated faults should remain.
+            full_core(
+                simulator.options.cluster.replica_count,
+                simulator.options.cluster.standby_count,
+            );
+
         simulator.transition_to_liveness_mode(core);
 
         tick = 0;
@@ -754,19 +738,12 @@ pub const Simulator = struct {
 
     pub fn pending(simulator: *const Simulator) ?[]const u8 {
         assert(simulator.core.count() > 0);
-        assert(simulator.requests_sent - simulator.cluster.client_eviction_requests_cancelled ==
+        assert(simulator.requests_sent - simulator.cluster.client_eviction_requests_cancelled <=
             simulator.options.requests_max);
         assert(simulator.reply_sequence.empty());
         for (simulator.cluster.clients) |*client_maybe| {
             if (client_maybe.*) |client| {
-                if (client.request_inflight) |request| {
-                    // Registration and reformatting (noop's) aren't counted by requests_sent, so an
-                    // operation=register|noop may still be in-flight. Any other requests should
-                    // already be complete before done() is called.
-                    assert(request.message.header.operation == .register or
-                        request.message.header.operation == .noop);
-                    return "pending register request";
-                }
+                if (client.request_inflight) |_| return "pending request";
             }
         }
 
@@ -1704,14 +1681,14 @@ fn random_core(prng: *stdx.PRNG, replica_count: u8, standby_count: u8) Core {
     const replica_core_count = prng.range_inclusive(u8, quorum_view_change, replica_count);
     const standby_core_count = prng.range_inclusive(u8, 0, standby_count);
 
-    var result: Core = .{};
+    var core: Core = .{};
 
     var combination = stdx.PRNG.Combination.init(.{
         .total = replica_count,
         .sample = replica_core_count,
     });
     for (0..replica_count) |replica| {
-        if (combination.take(prng)) result.set(replica);
+        if (combination.take(prng)) core.set(replica);
     }
     assert(combination.done());
 
@@ -1719,14 +1696,29 @@ fn random_core(prng: *stdx.PRNG, replica_count: u8, standby_count: u8) Core {
         .total = standby_count,
         .sample = standby_core_count,
     });
-    for (replica_count..replica_count + standby_count) |replica| {
-        if (combination.take(prng)) result.set(replica);
+    for (replica_count..replica_count + standby_count) |standby| {
+        if (combination.take(prng)) core.set(standby);
     }
     assert(combination.done());
 
-    assert(result.count() == replica_core_count + standby_core_count);
+    assert(core.count() == replica_core_count + standby_core_count);
 
-    return result;
+    return core;
+}
+
+/// Returns a random fully-connected subgraph which includes all replicas and standbys.
+fn full_core(replica_count: u8, standby_count: u8) Core {
+    assert(replica_count > 0);
+    assert(replica_count <= constants.replicas_max);
+    assert(standby_count <= constants.standbys_max);
+
+    var core: Core = .{};
+
+    for (0..replica_count + standby_count) |replica| core.set(replica);
+
+    assert(core.count() == replica_count + standby_count);
+
+    return core;
 }
 
 var log_buffer: std.io.BufferedWriter(4096, std.fs.File.Writer) = .{


### PR DESCRIPTION
At the end of the safety-mode in the VOPR, in case the cluster can't respond to all client requests within the defined timeout, we try to figure out _why_ it couldn't using some liveness checks. This helps us ascertain whether the cluster is stuck due to a legitimate correlated fault (which is irrecoverable), or whether there is a true liveness bug at play. Before performing these liveness checks, we "shake off" all non-correlated faults in the cluster by healing all network partitions and letting the cluster converge to a steady state. The timeout that we choose for this is `600_000`, which is arbitrary. 

This PR changes this timeout to use `ticks_max_convergence` (which is already used in liveness mode). This is because the phase at the end of safety mode is also akin to liveness mode, since we're waiting for the fully connected core of replicas to converge to steady state, so we can run liveness checks on it.

---

Here are some details about the failed seed that this was discovered through:

Commit: ce86654194dd423c597721ef582536870d91caaf
Seed: ./zig/zig build -Drelease vopr -Dvopr-state-machine=testing -- 16418143961442690741

```C
Commit: ce86654194dd423c597721ef582536870d91caaf
Seed: ./zig/zig build -Drelease vopr -Dvopr-state-machine=testing -- 16418143961442690741

no liveness, final cluster state (requests_max=96 requests_replied=96):
 0   \ v      16028V  99/122/122C   0:122Jo  0/_0J!   0:122Wo <__0:103> v1:3   126Ga  0G!   0G?
 1   \  v     16029V  99/122/122C   0:122Jo  0/_0J!   0:122Wo <__0:103> v1:3   126Ga  0G!   2G?
 2   F
 3   /    v   16028V  99/122/122C  91:122Jo  0/_0J!  91:122Wo <__0:__0> v1:3   126Ga  0G!   0G?
 4   \     v  16028V  99/122/122C  91:122Jo  0/_0J!  91:122Wo <__0:__0> v1:3   126Ga  0G!   0G?
0: core_missing_blocks: found address=84 checksum=94094717264606390157416118620597677832
thread 38942846 panic: block found in core
/Users/chaitanyabhandari/Desktop/tigerbeetle/tigerbeetle/src/vopr.zig:1229:21: 0x1024c805f in cluster_recoverable (vopr)
                    @panic("block found in core");
```

 R1 does send `request_blocks` to all replicas, and R0, R3, and R4 _do have it_.
```C
[debug] (replica): 0: on_request_blocks: success: (destination=1 address=84 checksum=94094717264606390157416118620597677832)
[debug] (replica): 4: on_request_blocks: success: (destination=1 address=84 checksum=94094717264606390157416118620597677832)
[debug] (replica): 3: on_request_blocks: success: (destination=1 address=84 checksum=94094717264606390157416118620597677832)
```

However, all attempts by R0, R3 and R4 to send this block to R1 this are failing due to the message being dropped! The reason for this _seems_ to be that the path capacity for this VOPR run is is very small, `path_maximum_capacity=2 messages`. Also, R1 has to send a particular `request_blocks` message many times over before it finds a spot in the network path.
```
[warn] (packet_simulator): submit_packet: testing.packet_simulator.Path{ .source = 0, .target = 1 } reached capacity, dropped packet: vsr.message_header.Header.Block
```

Increasing the # of ticks allows block repair to complete and reveals the true cause of the liveness failure (a correlated fault):
```C
no liveness, final cluster state (requests_max=96 requests_replied=96):
 0   \ v      16193V  99/122/122C   0:122Jo  0/_0J!   0:122Wo <__0:103> v1:3   126Ga  0G!   0G?
 1   \  v     16193V  99/122/122C   0:122Jo  0/_0J!   0:122Wo <__0:103> v1:3   126Ga  0G!   0G?
 2   F
 3   /    .   16193V  99/122/122C  91:122Jo  0/_0J!  91:122Wo <__0:__0> v1:3   126Ga  0G!   0G?   0/4Pp  0/4Rq
 4   \     v  16193V  99/122/122C  91:122Jo  0/_0J!  91:122Wo <__0:__0> v1:3   126Ga  0G!   0G?
no liveness, reply op=118 is not available in core
```