### PR TITLE
vsr: fix repair_timeout not being fired for small batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Released: 2025-08-15
 
 ### Safety And Performance
 
+- [3187](https://github.com/tigerbeetle/tigerbeetle/pull/3187)
+
+  Make repair timeout reliably fire in a loaded cluster processing small batches.
+
 - [#2863](https://github.com/tigerbeetle/tigerbeetle/pull/2863)
 
   Make `tigerbeetle format` concurrent and only write essential data.
@@ -36,6 +40,10 @@ Released: 2025-08-15
   they are upgraded to at least 0.16.26.
 
 ### Internals
+
+- [#3186](https://github.com/tigerbeetle/tigerbeetle/pull/3186)
+
+  Improvements to the balance bounds, rate limiting, and two phase transfers recipes. Thanks @snth!
 
 - [#3150](https://github.com/tigerbeetle/tigerbeetle/pull/3150)
 


### PR DESCRIPTION
Since repair is driven by prepares, for a loaded cluster, we could hit an issue where the only time we trigger the repair timeout is the cluster is idle! This is because we invoke `self.repair_timeout.reset();` every time we invoke `repair`, so we would only trigger repair timeout if we have a 100ms period where the cluster is completely idle...

``` C
      fn repair(self: *Replica) void {
            if (!self.repair_timeout.ticking) {
                log.debug("{}: repair: ignoring (optimistic, not ticking)", .{self.log_prefix()});
                return;
            }

            self.repair_timeout.reset();
```

This is a _major_ issue because we rely on the repair timeout for replenishing our repair budget, which in turn also clears the map where we maintain requested prepares. So, we could encounter a scenario where we request a prepare, insert it into the requested prepare map, but it is never removed from the map (if for example, the RequestPrepare reaches another lagging replica which doesn't have the prepare). 

I observed this when I ran a benchmark with tiny batches (--transfer-batch-size=2), R5 emits `on_prepare: lagging behind the cluster prepare.op=983219` for 16 seconds (!) before it falls back to state sync. This is when the cluster is also on the same log wrap (notice that the cluster op and the op being read is ~200 ops apart), so the prepare should certainly be repaired! Specifically, we _do_ request op=983052, but only _once_ because it is never evicted from the requested prepares map since we keep resetting the repair timeout.

```C
2025-08-15 20:40:11.145Z debug(replica): 5n: repair_prepare: op=983052 checksum=170988613193317381780717095596875502163 (committed, dirty, normal)
2025-08-15 20:40:11.171Z warning(replica): 5n: on_prepare: lagging behind the cluster prepare.op=983219 (commit_min=983050 op=983218 commit_max=983211)
2025-08-15 20:40:11.178Z info(journal): 5: read_prepare: op=983052 checksum=170988613193317381780717095596875502163: no matching prepare
2025-08-15 20:40:27.793Z info(journal): 5: read_prepare: op=983052 checksum=170988613193317381780717095596875502163: no matching prepare
2025-08-15 20:40:27.843Z info(replica): 5n: sync: ops=981152..984031
2025-08-15 20:40:27.844Z warning(replica): 5n: on_prepare: lagging behind the cluster prepare.op=984049 (commit_min=983999 op=984046 commit_max=984041)
```

This PR removes `self.repair_timeout.reset()` from `repair`. We now have budgets in place to guard us from quadratic repair, and our repair is anyway as aggressive as the incoming rate of prepares, so invoking another repair via repair timeout wouldn't harm us. In fact, we _require_ the timeout to be fired so that we can re-request prepares that were requested from the wrong replica.