### PR TITLE
References the `native` subfolder so external files required by CGO aren't pruned.

### DIFF
--- a/src/clients/go/.gitignore
+++ b/src/clients/go/.gitignore
@@ -8,8 +8,5 @@ zigcc*
 main
 main.exe
 
-pkg/native/aarch64-linux/
-pkg/native/aarch64-macos/
-pkg/native/x86_64-linux/
-pkg/native/x86_64-macos/
-pkg/native/x86_64-windows/
+pkg/native/*.a
+pkg/native/*.lib

--- a/src/clients/go/pkg/native/native.go
+++ b/src/clients/go/pkg/native/native.go
@@ -1,0 +1,4 @@
+// Adds reference to sub-folders containing the external (non-Go) files
+// required to build the TigerBeetle client. Otherwise the `tb_client.h`
+// header and library object files would be pruned during `go mod vendor`.
+package native

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -2,11 +2,11 @@ package tigerbeetle_go
 
 /*
 #cgo CFLAGS: -g -Wall
-#cgo darwin,arm64 LDFLAGS: ${SRCDIR}/pkg/native/aarch64-macos/libtb_client.a -ldl -lm
-#cgo darwin,amd64 LDFLAGS: ${SRCDIR}/pkg/native/x86_64-macos/libtb_client.a -ldl -lm
-#cgo linux,arm64 LDFLAGS: ${SRCDIR}/pkg/native/aarch64-linux/libtb_client.a -ldl -lm
-#cgo linux,amd64 LDFLAGS: ${SRCDIR}/pkg/native/x86_64-linux/libtb_client.a -ldl -lm
-#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/pkg/native/x86_64-windows -ltb_client -lws2_32 -lntdll
+#cgo darwin,arm64 LDFLAGS: ${SRCDIR}/pkg/native/libtb_client_aarch64-macos.a -ldl -lm
+#cgo darwin,amd64 LDFLAGS: ${SRCDIR}/pkg/native/libtb_client_x86_64-macos.a -ldl -lm
+#cgo linux,arm64 LDFLAGS: ${SRCDIR}/pkg/native/libtb_client_aarch64-linux.a -ldl -lm
+#cgo linux,amd64 LDFLAGS: ${SRCDIR}/pkg/native/libtb_client_x86_64-linux.a -ldl -lm
+#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/pkg/native -ltb_client_x86_64-windows -lws2_32 -lntdll
 
 #include <stdlib.h>
 #include <string.h>
@@ -34,6 +34,7 @@ import (
 	"unsafe"
 
 	"github.com/tigerbeetle/tigerbeetle-go/pkg/errors"
+	_ "github.com/tigerbeetle/tigerbeetle-go/pkg/native"
 	"github.com/tigerbeetle/tigerbeetle-go/pkg/types"
 )
 


### PR DESCRIPTION
Related: https://github.com/golang/go/issues/26366

We could remove the `native` folder and move all files to the root. See ["#including source files in subdirectories is a bad idea"](https://go-review.googlesource.com/c/go/+/125297/5/src/cmd/cgo/doc.go).

But we prefer to keep the root clean and minimal, so we embrace the `native` subfolder and declare a dummy package there to force references.

Additionally, now the compiled library carries the platform as part of the filename instead of using subfolders, avoiding the need to declare packages to force reference each subfolder.

Closes https://github.com/tigerbeetle/tigerbeetle/issues/3158
