### PR TITLE
fuzz: fix false positive

### DIFF
--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -96,7 +96,7 @@ pub fn storage_format(
         .release = options.release,
         .view = null,
     });
-    for (0..1_000) |_| {
+    for (0..10_000) |_| {
         if (context.done) break;
         storage.run();
     } else @panic("superblock format loop stuck");


### PR DESCRIPTION
I've looked into this closer last time, and the issue there is just that exponential distribution can generate pretty high latencies at times!

SEED: ./zig/zig build -Drelease fuzz -- lsm_manifest_log 17845402891353762162