### PR TITLE
multiversion: avoid untrodden paths during upgrade

### DIFF
--- a/src/stdx/windows.zig
+++ b/src/stdx/windows.zig
@@ -41,3 +41,8 @@ pub extern "kernel32" fn LockFileEx(
 pub extern "kernel32" fn SetEndOfFile(
     hFile: windows.HANDLE,
 ) callconv(.winapi) windows.BOOL;
+
+pub extern "kernel32" fn ConnectNamedPipe(
+    hNamedPipe: windows.HANDLE,
+    lpOverlapped: ?*windows.OVERLAPPED,
+) callconv(.winapi) windows.BOOL;

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -363,7 +363,7 @@ fn tidy_dead_declarations(
                     }
                 } else {
                     switch (context_tag) {
-                        .keyword_inline => {},
+                        .keyword_inline, .keyword_extern, .string_literal => {},
                         // Public declaration can be used in a different file.
                         .keyword_pub, .keyword_export => continue :next_token,
                         // []const u8 or *const u8, not a declaration.


### PR DESCRIPTION
During upgrades, tigerbeetle dynamically re-executed itself at a different version. There can be only one tigerbeetle instance running at a time, due to any of:
- data file lock,
- incoming port,
- available RAM. On POSIX, execve semantics of replacing the parent process gives us this for free. On Windows, parent and child cooperate, with the child blocking until the parent exit. Blocking is achieved by passing down an anonymous pipe, a-la <https://matklad.github.io/2023/10/11/unix-structured-concurrency.html>

The previous implementation attempted to achieve a similar effect by de-initing the replica in the data file but that's actually panic prone (storage asserts, on deinit, that there are no next ticks scheduled), and, as a general rule, shutdown code that runs only on one operating system only during upgrade is bound to become buggy sooner or later.