### PR TITLE
vsr: fix typo in assertion

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -10162,7 +10162,7 @@ pub fn ReplicaType(
             assert(!self.solo());
             assert(self.syncing == .updating_checkpoint);
             assert(self.superblock.working.vsr_state.checkpoint.header.op <
-                self.syncing.updating_checkpoint.header.checksum);
+                self.syncing.updating_checkpoint.header.op);
             assert(self.sync_tables == null);
             assert(self.commit_stage == .idle);
             assert(self.grid.read_global_queue.empty());


### PR DESCRIPTION
Really embarrassing, this one, introduced in
60b4b6fb7d694da48fb2816f633b9b9c567a5238 when
implementing
https://github.com/tigerbeetle/tigerbeetle/pull/1951#discussion_r1700429660