### PR TITLE
stdx: Introduce optimized LSD-radix sort.

### DIFF
--- a/src/stdx/radix.zig
+++ b/src/stdx/radix.zig
@@ -1,0 +1,233 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const stdx = @import("stdx.zig");
+
+// Optimizations
+// - skip trivial passes
+// - one pass histogram
+// - insertion sort for small keys
+// - unrolling
+// - microptimizations
+//      - pointers
+
+// TODO: benchmark
+// - remove inline for?
+// - remvoe pointer types?
+// - can we simplify the code?
+
+pub fn sort(
+    comptime Key: type,
+    comptime Value: type,
+    comptime key_from_value: fn (*const Value) callconv(.Inline) Key,
+    values: []Value,
+    values_scratch: []Value,
+) void {
+    const radix_bits = if (@sizeOf(Value) >= 128) 11 else 8;
+    const radix_size = 1 << radix_bits;
+    const radix_mask = radix_size - 1;
+    const radix_passes = ((@bitSizeOf(Key) - 1) / radix_bits) + 1; // TODO(TZ): clean-up.
+    const count: u32 = @intCast(values.len);
+
+    // TODO: insertion sort.
+    // TODO: preconditions;
+    assert(values.len <= values_scratch.len);
+
+    if (count == 0) return;
+
+    // Inline helper struct as it shares many parameters of the sort function.
+    const context = struct {
+        // Create histogram for every pass and parition.
+        fn create_histogram(input: []Value) [radix_passes][radix_size]u32 {
+            var histogram: [radix_passes][radix_size]u32 = .{.{0} ** radix_size} ** radix_passes;
+            for (input) |*value| {
+                var key = key_from_value(value);
+                inline for (0..radix_passes) |pass| {
+                    const partition: u32 = @intCast(key & radix_mask);
+                    histogram[pass][partition] += 1;
+                    key >>= radix_bits;
+                }
+            }
+            return histogram;
+        }
+
+        // A pass is trival iff all frequencies are 0 or iff one bucket contains all elements.
+        fn trivial_pass(frequencies: [radix_size]u32, elements: u32) bool {
+            for (frequencies) |frequency| {
+                if (frequency == 0) continue;
+                return frequency == elements;
+            }
+            return true;
+        }
+    };
+
+    const histogram = context.create_histogram(values);
+
+    // TODO: understand again.
+    const bits = std.math.log2(@bitSizeOf(Key));
+    const shift_type = std.meta.Int(.unsigned, bits);
+
+    // should we simply make sure to swap the intial values back
+    var source: []Value = values;
+    var target: []Value = values_scratch;
+    var queue_ptrs: [radix_size][*]Value = undefined;
+    var non_trivial_passes: u32 = 0;
+
+    inline for (0..radix_passes) |pass| {
+        // Because the loop is unrolled we need to have the following for control flow reasons.
+        // A `continue` would be clearer but it does not work with `infline for`.
+        const elements = if (context.trivial_pass(histogram[pass], count)) 0 else count;
+        const target_offset = if (elements == 0) 0 else queue_ptrs.len;
+        const shift: shift_type = @intCast(pass * radix_bits);
+
+        // Count non-trivial passes so that we can swap the buffers in the correct order.
+        non_trivial_passes += if (elements == 0) 0 else 1;
+
+        // Build prefix sums.
+        // We take direct pointers here as it generates much faster code.
+        // TODO double check.
+        // TODO create invariants.
+        var next_offset: u32 = 0;
+        for (0..target_offset) |i| {
+            queue_ptrs[i] = target.ptr + next_offset;
+            next_offset += histogram[pass][i];
+        }
+
+        const source_ptr: [*]const Value = source.ptr;
+
+        for (0..elements) |i_i| {
+            const value = &source_ptr[i_i];
+            const key: Key = key_from_value(value);
+            const index: usize = @intCast((key >> shift) & radix_mask);
+
+            queue_ptrs[index][0] = value.*;
+            queue_ptrs[index] += 1; // advance the pointer
+            @prefetch(queue_ptrs[index] + 1, .{ .rw = .write, .locality = 3, .cache = .data });
+        }
+
+        if (elements != 0) std.mem.swap([]Value, &source, &target);
+    }
+    //
+    if (non_trivial_passes % 2 != 0) {
+        stdx.copy_disjoint(.exact, Value, values, values_scratch);
+    }
+}
+
+const ratio = stdx.PRNG.ratio;
+
+// TODO: test more of the keys (in particular edge case).
+//       e.g. large keys
+test "sort_stable" {
+    const Value = struct {
+        const Value = @This();
+
+        x: u32, // TODO: rename to key.
+        y: u32, // y ensures that values are distinct for the purpose of checking stability.
+
+        inline fn key_from_value(value: *const Value) u32 {
+            return value.x;
+        }
+
+        // Those functions are only required for the comparision based helpers.
+        fn compare_x_ascending(_: void, a: Value, b: Value) bool {
+            return a.x < b.x;
+        }
+
+        fn compare_x_descending(_: void, a: Value, b: Value) bool {
+            return a.x > b.x;
+        }
+
+        fn compare_xy_ascending(_: void, a: Value, b: Value) bool {
+            if (a.x < b.x) return true;
+            if (a.x > b.x) return false;
+            return a.y < b.y;
+        }
+    };
+
+    const allocator = std.testing.allocator;
+
+    var prng = stdx.PRNG.from_seed(0);
+
+    const values_max = 1 << 15;
+    const values_all = try allocator.alloc(Value, values_max);
+    defer allocator.free(values_all);
+
+    const values_all_expected = try allocator.alloc(Value, values_max);
+    defer allocator.free(values_all_expected);
+
+    const values_scratch = try allocator.alloc(Value, values_max);
+    defer allocator.free(values_scratch);
+
+    for (0..256) |_| {
+        const values_count = prng.range_inclusive(u32, 2, values_max);
+        const values_expected = values_all_expected[0..values_count];
+        const values = values_all[0..values_count];
+
+        {
+            // Set up `values`.
+
+            for (values) |*value| {
+                value.* = .{
+                    .x = prng.int_inclusive(u32, values_count * 2 - 1),
+                    .y = undefined,
+                };
+            }
+
+            // Sort algorithms often optimize the case of already-sorted (or already-reverse-sorted)
+            // sub-arrays.
+            const partitions_count = prng.range_inclusive(u32, 1, @max(values_count, 64) - 1);
+            // The `partition_reverse_probability` is a subset of the partitions sorted by
+            // `partition_sort_percent`.
+            const partition_sort_probability = ratio(prng.int_inclusive(u8, 100), 100);
+            const partition_reverse_probability = ratio(prng.int_inclusive(u8, 100), 100);
+
+            var partitions_remaining: u32 = partitions_count;
+            var partition_offset: u32 = 0;
+            while (partition_offset < values_count) {
+                const partition_size = size: {
+                    if (partitions_remaining == 1) {
+                        break :size values_count - partition_offset;
+                    } else {
+                        break :size prng.range_inclusive(u32, 1, values_count - partition_offset);
+                    }
+                };
+
+                if (prng.chance(partition_sort_probability)) {
+                    const partition = values[partition_offset..][0..partition_size];
+                    if (prng.chance(partition_reverse_probability)) {
+                        std.mem.sortUnstable(Value, partition, {}, Value.compare_x_descending);
+                    } else {
+                        std.mem.sortUnstable(Value, partition, {}, Value.compare_x_ascending);
+                    }
+                }
+
+                partitions_remaining -= 1;
+                partition_offset += partition_size;
+            }
+
+            for (values, 0..) |*value, i| value.y = @intCast(i);
+        }
+
+        {
+            // Set up `values_expected`.
+            stdx.copy_disjoint(.exact, Value, values_expected, values);
+            std.mem.sortUnstable(Value, values_expected, {}, Value.compare_xy_ascending);
+
+            // Sanity-check the expected values' order.
+            for (
+                values_expected[0 .. values_count - 1],
+                values_expected[1..],
+            ) |a, b| {
+                assert(a.x <= b.x);
+                if (a.x == b.x) assert(a.y < b.y);
+            }
+        }
+
+        //std.mem.sort(Value, values, {}, Value.compare_x_ascending);
+        sort(u32, Value, Value.key_from_value, values, values_scratch);
+
+        for (values, values_expected) |value, value_expected| {
+            try std.testing.expectEqual(value.x, value_expected.x);
+            try std.testing.expectEqual(value.y, value_expected.y);
+        }
+    }
+}

--- a/src/stdx/radix.zig
+++ b/src/stdx/radix.zig
@@ -53,7 +53,7 @@ fn radix_sort(
     const radix_bits = @min(@bitSizeOf(Key), radix_bits_heuristic);
     const radix_passes = stdx.div_ceil(@bitSizeOf(Key), radix_bits);
     const radix_partitions = 1 << radix_bits;
-    const radix_mask = radix_partitions - 1;
+    const radix_mask: u32 = radix_partitions - 1;
 
     const BitsKey = std.math.Log2Int(Key); // Used to shift the key for each pass.
     const Histograms: type = [radix_passes][radix_partitions]u32;

--- a/src/stdx/radix.zig
+++ b/src/stdx/radix.zig
@@ -135,6 +135,33 @@ pub fn TestValueType(comptime Key: type, comptime value_length: usize) type {
     };
 }
 
+test "radix_sort: smoke" {
+    const Value = TestValueType(u8, 0);
+    var values: [5]Value = .{
+        Value{ .x = 3, .y = 0 },
+        Value{ .x = 2, .y = 0 },
+        Value{ .x = 3, .y = 1 },
+        Value{ .x = 1, .y = 0 },
+        Value{ .x = 5, .y = 0 },
+    };
+    const values_expected: [5]Value = .{
+        Value{ .x = 1, .y = 0 },
+        Value{ .x = 2, .y = 0 },
+        Value{ .x = 3, .y = 0 },
+        Value{ .x = 3, .y = 1 },
+        Value{ .x = 5, .y = 0 },
+    };
+    var values_scratch: [5]Value = undefined;
+    radix_sort(
+        u8,
+        Value,
+        Value.key_from_value,
+        &values,
+        &values_scratch,
+    );
+    try std.testing.expectEqual(values_expected, values);
+}
+
 //  Ascending order + stability against a (x,y) baseline, with a large Value
 //  payload to exercise the 11-bit radix path (since @sizeOf(Value) >= 128).
 test "radix_sort: ascending & stable on many duplicates" {

--- a/src/stdx/radix.zig
+++ b/src/stdx/radix.zig
@@ -1,20 +1,18 @@
+//! Stable, non-allocating, out-of-place LSD radix sort over unsigned integer keys.
+//! Sorts `values` in ascending order by `key_from_value`, using `values_scratch`
+//! as an equally sized, disjoint swap buffer. Keys must be an unsigned `Int`.
+//! The sorted result is in the original buffer `values`.
+//! The implementation builds per-pass histograms, skips trivial passes (all items
+//! in one bucket), and uses a fixed digit width (8 or 11 bits based on `Value` size)
+//! to reduce the number of passes. Buffers are swapped after each non-trivial pass;
+//! if the number of such passes is odd, results are copied back so `values` holds
+//! the output on return.
+
 const std = @import("std");
 const assert = std.debug.assert;
 const stdx = @import("stdx.zig");
 
-// Optimizations
-// - skip trivial passes
-// - one pass histogram
-// - insertion sort for small keys
-// - unrolling
-// - microptimizations
-//      - pointers
-
-// TODO: benchmark
-// - remove inline for?
-// - remvoe pointer types?
-// - can we simplify the code?
-
+/// Stable, ascending radix sort for unsigned intergers. Sorted result will be in `values`.
 pub fn sort(
     comptime Key: type,
     comptime Value: type,
@@ -22,92 +20,93 @@ pub fn sort(
     values: []Value,
     values_scratch: []Value,
 ) void {
-    const radix_bits = if (@sizeOf(Value) >= 128) 11 else 8;
-    const radix_size = 1 << radix_bits;
-    const radix_mask = radix_size - 1;
-    const radix_passes = ((@bitSizeOf(Key) - 1) / radix_bits) + 1; // TODO(TZ): clean-up.
+    comptime {
+        assert(@typeInfo(Key) == .int);
+        assert(@typeInfo(Key).int.signedness == .unsigned);
+    }
+
+    assert(stdx.disjoint_slices(Value, Value, values, values_scratch));
+    assert(values.len == values_scratch.len);
+    assert(values.len <= std.math.maxInt(u32)); // At the moment we use u32 for the histogram.
+
     const count: u32 = @intCast(values.len);
 
-    // TODO: insertion sort.
-    // TODO: preconditions;
-    assert(values.len <= values_scratch.len);
-
     if (count == 0) return;
+    // TODO: insertion sort fallback.
 
-    // Inline helper struct as it shares many parameters of the sort function.
-    const context = struct {
-        // Create histogram for every pass and parition.
-        fn create_histogram(input: []Value) [radix_passes][radix_size]u32 {
-            var histogram: [radix_passes][radix_size]u32 = .{.{0} ** radix_size} ** radix_passes;
-            for (input) |*value| {
-                var key = key_from_value(value);
-                inline for (0..radix_passes) |pass| {
-                    const partition: u32 = @intCast(key & radix_mask);
-                    histogram[pass][partition] += 1;
-                    key >>= radix_bits;
-                }
-            }
-            return histogram;
-        }
+    // Heuristic: use wider digits for larger vlaue sizes to reduce the number of passes.
+    const radix_bits_heuristic = if (@sizeOf(Value) >= 128) 11 else 8;
+    //const radix_bits_heuristic = 8;
+    //const radix_bits_heuristic = if (@sizeOf(Value) >= 128 or @sizeOf(Key) >= 32) 11 else 8;
+    const radix_bits = @min(@bitSizeOf(Key), radix_bits_heuristic);
+    const radix_partitions = 1 << radix_bits;
+    const radix_mask = radix_partitions - 1;
+    const radix_passes = stdx.div_ceil(@bitSizeOf(Key), radix_bits);
 
-        // A pass is trival iff all frequencies are 0 or iff one bucket contains all elements.
-        fn trivial_pass(frequencies: [radix_size]u32, elements: u32) bool {
-            for (frequencies) |frequency| {
-                if (frequency == 0) continue;
-                return frequency == elements;
+    const BitsKey = std.math.Log2Int(Key);
+
+    // Create the histograms per pass in a single pass over `values`.
+    const histograms = blk: {
+        var histogram: [radix_passes][radix_partitions]u32 align(64) = @splat(@splat(0));
+        for (values) |*value| {
+            const key = key_from_value(value);
+            inline for (0..radix_passes) |pass| {
+                const pass_bit_offset: BitsKey = @intCast(pass * radix_bits);
+                const partition_id: u32 = @intCast((key >> pass_bit_offset) & radix_mask);
+                histogram[pass][partition_id] += 1;
             }
-            return true;
         }
+        break :blk histogram;
     };
 
-    const histogram = context.create_histogram(values);
-
-    // TODO: understand again.
-    const bits = std.math.log2(@bitSizeOf(Key));
-    const shift_type = std.meta.Int(.unsigned, bits);
-
-    // should we simply make sure to swap the intial values back
     var source: []Value = values;
     var target: []Value = values_scratch;
-    var queue_ptrs: [radix_size][*]Value = undefined;
-    var non_trivial_passes: u32 = 0;
+    var target_offsets: [radix_partitions]u32 = @splat(0);
+    var partition_passes: u32 = 0;
 
+    // This hot loop is unrolled as it gives ~10% performance improvement.
     inline for (0..radix_passes) |pass| {
-        // Because the loop is unrolled we need to have the following for control flow reasons.
-        // A `continue` would be clearer but it does not work with `infline for`.
-        const elements = if (context.trivial_pass(histogram[pass], count)) 0 else count;
-        const target_offset = if (elements == 0) 0 else queue_ptrs.len;
-        const shift: shift_type = @intCast(pass * radix_bits);
+        const pass_bit_offset: BitsKey = @intCast(pass * radix_bits);
+        // Determine if a pass is trivial if exactly one bucket has all `count` elements.
+        const pass_trivial: bool = trivial: {
+            for (histograms[pass]) |partition_count| {
+                if (partition_count == 0) continue;
+                break :trivial partition_count == count;
+            }
+            unreachable;
+        };
 
-        // Count non-trivial passes so that we can swap the buffers in the correct order.
-        non_trivial_passes += if (elements == 0) 0 else 1;
+        // Skip trival passes.
+        if (!pass_trivial) {
+            partition_passes += 1;
 
-        // Build prefix sums.
-        // We take direct pointers here as it generates much faster code.
-        // TODO double check.
-        // TODO create invariants.
-        var next_offset: u32 = 0;
-        for (0..target_offset) |i| {
-            queue_ptrs[i] = target.ptr + next_offset;
-            next_offset += histogram[pass][i];
+            // Build prefix sums to determin the partition target offsets.
+            var next_offset: u32 = 0;
+            for (0..radix_partitions) |partition_id| {
+                target_offsets[partition_id] = next_offset;
+                next_offset += histograms[pass][partition_id];
+            }
+
+            // Partition pass.
+            for (source) |*value| {
+                const key: Key = key_from_value(value);
+                const partition_id: u32 = @intCast((key >> pass_bit_offset) & radix_mask);
+
+                target[target_offsets[partition_id]] = value.*;
+                target_offsets[partition_id] += 1;
+            }
+            std.mem.swap([]Value, &source, &target);
         }
-
-        const source_ptr: [*]const Value = source.ptr;
-
-        for (0..elements) |i_i| {
-            const value = &source_ptr[i_i];
-            const key: Key = key_from_value(value);
-            const index: usize = @intCast((key >> shift) & radix_mask);
-
-            queue_ptrs[index][0] = value.*;
-            queue_ptrs[index] += 1; // advance the pointer
-            @prefetch(queue_ptrs[index] + 1, .{ .rw = .write, .locality = 3, .cache = .data });
-        }
-
-        if (elements != 0) std.mem.swap([]Value, &source, &target);
     }
-    //
-    if (non_trivial_passes % 2 != 0) {
+
+    //std.debug.print("partition_passes {} radix bits {} key {} bits value {} bytes \n", .{
+    //partition_passes,
+    //radix_bits,
+    //@bitSizeOf(Key),
+    //@sizeOf(Value),
+    //});
+    // Copy the values back in the input buffer `values`.
+    if (partition_passes % 2 != 0) {
         stdx.copy_disjoint(.exact, Value, values, values_scratch);
     }
 }
@@ -116,14 +115,17 @@ const ratio = stdx.PRNG.ratio;
 
 // TODO: test more of the keys (in particular edge case).
 //       e.g. large keys
-test "sort_stable" {
-    const Value = struct {
+//       what if we sort u6?
+
+pub fn TestValueType(comptime Key: type, comptime value_length: usize) type {
+    return struct {
         const Value = @This();
 
-        x: u32, // TODO: rename to key.
+        x: Key, // TODO: rename to key.
         y: u32, // y ensures that values are distinct for the purpose of checking stability.
+        padding: [value_length]u8 = @splat(0),
 
-        inline fn key_from_value(value: *const Value) u32 {
+        inline fn key_from_value(value: *const Value) Key {
             return value.x;
         }
 
@@ -142,92 +144,107 @@ test "sort_stable" {
             return a.y < b.y;
         }
     };
+}
 
-    const allocator = std.testing.allocator;
+test "radix_sort_stable" {
+    inline for (.{
+        u3, //  Smaller than radix bits.
+        u64, // Requires multiple passes.
+    }) |Key| {
+        inline for (.{
+            0,
+            130, // Test heuristic with larger values.
+        }) |value_size_min| {
+            const allocator = std.testing.allocator;
 
-    var prng = stdx.PRNG.from_seed(0);
+            const Value = TestValueType(Key, value_size_min);
 
-    const values_max = 1 << 15;
-    const values_all = try allocator.alloc(Value, values_max);
-    defer allocator.free(values_all);
+            var prng = stdx.PRNG.from_seed(0);
 
-    const values_all_expected = try allocator.alloc(Value, values_max);
-    defer allocator.free(values_all_expected);
+            const values_max = 1 << 18; // Explores uneven and even passes to test copy back.
+            const values_all = try allocator.alloc(Value, values_max);
+            defer allocator.free(values_all);
 
-    const values_scratch = try allocator.alloc(Value, values_max);
-    defer allocator.free(values_scratch);
+            const values_all_expected = try allocator.alloc(Value, values_max);
+            defer allocator.free(values_all_expected);
 
-    for (0..256) |_| {
-        const values_count = prng.range_inclusive(u32, 2, values_max);
-        const values_expected = values_all_expected[0..values_count];
-        const values = values_all[0..values_count];
+            const values_all_scratch = try allocator.alloc(Value, values_max);
+            defer allocator.free(values_all_scratch);
 
-        {
-            // Set up `values`.
+            for (0..256) |_| {
+                const values_count = prng.range_inclusive(u32, 2, values_max);
+                const values_expected = values_all_expected[0..values_count];
+                const values = values_all[0..values_count];
+                const values_scratch = values_all_scratch[0..values_count];
 
-            for (values) |*value| {
-                value.* = .{
-                    .x = prng.int_inclusive(u32, values_count * 2 - 1),
-                    .y = undefined,
-                };
-            }
+                {
+                    // Set up `values`.
 
-            // Sort algorithms often optimize the case of already-sorted (or already-reverse-sorted)
-            // sub-arrays.
-            const partitions_count = prng.range_inclusive(u32, 1, @max(values_count, 64) - 1);
-            // The `partition_reverse_probability` is a subset of the partitions sorted by
-            // `partition_sort_percent`.
-            const partition_sort_probability = ratio(prng.int_inclusive(u8, 100), 100);
-            const partition_reverse_probability = ratio(prng.int_inclusive(u8, 100), 100);
-
-            var partitions_remaining: u32 = partitions_count;
-            var partition_offset: u32 = 0;
-            while (partition_offset < values_count) {
-                const partition_size = size: {
-                    if (partitions_remaining == 1) {
-                        break :size values_count - partition_offset;
-                    } else {
-                        break :size prng.range_inclusive(u32, 1, values_count - partition_offset);
+                    for (values) |*value| {
+                        value.* = .{
+                            .x = prng.int_inclusive(Key, @min(std.math.maxInt(Key), values_count * 2 - 1)),
+                            .y = undefined,
+                        };
                     }
-                };
 
-                if (prng.chance(partition_sort_probability)) {
-                    const partition = values[partition_offset..][0..partition_size];
-                    if (prng.chance(partition_reverse_probability)) {
-                        std.mem.sortUnstable(Value, partition, {}, Value.compare_x_descending);
-                    } else {
-                        std.mem.sortUnstable(Value, partition, {}, Value.compare_x_ascending);
+                    // Sort algorithms often optimize the case of already-sorted (or already-reverse-sorted)
+                    // sub-arrays.
+                    const partitions_count = prng.range_inclusive(u32, 1, @max(values_count, 64) - 1);
+                    // The `partition_reverse_probability` is a subset of the partitions sorted by
+                    // `partition_sort_percent`.
+                    const partition_sort_probability = ratio(prng.int_inclusive(u8, 100), 100);
+                    const partition_reverse_probability = ratio(prng.int_inclusive(u8, 100), 100);
+
+                    var partitions_remaining: u32 = partitions_count;
+                    var partition_offset: u32 = 0;
+                    while (partition_offset < values_count) {
+                        const partition_size = size: {
+                            if (partitions_remaining == 1) {
+                                break :size values_count - partition_offset;
+                            } else {
+                                break :size prng.range_inclusive(u32, 1, values_count - partition_offset);
+                            }
+                        };
+
+                        if (prng.chance(partition_sort_probability)) {
+                            const partition = values[partition_offset..][0..partition_size];
+                            if (prng.chance(partition_reverse_probability)) {
+                                std.mem.sortUnstable(Value, partition, {}, Value.compare_x_descending);
+                            } else {
+                                std.mem.sortUnstable(Value, partition, {}, Value.compare_x_ascending);
+                            }
+                        }
+
+                        partitions_remaining -= 1;
+                        partition_offset += partition_size;
+                    }
+
+                    for (values, 0..) |*value, i| value.y = @intCast(i);
+                }
+
+                {
+                    // Set up `values_expected`.
+                    stdx.copy_disjoint(.exact, Value, values_expected, values);
+                    std.mem.sortUnstable(Value, values_expected, {}, Value.compare_xy_ascending);
+
+                    // Sanity-check the expected values' order.
+                    for (
+                        values_expected[0 .. values_count - 1],
+                        values_expected[1..],
+                    ) |a, b| {
+                        assert(a.x <= b.x);
+                        if (a.x == b.x) assert(a.y < b.y);
                     }
                 }
 
-                partitions_remaining -= 1;
-                partition_offset += partition_size;
+                //std.mem.sort(Value, values, {}, Value.compare_x_ascending);
+                sort(Key, Value, Value.key_from_value, values, values_scratch);
+
+                for (values, values_expected) |value, value_expected| {
+                    try std.testing.expectEqual(value.x, value_expected.x);
+                    try std.testing.expectEqual(value.y, value_expected.y);
+                }
             }
-
-            for (values, 0..) |*value, i| value.y = @intCast(i);
-        }
-
-        {
-            // Set up `values_expected`.
-            stdx.copy_disjoint(.exact, Value, values_expected, values);
-            std.mem.sortUnstable(Value, values_expected, {}, Value.compare_xy_ascending);
-
-            // Sanity-check the expected values' order.
-            for (
-                values_expected[0 .. values_count - 1],
-                values_expected[1..],
-            ) |a, b| {
-                assert(a.x <= b.x);
-                if (a.x == b.x) assert(a.y < b.y);
-            }
-        }
-
-        //std.mem.sort(Value, values, {}, Value.compare_x_ascending);
-        sort(u32, Value, Value.key_from_value, values, values_scratch);
-
-        for (values, values_expected) |value, value_expected| {
-            try std.testing.expectEqual(value.x, value_expected.x);
-            try std.testing.expectEqual(value.y, value_expected.y);
         }
     }
 }

--- a/src/stdx/radix.zig
+++ b/src/stdx/radix.zig
@@ -132,12 +132,6 @@ pub fn TestValueType(comptime Key: type, comptime value_length: usize) type {
         fn compare_x_descending(_: void, a: Value, b: Value) bool {
             return a.x > b.x;
         }
-
-        fn compare_xy_ascending(_: void, a: Value, b: Value) bool {
-            if (a.x < b.x) return true;
-            if (a.x > b.x) return false;
-            return a.y < b.y;
-        }
     };
 }
 

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -19,6 +19,7 @@ pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
 pub const timeit = @import("debug.zig").timeit;
 pub const unshare = @import("unshare.zig");
 pub const windows = @import("windows.zig");
+pub const radix = @import("radix.zig");
 
 // Import these as `const GiB = stdx.GiB;`
 pub const KiB = 1 << 10;

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1271,4 +1271,5 @@ comptime {
     _ = @import("testing/snaptest.zig");
     _ = @import("zipfian.zig");
     _ = @import("unshare.zig");
+    _ = @import("radix.zig");
 }

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -19,7 +19,7 @@ pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
 pub const timeit = @import("debug.zig").timeit;
 pub const unshare = @import("unshare.zig");
 pub const windows = @import("windows.zig");
-pub const radix = @import("radix.zig");
+pub const radix_sort = @import("radix.zig").sort;
 
 // Import these as `const GiB = stdx.GiB;`
 pub const KiB = 1 << 10;


### PR DESCRIPTION
This PR introduces an Least Significant Digit (LSD) radix sort, a stable, linear-time sorting algorithm. 

It is very predictable and runs in _O(n · k)_ time (where n is the number of elements and k is the key width (e.g., in bits) for best, average, and worst cases. Another benefit is that the code is very compact (< 100 lines) and relatively easy to understand compared to many other algorithms. 

## Benchmarks

This PR is well benchmarked (see below). We ran multiple trials for each optimization and checked statistical significance to ensure improvements weren’t noise. The results below are from the i4i.metal (the weakest of the instances), but we also measured on the i8g and our lab machine.

Note: The end-to-end measurements are when using the radix sort in `table_memory.zig`, which this PR has not yet introduced as we wait for #3250 to land first.


#### End-to-end:
This is our standard benchmark with --cache-grid=32GiB (and compiled with -Dconfig_verify=true)

baseline:  309041 
This PR:  **360990** (20% improvement only from the sort!)


#### Optimizations end-to-end: 
Despite its compact code size we have a few key optimizations: 

_Optimizations_: 

- Skip trivial passes: If a digit pass would be a no-op (histogram shows a single non-zero bucket), we skip it. This is pretty common and very effective if the keys are not random but have some pattern. For instance, timestamps often share the same prefix, or when the first few bits are 0, etc.
- Single scan per pass: We build the histogram for each digit pass in a single linear input scan.
- Hot-loop unrolling: Unrolling critical loops generates better code and yields a ~10–15% speedup.
- Cache-friendly histograms: We use u32 counters (instead of u64 or usize) to keep the histogram compact and cache-resident.
- Adaptive radix width: A heuristic adjusts the number of radix bits per pass to reduce the total number of passes.
- Small-N fallback: We fall back to insertion sort for very small inputs (≤ 32 elements).

_Optimizations discarded_: 

- Key-only sort + final gather: For “large value, small key” records (e.g., 8-byte key with ~120-byte value), we tried sorting only keys with indices, then reordering values at the end using the input scratch buffer. This helped on older hardware, but increased code complexity and tended to be a net pessimization on newer machines with larger caches.
- Micro-optimizations with low payoff: Direct pointers, prefetching the next write location, and maintaining two histograms to increase ILP produced statistically significant but small gains (<2%) and added complexity. We dropped them.
- Non-temporal writes, they are pretty good for large arrays but reduce performance when everything is in CPU cache (maybe we will revisit those once our use-case changes). The same goes for software-managed write combine buffers.
- SIMD for histogram building or prefix sum calculations.   

<img width="598" height="401" alt="image" src="https://github.com/user-attachments/assets/224a8680-188b-4407-be77-7bf299888316" />

Here is a brief ablation in which we disable two optimizations: (i) skipping trivial passes and (ii) loop unrolling. Skipping trivial passes is highly effective in practice, but it depends on the input so we want to see what the performance impact would be under pathological inputs. Even when it is disabled, our system remains faster than the baseline. This indicates that we retain an advantage even under a worst-case input of fully random keys, an important robustness property. In practice, this worst case is unlikely because part of our workload contains keys with known structure. Disabling loop unrolling causes a comparable slowdown. Overall, both optimizations are essential for peak performance.


<details>

### Methodology 

Sorting performance depends on input distribution, data types, and hardware. To develop this sort, we created a microbenchmark test suite for the integer types used in our indexes, and evaluated across the following distributions (common in academic papers): 

<img width="2121" height="1291" alt="image" src="https://github.com/user-attachments/assets/1870c8a7-247b-4972-a690-9309fcfdc29f" />


The values tested are:  

    8-byte Keys (no payload)
    16-byte Key (no payload)
    32-byte Key (no payload)
    8-byte Key and 120-byte payload (128-byte in total)


Here are the results that show the speedup over radix sort vs. std.sort: 

<img width="1531" height="1545" alt="image" src="https://github.com/user-attachments/assets/b4ed6b9e-eaa7-4a4f-8408-83189d698853" />


What we observe:
- Radix sort delivers a solid overall speedup over std.sort (merge sort).
- It performs especially well on skewed distributions (e.g., two-dup, root-dup).
- As the input size grows, cache misses reduce absolute throughput; however, the baseline slows even more, so the relative speedup recovers, consistent with the linear time complexity.
- For small inputs, std sort has a small advantage here, but the fallback to insertion is quite effective for <=32. 
- Results for sorted or nearly sorted inputs are omitted for brevity; std.sort can outperform radix sort here by exploiting existing runs. Here #3250 is important as it avoids cases where we call `sort` on sorted data.


