### PR TITLE
cli: don't remove datafile if formatting fail

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -220,13 +220,10 @@ const Command = struct {
         });
         defer command.deinit(gpa);
 
-        vsr.format(Storage, gpa, options, .{
+        try vsr.format(Storage, gpa, options, .{
             .storage = &command.storage,
             .storage_size_limit = data_file_size_min,
-        }) catch |err| {
-            std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
-            return err;
-        };
+        });
 
         log.info("{}: formatted: cluster={} replica_count={}", .{
             options.replica,
@@ -289,7 +286,6 @@ const Command = struct {
         switch (reformatter.done().?) {
             .failed => |err| {
                 log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
-                std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
                 return err;
             },
             .ok => log.info("{}: success", .{args.replica}),


### PR DESCRIPTION
Formatting is atomic, by virtue of superblock writes being atomic. If something fails, its better to let the user do the cleanup, cleaning up automatically might mess things up, and is pretty hard to test.

In particular, we are actually using unlinkat wrong here, as we pass parent directory as a fd, but we use path relative to cwd!