### PR TITLE
rust client: make returned future thread-safe

### DIFF
--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -340,12 +340,6 @@ pub use time_based_id::id;
 /// This is just a magic number to jump out of logs.
 const COMPLETION_CONTEXT: usize = 0xAB;
 
-// Thread-sendable wrapper for the owned packet.
-struct Packet(Box<tbc::tb_packet_t>);
-
-// Safety: after completion, zig no longer touches the packet; we own it exclusively.
-unsafe impl Send for Packet {}
-
 /// The TigerBeetle client.
 pub struct Client {
     client: *mut tbc::tb_client_t,
@@ -1790,6 +1784,12 @@ fn handle_message<CEvent, CResult>(
 
     Ok(result)
 }
+
+// Thread-sendable wrapper for the owned packet.
+struct Packet(Box<tbc::tb_packet_t>);
+
+// Safety: after completion, zig no longer touches the packet; we own it exclusively.
+unsafe impl Send for Packet {}
 
 struct CompletionMessage<E> {
     _context: usize,

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -341,24 +341,10 @@ pub use time_based_id::id;
 const COMPLETION_CONTEXT: usize = 0xAB;
 
 // Thread-sendable wrapper for the owned packet.
-pub struct Packet(Box<tbc::tb_packet_t>);
+struct Packet(Box<tbc::tb_packet_t>);
 
 // Safety: after completion, zig no longer touches the packet; we own it exclusively.
 unsafe impl Send for Packet {}
-
-impl std::ops::Deref for Packet {
-    type Target = tbc::tb_packet_t;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Packet {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 /// The TigerBeetle client.
 pub struct Client {
@@ -1781,7 +1767,7 @@ where
 fn handle_message<CEvent, CResult>(
     msg: &CompletionMessage<CEvent>,
 ) -> Result<&[CResult], PacketStatus> {
-    let packet = &msg.packet;
+    let packet = &msg.packet.0;
     let result = &msg.result;
 
     if packet.status != tbc::TB_PACKET_STATUS_TB_PACKET_OK {

--- a/src/clients/rust/tests/tests.rs
+++ b/src/clients/rust/tests/tests.rs
@@ -81,6 +81,10 @@ fn test_client() -> anyhow::Result<tb::Client> {
     Ok(client)
 }
 
+fn assert_send<T: Send>(t: T) -> T {
+    t
+}
+
 const TEST_LEDGER: u32 = 10;
 const TEST_CODE: u16 = 20;
 
@@ -97,40 +101,39 @@ fn smoke() -> anyhow::Result<()> {
         let client = test_client()?;
 
         {
-            let result = client
-                .create_accounts(&[
-                    tb::Account {
-                        id: account_id1,
-                        debits_pending: 0,
-                        debits_posted: 0,
-                        credits_pending: 0,
-                        credits_posted: 0,
-                        user_data_128: 0,
-                        user_data_64: 0,
-                        user_data_32: 0,
-                        reserved: tb::Reserved::default(),
-                        ledger: TEST_LEDGER,
-                        code: TEST_CODE,
-                        flags: tb::AccountFlags::History,
-                        timestamp: 0,
-                    },
-                    tb::Account {
-                        id: account_id2,
-                        debits_pending: 0,
-                        debits_posted: 0,
-                        credits_pending: 0,
-                        credits_posted: 0,
-                        user_data_128: account_id2_user_data_128,
-                        user_data_64: 0,
-                        user_data_32: 0,
-                        reserved: tb::Reserved::default(),
-                        ledger: TEST_LEDGER,
-                        code: TEST_CODE,
-                        flags: tb::AccountFlags::History,
-                        timestamp: 0,
-                    },
-                ])
-                .await?;
+            let fut = client.create_accounts(&[
+                tb::Account {
+                    id: account_id1,
+                    debits_pending: 0,
+                    debits_posted: 0,
+                    credits_pending: 0,
+                    credits_posted: 0,
+                    user_data_128: 0,
+                    user_data_64: 0,
+                    user_data_32: 0,
+                    reserved: tb::Reserved::default(),
+                    ledger: TEST_LEDGER,
+                    code: TEST_CODE,
+                    flags: tb::AccountFlags::History,
+                    timestamp: 0,
+                },
+                tb::Account {
+                    id: account_id2,
+                    debits_pending: 0,
+                    debits_posted: 0,
+                    credits_pending: 0,
+                    credits_posted: 0,
+                    user_data_128: account_id2_user_data_128,
+                    user_data_64: 0,
+                    user_data_32: 0,
+                    reserved: tb::Reserved::default(),
+                    ledger: TEST_LEDGER,
+                    code: TEST_CODE,
+                    flags: tb::AccountFlags::History,
+                    timestamp: 0,
+                },
+            ]);
+            let result = assert_send(fut).await?;
 
             assert_eq!(result.len(), 0);
         }


### PR DESCRIPTION
Currently, the docs claim that the client is thread-safe:

> The Client type implements Send and Sync and may be used in parallel
> across multiple threads or async tasks, e.g. by placing it into an \[Arc].
> In some cases this may be useful because it allows the client to leverage
> its internal request batching to batch events from multiple threads (or
> tasks), but otherwise it provides no performance advantage.

But this is not the case in practice as the returned future is not thread-safe yet.

This PR makes the returned future thread-safe by wrapping the `Box<tbc::tb_packet_t>` that's included in the completion message in a newtype that implements `Send`.