### PR TITLE
VSR: `send_request_blocks()` more proactively

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1816,12 +1816,11 @@ pub const RepairBudgetJournal = struct {
         budget.available = @min((budget.available + 1), budget.capacity - budget_spent_total);
     }
 
-    pub fn refill(budget: *RepairBudgetJournal, amount: u32) void {
-        assert(amount <= budget.refill_max);
+    pub fn refill(budget: *RepairBudgetJournal) void {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        budget.available = @min((budget.available + amount), budget.capacity);
+        budget.available = @min((budget.available + budget.refill_max), budget.capacity);
 
         budget.requested_prepares.clearRetainingCapacity();
         budget.requested_headers = 0;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1898,12 +1898,11 @@ pub const RepairBudgetGrid = struct {
         }
     }
 
-    pub fn refill(budget: *RepairBudgetGrid, amount: u32) void {
+    pub fn refill(budget: *RepairBudgetGrid) void {
         budget.assert_invariants();
         defer budget.assert_invariants();
-        assert(amount <= budget.refill_max);
 
-        budget.available = @min((budget.available + amount), budget.capacity);
+        budget.available = @min((budget.available + budget.refill_max), budget.capacity);
         budget.requested.clearRetainingCapacity();
     }
 };

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1843,33 +1843,67 @@ pub const RepairBudgetGrid = struct {
     capacity: u32,
     available: u32,
     refill_max: u32,
+    requested: std.AutoArrayHashMapUnmanaged(BlockIdentifier, void),
 
-    pub fn init(options: struct {
+    const BlockIdentifier = struct { address: u64, checksum: u128 };
+
+    pub fn init(gpa: std.mem.Allocator, options: struct {
         capacity: u32,
         refill_max: u32,
-    }) RepairBudgetGrid {
+    }) !RepairBudgetGrid {
         assert(options.refill_max <= options.capacity);
+
+        var requested: std.AutoArrayHashMapUnmanaged(BlockIdentifier, void) = .{};
+        try requested.ensureTotalCapacity(gpa, options.capacity);
+        errdefer requested.deinit();
+
         return RepairBudgetGrid{
             .capacity = options.capacity,
             .available = options.capacity,
             .refill_max = options.refill_max,
+            .requested = requested,
         };
     }
 
-    pub fn spend(budget: *RepairBudgetGrid, amount: u32) bool {
-        assert(budget.capacity > 0);
-        assert(budget.available <= budget.capacity);
-        assert(amount > 0);
+    pub fn deinit(budget: *RepairBudgetGrid, gpa: std.mem.Allocator) void {
+        budget.requested.deinit(gpa);
+    }
 
-        if (budget.available < amount) return false;
-        budget.available -= amount;
-        return true;
+    fn assert_internally_consistent(budget: *RepairBudgetGrid) void {
+        assert(budget.available <= budget.capacity);
+        assert(budget.available + budget.requested.count() <= budget.capacity);
+    }
+
+    pub fn decrement(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) bool {
+        budget.assert_internally_consistent();
+        defer budget.assert_internally_consistent();
+        assert(budget.available > 0);
+        assert(block_identifier.address > 0);
+
+        const gop = budget.requested.getOrPutAssumeCapacity(block_identifier);
+        if (gop.found_existing) {
+            return false;
+        } else {
+            budget.available -= 1;
+            return true;
+        }
+    }
+
+    pub fn increment(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) void {
+        budget.assert_internally_consistent();
+        defer budget.assert_internally_consistent();
+
+        if (budget.requested.swapRemove(block_identifier)) {
+            budget.available = @min((budget.available + 1), budget.capacity);
+        }
     }
 
     pub fn refill(budget: *RepairBudgetGrid, amount: u32) void {
+        budget.assert_internally_consistent();
+        defer budget.assert_internally_consistent();
         assert(amount <= budget.refill_max);
-        assert(budget.available <= budget.capacity);
 
         budget.available = @min((budget.available + amount), budget.capacity);
+        budget.requested.clearRetainingCapacity();
     }
 };

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1755,8 +1755,8 @@ pub const RepairBudgetJournal = struct {
         start_view: u32,
     }) bool {
         assert(budget.capacity > 0);
-        budget.assert_internally_consistent();
-        defer budget.assert_internally_consistent();
+        budget.assert_invariants();
+        defer budget.assert_invariants();
 
         if (budget.available == 0) return false;
 
@@ -1787,8 +1787,8 @@ pub const RepairBudgetJournal = struct {
         headers,
         start_view: u32,
     }) void {
-        budget.assert_internally_consistent();
-        defer budget.assert_internally_consistent();
+        budget.assert_invariants();
+        defer budget.assert_invariants();
 
         switch (repair_type) {
             .headers => budget.requested_headers -|= 1,
@@ -1818,8 +1818,8 @@ pub const RepairBudgetJournal = struct {
 
     pub fn refill(budget: *RepairBudgetJournal, amount: u32) void {
         assert(amount <= budget.refill_max);
-        budget.assert_internally_consistent();
-        defer budget.assert_internally_consistent();
+        budget.assert_invariants();
+        defer budget.assert_invariants();
 
         budget.available = @min((budget.available + amount), budget.capacity);
 
@@ -1828,7 +1828,7 @@ pub const RepairBudgetJournal = struct {
         budget.requested_start_view = null;
     }
 
-    fn assert_internally_consistent(budget: *const RepairBudgetJournal) void {
+    fn assert_invariants(budget: *const RepairBudgetJournal) void {
         const requested_start_views: u32 = @intFromBool(budget.requested_start_view != null);
         const requested_prepares: u32 = @as(u32, @intCast(budget.requested_prepares.count()));
         const requested_headers: u32 = budget.requested_headers;
@@ -1869,14 +1869,14 @@ pub const RepairBudgetGrid = struct {
         budget.requested.deinit(gpa);
     }
 
-    fn assert_internally_consistent(budget: *RepairBudgetGrid) void {
+    fn assert_invariants(budget: *RepairBudgetGrid) void {
         assert(budget.available <= budget.capacity);
         assert(budget.available + budget.requested.count() <= budget.capacity);
     }
 
     pub fn decrement(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) bool {
-        budget.assert_internally_consistent();
-        defer budget.assert_internally_consistent();
+        budget.assert_invariants();
+        defer budget.assert_invariants();
         assert(budget.available > 0);
         assert(block_identifier.address > 0);
 
@@ -1890,8 +1890,8 @@ pub const RepairBudgetGrid = struct {
     }
 
     pub fn increment(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) void {
-        budget.assert_internally_consistent();
-        defer budget.assert_internally_consistent();
+        budget.assert_invariants();
+        defer budget.assert_invariants();
 
         if (budget.requested.swapRemove(block_identifier)) {
             budget.available = @min((budget.available + 1), budget.capacity);
@@ -1899,8 +1899,8 @@ pub const RepairBudgetGrid = struct {
     }
 
     pub fn refill(budget: *RepairBudgetGrid, amount: u32) void {
-        budget.assert_internally_consistent();
-        defer budget.assert_internally_consistent();
+        budget.assert_invariants();
+        defer budget.assert_invariants();
         assert(amount <= budget.refill_max);
 
         budget.available = @min((budget.available + amount), budget.capacity);

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -535,9 +535,8 @@ pub const GridBlocksMissing = struct {
         if (queue.checkpoint_durable.?.aborting == 0) {
             queue.checkpoint_durable = null;
 
-            var faulty_blocks = queue.faulty_blocks.iterator();
-            while (faulty_blocks.next()) |fault_entry| {
-                assert(fault_entry.value_ptr.state != .aborting);
+            for (queue.faulty_blocks.values()) |*faulty_block| {
+                assert(faulty_block.state != .aborting);
             }
 
             return true;

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -183,6 +183,7 @@ pub const GridBlocksMissing = struct {
     /// Note that returning `null` doesn't necessarily indicate that there are no more blocks.
     pub fn next_request(queue: *GridBlocksMissing) ?vsr.BlockRequest {
         assert(queue.faulty_blocks.count() > 0);
+        assert(queue.faulty_blocks_repair_index < queue.faulty_blocks.count());
 
         const fault_addresses = queue.faulty_blocks.keys();
         const fault_data = queue.faulty_blocks.values();

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10852,6 +10852,10 @@ pub fn ReplicaType(
             assert(self.grid_repair_budget_timeout.ticking);
             assert(self.grid.callback != .cancel);
             maybe(self.state_machine_opened);
+            if (!self.solo()) {
+                assert(self.repair_messages_budget_grid.available >=
+                    constants.grid_repair_request_max);
+            }
 
             var message = self.message_bus.get_message(.request_blocks);
             defer self.message_bus.unref(message);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3735,8 +3735,7 @@ pub fn ReplicaType(
         fn on_repair_budget_timeout(self: *Replica) void {
             assert(self.status == .normal or self.status == .view_change);
 
-            const refill_amount = self.repair_messages_budget_journal.refill_max;
-            self.repair_messages_budget_journal.refill(refill_amount);
+            self.repair_messages_budget_journal.refill();
             self.repair_budget_timeout.reset();
 
             self.repair();
@@ -10272,8 +10271,7 @@ pub fn ReplicaType(
             // We just replaced our superblock, so any outstanding request_prepares are probably not
             // useful, and we are likely to need to repair soon (and quickly) in order to start
             // committing again.
-            const refill_amount = self.repair_messages_budget_journal.refill_max;
-            self.repair_messages_budget_journal.refill(refill_amount);
+            self.repair_messages_budget_journal.refill();
 
             if (self.repair_budget_timeout.ticking) self.repair_budget_timeout.reset();
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3783,6 +3783,8 @@ pub fn ReplicaType(
 
             self.grid_repair_budget_timeout.reset();
             self.repair_messages_budget_grid.refill();
+            assert(self.solo() or
+                self.repair_messages_budget_grid.available >= constants.grid_repair_request_max);
 
             // Proactively send a block request, because:
             // - we definitely have enough budget for it now, and


### PR DESCRIPTION
(I recommend reviewing commit-by-commit.)

## Bug

This is primarily important during the initial phase of state sync, when we sync the client sessions and manifest trailers.

Requesting grid blocks is triggered by receiving grid blocks -- when we receive a block that we need, we restore budget and if we have enough budget we make a new request.

This works great during table sync, but during trailer sync it doesn't work well. The trailers are repaired sequentially (free set → client sessions → manifest) but between each of these we need to do a read (to check for the grid block on our disk). That means that e.g. at the moment we repair the last free set block, we restore budget, then check whether we have more blocks to repair, but we don't yet. In a moment the client sessions read finishes (fails) and we queue a block for repair, but it is too late. So we wait for `grid_repair_message_timeout` (~500ms) before triggering the next request. Then this happens again during the transition from client sessions to manifest. This adds about a second of latency to state sync!

## Fix

To fix, we now send the block request from `repair()`. `repair()` is on a more frequent timer, but also it is called proactively often.
The `grid_repair_message_timeout` is still used to restore budget. (Renamed to `grid_repair_budget_timeout`).

**Amendment:** See https://github.com/tigerbeetle/tigerbeetle/pull/3185/commits/8f7dcbfe10e3d854252a68176c8ae8e0598a47ee. We still request blocks from `grid_repair_budget_timeout` after all, but it is not the main way blocks are repaired.

Some other possible fixes:
1. Concurrently repair all the trailers.
2. Send a summary of trailer blocks in the SV.
3. Add a new "survey" block which includes the address/checksums of all trailer blocks.
4. Wire up an event from grid → replica when a block is queued for repair.
5. Reduce `grid_repair_message_timeout`.

Probably we should eventually implement 1 and 2-or-3, but I think this change is useful even then, so that we are a little more proactive about repair.

I wanted to avoid 4, to avoid coupling replica + grid together in that direction.
5 only reduces the scale of the problem, but doesn't actually solve it.

## Repair Budget

Track in-flight block requests via `RepairBudgetGrid`.

Without in-flight request tracking, if a replica requests the same block multiple times in the same budget interval, then when the block arrives, the budget is still only incremented once, leaving the budget starved for the remainder of the interval. This is a very common case when there are few blocks being requested, such as during trailer sync.

As part of this, lift `request_blocks` construction into replica.

## Logs

Logs of a replica state syncing trailers before and after this change is applied (with some unrelated logs elided).

Mainly pay attention to the timestamps.

<details>
<summary>Before</summary>

```
2025-08-15 17:09:35.718Z info(replica): 0n: sync: ops=470432..487711
2025-08-15 17:09:36.199Z info(replica): 0n: on_block: fulfilled address=1794 checksum=222976420026131580906061225735420155686 free_set
2025-08-15 17:09:36.199Z info(replica): 0n: on_block: repairing address=1794 checksum=222976420026131580906061225735420155686 free_set
2025-08-15 17:09:36.202Z info(replica): 0n: on_block: fulfilled address=1795 checksum=58593412436848580214907331841939497839 free_set
2025-08-15 17:09:36.202Z info(replica): 0n: on_block: repairing address=1795 checksum=58593412436848580214907331841939497839 free_set
2025-08-15 17:09:36.701Z info(replica): 0n: on_block: fulfilled address=1725 checksum=212153718505234864535153087633500583820 client_sessions
2025-08-15 17:09:36.701Z info(replica): 0n: on_block: repairing address=1725 checksum=212153718505234864535153087633500583820 client_sessions
2025-08-15 17:09:37.207Z info(replica): 0n: sync: 35 tables (by level: { 35, 0, 0, 0, 0, 0, 0 })
```

</details>

<details>
<summary>After</summary>

```
2025-08-15 17:28:10.421Z info(replica): 0n: sync: ops=222752..224671
2025-08-15 17:28:10.422Z info(replica): 0n: on_block: fulfilled address=939 checksum=73337053751425680451193589040484341376 free_set
2025-08-15 17:28:10.422Z info(replica): 0n: on_block: repairing address=939 checksum=73337053751425680451193589040484341376 free_set
2025-08-15 17:28:10.425Z info(replica): 0n: on_block: fulfilled address=936 checksum=149582764964113425824743432799185874373 free_set
2025-08-15 17:28:10.425Z info(replica): 0n: on_block: repairing address=936 checksum=149582764964113425824743432799185874373 free_set
2025-08-15 17:28:10.427Z info(replica): 0n: on_block: fulfilled address=883 checksum=28498878219503029859547433952126740385 client_sessions
2025-08-15 17:28:10.427Z info(replica): 0n: on_block: repairing address=883 checksum=28498878219503029859547433952126740385 client_sessions
2025-08-15 17:28:10.430Z info(replica): 0n: sync: 21 tables (by level: { 21, 0, 0, 0, 0, 0, 0 })
```

</details>

The budget tracking change improves table sync performance as well, but that is higher variance between runs so it is hard to get a decent measurement of how much it actually improved.
