### PR TITLE
LSM: Skip sort step if mutable table is empty in absorb.

### DIFF
--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -170,6 +170,17 @@ pub fn TableMemoryType(comptime Table: type) type {
             assert(table_mutable.mutability == .mutable);
             maybe(table_mutable.value_context.sorted);
 
+            if (table_mutable.count() == 0) {
+                // Mutable table is empty so we can exit early.
+                table_mutable.reset();
+                table_immutable.mutability = .{ .immutable = .{
+                    .flushed = table_immutable.value_context.count == 0,
+                    .absorbed = true,
+                    .snapshot_min = snapshot_min,
+                } };
+                return;
+            }
+
             const values_count_limit = table_immutable.values.len;
             assert(values_count_limit == values_count_limit);
             assert(table_immutable.count() <= values_count_limit);


### PR DESCRIPTION
This PR skips the sort step in absorb when the mutable table is empty.

Normally, absorb merges the mutable table into the immutable table, then sorts and deduplicates the combined values. Currently, this process still runs even if the mutable table is empty. While the sort is not very expensive, since the sort algorithm exploits sorted runs, t is still unnecessary work. Skipping it saves roughly 1–2%.
