### PR TITLE
CI: Temporarily run release-validate from release branch head

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -23,7 +23,9 @@ jobs:
           ref: release
       # Run on the latest tag. The release branch is ahead of release tag over the weekend.
       - run: |
-          TAG=$(gh release list --limit 1 | cut -f1)
+          # TODO: Switch back after 2025-08-18's release.
+          #TAG=$(gh release list --limit 1 | cut -f1)
+          TAG=release
           git fetch origin $TAG && git switch -d FETCH_HEAD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Temporarily run release-validate from `release` branch head instead of the latest release tag.

This way we can cherry-pick https://github.com/tigerbeetle/tigerbeetle/pull/3166 onto `release`, and fix release validation without needing to cut an extra release this week.