### PR TITLE
cli: don't unlink data file on formatting failure and refactor main

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -857,6 +857,7 @@ pub const IO = struct {
     pub const fd_t = posix.fd_t;
     pub const INVALID_FILE: fd_t = -1;
 
+    pub const OpenDataFilePurpose = enum { format, open, inspect };
     /// Opens or creates a journal file:
     /// - For reading and writing.
     /// - For Direct I/O (required on darwin).
@@ -870,7 +871,7 @@ pub const IO = struct {
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,
-        purpose: enum { format, open, inspect },
+        purpose: OpenDataFilePurpose,
         direct_io: DirectIO,
     ) !fd_t {
         _ = self;

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1410,6 +1410,7 @@ pub const IO = struct {
     pub const fd_t = posix.fd_t;
     pub const INVALID_FILE: fd_t = -1;
 
+    pub const OpenDataFilePurpose = enum { format, open, inspect };
     /// Opens or creates a journal file:
     /// - For reading and writing.
     /// - For Direct I/O (if possible in development mode, but required in production mode).
@@ -1423,7 +1424,7 @@ pub const IO = struct {
         dir_fd: fd_t,
         relative_path: []const u8,
         size: u64,
-        purpose: enum { format, open, inspect },
+        purpose: OpenDataFilePurpose,
         direct_io: DirectIO,
     ) !fd_t {
         _ = self;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1250,6 +1250,7 @@ pub const IO = struct {
         return handle;
     }
 
+    pub const OpenDataFilePurpose = enum { format, open, inspect };
     /// Opens or creates a journal file:
     /// - For reading and writing.
     /// - For Direct I/O (required on windows).
@@ -1263,7 +1264,7 @@ pub const IO = struct {
         dir_handle: fd_t,
         relative_path: []const u8,
         size: u64,
-        purpose: enum { format, open, inspect },
+        purpose: OpenDataFilePurpose,
         direct_io: DirectIO,
     ) !fd_t {
         assert(relative_path.len > 0);

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -96,6 +96,7 @@ pub fn StorageType(comptime IO: type) type {
 
         io: *IO,
         tracer: *Tracer,
+        dir_fd: IO.fd_t,
         fd: IO.fd_t,
 
         next_tick_queue: QueueType(NextTick) = QueueType(NextTick).init(.{
@@ -104,10 +105,33 @@ pub fn StorageType(comptime IO: type) type {
         next_tick_completion_scheduled: bool = false,
         next_tick_completion: IO.Completion = undefined,
 
-        pub fn init(io: *IO, tracer: *Tracer, fd: IO.fd_t) !Storage {
+        pub fn init(io: *IO, tracer: *Tracer, options: struct {
+            path: []const u8,
+            size_min: u64,
+            purpose: IO.OpenDataFilePurpose,
+            direct_io: vsr.io.DirectIO,
+        }) !Storage {
+            // TODO Resolve the parent directory properly in the presence of .. and symlinks.
+            // TODO Handle physical volumes where there is no directory to fsync.
+            const dirname = std.fs.path.dirname(options.path) orelse ".";
+            const basename = std.fs.path.basename(options.path);
+
+            const dir_fd = try IO.open_dir(dirname);
+            errdefer std.posix.close(dir_fd);
+
+            const fd = try io.open_data_file(
+                dir_fd,
+                basename,
+                options.size_min,
+                options.purpose,
+                options.direct_io,
+            );
+            errdefer std.posix.close(fd);
+
             return .{
                 .io = io,
                 .tracer = tracer,
+                .dir_fd = dir_fd,
                 .fd = fd,
             };
         }
@@ -115,7 +139,13 @@ pub fn StorageType(comptime IO: type) type {
         pub fn deinit(storage: *Storage) void {
             assert(storage.next_tick_queue.empty());
             assert(storage.fd != IO.INVALID_FILE);
+            assert(storage.dir_fd != IO.INVALID_FILE);
+
+            std.posix.close(storage.fd);
             storage.fd = IO.INVALID_FILE;
+
+            std.posix.close(storage.dir_fd);
+            storage.dir_fd = IO.INVALID_FILE;
         }
 
         pub fn run(storage: *Storage) void {

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -81,7 +81,13 @@ pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
         var tracer = try fixtures.init_tracer(gpa, time, .{});
         defer tracer.deinit(gpa);
 
-        var storage = try Storage.init(&io, &tracer, 0);
+        var storage: Storage = .{
+            .io = &io,
+            .tracer = &tracer,
+            .dir_fd = 0,
+            .fd = 0,
+        };
+        // NB: Intentionally skipping deinit to avoid closing stdin.
 
         var write_completion: Storage.Write = undefined;
 

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -123,6 +123,8 @@ pub const IO = struct {
         self.completed.push(completion);
     }
 
+    pub const OpenDataFilePurpose = enum { format, open, inspect };
+
     pub const ReadError = error{
         WouldBlock,
         NotOpenForReading,

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -22,7 +22,7 @@ const benchmark_load = @import("./benchmark_load.zig");
 
 const log = std.log;
 
-pub fn main(
+pub fn command_benchmark(
     allocator: Allocator,
     io: *vsr.io.IO,
     time: vsr.time.Time,

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -34,7 +34,7 @@ const EventMetricAggregate = vsr.trace.EventMetricAggregate;
 const EventTiming = vsr.trace.EventTiming;
 const EventTimingAggregate = vsr.trace.EventTimingAggregate;
 
-pub fn main(
+pub fn command_inspect(
     allocator: std.mem.Allocator,
     io: *IO,
     tracer: *Tracer,
@@ -43,13 +43,19 @@ pub fn main(
     var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
     var stdout_writer = stdout_buffer.writer();
 
-    const inspect_result = main_inspect(allocator, io, tracer, cli_args, stdout_writer.any());
+    const inspect_result = run_inspect(allocator, io, tracer, cli_args, stdout_writer.any());
     const flush_result = stdout_buffer.flush();
-    try inspect_result;
-    try flush_result;
+
+    inline for (.{ inspect_result, flush_result }) |result| {
+        result catch |err| switch (err) {
+            // Ignore BrokenPipe so that e.g. "tigerbeetle inspect ... | head -n12" succeeds.
+            error.BrokenPipe => {},
+            else => return err,
+        };
+    }
 }
 
-fn main_inspect(
+fn run_inspect(
     allocator: std.mem.Allocator,
     io: *IO,
     tracer: *Tracer,
@@ -424,8 +430,6 @@ fn print_objects(output: std.io.AnyWriter) !void {
 
 const Inspector = struct {
     allocator: std.mem.Allocator,
-    dir_fd: std.posix.fd_t,
-    fd: std.posix.fd_t,
     io: *IO,
     storage: Storage,
 
@@ -446,29 +450,18 @@ const Inspector = struct {
 
         inspector.* = .{
             .allocator = allocator,
-            .dir_fd = undefined,
-            .fd = undefined,
             .io = io,
             .storage = undefined,
             .superblock_buffer = undefined,
             .superblock_headers = undefined,
         };
 
-        const dirname = std.fs.path.dirname(path) orelse ".";
-        inspector.dir_fd = try vsr.io.IO.open_dir(dirname);
-        errdefer std.posix.close(inspector.dir_fd);
-
-        const basename = std.fs.path.basename(path);
-        inspector.fd = try io.open_data_file(
-            inspector.dir_fd,
-            basename,
-            vsr.superblock.data_file_size_min,
-            .inspect,
-            .direct_io_optional,
-        );
-        errdefer std.posix.close(inspector.fd);
-
-        inspector.storage = try Storage.init(io, tracer, inspector.fd);
+        inspector.storage = try Storage.init(io, tracer, .{
+            .path = path,
+            .size_min = vsr.superblock.data_file_size_min,
+            .purpose = .inspect,
+            .direct_io = .direct_io_optional,
+        });
         errdefer inspector.storage.deinit();
 
         inspector.superblock_buffer = try allocator.alignedAlloc(
@@ -495,7 +488,7 @@ const Inspector = struct {
                 "invalid superblock version; inspector supports version={}, version in {s}={}",
                 .{
                     SuperBlockVersion,
-                    basename,
+                    path,
                     superblock.version,
                 },
             );
@@ -506,8 +499,6 @@ const Inspector = struct {
     fn destroy(inspector: *Inspector) void {
         inspector.allocator.free(inspector.superblock_buffer);
         inspector.storage.deinit();
-        std.posix.close(inspector.fd);
-        std.posix.close(inspector.dir_fd);
         inspector.allocator.destroy(inspector);
     }
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -32,7 +32,6 @@ const Client = vsr.ClientType(StateMachine, vsr.message_bus.MessageBusClient);
 const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, AOF);
 const ReplicaReformat =
     vsr.ReplicaReformatType(StateMachine, vsr.message_bus.MessageBusClient, Storage);
-const SuperBlock = vsr.SuperBlockType(Storage);
 const data_file_size_min = vsr.superblock.data_file_size_min;
 
 const KiB = stdx.KiB;
@@ -75,7 +74,7 @@ pub fn main() !void {
     var command = cli.parse_args(&arg_iterator);
 
     if (command == .version) {
-        try Command.version(gpa, command.version.verbose);
+        try command_version(gpa, command.version.verbose);
         return; // Exit early before initializing IO.
     }
 
@@ -122,21 +121,37 @@ pub fn main() !void {
 
     switch (command) {
         .version => unreachable, // Handled earlier.
-        .format => |*args| try Command.format(gpa, &io, &tracer, args, .{
-            .cluster = args.cluster,
-            .replica = args.replica,
-            .replica_count = args.replica_count,
-            .release = config.process.release,
-            .view = null,
-        }),
-        .recover => |*args| try Command.reformat(gpa, &io, &tracer, args),
-        .start => |*args| try Command.start(gpa, &io, &tracer, args),
-        .repl => |*args| try Command.repl(gpa, &io, time, args),
-        .benchmark => |*args| try benchmark_driver.main(gpa, &io, time, args),
-        .inspect => |*args| inspect.main(gpa, &io, &tracer, args) catch |err| {
-            // Ignore BrokenPipe so that e.g. "tigerbeetle inspect ... | head -n12" succeeds.
-            if (err != error.BrokenPipe) return err;
+        inline .format, .start, .recover => |*args, command_storage| {
+            const direct_io: vsr.io.DirectIO =
+                if (!constants.direct_io)
+                    .direct_io_disabled
+                else if (args.development)
+                    .direct_io_optional
+                else
+                    .direct_io_required;
+
+            var storage = try Storage.init(&io, &tracer, .{
+                .path = args.path,
+                .size_min = data_file_size_min,
+                .purpose = switch (command_storage) {
+                    .format, .recover => .format,
+                    .start => .open,
+                    else => comptime unreachable,
+                },
+                .direct_io = direct_io,
+            });
+            defer storage.deinit();
+
+            switch (command_storage) {
+                .format => try command_format(gpa, &storage, args),
+                .start => try command_start(gpa, &io, &tracer, &storage, args),
+                .recover => try command_reformat(gpa, &io, &tracer, &storage, args),
+                else => comptime unreachable,
+            }
         },
+        .repl => |*args| try command_repl(gpa, &io, time, args),
+        .benchmark => |*args| try benchmark_driver.command_benchmark(gpa, &io, time, args),
+        .inspect => |*args| try inspect.command_inspect(gpa, &io, &tracer, args),
         .multiversion => |*args| {
             var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
             var stdout_writer = stdout_buffer.writer();
@@ -145,504 +160,435 @@ pub fn main() !void {
             try vsr.multiversioning.print_information(gpa, args.path, stdout);
             try stdout_buffer.flush();
         },
-        .amqp => |*args| try Command.amqp(gpa, time, args),
+        .amqp => |*args| try command_amqp(gpa, time, args),
     }
 }
 
-const Command = struct {
-    dir_fd: std.posix.fd_t,
-    fd: std.posix.fd_t,
-    storage: Storage,
-    self_exe_path: [:0]const u8,
-    data_file_path: []const u8,
+fn command_version(gpa: mem.Allocator, verbose: bool) !void {
+    var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
+    var stdout_writer = stdout_buffer.writer();
+    const stdout = stdout_writer.any();
 
-    fn init(
-        command: *Command,
-        gpa: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        path: []const u8,
-        options: struct {
-            format: bool,
-            development: bool,
-        },
-    ) !void {
-        // TODO Resolve the parent directory properly in the presence of .. and symlinks.
-        // TODO Handle physical volumes where there is no directory to fsync.
-        const dirname = std.fs.path.dirname(path) orelse ".";
-        command.dir_fd = try IO.open_dir(dirname);
-        errdefer std.posix.close(command.dir_fd);
+    try std.fmt.format(stdout, "TigerBeetle version {}\n", .{constants.semver});
 
-        const direct_io: vsr.io.DirectIO = if (!constants.direct_io)
-            .direct_io_disabled
-        else if (options.development)
-            .direct_io_optional
-        else
-            .direct_io_required;
-
-        const basename = std.fs.path.basename(path);
-        command.fd = try io.open_data_file(
-            command.dir_fd,
-            basename,
-            data_file_size_min,
-            if (options.format) .format else .open,
-            direct_io,
-        );
-        errdefer std.posix.close(command.fd);
-
-        command.storage = try Storage.init(io, tracer, command.fd);
-        errdefer command.storage.deinit();
-
-        command.self_exe_path = try vsr.multiversioning.self_exe_path(gpa);
-        errdefer gpa.free(command.self_exe_path);
-
-        command.data_file_path = path;
-    }
-
-    fn deinit(command: *Command, gpa: mem.Allocator) void {
-        gpa.free(command.self_exe_path);
-        command.storage.deinit();
-        std.posix.close(command.fd);
-        std.posix.close(command.dir_fd);
-    }
-
-    pub fn format(
-        gpa: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        args: *const cli.Command.Format,
-        options: SuperBlock.FormatOptions,
-    ) !void {
-        var command: Command = undefined;
-        try command.init(gpa, io, tracer, args.path, .{
-            .format = true,
-            .development = args.development,
-        });
-        defer command.deinit(gpa);
-
-        try vsr.format(Storage, gpa, &command.storage, options);
-
-        log.info("{}: formatted: cluster={} replica_count={}", .{
-            options.replica,
-            options.cluster,
-            options.replica_count,
-        });
-    }
-
-    pub fn reformat(
-        gpa: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        args: *const cli.Command.Recover,
-    ) !void {
-        var command: Command = undefined;
-        try command.init(gpa, io, tracer, args.path, .{
-            .format = true,
-            .development = args.development,
-        });
-        defer command.deinit(gpa);
-
-        var message_pool = try MessagePool.init(gpa, .client);
-        defer message_pool.deinit(gpa);
-
-        var client = try Client.init(gpa, .{
-            .id = stdx.unique_u128(),
-            .cluster = args.cluster,
-            .replica_count = args.replica_count,
-            .time = tracer.time,
-            .message_pool = &message_pool,
-            .message_bus_options = .{
-                .configuration = args.addresses.const_slice(),
-                .io = io,
-                .clients_limit = null,
-            },
-            .eviction_callback = &reformat_client_eviction_callback,
-        });
-        defer client.deinit(gpa);
-
-        var reformatter = try ReplicaReformat.init(gpa, &client, &command.storage, .{
-            .cluster = args.cluster,
-            .replica = args.replica,
-            .replica_count = args.replica_count,
-            .release = config.process.release,
-            .view = null,
-        });
-        defer reformatter.deinit(gpa);
-
-        reformatter.start();
-        while (reformatter.done() == null) {
-            client.tick();
-            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
-        }
-        switch (reformatter.done().?) {
-            .failed => |err| {
-                log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
-                return err;
-            },
-            .ok => log.info("{}: success", .{args.replica}),
-        }
-    }
-
-    fn reformat_client_eviction_callback(
-        client: *Client,
-        eviction: *const MessagePool.Message.Eviction,
-    ) void {
-        _ = client;
-        std.debug.panic("error: client evicted: {s}", .{@tagName(eviction.header.reason)});
-    }
-
-    pub fn start(
-        base_allocator: mem.Allocator,
-        io: *IO,
-        tracer: *Tracer,
-        args: *const cli.Command.Start,
-    ) !void {
-        var counting_allocator = vsr.CountingAllocator.init(base_allocator);
-        const gpa = counting_allocator.allocator();
-
-        // TODO Panic if the data file's size is larger that args.storage_size_limit.
-        // (Here or in Replica.open()?).
-
-        var command: Command = undefined;
-        try command.init(gpa, io, tracer, args.path, .{
-            .format = false,
-            .development = args.development,
-        });
-        defer command.deinit(gpa);
-
-        var message_pool = try MessagePool.init(gpa, .{ .replica = .{
-            .members_count = args.addresses.count_as(u8),
-            .pipeline_requests_limit = args.pipeline_requests_limit,
-        } });
-        defer message_pool.deinit(gpa);
-
-        var aof: ?AOF = if (args.aof_file) |*aof_file| blk: {
-            const aof_dir = std.fs.path.dirname(aof_file.const_slice()) orelse ".";
-            const aof_dir_fd = try IO.open_dir(aof_dir);
-            defer std.posix.close(aof_dir_fd);
-
-            break :blk try AOF.init(io, .{
-                .dir_fd = aof_dir_fd,
-                .relative_path = std.fs.path.basename(aof_file.const_slice()),
-            });
-        } else null;
-        defer if (aof != null) aof.?.close();
-
-        const grid_cache_size = @as(u64, args.cache_grid_blocks) * constants.block_size;
-        const grid_cache_size_min = constants.block_size * Grid.Cache.value_count_max_multiple;
-
-        // The amount of bytes in `--cache-grid` must be a multiple of
-        // `constants.block_size` and `SetAssociativeCache.value_count_max_multiple`,
-        // and it may have been converted to zero if a smaller value is passed in.
-        if (grid_cache_size == 0) {
-            if (comptime (grid_cache_size_min >= MiB)) {
-                vsr.fatal(.cli, "Grid cache must be greater than {}MiB. See --cache-grid", .{
-                    @divExact(grid_cache_size_min, MiB),
-                });
-            } else {
-                vsr.fatal(.cli, "Grid cache must be greater than {}KiB. See --cache-grid", .{
-                    @divExact(grid_cache_size_min, KiB),
-                });
-            }
-        }
-        assert(grid_cache_size >= grid_cache_size_min);
-
-        const grid_cache_size_warn = 1 * GiB;
-        if (grid_cache_size < grid_cache_size_warn) {
-            log.warn("Grid cache size of {}MiB is small. See --cache-grid", .{
-                @divExact(grid_cache_size, MiB),
-            });
+    if (verbose) {
+        try stdout.writeAll("\n");
+        inline for (.{ "mode", "zig_version" }) |declaration| {
+            try print_value(stdout, "build." ++ declaration, @field(builtin, declaration));
         }
 
-        const nonce = stdx.unique_u128();
-
-        var multiversion: ?vsr.multiversioning.Multiversion = blk: {
-            if (constants.config.process.release.value ==
-                vsr.multiversioning.Release.minimum.value)
-            {
-                log.info("multiversioning: upgrades disabled for development ({}) release.", .{
-                    constants.config.process.release,
-                });
-                break :blk null;
-            }
-            if (constants.aof_recovery) {
-                log.info("multiversioning: upgrades disabled due to aof_recovery.", .{});
-                break :blk null;
-            }
-
-            if (args.addresses_zero) {
-                log.info("multiversioning: upgrades disabled due to --addresses=0", .{});
-                break :blk null;
-            }
-
-            break :blk try vsr.multiversioning.Multiversion.init(
-                gpa,
-                io,
-                command.self_exe_path,
-                .native,
+        // Zig 0.10 doesn't see field_name as comptime if this `comptime` isn't used.
+        try stdout.writeAll("\n");
+        inline for (comptime std.meta.fieldNames(@TypeOf(config.cluster))) |field_name| {
+            try print_value(
+                stdout,
+                "cluster." ++ field_name,
+                @field(config.cluster, field_name),
             );
-        };
-
-        defer if (multiversion != null) multiversion.?.deinit(gpa);
-
-        // The error from .open_sync() is ignored - timeouts and checking for new binaries are still
-        // enabled even if the first version fails to load.
-        if (multiversion != null) multiversion.?.open_sync() catch {};
-
-        var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .{};
-        releases_bundled_baseline.push(constants.config.process.release);
-
-        const releases_bundled = if (multiversion != null)
-            &multiversion.?.releases_bundled
-        else
-            &releases_bundled_baseline;
-
-        log.info("release={}", .{config.process.release});
-        log.info("release_client_min={}", .{config.process.release_client_min});
-        log.info("releases_bundled={any}", .{releases_bundled.const_slice()});
-        log.info("git_commit={?s}", .{config.process.git_commit});
-
-        const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
-
-        var replica: Replica = undefined;
-        replica.open(gpa, .{
-            .node_count = args.addresses.count_as(u8),
-            .release = config.process.release,
-            .release_client_min = config.process.release_client_min,
-            .releases_bundled = releases_bundled,
-            .release_execute = replica_release_execute,
-            .release_execute_context = if (multiversion) |*pointer| pointer else null,
-            .pipeline_requests_limit = args.pipeline_requests_limit,
-            .storage_size_limit = args.storage_size_limit,
-            .storage = &command.storage,
-            .aof = if (aof != null) &aof.? else null,
-            .message_pool = &message_pool,
-            .nonce = nonce,
-            .time = tracer.time,
-            .timeout_prepare_ticks = args.timeout_prepare_ticks,
-            .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
-            .commit_stall_probability = args.commit_stall_probability,
-            .state_machine_options = .{
-                .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
-                .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
-                .lsm_forest_node_count = args.lsm_forest_node_count,
-                .cache_entries_accounts = args.cache_accounts,
-                .cache_entries_transfers = args.cache_transfers,
-                .cache_entries_transfers_pending = args.cache_transfers_pending,
-            },
-            .message_bus_options = .{
-                .configuration = args.addresses.const_slice(),
-                .io = io,
-                .clients_limit = clients_limit,
-            },
-            .grid_cache_blocks_count = args.cache_grid_blocks,
-            .tracer = tracer,
-            .replicate_options = .{
-                .closed_loop = args.replicate_closed_loop,
-                .star = args.replicate_star,
-            },
-        }) catch |err| switch (err) {
-            error.NoAddress => vsr.fatal(.cli, "all --addresses must be provided", .{}),
-            else => |e| return e,
-        };
-
-        if (multiversion != null) {
-            if (args.development) {
-                log.info("multiversioning: upgrade polling disabled due to --development.", .{});
-            } else {
-                multiversion.?.timeout_start(replica.replica);
-            }
-
-            if (args.experimental) {
-                log.warn("multiversioning: upgrade polling and --experimental enabled - " ++
-                    "make sure to check CLI argument compatibility before upgrading.", .{});
-                log.warn("If the cluster upgrades automatically, and incompatible experimental " ++
-                    "CLI arguments are set, it will crash.", .{});
-            }
         }
 
-        // Note that this does not account for the fact that any allocations will be rounded up to
-        // the nearest page by `std.heap.page_allocator`.
-        log.info("{}: Allocated {}MiB during replica init", .{
-            replica.replica,
-            @divFloor(counting_allocator.live_size(), MiB),
-        });
-        log.info("{}: Grid cache: {}MiB, LSM-tree manifests: {}MiB", .{
-            replica.replica,
-            @divFloor(grid_cache_size, MiB),
-            @divFloor(args.lsm_forest_node_count * constants.lsm_manifest_node_size, MiB),
-        });
+        try stdout.writeAll("\n");
+        inline for (comptime std.meta.fieldNames(@TypeOf(config.process))) |field_name| {
+            try print_value(
+                stdout,
+                "process." ++ field_name,
+                @field(config.process, field_name),
+            );
+        }
 
-        log.info("{}: cluster={}: listening on {}", .{
-            replica.replica,
-            replica.cluster,
-            replica.message_bus.process.accept_address,
-        });
+        try stdout.writeAll("\n");
+        const self_exe_path = try vsr.multiversioning.self_exe_path(gpa);
+        defer gpa.free(self_exe_path);
 
+        vsr.multiversioning.print_information(gpa, self_exe_path, stdout) catch {};
+    }
+    try stdout_buffer.flush();
+}
+
+fn command_format(
+    gpa: mem.Allocator,
+    storage: *Storage,
+    args: *const cli.Command.Format,
+) !void {
+    try vsr.format(Storage, gpa, storage, .{
+        .cluster = args.cluster,
+        .replica = args.replica,
+        .replica_count = args.replica_count,
+        .release = config.process.release,
+        .view = null,
+    });
+
+    log.info("{}: formatted: cluster={} replica_count={}", .{
+        args.replica,
+        args.cluster,
+        args.replica_count,
+    });
+}
+
+fn command_start(
+    base_allocator: mem.Allocator,
+    io: *IO,
+    tracer: *Tracer,
+    storage: *Storage,
+    args: *const cli.Command.Start,
+) !void {
+    var counting_allocator = vsr.CountingAllocator.init(base_allocator);
+    const gpa = counting_allocator.allocator();
+
+    // TODO Panic if the data file's size is larger that args.storage_size_limit.
+    // (Here or in Replica.open()?).
+
+    var message_pool = try MessagePool.init(gpa, .{ .replica = .{
+        .members_count = args.addresses.count_as(u8),
+        .pipeline_requests_limit = args.pipeline_requests_limit,
+    } });
+    defer message_pool.deinit(gpa);
+
+    var aof: ?AOF = if (args.aof_file) |*aof_file| blk: {
+        const aof_dir = std.fs.path.dirname(aof_file.const_slice()) orelse ".";
+        const aof_dir_fd = try IO.open_dir(aof_dir);
+        defer std.posix.close(aof_dir_fd);
+
+        break :blk try AOF.init(io, .{
+            .dir_fd = aof_dir_fd,
+            .relative_path = std.fs.path.basename(aof_file.const_slice()),
+        });
+    } else null;
+    defer if (aof != null) aof.?.close();
+
+    const grid_cache_size = @as(u64, args.cache_grid_blocks) * constants.block_size;
+    const grid_cache_size_min = constants.block_size * Grid.Cache.value_count_max_multiple;
+
+    // The amount of bytes in `--cache-grid` must be a multiple of
+    // `constants.block_size` and `SetAssociativeCache.value_count_max_multiple`,
+    // and it may have been converted to zero if a smaller value is passed in.
+    if (grid_cache_size == 0) {
+        if (comptime (grid_cache_size_min >= MiB)) {
+            vsr.fatal(.cli, "Grid cache must be greater than {}MiB. See --cache-grid", .{
+                @divExact(grid_cache_size_min, MiB),
+            });
+        } else {
+            vsr.fatal(.cli, "Grid cache must be greater than {}KiB. See --cache-grid", .{
+                @divExact(grid_cache_size_min, KiB),
+            });
+        }
+    }
+    assert(grid_cache_size >= grid_cache_size_min);
+
+    const grid_cache_size_warn = 1 * GiB;
+    if (grid_cache_size < grid_cache_size_warn) {
+        log.warn("Grid cache size of {}MiB is small. See --cache-grid", .{
+            @divExact(grid_cache_size, MiB),
+        });
+    }
+
+    const nonce = stdx.unique_u128();
+
+    var self_exe_path: ?[:0]const u8 = null;
+    defer if (self_exe_path) |path| gpa.free(path);
+
+    var multiversion: ?vsr.multiversioning.Multiversion = blk: {
+        if (constants.config.process.release.value ==
+            vsr.multiversioning.Release.minimum.value)
+        {
+            log.info("multiversioning: upgrades disabled for development ({}) release.", .{
+                constants.config.process.release,
+            });
+            break :blk null;
+        }
         if (constants.aof_recovery) {
-            log.warn(
-                "{}: started in AOF recovery mode. This is potentially dangerous - if it's" ++
-                    " unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.",
-                .{replica.replica},
-            );
+            log.info("multiversioning: upgrades disabled due to aof_recovery.", .{});
+            break :blk null;
         }
 
-        if (constants.verify) {
-            log.info("{}: started with extra verification checks", .{replica.replica});
-        }
-
-        if (replica.aof != null) {
-            log.warn(
-                "{}: started with --aof - expect much reduced performance.",
-                .{replica.replica},
-            );
-        }
-
-        // It is possible to start tigerbeetle passing `0` as an address:
-        //     $ tigerbeetle start --addresses=0 0_0.tigerbeetle
-        // This enables a couple of special behaviors, useful in tests:
-        // - The operating system picks a free port, avoiding "address already in use" errors.
-        // - The port, and only the port, is printed to the stdout, so that the parent process
-        //   can learn it.
-        // - tigerbeetle process exits when its stdin gets closed.
         if (args.addresses_zero) {
-            const port_actual = replica.message_bus.process.accept_address.getPort();
-            const stdout = std.io.getStdOut();
-            try stdout.writer().print("{}\n", .{port_actual});
-            stdout.close();
-
-            // While it is possible to integrate stdin with our io_uring loop, using a dedicated
-            // thread is simpler, and gives us _un_graceful shutdown, which is exactly what we want
-            // to keep behavior close to the normal case.
-            const watchdog = try std.Thread.spawn(.{}, struct {
-                fn thread_main() void {
-                    var buf: [1]u8 = .{0};
-                    _ = std.io.getStdIn().read(&buf) catch {};
-                    log.info("stdin closed, exiting", .{});
-                    std.process.exit(0);
-                }
-            }.thread_main, .{});
-            watchdog.detach();
+            log.info("multiversioning: upgrades disabled due to --addresses=0", .{});
+            break :blk null;
         }
 
-        if (!args.development) {
-            // Try to lock all memory in the process to avoid the kernel swapping pages to disk and
-            // potentially introducing undetectable disk corruption into memory.
-            // This is a best-effort attempt and not a hard rule as it may not cover all memory edge
-            // case. So warn on error to notify the operator to adjust conditions if possible.
-            stdx.memory_lock_allocated(.{
-                .allocated_size = counting_allocator.live_size(),
-            }) catch {
-                log.warn(
-                    "If this is a production replica, consider either " ++
-                        "running the replica with CAP_IPC_LOCK privilege, " ++
-                        "increasing the MEMLOCK process limit, " ++
-                        "or disabling swap system-wide.",
-                    .{},
-                );
-            };
+        self_exe_path = try vsr.multiversioning.self_exe_path(gpa);
+        break :blk try vsr.multiversioning.Multiversion.init(
+            gpa,
+            io,
+            self_exe_path.?,
+            .native,
+        );
+    };
 
-            if (replica.cluster == 0) {
-                log.warn("a cluster id of 0 is reserved for testing and benchmarking, " ++
-                    "do not use in production", .{});
-            }
+    defer if (multiversion != null) multiversion.?.deinit(gpa);
+
+    // The error from .open_sync() is ignored - timeouts and checking for new binaries are still
+    // enabled even if the first version fails to load.
+    if (multiversion != null) multiversion.?.open_sync() catch {};
+
+    var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .{};
+    releases_bundled_baseline.push(constants.config.process.release);
+
+    const releases_bundled = if (multiversion != null)
+        &multiversion.?.releases_bundled
+    else
+        &releases_bundled_baseline;
+
+    log.info("release={}", .{config.process.release});
+    log.info("release_client_min={}", .{config.process.release_client_min});
+    log.info("releases_bundled={any}", .{releases_bundled.const_slice()});
+    log.info("git_commit={?s}", .{config.process.git_commit});
+
+    const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
+
+    var replica: Replica = undefined;
+    replica.open(gpa, .{
+        .node_count = args.addresses.count_as(u8),
+        .release = config.process.release,
+        .release_client_min = config.process.release_client_min,
+        .releases_bundled = releases_bundled,
+        .release_execute = replica_release_execute,
+        .release_execute_context = if (multiversion) |*pointer| pointer else null,
+        .pipeline_requests_limit = args.pipeline_requests_limit,
+        .storage_size_limit = args.storage_size_limit,
+        .storage = storage,
+        .aof = if (aof != null) &aof.? else null,
+        .message_pool = &message_pool,
+        .nonce = nonce,
+        .time = tracer.time,
+        .timeout_prepare_ticks = args.timeout_prepare_ticks,
+        .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
+        .commit_stall_probability = args.commit_stall_probability,
+        .state_machine_options = .{
+            .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
+            .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
+            .lsm_forest_node_count = args.lsm_forest_node_count,
+            .cache_entries_accounts = args.cache_accounts,
+            .cache_entries_transfers = args.cache_transfers,
+            .cache_entries_transfers_pending = args.cache_transfers_pending,
+        },
+        .message_bus_options = .{
+            .configuration = args.addresses.const_slice(),
+            .io = io,
+            .clients_limit = clients_limit,
+        },
+        .grid_cache_blocks_count = args.cache_grid_blocks,
+        .tracer = tracer,
+        .replicate_options = .{
+            .closed_loop = args.replicate_closed_loop,
+            .star = args.replicate_star,
+        },
+    }) catch |err| switch (err) {
+        error.NoAddress => vsr.fatal(.cli, "all --addresses must be provided", .{}),
+        else => |e| return e,
+    };
+
+    if (multiversion != null) {
+        if (args.development) {
+            log.info("multiversioning: upgrade polling disabled due to --development.", .{});
+        } else {
+            multiversion.?.timeout_start(replica.replica);
         }
 
-        while (true) {
-            replica.tick();
-            if (multiversion != null) multiversion.?.tick();
-            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+        if (args.experimental) {
+            log.warn("multiversioning: upgrade polling and --experimental enabled - " ++
+                "make sure to check CLI argument compatibility before upgrading.", .{});
+            log.warn("If the cluster upgrades automatically, and incompatible experimental " ++
+                "CLI arguments are set, it will crash.", .{});
         }
     }
 
-    pub fn version(gpa: mem.Allocator, verbose: bool) !void {
-        var stdout_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
-        var stdout_writer = stdout_buffer.writer();
-        const stdout = stdout_writer.any();
+    // Note that this does not account for the fact that any allocations will be rounded up to
+    // the nearest page by `std.heap.page_allocator`.
+    log.info("{}: Allocated {}MiB during replica init", .{
+        replica.replica,
+        @divFloor(counting_allocator.live_size(), MiB),
+    });
+    log.info("{}: Grid cache: {}MiB, LSM-tree manifests: {}MiB", .{
+        replica.replica,
+        @divFloor(grid_cache_size, MiB),
+        @divFloor(args.lsm_forest_node_count * constants.lsm_manifest_node_size, MiB),
+    });
 
-        try std.fmt.format(stdout, "TigerBeetle version {}\n", .{constants.semver});
+    log.info("{}: cluster={}: listening on {}", .{
+        replica.replica,
+        replica.cluster,
+        replica.message_bus.process.accept_address,
+    });
 
-        if (verbose) {
-            try stdout.writeAll("\n");
-            inline for (.{ "mode", "zig_version" }) |declaration| {
-                try print_value(stdout, "build." ++ declaration, @field(builtin, declaration));
-            }
-
-            // Zig 0.10 doesn't see field_name as comptime if this `comptime` isn't used.
-            try stdout.writeAll("\n");
-            inline for (comptime std.meta.fieldNames(@TypeOf(config.cluster))) |field_name| {
-                try print_value(
-                    stdout,
-                    "cluster." ++ field_name,
-                    @field(config.cluster, field_name),
-                );
-            }
-
-            try stdout.writeAll("\n");
-            inline for (comptime std.meta.fieldNames(@TypeOf(config.process))) |field_name| {
-                try print_value(
-                    stdout,
-                    "process." ++ field_name,
-                    @field(config.process, field_name),
-                );
-            }
-
-            try stdout.writeAll("\n");
-            const self_exe_path = try vsr.multiversioning.self_exe_path(gpa);
-            defer gpa.free(self_exe_path);
-
-            vsr.multiversioning.print_information(gpa, self_exe_path, stdout) catch {};
-        }
-        try stdout_buffer.flush();
+    if (constants.aof_recovery) {
+        log.warn(
+            "{}: started in AOF recovery mode. This is potentially dangerous - if it's" ++
+                " unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.",
+            .{replica.replica},
+        );
     }
 
-    pub fn repl(
-        gpa: mem.Allocator,
-        io: *IO,
-        time: Time,
-        args: *const cli.Command.Repl,
-    ) !void {
-        const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient);
+    if (constants.verify) {
+        log.info("{}: started with extra verification checks", .{replica.replica});
+    }
 
-        var repl_instance = try Repl.init(gpa, io, time, .{
+    if (replica.aof != null) {
+        log.warn(
+            "{}: started with --aof - expect much reduced performance.",
+            .{replica.replica},
+        );
+    }
+
+    // It is possible to start tigerbeetle passing `0` as an address:
+    //     $ tigerbeetle start --addresses=0 0_0.tigerbeetle
+    // This enables a couple of special behaviors, useful in tests:
+    // - The operating system picks a free port, avoiding "address already in use" errors.
+    // - The port, and only the port, is printed to the stdout, so that the parent process
+    //   can learn it.
+    // - tigerbeetle process exits when its stdin gets closed.
+    if (args.addresses_zero) {
+        const port_actual = replica.message_bus.process.accept_address.getPort();
+        const stdout = std.io.getStdOut();
+        try stdout.writer().print("{}\n", .{port_actual});
+        stdout.close();
+
+        // While it is possible to integrate stdin with our io_uring loop, using a dedicated
+        // thread is simpler, and gives us _un_graceful shutdown, which is exactly what we want
+        // to keep behavior close to the normal case.
+        const watchdog = try std.Thread.spawn(.{}, struct {
+            fn thread_main() void {
+                var buf: [1]u8 = .{0};
+                _ = std.io.getStdIn().read(&buf) catch {};
+                log.info("stdin closed, exiting", .{});
+                std.process.exit(0);
+            }
+        }.thread_main, .{});
+        watchdog.detach();
+    }
+
+    if (!args.development) {
+        // Try to lock all memory in the process to avoid the kernel swapping pages to disk and
+        // potentially introducing undetectable disk corruption into memory.
+        // This is a best-effort attempt and not a hard rule as it may not cover all memory edge
+        // case. So warn on error to notify the operator to adjust conditions if possible.
+        stdx.memory_lock_allocated(.{
+            .allocated_size = counting_allocator.live_size(),
+        }) catch {
+            log.warn(
+                "If this is a production replica, consider either " ++
+                    "running the replica with CAP_IPC_LOCK privilege, " ++
+                    "increasing the MEMLOCK process limit, " ++
+                    "or disabling swap system-wide.",
+                .{},
+            );
+        };
+
+        if (replica.cluster == 0) {
+            log.warn("a cluster id of 0 is reserved for testing and benchmarking, " ++
+                "do not use in production", .{});
+        }
+    }
+
+    while (true) {
+        replica.tick();
+        if (multiversion != null) multiversion.?.tick();
+        try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+    }
+}
+
+fn command_reformat(
+    gpa: mem.Allocator,
+    io: *IO,
+    tracer: *Tracer,
+    storage: *Storage,
+    args: *const cli.Command.Recover,
+) !void {
+    var message_pool = try MessagePool.init(gpa, .client);
+    defer message_pool.deinit(gpa);
+
+    var client = try Client.init(gpa, .{
+        .id = stdx.unique_u128(),
+        .cluster = args.cluster,
+        .replica_count = args.replica_count,
+        .time = tracer.time,
+        .message_pool = &message_pool,
+        .message_bus_options = .{
+            .configuration = args.addresses.const_slice(),
+            .io = io,
+            .clients_limit = null,
+        },
+        .eviction_callback = &reformat_client_eviction_callback,
+    });
+    defer client.deinit(gpa);
+
+    var reformatter = try ReplicaReformat.init(gpa, &client, storage, .{
+        .cluster = args.cluster,
+        .replica = args.replica,
+        .replica_count = args.replica_count,
+        .release = config.process.release,
+        .view = null,
+    });
+    defer reformatter.deinit(gpa);
+
+    reformatter.start();
+    while (reformatter.done() == null) {
+        client.tick();
+        try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
+    }
+    switch (reformatter.done().?) {
+        .failed => |err| {
+            log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
+            return err;
+        },
+        .ok => log.info("{}: success", .{args.replica}),
+    }
+}
+
+fn reformat_client_eviction_callback(
+    client: *Client,
+    eviction: *const MessagePool.Message.Eviction,
+) void {
+    _ = client;
+    std.debug.panic("error: client evicted: {s}", .{@tagName(eviction.header.reason)});
+}
+
+fn command_repl(
+    gpa: mem.Allocator,
+    io: *IO,
+    time: Time,
+    args: *const cli.Command.Repl,
+) !void {
+    const Repl = vsr.repl.ReplType(vsr.message_bus.MessageBusClient);
+
+    var repl_instance = try Repl.init(gpa, io, time, .{
+        .cluster_id = args.cluster,
+        .addresses = args.addresses.const_slice(),
+        .verbose = args.verbose,
+    });
+    defer repl_instance.deinit(gpa);
+
+    try repl_instance.run(args.statements);
+}
+
+fn command_amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !void {
+    var runner: vsr.cdc.Runner = undefined;
+    try runner.init(
+        gpa,
+        time,
+        .{
             .cluster_id = args.cluster,
             .addresses = args.addresses.const_slice(),
-            .verbose = args.verbose,
-        });
-        defer repl_instance.deinit(gpa);
+            .host = args.host,
+            .user = args.user,
+            .password = args.password,
+            .vhost = args.vhost,
+            .publish_exchange = args.publish_exchange,
+            .publish_routing_key = args.publish_routing_key,
+            .event_count_max = args.event_count_max,
+            .idle_interval_ms = args.idle_interval_ms,
+            .recovery_mode = if (args.timestamp_last) |timestamp_last|
+                .{ .override = timestamp_last }
+            else
+                .recover,
+        },
+    );
+    defer runner.deinit();
 
-        try repl_instance.run(args.statements);
+    while (true) {
+        runner.tick();
     }
-
-    pub fn amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !void {
-        var runner: vsr.cdc.Runner = undefined;
-        try runner.init(
-            gpa,
-            time,
-            .{
-                .cluster_id = args.cluster,
-                .addresses = args.addresses.const_slice(),
-                .host = args.host,
-                .user = args.user,
-                .password = args.password,
-                .vhost = args.vhost,
-                .publish_exchange = args.publish_exchange,
-                .publish_routing_key = args.publish_routing_key,
-                .event_count_max = args.event_count_max,
-                .idle_interval_ms = args.idle_interval_ms,
-                .recovery_mode = if (args.timestamp_last) |timestamp_last|
-                    .{ .override = timestamp_last }
-                else
-                    .recover,
-            },
-        );
-        defer runner.deinit();
-
-        while (true) {
-            runner.tick();
-        }
-    }
-};
+}
 
 fn replica_release_execute(replica: *Replica, release: vsr.Release) noreturn {
     assert(release.value != replica.release.value);

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -220,10 +220,7 @@ const Command = struct {
         });
         defer command.deinit(gpa);
 
-        vsr.format(Storage, gpa, &command.storage, options) catch |err| {
-            std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
-            return err;
-        };
+        try vsr.format(Storage, gpa, &command.storage, options);
 
         log.info("{}: formatted: cluster={} replica_count={}", .{
             options.replica,
@@ -280,7 +277,6 @@ const Command = struct {
         switch (reformatter.done().?) {
             .failed => |err| {
                 log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
-                std.posix.unlinkat(command.dir_fd, command.data_file_path, 0) catch {};
                 return err;
             },
             .ok => log.info("{}: success", .{args.replica}),


### PR DESCRIPTION
This is basically two independent commits: 

* don't unlink file
* cleanup main to get rid of `Command` struct

I _thought_ that the two would build upon each other (in particular, I was thinking about refactoring the time when we create a storage), but that turned out to be not fruitful. So submitting a combined PR for simplicity!

Would be happy to split if needed!