### PR TITLE
multiversion: beef up ReleaseList

### DIFF
--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1796,26 +1796,26 @@ test parse_elf {
 }
 
 pub fn print_information(
-    allocator: std.mem.Allocator,
+    gpa: std.mem.Allocator,
     exe_path: []const u8,
     output: std.io.AnyWriter,
 ) !void {
     var io = try IO.init(32, 0);
     defer io.deinit();
 
-    const absolute_exe_path = try std.fs.cwd().realpathAlloc(allocator, exe_path);
-    defer allocator.free(absolute_exe_path);
+    const absolute_exe_path = try std.fs.cwd().realpathAlloc(gpa, exe_path);
+    defer gpa.free(absolute_exe_path);
 
-    const absolute_exe_path_z = try allocator.dupeZ(u8, absolute_exe_path);
-    defer allocator.free(absolute_exe_path_z);
+    const absolute_exe_path_z = try gpa.dupeZ(u8, absolute_exe_path);
+    defer gpa.free(absolute_exe_path_z);
 
     var multiversion = try Multiversion.init(
-        allocator,
+        gpa,
         &io,
         absolute_exe_path_z,
         .detect,
     );
-    defer multiversion.deinit(allocator);
+    defer multiversion.deinit(gpa);
 
     multiversion.open_sync() catch |err| {
         try output.print("multiversioning not enabled: {}\n", .{err});

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1841,69 +1841,72 @@ pub fn print_information(
         .{multiversion.releases_bundled.slice()},
     );
 
-    inline for (comptime std.meta.fieldNames(MultiversionHeader)) |field| {
-        if (std.mem.eql(u8, field, "current_git_commit")) {
-            try output.print("multiversioning.header.{s}={s}\n", .{
-                field,
-                std.fmt.fmtSliceHexLower(&header.current_git_commit),
-            });
-        } else if (!std.mem.eql(u8, field, "past") and
-            !std.mem.eql(u8, field, "current_flags_padding") and
-            !std.mem.eql(u8, field, "past_padding") and
-            !std.mem.eql(u8, field, "reserved"))
-        {
-            try output.print("multiversioning.header.{s}={any}\n", .{
-                field,
-                if (comptime std.mem.eql(u8, field, "current_release"))
-                    Release{ .value = @field(header, field) }
-                else
-                    @field(header, field),
-            });
+    inline for (
+        comptime std.enums.values(std.meta.FieldEnum(MultiversionHeader)),
+    ) |field| {
+        const field_name = @tagName(field);
+        switch (field) {
+            .past, .current_flags_padding, .past_padding, .reserved => continue,
+            .current_git_commit => {
+                try output.print("multiversioning.header.{s}={s}\n", .{
+                    field_name,
+                    std.fmt.fmtSliceHexLower(&header.current_git_commit),
+                });
+            },
+            .current_release, .current_release_client_min => {
+                try output.print("multiversioning.header.{s}={any}\n", .{
+                    field_name,
+                    Release{ .value = @field(header, field_name) },
+                });
+            },
+            .checksum_header,
+            .checksum_binary_without_header,
+            .current_checksum,
+            .schema_version,
+            .vsr_releases_max,
+            .current_flags,
+            => {
+                try output.print("multiversioning.header.{s}={any}\n", .{
+                    field_name,
+                    @field(header, field_name),
+                });
+            },
         }
     }
 
-    try std.fmt.format(
-        output,
-        "multiversioning.header.past.count={}\n",
-        .{header.past.count},
-    );
-    inline for (comptime std.meta.fieldNames(MultiversionHeader.PastReleases)) |field| {
-        if ((comptime std.mem.eql(u8, field, "releases")) or
-            (comptime std.mem.eql(u8, field, "release_client_mins")))
-        {
-            comptime assert(@sizeOf(Release) == @sizeOf(@TypeOf(@field(header.past, field)[0])));
-            const release_list: []const Release =
-                @ptrCast(@field(header.past, field)[0..header.past.count]);
+    try output.print("multiversioning.header.past.count={}\n", .{header.past.count});
+    inline for (
+        comptime std.enums.values(std.meta.FieldEnum(MultiversionHeader.PastReleases)),
+    ) |field| {
+        const field_name = @tagName(field);
+        switch (field) {
+            .count, .flags_padding => {},
+            .releases, .release_client_mins => {
+                comptime assert(@sizeOf(Release) ==
+                    @sizeOf(@TypeOf(@field(header.past, field_name)[0])));
+                const release_list: []const Release =
+                    @ptrCast(@field(header.past, field_name)[0..header.past.count]);
 
-            try output.print("multiversioning.header.past.{s}={any}\n", .{
-                field,
-                release_list,
-            });
-        } else if (comptime std.mem.eql(u8, field, "git_commits")) {
-            for (@field(header.past, field)[0..header.past.count], 0..) |*git_commit, i| {
-                try output.print("multiversioning.header.past.{s}.{}={}\n", .{
-                    field,
-                    Release{ .value = header.past.releases[i] },
-                    std.fmt.fmtSliceHexLower(git_commit),
+                try output.print("multiversioning.header.past.{s}={any}\n", .{
+                    field_name,
+                    release_list,
                 });
-            }
-        } else if ((comptime std.mem.eql(u8, field, "checksums")) or
-            (comptime std.mem.eql(u8, field, "flags")))
-        {
-            for (@field(header.past, field)[0..header.past.count], 0..) |value, i| {
-                try output.print("multiversioning.header.past.{s}.{}={}\n", .{
-                    field,
-                    Release{ .value = header.past.releases[i] },
-                    value,
+            },
+            .git_commits => {
+                for (@field(header.past, field_name)[0..header.past.count], 0..) |*git_commit, i| {
+                    try output.print("multiversioning.header.past.{s}.{}={}\n", .{
+                        field_name,
+                        Release{ .value = header.past.releases[i] },
+                        std.fmt.fmtSliceHexLower(git_commit),
+                    });
+                }
+            },
+            .checksums, .offsets, .sizes, .flags => {
+                try output.print("multiversioning.header.past.{s}={any}\n", .{
+                    field_name,
+                    @field(header.past, field_name)[0..header.past.count],
                 });
-            }
-        } else if (comptime (!std.mem.eql(u8, field, "count") and
-            !std.mem.eql(u8, field, "flags_padding")))
-        {
-            try output.print("multiversioning.header.past.{s}={any}\n", .{
-                field,
-                @field(header.past, field)[0..header.past.count],
-            });
+            },
         }
     }
 }

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1871,14 +1871,13 @@ pub fn print_information(
         if ((comptime std.mem.eql(u8, field, "releases")) or
             (comptime std.mem.eql(u8, field, "release_client_mins")))
         {
-            var release_list: ReleaseList = .empty;
-            for (@field(header.past, field)[0..header.past.count]) |release| {
-                release_list.push(Release{ .value = release });
-            }
+            comptime assert(@sizeOf(Release) == @sizeOf(@TypeOf(@field(header.past, field)[0])));
+            const release_list: []const Release =
+                @ptrCast(@field(header.past, field)[0..header.past.count]);
 
             try output.print("multiversioning.header.past.{s}={any}\n", .{
                 field,
-                release_list.slice(),
+                release_list,
             });
         } else if (comptime std.mem.eql(u8, field, "git_commits")) {
             for (@field(header.past, field)[0..header.past.count], 0..) |*git_commit, i| {

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -325,7 +325,7 @@ fn command_start(
     // enabled even if the first version fails to load.
     if (multiversion != null) multiversion.?.open_sync() catch {};
 
-    var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .{};
+    var releases_bundled_baseline: vsr.multiversioning.ReleaseList = .empty;
     releases_bundled_baseline.push(constants.config.process.release);
 
     const releases_bundled = if (multiversion != null)
@@ -335,7 +335,7 @@ fn command_start(
 
     log.info("release={}", .{config.process.release});
     log.info("release_client_min={}", .{config.process.release_client_min});
-    log.info("releases_bundled={any}", .{releases_bundled.const_slice()});
+    log.info("releases_bundled={any}", .{releases_bundled.slice()});
     log.info("git_commit={?s}", .{config.process.git_commit});
 
     const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
@@ -605,9 +605,7 @@ fn replica_release_execute(replica: *Replica, release: vsr.Release) noreturn {
     const multiversion: *vsr.multiversioning.Multiversion =
         @ptrCast(@alignCast(release_execute_context));
 
-    for (replica.releases_bundled.const_slice()) |release_bundled| {
-        if (release_bundled.value == release.value) break;
-    } else {
+    if (!replica.releases_bundled.contains(release)) {
         log.err("{}: release_execute: release {} is not available;" ++
             " upgrade (or downgrade) the binary", .{
             replica.replica,

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1617,10 +1617,11 @@ pub const Simulator = struct {
 
     fn replica_release_list(simulator: *const Simulator, replica_index: u8) vsr.ReleaseList {
         const replica_releases_count = simulator.replica_releases[replica_index];
-        var release_list = vsr.ReleaseList{};
+        var release_list: vsr.ReleaseList = .empty;
         for (0..replica_releases_count) |i| {
             release_list.push(releases[i].release);
         }
+        release_list.verify();
         return release_list;
     }
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1232,24 +1232,6 @@ pub fn member_index(members: *const Members, replica_id: u128) ?u8 {
     } else return null;
 }
 
-pub fn verify_release_list(releases: []const Release, release_included: Release) void {
-    assert(releases.len >= 1);
-    assert(releases.len <= constants.vsr_releases_max);
-
-    for (
-        releases[0 .. releases.len - 1],
-        releases[1..],
-    ) |release_a, release_b| {
-        assert(release_a.value < release_b.value);
-    }
-
-    for (releases) |release| {
-        if (release.value == release_included.value) return;
-    } else {
-        @panic("verify_release_list_contains: release not found");
-    }
-}
-
 pub const Headers = struct {
     pub const Array = stdx.BoundedArrayType(Header.Prepare, constants.view_headers_max);
     /// The SuperBlock's persisted VSR headers.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1175,7 +1175,8 @@ pub fn ReplicaType(
             // Flexible quorums are safe if these two quorums intersect so that this relation holds:
             assert(quorum_replication + quorum_view_change > replica_count);
 
-            vsr.verify_release_list(options.releases_bundled.const_slice(), options.release);
+            options.releases_bundled.verify();
+            assert(options.releases_bundled.contains(options.release));
 
             const request_size_limit =
                 @sizeOf(Header) + options.state_machine_options.batch_size_limit;
@@ -1782,19 +1783,19 @@ pub fn ReplicaType(
                     upgrade_targets.* = .{
                         .checkpoint = message.header.checkpoint_op,
                         .view = message.header.view,
-                        .releases = .{},
+                        .releases = .empty,
                     };
 
-                    const releases_all = std.mem.bytesAsSlice(vsr.Release, message.body_used());
-                    const releases = releases_all[0..message.header.release_count];
-                    assert(releases.len == message.header.release_count);
-                    vsr.verify_release_list(releases, message.header.release);
-                    for (releases_all[message.header.release_count..]) |r| assert(r.value == 0);
+                    const releases = ping_message_release_list(message);
+                    assert(releases.contains(message.header.release));
 
-                    for (releases) |release| {
+                    for (releases.slice()) |release| {
                         if (release.value > self.release.value) {
                             upgrade_targets.*.?.releases.push(release);
                         }
+                    }
+                    if (upgrade_targets.*.?.releases.count > 0) {
+                        upgrade_targets.*.?.releases.verify();
                     }
                 }
             }
@@ -3470,21 +3471,22 @@ pub fn ReplicaType(
                 .checkpoint_op = self.op_checkpoint(),
                 .ping_timestamp_monotonic = self.clock.monotonic(),
                 .route = ping_route,
-                .release_count = self.releases_bundled.count_as(u16),
+                .release_count = self.releases_bundled.count,
             };
 
             // self.releases_bundled is usually pointer into Multiversion, which might update in
             // place if a new binary is available on disk.
-            vsr.verify_release_list(self.releases_bundled.const_slice(), self.release);
+            self.releases_bundled.verify();
+            assert(self.releases_bundled.contains(self.release));
 
             const ping_versions = std.mem.bytesAsSlice(vsr.Release, message.body_used());
             stdx.copy_disjoint(
                 .inexact,
                 vsr.Release,
                 ping_versions,
-                self.releases_bundled.const_slice(),
+                self.releases_bundled.slice(),
             );
-            @memset(ping_versions[self.releases_bundled.count()..], vsr.Release.zero);
+            @memset(ping_versions[self.releases_bundled.count..], vsr.Release.zero);
             message.header.set_checksum_body(message.body_used());
             message.header.set_checksum();
 
@@ -3928,8 +3930,8 @@ pub fn ReplicaType(
 
             const release_target: ?vsr.Release = release: {
                 var release_target: ?vsr.Release = null;
-                for (self.releases_bundled.const_slice(), 0..) |release, i| {
-                    if (i > 0) assert(release.value > self.releases_bundled.get(i - 1).value);
+                for (self.releases_bundled.slice(), 0..) |release, i| {
+                    if (i > 0) assert(release.value > self.releases_bundled.slice()[i - 1].value);
                     // Ignore old releases.
                     if (release.value <= self.release.value) continue;
 
@@ -3938,14 +3940,7 @@ pub fn ReplicaType(
                         const targets = targets_or_null orelse continue;
                         assert(replica != self.replica);
 
-                        for (targets.releases.const_slice()) |target_release| {
-                            assert(target_release.value > self.release.value);
-
-                            if (target_release.value == release.value) {
-                                release_replicas += 1;
-                                break;
-                            }
-                        }
+                        release_replicas += @intFromBool(targets.releases.contains(release));
                     }
 
                     if (release_replicas >= vsr.quorums(self.replica_count).upgrade) {
@@ -10470,7 +10465,7 @@ pub fn ReplicaType(
                 //
                 // Even though we are upgrading, our target version is not necessarily available in
                 // our binary. (In this case, release_execute() is responsible for error-ing out.)
-                maybe(self.release.value == self.releases_bundled.get(0).value);
+                maybe(self.release.value == self.releases_bundled.first().value);
                 assert(self.commit_min == self.op_checkpoint() or
                     self.commit_min == vsr.Checkpoint.trigger_for_checkpoint(self.op_checkpoint()));
                 maybe(self.journal.status == .init);
@@ -11603,6 +11598,22 @@ fn start_view_message_headers(message: *const Message.StartView) []const Header.
         }
     }
     return headers;
+}
+
+fn ping_message_release_list(message: *const Message.Ping) vsr.ReleaseList {
+    assert(message.header.release_count <= constants.vsr_releases_max);
+
+    const releases_all = std.mem.bytesAsSlice(vsr.Release, message.body_used());
+    for (releases_all[message.header.release_count..]) |r| assert(r.value == 0);
+    const releases = releases_all[0..message.header.release_count];
+    assert(releases.len == message.header.release_count);
+
+    var result: vsr.ReleaseList = .empty;
+    for (releases) |release| result.push(release);
+
+    result.verify();
+    assert(result.contains(message.header.release));
+    return result;
 }
 
 /// The PipelineQueue belongs to a normal-status primary. It consists of two queues:

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2235,7 +2235,7 @@ const TestReplicas = struct {
     }
 
     pub fn open_upgrade(t: *const TestReplicas, releases_bundled_patch: []const u8) !void {
-        var releases_bundled = vsr.ReleaseList{};
+        var releases_bundled: vsr.ReleaseList = .empty;
         for (releases_bundled_patch) |patch| {
             releases_bundled.push(vsr.Release.from(.{
                 .major = 0,
@@ -2243,6 +2243,7 @@ const TestReplicas = struct {
                 .patch = patch,
             }));
         }
+        releases_bundled.verify();
 
         for (t.replicas.const_slice()) |r| {
             log.info("{}: restart replica", .{r});


### PR DESCRIPTION
There's quite a bit of logic that naturally belongs to the ReleaseList, so we might as well make it a real thing rather than just a bounded array.