### PR TITLE
Preparation for Zig 0.15.1 (part 1 of many)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 const Query = std.Target.Query;
-const Mode = std.builtin.Mode;
 
 const config = @import("./src/config.zig");
 
@@ -173,8 +172,10 @@ pub fn build(b: *std.Build) !void {
     const tb_client_header = blk: {
         const tb_client_header_generator = b.addExecutable(.{
             .name = "tb_client_header",
-            .root_source_file = b.path("src/clients/c/tb_client_header.zig"),
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/clients/c/tb_client_header.zig"),
+                .target = b.graph.host,
+            }),
         });
         tb_client_header_generator.root_module.addImport("vsr", vsr_module);
         tb_client_header_generator.root_module.addOptions("vsr_options", vsr_options);
@@ -576,9 +577,11 @@ fn build_check(
 ) void {
     const tigerbeetle = b.addExecutable(.{
         .name = "tigerbeetle",
-        .root_source_file = b.path("src/tigerbeetle/main.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tigerbeetle/main.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
     tigerbeetle.root_module.addImport("stdx", options.stdx_module);
     tigerbeetle.root_module.addImport("vsr", options.vsr_module);
@@ -690,9 +693,11 @@ fn build_tigerbeetle_executable_multiversion(b: *std.Build, options: struct {
     // build_multiversion a custom step that would take care of packing several releases into one
     const build_multiversion_exe = b.addExecutable(.{
         .name = "build_multiversion",
-        .root_source_file = b.path("src/build_multiversion.zig"),
-        // Enable aes extensions for vsr.checksum on the host.
-        .target = resolve_target(b, null) catch @panic("unsupported host"),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/build_multiversion.zig"),
+            // Enable aes extensions for vsr.checksum on the host.
+            .target = resolve_target(b, null) catch @panic("unsupported host"),
+        }),
     });
     build_multiversion_exe.root_module.addImport("stdx", options.stdx_module);
     // Ideally, we should pass `vsr_options` here at runtime. Making them comptime
@@ -812,9 +817,11 @@ fn build_aof(
 ) void {
     const aof = b.addExecutable(.{
         .name = "aof",
-        .root_source_file = b.path("src/aof.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/aof.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
     aof.root_module.addImport("stdx", options.stdx_module);
     aof.root_module.addOptions("vsr_options", options.vsr_options);
@@ -844,16 +851,20 @@ fn build_test(
 ) !void {
     const stdx_unit_tests = b.addTest(.{
         .name = "test-stdx",
-        .root_source_file = b.path("src/stdx/stdx.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/stdx/stdx.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
         .filters = b.args orelse &.{},
     });
     const unit_tests = b.addTest(.{
         .name = "test-unit",
-        .root_source_file = b.path("src/unit_tests.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/unit_tests.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
         .filters = b.args orelse &.{},
     });
     unit_tests.root_module.addImport("stdx", options.stdx_module);
@@ -953,9 +964,11 @@ fn build_test_integration(
     integration_tests_options.addOptionPath("vortex_exe", vortex_exe);
     const integration_tests = b.addTest(.{
         .name = "test-integration",
-        .root_source_file = b.path("src/integration_tests.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/integration_tests.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
         .filters = b.args orelse &.{},
     });
     integration_tests.root_module.addImport("stdx", options.stdx_module);
@@ -994,14 +1007,16 @@ fn build_test_jni(
     });
 
     const tests = b.addTest(.{
-        .root_source_file = b.path("src/clients/java/src/jni_tests.zig"),
-        .target = options.target,
-        // TODO(zig): The function `JNI_CreateJavaVM` tries to detect
-        // the stack size and causes a SEGV that is handled by Zig's panic handler.
-        // https://bugzilla.redhat.com/show_bug.cgi?id=1572811#c7
-        //
-        // The workaround is run the tests in "ReleaseFast" mode.
-        .optimize = if (builtin.os.tag == .windows) .ReleaseFast else options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/java/src/jni_tests.zig"),
+            .target = options.target,
+            // TODO(zig): The function `JNI_CreateJavaVM` tries to detect
+            // the stack size and causes a SEGV that is handled by Zig's panic handler.
+            // https://bugzilla.redhat.com/show_bug.cgi?id=1572811#c7
+            //
+            // The workaround is run the tests in "ReleaseFast" mode.
+            .optimize = if (builtin.os.tag == .windows) .ReleaseFast else options.mode,
+        }),
     });
     tests.linkLibC();
 
@@ -1064,10 +1079,12 @@ fn build_vopr(
 
     const vopr = b.addExecutable(.{
         .name = "vopr",
-        .root_source_file = b.path("src/vopr.zig"),
-        .target = options.target,
-        // When running without a SEED, default to release.
-        .optimize = if (b.args == null) .ReleaseSafe else options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/vopr.zig"),
+            .target = options.target,
+            // When running without a SEED, default to release.
+            .optimize = if (b.args == null) .ReleaseSafe else options.mode,
+        }),
     });
     vopr.stack_size = 4 * MiB;
     vopr.root_module.addImport("stdx", options.stdx_module);
@@ -1098,9 +1115,11 @@ fn build_fuzz(
 ) void {
     const fuzz_exe = b.addExecutable(.{
         .name = "fuzz",
-        .root_source_file = b.path("src/fuzz_tests.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/fuzz_tests.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
     fuzz_exe.stack_size = 4 * MiB;
     fuzz_exe.root_module.addImport("stdx", options.stdx_module);
@@ -1127,9 +1146,11 @@ fn build_scripts(
 ) *std.Build.Step.Compile {
     const scripts_exe = b.addExecutable(.{
         .name = "scripts",
-        .root_source_file = b.path("src/scripts.zig"),
-        .target = options.target,
-        .optimize = .Debug,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/scripts.zig"),
+            .target = options.target,
+            .optimize = .Debug,
+        }),
     });
     scripts_exe.root_module.addImport("stdx", options.stdx_module);
     scripts_exe.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1157,11 +1178,14 @@ fn build_vortex(
         mode: std.builtin.OptimizeMode,
     },
 ) std.Build.LazyPath {
-    const tb_client = b.addStaticLibrary(.{
+    const tb_client = b.addLibrary(.{
         .name = "tb_client",
-        .root_source_file = b.path("src/tigerbeetle/libtb_client.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tigerbeetle/libtb_client.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
     tb_client.linkLibC();
     tb_client.pie = true;
@@ -1175,13 +1199,14 @@ fn build_vortex(
 
     const vortex = b.addExecutable(.{
         .name = "vortex",
-        .root_source_file = b.path("src/vortex.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/vortex.zig"),
+            .omit_frame_pointer = false,
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
     vortex.root_module.addImport("stdx", options.stdx_module);
-
-    vortex.root_module.omit_frame_pointer = false;
     vortex.linkLibC();
     vortex.linkLibrary(tb_client);
     vortex.addIncludePath(options.tb_client_header.dirname());
@@ -1218,13 +1243,15 @@ fn build_rust_client(
     options: struct {
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     const rust_bindings_generator = b.addExecutable(.{
         .name = "rust_bindings",
-        .root_source_file = b.path("src/clients/rust/rust_bindings.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/rust/rust_bindings.zig"),
+            .target = b.graph.host,
+        }),
     });
     rust_bindings_generator.root_module.addImport("vsr", options.vsr_module);
     rust_bindings_generator.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1243,7 +1270,7 @@ fn build_go_client(
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
         tb_client_header: std.Build.LazyPath,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     // Updates the generated header file:
@@ -1254,8 +1281,10 @@ fn build_go_client(
 
     const go_bindings_generator = b.addExecutable(.{
         .name = "go_bindings",
-        .root_source_file = b.path("src/clients/go/go_bindings.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/go/go_bindings.zig"),
+            .target = b.graph.host,
+        }),
     });
     go_bindings_generator.root_module.addImport("vsr", options.vsr_module);
     go_bindings_generator.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1292,8 +1321,9 @@ fn build_go_client(
         root_module.addOptions("vsr_options", options.vsr_options);
         if (options.mode == .ReleaseSafe) strip_root_module(root_module);
 
-        const lib = b.addStaticLibrary(.{
+        const lib = b.addLibrary(.{
             .name = "tb_client",
+            .linkage = .static,
             .root_module = root_module,
         });
         lib.linkLibC();
@@ -1326,13 +1356,15 @@ fn build_java_client(
     options: struct {
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     const java_bindings_generator = b.addExecutable(.{
         .name = "java_bindings",
-        .root_source_file = b.path("src/clients/java/java_bindings.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/java/java_bindings.zig"),
+            .target = b.graph.host,
+        }),
     });
     java_bindings_generator.root_module.addImport("vsr", options.vsr_module);
     java_bindings_generator.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1357,8 +1389,9 @@ fn build_java_client(
         root_module.addOptions("vsr_options", options.vsr_options);
         if (options.mode == .ReleaseSafe) strip_root_module(root_module);
 
-        const lib = b.addSharedLibrary(.{
+        const lib = b.addLibrary(.{
             .name = "tb_jniclient",
+            .linkage = .dynamic,
             .root_module = root_module,
         });
         lib.linkLibC();
@@ -1383,13 +1416,15 @@ fn build_dotnet_client(
     options: struct {
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     const dotnet_bindings_generator = b.addExecutable(.{
         .name = "dotnet_bindings",
-        .root_source_file = b.path("src/clients/dotnet/dotnet_bindings.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/dotnet/dotnet_bindings.zig"),
+            .target = b.graph.host,
+        }),
     });
     dotnet_bindings_generator.root_module.addImport("vsr", options.vsr_module);
     dotnet_bindings_generator.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1414,7 +1449,11 @@ fn build_dotnet_client(
         root_module.addOptions("vsr_options", options.vsr_options);
         if (options.mode == .ReleaseSafe) strip_root_module(root_module);
 
-        const lib = b.addSharedLibrary(.{ .name = "tb_client", .root_module = root_module });
+        const lib = b.addLibrary(.{
+            .name = "tb_client",
+            .linkage = .dynamic,
+            .root_module = root_module,
+        });
         lib.linkLibC();
         if (resolved_target.result.os.tag == .windows) {
             lib.linkSystemLibrary("ws2_32");
@@ -1437,13 +1476,15 @@ fn build_node_client(
     options: struct {
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     const node_bindings_generator = b.addExecutable(.{
         .name = "node_bindings",
-        .root_source_file = b.path("src/clients/node/node_bindings.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/node/node_bindings.zig"),
+            .target = b.graph.host,
+        }),
     });
     node_bindings_generator.root_module.addImport("vsr", options.vsr_module);
     node_bindings_generator.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1503,8 +1544,9 @@ fn build_node_client(
         root_module.addOptions("vsr_options", options.vsr_options);
         if (options.mode == .ReleaseSafe) strip_root_module(root_module);
 
-        const lib = b.addSharedLibrary(.{
+        const lib = b.addLibrary(.{
             .name = "tb_nodeclient",
+            .linkage = .dynamic,
             .root_module = root_module,
         });
         lib.linkLibC();
@@ -1538,13 +1580,15 @@ fn build_python_client(
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
         tb_client_header: std.Build.LazyPath,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     const python_bindings_generator = b.addExecutable(.{
         .name = "python_bindings",
-        .root_source_file = b.path("src/clients/python/python_bindings.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/clients/python/python_bindings.zig"),
+            .target = b.graph.host,
+        }),
     });
     python_bindings_generator.root_module.addImport("vsr", options.vsr_module);
     python_bindings_generator.root_module.addOptions("vsr_options", options.vsr_options);
@@ -1569,7 +1613,11 @@ fn build_python_client(
         root_module.addOptions("vsr_options", options.vsr_options);
         if (options.mode == .ReleaseSafe) strip_root_module(root_module);
 
-        const shared_lib = b.addSharedLibrary(.{ .name = "tb_client", .root_module = root_module });
+        const shared_lib = b.addLibrary(.{
+            .name = "tb_client",
+            .linkage = .dynamic,
+            .root_module = root_module,
+        });
         shared_lib.linkLibC();
         if (resolved_target.result.os.tag == .windows) {
             shared_lib.linkSystemLibrary("ws2_32");
@@ -1596,7 +1644,7 @@ fn build_c_client(
         vsr_module: *std.Build.Module,
         vsr_options: *std.Build.Step.Options,
         tb_client_header: *Generated,
-        mode: Mode,
+        mode: std.builtin.OptimizeMode,
     },
 ) void {
     step_clients_c.dependOn(&options.tb_client_header.step);
@@ -1617,13 +1665,15 @@ fn build_c_client(
         root_module.addOptions("vsr_options", options.vsr_options);
         if (options.mode == .ReleaseSafe) strip_root_module(root_module);
 
-        const shared_lib = b.addSharedLibrary(.{
+        const shared_lib = b.addLibrary(.{
             .name = "tb_client",
+            .linkage = .dynamic,
             .root_module = root_module,
         });
 
-        const static_lib = b.addStaticLibrary(.{
+        const static_lib = b.addLibrary(.{
             .name = "tb_client",
+            .linkage = .static,
             .root_module = root_module,
         });
         static_lib.bundle_compiler_rt = true;
@@ -1655,11 +1705,14 @@ fn build_clients_c_sample(
         mode: std.builtin.OptimizeMode,
     },
 ) void {
-    const static_lib = b.addStaticLibrary(.{
+    const static_lib = b.addLibrary(.{
         .name = "tb_client",
-        .root_source_file = b.path("src/tigerbeetle/libtb_client.zig"),
-        .target = options.target,
-        .optimize = options.mode,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tigerbeetle/libtb_client.zig"),
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
     static_lib.linkLibC();
     static_lib.pie = true;
@@ -1670,10 +1723,12 @@ fn build_clients_c_sample(
 
     const sample = b.addExecutable(.{
         .name = "c_sample",
-        .target = options.target,
-        .optimize = options.mode,
+        .root_module = b.createModule(.{
+            .target = options.target,
+            .optimize = options.mode,
+        }),
     });
-    sample.addCSourceFile(.{
+    sample.root_module.addCSourceFile(.{
         .file = b.path("src/clients/c/samples/main.c"),
     });
     sample.linkLibrary(static_lib);
@@ -2017,39 +2072,41 @@ fn fetch(b: *std.Build, options: struct {
 }) std.Build.LazyPath {
     const copy_from_cache = b.addRunArtifact(b.addExecutable(.{
         .name = "copy-from-cache",
-        .root_source_file = b.addWriteFiles().add("main.zig",
-            \\const builtin = @import("builtin");
-            \\const std = @import("std");
-            \\const assert = std.debug.assert;
-            \\
-            \\pub fn main() !void {
-            \\    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-            \\    const allocator = arena.allocator();
-            \\    const args = try std.process.argsAlloc(allocator);
-            \\    assert(args.len == 5 or args.len == 6);
-            \\
-            \\    const hash_and_newline = try std.fs.cwd().readFileAlloc(allocator, args[2], 128);
-            \\    assert(hash_and_newline[hash_and_newline.len - 1] == '\n');
-            \\    const hash = hash_and_newline[0 .. hash_and_newline.len - 1];
-            \\    if (args.len == 6 and !std.mem.eql(u8, args[5], hash)) {
-            \\        std.debug.panic(
-            \\            \\bad hash
-            \\            \\specified:  {s}
-            \\            \\downloaded: {s}
-            \\            \\
-            \\        , .{ args[5], hash });
-            \\    }
-            \\
-            \\    const source_path = try std.fs.path.join(allocator, &.{ args[1], hash, args[3] });
-            \\    try std.fs.cwd().copyFile(
-            \\        source_path,
-            \\        std.fs.cwd(),
-            \\        args[4],
-            \\        .{},
-            \\    );
-            \\}
-        ),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.addWriteFiles().add("main.zig",
+                \\const builtin = @import("builtin");
+                \\const std = @import("std");
+                \\const assert = std.debug.assert;
+                \\
+                \\pub fn main() !void {
+                \\    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+                \\    const allocator = arena.allocator();
+                \\    const args = try std.process.argsAlloc(allocator);
+                \\    assert(args.len == 5 or args.len == 6);
+                \\
+                \\    const hash_and_newline = try std.fs.cwd().readFileAlloc(allocator, args[2], 128);
+                \\    assert(hash_and_newline[hash_and_newline.len - 1] == '\n');
+                \\    const hash = hash_and_newline[0 .. hash_and_newline.len - 1];
+                \\    if (args.len == 6 and !std.mem.eql(u8, args[5], hash)) {
+                \\        std.debug.panic(
+                \\            \\bad hash
+                \\            \\specified:  {s}
+                \\            \\downloaded: {s}
+                \\            \\
+                \\        , .{ args[5], hash });
+                \\    }
+                \\
+                \\    const source_path = try std.fs.path.join(allocator, &.{ args[1], hash, args[3] });
+                \\    try std.fs.cwd().copyFile(
+                \\        source_path,
+                \\        std.fs.cwd(),
+                \\        args[4],
+                \\        .{},
+                \\    );
+                \\}
+            ),
+            .target = b.graph.host,
+        }),
     }));
     copy_from_cache.addArg(
         b.graph.global_cache_root.join(b.allocator, &.{"p"}) catch @panic("OOM"),

--- a/src/cdc/amqp/protocol.zig
+++ b/src/cdc/amqp/protocol.zig
@@ -414,9 +414,9 @@ pub const Decoder = struct {
 pub const Encoder = struct {
     pub const FrameHeader = struct {
         /// Total size in bytes including the `size` field.
-        pub const size_total = @sizeOf(std.meta.FieldType(Decoder.FrameHeader, .type)) +
-            @sizeOf(std.meta.FieldType(Decoder.FrameHeader, .channel)) +
-            @sizeOf(std.meta.FieldType(Decoder.FrameHeader, .size));
+        pub const size_total = @sizeOf(@FieldType(Decoder.FrameHeader, "type")) +
+            @sizeOf(@FieldType(Decoder.FrameHeader, "channel")) +
+            @sizeOf(@FieldType(Decoder.FrameHeader, "size"));
 
         type: FrameType,
         channel: Channel,
@@ -424,9 +424,9 @@ pub const Encoder = struct {
 
     pub const Header = struct {
         /// Total size in bytes including the `body_size` field.
-        pub const size_total = @sizeOf(std.meta.FieldType(Decoder.Header, .class)) +
-            @sizeOf(std.meta.FieldType(Decoder.Header, .weight)) +
-            @sizeOf(std.meta.FieldType(Decoder.Header, .body_size));
+        pub const size_total = @sizeOf(@FieldType(Decoder.Header, "class")) +
+            @sizeOf(@FieldType(Decoder.Header, "weight")) +
+            @sizeOf(@FieldType(Decoder.Header, "body_size"));
 
         class: u16,
         weight: u16,
@@ -904,7 +904,7 @@ test "amqp: BasicProperties property_flags" {
             var properties: BasicProperties = .{};
             switch (set_field) {
                 inline else => |field| {
-                    const Field = std.meta.Child(std.meta.FieldType(BasicProperties, field));
+                    const Field = std.meta.Child(@FieldType(BasicProperties, @tagName(field)));
                     @field(properties, @tagName(field)) = switch (Field) {
                         []const u8 => "",
                         DeliveryMode => .persistent,
@@ -1116,7 +1116,7 @@ const TestingTable = struct {
             const entry_field = std.meta.stringToEnum(FieldEnum, entry.key).?;
             switch (entry_field) {
                 inline else => |field| {
-                    const Field = std.meta.FieldType(TestingTable, field);
+                    const Field = @FieldType(TestingTable, @tagName(field));
                     @field(object, @tagName(field)) = switch (std.meta.Child(Field)) {
                         bool => entry.value.boolean,
                         []const u8 => entry.value.string,

--- a/src/clients/java/src/jni_thread_cleaner.zig
+++ b/src/clients/java/src/jni_thread_cleaner.zig
@@ -165,7 +165,7 @@ test "JNIThreadCleaner:tls" {
         fn destructor_callback(tls_value: *anyopaque) callconv(.C) void {
             assert(tls_key != null);
 
-            const self: *TestContext = @alignCast(@ptrCast(tls_value));
+            const self: *TestContext = @ptrCast(@alignCast(tls_value));
             _ = self.counter.fetchAdd(1, .monotonic);
         }
     };

--- a/src/counting_allocator.zig
+++ b/src/counting_allocator.zig
@@ -32,13 +32,13 @@ pub fn live_size(self: *CountingAllocator) u64 {
 }
 
 fn alloc(ctx: *anyopaque, len: usize, ptr_align: Alignment, ret_addr: usize) ?[*]u8 {
-    const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
+    const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
     self.alloc_size += len;
     return self.parent_allocator.rawAlloc(len, ptr_align, ret_addr);
 }
 
 fn resize(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_addr: usize) bool {
-    const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
+    const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
 
     if (self.parent_allocator.rawResize(buf, buf_align, new_len, ret_addr)) {
         if (new_len > buf.len) {
@@ -53,7 +53,7 @@ fn resize(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_
 }
 
 fn remap(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
-    const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
+    const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
     if (self.parent_allocator.rawRemap(buf, buf_align, new_len, ret_addr)) |remapped| {
         if (new_len > buf.len) {
             self.alloc_size += new_len - buf.len;
@@ -66,7 +66,7 @@ fn remap(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_a
 }
 
 fn free(ctx: *anyopaque, buf: []u8, buf_align: Alignment, ret_addr: usize) void {
-    const self: *CountingAllocator = @alignCast(@ptrCast(ctx));
+    const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
     self.free_size += buf.len;
     return self.parent_allocator.rawFree(buf, buf_align, ret_addr);
 }

--- a/src/list.zig
+++ b/src/list.zig
@@ -13,11 +13,11 @@ pub fn DoublyLinkedListType(
 ) type {
     assert(@typeInfo(Node) == .@"struct");
     assert(field_back_enum != field_next_enum);
-    assert(std.meta.FieldType(Node, field_back_enum) == ?*Node);
-    assert(std.meta.FieldType(Node, field_next_enum) == ?*Node);
 
     const field_back = @tagName(field_back_enum);
     const field_next = @tagName(field_next_enum);
+    assert(@FieldType(Node, field_back) == ?*Node);
+    assert(@FieldType(Node, field_next) == ?*Node);
 
     return struct {
         const DoublyLinkedList = @This();

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -96,7 +96,7 @@ pub fn is_composite_key(comptime Value: type) bool {
         @hasField(Value, "field") and
         @hasField(Value, "timestamp"))
     {
-        const Field = std.meta.FieldType(Value, .field);
+        const Field = @FieldType(Value, "field");
         return switch (Field) {
             void, u64, u128 => Value == CompositeKeyType(Field),
             else => false,

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -386,7 +386,7 @@ const Environment = struct {
     }
 
     fn ScannerIndexType(comptime index: std.meta.FieldEnum(GrooveAccounts.IndexTrees)) type {
-        const Tree = std.meta.fieldInfo(GrooveAccounts.IndexTrees, index).type;
+        const Tree = @FieldType(GrooveAccounts.IndexTrees, @tagName(index));
         const Value = Tree.Table.Value;
         const Index = GrooveAccounts.IndexTreeFieldHelperType(@tagName(index)).Index;
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -23,7 +23,7 @@ const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 fn ObjectTreeHelperType(comptime Object: type) type {
     assert(@hasField(Object, "timestamp"));
-    assert(std.meta.fieldInfo(Object, .timestamp).type == u64);
+    assert(@FieldType(Object, "timestamp") == u64);
 
     return struct {
         inline fn key_from_value(value: *const Object) u64 {
@@ -178,11 +178,11 @@ pub fn GrooveType(
     @setEvalBranchQuota(64_000);
 
     const has_id = @hasField(Object, "id");
-    comptime if (has_id) assert(std.meta.FieldType(Object, .id) == u128);
+    comptime if (has_id) assert(@FieldType(Object, "id") == u128);
     comptime if (groove_options.orphaned_ids) assert(has_id);
 
     assert(@hasField(Object, "timestamp"));
-    assert(std.meta.FieldType(Object, .timestamp) == u64);
+    assert(@FieldType(Object, "timestamp") == u64);
 
     comptime var index_fields: []const std.builtin.Type.StructField = &.{};
 
@@ -1088,7 +1088,7 @@ pub fn GrooveType(
 
                 pub const Field = std.meta.FieldEnum(LookupContext);
                 pub fn FieldType(comptime field: Field) type {
-                    return std.meta.fieldInfo(LookupContext, field).type;
+                    return @FieldType(LookupContext, @tagName(field));
                 }
 
                 pub inline fn parent(

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -265,17 +265,17 @@ pub fn ScanBuilderType(
         }
 
         fn CompositeKeyType(comptime index: std.meta.FieldEnum(Groove.IndexTrees)) type {
-            const IndexTree = std.meta.fieldInfo(Groove.IndexTrees, index).type;
+            const IndexTree = @FieldType(Groove.IndexTrees, @tagName(index));
             return IndexTree.Table.Value;
         }
 
         fn CompositeKeyPrefixType(comptime index: std.meta.FieldEnum(Groove.IndexTrees)) type {
             const CompositeKey = CompositeKeyType(index);
-            return std.meta.fieldInfo(CompositeKey, .field).type;
+            return @FieldType(CompositeKey, "field");
         }
 
         fn ScanImplType(comptime field: std.meta.FieldEnum(Scan.Dispatcher)) type {
-            return std.meta.fieldInfo(Scan.Dispatcher, field).type;
+            return @FieldType(Scan.Dispatcher, @tagName(field));
         }
 
         fn key_from_value(
@@ -522,7 +522,7 @@ pub fn ScanType(
 
         inline fn parent(
             comptime field: std.meta.FieldEnum(Dispatcher),
-            impl: *std.meta.FieldType(Dispatcher, field),
+            impl: *@FieldType(Dispatcher, @tagName(field)),
         ) *Scan {
             const dispatcher: *Dispatcher = @alignCast(@fieldParentPtr(
                 @tagName(field),

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const mem = std.mem;
-const meta = std.meta;
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
@@ -863,8 +862,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             read: *Grid.Read,
             index_block: BlockPtrConst,
         ) void {
-            const State = std.meta.FieldType(ScanTreeLevel, .state);
-            const LoadingIndex = std.meta.FieldType(State, .loading_index);
+            const State = @FieldType(ScanTreeLevel, "state");
+            const LoadingIndex = @FieldType(State, "loading_index");
             const loading_index: *LoadingIndex = @fieldParentPtr("read", read);
             const state: *State = @fieldParentPtr("loading_index", loading_index);
             const self: *ScanTreeLevel = @fieldParentPtr("state", state);
@@ -958,9 +957,9 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             iterator: *TableValueIterator,
             value_block: BlockPtrConst,
         ) void {
-            const State = std.meta.FieldType(ScanTreeLevel, .state);
-            const Iterating = std.meta.FieldType(State, .iterating);
-            const IteratingValues = std.meta.FieldType(Iterating, .values);
+            const State = @FieldType(ScanTreeLevel, "state");
+            const Iterating = @FieldType(State, "iterating");
+            const IteratingValues = @FieldType(Iterating, "values");
             const iterating_values: *IteratingValues = @fieldParentPtr("iterator", iterator);
             const iterating: *Iterating = @fieldParentPtr("values", iterating_values);
             const state: *State = @fieldParentPtr("iterating", iterating);
@@ -1022,8 +1021,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
         }
 
         fn finished_callback(next_tick: *Grid.NextTick) void {
-            const State = std.meta.FieldType(ScanTreeLevel, .state);
-            const Finished = std.meta.FieldType(State, .finished);
+            const State = @FieldType(ScanTreeLevel, "state");
+            const Finished = @FieldType(State, "finished");
             const finished: *Finished = @fieldParentPtr("next_tick", next_tick);
             const state: *State = @alignCast(@fieldParentPtr("finished", finished));
             const self: *ScanTreeLevel = @fieldParentPtr("state", state);

--- a/src/message_buffer.zig
+++ b/src/message_buffer.zig
@@ -139,7 +139,7 @@ pub const MessageBuffer = struct {
 
         // Check that command is valid without materializing invalid Zig enum value.
         comptime assert(@sizeOf(vsr.Command) == @sizeOf(u8) and
-            std.meta.FieldType(Header, .command) == vsr.Command);
+            @FieldType(Header, "command") == vsr.Command);
         const command_raw: u8 = header_bytes[@offsetOf(Header, "command")];
         _ = std.meta.intToEnum(vsr.Command, command_raw) catch {
             vsr.fatal(

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -135,7 +135,7 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                 .client => @as(u64, @truncate(process_id.client)),
             };
 
-            const process: std.meta.FieldType(MessageBus, .process) = switch (process_type) {
+            const process: @FieldType(MessageBus, "process") = switch (process_type) {
                 .replica => blk: {
                     const address = options.configuration[process_id.replica];
                     const fd = try init_tcp(options.io, address.any.family);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -803,7 +803,7 @@ pub fn StateMachineType(
 
             pub const Field = std.meta.FieldEnum(PrefetchContext);
             pub fn FieldType(comptime field: Field) type {
-                return std.meta.fieldInfo(PrefetchContext, field).type;
+                return @FieldType(PrefetchContext, @tagName(field));
             }
 
             pub fn parent(
@@ -839,7 +839,7 @@ pub fn StateMachineType(
 
             pub const Field = std.meta.FieldEnum(ScanLookup);
             pub fn FieldType(comptime field: Field) type {
-                return std.meta.fieldInfo(ScanLookup, field).type;
+                return @FieldType(ScanLookup, @tagName(field));
             }
 
             pub fn parent(
@@ -4780,7 +4780,7 @@ fn ExpirePendingTransfersType(
         const EvaluateNext = @import("lsm/scan_range.zig").EvaluateNext;
         const ScanLookupStatus = @import("lsm/scan_lookup.zig").ScanLookupStatus;
 
-        const Tree = std.meta.FieldType(TransfersGroove.IndexTrees, .expires_at);
+        const Tree = @FieldType(TransfersGroove.IndexTrees, "expires_at");
         const Value = Tree.Table.Value;
 
         // TODO(zig) Context should be `*ExpirePendingTransfers`,

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -874,7 +874,7 @@ pub fn IteratorForCreateType(comptime Result: type) type {
         pub fn take(
             self: *IteratorForCreate,
             event_index: usize,
-        ) ?std.meta.fieldInfo(Result, .result).type {
+        ) ?@FieldType(Result, "result") {
             if (self.results.len > 0 and self.results[0].index == event_index) {
                 defer self.results = self.results[1..];
                 return self.results[0].result;

--- a/src/static_allocator.zig
+++ b/src/static_allocator.zig
@@ -56,25 +56,25 @@ pub fn allocator(self: *StaticAllocator) mem.Allocator {
 }
 
 fn alloc(ctx: *anyopaque, len: usize, ptr_align: Alignment, ret_addr: usize) ?[*]u8 {
-    const self: *StaticAllocator = @alignCast(@ptrCast(ctx));
+    const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
     assert(self.state == .init);
     return self.parent_allocator.rawAlloc(len, ptr_align, ret_addr);
 }
 
 fn resize(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_addr: usize) bool {
-    const self: *StaticAllocator = @alignCast(@ptrCast(ctx));
+    const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
     assert(self.state == .init);
     return self.parent_allocator.rawResize(buf, buf_align, new_len, ret_addr);
 }
 
 fn remap(ctx: *anyopaque, buf: []u8, buf_align: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
-    const self: *StaticAllocator = @alignCast(@ptrCast(ctx));
+    const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
     assert(self.state == .init);
     return self.parent_allocator.rawRemap(buf, buf_align, new_len, ret_addr);
 }
 
 fn free(ctx: *anyopaque, buf: []u8, buf_align: Alignment, ret_addr: usize) void {
-    const self: *StaticAllocator = @alignCast(@ptrCast(ctx));
+    const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
     assert(self.state == .init or self.state == .deinit);
     // Once you start freeing, you don't stop.
     self.state = .deinit;

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -120,7 +120,7 @@ pub const Event = union(enum) {
         @setEvalBranchQuota(32_000);
         return switch (event.*) {
             inline else => |source_payload, tag| {
-                const TargetPayload = std.meta.fieldInfo(EventType, tag).type;
+                const TargetPayload = @FieldType(EventType, @tagName(tag));
                 const target_payload_info = @typeInfo(TargetPayload);
                 assert(target_payload_info == .void or target_payload_info == .@"struct");
 

--- a/src/vsr/multi_batch.zig
+++ b/src/vsr/multi_batch.zig
@@ -468,7 +468,7 @@ pub const MultiBatchEncoder = struct {
             TrailerItem.padding,
         );
 
-        const postamble: *Postamble = @alignCast(@ptrCast(
+        const postamble: *Postamble = @ptrCast(@alignCast(
             buffer[self.buffer_index + padding + trailer_size - @sizeOf(Postamble) ..],
         ));
         postamble.* = .{
@@ -623,7 +623,7 @@ test "batch: invalid format" {
         .{ .element_size = element_size / 2 },
     ));
 
-    const postamble: *Postamble = @alignCast(@ptrCast(
+    const postamble: *Postamble = @ptrCast(@alignCast(
         buffer[bytes_written - @sizeOf(Postamble) ..],
     ));
     postamble.batch_count = batch_count + 1;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4898,7 +4898,7 @@ pub fn ReplicaType(
         }
 
         fn commit_checkpoint_data_aof_callback(replica: *anyopaque) void {
-            const self: *Replica = @alignCast(@ptrCast(replica));
+            const self: *Replica = @ptrCast(@alignCast(replica));
             assert(self.commit_stage == .checkpoint_data);
             self.trace.stop(.replica_aof_checkpoint);
             self.commit_checkpoint_data_callback_join(.aof);
@@ -8527,9 +8527,9 @@ pub fn ReplicaType(
 
             const BitSet = stdx.BitSetType(128);
             comptime assert(BitSet.Word ==
-                std.meta.fieldInfo(Header.DoViewChange, .present_bitset).type);
+                @FieldType(Header.DoViewChange, "present_bitset"));
             comptime assert(BitSet.Word ==
-                std.meta.fieldInfo(Header.DoViewChange, .nack_bitset).type);
+                @FieldType(Header.DoViewChange, "nack_bitset"));
 
             // Collect nack and presence bits for the headers, so that the new primary can run CTRL
             // protocol to truncate uncommitted headers. When:

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2290,8 +2290,8 @@ const TestReplicas = struct {
     fn get(
         t: *const TestReplicas,
         comptime field: std.meta.FieldEnum(Cluster.Replica),
-    ) std.meta.fieldInfo(Cluster.Replica, field).type {
-        var value_all: ?std.meta.fieldInfo(Cluster.Replica, field).type = null;
+    ) @FieldType(Cluster.Replica, @tagName(field)) {
+        var value_all: ?@FieldType(Cluster.Replica, @tagName(field)) = null;
         for (t.replicas.const_slice()) |r| {
             const replica = &t.cluster.replicas[r];
             const value = @field(replica, @tagName(field));


### PR DESCRIPTION
- Refactored `build.zig` to remove deprecated API usage. https://ziglang.org/download/0.14.0/release-notes.html#Creating-Artifacts-from-Existing-Modules

- Replaced deprecated `std.meta.FieldType` with `@FieldType`. Also replaced `std.meta.fieldInfo(...).type` with `@FieldType`.

- Adopted canonical `@ptrCast(@alignCast(...))` form instead of `@alignCast(@ptrCast(...))`. https://github.com/ziglang/zig/issues/24106