### PR TITLE
[Experimental] Expose `get_change_events` to the Go client

### DIFF
--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -210,6 +210,7 @@ fn EchoStateMachineType(comptime StateMachine: type) type {
         pub const operation_event_max = StateMachine.operation_event_max;
         pub const operation_result_max = StateMachine.operation_result_max;
         pub const operation_result_count_expected = StateMachine.operation_result_count_expected;
+        pub const operation_is_multi_batch = StateMachine.operation_is_multi_batch;
 
         // Re-exporting functions where results are equal to events.
         pub const ResultType = StateMachine.EventType;

--- a/src/clients/go/go_bindings.zig
+++ b/src/clients/go/go_bindings.zig
@@ -19,6 +19,9 @@ const type_mappings = .{
     .{ tb.AccountFilter, "AccountFilter" },
     .{ tb.AccountBalance, "AccountBalance" },
     .{ tb.QueryFilter, "QueryFilter" },
+    .{ tb.ChangeEvent, "ChangeEvent" },
+    .{ tb.ChangeEventType, "ChangeEventType", "ChangeEvent" },
+    .{ tb.ChangeEventsFilter, "ChangeEventsFilter" },
 };
 
 fn go_type(comptime Type: type) []const u8 {

--- a/src/clients/go/pkg/types/bindings.go
+++ b/src/clients/go/pkg/types/bindings.go
@@ -564,3 +564,75 @@ func (o QueryFilter) QueryFilterFlags() QueryFilterFlags {
 	f.Reversed = ((o.Flags >> 0) & 0x1) == 1
 	return f
 }
+
+type ChangeEvent struct {
+	TransferID                  Uint128
+	TransferAmount              Uint128
+	TransferPendingID           Uint128
+	TransferUserData128         Uint128
+	TransferUserData64          uint64
+	TransferUserData32          uint32
+	TransferTimeout             uint32
+	TransferCode                uint16
+	TransferFlags               uint16
+	Ledger                      uint32
+	Type                        ChangeEventType
+	Reserved                    [39]uint8
+	DebitAccountID              Uint128
+	DebitAccountDebitsPending   Uint128
+	DebitAccountDebitsPosted    Uint128
+	DebitAccountCreditsPending  Uint128
+	DebitAccountCreditsPosted   Uint128
+	DebitAccountUserData128     Uint128
+	DebitAccountUserData64      uint64
+	DebitAccountUserData32      uint32
+	DebitAccountCode            uint16
+	DebitAccountFlags           uint16
+	CreditAccountID             Uint128
+	CreditAccountDebitsPending  Uint128
+	CreditAccountDebitsPosted   Uint128
+	CreditAccountCreditsPending Uint128
+	CreditAccountCreditsPosted  Uint128
+	CreditAccountUserData128    Uint128
+	CreditAccountUserData64     uint64
+	CreditAccountUserData32     uint32
+	CreditAccountCode           uint16
+	CreditAccountFlags          uint16
+	Timestamp                   uint64
+	TransferTimestamp           uint64
+	DebitAccountTimestamp       uint64
+	CreditAccountTimestamp      uint64
+}
+
+type ChangeEventType uint8
+
+const (
+	ChangeEventSinglePhase     ChangeEventType = 0
+	ChangeEventTwoPhasePending ChangeEventType = 1
+	ChangeEventTwoPhasePosted  ChangeEventType = 2
+	ChangeEventTwoPhaseVoided  ChangeEventType = 3
+	ChangeEventTwoPhaseExpired ChangeEventType = 4
+)
+
+func (i ChangeEventType) String() string {
+	switch i {
+	case ChangeEventSinglePhase:
+		return "ChangeEventSinglePhase"
+	case ChangeEventTwoPhasePending:
+		return "ChangeEventTwoPhasePending"
+	case ChangeEventTwoPhasePosted:
+		return "ChangeEventTwoPhasePosted"
+	case ChangeEventTwoPhaseVoided:
+		return "ChangeEventTwoPhaseVoided"
+	case ChangeEventTwoPhaseExpired:
+		return "ChangeEventTwoPhaseExpired"
+	}
+	return "ChangeEventType(" + strconv.FormatInt(int64(i+1), 10) + ")"
+}
+
+type ChangeEventsFilter struct {
+	TimestampMin uint64
+	TimestampMax uint64
+	Limit        uint32
+	Reserved     [44]uint8
+}

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -1530,6 +1530,20 @@ func doTestClient(t *testing.T, client Client) {
 		}
 		assert.Len(t, query, 0)
 	})
+
+	t.Run("get change events", func(t *testing.T) {
+		t.Parallel()
+		filter := types.ChangeEventsFilter{
+			TimestampMin: 0,
+			TimestampMax: 0,
+			Limit:        10,
+		}
+		events, err := client.GetChangeEvents(filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, events, int(filter.Limit))
+	})
 }
 
 func doTestImportedFlag(t *testing.T, client Client) {


### PR DESCRIPTION
This PR adds support for `get_change_events` to the Go client: an **experimental and undocumented API** at this point.

The reason behind not fully supporting `get_change_events` to all clients is that this API is still subject to changes, as we might want to extend it to also notify `Account`s creation.