### PR TITLE
vsr: adaptive repair timeouts

### DIFF
--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -1,60 +1,198 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
+const stdx = @import("stdx");
+const ratio = stdx.PRNG.ratio;
+const Ratio = stdx.PRNG.Ratio;
+
 pub const RepairBudgetJournal = struct {
     capacity: u32,
     available: u32,
-    refill_max: u32,
 
-    // Tracks the headers for prepares requested by inflight RequestPrepare messages.
-    requested_prepares: std.AutoArrayHashMapUnmanaged(PrepareIdentifier, void),
+    replica_index: u8,
 
-    const PrepareIdentifier = struct { view: u32, op: u64 };
+    // Tracks the prepare ops requested from each remote replica.
+    replicas_requested_prepares: []RequestedPrepares,
+
+    // Exponential weighted moving average of the repair latency for each remote replica.
+    //
+    // Repair latency is calculated as the duration elapsed between when a prepare is requested from
+    // a remote replica, and when it is either received from the remote replica (see `decrement`),
+    // or expired (see `maybe_expire_requested_prepares`).
+    replicas_repair_latency: []stdx.Duration,
+
+    // Probability of choosing a random replica with available budget, as opposed to one with the
+    // best repair latency with available budget.
+    //
+    // Experiments ensure that we try alternative repair routes, and avoids potential resonance
+    // wherein we keep requesting from a permanently crashed replica with the best repair latency.
+    // This is because we don't penalize the repair latency once it exceeds `duration_expiry_max`,
+    // so if a crashed replica has the best latency, it may remain that way forever.
+    experiment_chance: Ratio = ratio(1, 10),
+
+    // Multiple of repair latency used to determine expiry duration, which is the time we wait
+    // before reclaiming the budget for an inflight repair request.
+    repair_latency_multiple_expiry: u8 = 2,
+
+    // The maximum amount of time we wait before reclaiming the budget for an inflight repair
+    // request.
+    //
+    // Capped at 500ms to avoid an unbounded increase in the tracked repair latency for remote
+    // replicas. Specifically, helps avoid the case where a partitioned replica with missing
+    // prepares gets into a cycle of requesting prepares, waiting for them to expire, and then
+    // increasing the repair latency on expiry.
+    duration_expiry_max: stdx.Duration = .ms(500),
+
+    // Maximum inflight `request_prepare` messages per remote replica, at any point of time.
+    //
+    // This is kept small to ensure that even if the budget to a remote replica is saturated
+    // by multiple replicas, overflowing the egress `send_queue` (which leads to dropped messages)
+    // on the remote replica is unlikely. For example, since the `send_queue` is currently sized
+    // to 4 messages, if we were to set this limit to 4 as well, multiple repairing replicas are
+    // more likely to overflow the remote replica's send queue.
+    const repair_messages_inflight_count_max = 2;
+
+    const RequestedPrepares = std.AutoArrayHashMapUnmanaged(u64, stdx.Instant);
 
     pub fn init(gpa: std.mem.Allocator, options: struct {
-        capacity: u32,
-        refill_max: u32,
+        replica_index: u8,
+        replica_count: u8,
     }) !RepairBudgetJournal {
-        assert(options.refill_max <= options.capacity);
+        const remote_replica_count = if (options.replica_index < options.replica_count)
+            // Replicas can repair from all replicas but themselves.
+            options.replica_count - 1
+        else
+            // Standbys can repair from all replicas.
+            options.replica_count;
 
-        var requested_prepares: std.AutoArrayHashMapUnmanaged(PrepareIdentifier, void) = .{};
-        try requested_prepares.ensureTotalCapacity(gpa, options.capacity);
-        errdefer requested_prepares.deinit();
+        var replicas_requested_prepares = try gpa.alloc(RequestedPrepares, options.replica_count);
+        errdefer gpa.free(replicas_requested_prepares);
+
+        for (replicas_requested_prepares, 0..) |*requested_prepares, replica| {
+            errdefer for (replicas_requested_prepares[0..replica]) |*m| m.deinit(gpa);
+            requested_prepares.* = .{};
+
+            try requested_prepares.ensureTotalCapacity(gpa, repair_messages_inflight_count_max);
+            errdefer requested_prepares.deinit(gpa);
+        }
+
+        errdefer for (replicas_requested_prepares) |*m| m.deinit(gpa);
+
+        const replicas_repair_latency = try gpa.alloc(stdx.Duration, options.replica_count);
+        errdefer gpa.free(replicas_repair_latency);
+
+        // Initialize repair latency to 1 ms for all replicas, this gets refined as we start
+        // repairing from these replicas. We choose a value lower than the the typical latency
+        // between two replicas, so as to not bias replica selection when we have few measurements.
+        @memset(replicas_repair_latency, .ms(1));
 
         return RepairBudgetJournal{
-            .capacity = options.capacity,
-            .available = options.capacity,
-            .refill_max = options.refill_max,
-            .requested_prepares = requested_prepares,
+            .capacity = repair_messages_inflight_count_max * remote_replica_count,
+            .available = repair_messages_inflight_count_max * remote_replica_count,
+            .replica_index = options.replica_index,
+            .replicas_requested_prepares = replicas_requested_prepares,
+            .replicas_repair_latency = replicas_repair_latency,
         };
     }
 
     pub fn deinit(budget: *RepairBudgetJournal, gpa: std.mem.Allocator) void {
-        budget.requested_prepares.deinit(gpa);
+        for (budget.replicas_requested_prepares) |*requested_prepares| {
+            requested_prepares.deinit(gpa);
+        }
+        gpa.free(budget.replicas_requested_prepares);
+        gpa.free(budget.replicas_repair_latency);
     }
 
-    pub fn decrement(budget: *RepairBudgetJournal, prepare_identifier: PrepareIdentifier) bool {
+    /// Returns the index of the replica with the lowest repair latency, and budget availability, if
+    /// one exists. Otherwise, returns null. For a fraction of ops (guided by `experiment_chance`),
+    /// diverges from this heuristic and returns the index of a random replica with budget
+    /// availability, using reservoir sampling.
+    pub fn decrement(budget: *RepairBudgetJournal, options: struct {
+        op: u64,
+        now: stdx.Instant,
+        prng: *stdx.PRNG,
+    }) ?u8 {
         assert(budget.capacity > 0);
+        assert(budget.available > 0);
+
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        if (budget.available == 0) return false;
+        const experiment = options.prng.chance(budget.experiment_chance);
+        var experiment_replica_index: ?u8 = null;
+        var reservoir = stdx.PRNG.Reservoir.init();
 
-        const gop = budget.requested_prepares.getOrPutAssumeCapacity(prepare_identifier);
-        if (gop.found_existing) return false;
+        var repair_latency_min: ?stdx.Duration = null;
+        var repair_latency_min_replica_index: ?u8 = null;
 
-        budget.available -= 1;
+        for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
+            // Disallow requesting from a replica from which this op already been requested.
+            if (requested_prepares.get(options.op) != null) continue;
+            // Disallow requests to self.
+            if (replica_index == budget.replica_index) continue;
+            // Enforce per-replica budget.
+            if (requested_prepares.count() == repair_messages_inflight_count_max) continue;
 
-        return true;
+            const replica_repair_latency = budget.replicas_repair_latency[replica_index];
+
+            if (repair_latency_min == null or replica_repair_latency.ns < repair_latency_min.?.ns) {
+                repair_latency_min = replica_repair_latency;
+                repair_latency_min_replica_index = @intCast(replica_index);
+            }
+
+            // Reservoir sampling with an arbitrarily chosen weight of 1 for each item suffices
+            // our use case, as the goal is to get some degree of randomness during experiments.
+            if (reservoir.replace(options.prng, 1)) {
+                experiment_replica_index = @intCast(replica_index);
+            }
+        }
+        assert((repair_latency_min == null) == (repair_latency_min_replica_index == null));
+        assert((repair_latency_min_replica_index == null) == (experiment_replica_index == null));
+
+        const replica_index_maybe = if (experiment)
+            experiment_replica_index
+        else
+            repair_latency_min_replica_index;
+
+        if (replica_index_maybe) |replica_index| {
+            assert(replica_index != budget.replica_index);
+            budget.replicas_requested_prepares[replica_index].putAssumeCapacityNoClobber(
+                options.op,
+                options.now,
+            );
+
+            budget.available -= 1;
+        }
+
+        return replica_index_maybe;
     }
 
-    pub fn increment(budget: *RepairBudgetJournal, prepare_identifier: PrepareIdentifier) void {
+    /// Increments the budget by 1 for each replica that this prepare op has been requested from.
+    /// Also refines the repair latency for each of these replicas.
+    pub fn increment(budget: *RepairBudgetJournal, options: struct {
+        op: u64,
+        now: stdx.Instant,
+    }) void {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        // Increment budget iff we had requested this prepare.
-        if (budget.requested_prepares.swapRemove(prepare_identifier)) {
-            budget.available = @min((budget.available + 1), budget.capacity);
+        for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
+            if (requested_prepares.fetchSwapRemove(options.op)) |requested_prepare| {
+                budget.available += 1;
+
+                // We have no information about the replica that sent this prepare, as the message
+                // header stores the index of the primary processed that prepare. Consequently, we
+                // refine repair latency for all replicas that this prepare op was requested from.
+                // This would lead to some inaccuracy in the latency measurement, but is acceptable
+                // since the scenario where a prepare has been requested from multiple replicas is
+                // rare in practice. The more common scenario is that we have a large number of
+                // prepares missing (for e.g. after state sync, or if a lagging replica transitions
+                // to a new checkpoint), in which case we request a unique op from each replica.
+                budget.replicas_repair_latency[replica_index] = ewma_add_duration(
+                    budget.replicas_repair_latency[replica_index],
+                    options.now.duration_since(requested_prepare.value),
+                );
+            }
         }
     }
 
@@ -62,14 +200,66 @@ pub const RepairBudgetJournal = struct {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        budget.requested_prepares.clearRetainingCapacity();
-        budget.available = @min((budget.available + budget.refill_max), budget.capacity);
+        for (budget.replicas_requested_prepares) |*requested_prepares| {
+            requested_prepares.clearRetainingCapacity();
+        }
+        budget.available = budget.capacity;
+    }
+
+    /// Iterates through the inflight requests across all remote replicas, and reclaims the budget
+    /// for expired requests. Penalizes the replicas for which some expired requests were found,
+    /// duration spent waiting for the expired requests to their repair latency.
+    ///
+    /// Expiry provides resilience to network faults, by ensuring that a dropped packet or the
+    /// remote replica crashing doesn't cause an op to get stuck in the queue for a remote replica.
+    /// We avoid spurious expiry due to transient network hiccups like increased latency by waiting
+    /// for twice the measured repair latency.
+    pub fn maybe_expire_requested_prepares(budget: *RepairBudgetJournal, now: stdx.Instant) void {
+        budget.assert_invariants();
+        defer budget.assert_invariants();
+
+        for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
+            var requested_prepares_index: u32 = 0;
+
+            while (requested_prepares_index < requested_prepares.entries.len) {
+                const requested_at = requested_prepares.values()[requested_prepares_index];
+                const duration_since_requested_at = now.duration_since(requested_at);
+                const duration_expiry_ns = @min(
+                    budget.repair_latency_multiple_expiry *
+                        budget.replicas_repair_latency[replica_index].ns,
+                    budget.duration_expiry_max.ns,
+                );
+                if (duration_since_requested_at.ns > duration_expiry_ns) {
+                    requested_prepares.swapRemoveAt(requested_prepares_index);
+                    budget.replicas_repair_latency[replica_index] = ewma_add_duration(
+                        budget.replicas_repair_latency[replica_index],
+                        duration_since_requested_at,
+                    );
+                    budget.available += 1;
+                } else {
+                    requested_prepares_index += 1;
+                }
+            }
+        }
     }
 
     fn assert_invariants(budget: *const RepairBudgetJournal) void {
         assert(budget.available <= budget.capacity);
-        assert(budget.capacity - budget.available >=
-            @as(u32, @intCast(budget.requested_prepares.count())));
+        if (budget.replica_index < budget.replicas_requested_prepares.len) {
+            assert(budget.replicas_requested_prepares[budget.replica_index].count() == 0);
+        }
+
+        var requested_prepares_count: u32 = 0;
+        for (budget.replicas_requested_prepares) |*requested_prepares| {
+            requested_prepares_count += @intCast(requested_prepares.count());
+        }
+        assert(budget.capacity - budget.available == requested_prepares_count);
+    }
+
+    fn ewma_add_duration(old: stdx.Duration, new: stdx.Duration) stdx.Duration {
+        return .{
+            .ns = @divFloor((old.ns * 4) + new.ns, 5),
+        };
     }
 };
 
@@ -89,7 +279,7 @@ pub const RepairBudgetGrid = struct {
 
         var requested: std.AutoArrayHashMapUnmanaged(BlockIdentifier, void) = .{};
         try requested.ensureTotalCapacity(gpa, options.capacity);
-        errdefer requested.deinit();
+        errdefer requested.deinit(gpa);
 
         return RepairBudgetGrid{
             .capacity = options.capacity,


### PR DESCRIPTION
### Summary

This PR implements adaptive repair timeouts (ARTs), to make repair robust in the face of changing network topology and latencies. 

A key deficiency in WAL repair currently is that it _randomly chooses a remote replica_ to request a prepare from. This doesn't work well with one of our most common repair workloads -- when a lagging replica transitions to a new checkpoint, it must repair the portion of the WAL that its missing. If we request a prepare from another lagging replica (3/6 replicas tend to lag behind the fastest quorum, even with adaptive replication), we have to wait a repair timeout to re-request it, as we only request a prepare once between two timeouts. With our random replica selection, we may even go multiple repair timeouts without the prepare. Requesting a prepare only once between repair timeouts also meant that a replica's repair budget is well utilized when it has many prepares to repair, but mostly unutilized if it only had very few missing prepares.

Adaptive repair timeouts improve upon this, since we now rely on measured repair latency to choose a replica to repair from. Specifically, replicas attempt to direct their request to a replica that has previously provided us with a good repair quality of service (low repair latency). 

Additionally, this PR makes a crucial change to how replicas utilize their repair budgets. Now, replicas _always_ fully utilize their repair budget. Even, if a single prepare is missing, it is requested from _all_ remote replicas (with at most one request to a remote replica). The rationale here is as follows:

* By speeding up the repair for the single missing prepare (by sending redundant requests), even though we use some extra disk/network bandwidth on remote replicas, it _saves future bandwidth_ since it reduces the likelihood of the replica falling further behind. 
* Since we expect the cluster to handle the repair load when a replica is lagging by more and completely saturates the budget, it would be reasonable to expect that even if there’s a single missing prepare. And perhaps even better, since we predictably keep the repair bandwidth utilisation similar despite how much we’re lagging.


### Implementation Details

We implement adaptive repair timeouts without explicitly maintaining a timeout with dynamically varying interval!Instead, we maintain the instant at which a prepare is requested for repair, and which replica it has been requested from. We use this instant to compute the repair latency for each remote replica, by measuring the duration up till either:
* The requested prepare is received from the remote replica. Or,
* The requested prepare hits its _expiry duration_.
  * Expiry is enforced by `journal_repair_budget_timeout`, which fires every 10ms, peeks into each budget, and expires requests that are due for expiration.  At expiry, we penalize the replica to which the request expired, by adding the duration that we waited  for, to its current repair latency. 
  * The *expiry duration* for a request is a multiple of the repair latency to that replica (set to 2x in the PR), *and* is also capped to 500ms, to avoid the scenario where a partitioned replica with missing prepares triggers repair over and over on timeout, and unboundedly increases the repair latency for all replicas.
 
The criterion for selecting a replica to repair from is simple, we choose the replica with the *lowest repair latency, that also has available budget* (we allocate a budget of 2 for each remote replica, so as to not overwhelm a remote replica). Additionally, a fraction of ops are experimental ops, for which we try an alternative repair routes. This avoids potential resonance wherein we keep requesting from a permanently crashed replica with the best repair latency. This is because we don't penalize the repair latency once it exceeds the maximum expiry duration, so if a crashed replica has the best latency, it may remain that way forever.

### Deterministic Performance Testing (Median over 100 runs)

#### 30% packet loss

| Metric               | main | ART | Δ (absolute) | Δ (%)      |
|----------------------|-----------|------------|--------------:|-----------:|
|Ticks | 294613   | 280103    |-14510     | **-4.92%** |

Packet loss is a good way to simulate a scenario where our old replica selection criterion would send a RequestPrepare to a replica that doesn't have the prepare. In this case, the requesting replica's RequestPrepare/the remote replica's Prepare may be dropped.

**With ARTs, get a ~5% end-to-end performance boost in the presence of 30% packet loss, because we now _hedge_ RequestPrepares for an op, as long as we have the budget to do so.** Where earlier, a dropped RequestPrepare/Prepare could lead to at most a 100ms delay before we send _another_ RequestPrepare. Now, we send more RequestPrepare requests as long as we have the budget!

#### Missing Replicas


| Metric               | Missing Replicas| main | ART | Δ (absolute) | Δ (%)      |
|----------------------|-|-----------|------------|--------------:|-----------:|
|Ticks |1| 103494   | 101863    | -1631    | **-1.57%** |
|Ticks |2| 116372   | 112782    | -3590    | **-3.08%** |

My initial intuition was that with ART, we should see predictable performance regardless _regardless of the number of crashed replicas_. I since realized that is not possible, since missing replicas _also_ reduce our repair throughput, we have fewer replicas to repair from! 

However, ART _does_ increase end-to-end performance by **~3%** since the replicas that are missing are automatically deprioritized, whereas the algorithm on main randomly selects replicas for repair, so it sends relatively more requests to the missing replicas. With R2 and R3 as missing replicas, here is the count of RequestPrepares sent by R4 (randomly chosen):

| Remote Replica               | Status| ART | main |
|----------------------|-|-----------|------------|
|0 |🌱 | 2648   | 2160    | 
|1 👑 |🌱 | 4085   | 2180    | 
|2 |💀| 608   | 2179    | 
|3 |💀| 621   | 2160    | 
|5 |🌱| 2801   | 2140    | 

We can see that with ART, the maximum # of repair requests were directed towards the primary, which gave the best quality of service to R4 since it is guaranteed to have all prepares. On the other hand, with ART, **~5.6%** of requests were directed towards the crashed replicas (R2 and R3), while with main, **~20%** of requests were directed towards them (as it randomly selects replicas).
