### PR TITLE
VSR: Don't try to cancel commit_stage=checkpoint_durable

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4246,7 +4246,13 @@ pub fn ReplicaType(
 
             if (self.syncing == .canceling_commit) {
                 switch (self.commit_stage) {
-                    .start, .reply_setup, .stall, .checkpoint_data, .checkpoint_superblock => {
+                    .start,
+                    .reply_setup,
+                    .stall,
+                    .checkpoint_durable,
+                    .checkpoint_data,
+                    .checkpoint_superblock,
+                    => {
                         self.sync_dispatch(.canceling_grid);
                         return;
                     },
@@ -4254,7 +4260,6 @@ pub fn ReplicaType(
                     .check_prepare,
                     .prefetch,
                     .execute,
-                    .checkpoint_durable,
                     .compact,
                     => unreachable,
                 }
@@ -10161,6 +10166,7 @@ pub fn ReplicaType(
                 .start,
                 .reply_setup,
                 .stall,
+                .checkpoint_durable,
                 .checkpoint_data,
                 .checkpoint_superblock,
                 => self.sync_dispatch(.canceling_commit),
@@ -10168,7 +10174,6 @@ pub fn ReplicaType(
                 .idle, // (StateMachine.open() may be running.)
                 .prefetch,
                 .compact,
-                .checkpoint_durable,
                 => self.sync_dispatch(.canceling_grid),
             }
         }


### PR DESCRIPTION
Don't call `grid.cancel()` part-way through `commit_stage=checkpoint_durable`.

This was hitting an `unreachable`:

```zig
    pub fn cancel(queue: *GridBlocksMissing) void {
        queue.verify();
        defer queue.verify();

        for (queue.faulty_blocks.values()) |*fault| {
            switch (fault.state) {
                .aborting => unreachable, // <----------------------------------
```

There's no reason we can't just wait until `checkpoint_durable()` is complete before we cancel.

Seed: ./zig/zig build vopr -Drelease -- --lite 18196054238508828398
Seed: ./zig/zig build vopr -Drelease -- 17488509886073355912