### PR TITLE
VSR: State sync ratchet

### DIFF
--- a/docs/internals/sync.md
+++ b/docs/internals/sync.md
@@ -73,7 +73,10 @@ Checkpoints:
 
 If the replica starts up with `vsr_state.sync_op_max ≠ 0`, go to step _4_.
 
-If we receive a new sync target while we were still syncing the old one, `replica.sync_tables_op_range` is not updated immediately. We don't start syncing the tables from the new sync range until all the tables from the old sync range are completed. (This is the "state sync ratchet").
+If we receive a new sync target while we were still syncing the old one,
+`replica.sync_tables_op_range` is not updated immediately. We don't start syncing the tables from
+the new sync range until all the tables from the old sync range are completed. (This is the "state
+sync ratchet").
 
 ### 0: Scenarios
 

--- a/docs/internals/sync.md
+++ b/docs/internals/sync.md
@@ -61,15 +61,19 @@ Checkpoints:
    - Bump `replica.commit_min`.
    - Set `vsr_state.sync_op_min` to the minimum op which has not been repaired.
    - Set `vsr_state.sync_op_max` to the maximum op which has not been repaired.
-4. Repair [replies](./vsr.md#protocol-sync-client-replies),
-   [free set, client sessions, and manifest blocks](./vsr.md#protocol-repair-grid), and
-   [table blocks](./vsr.md#protocol-sync-forest) that were created within the `sync_op_{min,max}`
-   range.
+   - Set `replica.sync_tables_op_range` if it is not already set. (See below).
+4. Repair [replies](./vsr.md#protocol-sync-client-replies) and
+   [free set, client sessions, and manifest blocks](./vsr.md#protocol-repair-grid)
+   that were created within the `vsr_state.sync_op_{min,max}` range.
+   Repair [table blocks](./vsr.md#protocol-sync-forest) that were created within
+   `replica.sync_tables_op_range`.
 5. As part of the [*next checkpoint*](#5-conclusion), update the superblock with:
     - Set `vsr_state.sync_op_min = 0`
     - Set `vsr_state.sync_op_max = 0`
 
 If the replica starts up with `vsr_state.sync_op_max ≠ 0`, go to step _4_.
+
+If we receive a new sync target while we were still syncing the old one, `replica.sync_tables_op_range` is not updated immediately. We don't start syncing the tables from the new sync range until all the tables from the old sync range are completed. (This is the "state sync ratchet").
 
 ### 0: Scenarios
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -632,6 +632,29 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             }
         }
 
+        /// Returns whether the forest contains this table (ignoring differences in snapshot_max) at
+        /// any level.
+        pub fn contains_table(
+            forest: *const Forest,
+            table: *const schema.ManifestNode.TableInfo,
+        ) bool {
+            switch (tree_id_cast(table.tree_id)) {
+                inline else => |tree_id| {
+                    const tree = forest.tree_for_id_const(tree_id);
+                    const Tree = Forest.TreeForIdType(tree_id);
+                    const tree_table = Tree.Manifest.TreeTableInfo.decode(table);
+                    for (&tree.manifest.levels) |manifest_level| {
+                        if (manifest_level.find(&tree_table)) |level_table| {
+                            assert(table.checksum == level_table.table_info.checksum);
+                            assert(table.snapshot_max <= level_table.table_info.snapshot_max);
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+            }
+        }
+
         /// Verify that `ManifestLog.table_extents` has an extent for every active table.
         ///
         /// (Invoked between beats.)

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -645,8 +645,13 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     const tree_table = Tree.Manifest.TreeTableInfo.decode(table);
                     for (&tree.manifest.levels) |manifest_level| {
                         if (manifest_level.find(&tree_table)) |level_table| {
-                            assert(table.checksum == level_table.table_info.checksum);
-                            assert(table.snapshot_max <= level_table.table_info.snapshot_max);
+                            assert(tree_table.checksum == level_table.table_info.checksum);
+                            assert(tree_table.address == level_table.table_info.address);
+                            assert(tree_table.key_min == level_table.table_info.key_min);
+                            assert(tree_table.key_max == level_table.table_info.key_max);
+                            assert(tree_table.snapshot_min == level_table.table_info.snapshot_min);
+
+                            assert(tree_table.snapshot_max <= level_table.table_info.snapshot_max);
                             return true;
                         }
                     }

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -538,7 +538,7 @@ pub fn ManifestLevelType(
         }
 
         /// Returns a table which matches the given table *except possibly the snapshot_max*.
-        fn find(level: ManifestLevel, table: *const TableInfo) ?TableInfoReference {
+        pub fn find(level: ManifestLevel, table: *const TableInfo) ?TableInfoReference {
             const table_key =
                 KeyMaxSnapshotMin{ .key_max = table.key_max, .snapshot_min = table.snapshot_min };
             const table_cursor = level.tables.search(table_key.key_from_value());

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -537,19 +537,30 @@ pub fn ManifestLevelType(
             return adjusted;
         }
 
-        /// The function is only used for verification; it is not performance-critical.
-        pub fn contains(level: ManifestLevel, table: *const TableInfo) bool {
-            comptime assert(constants.verify);
-            var level_tables = level.iterator(.visible, &.{
-                table.snapshot_min,
-            }, .ascending, KeyRange{
-                .key_min = table.key_min,
-                .key_max = table.key_max,
-            });
-            while (level_tables.next()) |level_table| {
-                if (level_table.equal(table)) return true;
+        /// Returns a table which matches the given table *except possibly the snapshot_max*.
+        fn find(level: ManifestLevel, table: *const TableInfo) ?TableInfoReference {
+            const table_key =
+                KeyMaxSnapshotMin{ .key_max = table.key_max, .snapshot_min = table.snapshot_min };
+            const table_cursor = level.tables.search(table_key.key_from_value());
+            var level_tables = level.tables.iterator_from_cursor(table_cursor, .ascending);
+            const level_table = level_tables.next() orelse return null;
+            if (level_table.address == table.address and
+                level_table.checksum == table.checksum)
+            {
+                maybe(level_table.snapshot_max != table.snapshot_max);
+                return .{ .table_info = level_table, .generation = level.generation };
+            } else {
+                return null;
             }
-            return false;
+        }
+
+        /// Returns whether the ManifestLevel contains the *exact* table.
+        pub fn contains(level: ManifestLevel, table: *const TableInfo) bool {
+            assert(constants.verify); // Currently only used for testing.
+            const table_found = level.find(table) orelse return false;
+            const table_exact = table.snapshot_max == table_found.table_info.snapshot_max;
+            assert(table_exact == table.equal(table_found.table_info));
+            return table_exact;
         }
 
         /// Given two levels (where A is the level on which this function

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1754,8 +1754,11 @@ fn log_override(
         // Always print a message for vsr.fatal.
     } else {
         if (vsr_vopr_options.log == .short) {
-            if (scope != .cluster and scope != .simulator) return;
-            if (log_performance_mode and scope != .simulator) return;
+            if (log_performance_mode) {
+                if (scope != .simulator) return;
+            } else {
+                if (scope != .simulator and scope != .cluster) return;
+            }
         }
     }
 

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -485,7 +485,7 @@ pub fn GridType(comptime Storage: type) type {
             grid.callback = .{ .checkpoint_durable = callback };
 
             grid.blocks_missing.checkpoint_durable_commence(&grid.free_set);
-            if (grid.blocks_missing.checkpoint_durable.?.aborting == 0) {
+            if (grid.blocks_missing.state.checkpoint_durable.aborting == 0) {
                 grid.checkpoint_durable_join();
             }
         }

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -392,8 +392,7 @@ pub fn GridType(comptime Storage: type) type {
         ///   4. Write the free set blocks to disk.
         ///   5. Mark the free set's own blocks as released (but not yet free).
         ///
-        /// This function handles step 1, and calls CheckpointTrailer.checkpoint, which handles
-        /// 2-4.
+        /// This function handles step 1, and calls CheckpointTrailer.checkpoint, which handles 2-4.
         /// The caller is responsible for calling Grid.mark_checkpoint_not_durable, which handles 5.
         pub fn checkpoint(grid: *Grid, callback: *const fn (*Grid) void) void {
             assert(grid.callback == .none);
@@ -726,6 +725,7 @@ pub fn GridType(comptime Storage: type) type {
         }
 
         pub fn fulfill_block(grid: *Grid, block: BlockPtrConst) bool {
+            assert(grid.superblock.opened);
             assert(grid.callback != .cancel);
 
             const block_header = schema.header_from_block(block);

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -11,8 +11,10 @@
 //!   corrupt blocks.
 const std = @import("std");
 const assert = std.debug.assert;
+const maybe = stdx.maybe;
 
 const constants = @import("../constants.zig");
+const stdx = @import("stdx");
 const schema = @import("../lsm/schema.zig");
 const vsr = @import("../vsr.zig");
 
@@ -98,8 +100,13 @@ pub const GridBlocksMissing = struct {
     /// - faulty_blocks.count() = 0 implies faulty_blocks_repair_index = faulty_blocks.count()
     faulty_blocks_repair_index: usize = 0,
 
+    /// On `sync_commence()` and `sync_complete()`, swap this with `faulty_blocks` so that the
+    /// (possibly invalid) table blocks don't interfere.
+    syncing_faulty_blocks: FaultyBlocks,
+
     /// Invariants:
-    /// - enqueued_blocks_table + enqueued_blocks_single = faulty_blocks.count()
+    /// - enqueued_blocks_table + enqueued_blocks_single =
+    ///   faulty_blocks.count() + syncing_faulty_blocks.count()
     /// - enqueued_blocks_table ≤ options.tables_max * lsm_table_content_blocks_max
     enqueued_blocks_single: usize = 0,
     enqueued_blocks_table: usize = 0,
@@ -118,6 +125,12 @@ pub const GridBlocksMissing = struct {
 
     state: union(enum) {
         repairing,
+        /// Set while the replica is syncing its superblock and opening its grid/forest.
+        /// While `state=syncing`, only repair single blocks, not tables.
+        ///
+        /// (Tables are temporarily in `syncing_faulty_blocks` rather than `faulty_blocks` -- they
+        /// may or may not belong in the new (upcoming) checkpoint.)
+        syncing,
         checkpoint_durable: struct {
             /// The number of faulty_blocks with state=aborting.
             aborting: usize,
@@ -131,32 +144,47 @@ pub const GridBlocksMissing = struct {
         var faulty_blocks = FaultyBlocks{};
         errdefer faulty_blocks.deinit(allocator);
 
+        var syncing_faulty_blocks = FaultyBlocks{};
+        errdefer syncing_faulty_blocks.deinit(allocator);
+
         try faulty_blocks.ensureTotalCapacity(
             allocator,
             options.blocks_max + options.tables_max * constants.lsm_table_value_blocks_max,
         );
+        // During state=syncing, we only need to sync single blocks, not full tables.
+        // (This sounds backwards! But the reason is that state=syncing corresponds to grid
+        // cancellation + checkpoint replacement, not table/content sync. We repair missing blocks
+        // from the free set and checkpoint trailers.)
+        try syncing_faulty_blocks.ensureTotalCapacity(allocator, options.blocks_max);
 
         return GridBlocksMissing{
             .options = options,
             .faulty_blocks = faulty_blocks,
+            .syncing_faulty_blocks = syncing_faulty_blocks,
         };
     }
 
     pub fn deinit(queue: *GridBlocksMissing, allocator: std.mem.Allocator) void {
+        queue.syncing_faulty_blocks.deinit(allocator);
         queue.faulty_blocks.deinit(allocator);
 
         queue.* = undefined;
     }
 
     pub fn verify(queue: *const GridBlocksMissing) void {
+        assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
+            queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         assert(queue.faulty_blocks_repair_index == 0 or
             queue.faulty_blocks_repair_index < queue.faulty_blocks.count());
 
         var enqueued_blocks_single: u32 = 0;
         var enqueued_blocks_table: u32 = 0;
         var enqueued_blocks_aborting: u32 = 0;
-        {
-            for (queue.faulty_blocks.values()) |fault| {
+        for ([_]FaultyBlocks{
+            queue.faulty_blocks,
+            queue.syncing_faulty_blocks,
+        }) |faulty_blocks| {
+            for (faulty_blocks.values()) |fault| {
                 switch (fault.progress) {
                     .table_index,
                     .table_value,
@@ -184,6 +212,14 @@ pub const GridBlocksMissing = struct {
             assert(enqueued_blocks_aborting == queue.state.checkpoint_durable.aborting);
         } else {
             assert(enqueued_blocks_aborting == 0);
+        }
+
+        assert(queue.syncing_faulty_blocks.capacity() != queue.faulty_blocks.capacity());
+        if (queue.state == .syncing) {
+            assert(queue.syncing_faulty_blocks.capacity() > queue.faulty_blocks.capacity());
+        } else {
+            assert(queue.syncing_faulty_blocks.capacity() < queue.faulty_blocks.capacity());
+            assert(queue.syncing_faulty_blocks.count() == 0);
         }
 
         var faulty_tables_free = queue.faulty_tables_free.iterate();
@@ -222,27 +258,35 @@ pub const GridBlocksMissing = struct {
     /// Count the number of *non-table* block repairs available.
     pub fn enqueue_blocks_available(queue: *const GridBlocksMissing) usize {
         assert(queue.faulty_tables.count() <= queue.options.tables_max);
-        assert(queue.faulty_blocks.count() ==
+        assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         assert(queue.enqueued_blocks_table <=
             queue.options.tables_max * constants.lsm_table_value_blocks_max);
 
-        const faulty_blocks_free =
-            queue.faulty_blocks.capacity() -
-            queue.enqueued_blocks_single -
-            queue.options.tables_max * constants.lsm_table_value_blocks_max;
-        return faulty_blocks_free;
+        if (queue.state == .syncing) {
+            const faulty_blocks_free =
+                queue.faulty_blocks.capacity() -
+                queue.enqueued_blocks_single;
+            return faulty_blocks_free;
+        } else {
+            const faulty_blocks_free =
+                queue.faulty_blocks.capacity() -
+                queue.enqueued_blocks_single -
+                queue.options.tables_max * constants.lsm_table_value_blocks_max;
+            return faulty_blocks_free;
+        }
     }
 
     /// Queue a faulty block to request from the cluster and repair.
     pub fn enqueue_block(queue: *GridBlocksMissing, address: u64, checksum: u128) void {
         assert(queue.enqueue_blocks_available() > 0);
         assert(queue.faulty_tables.count() <= queue.options.tables_max);
-        assert(queue.faulty_blocks.count() ==
+        assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
 
         const enqueue = queue.enqueue_faulty_block(address, checksum, .block);
-        assert(enqueue == .insert or enqueue == .duplicate);
+        assert(enqueue == .insert or enqueue == .duplicate or
+            (enqueue == .replace and queue.state == .syncing));
     }
 
     pub fn enqueue_table(
@@ -251,8 +295,9 @@ pub const GridBlocksMissing = struct {
         table_bitset: *std.DynamicBitSetUnmanaged,
         table_info: *const schema.ManifestNode.TableInfo,
     ) enum { insert, duplicate } {
+        assert(queue.state == .repairing or queue.state == .checkpoint_durable);
         assert(queue.faulty_tables.count() < queue.options.tables_max);
-        assert(queue.faulty_blocks.count() ==
+        assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         assert(table_bitset.capacity() == constants.lsm_table_value_blocks_max);
         assert(table_bitset.count() == 0);
@@ -300,11 +345,11 @@ pub const GridBlocksMissing = struct {
         duplicate,
     } {
         assert(queue.faulty_tables.count() <= queue.options.tables_max);
-        assert(queue.faulty_blocks.count() ==
+        assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
 
         defer {
-            assert(queue.faulty_blocks.count() ==
+            assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
                 queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         }
 
@@ -344,19 +389,30 @@ pub const GridBlocksMissing = struct {
         }
     }
 
+    pub fn repairing_blocks(queue: *const GridBlocksMissing) bool {
+        return queue.repairing_tables() or queue.enqueued_blocks_single > 0;
+    }
+
+    pub fn repairing_tables(queue: *const GridBlocksMissing) bool {
+        return queue.state != .syncing and queue.enqueued_blocks_table > 0;
+    }
+
     pub fn repair_waiting(queue: *const GridBlocksMissing, address: u64, checksum: u128) bool {
         const fault_index = queue.faulty_blocks.getIndex(address) orelse return false;
         const fault = &queue.faulty_blocks.values()[fault_index];
         return fault.checksum == checksum and fault.state == .waiting;
     }
 
-    pub fn repair_commence(queue: *const GridBlocksMissing, address: u64, checksum: u128) void {
+    pub fn repair_commence(queue: *GridBlocksMissing, address: u64, checksum: u128) void {
         assert(queue.repair_waiting(address, checksum));
+        maybe(queue.state == .checkpoint_durable);
+        maybe(queue.state == .syncing);
 
         const fault_index = queue.faulty_blocks.getIndex(address).?;
         const fault = &queue.faulty_blocks.values()[fault_index];
         assert(fault.checksum == checksum);
         assert(fault.state == .waiting);
+        if (queue.state == .syncing) assert(fault.progress == .block);
 
         if (fault.progress == .table_value) {
             const progress = &fault.progress.table_value;
@@ -377,6 +433,7 @@ pub const GridBlocksMissing = struct {
         assert(fault_address == block_header.address);
         assert(fault.checksum == block_header.checksum);
         assert(fault.state == .aborting or fault.state == .writing);
+        if (queue.state == .syncing) assert(fault.progress == .block);
 
         queue.release_fault(fault_index);
 
@@ -386,8 +443,11 @@ pub const GridBlocksMissing = struct {
         }
 
         switch (fault.progress) {
-            .block => {},
+            .block => {
+                maybe(queue.state == .syncing);
+            },
             .table_index => |progress| {
+                assert(queue.state != .syncing);
                 assert(progress.table.value_blocks_received.count() == 0);
 
                 // The reason that the value blocks are queued here (when the write ends) rather
@@ -396,6 +456,7 @@ pub const GridBlocksMissing = struct {
                 queue.enqueue_table_value(fault.progress.table_index.table, block);
             },
             .table_value => |progress| {
+                assert(queue.state != .syncing);
                 assert(progress.table.value_blocks_received.isSet(progress.index));
             },
         }
@@ -422,6 +483,7 @@ pub const GridBlocksMissing = struct {
         table: *RepairTable,
         index_block: BlockPtrConst,
     ) void {
+        assert(queue.state != .syncing);
         assert(queue.faulty_blocks.count() ==
             queue.enqueued_blocks_single + queue.enqueued_blocks_table);
         assert(table.table_blocks_total == null);
@@ -475,16 +537,130 @@ pub const GridBlocksMissing = struct {
 
     pub fn cancel(queue: *GridBlocksMissing) void {
         queue.verify();
-        queue.faulty_blocks.clearRetainingCapacity();
-        while (queue.faulty_tables.pop()) |table| {
-            queue.faulty_tables_free.push(table);
+        defer queue.verify();
+
+        var faulty_blocks = queue.faulty_blocks.iterator();
+        while (faulty_blocks.next()) |fault_entry| {
+            const fault = fault_entry.value_ptr;
+            assert(fault.state != .aborting);
+
+            if (fault.state == .writing) {
+                // Due to Grid.cancel() this write may not actually take place.
+                fault.state = .waiting;
+
+                if (fault.progress == .table_value) {
+                    const progress = &fault.progress.table_value;
+                    assert(progress.table.value_blocks_received.isSet(progress.index));
+                    progress.table.value_blocks_received.unset(progress.index);
+                }
+            }
+        }
+    }
+
+    /// When we state sync, cancellation of our already-queued missing blocks happens in two stages:
+    /// 1. First (in this function, called immediately after grid.cancel()) we clean up single-block
+    ///    faults.
+    /// 2. Later (in sync_complete()), after the state machine is opened with the new checkpoint, we
+    ///    clean up any tables which did not survive into the new checkpoint.
+    pub fn sync_commence(queue: *GridBlocksMissing) void {
+        queue.verify();
+        defer if (constants.verify) queue.verify();
+        // The replica may call sync_commence() without ever calling sync_complete() if it syncs
+        // multiple checkpoints without successfully opening the state machine.
+        assert(queue.state == .repairing or queue.state == .syncing);
+
+        // Release the "single" blocks since when we finish syncing we have no easy way of checking
+        // whether they will still be valid.
+        var faulty_blocks = queue.faulty_blocks.iterator();
+        while (faulty_blocks.next()) |fault_entry| {
+            assert(fault_entry.value_ptr.state == .waiting);
+            if (fault_entry.value_ptr.progress == .block) {
+                faulty_blocks.index -= 1;
+                faulty_blocks.len -= 1;
+                queue.release_fault(faulty_blocks.index);
+            } else {
+                assert(queue.state == .repairing);
+            }
+        }
+        assert(queue.enqueued_blocks_single == 0);
+
+        if (queue.state == .repairing) {
+            queue.state = .syncing;
+
+            assert(queue.syncing_faulty_blocks.count() == 0);
+            std.mem.swap(FaultyBlocks, &queue.faulty_blocks, &queue.syncing_faulty_blocks);
+            queue.faulty_blocks_repair_index = 0;
+        }
+        assert(queue.faulty_blocks.count() == 0);
+        assert(queue.syncing_faulty_blocks.count() == queue.enqueued_blocks_table);
+    }
+
+    /// Cancel repair for a table that does not belong in the new (sync target) checkpoint.
+    /// (Unlike checkpoint, we can't just use the free set to determine which blocks to discard.)
+    pub fn sync_table_cancel(queue: *GridBlocksMissing, table: *RepairTable) void {
+        queue.verify();
+        defer if (constants.verify) queue.verify();
+        assert(queue.state == .syncing);
+        assert(queue.faulty_tables.contains(table) != queue.faulty_tables_free.contains(table));
+
+        // The table was already cancelled/completed, it just hasn't been reclaimed yet.
+        if (queue.faulty_tables_free.contains(table)) return;
+
+        var faulty_blocks_removed: u32 = 0;
+        var faulty_blocks = queue.syncing_faulty_blocks.iterator();
+        while (faulty_blocks.next()) |fault_entry| {
+            const fault = fault_entry.value_ptr;
+            assert(fault.state != .aborting);
+
+            switch (fault.progress) {
+                .block => {},
+                //.block => unreachable,
+                inline .table_index, .table_value => |*progress| {
+                    assert(fault.state == .waiting);
+                    if (progress.table == table) {
+                        faulty_blocks_removed += 1;
+                        faulty_blocks.index -= 1;
+                        faulty_blocks.len -= 1;
+                        queue.enqueued_blocks_table -= 1;
+                        queue.syncing_faulty_blocks.swapRemoveAt(faulty_blocks.index);
+                    }
+                },
+            }
+        }
+        assert(faulty_blocks_removed ==
+            (table.table_blocks_total orelse 1) - table.table_blocks_written);
+        assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
+            queue.enqueued_blocks_table + queue.enqueued_blocks_single);
+
+        queue.faulty_tables.remove(table);
+        queue.faulty_tables_free.push(table);
+    }
+
+    pub fn sync_complete(queue: *GridBlocksMissing, free_set: *const vsr.FreeSet) void {
+        queue.verify();
+        defer if (constants.verify) queue.verify();
+        assert(queue.state == .syncing);
+        assert(free_set.opened);
+
+        queue.state = .repairing;
+        std.mem.swap(FaultyBlocks, &queue.faulty_blocks, &queue.syncing_faulty_blocks);
+
+        // Move any leftover block repairs (from faults incurred during since `sync_commence()`)
+        // back to `faulty_blocks`.
+        while (queue.syncing_faulty_blocks.pop()) |fault_entry| {
+            assert(fault_entry.value.progress == .block);
+
+            const fault_address = fault_entry.key;
+            const fault_result = queue.faulty_blocks.getOrPutAssumeCapacity(fault_address);
+            assert(!fault_result.found_existing);
+            fault_result.value_ptr.* = fault_entry.value;
         }
 
-        queue.* = .{
-            .options = queue.options,
-            .faulty_blocks = queue.faulty_blocks,
-            .faulty_tables_free = queue.faulty_tables_free,
-        };
+        var faulty_blocks = queue.faulty_blocks.iterator();
+        while (faulty_blocks.next()) |fault_entry| {
+            const fault_address = fault_entry.key_ptr.*;
+            assert(!free_set.is_free(fault_address));
+        }
     }
 
     /// Aborts queued repairs to blocks to be freed, now that the current checkpoint is durable.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10508,8 +10508,8 @@ pub fn ReplicaType(
                         "address={} checksum={} wrote={}/{?}",
                     .{
                         self.log_prefix(),
-                        table.index_address,
-                        table.index_checksum,
+                        table.table_info.address,
+                        table.table_info.checksum,
                         table.table_blocks_written,
                         table.table_blocks_total,
                     },

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10381,12 +10381,8 @@ pub fn ReplicaType(
                     const table_bitset: *std.DynamicBitSetUnmanaged =
                         &self.grid_repair_table_bitsets[self.grid_repair_tables.index(table)];
 
-                    const enqueue_result = self.grid.blocks_missing.enqueue_table(
-                        table,
-                        table_bitset,
-                        table_info.address,
-                        table_info.checksum,
-                    );
+                    const enqueue_result =
+                        self.grid.blocks_missing.enqueue_table(table, table_bitset, &table_info);
 
                     switch (enqueue_result) {
                         .insert => self.trace.start(.{ .replica_sync_table = .{

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10430,8 +10430,9 @@ pub fn ReplicaType(
         fn sync_reclaim_tables(self: *Replica) void {
             while (self.grid.blocks_missing.reclaim_table()) |table| {
                 log.info(
-                    "sync_reclaim_tables: table synced: address={} checksum={} wrote={}/{?}",
+                    "{}: sync_reclaim_tables: table synced: address={} checksum={} wrote={}/{?}",
                     .{
+                        self.log_prefix(),
                         table.index_address,
                         table.index_checksum,
                         table.table_blocks_written,


### PR DESCRIPTION
## Context

State sync overview:

1. Replica discovers that it is lagging behind the cluster.
2. Lagging replica replaces its superblock (in particular the `CheckpointState`) with a newer one from the cluster.
3. Lagging replica syncs the trailer blocks referenced by the new superblock.
4. Lagging replica syncs the table index/value blocks referenced by the new manifest.

In a large database, step 4 might involve syncing a lot of data, and so take quite a long time.

And during this whole time, the remainder of the cluster is likely still processing requests and periodically checkpointing.

Previously, each time we change the sync target checkpoint, we start sync over from the beginning. When we get to table sync, we potentially need to re-sync tables that were already synced.

In this PR, we ratchet progress of table sync, to retain progress across checkpoint boundaries.

## Fix

In `Replica`:
- Add `sync_tables_op_range`.
- If we load a new sync target, we continue syncing the old range already in `sync_tables_op_range` until it is complete, at which point we change the range to cover all unsynced ops.

In `GridBlocksMissing`:
- When we begin the replace the superblock for state sync, we pause table sync. (See the `faulty_blocks`/`syncing_faulty_blocks` swap.)
- When we open that's grid/forest, we resume table sync. If any of the tables we were syncing didn't survive into the new checkpoint, they are canceled.

Note that if a replica restarts before persisting the fact that it completed state sync (via a checkpoint) then it will still need to start sync over.

## VOPR

Note that this is run with a modified config:

<details>
<summary>diff</summary>

```diff
diff --git i/src/config.zig w/src/config.zig
index 90b06bccb..f7edf01b1 100644
--- i/src/config.zig
+++ w/src/config.zig
@@ -265,7 +265,7 @@ pub const configs = struct {
             .clients_max = 4 + 3,
             .pipeline_prepare_queue_max = 4,
             .view_change_headers_suffix_max = 4 + 1,
-            .journal_slot_count = Config.Cluster.journal_slot_count_min,
+            .journal_slot_count = Config.Cluster.journal_slot_count_min * 4,
             .message_size_max = Config.Cluster.message_size_max_min(4),

             .block_size = sector_size,
diff --git i/src/vopr.zig w/src/vopr.zig
index eea2fcf6f..fc328e239 100644
--- i/src/vopr.zig
+++ w/src/vopr.zig
@@ -528,6 +528,10 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {
                 .cache_entries_transfers_pending = 0,
             },
         },
+        .replicate_options = .{
+            .closed_loop = false,
+            .star = true,
+        },
     };

     const network_options: Cluster.NetworkOptions = .{
@@ -536,10 +540,10 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {

         .seed = prng.int(u64),

-        .one_way_delay_mean = .ms(50),
+        .one_way_delay_mean = .ms(5),
         .one_way_delay_min = .{ .ns = 0 },
         .packet_loss_probability = Ratio.zero(),
-        .path_maximum_capacity = 10,
+        .path_maximum_capacity = 20,
         .path_clog_duration_mean = .ms(2_000),
         .path_clog_probability = Ratio.zero(),
         .packet_replay_probability = Ratio.zero(),
@@ -556,9 +560,9 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {
         .size = cluster_options.storage_size_limit,
         .seed = prng.int(u64),
         .read_latency_min = .{ .ns = 0 },
-        .read_latency_mean = .{ .ns = 0 },
+        .read_latency_mean = .{ .ns = 1 * std.time.ns_per_us },
         .write_latency_min = .{ .ns = 0 },
-        .write_latency_mean = .{ .ns = 0 },
+        .write_latency_mean = .{ .ns = 5 * std.time.ns_per_us },
         .read_fault_probability = Ratio.zero(),
         .write_fault_probability = Ratio.zero(),
         .write_misdirect_probability = Ratio.zero(),
@@ -588,7 +592,7 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {
         .workload = workload_options,
         .replica_crash_probability = Ratio.zero(),
         .replica_crash_stability = 500,
-        .replica_restart_probability = Ratio.zero(),
+        .replica_restart_probability = ratio(1, 1),
         .replica_restart_stability = 500,
         .replica_reformat_probability = ratio(0, 100),
```

</details>

The VOPR config's small blocks/tables mean there are unrealistically many manifest log blocks, which are currently repaired in sequence.
Because of this, I increased `config.test_min`'s `journal_slot_count` to give it enough time to finish syncing trailers before the next checkpoint.

(The "real" solution to this issue is for performance vopr to use a config closer to production!)

```
./zig/zig build -Drelease vopr -- --performance --replica-missing=3 --replica-missing-until-request=5000 --requests-max=15000 1234
```

<details>
<summary>Before</summary>

```
Messages:
prepare                    78844   56.18MiB
prepare_ok                 67298   16.43MiB
ping                       45095   22.02MiB
pong                       43263   10.56MiB
request                    26394   19.21MiB
commit                     19530    4.77MiB
reply                      15770   16.12MiB
block                      15383   43.16MiB
request_blocks             14165    3.96MiB
ping_client                12638    3.09MiB
pong_client                11916    2.91MiB
start_view                  6580   17.70MiB
request_start_view          2720  680.00KiB
request_prepare             1855  463.75KiB
request_reply               1748  437.00KiB
request_headers             1574  393.50KiB
headers                     1187    3.86MiB
do_view_change                25   12.50KiB
total                     365985  221.91MiB

          PASSED (155974 ticks)
```

</details>
 
<details>
<summary>After</summary>

```
Messages:
prepare                    80245   57.05MiB
prepare_ok                 73216   17.88MiB
ping                       20510   10.01MiB
pong                       19510    4.76MiB
request                    17503   12.80MiB
reply                      15151   15.51MiB
commit                      7840    1.91MiB
start_view                  3149    8.46MiB
request_prepare             3139  784.75KiB
ping_client                 3051  762.75KiB
pong_client                 2867  716.75KiB
request_headers             2526  631.50KiB
request_start_view          2474  618.50KiB
headers                     2317    7.19MiB
block                       1508    3.31MiB
request_blocks               898  273.19KiB
request_reply                389   97.25KiB
do_view_change                25   12.50KiB
total                     256318  142.68MiB

          PASSED (71293 ticks)
```

</details>
