### PR TITLE
vsr: fix formatting options

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -357,16 +357,13 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 try vsr.format(
                     Storage,
                     allocator,
+                    storage,
                     .{
                         .cluster = options.cluster.cluster_id,
                         .release = options.cluster.releases[0].release,
                         .replica = @intCast(replica_index),
                         .replica_count = options.cluster.replica_count,
                         .view = null,
-                    },
-                    .{
-                        .storage = storage,
-                        .storage_size_limit = options.cluster.storage_size_limit,
                     },
                 );
             }
@@ -860,18 +857,13 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             cluster.replica_reformats[replica_index] = try ReplicaReformat.init(
                 cluster.allocator,
                 &cluster.clients[client_index].?,
+                storage,
                 .{
-                    .format = .{
-                        .cluster = cluster.options.cluster_id,
-                        .release = cluster.options.releases[0].release,
-                        .replica = @intCast(replica_index),
-                        .replica_count = cluster.options.replica_count,
-                        .view = null,
-                    },
-                    .superblock = .{
-                        .storage = storage,
-                        .storage_size_limit = cluster.options.storage_size_limit,
-                    },
+                    .cluster = cluster.options.cluster_id,
+                    .release = cluster.options.releases[0].release,
+                    .replica = @intCast(replica_index),
+                    .replica_count = cluster.options.replica_count,
+                    .view = null,
                 },
             );
             cluster.replica_reformats[replica_index].?.start();

--- a/src/testing/fixtures.zig
+++ b/src/testing/fixtures.zig
@@ -107,8 +107,7 @@ pub fn storage_format(
 pub fn init_superblock(gpa: std.mem.Allocator, storage: *Storage, options: struct {
     storage_size_limit: ?u64 = null,
 }) !SuperBlock {
-    return try SuperBlock.init(gpa, .{
-        .storage = storage,
+    return try SuperBlock.init(gpa, storage, .{
         .storage_size_limit = options.storage_size_limit orelse storage.size,
     });
 }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -220,10 +220,7 @@ const Command = struct {
         });
         defer command.deinit(gpa);
 
-        vsr.format(Storage, gpa, options, .{
-            .storage = &command.storage,
-            .storage_size_limit = data_file_size_min,
-        }) catch |err| {
+        vsr.format(Storage, gpa, &command.storage, options) catch |err| {
             std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
             return err;
         };
@@ -266,18 +263,12 @@ const Command = struct {
         });
         defer client.deinit(gpa);
 
-        var reformatter = try ReplicaReformat.init(gpa, &client, .{
-            .format = .{
-                .cluster = args.cluster,
-                .replica = args.replica,
-                .replica_count = args.replica_count,
-                .release = config.process.release,
-                .view = null,
-            },
-            .superblock = .{
-                .storage = &command.storage,
-                .storage_size_limit = data_file_size_min,
-            },
+        var reformatter = try ReplicaReformat.init(gpa, &client, &command.storage, .{
+            .cluster = args.cluster,
+            .replica = args.replica,
+            .replica_count = args.replica_count,
+            .release = config.process.release,
+            .view = null,
         });
         defer reformatter.deinit(gpa);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -670,8 +670,8 @@ pub fn ReplicaType(
 
             self.superblock = try SuperBlock.init(
                 allocator,
+                options.storage,
                 .{
-                    .storage = options.storage,
                     .storage_size_limit = options.storage_size_limit,
                 },
             );


### PR DESCRIPTION
The seed of the commit is

```diff
modified   src/vsr/superblock.zig
@@ -713,31 +713,28 @@ pub fn SuperBlockType(comptime Storage: type) type {
         /// Used for logging.
         replica_index: ?u8 = null,

-        pub const Options = struct {
-            storage: *Storage,
+        pub fn init(gpa: mem.Allocator, storage: *Storage, options: struct {
             storage_size_limit: u64,
-        };
-
-        pub fn init(allocator: mem.Allocator, options: Options) !SuperBlock {
+        }) !SuperBlock {
```

which in turn is just an application of TigerStyle rule about injecting dependencies positionally.

But a bunch of good stuff falls out of this mechanical change:

* `format` can now set `storage_size_limit` directly, as it knows how much its going to write.
* `reformat` now can avoid awkward options-inside-options structure
* and it becomes obvious, looking at Reformat.init, that something's not right, that we create storage earlier than we should (but that's future work)