### PR TITLE
io: convey intention in open_data_file

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -870,7 +870,7 @@ pub const IO = struct {
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,
-        method: enum { create, create_or_open, open, open_read_only },
+        purpose: enum { format, open, inspect },
         direct_io: DirectIO,
     ) !fd_t {
         _ = self;
@@ -887,7 +887,7 @@ pub const IO = struct {
         // To work around this, fs_sync() is explicitly called after writing in do_operation.
         var flags: posix.O = .{
             .CLOEXEC = true,
-            .ACCMODE = if (method == .open_read_only) .RDONLY else .RDWR,
+            .ACCMODE = if (purpose == .inspect) .RDONLY else .RDWR,
             .DSYNC = true,
         };
         var mode: posix.mode_t = 0;
@@ -895,19 +895,14 @@ pub const IO = struct {
         // TODO Document this and investigate whether this is in fact correct to set here.
         if (@hasField(posix.O, "LARGEFILE")) flags.LARGEFILE = true;
 
-        switch (method) {
-            .create => {
+        switch (purpose) {
+            .format => {
                 flags.CREAT = true;
                 flags.EXCL = true;
                 mode = 0o666;
                 log.info("creating \"{s}\"...", .{relative_path});
             },
-            .create_or_open => {
-                flags.CREAT = true;
-                mode = 0o666;
-                log.info("opening or creating \"{s}\"...", .{relative_path});
-            },
-            .open, .open_read_only => {
+            .open, .inspect => {
                 log.info("opening \"{s}\"...", .{relative_path});
             },
         }
@@ -933,7 +928,7 @@ pub const IO = struct {
         // LOCK_NB means that we want to fail the lock without waiting if another process has it.
         posix.flock(fd, posix.LOCK.EX | posix.LOCK.NB) catch |err| switch (err) {
             error.WouldBlock => {
-                if (method == .open_read_only) {
+                if (purpose == .inspect) {
                     log.warn(
                         "another process holds the data file lock - results may be inconsistent",
                         .{},
@@ -948,7 +943,7 @@ pub const IO = struct {
         // Ask the file system to allocate contiguous sectors for the file (if possible):
         // If the file system does not support `fallocate()`, then this could mean more seeks or a
         // panic if we run out of disk space (ENOSPC).
-        if (method == .create) try fs_allocate(fd, size);
+        if (purpose == .format) try fs_allocate(fd, size);
 
         // The best fsync strategy is always to fsync before reading because this prevents us from
         // making decisions on data that was never durably written by a previously crashed process.

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1423,7 +1423,7 @@ pub const IO = struct {
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,
-        method: enum { create, create_or_open, open, open_read_only },
+        purpose: enum { format, open, inspect },
         direct_io: DirectIO,
     ) !fd_t {
         _ = self;
@@ -1435,7 +1435,7 @@ pub const IO = struct {
 
         var flags: posix.O = .{
             .CLOEXEC = true,
-            .ACCMODE = if (method == .open_read_only) .RDONLY else .RDWR,
+            .ACCMODE = if (purpose == .inspect) .RDONLY else .RDWR,
             .DSYNC = true,
         };
         var mode: posix.mode_t = 0;
@@ -1447,7 +1447,7 @@ pub const IO = struct {
                 0,
             ) catch |err| switch (err) {
                 error.FileNotFound => {
-                    if (method == .create or method == .create_or_open) {
+                    if (purpose == .format) {
                         // It's impossible to distinguish creating a new file and opening a new
                         // block device with the current API. So if it's possible that we should
                         // create a file we try that instead of failing here.
@@ -1529,19 +1529,14 @@ pub const IO = struct {
                     }
                 }
 
-                switch (method) {
-                    .create => {
+                switch (purpose) {
+                    .format => {
                         flags.CREAT = true;
                         flags.EXCL = true;
                         mode = 0o666;
                         log.info("creating \"{s}\"...", .{relative_path});
                     },
-                    .create_or_open => {
-                        flags.CREAT = true;
-                        mode = 0o666;
-                        log.info("opening or creating \"{s}\"...", .{relative_path});
-                    },
-                    .open, .open_read_only => {
+                    .open, .inspect => {
                         log.info("opening \"{s}\"...", .{relative_path});
                     },
                 }
@@ -1594,7 +1589,7 @@ pub const IO = struct {
             }
         };
 
-        if (method == .open_read_only) {
+        if (purpose == .inspect) {
             assert(flags.ACCMODE == .RDONLY);
             maybe(lock_acquired);
 
@@ -1613,7 +1608,7 @@ pub const IO = struct {
         // Ask the file system to allocate contiguous sectors for the file (if possible):
         // If the file system does not support `fallocate()`, then this could mean more seeks or a
         // panic if we run out of disk space (ENOSPC).
-        if (method == .create and kind == .file) {
+        if (purpose == .format and kind == .file) {
             log.info("allocating {}...", .{std.fmt.fmtIntSizeBin(size)});
             fs_allocate(fd, size) catch |err| switch (err) {
                 error.OperationNotSupported => {
@@ -1681,7 +1676,7 @@ pub const IO = struct {
                     );
                 }
 
-                if (method == .create or method == .create_or_open) {
+                if (purpose == .format) {
                     // Check that the first superblock_zone_size bytes are 0.
                     // - It'll ensure that the block device is not directly TigerBeetle.
                     // - It'll be very likely to catch any cases where there's an existing

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1177,18 +1177,18 @@ pub const IO = struct {
         self: *IO,
         dir_handle: fd_t,
         relative_path: []const u8,
-        method: enum { create, open, open_read_only },
+        purpose: enum { format, open, inspect },
     ) !fd_t {
         const path_w = try os.windows.sliceToPrefixedFileW(dir_handle, relative_path);
 
         // FILE_CREATE = O_CREAT | O_EXCL
         var creation_disposition: os.windows.DWORD = 0;
-        switch (method) {
-            .create => {
+        switch (purpose) {
+            .format => {
                 creation_disposition = os.windows.FILE_CREATE;
                 log.info("creating \"{s}\"...", .{relative_path});
             },
-            .open, .open_read_only => {
+            .open, .inspect => {
                 creation_disposition = os.windows.OPEN_EXISTING;
                 log.info("opening \"{s}\"...", .{relative_path});
             },
@@ -1205,7 +1205,7 @@ pub const IO = struct {
         access_mask |= os.windows.SYNCHRONIZE;
         access_mask |= os.windows.GENERIC_READ;
 
-        if (method != .open_read_only) {
+        if (purpose != .inspect) {
             access_mask |= os.windows.GENERIC_WRITE;
         }
 
@@ -1263,7 +1263,7 @@ pub const IO = struct {
         dir_handle: fd_t,
         relative_path: []const u8,
         size: u64,
-        method: enum { create, create_or_open, open, open_read_only },
+        purpose: enum { format, open, inspect },
         direct_io: DirectIO,
     ) !fd_t {
         assert(relative_path.len > 0);
@@ -1271,27 +1271,14 @@ pub const IO = struct {
         // On windows, assume that Direct IO is always available.
         _ = direct_io;
 
-        const handle = switch (method) {
+        const handle = switch (purpose) {
+            .format => try self.open_file_handle(dir_handle, relative_path, .format),
             .open => try self.open_file_handle(dir_handle, relative_path, .open),
-            .open_read_only => try self.open_file_handle(
+            .inspect => try self.open_file_handle(
                 dir_handle,
                 relative_path,
-                .open_read_only,
+                .inspect,
             ),
-            .create => try self.open_file_handle(dir_handle, relative_path, .create),
-            .create_or_open => open_file_handle(
-                self,
-                dir_handle,
-                relative_path,
-                .open,
-            ) catch |err| switch (err) {
-                error.FileNotFound => try self.open_file_handle(
-                    dir_handle,
-                    relative_path,
-                    .create,
-                ),
-                else => return err,
-            },
         };
         errdefer os.windows.CloseHandle(handle);
 
@@ -1299,7 +1286,7 @@ pub const IO = struct {
         // even when we haven't given shared access to other processes.
         fs_lock(handle, size) catch |err| switch (err) {
             error.WouldBlock => {
-                if (method == .open_read_only) {
+                if (purpose == .inspect) {
                     log.warn(
                         "another process holds the data file lock - results may be inconsistent",
                         .{},
@@ -1312,7 +1299,7 @@ pub const IO = struct {
         };
 
         // Ask the file system to allocate contiguous sectors for the file (if possible):
-        if (method == .create) {
+        if (purpose == .format) {
             log.info("allocating {}...", .{std.fmt.fmtIntSizeBin(size)});
             fs_allocate(handle, size) catch {
                 log.warn("file system failed to preallocate the file memory", .{});
@@ -1338,7 +1325,7 @@ pub const IO = struct {
         // making decisions on data that was never durably written by a previously crashed process.
         // We therefore always fsync when we open the path, also to wait for any pending O_DSYNC.
         // Thanks to Alex Miller from FoundationDB for diving into our source and pointing this out.
-        if (method != .open_read_only) {
+        if (purpose != .inspect) {
             try posix.fsync(handle);
         }
 

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -463,7 +463,7 @@ const Inspector = struct {
             inspector.dir_fd,
             basename,
             vsr.superblock.data_file_size_min,
-            .open_read_only,
+            .inspect,
             .direct_io_optional,
         );
         errdefer std.posix.close(inspector.fd);

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -163,7 +163,7 @@ const Command = struct {
         tracer: *Tracer,
         path: []const u8,
         options: struct {
-            must_create: bool,
+            format: bool,
             development: bool,
         },
     ) !void {
@@ -185,7 +185,7 @@ const Command = struct {
             command.dir_fd,
             basename,
             data_file_size_min,
-            if (options.must_create) .create else .open,
+            if (options.format) .format else .open,
             direct_io,
         );
         errdefer std.posix.close(command.fd);
@@ -215,7 +215,7 @@ const Command = struct {
     ) !void {
         var command: Command = undefined;
         try command.init(gpa, io, tracer, args.path, .{
-            .must_create = true,
+            .format = true,
             .development = args.development,
         });
         defer command.deinit(gpa);
@@ -243,7 +243,7 @@ const Command = struct {
     ) !void {
         var command: Command = undefined;
         try command.init(gpa, io, tracer, args.path, .{
-            .must_create = true,
+            .format = true,
             .development = args.development,
         });
         defer command.deinit(gpa);
@@ -318,7 +318,7 @@ const Command = struct {
 
         var command: Command = undefined;
         try command.init(gpa, io, tracer, args.path, .{
-            .must_create = false,
+            .format = false,
             .development = args.development,
         });
         defer command.deinit(gpa);


### PR DESCRIPTION
Previously, `open_data_file` would take in an enum that included things like `.open`, `.create`, `.open_read_only`.

However, `open_data_file` is _specifically_ for opening a TigerBeetle data file, it's not a generic way to open a file. Thread the higher level intention (`.format`, `.open`, `.inspect`) through rather.

Additionally, remove `.create_or_open` (since it was used for the AOF but no longer) and rename `.must_create` to `.format`.