### PR TITLE
ci: change log to a panic

### DIFF
--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -154,11 +154,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         // Slice the output to suppress the names.
         if (!std.mem.eql(u8, checksum_downloaded[0..64], checksum_built[0..64])) {
             // Still run the code, but suppress failing until a release cycle has taken place.
-            std.log.info(
-                "deterministic builds still need a release cycle for validation to pass:",
-                .{},
-            );
-            std.log.info("checksum mismatch - {s}: downloaded {s}, built {s}", .{
+            std.debug.panic("checksum mismatch - {s}: downloaded {s}, built {s}", .{
                 artifact,
                 checksum_downloaded[0..64],
                 checksum_built[0..64],


### PR DESCRIPTION
Now that deterministic zips have been up for a while, and confirmed that we're not logging that things are different, switch the log to a panic.