### PR TITLE
cli: refactor main.zig

### DIFF
--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -22,7 +22,7 @@ const benchmark_load = @import("./benchmark_load.zig");
 
 const log = std.log;
 
-pub fn main(
+pub fn command_benchmark(
     allocator: Allocator,
     io: *vsr.io.IO,
     time: vsr.time.Time,

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -34,7 +34,7 @@ const EventMetricAggregate = vsr.trace.EventMetricAggregate;
 const EventTiming = vsr.trace.EventTiming;
 const EventTimingAggregate = vsr.trace.EventTimingAggregate;
 
-pub fn main(
+pub fn command_inspect(
     allocator: std.mem.Allocator,
     io: *IO,
     tracer: *Tracer,
@@ -45,8 +45,14 @@ pub fn main(
 
     const inspect_result = main_inspect(allocator, io, tracer, cli_args, stdout_writer.any());
     const flush_result = stdout_buffer.flush();
-    try inspect_result;
-    try flush_result;
+
+    inline for (.{ inspect_result, flush_result }) |result| {
+        result catch |err| switch (err) {
+            // Ignore BrokenPipe so that e.g. "tigerbeetle inspect ... | head -n12" succeeds.
+            error.BrokenPipe => {},
+            else => return err,
+        };
+    }
 }
 
 fn main_inspect(
@@ -454,21 +460,12 @@ const Inspector = struct {
             .superblock_headers = undefined,
         };
 
-        const dirname = std.fs.path.dirname(path) orelse ".";
-        inspector.dir_fd = try vsr.io.IO.open_dir(dirname);
-        errdefer std.posix.close(inspector.dir_fd);
-
-        const basename = std.fs.path.basename(path);
-        inspector.fd = try io.open_data_file(
-            inspector.dir_fd,
-            basename,
-            vsr.superblock.data_file_size_min,
-            .open_read_only,
-            .direct_io_optional,
-        );
-        errdefer std.posix.close(inspector.fd);
-
-        inspector.storage = try Storage.init(io, tracer, inspector.fd);
+        inspector.storage = try Storage.init(io, tracer, .{
+            .path = path,
+            .size_min = vsr.superblock.data_file_size_min,
+            .mode = .open_read_only,
+            .direct_io = .direct_io_optional,
+        });
         errdefer inspector.storage.deinit();
 
         inspector.superblock_buffer = try allocator.alignedAlloc(
@@ -495,7 +492,7 @@ const Inspector = struct {
                 "invalid superblock version; inspector supports version={}, version in {s}={}",
                 .{
                     SuperBlockVersion,
-                    basename,
+                    inspector.storage.basename.const_slice(),
                     superblock.version,
                 },
             );
@@ -506,8 +503,6 @@ const Inspector = struct {
     fn destroy(inspector: *Inspector) void {
         inspector.allocator.free(inspector.superblock_buffer);
         inspector.storage.deinit();
-        std.posix.close(inspector.fd);
-        std.posix.close(inspector.dir_fd);
         inspector.allocator.destroy(inspector);
     }
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -14,6 +14,7 @@ const config = constants.config;
 const benchmark_driver = @import("benchmark_driver.zig");
 const cli = @import("cli.zig");
 const inspect = @import("inspect.zig");
+const sigill = @import("sigill.zig");
 
 const IO = vsr.io.IO;
 const Time = vsr.time.Time;
@@ -32,7 +33,6 @@ const Client = vsr.ClientType(StateMachine, vsr.message_bus.MessageBusClient);
 const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, AOF);
 const ReplicaReformat =
     vsr.ReplicaReformatType(StateMachine, vsr.message_bus.MessageBusClient, Storage);
-const SuperBlock = vsr.SuperBlockType(Storage);
 const data_file_size_min = vsr.superblock.data_file_size_min;
 
 const KiB = stdx.KiB;
@@ -43,7 +43,7 @@ const GiB = stdx.GiB;
 /// One of: .err, .warn, .info, .debug
 pub var log_level_runtime: std.log.Level = .info;
 
-pub fn log_runtime(
+fn log_runtime(
     comptime message_level: std.log.Level,
     comptime scope: @Type(.enum_literal),
     comptime format: []const u8,
@@ -63,7 +63,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main() !void {
-    try SigIllHandler.register();
+    try sigill.install_handler();
 
     var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_instance.deinit();
@@ -77,7 +77,7 @@ pub fn main() !void {
     var command = cli.parse_args(&arg_iterator);
 
     if (command == .version) {
-        try Command.version(gpa, command.version.verbose);
+        try command_version(gpa, command.version.verbose);
         return; // Exit early before initializing IO.
     }
 
@@ -110,7 +110,10 @@ pub fn main() !void {
             }
             if (args.statsd) |address| statsd_address = address;
         },
-        else => {},
+        inline else => |args| comptime {
+            assert(!@hasField(args, "trace"));
+            assert(!@hasField(args, "statsd"));
+        },
     }
 
     var tracer = try Tracer.init(gpa, time, .unknown, .{
@@ -124,21 +127,37 @@ pub fn main() !void {
 
     switch (command) {
         .version => unreachable, // Handled earlier.
-        .format => |*args| try Command.format(gpa, &io, &tracer, args, .{
-            .cluster = args.cluster,
-            .replica = args.replica,
-            .replica_count = args.replica_count,
-            .release = config.process.release,
-            .view = null,
-        }),
-        .recover => |*args| try Command.reformat(gpa, &io, &tracer, args),
-        .start => |*args| try Command.start(gpa, &io, &tracer, args),
-        .repl => |*args| try Command.repl(gpa, &io, time, args),
-        .benchmark => |*args| try benchmark_driver.main(gpa, &io, time, args),
-        .inspect => |*args| inspect.main(gpa, &io, &tracer, args) catch |err| {
-            // Ignore BrokenPipe so that e.g. "tigerbeetle inspect ... | head -n12" succeeds.
-            if (err != error.BrokenPipe) return err;
+        inline .format, .start, .recover => |*args, command_storage| {
+            const direct_io: vsr.io.DirectIO =
+                if (!constants.direct_io)
+                    .direct_io_disabled
+                else if (args.development)
+                    .direct_io_optional
+                else
+                    .direct_io_required;
+
+            var storage = try Storage.init(&io, &tracer, .{
+                .path = args.path,
+                .size_min = data_file_size_min,
+                .mode = switch (command_storage) {
+                    .format, .recover => .create,
+                    .start => .open,
+                    else => comptime unreachable,
+                },
+                .direct_io = direct_io,
+            });
+            defer storage.deinit();
+
+            switch (command_storage) {
+                .format => try command_format(gpa, &storage, args),
+                .start => try command_start(gpa, &io, &tracer, &storage, args),
+                .recover => try command_reformat(gpa, &io, &tracer, &storage, args),
+                else => comptime unreachable,
+            }
         },
+        .repl => |*args| try command_repl(gpa, &io, time, args),
+        .benchmark => |*args| try benchmark_driver.command_benchmark(gpa, &io, time, args),
+        .inspect => |*args| try inspect.command_inspect(gpa, &io, &tracer, args),
         .multiversion => |*args| {
             var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
             var stdout_writer = stdout_buffer.writer();
@@ -147,580 +166,452 @@ pub fn main() !void {
             try vsr.multiversioning.print_information(gpa, args.path, stdout);
             try stdout_buffer.flush();
         },
-        .amqp => |*args| try Command.amqp(gpa, time, args),
+        .amqp => |*args| try command_amqp(gpa, time, args),
     }
 }
 
-const SigIllHandler = struct {
-    var original_posix_sigill_handler: ?*const fn (
-        i32,
-        *const std.posix.siginfo_t,
-        ?*anyopaque,
-    ) callconv(.C) void = null;
+fn command_version(gpa: mem.Allocator, verbose: bool) !void {
+    var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
+    var stdout_writer = stdout_buffer.writer();
+    const stdout = stdout_writer.any();
 
-    fn handle_sigill_windows(
-        info: *std.os.windows.EXCEPTION_POINTERS,
-    ) callconv(std.os.windows.WINAPI) c_long {
-        if (info.ExceptionRecord.ExceptionCode == std.os.windows.EXCEPTION_ILLEGAL_INSTRUCTION) {
-            display_message();
+    try stdout.print("TigerBeetle version {}\n", .{constants.semver});
+
+    if (verbose) {
+        try stdout.writeAll("\n");
+        inline for (.{ "mode", "zig_version" }) |declaration| {
+            try print_value(stdout, "build." ++ declaration, @field(builtin, declaration));
         }
-        return std.os.windows.EXCEPTION_CONTINUE_SEARCH;
-    }
 
-    fn handle_sigill_posix(
-        sig: i32,
-        info: *const std.posix.siginfo_t,
-        ctx_ptr: ?*anyopaque,
-    ) callconv(.C) noreturn {
-        display_message();
-        original_posix_sigill_handler.?(sig, info, ctx_ptr);
-        unreachable;
-    }
-
-    fn display_message() void {
-        std.log.err("", .{});
-        std.log.err("TigerBeetle's binary releases are compiled targeting modern CPU", .{});
-        std.log.err("instructions such as NEON / AES on ARM and x86_64_v3 / AES-NI on", .{});
-        std.log.err("x86-64.", .{});
-        std.log.err("", .{});
-        std.log.err("These instructions can be unsupported on older processors, leading to", .{});
-        std.log.err("\"illegal instruction\" panics.", .{});
-        std.log.err("", .{});
-    }
-
-    fn register() !void {
-        switch (builtin.os.tag) {
-            .windows => {
-                // The 1 indicates this will run first, before Zig's built in handler. Internally,
-                // it returns EXCEPTION_CONTINUE_SEARCH so that Zig's handler is called next.
-                _ = std.os.windows.kernel32.AddVectoredExceptionHandler(1, handle_sigill_windows);
-            },
-            .linux, .macos => {
-                // For Linux / macOS, save the original signal handler so it can be called by this
-                // new handler once the log message has been printed.
-                assert(original_posix_sigill_handler == null);
-                var act = std.posix.Sigaction{
-                    .handler = .{ .sigaction = handle_sigill_posix },
-                    .mask = std.posix.empty_sigset,
-                    .flags = (std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND),
-                };
-
-                var oact: std.posix.Sigaction = undefined;
-
-                std.posix.sigaction(std.posix.SIG.ILL, &act, &oact);
-                original_posix_sigill_handler = oact.handler.sigaction.?;
-            },
-            else => unreachable,
+        // Zig 0.10 doesn't see field_name as comptime if this `comptime` isn't used.
+        try stdout.writeAll("\n");
+        inline for (comptime std.meta.fieldNames(@TypeOf(config.cluster))) |field_name| {
+            try print_value(
+                stdout,
+                "cluster." ++ field_name,
+                @field(config.cluster, field_name),
+            );
         }
+
+        try stdout.writeAll("\n");
+        inline for (comptime std.meta.fieldNames(@TypeOf(config.process))) |field_name| {
+            try print_value(
+                stdout,
+                "process." ++ field_name,
+                @field(config.process, field_name),
+            );
+        }
+
+        try stdout.writeAll("\n");
+        const self_exe_path = try vsr.multiversioning.self_exe_path(gpa);
+        defer gpa.free(self_exe_path);
+        vsr.multiversioning.print_information(gpa, self_exe_path, stdout) catch {};
     }
-};
+    try stdout_buffer.flush();
+}
 
-const Command = struct {
-    dir_fd: std.posix.fd_t,
-    fd: std.posix.fd_t,
-    storage: Storage,
-    self_exe_path: [:0]const u8,
-    data_file_path: []const u8,
-
-    fn init(
-        command: *Command,
-        allocator: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        path: []const u8,
-        options: struct {
-            must_create: bool,
-            development: bool,
-        },
-    ) !void {
-        // TODO Resolve the parent directory properly in the presence of .. and symlinks.
-        // TODO Handle physical volumes where there is no directory to fsync.
-        const dirname = std.fs.path.dirname(path) orelse ".";
-        command.dir_fd = try IO.open_dir(dirname);
-        errdefer std.posix.close(command.dir_fd);
-
-        const direct_io: vsr.io.DirectIO = if (!constants.direct_io)
-            .direct_io_disabled
-        else if (options.development)
-            .direct_io_optional
-        else
-            .direct_io_required;
-
-        const basename = std.fs.path.basename(path);
-        command.fd = try io.open_data_file(
-            command.dir_fd,
-            basename,
-            data_file_size_min,
-            if (options.must_create) .create else .open,
-            direct_io,
-        );
-        errdefer std.posix.close(command.fd);
-
-        command.storage = try Storage.init(io, tracer, command.fd);
-        errdefer command.storage.deinit();
-
-        command.self_exe_path = try vsr.multiversioning.self_exe_path(allocator);
-        errdefer allocator.free(command.self_exe_path);
-
-        command.data_file_path = path;
-    }
-
-    fn deinit(command: *Command, allocator: mem.Allocator) void {
-        allocator.free(command.self_exe_path);
-        command.storage.deinit();
-        std.posix.close(command.fd);
-        std.posix.close(command.dir_fd);
-    }
-
-    pub fn format(
-        allocator: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        args: *const cli.Command.Format,
-        options: SuperBlock.FormatOptions,
-    ) !void {
-        var command: Command = undefined;
-        try command.init(allocator, io, tracer, args.path, .{
-            .must_create = true,
-            .development = args.development,
-        });
-        defer command.deinit(allocator);
-
-        vsr.format(Storage, allocator, options, .{
-            .storage = &command.storage,
-            .storage_size_limit = data_file_size_min,
-        }) catch |err| {
-            std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
-            return err;
-        };
-
-        log.info("{}: formatted: cluster={} replica_count={}", .{
-            options.replica,
-            options.cluster,
-            options.replica_count,
-        });
-    }
-
-    pub fn reformat(
-        allocator: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        args: *const cli.Command.Recover,
-    ) !void {
-        var command: Command = undefined;
-        try command.init(allocator, io, tracer, args.path, .{
-            .must_create = true,
-            .development = args.development,
-        });
-        defer command.deinit(allocator);
-
-        var message_pool = try MessagePool.init(allocator, .client);
-        defer message_pool.deinit(allocator);
-
-        var client = try Client.init(allocator, .{
-            .id = stdx.unique_u128(),
+fn command_format(
+    gpa: mem.Allocator,
+    storage: *Storage,
+    args: *const cli.Command.Format,
+) !void {
+    vsr.format(
+        Storage,
+        gpa,
+        .{
             .cluster = args.cluster,
+            .replica = args.replica,
             .replica_count = args.replica_count,
-            .time = tracer.time,
-            .message_pool = &message_pool,
-            .message_bus_options = .{
-                .configuration = args.addresses.const_slice(),
-                .io = io,
-                .clients_limit = null,
-            },
-            .eviction_callback = &reformat_client_eviction_callback,
-        });
-        defer client.deinit(allocator);
-
-        var reformatter = try ReplicaReformat.init(allocator, &client, .{
-            .format = .{
-                .cluster = args.cluster,
-                .replica = args.replica,
-                .replica_count = args.replica_count,
-                .release = config.process.release,
-                .view = null,
-            },
-            .superblock = .{
-                .storage = &command.storage,
-                .storage_size_limit = data_file_size_min,
-            },
-        });
-        defer reformatter.deinit(allocator);
-
-        reformatter.start();
-        while (reformatter.done() == null) {
-            client.tick();
-            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
-        }
-        switch (reformatter.done().?) {
-            .failed => |err| {
-                log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
-                std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
-                return err;
-            },
-            .ok => log.info("{}: success", .{args.replica}),
-        }
-    }
-
-    fn reformat_client_eviction_callback(
-        client: *Client,
-        eviction: *const MessagePool.Message.Eviction,
-    ) void {
-        _ = client;
-        std.debug.panic("error: client evicted: {s}", .{@tagName(eviction.header.reason)});
-    }
-
-    pub fn start(
-        base_allocator: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        args: *const cli.Command.Start,
-    ) !void {
-        var counting_allocator = vsr.CountingAllocator.init(base_allocator);
-        const allocator = counting_allocator.allocator();
-
-        // TODO Panic if the data file's size is larger that args.storage_size_limit.
-        // (Here or in Replica.open()?).
-
-        var command: Command = undefined;
-        try command.init(allocator, io, tracer, args.path, .{
-            .must_create = false,
-            .development = args.development,
-        });
-        defer command.deinit(allocator);
-
-        var message_pool = try MessagePool.init(allocator, .{ .replica = .{
-            .members_count = args.addresses.count_as(u8),
-            .pipeline_requests_limit = args.pipeline_requests_limit,
-        } });
-        defer message_pool.deinit(allocator);
-
-        var aof: ?AOF = if (args.aof_file) |*aof_file| blk: {
-            const aof_dir = std.fs.path.dirname(aof_file.const_slice()) orelse ".";
-            const aof_dir_fd = try IO.open_dir(aof_dir);
-            defer std.posix.close(aof_dir_fd);
-
-            break :blk try AOF.init(io, .{
-                .dir_fd = aof_dir_fd,
-                .relative_path = std.fs.path.basename(aof_file.const_slice()),
-            });
-        } else null;
-        defer if (aof != null) aof.?.close();
-
-        const grid_cache_size = @as(u64, args.cache_grid_blocks) * constants.block_size;
-        const grid_cache_size_min = constants.block_size * Grid.Cache.value_count_max_multiple;
-
-        // The amount of bytes in `--cache-grid` must be a multiple of
-        // `constants.block_size` and `SetAssociativeCache.value_count_max_multiple`,
-        // and it may have been converted to zero if a smaller value is passed in.
-        if (grid_cache_size == 0) {
-            if (comptime (grid_cache_size_min >= MiB)) {
-                vsr.fatal(.cli, "Grid cache must be greater than {}MiB. See --cache-grid", .{
-                    @divExact(grid_cache_size_min, MiB),
-                });
-            } else {
-                vsr.fatal(.cli, "Grid cache must be greater than {}KiB. See --cache-grid", .{
-                    @divExact(grid_cache_size_min, KiB),
-                });
-            }
-        }
-        assert(grid_cache_size >= grid_cache_size_min);
-
-        const grid_cache_size_warn = 1 * GiB;
-        if (grid_cache_size < grid_cache_size_warn) {
-            log.warn("Grid cache size of {}MiB is small. See --cache-grid", .{
-                @divExact(grid_cache_size, MiB),
-            });
-        }
-
-        const nonce = stdx.unique_u128();
-
-        var multiversion: ?vsr.multiversioning.Multiversion = blk: {
-            if (constants.config.process.release.value ==
-                vsr.multiversioning.Release.minimum.value)
-            {
-                log.info("multiversioning: upgrades disabled for development ({}) release.", .{
-                    constants.config.process.release,
-                });
-                break :blk null;
-            }
-            if (constants.aof_recovery) {
-                log.info("multiversioning: upgrades disabled due to aof_recovery.", .{});
-                break :blk null;
-            }
-
-            if (args.addresses_zero) {
-                log.info("multiversioning: upgrades disabled due to --addresses=0", .{});
-                break :blk null;
-            }
-
-            break :blk try vsr.multiversioning.Multiversion.init(
-                allocator,
-                io,
-                command.self_exe_path,
-                .native,
-            );
-        };
-
-        defer if (multiversion != null) multiversion.?.deinit(allocator);
-
-        // The error from .open_sync() is ignored - timeouts and checking for new binaries are still
-        // enabled even if the first version fails to load.
-        if (multiversion != null) multiversion.?.open_sync() catch {};
-
-        var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .{};
-        releases_bundled_baseline.push(constants.config.process.release);
-
-        const releases_bundled = if (multiversion != null)
-            &multiversion.?.releases_bundled
-        else
-            &releases_bundled_baseline;
-
-        log.info("release={}", .{config.process.release});
-        log.info("release_client_min={}", .{config.process.release_client_min});
-        log.info("releases_bundled={any}", .{releases_bundled.const_slice()});
-        log.info("git_commit={?s}", .{config.process.git_commit});
-
-        const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
-
-        var replica: Replica = undefined;
-        replica.open(allocator, .{
-            .node_count = args.addresses.count_as(u8),
             .release = config.process.release,
-            .release_client_min = config.process.release_client_min,
-            .releases_bundled = releases_bundled,
-            .release_execute = replica_release_execute,
-            .release_execute_context = if (multiversion) |*pointer| pointer else null,
-            .pipeline_requests_limit = args.pipeline_requests_limit,
-            .storage_size_limit = args.storage_size_limit,
-            .storage = &command.storage,
-            .aof = if (aof != null) &aof.? else null,
-            .message_pool = &message_pool,
-            .nonce = nonce,
-            .time = tracer.time,
-            .timeout_prepare_ticks = args.timeout_prepare_ticks,
-            .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
-            .commit_stall_probability = args.commit_stall_probability,
-            .state_machine_options = .{
-                .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
-                .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
-                .lsm_forest_node_count = args.lsm_forest_node_count,
-                .cache_entries_accounts = args.cache_accounts,
-                .cache_entries_transfers = args.cache_transfers,
-                .cache_entries_transfers_pending = args.cache_transfers_pending,
-            },
-            .message_bus_options = .{
-                .configuration = args.addresses.const_slice(),
-                .io = io,
-                .clients_limit = clients_limit,
-            },
-            .grid_cache_blocks_count = args.cache_grid_blocks,
-            .tracer = tracer,
-            .replicate_options = .{
-                .closed_loop = args.replicate_closed_loop,
-                .star = args.replicate_star,
-            },
-        }) catch |err| switch (err) {
-            error.NoAddress => vsr.fatal(.cli, "all --addresses must be provided", .{}),
-            else => |e| return e,
+            .view = null,
+        },
+        .{
+            .storage = storage,
+            .storage_size_limit = data_file_size_min,
+        },
+    ) catch |err| {
+        log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
+        storage.dangerously_delete_data_file();
+        return err;
+    };
+
+    log.info("{}: formatted: cluster={} replica_count={}", .{
+        args.replica,
+        args.cluster,
+        args.replica_count,
+    });
+}
+
+fn command_start(
+    base_allocator: mem.Allocator,
+    io: *IO,
+    tracer: *Tracer,
+    storage: *Storage,
+    args: *const cli.Command.Start,
+) !void {
+    var counting_allocator = vsr.CountingAllocator.init(base_allocator);
+    const gpa = counting_allocator.allocator();
+
+    // TODO Panic if the data file's size is larger that args.storage_size_limit.
+    // (Here or in Replica.open()?).
+
+    var message_pool = try MessagePool.init(gpa, .{ .replica = .{
+        .members_count = args.addresses.count_as(u8),
+        .pipeline_requests_limit = args.pipeline_requests_limit,
+    } });
+    defer message_pool.deinit(gpa);
+
+    var aof: ?AOF = if (args.aof_file) |*aof_file| blk: {
+        const aof_dir = std.fs.path.dirname(aof_file.const_slice()) orelse ".";
+        const aof_dir_fd = try IO.open_dir(aof_dir);
+        defer std.posix.close(aof_dir_fd);
+
+        break :blk try AOF.init(io, .{
+            .dir_fd = aof_dir_fd,
+            .relative_path = std.fs.path.basename(aof_file.const_slice()),
+        });
+    } else null;
+    defer if (aof != null) aof.?.close();
+
+    const grid_cache_size = @as(u64, args.cache_grid_blocks) * constants.block_size;
+    const grid_cache_size_min = constants.block_size * Grid.Cache.value_count_max_multiple;
+
+    // The amount of bytes in `--cache-grid` must be a multiple of
+    // `constants.block_size` and `SetAssociativeCache.value_count_max_multiple`,
+    // and it may have been converted to zero if a smaller value is passed in.
+    if (grid_cache_size == 0) {
+        if (comptime (grid_cache_size_min >= MiB)) {
+            vsr.fatal(.cli, "Grid cache must be greater than {}MiB. See --cache-grid", .{
+                @divExact(grid_cache_size_min, MiB),
+            });
+        } else {
+            vsr.fatal(.cli, "Grid cache must be greater than {}KiB. See --cache-grid", .{
+                @divExact(grid_cache_size_min, KiB),
+            });
+        }
+    }
+    assert(grid_cache_size >= grid_cache_size_min);
+
+    const grid_cache_size_warn = 1 * GiB;
+    if (grid_cache_size < grid_cache_size_warn) {
+        log.warn("Grid cache size of {}MiB is small. See --cache-grid", .{
+            @divExact(grid_cache_size, MiB),
+        });
+    }
+
+    const nonce = stdx.unique_u128();
+
+    var self_exe_path: ?[:0]const u8 = null;
+    defer if (self_exe_path) |path| gpa.free(path);
+
+    var multiversion: ?vsr.multiversioning.Multiversion = blk: {
+        if (constants.config.process.release.value ==
+            vsr.multiversioning.Release.minimum.value)
+        {
+            log.info("multiversioning: upgrades disabled for development ({}) release.", .{
+                constants.config.process.release,
+            });
+            break :blk null;
+        }
+        if (constants.aof_recovery) {
+            log.info("multiversioning: upgrades disabled due to aof_recovery.", .{});
+            break :blk null;
+        }
+
+        if (args.addresses_zero) {
+            log.info("multiversioning: upgrades disabled due to --addresses=0", .{});
+            break :blk null;
+        }
+
+        self_exe_path = try vsr.multiversioning.self_exe_path(gpa);
+        break :blk try vsr.multiversioning.Multiversion.init(
+            gpa,
+            io,
+            self_exe_path.?,
+            .native,
+        );
+    };
+
+    defer if (multiversion != null) multiversion.?.deinit(gpa);
+
+    // The error from .open_sync() is ignored - timeouts and checking for new binaries are still
+    // enabled even if the first version fails to load.
+    if (multiversion != null) multiversion.?.open_sync() catch {};
+
+    var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .{};
+    releases_bundled_baseline.push(constants.config.process.release);
+
+    const releases_bundled = if (multiversion != null)
+        &multiversion.?.releases_bundled
+    else
+        &releases_bundled_baseline;
+
+    log.info("release={}", .{config.process.release});
+    log.info("release_client_min={}", .{config.process.release_client_min});
+    log.info("releases_bundled={any}", .{releases_bundled.const_slice()});
+    log.info("git_commit={?s}", .{config.process.git_commit});
+
+    const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
+
+    var replica: Replica = undefined;
+    replica.open(gpa, .{
+        .node_count = args.addresses.count_as(u8),
+        .release = config.process.release,
+        .release_client_min = config.process.release_client_min,
+        .releases_bundled = releases_bundled,
+        .release_execute = replica_release_execute,
+        .release_execute_context = if (multiversion) |*pointer| pointer else null,
+        .pipeline_requests_limit = args.pipeline_requests_limit,
+        .storage_size_limit = args.storage_size_limit,
+        .storage = storage,
+        .aof = if (aof != null) &aof.? else null,
+        .message_pool = &message_pool,
+        .nonce = nonce,
+        .time = tracer.time,
+        .timeout_prepare_ticks = args.timeout_prepare_ticks,
+        .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
+        .commit_stall_probability = args.commit_stall_probability,
+        .state_machine_options = .{
+            .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
+            .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
+            .lsm_forest_node_count = args.lsm_forest_node_count,
+            .cache_entries_accounts = args.cache_accounts,
+            .cache_entries_transfers = args.cache_transfers,
+            .cache_entries_transfers_pending = args.cache_transfers_pending,
+        },
+        .message_bus_options = .{
+            .configuration = args.addresses.const_slice(),
+            .io = io,
+            .clients_limit = clients_limit,
+        },
+        .grid_cache_blocks_count = args.cache_grid_blocks,
+        .tracer = tracer,
+        .replicate_options = .{
+            .closed_loop = args.replicate_closed_loop,
+            .star = args.replicate_star,
+        },
+    }) catch |err| switch (err) {
+        error.NoAddress => vsr.fatal(.cli, "all --addresses must be provided", .{}),
+        else => |e| return e,
+    };
+
+    if (multiversion != null) {
+        if (args.development) {
+            log.info("multiversioning: upgrade polling disabled due to --development.", .{});
+        } else {
+            multiversion.?.timeout_start(replica.replica);
+        }
+
+        if (args.experimental) {
+            log.warn("multiversioning: upgrade polling and --experimental enabled - " ++
+                "make sure to check CLI argument compatibility before upgrading.", .{});
+            log.warn("If the cluster upgrades automatically, and incompatible experimental " ++
+                "CLI arguments are set, it will crash.", .{});
+        }
+    }
+
+    // Note that this does not account for the fact that any allocations will be rounded up to
+    // the nearest page by `std.heap.page_allocator`.
+    log.info("{}: Allocated {}MiB during replica init", .{
+        replica.replica,
+        @divFloor(counting_allocator.live_size(), MiB),
+    });
+    log.info("{}: Grid cache: {}MiB, LSM-tree manifests: {}MiB", .{
+        replica.replica,
+        @divFloor(grid_cache_size, MiB),
+        @divFloor(args.lsm_forest_node_count * constants.lsm_manifest_node_size, MiB),
+    });
+
+    log.info("{}: cluster={}: listening on {}", .{
+        replica.replica,
+        replica.cluster,
+        replica.message_bus.process.accept_address,
+    });
+
+    if (constants.aof_recovery) {
+        log.warn(
+            "{}: started in AOF recovery mode. This is potentially dangerous - if it's" ++
+                " unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.",
+            .{replica.replica},
+        );
+    }
+
+    if (constants.verify) {
+        log.info("{}: started with extra verification checks", .{replica.replica});
+    }
+
+    if (replica.aof != null) {
+        log.warn(
+            "{}: started with --aof - expect much reduced performance.",
+            .{replica.replica},
+        );
+    }
+
+    // It is possible to start tigerbeetle passing `0` as an address:
+    //     $ tigerbeetle start --addresses=0 0_0.tigerbeetle
+    // This enables a couple of special behaviors, useful in tests:
+    // - The operating system picks a free port, avoiding "address already in use" errors.
+    // - The port, and only the port, is printed to the stdout, so that the parent process
+    //   can learn it.
+    // - tigerbeetle process exits when its stdin gets closed.
+    if (args.addresses_zero) {
+        const port_actual = replica.message_bus.process.accept_address.getPort();
+        const stdout = std.io.getStdOut();
+        try stdout.writer().print("{}\n", .{port_actual});
+        stdout.close();
+
+        // While it is possible to integrate stdin with our io_uring loop, using a dedicated
+        // thread is simpler, and gives us _un_graceful shutdown, which is exactly what we want
+        // to keep behavior close to the normal case.
+        const watchdog = try std.Thread.spawn(.{}, struct {
+            fn thread_main() void {
+                var buf: [1]u8 = .{0};
+                _ = std.io.getStdIn().read(&buf) catch {};
+                log.info("stdin closed, exiting", .{});
+                std.process.exit(0);
+            }
+        }.thread_main, .{});
+        watchdog.detach();
+    }
+
+    if (!args.development) {
+        // Try to lock all memory in the process to avoid the kernel swapping pages to disk and
+        // potentially introducing undetectable disk corruption into memory.
+        // This is a best-effort attempt and not a hard rule as it may not cover all memory edge
+        // case. So warn on error to notify the operator to adjust conditions if possible.
+        stdx.memory_lock_allocated(.{
+            .allocated_size = counting_allocator.live_size(),
+        }) catch {
+            log.warn(
+                "If this is a production replica, consider either " ++
+                    "running the replica with CAP_IPC_LOCK privilege, " ++
+                    "increasing the MEMLOCK process limit, " ++
+                    "or disabling swap system-wide.",
+                .{},
+            );
         };
 
-        if (multiversion != null) {
-            if (args.development) {
-                log.info("multiversioning: upgrade polling disabled due to --development.", .{});
-            } else {
-                multiversion.?.timeout_start(replica.replica);
-            }
-
-            if (args.experimental) {
-                log.warn("multiversioning: upgrade polling and --experimental enabled - " ++
-                    "make sure to check CLI argument compatibility before upgrading.", .{});
-                log.warn("If the cluster upgrades automatically, and incompatible experimental " ++
-                    "CLI arguments are set, it will crash.", .{});
-            }
-        }
-
-        // Note that this does not account for the fact that any allocations will be rounded up to
-        // the nearest page by `std.heap.page_allocator`.
-        log.info("{}: Allocated {}MiB during replica init", .{
-            replica.replica,
-            @divFloor(counting_allocator.live_size(), MiB),
-        });
-        log.info("{}: Grid cache: {}MiB, LSM-tree manifests: {}MiB", .{
-            replica.replica,
-            @divFloor(grid_cache_size, MiB),
-            @divFloor(args.lsm_forest_node_count * constants.lsm_manifest_node_size, MiB),
-        });
-
-        log.info("{}: cluster={}: listening on {}", .{
-            replica.replica,
-            replica.cluster,
-            replica.message_bus.process.accept_address,
-        });
-
-        if (constants.aof_recovery) {
-            log.warn(
-                "{}: started in AOF recovery mode. This is potentially dangerous - if it's" ++
-                    " unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.",
-                .{replica.replica},
-            );
-        }
-
-        if (constants.verify) {
-            log.info("{}: started with extra verification checks", .{replica.replica});
-        }
-
-        if (replica.aof != null) {
-            log.warn(
-                "{}: started with --aof - expect much reduced performance.",
-                .{replica.replica},
-            );
-        }
-
-        // It is possible to start tigerbeetle passing `0` as an address:
-        //     $ tigerbeetle start --addresses=0 0_0.tigerbeetle
-        // This enables a couple of special behaviors, useful in tests:
-        // - The operating system picks a free port, avoiding "address already in use" errors.
-        // - The port, and only the port, is printed to the stdout, so that the parent process
-        //   can learn it.
-        // - tigerbeetle process exits when its stdin gets closed.
-        if (args.addresses_zero) {
-            const port_actual = replica.message_bus.process.accept_address.getPort();
-            const stdout = std.io.getStdOut();
-            try stdout.writer().print("{}\n", .{port_actual});
-            stdout.close();
-
-            // While it is possible to integrate stdin with our io_uring loop, using a dedicated
-            // thread is simpler, and gives us _un_graceful shutdown, which is exactly what we want
-            // to keep behavior close to the normal case.
-            const watchdog = try std.Thread.spawn(.{}, struct {
-                fn thread_main() void {
-                    var buf: [1]u8 = .{0};
-                    _ = std.io.getStdIn().read(&buf) catch {};
-                    log.info("stdin closed, exiting", .{});
-                    std.process.exit(0);
-                }
-            }.thread_main, .{});
-            watchdog.detach();
-        }
-
-        if (!args.development) {
-            // Try to lock all memory in the process to avoid the kernel swapping pages to disk and
-            // potentially introducing undetectable disk corruption into memory.
-            // This is a best-effort attempt and not a hard rule as it may not cover all memory edge
-            // case. So warn on error to notify the operator to adjust conditions if possible.
-            stdx.memory_lock_allocated(.{
-                .allocated_size = counting_allocator.live_size(),
-            }) catch {
-                log.warn(
-                    "If this is a production replica, consider either " ++
-                        "running the replica with CAP_IPC_LOCK privilege, " ++
-                        "increasing the MEMLOCK process limit, " ++
-                        "or disabling swap system-wide.",
-                    .{},
-                );
-            };
-
-            if (replica.cluster == 0) {
-                log.warn("a cluster id of 0 is reserved for testing and benchmarking, " ++
-                    "do not use in production", .{});
-            }
-        }
-
-        while (true) {
-            replica.tick();
-            if (multiversion != null) multiversion.?.tick();
-            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        if (replica.cluster == 0) {
+            log.warn("a cluster id of 0 is reserved for testing and benchmarking, " ++
+                "do not use in production", .{});
         }
     }
 
-    pub fn version(allocator: mem.Allocator, verbose: bool) !void {
-        var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
-        var stdout_writer = stdout_buffer.writer();
-        const stdout = stdout_writer.any();
-
-        try std.fmt.format(stdout, "TigerBeetle version {}\n", .{constants.semver});
-
-        if (verbose) {
-            try stdout.writeAll("\n");
-            inline for (.{ "mode", "zig_version" }) |declaration| {
-                try print_value(stdout, "build." ++ declaration, @field(builtin, declaration));
-            }
-
-            // Zig 0.10 doesn't see field_name as comptime if this `comptime` isn't used.
-            try stdout.writeAll("\n");
-            inline for (comptime std.meta.fieldNames(@TypeOf(config.cluster))) |field_name| {
-                try print_value(
-                    stdout,
-                    "cluster." ++ field_name,
-                    @field(config.cluster, field_name),
-                );
-            }
-
-            try stdout.writeAll("\n");
-            inline for (comptime std.meta.fieldNames(@TypeOf(config.process))) |field_name| {
-                try print_value(
-                    stdout,
-                    "process." ++ field_name,
-                    @field(config.process, field_name),
-                );
-            }
-
-            try stdout.writeAll("\n");
-            const self_exe_path = try vsr.multiversioning.self_exe_path(allocator);
-            defer allocator.free(self_exe_path);
-            vsr.multiversioning.print_information(allocator, self_exe_path, stdout) catch {};
-        }
-        try stdout_buffer.flush();
+    while (true) {
+        replica.tick();
+        if (multiversion != null) multiversion.?.tick();
+        try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
+}
 
-    pub fn repl(
-        allocator: mem.Allocator,
-        io: *IO,
-        time: Time,
-        args: *const cli.Command.Repl,
-    ) !void {
-        const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient);
+fn command_reformat(
+    gpa: mem.Allocator,
+    io: *IO,
+    tracer: *Tracer,
+    storage: *Storage,
+    args: *const cli.Command.Recover,
+) !void {
+    var message_pool = try MessagePool.init(gpa, .client);
+    defer message_pool.deinit(gpa);
 
-        var repl_instance = try Repl.init(allocator, io, time, .{
+    var client = try Client.init(gpa, .{
+        .id = stdx.unique_u128(),
+        .cluster = args.cluster,
+        .replica_count = args.replica_count,
+        .time = tracer.time,
+        .message_pool = &message_pool,
+        .message_bus_options = .{
+            .configuration = args.addresses.const_slice(),
+            .io = io,
+            .clients_limit = null,
+        },
+        .eviction_callback = &command_reformat_client_eviction_callback,
+    });
+    defer client.deinit(gpa);
+
+    var reformatter = try ReplicaReformat.init(gpa, &client, .{
+        .format = .{
+            .cluster = args.cluster,
+            .replica = args.replica,
+            .replica_count = args.replica_count,
+            .release = config.process.release,
+            .view = null,
+        },
+        .superblock = .{
+            .storage = storage,
+            .storage_size_limit = data_file_size_min,
+        },
+    });
+    defer reformatter.deinit(gpa);
+
+    reformatter.start();
+    while (reformatter.done() == null) {
+        client.tick();
+        try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+    }
+    switch (reformatter.done().?) {
+        .failed => |err| {
+            log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
+            storage.dangerously_delete_data_file();
+            return err;
+        },
+        .ok => log.info("{}: success", .{args.replica}),
+    }
+}
+
+fn command_reformat_client_eviction_callback(
+    _: *Client,
+    eviction: *const MessagePool.Message.Eviction,
+) void {
+    std.debug.panic("error: client evicted: {s}", .{@tagName(eviction.header.reason)});
+}
+
+fn command_repl(
+    gpa: mem.Allocator,
+    io: *IO,
+    time: Time,
+    args: *const cli.Command.Repl,
+) !void {
+    const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient);
+
+    var repl_instance = try Repl.init(gpa, io, time, .{
+        .cluster_id = args.cluster,
+        .addresses = args.addresses.const_slice(),
+        .verbose = args.verbose,
+    });
+    defer repl_instance.deinit(gpa);
+
+    try repl_instance.run(args.statements);
+}
+
+fn command_amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !void {
+    var runner: vsr.cdc.Runner = undefined;
+    try runner.init(
+        gpa,
+        time,
+        .{
             .cluster_id = args.cluster,
             .addresses = args.addresses.const_slice(),
-            .verbose = args.verbose,
-        });
-        defer repl_instance.deinit(allocator);
+            .host = args.host,
+            .user = args.user,
+            .password = args.password,
+            .vhost = args.vhost,
+            .publish_exchange = args.publish_exchange,
+            .publish_routing_key = args.publish_routing_key,
+            .event_count_max = args.event_count_max,
+            .idle_interval_ms = args.idle_interval_ms,
+            .recovery_mode = if (args.timestamp_last) |timestamp_last|
+                .{ .override = timestamp_last }
+            else
+                .recover,
+        },
+    );
+    defer runner.deinit();
 
-        try repl_instance.run(args.statements);
+    while (true) {
+        runner.tick();
     }
-
-    pub fn amqp(allocator: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !void {
-        var runner: vsr.cdc.Runner = undefined;
-        try runner.init(
-            allocator,
-            time,
-            .{
-                .cluster_id = args.cluster,
-                .addresses = args.addresses.const_slice(),
-                .host = args.host,
-                .user = args.user,
-                .password = args.password,
-                .vhost = args.vhost,
-                .publish_exchange = args.publish_exchange,
-                .publish_routing_key = args.publish_routing_key,
-                .event_count_max = args.event_count_max,
-                .idle_interval_ms = args.idle_interval_ms,
-                .recovery_mode = if (args.timestamp_last) |timestamp_last|
-                    .{ .override = timestamp_last }
-                else
-                    .recover,
-            },
-        );
-        defer runner.deinit();
-
-        while (true) {
-            runner.tick();
-        }
-    }
-};
+}
 
 fn replica_release_execute(replica: *Replica, release: vsr.Release) noreturn {
     assert(release.value != replica.release.value);

--- a/src/tigerbeetle/sigill.zig
+++ b/src/tigerbeetle/sigill.zig
@@ -1,0 +1,66 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+const assert = std.debug.assert;
+
+var original_posix_sigill_handler: ?*const fn (
+    i32,
+    *const std.posix.siginfo_t,
+    ?*anyopaque,
+) callconv(.C) void = null;
+
+fn handle_sigill_windows(
+    info: *std.os.windows.EXCEPTION_POINTERS,
+) callconv(std.os.windows.WINAPI) c_long {
+    if (info.ExceptionRecord.ExceptionCode == std.os.windows.EXCEPTION_ILLEGAL_INSTRUCTION) {
+        display_message();
+    }
+    return std.os.windows.EXCEPTION_CONTINUE_SEARCH;
+}
+
+fn handle_sigill_posix(
+    sig: i32,
+    info: *const std.posix.siginfo_t,
+    ctx_ptr: ?*anyopaque,
+) callconv(.C) noreturn {
+    display_message();
+    original_posix_sigill_handler.?(sig, info, ctx_ptr);
+    unreachable;
+}
+
+fn display_message() void {
+    std.log.err("", .{});
+    std.log.err("TigerBeetle's binary releases are compiled targeting modern CPU", .{});
+    std.log.err("instructions such as NEON / AES on ARM and x86_64_v3 / AES-NI on", .{});
+    std.log.err("x86-64.", .{});
+    std.log.err("", .{});
+    std.log.err("These instructions can be unsupported on older processors, leading to", .{});
+    std.log.err("\"illegal instruction\" panics.", .{});
+    std.log.err("", .{});
+}
+
+pub fn install_handler() !void {
+    switch (builtin.os.tag) {
+        .windows => {
+            // The 1 indicates this will run first, before Zig's built in handler. Internally,
+            // it returns EXCEPTION_CONTINUE_SEARCH so that Zig's handler is called next.
+            _ = std.os.windows.kernel32.AddVectoredExceptionHandler(1, handle_sigill_windows);
+        },
+        .linux, .macos => {
+            // For Linux / macOS, save the original signal handler so it can be called by this
+            // new handler once the log message has been printed.
+            assert(original_posix_sigill_handler == null);
+            var act = std.posix.Sigaction{
+                .handler = .{ .sigaction = handle_sigill_posix },
+                .mask = std.posix.empty_sigset,
+                .flags = (std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND),
+            };
+
+            var oact: std.posix.Sigaction = undefined;
+
+            std.posix.sigaction(std.posix.SIG.ILL, &act, &oact);
+            original_posix_sigill_handler = oact.handler.sigaction.?;
+        },
+        else => unreachable,
+    }
+}


### PR DESCRIPTION
That's the main file everyone will be looking at, so its woth to make it tidier:

- move Command logic to Storage
- Remove Command, so we are only to two structs per subcommand, rather than three, yay!
- Centralize storage creation for the three commands that need it (inspect still duplicates the logic, becaues it _optionally_ needs a storage).
- Make sure that version, format, and start are the first three commands, as per suggested reading order.
- Banish sigill handling to a separate file, main is much to valuable to waste it on posix trivia.
- Move datafile delition to storage, and also fix it to remove the data file, rather than a potentially other file :P
- Rename allocator to gpa