### PR TITLE
python: make close() async on ClientAsync

### DIFF
--- a/src/clients/python/README.md
+++ b/src/clients/python/README.md
@@ -75,6 +75,11 @@ environment variable and defaults to port `3000`.
 with tb.ClientSync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000")) as client:
     # Use the client.
     pass
+
+# Alternatively:
+async with tb.ClientAsync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000")) as client:
+    # Use the client, async!
+    pass
 ```
 
 The following are valid addresses:

--- a/src/clients/python/samples/walkthrough/main.py
+++ b/src/clients/python/samples/walkthrough/main.py
@@ -10,11 +10,18 @@ print("Import OK!")
 # tb.configure_logging(debug=True)
 # endsection:imports
 
-# section:client
-with tb.ClientSync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000")) as client:
-    # Use the client.
-    pass
-# endsection:client
+# Need to wrap in an async function for the async with to be valid Python.
+async def example_init():
+    # section:client
+    with tb.ClientSync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000")) as client:
+        # Use the client.
+        pass
+
+    # Alternatively:
+    async with tb.ClientAsync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000")) as client:
+        # Use the client, async!
+        pass
+    # endsection:client
 
 # The examples currently throws because the batch is actually invalid (most of fields are
 # undefined). Ideally, we prepare a correct batch here while keeping the syntax compact,

--- a/src/clients/python/src/tigerbeetle/__init__.py
+++ b/src/clients/python/src/tigerbeetle/__init__.py
@@ -1,5 +1,5 @@
 from .bindings import * # noqa
-from .client import ClientAsync, ClientSync, id, amount_max, configure_logging # noqa
+from .client import ClientAsync, ClientSync, id, amount_max, configure_logging, PacketError # noqa
 from .lib import IntegerOverflowError, NativeError
 
 # Explicitly declare public exports:

--- a/src/clients/python/tests/test_close.py
+++ b/src/clients/python/tests/test_close.py
@@ -1,0 +1,87 @@
+import asyncio
+import ctypes
+import itertools
+import socket
+import threading
+import time
+
+import pytest
+
+import tigerbeetle as tb
+tb.configure_logging(debug=True)
+
+def _blocking_lookup(client, result):
+    assert isinstance(result, list)
+    try:
+        result = client.lookup_accounts([1])
+        raise AssertionError("lookup_accounts didn't throw an exception")
+    except Exception as e:
+        result.append(e)
+
+def test_close_sync():
+    # Bind a socket to a free port to get a socket that's definitely not TigerBeetle.
+    not_tigerbeetle = socket.socket()
+    not_tigerbeetle.bind(('127.0.0.1', 0))
+    not_tigerbeetle_port = not_tigerbeetle.getsockname()[1]
+
+    client = tb.ClientSync(cluster_id=1234, replica_addresses=f"127.0.0.1:{not_tigerbeetle_port}")
+
+    # Submit a request, which would normally block.
+    thread_result = []
+    thread = threading.Thread(target=_blocking_lookup, args=(client, thread_result))
+    thread.start()
+
+    # Wait until the request is actually in-flight.
+    for i in range(0, 10):
+        if len(client._inflight_packets) == 1:
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("thread didn't create a request in time")
+
+    assert len(client._inflight_packets) == 1
+
+    client.close()
+    thread.join()
+
+    assert len(thread_result) == 1
+    with pytest.raises(tb.PacketError, match='CLIENT_SHUTDOWN'):
+        raise thread_result[0]
+
+    # Closing the client should have resulted in the request being terminated.
+    assert len(client._inflight_packets) == 0
+    assert client._client_key not in tb.ClientSync._clients
+
+def test_close_async():
+    # Saves having an extra dependency like pytest-asyncio!
+    asyncio.run(_test_close_async())
+
+async def _test_close_async():
+    # Bind a socket to a free port to get a socket that's definitely not TigerBeetle.
+    not_tigerbeetle = socket.socket()
+    not_tigerbeetle.bind(('127.0.0.1', 0))
+    not_tigerbeetle_port = not_tigerbeetle.getsockname()[1]
+
+    client = tb.ClientAsync(cluster_id=1234, replica_addresses=f"127.0.0.1:{not_tigerbeetle_port}")
+
+    # Submit a request, as a task.
+    lookup_task = asyncio.create_task(client.lookup_accounts([1]))
+
+    # Wait until the request is actually in-flight.
+    for i in range(0, 10):
+        if len(client._inflight_packets) == 1:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise AssertionError("thread didn't create a request in time")
+
+    assert len(client._inflight_packets) == 1
+
+    await client.close()
+
+    with pytest.raises(tb.PacketError, match='CLIENT_SHUTDOWN'):
+        lookup_result = await lookup_task
+
+    # Closing the client should have resulted in the request being terminated.
+    assert len(client._inflight_packets) == 0
+    assert client._client_key not in tb.ClientSync._clients

--- a/src/docs_website/src/file_checker.zig
+++ b/src/docs_website/src/file_checker.zig
@@ -5,8 +5,8 @@ const log = std.log.scoped(.validate);
 const assert = std.debug.assert;
 
 const file_size_max = 166 * 1024;
-const search_index_size_max = 970 * 1024;
-const single_page_size_max = 970 * 1024;
+const search_index_size_max = 1024 * 1024;
+const single_page_size_max = 1024 * 1024;
 
 // If this is set to true, we check if we get a 200 response for any external links.
 const check_links_external: bool = false;


### PR DESCRIPTION
This fixes `client.close()` triggering an assert when using the async Python client, and adds test for both variants.

The underlying problem is that when shutting down using the sync client, callbacks are invoked immediately - so asserting `len(self._inflight_packets) == 0` immediately after `deinit` is safe.

However, in the async client, callbacks are scheduled using `call_soon_threadsafe`, which means in `close()` itself, we can't assert that there are no inflight packets yet.

Fix this, by waiting on all the async events to fire, but this requires changing the signature of `AsyncClient.close()` to be async.