### PR TITLE
stdx: add stdx.windows 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1688,28 +1688,20 @@ fn strip_root_module(root_module: *std.Build.Module) void {
 fn set_windows_dll(allocator: std.mem.Allocator, java_home: []const u8) void {
     comptime assert(builtin.os.tag == .windows);
 
-    // Declaring the function with an alternative name because `CamelCase` functions are
-    // by convention, used for building generic types.
-    const set_dll_directory = @extern(
-        *const fn (path: [*:0]const u8) callconv(.C) std.os.windows.BOOL,
-        .{
-            .library_name = "kernel32",
-            .name = "SetDllDirectoryA",
-        },
-    );
-
     const java_bin_path = std.fs.path.joinZ(
         allocator,
         &.{ java_home, "\\bin" },
     ) catch unreachable;
-    _ = set_dll_directory(java_bin_path);
+    _ = SetDllDirectoryA(java_bin_path);
 
     const java_bin_server_path = std.fs.path.joinZ(
         allocator,
         &.{ java_home, "\\bin\\server" },
     ) catch unreachable;
-    _ = set_dll_directory(java_bin_server_path);
+    _ = SetDllDirectoryA(java_bin_server_path);
 }
+
+extern "kernel32" fn SetDllDirectoryA(path: [*:0]const u8) callconv(.C) std.os.windows.BOOL;
 
 fn print_or_install(b: *std.Build, compile: *std.Build.Step.Compile, print: bool) *std.Build.Step {
     const PrintStep = struct {

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -170,21 +170,7 @@ const Benchmark = struct {
             var kernel_time: std.os.windows.FILETIME = undefined;
             var user_time: std.os.windows.FILETIME = undefined;
 
-            const get_process_times = @extern(
-                *const fn (
-                    in_hProcess: std.os.windows.HANDLE,
-                    out_lpCreationTime: *std.os.windows.FILETIME,
-                    out_lpExitTime: *std.os.windows.FILETIME,
-                    out_lpKernelTime: *std.os.windows.FILETIME,
-                    out_lpUserTime: *std.os.windows.FILETIME,
-                ) callconv(std.os.windows.WINAPI) std.os.windows.BOOL,
-                .{
-                    .library_name = "kernel32",
-                    .name = "GetProcessTimes",
-                },
-            );
-
-            if (get_process_times(
+            if (stdx.windows.GetProcessTimes(
                 std.os.windows.kernel32.GetCurrentProcess(),
                 &creation_time,
                 &exit_time,

--- a/src/multiversioning.zig
+++ b/src/multiversioning.zig
@@ -1296,14 +1296,7 @@ pub const Multiversion = struct {
                 // That said, with how CreateProcessW is called, this should _never_ happen, since
                 // its both provided a full lpApplicationName, and because GetCommandLineW actually
                 // points to a copy of memory from the PEB.
-                const get_command_line_w = @extern(
-                    *const fn () callconv(.C) std.os.windows.LPWSTR,
-                    .{
-                        .library_name = "kernel32",
-                        .name = "GetCommandLineW",
-                    },
-                );
-                const cmd_line_w = get_command_line_w();
+                const cmd_line_w = stdx.windows.GetCommandLineW();
 
                 var lp_startup_info = std.mem.zeroes(std.os.windows.STARTUPINFOW);
                 lp_startup_info.cb = @sizeOf(std.os.windows.STARTUPINFOW);

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -18,6 +18,7 @@ pub const flags = @import("flags.zig").parse;
 pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
 pub const timeit = @import("debug.zig").timeit;
 pub const unshare = @import("unshare.zig");
+pub const windows = @import("windows.zig");
 
 // Import these as `const GiB = stdx.GiB;`
 pub const KiB = 1 << 10;

--- a/src/stdx/windows.zig
+++ b/src/stdx/windows.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const windows = std.os.windows;
+
+pub extern "kernel32" fn GetSystemTimePreciseAsFileTime(
+    lpFileTime: *windows.FILETIME,
+) callconv(.winapi) void;
+
+pub extern "kernel32" fn GetCommandLineW() callconv(.C) windows.LPWSTR;
+
+pub extern "kernel32" fn GetProcessTimes(
+    in_hProcess: windows.HANDLE,
+    out_lpCreationTime: *windows.FILETIME,
+    out_lpExitTime: *windows.FILETIME,
+    out_lpKernelTime: *windows.FILETIME,
+    out_lpUserTime: *windows.FILETIME,
+) callconv(.winapi) windows.BOOL;
+
+pub extern "kernel32" fn SetProcessWorkingSetSize(
+    hProcess: windows.HANDLE,
+    dwMinimumWorkingSetSize: windows.SIZE_T,
+    dwMaximumWorkingSetSize: windows.SIZE_T,
+) callconv(.winapi) windows.BOOL;
+
+pub extern "kernel32" fn GetProcessWorkingSetSize(
+    hProcess: windows.HANDLE,
+    lpMinimumWorkingSetSize: *windows.SIZE_T,
+    lpMaximumWorkingSetSize: *windows.SIZE_T,
+) callconv(.winapi) windows.BOOL;
+
+pub const LOCKFILE_EXCLUSIVE_LOCK = 0x2;
+pub const LOCKFILE_FAIL_IMMEDIATELY = 0x1;
+pub extern "kernel32" fn LockFileEx(
+    hFile: windows.HANDLE,
+    dwFlags: windows.DWORD,
+    dwReserved: windows.DWORD,
+    nNumberOfBytesToLockLow: windows.DWORD,
+    nNumberOfBytesToLockHigh: windows.DWORD,
+    lpOverlapped: ?*windows.OVERLAPPED,
+) callconv(.winapi) windows.BOOL;
+
+pub extern "kernel32" fn SetEndOfFile(
+    hFile: windows.HANDLE,
+) callconv(.winapi) windows.BOOL;

--- a/src/stdx/windows.zig
+++ b/src/stdx/windows.zig
@@ -5,7 +5,7 @@ pub extern "kernel32" fn GetSystemTimePreciseAsFileTime(
     lpFileTime: *windows.FILETIME,
 ) callconv(.winapi) void;
 
-pub extern "kernel32" fn GetCommandLineW() callconv(.C) windows.LPWSTR;
+pub extern "kernel32" fn GetCommandLineW() callconv(.winapi) windows.LPWSTR;
 
 pub extern "kernel32" fn GetProcessTimes(
     in_hProcess: windows.HANDLE,

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -363,7 +363,7 @@ fn tidy_dead_declarations(
                     }
                 } else {
                     switch (context_tag) {
-                        .keyword_inline => {},
+                        .keyword_inline, .keyword_extern, .string_literal => {},
                         // Public declaration can be used in a different file.
                         .keyword_pub, .keyword_export => continue :next_token,
                         // []const u8 or *const u8, not a declaration.

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -515,6 +515,9 @@ fn tidy_generic_functions(
                 const end = std.mem.indexOf(u8, line[begin..], "(") orelse continue;
                 if (end == 0) continue;
 
+                if (std.mem.indexOf(u8, line, "extern \"kernel32\"") != null) {
+                    continue; // Windows use CamelCase functions.
+                }
                 assert(begin + end < line.len);
                 break :function_name line[begin..][0..end];
             }

--- a/src/time.zig
+++ b/src/time.zig
@@ -157,18 +157,8 @@ pub const TimeOS = struct {
         // TODO(zig): Maybe use `std.time.nanoTimestamp()`.
         // https://github.com/ziglang/zig/pull/22871
         assert(is_windows);
-        const get_system_time_precise_as_file_time = @extern(
-            *const fn (
-                lpFileTime: *os.windows.FILETIME,
-            ) callconv(os.windows.WINAPI) void,
-            .{
-                .library_name = "kernel32",
-                .name = "GetSystemTimePreciseAsFileTime",
-            },
-        );
-
         var ft: os.windows.FILETIME = undefined;
-        get_system_time_precise_as_file_time(&ft);
+        stdx.windows.GetSystemTimePreciseAsFileTime(&ft);
         const ft64 = (@as(u64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
 
         // FileTime is in units of 100 nanoseconds


### PR DESCRIPTION
Windows API is comprised from syscalls proper, as well as from library
functions implemented on top of syscalls. Zig std generally prefers to
only link syscalls, and re-implement the library logic in Zig. However,
not all library functionality has appropriate wrappers, and we sometimes
would prefer to just call a dll function.

Use stdx to collect most of such wrappers. For simplicity, resort to
in-line extern declarations for cases which don't otherwise depend on
stdx.