### PR TITLE
grid: mark cache blocks as MADV_DONTDUMP

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -375,6 +375,13 @@ fn command_start(
         else => |e| return e,
     };
 
+    // Mark grid cache as MADV_DONTDUMP, after transitioning to static in replica.open, to reduce
+    // core dump size.
+    replica.grid.madv_dont_dump() catch |e| {
+        log.warn("unable to mark grid cache as MADV_DONTDUMP - " ++
+            "core dumps will be large: {}", .{e});
+    };
+
     if (multiversion_os != null) {
         if (args.development) {
             log.info("multiversioning: upgrade polling disabled due to --development.", .{});

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -727,6 +727,13 @@ pub fn ReplicaType(
             // Disable all dynamic allocation from this point onwards.
             self.static_allocator.transition_from_init_to_static();
 
+            // Mark grid cache as MADV_DONTDUMP, after transitioning to static, to reduce core dump
+            // size.
+            self.grid.madv_dont_dump() catch |e| {
+                log.warn("unable to mark grid cache as MADV_DONTDUMP - " ++
+                    "core dumps will be large: {}", .{e});
+            };
+
             const release_target = self.superblock.working.vsr_state.checkpoint.release;
             assert(release_target.value >= self.superblock.working.release_format.value);
             log.info("superblock release={}", .{release_target});

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -727,13 +727,6 @@ pub fn ReplicaType(
             // Disable all dynamic allocation from this point onwards.
             self.static_allocator.transition_from_init_to_static();
 
-            // Mark grid cache as MADV_DONTDUMP, after transitioning to static, to reduce core dump
-            // size.
-            self.grid.madv_dont_dump() catch |e| {
-                log.warn("unable to mark grid cache as MADV_DONTDUMP - " ++
-                    "core dumps will be large: {}", .{e});
-            };
-
             const release_target = self.superblock.working.vsr_state.checkpoint.release;
             assert(release_target.value >= self.superblock.working.release_format.value);
             log.info("superblock release={}", .{release_target});


### PR DESCRIPTION
This allows core dumps to be manageable, even with a large grid cache size. The implementation might look a little peculiar, but I explicitly didn't want to change much with `allocate_block` for now...