### PR TITLE
cfo: Revert moving unshare into cfo script

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -154,16 +154,6 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
         return error.NotSupported;
     }
 
-    if (builtin.os.tag == .linux) {
-        // Relaunch in a fresh pid namespace.
-        try stdx.unshare.maybe_unshare_and_relaunch(gpa, .{
-            .pid = true,
-            .network = false,
-        });
-    } else {
-        log.warn("cfo may spawn runaway processes when run on a non-Linux OS", .{});
-    }
-
     if (cli_args.budget_minutes == 0) fatal("--budget-minutes: must be greater than zero", .{});
     if (cli_args.refresh_minutes == 0) fatal("--refresh-minutes: must be greater than zero", .{});
     if (cli_args.timeout_minutes == 0) fatal("--timeout-minutes: must be greater than zero", .{});

--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -24,6 +24,6 @@ do
         git fetch
         git switch --discard-changes --detach origin/main
         ./zig/download.sh
-        ./zig/zig build -Drelease scripts -- cfo
+        unshare --user --pid --fork ./zig/zig build -Drelease scripts -- cfo
     ) || sleep 10 # Be resilient to cfo bugs and network errors, but avoid busy-loop retries.
 done


### PR DESCRIPTION
At the moment the cfo_supervisor.sh script doesn't respond correctly to ctrl-c - the child script continues to run while the parent zig and build processes become zombies. This happened after we moved the call to `unshare` from a command in the cfo_supervisor script to a syscall in the `script` binary.

After quite a big of debugging I have not solved the problem and think we should revert temporarily.

The unshare code on master is not quite correct yet - after forking the child should be resetting sigprocmask before `exec`ing. But that fix does not fix the ctrl-c problem.

I still do not understand what is going wrong but I think it has to do with delivery of SIGINT to the foreground process group, and this is affected by the exact hierarchy of processes in play, how they set their signal masks and how they wait on their children.

The bug only occurs when we are unsharing from a subprocess of the zig build system and the `build` program. If I e.g. use our unshare code to build an unshare bin, that bin seems to behave the same as stock unshare. But when the process hierarchy has the zig build system in between, like `bash > zig > build > script` something is going wrong with SIGINT. I am still debugging this but it seems to be pretty deep and I don't see a fix on the horizon.