### PR TITLE
LSM: Remove empty function in KWayMerge (unused and prone to misuse).

### DIFF
--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -72,11 +72,6 @@ pub fn KWayMergeIteratorType(
             };
         }
 
-        pub fn empty(it: *const KWayMergeIterator) bool {
-            assert(it.state == .iterating);
-            return it.k == 0;
-        }
-
         pub fn reset(it: *KWayMergeIterator) void {
             it.* = .{
                 .context = it.context,


### PR DESCRIPTION
The function is unused and easy to misuse. 
Calling it immediately after `init()` triggers an assertion, since the iterator is not yet in the iterating state:
```zig
var k_way = KWay.init(..);
if(k_way.empty()){ // <- crashes here.
...
```

In all our use cases, exhaustion is checked via pop(), so empty() is unnecessary.