### PR TITLE
vsr: rename vsr_headers -> view headers

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -244,7 +244,7 @@ comptime {
     assert(message_size_max >= Config.Cluster.message_size_max_min(clients_max));
 
     // Ensure that DVC/SV messages can fit all necessary headers.
-    assert(message_body_size_max >= view_change_headers_max * @sizeOf(vsr.Header));
+    assert(message_body_size_max >= view_headers_max * @sizeOf(vsr.Header));
 
     assert(message_body_size_max >= @sizeOf(vsr.ReconfigurationRequest));
     assert(message_body_size_max >= @sizeOf(vsr.BlockRequest));
@@ -303,19 +303,19 @@ pub const view_change_headers_suffix_max = config.cluster.view_change_headers_su
 /// - We must include all uncommitted headers.
 /// - +1 We must include the highest cluster-committed header, so that the new primary still has a
 ///   head op if it truncates the entire pipeline.
-pub const view_change_headers_max = view_change_headers_suffix_max + 2;
+pub const view_headers_max = view_change_headers_suffix_max + 2;
 
 comptime {
     assert(view_change_headers_suffix_max >= pipeline_prepare_queue_max + 1);
 
-    assert(view_change_headers_max > 0);
-    assert(view_change_headers_max >= pipeline_prepare_queue_max + 3);
-    assert(view_change_headers_max <= journal_slot_count);
-    assert(view_change_headers_max <= @divFloor(
+    assert(view_headers_max > 0);
+    assert(view_headers_max >= pipeline_prepare_queue_max + 3);
+    assert(view_headers_max <= journal_slot_count);
+    assert(view_headers_max <= @divFloor(
         message_body_size_max - @sizeOf(vsr.CheckpointState),
         @sizeOf(vsr.Header),
     ));
-    assert(view_change_headers_max > view_change_headers_suffix_max);
+    assert(view_headers_max > view_change_headers_suffix_max);
 }
 
 /// The maximum number of headers to include with a response to a command=request_headers message.

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1026,9 +1026,9 @@ pub const Simulator = struct {
                             // (e.g. due to "quorum received, awaiting repair") then they may
                             // linger, so if we only looked at the journal headers it would appear
                             // as if the replicas disagreed about the uncommitted headers.
-                            const headers_count = replica.superblock.working.vsr_headers_count;
+                            const headers_count = replica.superblock.working.view_headers_count;
                             const headers =
-                                replica.superblock.working.vsr_headers_all[0..headers_count];
+                                replica.superblock.working.view_headers_all[0..headers_count];
                             for (headers) |*header| {
                                 if (header.op == op) {
                                     break :header switch (vsr.Headers.dvc_header_type(header)) {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1252,7 +1252,7 @@ pub fn verify_release_list(releases: []const Release, release_included: Release)
 }
 
 pub const Headers = struct {
-    pub const Array = stdx.BoundedArrayType(Header.Prepare, constants.view_change_headers_max);
+    pub const Array = stdx.BoundedArrayType(Header.Prepare, constants.view_headers_max);
     /// The SuperBlock's persisted VSR headers.
     /// One of the following:
     ///
@@ -1311,7 +1311,7 @@ const ViewChangeHeadersSlice = struct {
 
     pub fn verify(headers: ViewChangeHeadersSlice) void {
         assert(headers.slice.len > 0);
-        assert(headers.slice.len <= constants.view_change_headers_max);
+        assert(headers.slice.len <= constants.view_headers_max);
 
         const head = &headers.slice[0];
         // A DVC's head op is never a gap or faulty.
@@ -1340,7 +1340,7 @@ const ViewChangeHeadersSlice = struct {
                     // superblock.checkpoint could make .do_view_change headers durable instead of
                     // .start_view headers when view == log_view (see `commit_checkpoint_superblock`
                     // in `replica.zig`). When these headers are loaded from the superblock on
-                    // startup, they are considered to be .start_view headers (see `vsr_headers` in
+                    // startup, they are considered to be .start_view headers (see `view_headers` in
                     // `superblock.zig`).
                     maybe(headers.command == .do_view_change);
                     maybe(headers.command == .start_view);

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -1243,7 +1243,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         fn recover_slots(journal: *Journal) void {
             const replica: *Replica = @alignCast(@fieldParentPtr("journal", journal));
             const log_view = replica.superblock.working.vsr_state.log_view;
-            const view_change_headers = replica.superblock.working.vsr_headers();
+            const view_headers = replica.superblock.working.view_headers();
 
             assert(journal.status == .recovering);
             assert(journal.reads.executing() == 0);
@@ -1317,7 +1317,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             for (journal.headers, 0..) |*header_untrusted, index| {
                 const slot = Slot{ .index = index };
                 if (header_ok(replica.cluster, slot, header_untrusted)) |header| {
-                    const view_range = view_change_headers.view_for_op(header.op, log_view);
+                    const view_range = view_headers.view_for_op(header.op, log_view);
                     assert(view_range.max <= log_view);
 
                     if (header.operation != .reserved and !view_range.contains(header.view)) {

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -905,9 +905,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     .replica_count = options.replica_count,
                 },
                 .view_headers_count = 0,
-                .view_headers_all = mem.zeroes(
-                    [constants.view_change_headers_max]vsr.Header.Prepare,
-                ),
+                .view_headers_all = @splat(mem.zeroes(vsr.Header.Prepare)),
             };
 
             superblock.working.set_checksum();


### PR DESCRIPTION
We have three names for this concept:

* view_headers (replica)
* view_change_headers (vsr.Headers)
* vsr_headers (superblock)

I think we need to pick one :-)

view_headers makes most sense to me:

* vsr_headers is to general --- all headers are VSR headers
* view_change_headers are imprecise --- primary can generate new SV
  headers without view change!