### PR TITLE
io: prefer `sockaddr` instead of `net.Address`

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -201,7 +201,8 @@ pub const IO = struct {
         },
         connect: struct {
             socket: socket_t,
-            address: std.net.Address,
+            address: posix.sockaddr,
+            address_size: posix.socklen_t,
             initiated: bool,
         },
         fsync: struct {
@@ -407,7 +408,8 @@ pub const IO = struct {
             .connect,
             .{
                 .socket = socket,
-                .address = address,
+                .address = address.any,
+                .address_size = address.getOsSockLen(),
                 .initiated = false,
             },
             struct {
@@ -418,8 +420,8 @@ pub const IO = struct {
                         true => posix.getsockoptError(op.socket),
                         else => posix.connect(
                             op.socket,
-                            &op.address.any,
-                            op.address.getOsSockLen(),
+                            &op.address,
+                            op.address_size,
                         ),
                     };
 

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -402,8 +402,8 @@ pub const IO = struct {
                 .connect => |*op| {
                     sqe.prep_connect(
                         op.socket,
-                        &op.address.any,
-                        op.address.getOsSockLen(),
+                        &op.address,
+                        op.address_size,
                     );
                 },
                 .fsync => |op| {
@@ -803,7 +803,8 @@ pub const IO = struct {
         },
         connect: struct {
             socket: socket_t,
-            address: std.net.Address,
+            address: posix.sockaddr,
+            address_size: posix.socklen_t,
         },
         fsync: struct {
             fd: fd_t,
@@ -957,7 +958,8 @@ pub const IO = struct {
             .operation = .{
                 .connect = .{
                     .socket = socket,
-                    .address = address,
+                    .address = address.any,
+                    .address_size = address.getOsSockLen(),
                 },
             },
         };

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -205,7 +205,8 @@ pub const IO = struct {
             },
             connect: struct {
                 socket: socket_t,
-                address: std.net.Address,
+                address: os.windows.ws2_32.sockaddr,
+                address_size: os.windows.ws2_32.socklen_t,
                 overlapped: Overlapped,
                 pending: bool,
             },
@@ -444,6 +445,7 @@ pub const IO = struct {
             .{
                 .socket = socket,
                 .address = address,
+                .address_size = address.getOsSockLen(),
                 .overlapped = undefined,
                 .pending = false,
             },
@@ -527,8 +529,8 @@ pub const IO = struct {
                         // Start the connect operation.
                         break :blk (connect_ex)(
                             op.socket,
-                            &op.address.any,
-                            op.address.getOsSockLen(),
+                            &op.address,
+                            op.address_size,
                             null,
                             0,
                             &transferred,


### PR DESCRIPTION
This PR makes `Operation` union to take `sockaddr` instead of `std.net.Address` for size efficiency. Behavior should be the same.