### PR TITLE
vsr: clients hedge request, backups send replies

### DIFF
--- a/src/message_buffer.zig
+++ b/src/message_buffer.zig
@@ -166,22 +166,10 @@ pub const MessageBuffer = struct {
 
         // To avoid dropping outgoing messages, set the peer as soon as we can,
         // and not when we receive a full message.
-        const message_peer = header.peer_type();
-        if (message_peer != .unknown) {
-            if (buffer.peer == .unknown or
-                // Allow transition from client → replica, as peer_type always returns client ID
-                // for request messages, even if they are being forwarded by replicas.
-                // Other transitions like client → client, client → replica, or replica  → replica
-                // are unexpected, the peer must not change in the middle of a TCP session.
-                (buffer.peer == .client and message_peer == .replica))
-            {
-                buffer.peer = message_peer;
-            } else {
-                if (!std.meta.eql(buffer.peer, message_peer)) {
-                    buffer.invalidate(.misdirected);
-                    return;
-                }
-            }
+        switch (vsr.Peer.transition(buffer.peer, header.peer_type())) {
+            .reject => buffer.invalidate(.misdirected),
+            .update => buffer.peer = header.peer_type(),
+            .retain => {},
         }
     }
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -758,8 +758,9 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
                         switch (connection.peer) {
                             .client => |existing| assert(bus.process.clients.remove(existing)),
+                            .replica => assert(connection.recv_buffer.?.invalid.? == .misdirected),
                             .unknown => {},
-                            .none, .replica => unreachable,
+                            .none => unreachable,
                         }
 
                         bus.replicas[replica_index] = connection;
@@ -786,7 +787,8 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         } else {
                             switch (connection.peer) {
                                 .unknown => {},
-                                .client, .replica, .none => unreachable,
+                                .client, .replica => assert(connection.recv_buffer.?.invalid.? == .misdirected),
+                                .none => unreachable,
                             }
                         }
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -745,7 +745,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         // If there is a connection to this replica, terminate and replace it.
                         // Otherwise, this connection was misclassified to a client due to a
                         // forwarded request message (see `peer_type` in message_header.zig), map it
-                        // to the the correct replica. Allowed transitions:
+                        // to the correct replica. Allowed transitions:
                         // * unknown → replica
                         // * client  → replica
                         if (bus.replicas[replica_index]) |old| {

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -758,7 +758,8 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
 
                         switch (connection.peer) {
                             .client => |existing| assert(bus.process.clients.remove(existing)),
-                            .unknown, .replica => {},
+                            .replica => |existing| bus.replicas[existing] = null,
+                            .unknown => {},
                             .none => unreachable,
                         }
 
@@ -789,15 +790,14 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                             switch (connection.peer) {
                                 .client => |existing| assert(bus.process.clients.remove(existing)),
                                 .unknown => {},
-                                .replica => unreachable,
-                                .none => unreachable,
+                                .replica, .none => unreachable,
                             }
                         }
 
                         result.value_ptr.* = connection;
                         log.info("{}: set_and_verify_peer connection from client={}", .{
                             bus.id,
-                            connection.peer.client,
+                            client_id,
                         });
                     },
                     .none, .unknown => unreachable,

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -732,7 +732,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 const header_peer: Connection.Peer = switch (connection.recv_buffer.?.peer) {
                     .unknown => return,
                     .replica => |replica| .{ .replica = replica },
-                    .client => |client| .{ .client = client },
+                    .client, .client_likely => |client| .{ .client = client },
                 };
 
                 if (std.meta.eql(connection.peer, header_peer)) return;
@@ -757,9 +757,9 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         }
 
                         switch (connection.peer) {
+                            .unknown => {},
                             .client => |existing| assert(bus.process.clients.remove(existing)),
                             .replica => assert(connection.recv_buffer.?.invalid.? == .misdirected),
-                            .unknown => {},
                             .none => unreachable,
                         }
 
@@ -787,7 +787,9 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                         } else {
                             switch (connection.peer) {
                                 .unknown => {},
-                                .client, .replica => assert(connection.recv_buffer.?.invalid.? == .misdirected),
+                                .client, .replica => assert(
+                                    connection.recv_buffer.?.invalid.? == .misdirected,
+                                ),
                                 .none => unreachable,
                             }
                         }

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -666,19 +666,6 @@ pub fn ClientType(
             });
 
             self.send_request_with_hedging(message);
-
-            // Try to learn the new view.
-            const ping = Header.PingClient{
-                .command = .ping_client,
-                .cluster = self.cluster,
-                .release = self.release,
-                .client = self.id,
-                .ping_timestamp_monotonic = self.time.monotonic(),
-            };
-
-            const next_backup: u32 =
-                (self.view + self.request_timeout.attempts) % self.replica_count;
-            self.send_header_to_replica(@as(u8, @intCast(next_backup)), ping.frame_const());
         }
 
         /// The caller owns the returned message, if any, which has exactly 1 reference.
@@ -701,13 +688,6 @@ pub fn ClientType(
             defer self.message_bus.unref(message);
 
             self.send_message_to_replicas(message);
-        }
-
-        fn send_header_to_replica(self: *Client, replica: u8, header: *const Header) void {
-            const message = self.create_message_from_header(header);
-            defer self.message_bus.unref(message);
-
-            self.send_message_to_replica(replica, message);
         }
 
         fn send_message_to_replicas(self: *Client, message: *Message) void {

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -665,9 +665,7 @@ pub fn ClientType(
                 message.header.checksum,
             });
 
-            // Retransmit potentially dropped message.
-            const primary: u32 = self.view % self.replica_count;
-            self.send_message_to_replica(@as(u8, @intCast(primary)), message.base());
+            self.send_request_with_hedging(message);
 
             // Try to learn the new view.
             const ping = Header.PingClient{
@@ -745,6 +743,22 @@ pub fn ClientType(
             self.message_bus.send_message_to_replica(replica, message);
         }
 
+        fn send_request_with_hedging(self: *Client, message: *Message.Request) void {
+            const primary: u8 = @intCast(self.view % self.replica_count);
+            self.send_message_to_replica(primary, message.base());
+
+            // Send request to a random backup to handle the case where the client → primary link
+            // is down. This ensures logical availability of the cluster, i.e., as long the
+            // client is connected to a backup that in turn is connected to the primary, the
+            // request will be processed by the cluster.
+            if (self.replica_count > 1) {
+                const offset_random = self.prng.range_inclusive(u8, 1, self.replica_count - 1);
+                const backup_random = (primary + offset_random) % self.replica_count;
+                assert(backup_random != primary);
+                self.send_message_to_replica(backup_random, message.base());
+            }
+        }
+
         fn send_request_for_the_first_time(self: *Client, message: *Message.Request) void {
             assert(self.request_inflight.?.message == message);
             assert(self.request_number > 0);
@@ -780,10 +794,7 @@ pub fn ClientType(
             assert(!self.request_timeout.ticking);
             self.request_timeout.start();
 
-            self.send_message_to_replica(
-                @as(u8, @intCast(self.view % self.replica_count)),
-                message.base(),
-            );
+            self.send_request_with_hedging(message);
         }
     };
 }

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -197,22 +197,17 @@ pub const Header = extern struct {
     pub fn peer_type(self: *const Header) vsr.Peer {
         switch (self.into_any()) {
             .reserved => unreachable,
-            // TODO: replicas used to forward requests. They no longer do, and can always return
-            // request.client starting with the next release.
-            .request => |request| {
-                switch (request.operation) {
-                    // However, we do not forward the first .register request sent by a client:
-                    .register => return .{ .client = request.client },
-                    else => return .unknown,
-                }
-            },
-            .prepare => return .unknown,
-            .block => return .unknown,
-            .reply => return .unknown,
-            .deprecated_12 => return .unknown,
-            .deprecated_21 => return .unknown,
-            .deprecated_22 => return .unknown,
-            .deprecated_23 => return .unknown,
+
+            .request,
+            .reply,
+            .prepare,
+            .block,
+            .deprecated_12,
+            .deprecated_21,
+            .deprecated_22,
+            .deprecated_23,
+            => return .unknown,
+
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
             // All other messages identify the peer as a replica:

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -198,7 +198,6 @@ pub const Header = extern struct {
         switch (self.into_any()) {
             .reserved => unreachable,
 
-            .request,
             .reply,
             .prepare,
             .block,
@@ -210,6 +209,7 @@ pub const Header = extern struct {
 
             // These messages identify the peer as either a replica or a client:
             .ping_client => |ping| return .{ .client = ping.client },
+            .request => |request| return .{ .client = request.client },
             // All other messages identify the peer as a replica:
             .ping,
             .pong,

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -207,7 +207,7 @@ pub const Header = extern struct {
             // However, we return the client ID, as it is useful for the MessageBus. Specifically,
             // a replica that receives a request from a client can immediately cache the connection
             // in its client map, instead of waiting for an infrequent PingClient message to do so.
-            .request => |request| .{ .client = request.client },
+            .request => |request| .{ .client_likely = request.client },
 
             // The peer is certainly a client:
             .ping_client => |ping| .{ .client = ping.client },

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5195,7 +5195,8 @@ pub fn ReplicaType(
 
             var prng = stdx.PRNG.from_seed(op);
             const offset_random = prng.range_inclusive(u8, 1, self.replica_count - 1);
-            const backup_random = (self.primary_index(self.view) + offset_random) % self.replica_count;
+            const backup_random =
+                (self.primary_index(self.view) + offset_random) % self.replica_count;
             assert(backup_random != self.primary_index(self.view));
             return self.replica == backup_random;
         }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6109,7 +6109,6 @@ pub fn ReplicaType(
                     message.header.client,
                     .client_release_too_low,
                 );
-
                 return true;
             }
 
@@ -6125,7 +6124,6 @@ pub fn ReplicaType(
                     message.header.client,
                     .client_release_too_high,
                 );
-
                 return true;
             }
 
@@ -6218,10 +6216,10 @@ pub fn ReplicaType(
             return false;
         }
 
-        // If backups recognize a client, they reply directly if it is a duplicate request, while
-        // newer requests are forwarded to the primary. Older requests are dropped. If they don't
+        // If backups recognize a client, they reply directly to duplicate requests, while newer
+        // requests are forwarded to the primary. Older requests are dropped. If they don't
         // recognize a client (or the client may have been evicted), only register requests are
-        // qforwarded to the primary.
+        // forwarded to the primary.
         // The key motivation here is to only forward requests to the primary if there is a positive
         // reason to do so, otherwise we risk flooding the network with spurious request messages.
         fn ignore_request_message_backup(self: *Replica, message: *Message.Request) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5185,6 +5185,10 @@ pub fn ReplicaType(
         // at the same random backup. This improves logical availability in the case where the
         // the primary → client link is down. If it doesn't work, we have a fallback where a
         // backup directly replies to client requests (see `ignore_request_message`).
+        // Selecting a random backup as opposed to using a determistic function also guards us from
+        // subtle resonance issues wherein the same backup replies to the same client every time.
+        // This could happen if `active client count % replica count == 0`, and these clients'
+        // requests arrive at the primary in the same order every time.
         fn execute_op_reply_to_client(self: *Replica, op: u64) bool {
             if (self.replica == self.primary_index(self.view)) return true;
 

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -37,7 +37,7 @@ const checkpoint_2_prepare_ok_max = checkpoint_2_trigger + constants.pipeline_pr
 
 const MiB = stdx.MiB;
 
-const log_level = std.log.Level.err;
+const log_level = std.log.Level.debug;
 
 const releases = [_]Release{
     .{
@@ -484,9 +484,7 @@ test "Cluster: network: partition client-primary (symmetric)" {
     var c = t.clients(.{});
 
     t.replica(.A0).drop_all(.C_, .bidirectional);
-    // TODO: https://github.com/tigerbeetle/tigerbeetle/issues/444
-    // try c.request(1, 1);
-    try c.request(1, 0);
+    try c.request(1, 1);
 }
 
 test "Cluster: network: partition client-primary (asymmetric, drop requests)" {
@@ -497,9 +495,7 @@ test "Cluster: network: partition client-primary (asymmetric, drop requests)" {
     var c = t.clients(.{});
 
     t.replica(.A0).drop_all(.C_, .incoming);
-    // TODO: https://github.com/tigerbeetle/tigerbeetle/issues/444
-    // try c.request(1, 1);
-    try c.request(1, 0);
+    try c.request(1, 1);
 }
 
 test "Cluster: network: partition client-primary (asymmetric, drop replies)" {
@@ -510,9 +506,7 @@ test "Cluster: network: partition client-primary (asymmetric, drop replies)" {
     var c = t.clients(.{});
 
     t.replica(.A0).drop_all(.C_, .outgoing);
-    // TODO: https://github.com/tigerbeetle/tigerbeetle/issues/444
-    // try c.request(1, 1);
-    try c.request(1, 0);
+    try c.request(1, 1);
 }
 
 test "Cluster: network: partition flexible quorum" {

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -37,7 +37,7 @@ const checkpoint_2_prepare_ok_max = checkpoint_2_trigger + constants.pipeline_pr
 
 const MiB = stdx.MiB;
 
-const log_level = std.log.Level.debug;
+const log_level: std.log.Level = .err;
 
 const releases = [_]Release{
     .{


### PR DESCRIPTION
### Problem

Before https://github.com/tigerbeetle/tigerbeetle/pull/2821, clients would contact backups upon request timeout (currently set to a static value of 600ms) if their attempt at reaching the primary would fail. Backups would forward requests to the primary, but only if the request's view was smaller than the backup's view. Consequently, a single message drop between the client → primary would cause the client to round-robin sending the request to _all_ backups before trying the primary again, leading to a multi-second latency before the cluster processes the request. 

To resolve this and remove bimodality wherein forwarding happens only in the _failure_ path, https://github.com/tigerbeetle/tigerbeetle/pull/2821 makes it so that clients only send requests to the primary. While this solves the problem of the client → cluster protocol being very brittle in the face of message drops, and also the bimodality, it compromises _logical availability_ of the cluster. Specifically, if the client → primary link is down, the client simply keeps retrying its request to the primary, even if it can connect to backup which can further connect to primary!

### Solution

This PR improves the cluster's logical availability by making it so that a client partitioned from the primary can submit a request to the cluster, and *also* receive a reply from the cluster. It also resolves https://github.com/tigerbeetle/tigerbeetle/issues/444!

Now, the client _always_ sends a request to two replicas to hedge its requests, to avoid bimodality wherein we only forward _after_ request timeout is fired:
1. **Primary (based on the view that it knows about)**: This assumes the client → primary path would provide the smallest request-response latency. We *could* precisely track the request-response latencies and select a replica based on those measurements, but we settled on the 90% solution where we always forward to the primary. 
2. **Randomly selected backup**: It is crucial that this replica is randomly selected as opposed to selecting the replica that provides the second best request-response latency. This is because the latter *could* make us more prone to being affected by a correlated fault, wherein both our requests are forwarded to replicas within an AZ to which the client has no connectivity.

_Sending requests to two replicas increases egress network bandwidth utilization on the client by 2x, but we decided that its a worthwhile price to pay for predictability in performance, even in the face of client → primary network partitions!_

Additionally, backups can also send replies directly to clients, if they receive a duplicate request from the client for which they already have a reply in the client table. Additionally, for each op, the primary _and_ a randomly selected backup send a reply to the client, to avoid bimodality wherein clients wait to resend a duplicate request to a backup _after_ request timeout is fired.

_Sending replies via the primary and a random backup increases ingress network bandwidth utilization on the client by 2x, but we decided that its a worthwhile price to pay for predictability in performance, even in the face of client → primary network partitions!_

