### PR TITLE
logs: add --log-trace and gate per event + tracing logs

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -80,6 +80,7 @@ const Environment = struct {
         .cache_entries_accounts = cache_entries_max,
         .cache_entries_transfers = cache_entries_max,
         .cache_entries_transfers_pending = cache_entries_max,
+        .log_trace = true,
     });
 
     const free_set_fragments_max = 2048;

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -144,7 +144,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     );
 
     const benchmark_result = try shell.exec_stdout(
-        "./tigerbeetle benchmark --validate --checksum-performance",
+        "./tigerbeetle benchmark --validate --checksum-performance --log-debug",
         .{},
     );
     const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -791,6 +791,7 @@ pub fn StateMachineType(
             cache_entries_accounts: u32,
             cache_entries_transfers: u32,
             cache_entries_transfers_pending: u32,
+            log_trace: bool,
         };
 
         /// Since prefetch contexts are used one at a time, it's safe to access
@@ -1007,6 +1008,7 @@ pub fn StateMachineType(
 
         /// Temporary metrics, until proper ones are merged.
         metrics: Metrics,
+        log_trace: bool,
 
         pub fn init(
             self: *StateMachine,
@@ -1033,6 +1035,8 @@ pub fn StateMachineType(
                 .metrics = .{
                     .timer = .init(time),
                 },
+
+                .log_trace = options.log_trace,
             };
 
             try self.forest.init(
@@ -1138,6 +1142,8 @@ pub fn StateMachineType(
                 .metrics = .{
                     .timer = self.metrics.timer,
                 },
+
+                .log_trace = self.log_trace,
             };
         }
 
@@ -3189,14 +3195,16 @@ pub fn StateMachineType(
                         else => comptime unreachable,
                     };
                 };
-                log.debug("{?}: {s} {}/{}: {}: {}", .{
-                    self.forest.grid.superblock.replica_index,
-                    @tagName(operation),
-                    index + 1,
-                    events.len,
-                    result,
-                    event,
-                });
+                if (self.log_trace) {
+                    log.debug("{?}: {s} {}/{}: {}: {}", .{
+                        self.forest.grid.superblock.replica_index,
+                        @tagName(operation),
+                        index + 1,
+                        events.len,
+                        result,
+                        event,
+                    });
+                }
                 if (result != .ok) {
                     if (chain) |chain_start_index| {
                         if (!chain_broken) {

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -95,6 +95,7 @@ pub const TestContext = struct {
                 .cache_entries_accounts = 0,
                 .cache_entries_transfers = 0,
                 .cache_entries_transfers_pending = 0,
+                .log_trace = true,
             },
         );
         errdefer ctx.state_machine.deinit(allocator);

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -341,8 +341,6 @@ pub fn log_with_timestamp(
     var buffered_writer = std.io.bufferedWriter(stderr);
     const writer = buffered_writer.writer();
 
-    std.debug.lockStdErr();
-    defer std.debug.unlockStdErr();
     nosuspend {
         date_time.format("", .{}, writer) catch return;
         writer.print(" " ++ level_text ++ scope_prefix ++ format ++ "\n", args) catch return;

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -82,6 +82,7 @@ const CLIArgs = union(enum) {
         memory_lsm_compaction: ?ByteSize = null,
         trace: ?[]const u8 = null,
         log_debug: bool = false,
+        log_trace: bool = false,
         timeout_prepare_ms: ?u64 = null,
         timeout_grid_repair_message_ms: ?u64 = null,
         commit_stall_probability: ?Ratio = null,
@@ -503,6 +504,7 @@ pub const Command = union(enum) {
         aof_file: ?Path,
         path: []const u8,
         log_debug: bool,
+        log_trace: bool,
         statsd: ?std.net.Address,
     };
 
@@ -1010,6 +1012,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         .aof_file = aof_file,
         .path = start.positional.path,
         .log_debug = start.log_debug,
+        .log_trace = start.log_trace,
         .statsd = if (start.statsd) |statsd_address|
             parse_address_and_port(statsd_address, "--statsd", 8125)
         else

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -964,6 +964,10 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         break :blk aof_file;
     } else null;
 
+    if (start.log_trace and !start.log_debug) {
+        vsr.fatal(.cli, "--log-debug must be provided when using --log-trace", .{});
+    }
+
     return .{
         .addresses = addresses,
         .addresses_zero = std.mem.eql(u8, start.addresses, "0"),

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -129,6 +129,8 @@ events_timing: []?EventTimingAggregate,
 
 time_start: stdx.Instant,
 
+log_trace: bool,
+
 pub const ProcessID = union(enum) {
     unknown,
     replica: struct {
@@ -168,6 +170,7 @@ pub const Options = struct {
             address: std.net.Address,
         },
     } = .log,
+    log_trace: bool = true,
 };
 
 pub fn init(
@@ -215,6 +218,8 @@ pub fn init(
         .events_timing = events_timing,
 
         .time_start = time.monotonic(),
+
+        .log_trace = options.log_trace,
     };
 }
 
@@ -269,10 +274,12 @@ pub fn start(tracer: *Tracer, event: Event) void {
     assert(tracer.events_started[stack] == null);
     tracer.events_started[stack] = time_now;
 
-    log.debug(
-        "{}: {s}({}): start: {}",
-        .{ tracer.process_id, @tagName(event), event_tracing, event_timing },
-    );
+    if (tracer.log_trace) {
+        log.debug(
+            "{}: {s}({}): start: {}",
+            .{ tracer.process_id, @tagName(event), event_tracing, event_timing },
+        );
+    }
 
     const writer = tracer.options.writer orelse return;
     const time_elapsed = time_now.duration_since(tracer.time_start);
@@ -328,17 +335,19 @@ pub fn stop(tracer: *Tracer, event: Event) void {
     tracer.events_started[stack] = null;
 
     // Double leading space to align with 'start: '.
-    log.debug("{}: {s}({}): stop:  {} (duration={}{s})", .{
-        tracer.process_id,
-        @tagName(event),
-        event_tracing,
-        event_timing,
-        if (event_duration.ns < us_log_threshold_ns)
-            event_duration.to_us()
-        else
-            event_duration.to_ms(),
-        if (event_duration.ns < us_log_threshold_ns) "us" else "ms",
-    });
+    if (tracer.log_trace) {
+        log.debug("{}: {s}({}): stop:  {} (duration={}{s})", .{
+            tracer.process_id,
+            @tagName(event),
+            event_tracing,
+            event_timing,
+            if (event_duration.ns < us_log_threshold_ns)
+                event_duration.to_us()
+            else
+                event_duration.to_ms(),
+            if (event_duration.ns < us_log_threshold_ns) "us" else "ms",
+        });
+    }
 
     tracer.timing(event_timing, event_duration);
 
@@ -351,7 +360,9 @@ pub fn cancel(tracer: *Tracer, event_tag: Event.Tag) void {
     const event_end = tracer.time.monotonic();
     for (stack_base..stack_base + cardinality) |stack| {
         if (tracer.events_started[stack]) |_| {
-            log.debug("{}: {s}: cancel", .{ tracer.process_id, @tagName(event_tag) });
+            if (tracer.log_trace) {
+                log.debug("{}: {s}: cancel", .{ tracer.process_id, @tagName(event_tag) });
+            }
 
             const event_duration = event_end.duration_since(tracer.time_start);
 

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -334,8 +334,8 @@ pub fn stop(tracer: *Tracer, event: Event) void {
     assert(tracer.events_started[stack] != null);
     tracer.events_started[stack] = null;
 
-    // Double leading space to align with 'start: '.
     if (tracer.log_trace) {
+        // Double leading space to align with 'start: '.
         log.debug("{}: {s}({}): stop:  {} (duration={}{s})", .{
             tracer.process_id,
             @tagName(event),

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -400,6 +400,7 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
                 .cache_entries_accounts = if (prng.boolean()) 256 else 0,
                 .cache_entries_transfers = if (prng.boolean()) 256 else 0,
                 .cache_entries_transfers_pending = if (prng.boolean()) 256 else 0,
+                .log_trace = true,
             },
         },
         .replicate_options = .{
@@ -526,6 +527,7 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {
                 .cache_entries_accounts = 256,
                 .cache_entries_transfers = 0,
                 .cache_entries_transfers_pending = 0,
+                .log_trace = true,
             },
         },
     };


### PR DESCRIPTION
Originally, I was looking at keeping an in-memory buffer of logs, so that if we panicked, we could dump debug logs even when running without them enabled. That led to a rabbit hole of "well, it would be nice to get said debug logs out while the process is running", and into the land of `memfd`s, `mmap` and `MAP_SHARED`.

Somehow, I managed to pull myself out of said hole, and figure out what we _actually_ want: the ability to run with debug logs always on in production.

The biggest problem were the two logs in 30ae3a1c1e143d58a6466a21619d07f89f1a62f9 - being extremely frequent (~ per transfer) and accounting for the vast majority of logs in debug mode.

By gating them behind a new flag, `--log-trace`, running with `--log-debug` is now fast enough to be enabled in production! Even without fancy tricks like using our event loop to write to `stderr` required! (Although, I'll leave that there for when @toziegler wants to gain an extra percent :smile:).

For full batches, the actual performance hit, running the benchmark on tmpfs, and redirecting stderr to tmpfs, is ~2%. 696f23176ea38aedac670b16bd6a416bbd63fa1e takes that down to just under ~1%. When running with the datafile on NVMe, the difference should be even less. For a batch size of 2, the hit is around ~5% on tmpfs and indistinguishable on NVMe.

Done as an explicit parameter and check, rather than overriding the entire logging library, or adding a new function and a global: I'm not sure we want to make adding new cases like this too easy!
