### PR TITLE
VOPR: Fix core_reformat_evicted assert

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1279,7 +1279,7 @@ pub const Simulator = struct {
         for (eviction_reasons_reformats) |reason_or_null| {
             if (reason_or_null) |reason| {
                 log.err("reformat evicted with {s}", .{@tagName(reason)});
-                assert(reason == .no_session);
+                assert(reason == .no_session or reason == .session_too_low);
                 return true;
             }
         }


### PR DESCRIPTION
`core_reformat_evicted` checks whether the reformat client was evicted (since this can prevent the cluster from upgrading).

Previously we asserted that the eviction reason was always `no_session`.

But `session_too_low` is also possible, following the latter case of the `session_too_low` comment in `Replica.ignore_request_message_duplicate()`. (See client `22` in the seed.):

> 1. Client `A` sends an `operation=register` to a fresh cluster. (`A₁`)
> 2. Cluster prepares + commits `A₁`, and sends the reply to `A`.
> 4. `A` receives the reply to `A₁`, and issues a second request (`A₂`).
> 5. `clients_max` other clients register, evicting `A`'s session.
> 6. An old retry (or replay) of `A₁` arrives at the cluster.
> 7. `A₁` is committed (for a second time, as a different op, evicting one of
>    the other clients).
> 8. `A` sends a second request (`A₂`), but `A` has the session number from the
>    first time `A₁` was committed.

(Seed runs on commit `aeef5a9`).

Seed: ./zig/zig build vopr -Drelease -- 12756167268842564071