### PR TITLE
LSM: Branchless with @branchHint

### DIFF
--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -900,11 +900,11 @@ fn SegmentedArrayBaseType(
                     const mid = offset + half;
 
                     const node = &array.nodes[mid].?[0];
-                    // This trick seems to be what's needed to get llvm to emit branchless code for
-                    // this, a ternary-style if expression was generated as a jump here for whatever
-                    // reason.
-                    const next_offsets = [_]usize{ offset, mid };
-                    offset = next_offsets[@intFromBool(key_from_value(node) < key)];
+
+                    if (key_from_value(node) < key) {
+                        @branchHint(.unpredictable);
+                        offset = mid;
+                    }
 
                     length -= half;
                 }


### PR DESCRIPTION
This PR replaces our previous "acrobatics" for generating branchless code with the new `@branchHint(.unpredictable)` intrinsic in `binary_search.zig` and `segmented_array.zig`.

## Benchmark 

I tested two scenarios:

i) Standard benchmark

Before:  402,450 tx/s
After: 407,657 tx/s

ii) Binary-search heavy workload (--account-count=2M to force object cache misses)

Before: 180,771 tx/s
After:    186,343 tx/s

Overall, the changes yield small gains, with the biggest improvement visible under binary-search–intensive conditions.

## Microbenchmark 
The microbenchmark shows, that the new version generates less instructions and is still branchless. 

| name         | element\_count | time | cycles | instructions | cache\_references | cache\_misses | branch\_misses | ipc  | maxrss\_mb | scale   |
| ------------ | -------------- | ---- | ------ | ------------ | ----------------- | ------------- | -------------- | ---- | ---------- | ------- |
| baseline     | 2              | 0.02 | 56.11  | 143.31       | 0.00              | 0.00          | 0.00           | 2.55 | 2          | 1000000 |
| baseline\_14 | 2              | 0.01 | 46.21  | 107.12       | 0.00              | 0.00          | 0.00           | 2.32 | 2          | 1000000 |
| baseline     | 8              | 0.02 | 84.02  | 180.00       | 0.00              | 0.00          | 0.00           | 2.14 | 2          | 1000000 |
| baseline\_14 | 8              | 0.02 | 65.39  | 117.94       | 0.00              | 0.00          | 0.00           | 1.80 | 2          | 1000000 |
| baseline     | 32             | 0.03 | 113.71 | 216.10       | 0.00              | 0.00          | 0.00           | 1.90 | 2          | 1000000 |
| baseline\_14 | 32             | 0.02 | 83.43  | 128.07       | 0.00              | 0.00          | 0.00           | 1.54 | 2          | 1000000 |
| baseline     | 128            | 0.04 | 141.69 | 252.10       | 0.00              | 0.00          | 0.00           | 1.78 | 2          | 1000000 |
| baseline\_14 | 128            | 0.03 | 101.84 | 138.16       | 0.00              | 0.00          | 0.00           | 1.36 | 2          | 1000000 |
| baseline     | 512            | 0.05 | 201.47 | 288.42       | 0.00              | 0.00          | 0.00           | 1.43 | 2          | 1000000 |
| baseline\_14 | 512            | 0.04 | 151.94 | 148.46       | 0.00              | 0.00          | 0.00           | 0.98 | 2          | 1000000 |
| baseline     | 2048           | 0.07 | 272.10 | 324.42       | 0.00              | 0.00          | 0.01           | 1.19 | 2          | 1000000 |
| baseline\_14 | 2048           | 0.05 | 212.47 | 158.41       | 0.00              | 0.00          | 0.00           | 0.75 | 2          | 1000000 |
| baseline     | 8192           | 0.11 | 413.47 | 360.79       | 0.76              | 0.00          | 0.01           | 0.87 | 2          | 1000000 |
| baseline\_14 | 8192           | 0.09 | 336.70 | 168.65       | 0.72              | 0.00          | 0.00           | 0.50 | 2          | 1000000 |


Hat tip to @batiati that pointed me to these places :-)  