### PR TITLE
zig: check error prone error check

### DIFF
--- a/src/lsm/zig_zag_merge.zig
+++ b/src/lsm/zig_zag_merge.zig
@@ -201,7 +201,12 @@ pub fn ZigZagMergeIteratorType(
                     // Probing the drained stream will update the key range for the next read.
                     stream_probe(it.context, @intCast(stream_index), probe_key);
                     // The stream must remain drained after probed.
-                    assert(stream_peek(it.context, @intCast(stream_index)) == error.Drained);
+                    if (stream_peek(it.context, @intCast(stream_index))) |_| {
+                        unreachable;
+                    } else |err| switch (err) {
+                        error.Drained => {},
+                        error.Empty => unreachable,
+                    }
                 } else {
                     // At this point, all the buffered streams must have produced a matching key.
                     assert(stream_peek(it.context, @intCast(stream_index)) catch {

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -203,6 +203,10 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
         return "use unqualified assert()";
     }
 
+    if (std.mem.indexOf(u8, source, "== error" ++ ".") != null) {
+        return "switch on error to avoid silent anyerror upcast";
+    }
+
     return null;
 }
 

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -239,11 +239,12 @@ pub const StatsD = struct {
                     format_metric(send_writer, stat, .{
                         .cluster = cluster,
                         .replica = replica,
-                    }) catch |err| {
+                    }) catch |err| switch (err) {
                         // This shouldn't ever happen, but don't allow metrics to kill the system.
-                        assert(err == error.NoSpaceLeft);
-                        log.err("{}: insufficient buffer space", .{self.process_id});
-                        break;
+                        error.NoSpaceLeft => {
+                            log.err("{}: insufficient buffer space", .{self.process_id});
+                            break;
+                        },
                     };
 
                     const send_position_after = send_stream.getPos() catch unreachable;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3136,12 +3136,12 @@ pub fn ReplicaType(
                     entry,
                     on_request_reply_read_callback,
                     message.header.replica,
-                ) catch |err| {
-                    assert(err == error.Busy);
-
-                    log.debug("{}: on_request_reply: ignoring, client_replies busy", .{
-                        self.log_prefix(),
-                    });
+                ) catch |err| switch (err) {
+                    error.Busy => {
+                        log.debug("{}: on_request_reply: ignoring, client_replies busy", .{
+                            self.log_prefix(),
+                        });
+                    },
                 };
             }
         }
@@ -6472,12 +6472,12 @@ pub fn ReplicaType(
                     entry,
                     on_request_repeat_reply_callback,
                     null,
-                ) catch |err| {
-                    assert(err == error.Busy);
-
-                    log.debug("{}: on_request: ignoring (client_replies busy)", .{
-                        self.log_prefix(),
-                    });
+                ) catch |err| switch (err) {
+                    error.Busy => {
+                        log.debug("{}: on_request: ignoring (client_replies busy)", .{
+                            self.log_prefix(),
+                        });
+                    },
                 };
             }
         }


### PR DESCRIPTION
`lhs == error.foo` is happy to cast `lhs` to anyerror, making the comparison insensitive to typos (or just normal code evolution). The following code compiles as of Zig 0.14.1

```zig
fn foo() error{Fail}!void {
    return error.Fail;
}

pub fn main() void {
    if (foo() == error.Pineapple) {
        // 😱
    }
}
```

Ban the pattern. Usage in zig_zag_merge does become noticeably worse, but this seems to be such a giant foot gun that that its worth to eat the verbosity

Hat tip to https://lubeno.dev/blog/rusts-productivity-curve