### PR TITLE
Preparation for Zig 0.15.1 - Chapter two

### DIFF
--- a/src/clients/java/src/jni.zig
+++ b/src/clients/java/src/jni.zig
@@ -723,7 +723,7 @@ pub const JNIEnv = opaque {
         get_module = 233,
     };
 
-    usingnamespace JniInterfaceType(JNIEnv);
+    const JNIInterface = JNIInterfaceType(JNIEnv);
 
     /// Returns the major version number in the higher 16 bits
     /// and the minor version number in the lower 16 bits.
@@ -731,7 +731,7 @@ pub const JNIEnv = opaque {
     pub inline fn get_version(
         env: *JNIEnv,
     ) JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_version,
             .{},
@@ -746,7 +746,7 @@ pub const JNIEnv = opaque {
         buf: [*]const JByte,
         buf_len: JSize,
     ) JClass {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .define_class,
             .{ name, loader, buf, buf_len },
@@ -761,7 +761,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         name: [*:0]const u8,
     ) JClass {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .find_class,
             .{name},
@@ -773,7 +773,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         jobject: JObject,
     ) JMethodID {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .from_reflected_method,
             .{jobject},
@@ -785,7 +785,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         jobject: JObject,
     ) JFieldID {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .from_feflected_field,
             .{jobject},
@@ -799,7 +799,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         is_static: JBoolean,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .to_reflected_method,
             .{ cls, method_id, is_static },
@@ -811,7 +811,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         clazz: JClass,
     ) JClass {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_super_class,
             .{clazz},
@@ -824,7 +824,7 @@ pub const JNIEnv = opaque {
         clazz_1: JClass,
         clazz_2: JClass,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .is_assignable_from,
             .{ clazz_1, clazz_2 },
@@ -838,7 +838,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         is_static: JBoolean,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .to_reflected_field,
             .{ cls, field_id, is_static },
@@ -850,7 +850,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         obj: JThrowable,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .throw,
             .{obj},
@@ -863,7 +863,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         message: ?[*:0]const u8,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .throw_new,
             .{ clazz, message },
@@ -876,7 +876,7 @@ pub const JNIEnv = opaque {
     pub inline fn exception_occurred(
         env: *JNIEnv,
     ) JThrowable {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .exception_occurred,
             .{},
@@ -889,7 +889,7 @@ pub const JNIEnv = opaque {
     pub inline fn exception_describe(
         env: *JNIEnv,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .exception_describe,
             .{},
@@ -902,7 +902,7 @@ pub const JNIEnv = opaque {
     pub inline fn exception_clear(
         env: *JNIEnv,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .exception_clear,
             .{},
@@ -916,7 +916,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         msg: [*:0]const u8,
     ) noreturn {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .fatal_error,
             .{msg},
@@ -929,7 +929,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         capacity: JInt,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .push_local_frame,
             .{capacity},
@@ -941,7 +941,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         result: JObject,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .pop_local_frame,
             .{result},
@@ -958,7 +958,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         obj: JObject,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_global_ref,
             .{obj},
@@ -970,7 +970,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         global_ref: JObject,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .delete_global_ref,
             .{global_ref},
@@ -982,7 +982,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         local_ref: JObject,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .delete_local_ref,
             .{local_ref},
@@ -995,7 +995,7 @@ pub const JNIEnv = opaque {
         ref_1: JObject,
         ref_2: JObject,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .is_same_object,
             .{ ref_1, ref_2 },
@@ -1008,7 +1008,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         ref: JObject,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_local_ref,
             .{ref},
@@ -1020,7 +1020,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         capacity: JInt,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .ensure_local_capacity,
             .{capacity},
@@ -1034,7 +1034,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         clazz: JClass,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .alloc_object,
             .{clazz},
@@ -1049,7 +1049,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_object,
             .{ clazz, method_id, args },
@@ -1061,7 +1061,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         jobject: JObject,
     ) JClass {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_object_class,
             .{jobject},
@@ -1074,7 +1074,7 @@ pub const JNIEnv = opaque {
         jobject: JObject,
         clazz: JClass,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .is_instance_of,
             .{ jobject, clazz },
@@ -1088,7 +1088,7 @@ pub const JNIEnv = opaque {
         name: [*:0]const u8,
         sig: [*:0]const u8,
     ) JMethodID {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_method_id,
             .{ clazz, name, sig },
@@ -1102,7 +1102,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_object_method,
             .{ obj, method_id, args },
@@ -1116,7 +1116,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_boolean_method,
             .{ obj, method_id, args },
@@ -1130,7 +1130,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JByte {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_byte_method,
             .{ obj, method_id, args },
@@ -1144,7 +1144,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_char_method,
             .{ obj, method_id, args },
@@ -1158,7 +1158,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JShort {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_short_method,
             .{ obj, method_id, args },
@@ -1172,7 +1172,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_int_method,
             .{ obj, method_id, args },
@@ -1186,7 +1186,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_long_method,
             .{ obj, method_id, args },
@@ -1200,7 +1200,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JFloat {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_float_method,
             .{ obj, method_id, args },
@@ -1214,7 +1214,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JDouble {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_double_method,
             .{ obj, method_id, args },
@@ -1228,7 +1228,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .call_void_method,
             .{ obj, method_id, args },
@@ -1243,7 +1243,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_object_method,
             .{ obj, clazz, method_id, args },
@@ -1258,7 +1258,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_boolean_method,
             .{ obj, clazz, method_id, args },
@@ -1273,7 +1273,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JByte {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_byte_method,
             .{ obj, clazz, method_id, args },
@@ -1288,7 +1288,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_char_method,
             .{ obj, clazz, method_id, args },
@@ -1303,7 +1303,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JShort {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_short_method,
             .{ obj, clazz, method_id, args },
@@ -1318,7 +1318,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_int_method,
             .{ obj, clazz, method_id, args },
@@ -1333,7 +1333,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_long_method,
             .{ obj, clazz, method_id, args },
@@ -1348,7 +1348,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JFloat {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_float_method,
             .{ obj, clazz, method_id, args },
@@ -1363,7 +1363,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JDouble {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_nonvirtual_double_method,
             .{ obj, clazz, method_id, args },
@@ -1378,7 +1378,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .call_nonvirtual_void_method,
             .{ obj, clazz, method_id, args },
@@ -1392,7 +1392,7 @@ pub const JNIEnv = opaque {
         name: [*:0]const u8,
         sig: [*:0]const u8,
     ) JFieldID {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_field_id,
             .{ clazz, name, sig },
@@ -1405,7 +1405,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_object_field,
             .{ obj, field_id },
@@ -1418,7 +1418,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_boolean_field,
             .{ obj, field_id },
@@ -1431,7 +1431,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JByte {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_byte_field,
             .{ obj, field_id },
@@ -1444,7 +1444,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_char_field,
             .{ obj, field_id },
@@ -1457,7 +1457,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JShort {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_short_field,
             .{ obj, field_id },
@@ -1470,7 +1470,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_int_field,
             .{ obj, field_id },
@@ -1483,7 +1483,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_long_field,
             .{ obj, field_id },
@@ -1496,7 +1496,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JFloat {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_float_field,
             .{ obj, field_id },
@@ -1509,7 +1509,7 @@ pub const JNIEnv = opaque {
         obj: JObject,
         field_id: JFieldID,
     ) JDouble {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_double_field,
             .{ obj, field_id },
@@ -1523,7 +1523,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JObject,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_object_field,
             .{ obj, field_id, value },
@@ -1537,7 +1537,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JBoolean,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_boolean_field,
             .{ obj, field_id, value },
@@ -1551,7 +1551,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JByte,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_byte_field,
             .{ obj, field_id, value },
@@ -1565,7 +1565,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_char_field,
             .{ obj, field_id, value },
@@ -1579,7 +1579,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JShort,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_short_field,
             .{ obj, field_id, value },
@@ -1593,7 +1593,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JInt,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_int_field,
             .{ obj, field_id, value },
@@ -1607,7 +1607,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JLong,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_long_field,
             .{ obj, field_id, value },
@@ -1621,7 +1621,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JFloat,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_float_field,
             .{ obj, field_id, value },
@@ -1635,7 +1635,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JDouble,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_double_field,
             .{ obj, field_id, value },
@@ -1649,7 +1649,7 @@ pub const JNIEnv = opaque {
         name: [*:0]const u8,
         sig: [*:0]const u8,
     ) JMethodID {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_method_id,
             .{ clazz, name, sig },
@@ -1663,7 +1663,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_object_method,
             .{ clazz, method_id, args },
@@ -1677,7 +1677,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_boolean_method,
             .{ clazz, method_id, args },
@@ -1691,7 +1691,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JByte {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_byte_method,
             .{ clazz, method_id, args },
@@ -1705,7 +1705,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_char_method,
             .{ clazz, method_id, args },
@@ -1719,7 +1719,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JShort {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_short_method,
             .{ clazz, method_id, args },
@@ -1733,7 +1733,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_int_method,
             .{ clazz, method_id, args },
@@ -1747,7 +1747,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_long_method,
             .{ clazz, method_id, args },
@@ -1761,7 +1761,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JFloat {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_float_method,
             .{ clazz, method_id, args },
@@ -1775,7 +1775,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) JDouble {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .call_static_double_method,
             .{ clazz, method_id, args },
@@ -1789,7 +1789,7 @@ pub const JNIEnv = opaque {
         method_id: JMethodID,
         args: ?[*]const JValue,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .call_static_void_method,
             .{ clazz, method_id, args },
@@ -1804,7 +1804,7 @@ pub const JNIEnv = opaque {
         name: [*:0]const u8,
         sig: [*:0]const u8,
     ) JFieldID {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_field_id,
             .{ clazz, name, sig },
@@ -1817,7 +1817,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_object_field,
             .{ clazz, field_id },
@@ -1830,7 +1830,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_boolean_field,
             .{ clazz, field_id },
@@ -1843,7 +1843,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JByte {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_byte_field,
             .{ clazz, field_id },
@@ -1856,7 +1856,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_char_field,
             .{ clazz, field_id },
@@ -1869,7 +1869,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JShort {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_short_field,
             .{ clazz, field_id },
@@ -1882,7 +1882,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_int_field,
             .{ clazz, field_id },
@@ -1895,7 +1895,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_long_field,
             .{ clazz, field_id },
@@ -1908,7 +1908,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JFloat {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_float_field,
             .{ clazz, field_id },
@@ -1921,7 +1921,7 @@ pub const JNIEnv = opaque {
         clazz: JClass,
         field_id: JFieldID,
     ) JDouble {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_static_double_field,
             .{ clazz, field_id },
@@ -1935,7 +1935,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JObject,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_object_field,
             .{ clazz, field_id, value },
@@ -1949,7 +1949,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JBoolean,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_boolean_field,
             .{ clazz, field_id, value },
@@ -1963,7 +1963,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JByte,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_byte_field,
             .{ clazz, field_id, value },
@@ -1977,7 +1977,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_char_field,
             .{ clazz, field_id, value },
@@ -1991,7 +1991,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JShort,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_short_field,
             .{ clazz, field_id, value },
@@ -2005,7 +2005,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JInt,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_int_field,
             .{ clazz, field_id, value },
@@ -2019,7 +2019,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JLong,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_long_field,
             .{ clazz, field_id, value },
@@ -2033,7 +2033,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JFloat,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_float_field,
             .{ clazz, field_id, value },
@@ -2047,7 +2047,7 @@ pub const JNIEnv = opaque {
         field_id: JFieldID,
         value: JDouble,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_static_double_field,
             .{ clazz, field_id, value },
@@ -2060,7 +2060,7 @@ pub const JNIEnv = opaque {
         unicode_chars: [*]const JChar,
         size: JSize,
     ) JString {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_string,
             .{ unicode_chars, size },
@@ -2072,7 +2072,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         string: JString,
     ) JSize {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_string_length,
             .{string},
@@ -2089,7 +2089,7 @@ pub const JNIEnv = opaque {
         string: JString,
         is_copy: ?*JBoolean,
     ) ?[*]const JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_string_chars,
             .{ string, is_copy },
@@ -2102,7 +2102,7 @@ pub const JNIEnv = opaque {
         string: JString,
         chars: [*]const JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_string_chars,
             .{ string, chars },
@@ -2114,7 +2114,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         bytes: [*:0]const u8,
     ) JString {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_string_utf,
             .{bytes},
@@ -2126,7 +2126,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         string: JString,
     ) JSize {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_string_utf_length,
             .{string},
@@ -2143,7 +2143,7 @@ pub const JNIEnv = opaque {
         string: JString,
         is_copy: ?*JBoolean,
     ) ?[*:0]const u8 {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_string_utf_chars,
             .{ string, is_copy },
@@ -2156,7 +2156,7 @@ pub const JNIEnv = opaque {
         string: JString,
         utf: [*:0]const u8,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_string_utf_chars,
             .{ string, utf },
@@ -2168,7 +2168,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         array: JArray,
     ) JSize {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_array_length,
             .{array},
@@ -2185,7 +2185,7 @@ pub const JNIEnv = opaque {
         element_class: JClass,
         initial_element: JObject,
     ) JObjectArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_object_array,
             .{ length, element_class, initial_element },
@@ -2198,7 +2198,7 @@ pub const JNIEnv = opaque {
         array: JObjectArray,
         index: JSize,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_object_array_element,
             .{ array, index },
@@ -2212,7 +2212,7 @@ pub const JNIEnv = opaque {
         index: JSize,
         value: JObject,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_object_array_element,
             .{ array, index, value },
@@ -2225,7 +2225,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JBooleanArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_boolean_array,
             .{length},
@@ -2238,7 +2238,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JByteArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_byte_array,
             .{length},
@@ -2251,7 +2251,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JCharArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_char_array,
             .{length},
@@ -2264,7 +2264,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JShortArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_short_array,
             .{length},
@@ -2277,7 +2277,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JIntArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_int_array,
             .{length},
@@ -2290,7 +2290,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JLongArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_long_array,
             .{length},
@@ -2303,7 +2303,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JFloatArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_float_array,
             .{length},
@@ -2316,7 +2316,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         length: JSize,
     ) JDoubleArray {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_double_array,
             .{length},
@@ -2333,7 +2333,7 @@ pub const JNIEnv = opaque {
         array: JBooleanArray,
         is_copy: ?*JBoolean,
     ) ?[*]JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_boolean_array_elements,
             .{ array, is_copy },
@@ -2350,7 +2350,7 @@ pub const JNIEnv = opaque {
         array: JByteArray,
         is_copy: ?*JBoolean,
     ) ?[*]JByte {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_byte_array_elements,
             .{ array, is_copy },
@@ -2367,7 +2367,7 @@ pub const JNIEnv = opaque {
         array: JCharArray,
         is_copy: ?*JBoolean,
     ) ?[*]JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_char_array_elements,
             .{ array, is_copy },
@@ -2384,7 +2384,7 @@ pub const JNIEnv = opaque {
         array: JShortArray,
         is_copy: ?*JBoolean,
     ) ?[*]JShort {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_short_array_elements,
             .{ array, is_copy },
@@ -2401,7 +2401,7 @@ pub const JNIEnv = opaque {
         array: JIntArray,
         is_copy: ?*JBoolean,
     ) ?[*]JInt {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_int_array_elements,
             .{ array, is_copy },
@@ -2418,7 +2418,7 @@ pub const JNIEnv = opaque {
         array: JLongArray,
         is_copy: ?*JBoolean,
     ) ?[*]JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_long_array_elements,
             .{ array, is_copy },
@@ -2435,7 +2435,7 @@ pub const JNIEnv = opaque {
         array: JFloatArray,
         is_copy: ?*JBoolean,
     ) ?[*]JFloat {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_float_array_elements,
             .{ array, is_copy },
@@ -2453,7 +2453,7 @@ pub const JNIEnv = opaque {
         array: JDoubleArray,
         is_copy: ?*JBoolean,
     ) ?[*]JDouble {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_double_array_elements,
             .{ array, is_copy },
@@ -2467,7 +2467,7 @@ pub const JNIEnv = opaque {
         elems: [*]JBoolean,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_boolean_array_elements,
             .{ array, elems, mode },
@@ -2481,7 +2481,7 @@ pub const JNIEnv = opaque {
         elems: [*]JByte,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_byte_array_elements,
             .{ array, elems, mode },
@@ -2495,7 +2495,7 @@ pub const JNIEnv = opaque {
         elems: [*]JChar,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_char_array_elements,
             .{ array, elems, mode },
@@ -2509,7 +2509,7 @@ pub const JNIEnv = opaque {
         elems: [*]JShort,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_short_array_elements,
             .{ array, elems, mode },
@@ -2523,7 +2523,7 @@ pub const JNIEnv = opaque {
         elems: [*]JInt,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_int_array_elements,
             .{ array, elems, mode },
@@ -2537,7 +2537,7 @@ pub const JNIEnv = opaque {
         elems: [*]JLong,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_long_array_elements,
             .{ array, elems, mode },
@@ -2551,7 +2551,7 @@ pub const JNIEnv = opaque {
         elems: [*]JFloat,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_float_array_elements,
             .{ array, elems, mode },
@@ -2565,7 +2565,7 @@ pub const JNIEnv = opaque {
         elems: [*]JDouble,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_double_array_elements,
             .{ array, elems, mode },
@@ -2580,7 +2580,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JBoolean,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_boolean_array_region,
             .{ array, start, len, buf },
@@ -2595,7 +2595,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JByte,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_byte_array_region,
             .{ array, start, len, buf },
@@ -2610,7 +2610,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_char_array_region,
             .{ array, start, len, buf },
@@ -2625,7 +2625,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JShort,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_short_array_region,
             .{ array, start, len, buf },
@@ -2640,7 +2640,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JInt,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_int_array_region,
             .{ array, start, len, buf },
@@ -2655,7 +2655,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JLong,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_long_array_region,
             .{ array, start, len, buf },
@@ -2670,7 +2670,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JFloat,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_float_array_region,
             .{ array, start, len, buf },
@@ -2685,7 +2685,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JDouble,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_double_array_region,
             .{ array, start, len, buf },
@@ -2700,7 +2700,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JBoolean,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_boolean_array_region,
             .{ array, start, len, buf },
@@ -2715,7 +2715,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JByte,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_byte_array_region,
             .{ array, start, len, buf },
@@ -2730,7 +2730,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_char_array_region,
             .{ array, start, len, buf },
@@ -2745,7 +2745,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JShort,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_short_array_region,
             .{ array, start, len, buf },
@@ -2760,7 +2760,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JInt,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_int_array_region,
             .{ array, start, len, buf },
@@ -2775,7 +2775,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JLong,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_long_array_region,
             .{ array, start, len, buf },
@@ -2790,7 +2790,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JFloat,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_float_array_region,
             .{ array, start, len, buf },
@@ -2805,7 +2805,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]const JDouble,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .set_double_array_region,
             .{ array, start, len, buf },
@@ -2819,7 +2819,7 @@ pub const JNIEnv = opaque {
         methods: [*]const JNINativeMethod,
         methods_len: JInt,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .register_natives,
             .{ clazz, methods, methods_len },
@@ -2831,7 +2831,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         clazz: JClass,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .unregister_natives,
             .{clazz},
@@ -2843,7 +2843,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         obj: JObject,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .monitor_enter,
             .{obj},
@@ -2855,7 +2855,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         obj: JObject,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .monitor_exit,
             .{obj},
@@ -2867,7 +2867,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         vm: **JavaVM,
     ) JNIResultType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_java_vm,
             .{vm},
@@ -2882,7 +2882,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_string_region,
             .{ string, start, len, buf },
@@ -2897,7 +2897,7 @@ pub const JNIEnv = opaque {
         len: JSize,
         buf: [*]u8,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .get_string_utf_region,
             .{ string, start, len, buf },
@@ -2910,7 +2910,7 @@ pub const JNIEnv = opaque {
         array: JArray,
         is_copy: ?*JBoolean,
     ) ?*anyopaque {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_primitive_array_critical,
             .{ array, is_copy },
@@ -2924,7 +2924,7 @@ pub const JNIEnv = opaque {
         c_array: *anyopaque,
         mode: JArrayReleaseMode,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_primitive_array_critical,
             .{ array, c_array, mode },
@@ -2937,7 +2937,7 @@ pub const JNIEnv = opaque {
         string: JString,
         is_copy: ?*JBoolean,
     ) ?[*]const JChar {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_string_critical,
             .{ string, is_copy },
@@ -2950,7 +2950,7 @@ pub const JNIEnv = opaque {
         string: JString,
         chars: [*]const JChar,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .release_string_critical,
             .{ string, chars },
@@ -2963,7 +2963,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         obj: JObject,
     ) JWeakReference {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_weak_global_ref,
             .{obj},
@@ -2975,7 +2975,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         ref: JWeakReference,
     ) void {
-        JNIEnv.interface_call(
+        JNIInterface.call(
             env,
             .delete_weak_global_ref,
             .{ref},
@@ -2987,7 +2987,7 @@ pub const JNIEnv = opaque {
     pub inline fn exception_check(
         env: *JNIEnv,
     ) JBoolean {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .exception_check,
             .{},
@@ -3003,7 +3003,7 @@ pub const JNIEnv = opaque {
         address: *anyopaque,
         capacity: JLong,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .new_direct_byte_buffer,
             .{ address, capacity },
@@ -3019,7 +3019,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         buf: JObject,
     ) ?[*]u8 {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_direct_buffer_address,
             .{buf},
@@ -3036,7 +3036,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         buf: JObject,
     ) JLong {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_direct_buffer_capacity,
             .{buf},
@@ -3048,7 +3048,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         obj: JObject,
     ) JObjectRefType {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_object_ref_type,
             .{obj},
@@ -3060,7 +3060,7 @@ pub const JNIEnv = opaque {
         env: *JNIEnv,
         clazz: JClass,
     ) JObject {
-        return JNIEnv.interface_call(
+        return JNIInterface.call(
             env,
             .get_module,
             .{clazz},
@@ -3137,13 +3137,13 @@ pub const JavaVM = opaque {
         ) callconv(.C) JNIResultType;
     }.JNI_CreateJavaVM;
 
-    usingnamespace JniInterfaceType(JavaVM);
+    const JNIInterface = JNIInterfaceType(JavaVM);
 
     /// https://docs.oracle.com/en/java/javase/17/docs/specs/jni/invocation.html#destroyjavavm.
     pub inline fn destroy_java_vm(
         vm: *JavaVM,
     ) JNIResultType {
-        return JavaVM.interface_call(
+        return JNIInterface.call(
             vm,
             .destroy_java_vm,
             .{},
@@ -3156,7 +3156,7 @@ pub const JavaVM = opaque {
         env: **JNIEnv,
         args: ?*JavaVMAttachArgs,
     ) JNIResultType {
-        return JavaVM.interface_call(
+        return JNIInterface.call(
             vm,
             .attach_current_thread,
             .{ env, args },
@@ -3167,7 +3167,7 @@ pub const JavaVM = opaque {
     pub inline fn detach_current_thread(
         vm: *JavaVM,
     ) JNIResultType {
-        return JavaVM.interface_call(
+        return JNIInterface.call(
             vm,
             .detach_current_thread,
             .{},
@@ -3180,7 +3180,7 @@ pub const JavaVM = opaque {
         env: **JNIEnv,
         args: ?*JavaVMAttachArgs,
     ) JNIResultType {
-        return JavaVM.interface_call(
+        return JNIInterface.call(
             vm,
             .attach_current_thread_as_daemon,
             .{ env, args },
@@ -3193,7 +3193,7 @@ pub const JavaVM = opaque {
         env: **JNIEnv,
         version: JInt,
     ) JNIResultType {
-        return JavaVM.interface_call(
+        return JNIInterface.call(
             vm,
             .get_env,
             .{ env, version },
@@ -3205,7 +3205,7 @@ pub const JavaVM = opaque {
 /// without the need to declare a VTable layout, where the ordering of fields defines the ABI.
 /// The function index is stored within T.FunctionTable enum, which only holds the index value.
 /// The function signature is declared as an inline function within the T opaque type.
-fn JniInterfaceType(comptime T: type) type {
+fn JNIInterfaceType(comptime T: type) type {
     return struct {
         fn JniFnType(comptime function: T.FunctionTable) type {
             const Fn = @TypeOf(@field(T, @tagName(function)));
@@ -3219,7 +3219,7 @@ fn JniInterfaceType(comptime T: type) type {
             }
         }
 
-        pub inline fn interface_call(
+        pub inline fn call(
             self: *T,
             comptime function: T.FunctionTable,
             args: anytype,

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const c = @import("src/c.zig");
+const c = @import("src/c.zig").c;
 const translate = @import("src/translate.zig");
 const tb = vsr.tigerbeetle;
 const tb_client = vsr.tb_client;

--- a/src/clients/node/src/c.zig
+++ b/src/clients/node/src/c.zig
@@ -1,3 +1,3 @@
-pub usingnamespace @cImport({
+pub const c = @cImport({
     @cInclude("node_api.h");
 });

--- a/src/clients/node/src/translate.zig
+++ b/src/clients/node/src/translate.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const c = @import("c.zig");
+const c = @import("c.zig").c;
 
 pub fn register_function(
     env: c.napi_env,

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -205,51 +205,52 @@ fn SegmentedArrayBaseType(
             }
         }
 
-        pub usingnamespace if (Key) |_| struct {
-            /// Returns the absolute index of the element being inserted.
-            pub fn insert_element(
-                array: *SegmentedArray,
-                node_pool: *NodePool,
-                element: T,
-            ) u32 {
-                if (options.verify) array.verify();
+        /// Returns the absolute index of the element being inserted.
+        /// Available only when `Key != null`.
+        pub fn insert_element(
+            array: *SegmentedArray,
+            node_pool: *NodePool,
+            element: T,
+        ) u32 {
+            comptime assert(Key != null);
+            if (options.verify) array.verify();
 
-                const count_before = array.len();
+            const count_before = array.len();
 
-                const cursor = array.search(key_from_value(&element));
-                const absolute_index = array.absolute_index_for_cursor(cursor);
-                array.insert_elements_at_absolute_index(node_pool, absolute_index, &[_]T{element});
+            const cursor = array.search(key_from_value(&element));
+            const absolute_index = array.absolute_index_for_cursor(cursor);
+            array.insert_elements_at_absolute_index(node_pool, absolute_index, &[_]T{element});
 
-                if (options.verify) array.verify();
+            if (options.verify) array.verify();
 
-                const count_after = array.len();
-                assert(count_after == count_before + 1);
+            const count_after = array.len();
+            assert(count_after == count_before + 1);
 
-                return absolute_index;
-            }
-        } else struct {
-            pub fn insert_elements(
-                array: *SegmentedArray,
-                node_pool: *NodePool,
-                absolute_index: u32,
-                elements: []const T,
-            ) void {
-                if (options.verify) array.verify();
+            return absolute_index;
+        }
 
-                const count_before = array.len();
+        /// Available only when `Key == null`.
+        pub fn insert_elements(
+            array: *SegmentedArray,
+            node_pool: *NodePool,
+            absolute_index: u32,
+            elements: []const T,
+        ) void {
+            comptime assert(Key == null);
+            if (options.verify) array.verify();
 
-                array.insert_elements_at_absolute_index(
-                    node_pool,
-                    absolute_index,
-                    elements,
-                );
+            const count_before = array.len();
+            array.insert_elements_at_absolute_index(
+                node_pool,
+                absolute_index,
+                elements,
+            );
 
-                const count_after = array.len();
-                assert(count_after == count_before + elements.len);
+            const count_after = array.len();
+            assert(count_after == count_before + elements.len);
 
-                if (options.verify) array.verify();
-            }
-        };
+            if (options.verify) array.verify();
+        }
 
         fn insert_elements_at_absolute_index(
             array: *SegmentedArray,
@@ -882,68 +883,74 @@ fn SegmentedArrayBaseType(
             }
         }
 
-        pub usingnamespace if (Key) |K| struct {
-            /// Returns a cursor to the index of the key either exactly equal to the target key or,
-            /// if there is no exact match, the next greatest key.
-            pub fn search(array: *const SegmentedArray, key: K) Cursor {
-                if (array.node_count == 0) {
-                    return .{
-                        .node = 0,
-                        .relative_index = 0,
-                    };
-                }
-
-                var offset: usize = 0;
-                var length: usize = array.node_count;
-                while (length > 1) {
-                    const half = length / 2;
-                    const mid = offset + half;
-
-                    const node = &array.nodes[mid].?[0];
-
-                    if (key_from_value(node) < key) {
-                        @branchHint(.unpredictable);
-                        offset = mid;
-                    }
-
-                    length -= half;
-                }
-
-                // Unlike a normal binary search, don't increment the offset when "key" is higher
-                // than the element — "round down" to the previous node.
-                // This guarantees that the node result is never "== node_count".
-                //
-                // (If there are two adjacent nodes starting with keys A and C, and we search B,
-                // we want to pick the A node.)
-                const node: u32 = @intCast(offset);
-                assert(node < array.node_count);
-
-                const relative_index = binary_search_values_upsert_index(
-                    K,
-                    T,
-                    key_from_value,
-                    array.node_elements(node),
-                    key,
-                    .{},
-                );
-
-                // Follow the same rule as absolute_index_for_cursor:
-                // only return relative_index==array.count() at the last node.
-                if (node + 1 < array.node_count and
-                    relative_index == array.count(node))
-                {
-                    return .{
-                        .node = node + 1,
-                        .relative_index = 0,
-                    };
-                } else {
-                    return .{
-                        .node = node,
-                        .relative_index = relative_index,
-                    };
-                }
+        /// Returns a cursor to the index of the key either exactly equal to the target key or,
+        /// if there is no exact match, the next greatest key.
+        /// Available only when `Key != null`.
+        pub fn search(
+            array: *const SegmentedArray,
+            key: K: {
+                assert(Key != null);
+                break :K Key.?;
+            },
+        ) Cursor {
+            const K = Key.?;
+            if (array.node_count == 0) {
+                return .{
+                    .node = 0,
+                    .relative_index = 0,
+                };
             }
-        } else struct {};
+
+            var offset: usize = 0;
+            var length: usize = array.node_count;
+            while (length > 1) {
+                const half = length / 2;
+                const mid = offset + half;
+
+                const node = &array.nodes[mid].?[0];
+
+                if (key_from_value(node) < key) {
+                    @branchHint(.unpredictable);
+                    offset = mid;
+                }
+
+                length -= half;
+            }
+
+            // Unlike a normal binary search, don't increment the offset when "key" is higher
+            // than the element — "round down" to the previous node.
+            // This guarantees that the node result is never "== node_count".
+            //
+            // (If there are two adjacent nodes starting with keys A and C, and we search B,
+            // we want to pick the A node.)
+            const node: u32 = @intCast(offset);
+            assert(node < array.node_count);
+
+            const relative_index = binary_search_values_upsert_index(
+                K,
+                T,
+                key_from_value,
+                array.node_elements(node),
+                key,
+                .{},
+            );
+
+            // Follow the same rule as absolute_index_for_cursor:
+            // only return relative_index==array.count() at the last node.
+            if (node + 1 < array.node_count and
+                relative_index == array.count(node))
+            {
+                return .{
+                    .node = node + 1,
+                    .relative_index = 0,
+                };
+            } else {
+                return .{
+                    .node = node,
+                    .relative_index = relative_index,
+                };
+            }
+        }
     };
 }
 

--- a/src/stdx/ring_buffer.zig
+++ b/src/stdx/ring_buffer.zig
@@ -32,26 +32,34 @@ pub fn RingBufferType(
         /// The number of items in the buffer.
         count: usize = 0,
 
-        pub usingnamespace switch (buffer_type) {
-            .array => struct {
-                pub fn init() RingBuffer {
-                    return .{ .buffer = undefined };
-                }
-            },
-            .slice => struct {
-                pub fn init(allocator: mem.Allocator, capacity: usize) !RingBuffer {
-                    assert(capacity > 0);
-
-                    const buffer = try allocator.alloc(T, capacity);
-                    errdefer allocator.free(buffer);
-                    return RingBuffer{ .buffer = buffer };
-                }
-
-                pub fn deinit(self: *RingBuffer, allocator: mem.Allocator) void {
-                    allocator.free(self.buffer);
-                }
-            },
+        pub const init = switch (buffer_type) {
+            .array => init_array,
+            .slice => init_slice,
         };
+
+        fn init_array() RingBuffer {
+            comptime assert(buffer_type == .array);
+            return .{ .buffer = undefined };
+        }
+
+        fn init_slice(allocator: mem.Allocator, capacity: usize) !RingBuffer {
+            comptime assert(buffer_type == .slice);
+            assert(capacity > 0);
+
+            const buffer = try allocator.alloc(T, capacity);
+            errdefer allocator.free(buffer);
+            return RingBuffer{ .buffer = buffer };
+        }
+
+        pub const deinit = switch (buffer_type) {
+            .array => {},
+            .slice => deinit_slice,
+        };
+
+        fn deinit_slice(self: *RingBuffer, allocator: mem.Allocator) void {
+            comptime assert(buffer_type == .slice);
+            allocator.free(self.buffer);
+        }
 
         pub inline fn clear(self: *RingBuffer) void {
             self.index = 0;

--- a/src/testing/marks.zig
+++ b/src/testing/marks.zig
@@ -85,39 +85,35 @@ pub fn check(name: []const u8) Mark {
     return Mark{ .name = name };
 }
 
-pub fn wrap_log(comptime base: anytype) type {
-    if (builtin.is_test) {
-        return struct {
-            pub usingnamespace base;
+pub fn wrap_log(comptime base: type) type {
+    return struct {
+        pub const mark = if (builtin.is_test) struct {
+            pub fn err(comptime fmt: []const u8, args: anytype) void {
+                record(fmt);
+                base.err(fmt, args);
+            }
 
-            pub const mark = struct {
-                pub fn err(comptime fmt: []const u8, args: anytype) void {
-                    record(fmt);
-                    base.err(fmt, args);
-                }
+            pub fn warn(comptime fmt: []const u8, args: anytype) void {
+                record(fmt);
+                base.warn(fmt, args);
+            }
 
-                pub fn warn(comptime fmt: []const u8, args: anytype) void {
-                    record(fmt);
-                    base.warn(fmt, args);
-                }
+            pub fn info(comptime fmt: []const u8, args: anytype) void {
+                record(fmt);
+                base.info(fmt, args);
+            }
 
-                pub fn info(comptime fmt: []const u8, args: anytype) void {
-                    record(fmt);
-                    base.info(fmt, args);
-                }
+            pub fn debug(comptime fmt: []const u8, args: anytype) void {
+                record(fmt);
+                base.debug(fmt, args);
+            }
+        } else base;
 
-                pub fn debug(comptime fmt: []const u8, args: anytype) void {
-                    record(fmt);
-                    base.debug(fmt, args);
-                }
-            };
-        };
-    } else {
-        return struct {
-            pub usingnamespace base;
-            pub const mark = base;
-        };
-    }
+        pub const err = base.err;
+        pub const warn = base.warn;
+        pub const info = base.info;
+        pub const debug = base.debug;
+    };
 }
 
 fn record(fmt: []const u8) void {

--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -1,30 +1,35 @@
 const std = @import("std");
-const constants = @import("../../constants.zig");
+const constants = @This();
 
-pub usingnamespace constants;
+pub const vsr = @import("../../constants.zig");
 
-pub const cluster_id = 1;
-pub const connections_count_max = @divFloor(constants.clients_max, constants.replicas_max);
+pub const vortex = struct {
+    pub const cluster_id = 1;
+    pub const connections_count_max = @divFloor(
+        constants.vsr.clients_max,
+        constants.vsr.replicas_max,
+    );
 
-// We allow the cluster to not make progress processing requests for this amount of time. After
-// that it's considered a test failure.
-pub const liveness_requirement_seconds = 120;
-pub const liveness_requirement_micros = liveness_requirement_seconds * std.time.us_per_s;
+    // We allow the cluster to not make progress processing requests for this amount of time.
+    // After that it's considered a test failure.
+    pub const liveness_requirement_seconds = 120;
+    pub const liveness_requirement_micros = liveness_requirement_seconds * std.time.us_per_s;
 
-pub const replica_ports_actual = brk: {
-    var ports: [constants.replicas_max]u16 = undefined;
-    var replica_num: u16 = 0;
-    while (replica_num < constants.replicas_max) : (replica_num += 1) {
-        ports[replica_num] = 4000 + replica_num;
-    }
-    break :brk ports;
-};
+    pub const replica_ports_actual = brk: {
+        var ports: [constants.vsr.replicas_max]u16 = undefined;
+        var replica_num: u16 = 0;
+        while (replica_num < constants.vsr.replicas_max) : (replica_num += 1) {
+            ports[replica_num] = 4000 + replica_num;
+        }
+        break :brk ports;
+    };
 
-pub const replica_ports_proxied = brk: {
-    var ports: [constants.replicas_max]u16 = undefined;
-    var replica_num: u16 = 0;
-    while (replica_num < constants.replicas_max) : (replica_num += 1) {
-        ports[replica_num] = 3000 + replica_num;
-    }
-    break :brk ports;
+    pub const replica_ports_proxied = brk: {
+        var ports: [constants.vsr.replicas_max]u16 = undefined;
+        var replica_num: u16 = 0;
+        while (replica_num < constants.vsr.replicas_max) : (replica_num += 1) {
+            ports[replica_num] = 3000 + replica_num;
+        }
+        break :brk ports;
+    };
 };

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -21,7 +21,7 @@
 const std = @import("std");
 const stdx = @import("stdx");
 const IO = @import("../../io.zig").IO;
-const constants = @import("./constants.zig");
+const constants = @import("constants.zig");
 
 const assert = std.debug.assert;
 const log = std.log.scoped(.faulty_network);
@@ -60,7 +60,7 @@ const Pipe = struct {
     connection: *Connection,
     input: std.posix.socket_t = IO.INVALID_SOCKET,
     output: std.posix.socket_t = IO.INVALID_SOCKET,
-    buffer: [constants.message_size_max]u8 = undefined,
+    buffer: [constants.vsr.message_size_max]u8 = undefined,
     send_inflight: bool = false,
     recv_inflight: bool = false,
     recv_count: usize = 0,
@@ -454,7 +454,7 @@ const Proxy = struct {
     io: *IO,
     accept_fd: std.posix.socket_t,
     mapping: Mapping,
-    connections: [constants.connections_count_max]Connection,
+    connections: [constants.vortex.connections_count_max]Connection,
 
     fn deinit(proxy: *Proxy) void {
         proxy.io.close_socket(proxy.accept_fd);
@@ -535,7 +535,7 @@ pub const Network = struct {
                 log.err("failed to bind {any}", .{mapping.origin});
                 return err;
             };
-            try std.posix.listen(listen_fd, constants.tcp_backlog);
+            try std.posix.listen(listen_fd, constants.vsr.tcp_backlog);
 
             log.info("proxying {any} -> {any}", .{ mapping.origin, mapping.remote });
             proxies_initialized += 1;

--- a/src/testing/vortex/logged_process.zig
+++ b/src/testing/vortex/logged_process.zig
@@ -191,16 +191,16 @@ fn expect_state_in(self: *LoggedProcess, comptime valid_states: anytype) void {
 // The test for LoggedProcess needs an executable that runs forever which is solved (without
 // depending on system executables) by using the Zig compiler to build this very file as an
 // executable in a temporary directory.
-pub usingnamespace if (@import("root") != @This()) struct {
-    // For production builds, don't include the main function.
-    // This is `if __name__ == "__main__":` at comptime!
-} else struct {
-    pub fn main() !void {
-        while (true) {
-            _ = try std.io.getStdErr().write("yep\n");
+// For production builds, don't include the main function.
+// This is `if __name__ == "__main__":` at comptime!
+pub const main =
+    if (@import("root") != @This()) {} else struct {
+        fn main() !void {
+            while (true) {
+                _ = try std.io.getStdErr().write("yep\n");
+            }
         }
-    }
-};
+    }.main;
 
 test "LoggedProcess: starts and stops" {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -156,6 +156,11 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
         return "use stdx.copy_right instead of std version";
     }
 
+    // TODO(zig): Remove when upgrading to Zig 0.15.x:
+    if (std.mem.indexOf(u8, source, "using" ++ "namespace") != null) {
+        return "using" ++ "namespace was removed from Zig";
+    }
+
     if (std.mem.indexOf(u8, source, "@memcpy(") != null) {
         if (std.mem.indexOf(u8, source, "// Bypass tidy's ban, for stdx.") == null and
             std.mem.indexOf(u8, source, "// Bypass tidy's ban, for go_bindings.") == null)

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -295,8 +295,6 @@ pub const Header = extern struct {
     /// This type isn't ever actually a constructed, but makes Type() simpler by providing a header
     /// type for each command.
     pub const Reserved = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128,
         checksum_padding: u128 = 0,
         checksum_body: u128,
@@ -314,6 +312,16 @@ pub const Header = extern struct {
 
         reserved: [128]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .reserved);
             return "reserved is invalid";
@@ -323,8 +331,6 @@ pub const Header = extern struct {
     /// This type isn't ever actually a constructed, but makes Type() simpler by providing a header
     /// type for each command.
     pub const Deprecated = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128,
         checksum_padding: u128 = 0,
         checksum_body: u128,
@@ -342,14 +348,22 @@ pub const Header = extern struct {
 
         reserved: [128]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(_: *const @This()) ?[]const u8 {
             return "deprecated message type";
         }
     };
 
     pub const Ping = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -379,6 +393,16 @@ pub const Header = extern struct {
 
         reserved: [80]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .ping);
             if (self.size != @sizeOf(Header) + @sizeOf(vsr.Release) * constants.vsr_releases_max) {
@@ -399,8 +423,6 @@ pub const Header = extern struct {
     };
 
     pub const Pong = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -423,6 +445,16 @@ pub const Header = extern struct {
 
         reserved: [112]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .pong);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -436,8 +468,6 @@ pub const Header = extern struct {
     };
 
     pub const PingClient = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -457,6 +487,16 @@ pub const Header = extern struct {
         ping_timestamp_monotonic: u64,
         reserved: [104]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .ping_client);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -471,8 +511,6 @@ pub const Header = extern struct {
     };
 
     pub const PongClient = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -491,6 +529,16 @@ pub const Header = extern struct {
         ping_timestamp_monotonic: u64,
         reserved: [120]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .pong_client);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -502,8 +550,6 @@ pub const Header = extern struct {
     };
 
     pub const Request = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -559,6 +605,16 @@ pub const Header = extern struct {
         /// reply.
         previous_request_latency: u32,
         reserved: [52]u8 = @splat(0),
+
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request);
@@ -629,8 +685,6 @@ pub const Header = extern struct {
     };
 
     pub const Prepare = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -682,6 +736,16 @@ pub const Header = extern struct {
         /// The state machine operation to apply.
         operation: Operation,
         reserved: [3]u8 = @splat(0),
+
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
 
         fn invalid_header(self: *const Prepare) ?[]const u8 {
             assert(self.command == .prepare);
@@ -797,8 +861,6 @@ pub const Header = extern struct {
     };
 
     pub const PrepareOk = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -830,6 +892,16 @@ pub const Header = extern struct {
         request: u32,
         operation: Operation = .reserved,
         reserved: [3]u8 = @splat(0),
+
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .prepare_ok);
@@ -877,8 +949,6 @@ pub const Header = extern struct {
     };
 
     pub const Reply = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -919,6 +989,16 @@ pub const Header = extern struct {
         operation: Operation = .reserved,
         reserved: [19]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .reply);
             if (self.release.value == 0) return "release == 0";
@@ -946,8 +1026,6 @@ pub const Header = extern struct {
     };
 
     pub const Commit = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -980,6 +1058,16 @@ pub const Header = extern struct {
 
         reserved: [56]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .commit);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -993,8 +1081,6 @@ pub const Header = extern struct {
     };
 
     pub const StartViewChange = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1012,6 +1098,16 @@ pub const Header = extern struct {
 
         reserved: [128]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .start_view_change);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -1023,8 +1119,6 @@ pub const Header = extern struct {
     };
 
     pub const DoViewChange = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1055,6 +1149,16 @@ pub const Header = extern struct {
         log_view: u32,
         reserved: [68]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .do_view_change);
             if ((self.size - @sizeOf(Header)) % @sizeOf(Header) != 0) {
@@ -1069,8 +1173,6 @@ pub const Header = extern struct {
     };
 
     pub const StartView = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1096,6 +1198,16 @@ pub const Header = extern struct {
         checkpoint_op: u64,
         reserved: [88]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .start_view);
             if (self.release.value != 0) return "release != 0";
@@ -1107,8 +1219,6 @@ pub const Header = extern struct {
     };
 
     pub const RequestStartView = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1127,6 +1237,16 @@ pub const Header = extern struct {
         nonce: u128,
         reserved: [112]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_start_view);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -1139,8 +1259,6 @@ pub const Header = extern struct {
     };
 
     pub const RequestHeaders = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1162,6 +1280,16 @@ pub const Header = extern struct {
         op_max: u64,
         reserved: [112]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_headers);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -1175,8 +1303,6 @@ pub const Header = extern struct {
     };
 
     pub const RequestPrepare = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1197,6 +1323,16 @@ pub const Header = extern struct {
         prepare_op: u64,
         reserved: [88]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_prepare);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -1210,8 +1346,6 @@ pub const Header = extern struct {
     };
 
     pub const RequestReply = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1233,6 +1367,16 @@ pub const Header = extern struct {
         reply_op: u64,
         reserved: [72]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_reply);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
@@ -1247,8 +1391,6 @@ pub const Header = extern struct {
     };
 
     pub const Headers = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1266,6 +1408,16 @@ pub const Header = extern struct {
 
         reserved: [128]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .headers);
             if (self.size == @sizeOf(Header)) return "size == @sizeOf(Header)";
@@ -1276,8 +1428,6 @@ pub const Header = extern struct {
     };
 
     pub const Eviction = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1296,6 +1446,16 @@ pub const Header = extern struct {
         client: u128,
         reserved: [111]u8 = @splat(0),
         reason: Reason,
+
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .eviction);
@@ -1333,8 +1493,6 @@ pub const Header = extern struct {
     };
 
     pub const RequestBlocks = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
-
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1352,6 +1510,16 @@ pub const Header = extern struct {
 
         reserved: [128]u8 = @splat(0),
 
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
+
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .request_blocks);
             if (self.view != 0) return "view != 0";
@@ -1366,7 +1534,6 @@ pub const Header = extern struct {
     };
 
     pub const Block = extern struct {
-        pub usingnamespace HeaderFunctionsType(@This());
         pub const metadata_size = 96;
 
         checksum: u128 = 0,
@@ -1393,6 +1560,16 @@ pub const Header = extern struct {
         snapshot: u64,
         block_type: schema.BlockType,
         reserved_block: [15]u8 = @splat(0),
+
+        pub const frame = HeaderFunctionsType(@This()).frame;
+        pub const frame_const = HeaderFunctionsType(@This()).frame_const;
+        pub const invalid = HeaderFunctionsType(@This()).invalid;
+        pub const calculate_checksum = HeaderFunctionsType(@This()).calculate_checksum;
+        pub const calculate_checksum_body = HeaderFunctionsType(@This()).calculate_checksum_body;
+        pub const set_checksum = HeaderFunctionsType(@This()).set_checksum;
+        pub const set_checksum_body = HeaderFunctionsType(@This()).set_checksum_body;
+        pub const valid_checksum = HeaderFunctionsType(@This()).valid_checksum;
+        pub const valid_checksum_body = HeaderFunctionsType(@This()).valid_checksum_body;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
             assert(self.command == .block);
@@ -1434,6 +1611,16 @@ comptime {
                 assert(@offsetOf(CommandHeader, command_field.name) ==
                     @offsetOf(Header, header_field.name));
             }
+        }
+
+        // Verify that the command's header's re-exports all Header's functions.
+        const HeaderFunctions = Header.HeaderFunctionsType(CommandHeader);
+        for (@typeInfo(HeaderFunctions).@"struct".decls) |decl| {
+            assert(@hasDecl(CommandHeader, decl.name));
+
+            const a = @field(CommandHeader, decl.name);
+            const b = @field(HeaderFunctions, decl.name);
+            assert(a == b);
         }
     }
 }


### PR DESCRIPTION
Remove `usingnamespace`

Different situations required different approaches:

- Selective implementation is now `pub const my_fn = if (condition) fn_decl1 else fn_decl2;`.
Note that we can no longer conditionally include a function, its declaration is always present. However, we can make it `void`. For example: `pub const my_fn = if (condition) fn_decl1 else {};`.

- Since we can’t conditionally include declarations anymore, some patterns were simplified.
For example, `SegmentedArray` now has the function `insert` instead of conditionally including either `fn insert_element` or `fn insert_elements`.
In some cases, like `amqp.Protocol`, the simplest approach, instead of conditionally including either the `fn encode` or `fn decode`, we call `comptime assert(...)` to prevent these functions from ever being referenced in the wrong context.

- Mixins were rare in our code.
One case was merging `vsr` and `vortex` constants, which was solved by namespacing them as `constants.vsr` and `constants.vortex`.
Another case was `MessageHeader`, solved by re-exporting all functions (with a comptime block to check).

- `@cImport` and `usingnamespace` were used in the NAPI wrapper.
This was replaced by namespacing with `const c = @cImport(...)`.
