### PR TITLE
MessageBus: Fix crash due to corruption + misdirect

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -880,8 +880,9 @@ fn MessageBusType(comptime process_type: vsr.ProcessType) type {
                     // can send back to them.
                     .replica => {
                         while (connection.recv_buffer.?.next_header()) |header| {
-                            connection.recv_buffer.?.suspend_message(&header);
-                            if (!connection.set_and_verify_peer(bus, header.peer_type())) {
+                            if (connection.set_and_verify_peer(bus, header.peer_type())) {
+                                connection.recv_buffer.?.suspend_message(&header);
+                            } else {
                                 log.warn("{}: on_recv: invalid peer transition {any} -> {any}", .{
                                     bus.id,
                                     connection.peer,


### PR DESCRIPTION
Fix a crash found by a WIP version of the [message bus fuzzer](https://github.com/tigerbeetle/tigerbeetle/pull/3249):

```
thread 162828 panic: reached unreachable code
/var/home/djg/C/bin/zig-x86_64-linux-0.14.1/lib/std/debug.zig:550:14: 0x11e60fd in assert (fuzz)
    if (!ok) unreachable; // assertion failure
             ^
/var/home/djg/C/t/db/perf/src/message_buffer.zig:98:15: 0x17419d5 in invalidate (fuzz)
        assert(buffer.invalid == null);
              ^
/var/home/djg/C/t/db/perf/src/message_bus.zig:891:68: 0x1b148ee in on_recv (fuzz)
                                connection.recv_buffer.?.invalidate(.misdirected);
                                                                   ^
...
```

When we go to mark the buffer invalid due to `misdirected` (an invalid peer state transition), we find that it has already been marked invalid with `header_checksum` (i.e. a corrupt header).

The `header_checksum` error was hit by `suspend_message()`, since it advances the buffer after suspending.

To fix, we don't need to suspend the (valid) message if it was misdirect, since the misdirect takes precedence (i.e. it comes first in the stream).