### PR TITLE
test: use genuine randomness in tests

### DIFF
--- a/src/cdc/amqp.zig
+++ b/src/cdc/amqp.zig
@@ -1301,7 +1301,7 @@ test "amqp: SendBuffer" {
     const buffer = try testing.allocator.alloc(u8, frame_min_size);
     defer testing.allocator.free(buffer);
 
-    var prng: stdx.PRNG = stdx.PRNG.from_seed(42);
+    var prng: stdx.PRNG = stdx.PRNG.from_seed_testing();
     var send_buffer = SendBuffer.init(buffer);
     for (0..4096) |_| {
         const Element = u64;
@@ -1368,7 +1368,7 @@ test "amqp: ReceiveBuffer" {
     try testing.expect(receive_buffer.state == .receiving);
     try testing.expectEqual(buffer.len, receive_slice.len);
 
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     prng.fill(receive_slice);
 
     var decoded_remain: usize = 0;

--- a/src/cdc/amqp/protocol.zig
+++ b/src/cdc/amqp/protocol.zig
@@ -817,7 +817,7 @@ test "amqp: Encoder/Decoder primitives" {
         long_string,
     };
 
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     for (0..4096) |_| {
         var encoder = Encoder.init(buffer);
 
@@ -941,7 +941,7 @@ test "amqp: BasicProperties encode/decode" {
     var buffer = try testing.allocator.alloc(u8, frame_min_size);
     defer testing.allocator.free(buffer);
 
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     for (0..4096) |_| {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
@@ -974,7 +974,7 @@ test "amqp: Table encode/decode" {
     var buffer = try testing.allocator.alloc(u8, 64 * KiB);
     defer testing.allocator.free(buffer);
 
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     for (0..4096) |_| {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -1491,7 +1491,7 @@ test "amqp: RateLimit" {
 test "amqp: DualBuffer" {
     const event_count_max = Runner.constants.event_count_max;
 
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     var dual_buffer = try DualBuffer.init(testing.allocator, event_count_max);
     defer dual_buffer.deinit(testing.allocator);
 

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -310,7 +310,7 @@ pub fn ewah(comptime Word: type) type {
 
 test "ewah encode→decode cycle" {
     const fuzz = @import("./ewah_fuzz.zig");
-    var prng = stdx.PRNG.from_seed(123);
+    var prng = stdx.PRNG.from_seed_testing();
 
     inline for (.{ u8, u16, u32, u64, usize }) |Word| {
         const Context = fuzz.ContextType(Word);

--- a/src/list.zig
+++ b/src/list.zig
@@ -164,7 +164,7 @@ test "DoublyLinkedList fuzz" {
 
     const allocator = std.testing.allocator;
 
-    var prng = stdx.PRNG.from_seed(0);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const Node = struct { id: u32, back: ?*@This() = null, next: ?*@This() = null };
     const List = DoublyLinkedListType(Node, .back, .next);

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -685,7 +685,7 @@ test "binary search: duplicates" {
 }
 
 test "binary search: random" {
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     inline for (.{ .lower_bound, .upper_bound }) |mode| {
         var i: usize = 0;
         while (i < 2048) : (i += 1) {
@@ -842,7 +842,7 @@ test "binary search: duplicated range" {
 }
 
 test "binary search: random range" {
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
     var i: usize = 0;
     while (i < 2048) : (i += 1) {
         try test_binary_search.random_range_search(&prng, i);

--- a/src/message_buffer.zig
+++ b/src/message_buffer.zig
@@ -348,7 +348,7 @@ test "MessageBuffer fuzz" {
     // are received unless a fault is detected.
     const messages_max = 100;
 
-    var prng = stdx.PRNG.from_seed(92);
+    var prng = stdx.PRNG.from_seed_testing();
     const gpa = std.testing.allocator;
 
     var buffer: []u8 = try gpa.alloc(u8, 5 * constants.message_size_max);

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -266,7 +266,7 @@ test "Queue: fuzz" {
     const Model = stdx.RingBufferType(u64, .slice);
 
     const gpa = std.testing.allocator;
-    var prng = stdx.PRNG.from_seed(92);
+    var prng = stdx.PRNG.from_seed_testing();
 
     for (0..100) |_| {
         const N = 1000;

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -124,7 +124,7 @@ test "Stack: fuzz" {
 
     const allocator = std.testing.allocator;
 
-    var prng = stdx.PRNG.from_seed(0);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const Item = struct {
         id: u32,

--- a/src/stdx/bit_set.zig
+++ b/src/stdx/bit_set.zig
@@ -89,7 +89,7 @@ pub fn BitSetType(comptime with_capacity: u9) type {
 }
 
 test BitSetType {
-    var prng = stdx.PRNG.from_seed(92);
+    var prng = stdx.PRNG.from_seed_testing();
     inline for (.{ 0, 1, 8, 32, 65, 255, 256 }) |N| {
         const BitSet = BitSetType(N);
 

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -112,6 +112,11 @@ pub fn from_seed(seed: u64) PRNG {
     } };
 }
 
+pub fn from_seed_testing() PRNG {
+    comptime assert(@import("builtin").is_test);
+    return .from_seed(std.testing.random_seed);
+}
+
 fn split_mix_64(s: *u64) u64 {
     s.* +%= 0x9e3779b97f4a7c15;
 

--- a/src/stdx/sort_test.zig
+++ b/src/stdx/sort_test.zig
@@ -28,7 +28,7 @@ test "sort_stable" {
 
     const allocator = std.testing.allocator;
 
-    var prng = stdx.PRNG.from_seed(0);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const values_max = 1 << 15;
     const values_all = try allocator.alloc(Value, values_max);

--- a/src/testing/id.zig
+++ b/src/testing/id.zig
@@ -74,7 +74,7 @@ pub const IdPermutation = union(enum) {
 };
 
 test "IdPermutation" {
-    var prng = stdx.PRNG.from_seed(123);
+    var prng = stdx.PRNG.from_seed_testing();
 
     for ([_]IdPermutation{
         .{ .identity = {} },

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -857,7 +857,7 @@ pub fn exponential_backoff_with_jitter(
 }
 
 test "exponential_backoff_with_jitter" {
-    var prng = stdx.PRNG.from_seed(0);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const attempts = 1000;
     const max: u64 = std.math.maxInt(u64);
@@ -1080,9 +1080,7 @@ test "parse_addresses: fuzz" {
     const len_max = 32;
     const alphabet = " \t\n,:[]0123456789abcdefgABCDEFGXx";
 
-    const seed = std.crypto.random.int(u64);
-
-    var prng = stdx.PRNG.from_seed(seed);
+    var prng = stdx.PRNG.from_seed_testing();
 
     var input_max: [len_max]u8 = @splat(0);
     var buffer: [3]std.net.Address = undefined;

--- a/src/vsr/free_set.zig
+++ b/src/vsr/free_set.zig
@@ -1277,7 +1277,7 @@ fn find_bit(
 }
 
 test "find_bit" {
-    var prng = stdx.PRNG.from_seed(123);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const gpa = std.testing.allocator;
     for (1..(@bitSizeOf(std.DynamicBitSetUnmanaged.MaskInt) * 4) + 1) |bit_length| {

--- a/src/vsr/multi_batch.zig
+++ b/src/vsr/multi_batch.zig
@@ -495,7 +495,7 @@ pub const MultiBatchEncoder = struct {
 
 // The maximum number of batches, all with zero elements.
 test "batch: maximum batches with no elements" {
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const batch_count = Postamble.batch_count_max;
     const element_size = 128;
@@ -522,7 +522,7 @@ test "batch: maximum batches with no elements" {
 
 // The maximum number of batches, when each one has one single element.
 test "batch: maximum batches with a single element" {
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const element_size = 128;
     const buffer_size = (1 * MiB) - @sizeOf(vsr.Header); // 1MiB message.
@@ -551,7 +551,7 @@ test "batch: maximum batches with a single element" {
 
 // The maximum number of elements on a single batch.
 test "batch: maximum elements on a single batch" {
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const element_size = 128;
     const buffer_size = (1 * MiB) - @sizeOf(vsr.Header); // 1MiB message.
@@ -571,7 +571,7 @@ test "batch: maximum elements on a single batch" {
 }
 
 test "batch: invalid format" {
-    var prng = stdx.PRNG.from_seed(42);
+    var prng = stdx.PRNG.from_seed_testing();
 
     const element_size = 128;
     const buffer_size = (1 * MiB) - @sizeOf(vsr.Header); // 1MiB message.

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -376,7 +376,7 @@ pub fn QuorumsType(comptime options: Options) type {
 }
 
 test "Quorums.working" {
-    var prng = stdx.PRNG.from_seed(123);
+    var prng = stdx.PRNG.from_seed_testing();
 
     // Don't print warnings from the Quorums.
     const level = std.testing.log_level;
@@ -387,7 +387,7 @@ test "Quorums.working" {
 }
 
 test "Quorum.repairs" {
-    var prng = stdx.PRNG.from_seed(123);
+    var prng = stdx.PRNG.from_seed_testing();
 
     // Don't print warnings from the Quorums.
     const level = std.testing.log_level;


### PR DESCRIPTION
Zig introduced std.testing.random_seed which is set by the build system when running the tests. Lets use that in our micro-fuzzers to increase coverage!

I don't know how good of a developer experience we will get here (would Zig _always_ print the seed on failure), and we'll probably see at least some latent test bugs revealed, but we won't know about these problems unless we try!