### PR TITLE
CI: Run release-validate from latest release tag

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -23,9 +23,7 @@ jobs:
           ref: release
       # Run on the latest tag. The release branch is ahead of release tag over the weekend.
       - run: |
-          # TODO: Switch back after 2025-08-18's release.
-          #TAG=$(gh release list --limit 1 | cut -f1)
-          TAG=release
+          TAG=$(gh release list --limit 1 | cut -f1)
           git fetch origin $TAG && git switch -d FETCH_HEAD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts https://github.com/tigerbeetle/tigerbeetle/pull/3169 now that latest release includes fixed timeout.