### PR TITLE
release: manager should check for regressions in devhub graphs

### DIFF
--- a/docs/internals/releases.md
+++ b/docs/internals/releases.md
@@ -12,8 +12,10 @@ The motivation for specific steps follows after.
 
 1. Open [devhub](https://tigerbeetle.github.io/tigerbeetle/) to check that:
    - you are the release manager for the week
-   - that the VOPR results look reasonable (no failures and a bunch of successful runs for recent
+   - the VOPR results look reasonable (no failures and a bunch of successful runs for recent
      commits)
+   - the graphs look reasonable (for example, no drastic changes in the RSS, data file size, or
+     executable size during the past week)
 
 2. ```console
    $ ./zig/zig build scripts -- changelog


### PR DESCRIPTION
Recently, @sentientwaffle observed a regression in our RSS on DevHub, caused by https://github.com/tigerbeetle/tigerbeetle/pull/3090 (which was fixed in https://github.com/tigerbeetle/tigerbeetle/pull/3116). This made me realize that checking drastic variation in the graphs on DevHub should be a part of the release manager algorithm! 