### PR TITLE
Build: "build vortex" vs "build vortex:build"

### DIFF
--- a/src/testing/vortex/java_driver/README.md
+++ b/src/testing/vortex/java_driver/README.md
@@ -6,7 +6,7 @@ Run the following to test with this driver:
 
 ```
 ./zig/zig build -Drelease install
-./zig/zig build -Drelease vortex
+./zig/zig build -Drelease vortex:build
 ./zig/zig build clients:java -Drelease
 (cd src/clients/java && mvn package)
 (cd src/testing/vortex/java_driver && mvn package)

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -20,7 +20,7 @@
 //! be sure all child processes are killed, and to get network sandboxing.
 //!
 //!     $ zig build
-//!     $ zig build vortex
+//!     $ zig build vortex:build
 //!     $ unshare --net --fork --map-root-user --pid bash -c 'ip link set up dev lo ; \
 //!         ./zig-out/bin/vortex supervisor --tigerbeetle-executable=./zig-out/bin/tigerbeetle'
 //!


### PR DESCRIPTION
Make vortex build more similar to other tests:
- Add a run step for vortex, to make it more similar to the other tests (e.g. VOPR).
- `zig build vortex:build -Dprint-exe` now works, like it does for the other tests.
- Also this simplifies `build_test_integration` which previously retrieved vortex's path rather awkwardly.