### PR TITLE
vsr: make sure replica process uses different PRNGs

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1437,7 +1437,7 @@ pub fn ReplicaType(
                     // (`after` will be adjusted at runtime each time before it is started.)
                     .after = 10 / constants.tick_ms,
                 },
-                .prng = stdx.PRNG.from_seed(replica_index),
+                .prng = stdx.PRNG.from_seed(@truncate(options.nonce)),
 
                 .trace = self.trace,
                 .test_context = options.test_context,


### PR DESCRIPTION
Feels wrong if, after restart, replica ends up using the same PRNG sequence! We already have a unique number identifying an instance of replica process --- the nonce. So use that to init PRNG.