### PR TITLE
devhub: sync graph cursors and tooltips

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -343,6 +343,8 @@ function plot_series(series_list, root_node, batch_count) {
         text: series.name,
       },
       chart: {
+        id: series.name,
+        group: "devhub",
         type: "line",
         height: "400px",
         animations: {


### PR DESCRIPTION
Now, if you hover over one, it'll 'hover' over all of them:

<img width="2538" height="1124" alt="image" src="https://github.com/user-attachments/assets/17f6cc93-443a-4c5e-8634-be942a0a8173" />
