### PR TITLE
docs: Bump nav width so text doesn’t wrap

### DIFF
--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -153,7 +153,7 @@ nav.left-pane {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  width: 300px;
+  width: 310px;
 
   >.top-wrapper {
     position: sticky;


### PR DESCRIPTION
Bump the initial width of the side nav so the "no results" text doesn't need to wrap.

Before:
<img width="325" height="400" alt="image" src="https://github.com/user-attachments/assets/46c657d6-f509-42a5-a126-e529eef64bab" />

After: 
<img width="313" height="363" alt="image" src="https://github.com/user-attachments/assets/c9291e2b-c7cd-49b2-a150-47d176a662d6" />
