### PR TITLE
CI: Increase timeout for release-validate

### DIFF
--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -106,7 +106,9 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
     }
 
     const git_sha = try shell.exec_stdout("git rev-parse HEAD", .{});
-    try shell.exec_zig("build scripts -- release --build " ++
+    try shell.exec_zig_options(.{
+        .timeout_ns = 20 * std.time.ns_per_min,
+    }, "build scripts -- release --build " ++
         "--sha={git_sha} --language=zig", .{
         .git_sha = git_sha,
     });

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -448,13 +448,26 @@ pub fn exec_stdout_options(
 
 /// Runs the zig compiler.
 pub fn exec_zig(shell: *Shell, comptime cmd: []const u8, cmd_args: anytype) !void {
+    return shell.exec_zig_options(.{}, cmd, cmd_args);
+}
+
+pub fn exec_zig_options(
+    shell: *Shell,
+    options: struct {
+        timeout_ns: u64 = 10 * std.time.ns_per_min,
+    },
+    comptime cmd: []const u8,
+    cmd_args: anytype,
+) !void {
     var argv = Argv.init(shell.gpa);
     defer argv.deinit();
 
     try argv.append_new_arg("{s}", .{shell.zig_exe.?});
     try expand_argv(&argv, cmd, cmd_args);
 
-    return shell.exec_inner(argv.slice(), .{});
+    return shell.exec_inner(argv.slice(), .{
+        .timeout_ns = options.timeout_ns,
+    });
 }
 
 fn exec_inner(


### PR DESCRIPTION
See https://github.com/tigerbeetle/tigerbeetle/actions/runs/16885096607/job/47830668332 for example failure.

(Aside -- maybe we should change the `timeout_ns` flags into `stdx.Duration`s?)