### PR TITLE
CDC: Throttle the maximum number of requests per second.

### DIFF
--- a/docs/operating/cdc.md
+++ b/docs/operating/cdc.md
@@ -52,6 +52,10 @@ Here what the arguments mean:
   when the last query returned no events.<br>
   Optional. Defaults to `1000` ms if omitted.
 
+* `--requests-per-second-limit` throttles the maximum number of requests per second made
+  to TigerBeetle.<br>Must be greater than zero.<br>
+  Optional. No limit if omitted.
+
 * `--timestamp-last` overrides the last published timestamp, resuming from this point.<br>
   This is a TigerBeetle timestamp with nanosecond precision.<br>
   Optional. If omitted, the last acknowledged timestamp is used.
@@ -185,20 +189,20 @@ the `history` flag.
 
 ### High Availability
 
-The CDC job is single instance. Starting a second `tigerbeetle amqp` with the same `cluster_id` 
-will exit with a non-zero exit code. For high availability, the CDC job could be monitored for 
+The CDC job is single instance. Starting a second `tigerbeetle amqp` with the same `cluster_id`
+will exit with a non-zero exit code. For high availability, the CDC job could be monitored for
 crashes and restarted in case a failure.
 
-The CDC job itself is stateless, and will resume from the last event acknowledged by RabbitMQ, 
+The CDC job itself is stateless, and will resume from the last event acknowledged by RabbitMQ,
 however it may replay events that weren't acknowledged but received by the exchange.
 
 ### TLS Support
 
-For secure `AMQPS` connections, we recommend using a TLS Tunnel to wrap the connection between 
+For secure `AMQPS` connections, we recommend using a TLS Tunnel to wrap the connection between
 TigerBeetle and RabbitMQ.
 
 ### Event Replay
 
 By default, when the CDC job starts, it resumes from the timestamp of the last acknowledged event in
-RabbitMQ. This can be overridden to using `--timestamp-last`. For example, `--timestamp-last=0` will 
+RabbitMQ. This can be overridden to using `--timestamp-last`. For example, `--timestamp-last=0` will
 replay all events.

--- a/docs/operating/cdc.md
+++ b/docs/operating/cdc.md
@@ -53,7 +53,8 @@ Here what the arguments mean:
   Optional. Defaults to `1000` ms if omitted.
 
 * `--requests-per-second-limit` throttles the maximum number of requests per second made
-  to TigerBeetle.<br>Must be greater than zero.<br>
+  to TigerBeetle.<br>
+  Must be greater than zero.<br>
   Optional. No limit if omitted.
 
 * `--timestamp-last` overrides the last published timestamp, resuming from this point.<br>

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -328,8 +328,8 @@ pub fn AOFType(comptime IO: type) type {
 
                 client.* = try Client.init(
                     allocator,
-                    message_pool,
                     time,
+                    message_pool,
                     .{
                         .id = stdx.unique_u128(),
                         .cluster = 0,

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -328,12 +328,12 @@ pub fn AOFType(comptime IO: type) type {
 
                 client.* = try Client.init(
                     allocator,
+                    message_pool,
+                    time,
                     .{
                         .id = stdx.unique_u128(),
                         .cluster = 0,
                         .replica_count = @intCast(addresses.len),
-                        .time = time,
-                        .message_pool = message_pool,
                         .message_bus_options = .{
                             .configuration = addresses,
                             .io = io,

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -237,8 +237,8 @@ pub const Runner = struct {
 
         self.vsr_client = try Client.init(
             allocator,
-            &self.message_pool,
             time,
+            &self.message_pool,
             .{
                 .id = stdx.unique_u128(),
                 .cluster = options.cluster_id,
@@ -950,6 +950,7 @@ pub const RateLimit = struct {
     } {
         assert(self.options.limit > 0);
         assert(self.options.period.ns > 0);
+        assert(self.count <= self.options.limit);
 
         if (self.count == 0) {
             self.timer.reset();
@@ -957,7 +958,6 @@ pub const RateLimit = struct {
             return .ok;
         }
         assert(self.count > 0);
-        assert(self.count <= self.options.limit);
 
         const duration = self.timer.read();
         maybe(duration.ns == 0);

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -294,8 +294,8 @@ pub fn ContextType(
             });
             context.client = Client.init(
                 allocator,
-                &context.message_pool,
                 time,
+                &context.message_pool,
                 .{
                     .id = context.client_id,
                     .cluster = cluster_id,

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -294,12 +294,12 @@ pub fn ContextType(
             });
             context.client = Client.init(
                 allocator,
+                &context.message_pool,
+                time,
                 .{
                     .id = context.client_id,
                     .cluster = cluster_id,
                     .replica_count = context.addresses.count_as(u8),
-                    .time = time,
-                    .message_pool = &context.message_pool,
                     .message_bus_options = .{
                         .configuration = context.addresses.const_slice(),
                         .io = &context.io,
@@ -312,9 +312,7 @@ pub fn ContextType(
                     @errorName(err),
                 });
                 return switch (err) {
-                    error.TimerUnsupported => error.Unexpected,
                     error.OutOfMemory => error.OutOfMemory,
-                    else => unreachable,
                 };
             };
             errdefer context.client.deinit(allocator);

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -33,8 +33,8 @@ pub fn EchoClientType(
 
         pub fn init(
             allocator: mem.Allocator,
-            message_pool: *MessagePool,
             time: Time,
+            message_pool: *MessagePool,
             options: struct {
                 id: u128,
                 cluster: u128,

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -33,12 +33,12 @@ pub fn EchoClientType(
 
         pub fn init(
             allocator: mem.Allocator,
+            message_pool: *MessagePool,
+            time: Time,
             options: struct {
                 id: u128,
                 cluster: u128,
                 replica_count: u8,
-                time: Time,
-                message_pool: *MessagePool,
                 message_bus_options: MessageBus.Options,
                 eviction_callback: ?*const fn (
                     client: *EchoClient,
@@ -53,8 +53,8 @@ pub fn EchoClientType(
             return EchoClient{
                 .id = options.id,
                 .cluster = options.cluster,
-                .message_pool = options.message_pool,
-                .time = options.time,
+                .message_pool = message_pool,
+                .time = time,
             };
         }
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -679,8 +679,8 @@ pub fn ReplType(comptime MessageBus: type) type {
             const client_id = stdx.unique_u128();
             const client = try Client.init(
                 allocator,
-                message_pool,
                 time,
+                message_pool,
                 .{
                     .id = client_id,
                     .cluster = options.cluster_id,

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -679,12 +679,12 @@ pub fn ReplType(comptime MessageBus: type) type {
             const client_id = stdx.unique_u128();
             const client = try Client.init(
                 allocator,
+                message_pool,
+                time,
                 .{
                     .id = client_id,
                     .cluster = options.cluster_id,
                     .replica_count = @intCast(options.addresses.len),
-                    .time = time,
-                    .message_pool = message_pool,
                     .message_bus_options = .{
                         .configuration = options.addresses,
                         .io = io,

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -718,12 +718,12 @@ const VSRContext = struct {
         const address = try std.net.Address.parseIp4("127.0.0.1", port);
         self.client = try Client.init(
             gpa,
+            &self.message_pool,
+            time,
             .{
                 .id = stdx.unique_u128(),
                 .cluster = 0,
                 .replica_count = 1,
-                .time = time,
-                .message_pool = &self.message_pool,
                 .message_bus_options = .{
                     .configuration = &.{address},
                     .io = &self.io,

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -718,8 +718,8 @@ const VSRContext = struct {
         const address = try std.net.Address.parseIp4("127.0.0.1", port);
         self.client = try Client.init(
             gpa,
-            &self.message_pool,
             time,
+            &self.message_pool,
             .{
                 .id = stdx.unique_u128(),
                 .cluster = 0,

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1011,8 +1011,8 @@ pub fn StateMachineType(
         pub fn init(
             self: *StateMachine,
             allocator: mem.Allocator,
-            grid: *Grid,
             time: vsr.time.Time,
+            grid: *Grid,
             options: Options,
         ) !void {
             assert(options.batch_size_limit <= config.message_body_size_max);

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -83,15 +83,20 @@ pub const TestContext = struct {
         ctx.grid = try fixtures.init_grid(allocator, &ctx.trace, &ctx.superblock, .{});
         errdefer ctx.grid.deinit(allocator);
 
-        try ctx.state_machine.init(allocator, &ctx.grid, .{
-            .batch_size_limit = message_body_size_max,
-            .lsm_forest_compaction_block_count = StateMachine.Forest.Options
-                .compaction_block_count_min,
-            .lsm_forest_node_count = 1,
-            .cache_entries_accounts = 0,
-            .cache_entries_transfers = 0,
-            .cache_entries_transfers_pending = 0,
-        });
+        try ctx.state_machine.init(
+            allocator,
+            &ctx.grid,
+            ctx.time_sim.time(),
+            .{
+                .batch_size_limit = message_body_size_max,
+                .lsm_forest_compaction_block_count = StateMachine.Forest.Options
+                    .compaction_block_count_min,
+                .lsm_forest_node_count = 1,
+                .cache_entries_accounts = 0,
+                .cache_entries_transfers = 0,
+                .cache_entries_transfers_pending = 0,
+            },
+        );
         errdefer ctx.state_machine.deinit(allocator);
         // Usually, `pulse_next_timestamp` starts in an unknown state, signaling that the state
         // machine needs a `pulse` to scan for pending transfers and correctly determine when to

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -85,8 +85,8 @@ pub const TestContext = struct {
 
         try ctx.state_machine.init(
             allocator,
-            &ctx.grid,
             ctx.time_sim.time(),
+            &ctx.grid,
             .{
                 .batch_size_limit = message_body_size_max,
                 .lsm_forest_compaction_block_count = StateMachine.Forest.Options

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -958,6 +958,10 @@ pub const Duration = struct {
         return .{ .ns = amount_ms * std.time.ns_per_ms };
     }
 
+    pub fn seconds(amount_seconds: u64) Duration {
+        return .{ .ns = amount_seconds * std.time.ns_per_s };
+    }
+
     pub fn minutes(amount_minutes: u64) Duration {
         return .{ .ns = amount_minutes * std.time.ns_per_min };
     }
@@ -1006,6 +1010,10 @@ test "Instant/Duration" {
     assert(duration.ns == 1_000_000_000);
     assert(duration.to_us() == 1_000_000);
     assert(duration.to_ms() == 1_000);
+
+    assert(Duration.ms(1).ns == std.time.ns_per_ms);
+    assert(Duration.seconds(1).ns == std.time.ns_per_s);
+    assert(Duration.minutes(1).ns == std.time.ns_per_min);
 }
 
 /// DateTime in UTC, intended primarily for logging.

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -324,12 +324,12 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 errdefer for (clients[0..i]) |*c| c.*.?.deinit(allocator);
                 client.* = try Client.init(
                     allocator,
+                    &client_pools[i],
+                    client_times[i].time(),
                     .{
                         .id = client_id_permutation.encode(i + client_id_permutation_shift),
                         .cluster = options.cluster.cluster_id,
                         .replica_count = options.cluster.replica_count,
-                        .time = client_times[i].time(),
-                        .message_pool = &client_pools[i],
                         .message_bus_options = .{ .network = network },
                         .eviction_callback = client_on_eviction,
                     },
@@ -729,16 +729,16 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             var replica = &cluster.replicas[replica_index];
             try replica.open(
                 cluster.allocator,
+                &cluster.storages[replica_index],
+                &cluster.replica_pools[replica_index],
+                cluster.replica_times[replica_index].time(),
                 .{
                     .node_count = cluster.options.replica_count + cluster.options.standby_count,
                     .pipeline_requests_limit = cluster.replica_pipeline_requests_limit,
-                    .storage = &cluster.storages[replica_index],
                     .aof = &cluster.aofs[replica_index],
                     // TODO Test restarting with a higher storage limit.
                     .storage_size_limit = cluster.options.storage_size_limit,
-                    .message_pool = &cluster.replica_pools[replica_index],
                     .nonce = options.nonce,
-                    .time = cluster.replica_times[replica_index].time(),
                     .state_machine_options = cluster.options.state_machine,
                     .message_bus_options = .{ .network = cluster.network },
                     .release = options.release,

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -324,8 +324,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 errdefer for (clients[0..i]) |*c| c.*.?.deinit(allocator);
                 client.* = try Client.init(
                     allocator,
-                    &client_pools[i],
                     client_times[i].time(),
+                    &client_pools[i],
                     .{
                         .id = client_id_permutation.encode(i + client_id_permutation_shift),
                         .cluster = options.cluster.cluster_id,
@@ -729,9 +729,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             var replica = &cluster.replicas[replica_index];
             try replica.open(
                 cluster.allocator,
+                cluster.replica_times[replica_index].time(),
                 &cluster.storages[replica_index],
                 &cluster.replica_pools[replica_index],
-                cluster.replica_times[replica_index].time(),
                 .{
                     .node_count = cluster.options.replica_count + cluster.options.standby_count,
                     .pipeline_requests_limit = cluster.replica_pipeline_requests_limit,

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -87,8 +87,8 @@ pub fn StateMachineType(
         pub fn init(
             self: *StateMachine,
             allocator: std.mem.Allocator,
-            grid: *Grid,
             time: vsr.time.Time,
+            grid: *Grid,
             options: Options,
         ) !void {
             _ = time;

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -88,8 +88,10 @@ pub fn StateMachineType(
             self: *StateMachine,
             allocator: std.mem.Allocator,
             grid: *Grid,
+            time: vsr.time.Time,
             options: Options,
         ) !void {
+            _ = time;
             self.* = .{
                 .options = options,
                 .forest = undefined,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -91,14 +91,17 @@ pub fn main(
     defer for (clients.slice()) |*client| client.deinit(allocator);
 
     for (0..cli_args.clients) |i| {
-        clients.push(try Client.init(allocator, .{
-            .id = stdx.unique_u128(),
-            .cluster = cluster_id,
-            .replica_count = @intCast(addresses.len),
-            .time = time,
-            .message_pool = &message_pools.slice()[i],
-            .message_bus_options = .{ .configuration = addresses, .io = io },
-        }));
+        clients.push(try Client.init(
+            allocator,
+            &message_pools.slice()[i],
+            time,
+            .{
+                .id = stdx.unique_u128(),
+                .cluster = cluster_id,
+                .replica_count = @intCast(addresses.len),
+                .message_bus_options = .{ .configuration = addresses, .io = io },
+            },
+        ));
     }
 
     // Each array position corresponds to a histogram bucket of 1ms. The last bucket is 10_000ms+.

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -93,8 +93,8 @@ pub fn main(
     for (0..cli_args.clients) |i| {
         clients.push(try Client.init(
             allocator,
-            &message_pools.slice()[i],
             time,
+            &message_pools.slice()[i],
             .{
                 .id = stdx.unique_u128(),
                 .cluster = cluster_id,

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -281,6 +281,7 @@ const CLIArgs = union(enum) {
         publish_routing_key: ?[]const u8 = null,
         event_count_max: ?u32 = null,
         idle_interval_ms: ?u32 = null,
+        requests_per_second_limit: ?u32 = null,
         timestamp_last: ?u64 = null,
         verbose: bool = false,
     };
@@ -611,6 +612,7 @@ pub const Command = union(enum) {
         publish_routing_key: ?[]const u8,
         event_count_max: ?u32,
         idle_interval_ms: ?u32,
+        requests_per_second_limit: ?u32,
         timestamp_last: ?u64,
         log_debug: bool,
     };
@@ -1169,6 +1171,16 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         );
     }
 
+    if (amqp.requests_per_second_limit) |requests_per_second_limit| {
+        if (requests_per_second_limit == 0) {
+            vsr.fatal(
+                .cli,
+                "--request-per-second-limit must not be zero.",
+                .{},
+            );
+        }
+    }
+
     return .{
         .addresses = addresses,
         .cluster = amqp.cluster,
@@ -1180,6 +1192,7 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         .publish_routing_key = amqp.publish_routing_key,
         .event_count_max = amqp.event_count_max,
         .idle_interval_ms = amqp.idle_interval_ms,
+        .requests_per_second_limit = amqp.requests_per_second_limit,
         .timestamp_last = amqp.timestamp_last,
         .log_debug = amqp.verbose,
     };

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -1175,7 +1175,7 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         if (requests_per_second_limit == 0) {
             vsr.fatal(
                 .cli,
-                "--request-per-second-limit must not be zero.",
+                "--requests-per-second-limit must not be zero.",
                 .{},
             );
         }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -589,6 +589,7 @@ fn command_amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !
             .publish_routing_key = args.publish_routing_key,
             .event_count_max = args.event_count_max,
             .idle_interval_ms = args.idle_interval_ms,
+            .requests_per_second_limit = args.requests_per_second_limit,
             .recovery_mode = if (args.timestamp_last) |timestamp_last|
                 .{ .override = timestamp_last }
             else

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -150,8 +150,8 @@ pub fn main() !void {
 
             switch (command_storage) {
                 .format => try command_format(gpa, &storage, args),
-                .start => try command_start(gpa, &io, &tracer, &storage, args),
-                .recover => try command_reformat(gpa, &io, &tracer, &storage, args),
+                .start => try command_start(gpa, &io, &tracer, &storage, time, args),
+                .recover => try command_reformat(gpa, &io, &storage, time, args),
                 else => comptime unreachable,
             }
         },
@@ -236,6 +236,7 @@ fn command_start(
     io: *IO,
     tracer: *Tracer,
     storage: *Storage,
+    time: vsr.time.Time,
     args: *const cli.Command.Start,
 ) !void {
     var counting_allocator = vsr.CountingAllocator.init(base_allocator);
@@ -337,40 +338,44 @@ fn command_start(
     const clients_limit = constants.pipeline_prepare_queue_max + args.pipeline_requests_limit;
 
     var replica: Replica = undefined;
-    replica.open(gpa, .{
-        .node_count = args.addresses.count_as(u8),
-        .release = config.process.release,
-        .release_client_min = config.process.release_client_min,
-        .multiversion = multiversion,
-        .pipeline_requests_limit = args.pipeline_requests_limit,
-        .storage_size_limit = args.storage_size_limit,
-        .storage = storage,
-        .aof = if (aof != null) &aof.? else null,
-        .message_pool = &message_pool,
-        .nonce = nonce,
-        .time = tracer.time,
-        .timeout_prepare_ticks = args.timeout_prepare_ticks,
-        .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
-        .commit_stall_probability = args.commit_stall_probability,
-        .state_machine_options = .{
-            .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
-            .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
-            .lsm_forest_node_count = args.lsm_forest_node_count,
-            .cache_entries_accounts = args.cache_accounts,
-            .cache_entries_transfers = args.cache_transfers,
-            .cache_entries_transfers_pending = args.cache_transfers_pending,
+    replica.open(
+        gpa,
+        storage,
+        &message_pool,
+        time,
+
+        .{
+            .node_count = args.addresses.count_as(u8),
+            .release = config.process.release,
+            .release_client_min = config.process.release_client_min,
+            .multiversion = multiversion,
+            .pipeline_requests_limit = args.pipeline_requests_limit,
+            .storage_size_limit = args.storage_size_limit,
+            .aof = if (aof != null) &aof.? else null,
+            .nonce = nonce,
+            .timeout_prepare_ticks = args.timeout_prepare_ticks,
+            .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
+            .commit_stall_probability = args.commit_stall_probability,
+            .state_machine_options = .{
+                .batch_size_limit = args.request_size_limit - @sizeOf(vsr.Header),
+                .lsm_forest_compaction_block_count = args.lsm_forest_compaction_block_count,
+                .lsm_forest_node_count = args.lsm_forest_node_count,
+                .cache_entries_accounts = args.cache_accounts,
+                .cache_entries_transfers = args.cache_transfers,
+                .cache_entries_transfers_pending = args.cache_transfers_pending,
+            },
+            .message_bus_options = .{
+                .configuration = args.addresses.const_slice(),
+                .io = io,
+                .clients_limit = clients_limit,
+            },
+            .grid_cache_blocks_count = args.cache_grid_blocks,
+            .tracer = tracer,
+            .replicate_options = .{
+                .star = args.replicate_star,
+            },
         },
-        .message_bus_options = .{
-            .configuration = args.addresses.const_slice(),
-            .io = io,
-            .clients_limit = clients_limit,
-        },
-        .grid_cache_blocks_count = args.cache_grid_blocks,
-        .tracer = tracer,
-        .replicate_options = .{
-            .star = args.replicate_star,
-        },
-    }) catch |err| switch (err) {
+    ) catch |err| switch (err) {
         error.NoAddress => vsr.fatal(.cli, "all --addresses must be provided", .{}),
         else => |e| return e,
     };
@@ -493,26 +498,30 @@ fn command_start(
 fn command_reformat(
     gpa: mem.Allocator,
     io: *IO,
-    tracer: *Tracer,
     storage: *Storage,
+    time: vsr.time.Time,
     args: *const cli.Command.Recover,
 ) !void {
     var message_pool = try MessagePool.init(gpa, .client);
     defer message_pool.deinit(gpa);
 
-    var client = try Client.init(gpa, .{
-        .id = stdx.unique_u128(),
-        .cluster = args.cluster,
-        .replica_count = args.replica_count,
-        .time = tracer.time,
-        .message_pool = &message_pool,
-        .message_bus_options = .{
-            .configuration = args.addresses.const_slice(),
-            .io = io,
-            .clients_limit = null,
+    var client = try Client.init(
+        gpa,
+        &message_pool,
+        time,
+        .{
+            .id = stdx.unique_u128(),
+            .cluster = args.cluster,
+            .replica_count = args.replica_count,
+
+            .message_bus_options = .{
+                .configuration = args.addresses.const_slice(),
+                .io = io,
+                .clients_limit = null,
+            },
+            .eviction_callback = &reformat_client_eviction_callback,
         },
-        .eviction_callback = &reformat_client_eviction_callback,
-    });
+    );
     defer client.deinit(gpa);
 
     var reformatter = try ReplicaReformat.init(gpa, &client, storage, .{

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -150,8 +150,8 @@ pub fn main() !void {
 
             switch (command_storage) {
                 .format => try command_format(gpa, &storage, args),
-                .start => try command_start(gpa, &io, &tracer, &storage, time, args),
-                .recover => try command_reformat(gpa, &io, &storage, time, args),
+                .start => try command_start(gpa, &io, time, &tracer, &storage, args),
+                .recover => try command_reformat(gpa, &io, time, &storage, args),
                 else => comptime unreachable,
             }
         },
@@ -234,9 +234,9 @@ fn command_format(
 fn command_start(
     base_allocator: mem.Allocator,
     io: *IO,
+    time: vsr.time.Time,
     tracer: *Tracer,
     storage: *Storage,
-    time: vsr.time.Time,
     args: *const cli.Command.Start,
 ) !void {
     var counting_allocator = vsr.CountingAllocator.init(base_allocator);
@@ -340,10 +340,9 @@ fn command_start(
     var replica: Replica = undefined;
     replica.open(
         gpa,
+        time,
         storage,
         &message_pool,
-        time,
-
         .{
             .node_count = args.addresses.count_as(u8),
             .release = config.process.release,
@@ -498,8 +497,8 @@ fn command_start(
 fn command_reformat(
     gpa: mem.Allocator,
     io: *IO,
-    storage: *Storage,
     time: vsr.time.Time,
+    storage: *Storage,
     args: *const cli.Command.Recover,
 ) !void {
     var message_pool = try MessagePool.init(gpa, .client);
@@ -507,8 +506,8 @@ fn command_reformat(
 
     var client = try Client.init(
         gpa,
-        &message_pool,
         time,
+        &message_pool,
         .{
             .id = stdx.unique_u128(),
             .cluster = args.cluster,

--- a/src/time.zig
+++ b/src/time.zig
@@ -188,39 +188,28 @@ test "Time monotonic smoke" {
 /// Equivalent to `std.time.Timer`,
 /// but using the `vsr.Time` interface as the source of time.
 pub const Timer = struct {
-    started: Instant,
-    previous: Instant,
     time: Time,
+    started: Instant,
 
     pub fn init(time: Time) Timer {
-        const current = time.monotonic_instant();
         return .{
-            .started = current,
-            .previous = current,
             .time = time,
+            .started = time.monotonic_instant(),
         };
     }
 
-    /// Reads the timer value since start or the last reset in nanoseconds.
+    /// Reads the timer value since start or the last reset.
     pub fn read(self: *Timer) stdx.Duration {
-        const current = self.sample();
+        const current = self.time.monotonic_instant();
+        assert(current.ns >= self.started.ns);
         return current.duration_since(self.started);
     }
 
-    /// Resets the timer value to 0/now.
+    /// Resets the timer.
     pub fn reset(self: *Timer) void {
-        const current = self.sample();
-        self.started = current;
-    }
-
-    /// Returns an Instant sampled at the callsite that is
-    /// guaranteed to be monotonic with respect to the timer's starting point.
-    fn sample(self: *Timer) Instant {
         const current = self.time.monotonic_instant();
-        if (current.ns > self.previous.ns) {
-            self.previous = current;
-        }
-        return self.previous;
+        assert(current.ns >= self.started.ns);
+        self.started = current;
     }
 };
 

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -127,8 +127,8 @@ pub fn ClientType(
 
         pub fn init(
             allocator: mem.Allocator,
-            message_pool: *MessagePool,
             time: Time,
+            message_pool: *MessagePool,
             options: struct {
                 id: u128,
                 cluster: u128,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -82,7 +82,7 @@ pub fn ClientType(
 
         /// Measures the time elapsed between sending a request (in `raw_request`) and receiving the
         /// corresponding reply (in `on_reply`).
-        request_completion_timer: std.time.Timer,
+        request_completion_timer: vsr.time.Timer,
 
         /// The maximum body size for `command=request` messages.
         /// Set by the `register`'s reply.
@@ -127,12 +127,12 @@ pub fn ClientType(
 
         pub fn init(
             allocator: mem.Allocator,
+            message_pool: *MessagePool,
+            time: Time,
             options: struct {
                 id: u128,
                 cluster: u128,
                 replica_count: u8,
-                time: Time,
-                message_pool: *MessagePool,
                 message_bus_options: MessageBus.Options,
                 /// When eviction_callback is null, the client will panic on eviction.
                 ///
@@ -150,7 +150,7 @@ pub fn ClientType(
             var message_bus = try MessageBus.init(
                 allocator,
                 .{ .client = options.id },
-                options.message_pool,
+                message_pool,
                 Client.on_messages,
                 options.message_bus_options,
             );
@@ -158,11 +158,11 @@ pub fn ClientType(
 
             var self = Client{
                 .message_bus = message_bus,
-                .time = options.time,
+                .time = time,
                 .id = options.id,
                 .cluster = options.cluster,
                 .replica_count = options.replica_count,
-                .request_completion_timer = try std.time.Timer.start(),
+                .request_completion_timer = .init(time),
                 .request_timeout = .{
                     .name = "request_timeout",
                     .id = options.id,
@@ -570,18 +570,15 @@ pub fn ClientType(
             assert(reply.header.op == reply.header.commit);
             assert(reply.header.operation == inflight_vsr_operation);
 
-            const request_completion_time_ms = @divFloor(
-                self.request_completion_timer.read(),
-                std.time.ns_per_ms,
-            );
-            if (request_completion_time_ms > constants.client_request_completion_warn_ms) {
+            const request_completion_duration = self.request_completion_timer.read();
+            if (request_completion_duration.to_ms() > constants.client_request_completion_warn_ms) {
                 log.warn("{}: on_reply: slow request, request={} op={} size={} {s} time={}ms", .{
                     self.id,
                     inflight.message.header.request,
                     reply.header.op,
                     inflight.message.header.size,
                     inflight.message.header.operation.tag_name(StateMachine),
-                    request_completion_time_ms,
+                    request_completion_duration.to_ms(),
                 });
             }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -643,9 +643,9 @@ pub fn ReplicaType(
         pub fn open(
             self: *Replica,
             parent_allocator: std.mem.Allocator,
+            time: Time,
             storage: *Storage,
             message_pool: *MessagePool,
-            time: Time,
             options: OpenOptions,
         ) !void {
             assert(options.storage_size_limit <= constants.storage_size_limit_max);
@@ -703,9 +703,9 @@ pub fn ReplicaType(
             // Initialize the replica:
             try self.init(
                 allocator,
+                time,
                 storage,
                 message_pool,
-                time,
                 .{
                     .cluster = self.superblock.working.cluster,
                     .replica_index = replica,
@@ -1068,9 +1068,9 @@ pub fn ReplicaType(
         fn init(
             self: *Replica,
             allocator: Allocator,
+            time: Time,
             storage: *Storage,
             message_pool: *MessagePool,
-            time: Time,
             options: Options,
         ) !void {
             assert(options.nonce != 0);
@@ -1255,8 +1255,8 @@ pub fn ReplicaType(
 
             try self.state_machine.init(
                 allocator,
-                &self.grid,
                 time,
+                &self.grid,
                 options.state_machine_options,
             );
             errdefer self.state_machine.deinit(allocator);


### PR DESCRIPTION
Implements a `--requests-per-second-limit` option to throttle CDC `get_change_events` requests to TigerBeetle.  
Its usage is orthogonal to `--idle-interval-ms` and `--event-count-max`, allowing fine-tuning for low latency without overflowing the AMQP target queue.

This PR also includes unrelated but necessary refactors (best reviewed by commit):
- Adds `vsr.time.Timer`, an alternative to `std.time.Timer` that uses the VSR abstracted `Time` interface.  
- Replaces some usages of `std.time.Timer` with the new implementation.  
- Refactors `init` functions to avoid including dependencies in the `options` struct, enforcing recent TigerStyle updates (https://github.com/tigerbeetle/tigerbeetle/pull/3101):
>   Because dependencies like an allocator or a tracer are singletons with unique types, they should
  be threaded through constructors positionally, from the most general to the most specific.
