### PR TITLE
[Docs] Use absolute links in client READMEs

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -53,10 +53,10 @@ This document is primarily a reference guide to
 the client. Below are various sample projects demonstrating
 features of TigerBeetle.
 
-* [Basic](/src/clients/dotnet/samples/basic/): Create two accounts and transfer an amount between them.
-* [Two-Phase Transfer](/src/clients/dotnet/samples/two-phase/): Create two accounts and start a pending transfer between
+* [Basic](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/dotnet/samples/basic/): Create two accounts and transfer an amount between them.
+* [Two-Phase Transfer](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/dotnet/samples/two-phase/): Create two accounts and start a pending transfer between
 them, then post the transfer.
-* [Many Two-Phase Transfers](/src/clients/dotnet/samples/two-phase-many/): Create two accounts and start a number of pending transfer
+* [Many Two-Phase Transfers](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/dotnet/samples/two-phase-many/): Create two accounts and start a number of pending transfer
 between them, posting and voiding alternating transfers.
 ## Creating a Client
 

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -65,10 +65,10 @@ This document is primarily a reference guide to
 the client. Below are various sample projects demonstrating
 features of TigerBeetle.
 
-* [Basic](/src/clients/go/samples/basic/): Create two accounts and transfer an amount between them.
-* [Two-Phase Transfer](/src/clients/go/samples/two-phase/): Create two accounts and start a pending transfer between
+* [Basic](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/go/samples/basic/): Create two accounts and transfer an amount between them.
+* [Two-Phase Transfer](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/go/samples/two-phase/): Create two accounts and start a pending transfer between
 them, then post the transfer.
-* [Many Two-Phase Transfers](/src/clients/go/samples/two-phase-many/): Create two accounts and start a number of pending transfer
+* [Many Two-Phase Transfers](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/go/samples/two-phase-many/): Create two accounts and start a number of pending transfer
 between them, posting and voiding alternating transfers.
 ## Creating a Client
 

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -103,10 +103,10 @@ This document is primarily a reference guide to
 the client. Below are various sample projects demonstrating
 features of TigerBeetle.
 
-* [Basic](/src/clients/java/samples/basic/): Create two accounts and transfer an amount between them.
-* [Two-Phase Transfer](/src/clients/java/samples/two-phase/): Create two accounts and start a pending transfer between
+* [Basic](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/java/samples/basic/): Create two accounts and transfer an amount between them.
+* [Two-Phase Transfer](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/java/samples/two-phase/): Create two accounts and start a pending transfer between
 them, then post the transfer.
-* [Many Two-Phase Transfers](/src/clients/java/samples/two-phase-many/): Create two accounts and start a number of pending transfer
+* [Many Two-Phase Transfers](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/java/samples/two-phase-many/): Create two accounts and start a number of pending transfer
 between them, posting and voiding alternating transfers.
 ## Creating a Client
 

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -44,10 +44,10 @@ This document is primarily a reference guide to
 the client. Below are various sample projects demonstrating
 features of TigerBeetle.
 
-* [Basic](/src/clients/node/samples/basic/): Create two accounts and transfer an amount between them.
-* [Two-Phase Transfer](/src/clients/node/samples/two-phase/): Create two accounts and start a pending transfer between
+* [Basic](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/node/samples/basic/): Create two accounts and transfer an amount between them.
+* [Two-Phase Transfer](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/node/samples/two-phase/): Create two accounts and start a pending transfer between
 them, then post the transfer.
-* [Many Two-Phase Transfers](/src/clients/node/samples/two-phase-many/): Create two accounts and start a number of pending transfer
+* [Many Two-Phase Transfers](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/node/samples/two-phase-many/): Create two accounts and start a number of pending transfer
 between them, posting and voiding alternating transfers.
 ### Sidenote: `BigInt`
 TigerBeetle uses 64-bit integers for many fields while JavaScript's

--- a/src/clients/python/README.md
+++ b/src/clients/python/README.md
@@ -48,10 +48,10 @@ This document is primarily a reference guide to
 the client. Below are various sample projects demonstrating
 features of TigerBeetle.
 
-* [Basic](/src/clients/python/samples/basic/): Create two accounts and transfer an amount between them.
-* [Two-Phase Transfer](/src/clients/python/samples/two-phase/): Create two accounts and start a pending transfer between
+* [Basic](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/python/samples/basic/): Create two accounts and transfer an amount between them.
+* [Two-Phase Transfer](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/python/samples/two-phase/): Create two accounts and start a pending transfer between
 them, then post the transfer.
-* [Many Two-Phase Transfers](/src/clients/python/samples/two-phase-many/): Create two accounts and start a number of pending transfer
+* [Many Two-Phase Transfers](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/python/samples/two-phase-many/): Create two accounts and start a number of pending transfer
 between them, posting and voiding alternating transfers.
 ## Creating a Client
 

--- a/src/clients/rust/README.md
+++ b/src/clients/rust/README.md
@@ -50,10 +50,10 @@ This document is primarily a reference guide to
 the client. Below are various sample projects demonstrating
 features of TigerBeetle.
 
-* [Basic](/src/clients/rust/samples/basic/): Create two accounts and transfer an amount between them.
-* [Two-Phase Transfer](/src/clients/rust/samples/two-phase/): Create two accounts and start a pending transfer between
+* [Basic](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/rust/samples/basic/): Create two accounts and transfer an amount between them.
+* [Two-Phase Transfer](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/rust/samples/two-phase/): Create two accounts and start a pending transfer between
 them, then post the transfer.
-* [Many Two-Phase Transfers](/src/clients/rust/samples/two-phase-many/): Create two accounts and start a number of pending transfer
+* [Many Two-Phase Transfers](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/rust/samples/two-phase-many/): Create two accounts and start a number of pending transfer
 between them, posting and voiding alternating transfers.
 ## Creating a Client
 

--- a/src/scripts/client_readmes.zig
+++ b/src/scripts/client_readmes.zig
@@ -146,7 +146,7 @@ fn readme_root(ctx: *Context) !void {
         // Absolute paths here are necessary for resolving within the docs site.
         for (samples) |sample| {
             if (try ctx.sample_exists(sample)) {
-                ctx.print("* [{s}](/src/clients/{s}/samples/{s}/): {s}\n", .{
+                ctx.print("* [{s}](https://github.com/tigerbeetle/tigerbeetle/tree/release/src/clients/{s}/samples/{s}/): {s}\n", .{
                     sample.proper_name,
                     ctx.docs.directory,
                     sample.directory,


### PR DESCRIPTION
Currently, some sample project links (for example, in the [Python package](https://pypi.org/project/tigerbeetle/)) are relative paths, which break when viewed on the docs site. This change updates them to absolute GitHub URLs to ensure they are always reachable.