### PR TITLE
ci: Reduce time and memory used by vortex smoke tests

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -419,7 +419,7 @@ test "vortex smoke" {
     defer shell.destroy();
 
     try shell.exec(
-        "{vortex_exe} run --test-duration-seconds=10 " ++
+        "{vortex_exe} run --test-duration-seconds=1 " ++
             "--replica-count=1 --tigerbeetle-executable={tigerbeetle}",
         .{
             .vortex_exe = vortex_exe,

--- a/src/testing/vortex/java_driver/ci.zig
+++ b/src/testing/vortex/java_driver/ci.zig
@@ -30,8 +30,9 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 "run --driver-command={driver_command} " ++
                 "--tigerbeetle-executable={tigerbeetle_bin} " ++
                 "--output-directory={vortex_out_dir} " ++
+                "--replica-count=1 " ++
                 "--disable-faults " ++
-                "--test-duration-seconds=10",
+                "--test-duration-seconds=1",
             .{
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,

--- a/src/testing/vortex/rust_driver/ci.zig
+++ b/src/testing/vortex/rust_driver/ci.zig
@@ -25,8 +25,9 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 "run --driver-command={driver_command} " ++
                 "--tigerbeetle-executable={tigerbeetle_bin} " ++
                 "--output-directory={vortex_out_dir} " ++
+                "--replica-count=1 " ++
                 "--disable-faults " ++
-                "--test-duration-seconds=10",
+                "--test-duration-seconds=1",
             .{
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,


### PR DESCRIPTION
These `zig build ci` commands are used locally during development, so 10 seconds is way too much time to waste for a smoke test. 1 is enough to ensure vortex isn't completely broken. Also reduce replicas to 1.