### PR TITLE
Vortex: Clean up data files

### DIFF
--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -168,10 +168,10 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
         try trace.process_name_assign(@field(vortex_process_ids, field.name), field.name);
     }
 
-    if (args.test_duration_seconds % 60 == 0) {
+    if (args.test_duration_seconds % std.time.s_per_min == 0) {
         log.info(
             "starting test with target runtime of {d}m",
-            .{@divFloor(args.test_duration_seconds, 6)},
+            .{@divExact(args.test_duration_seconds, std.time.s_per_min)},
         );
     } else {
         log.info(

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -146,6 +146,13 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
     var output_directory_buffer: [std.fs.max_path_bytes]u8 = undefined;
     const output_directory = args.output_directory orelse
         try create_tmp_dir(&output_directory_buffer);
+    defer {
+        if (args.output_directory == null) {
+            std.fs.cwd().deleteTree(output_directory) catch |err| {
+                log.err("error deleting tree: {}", .{err});
+            };
+        }
+    }
     log.info("output directory: {s}", .{output_directory});
 
     var trace_file_buffer: [std.fs.max_path_bytes]u8 = undefined;


### PR DESCRIPTION
I'm not really sure why we didn't do this already... it was littering in `.zig-cache/.../` with data files after every run.

If output directory is specified then we don't delete the tree.

If the workload fails I think we won't delete the data files, since we exit with `std.process.exit(1);`. (I will probably refactor that at some point, since that seems awkward).

---

Also, completely unrelated, fix an incorrect unit division in a vortex log line.