### PR TITLE
time: unify monotonic and monotonic_instant

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -515,7 +515,7 @@ pub fn ContextType(
             if (self.client.request_inflight == null) {
                 assert(self.pending.count() == 0);
                 packet.phase = .pending;
-                packet.multi_batch_time_monotonic = self.client.time.monotonic();
+                packet.multi_batch_time_monotonic = self.client.time.monotonic().ns;
                 packet.multi_batch_count = 1;
                 packet.multi_batch_event_count = @intCast(batch.event_count);
                 packet.multi_batch_result_count_expected = @intCast(batch.result_count_expected);
@@ -573,7 +573,7 @@ pub fn ContextType(
 
             // Couldn't batch with existing packet so push to pending directly.
             packet.phase = .pending;
-            packet.multi_batch_time_monotonic = self.client.time.monotonic();
+            packet.multi_batch_time_monotonic = self.client.time.monotonic().ns;
             packet.multi_batch_count = 1;
             packet.multi_batch_event_count = @intCast(batch.event_count);
             packet.multi_batch_result_count_expected = @intCast(batch.result_count_expected);
@@ -778,7 +778,7 @@ pub fn ContextType(
             assert(timestamp > 0);
             packet_list.assert_phase(.sent);
 
-            const current_timestamp = self.client.time.monotonic_instant();
+            const current_timestamp = self.client.time.monotonic();
             self.previous_request_latency =
                 current_timestamp.duration_since(self.previous_request_instant.?);
 

--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -195,8 +195,8 @@ test "signal" {
             assert(self.count == events_count);
 
             // Make sure at least some time has passed.
-            const elapsed = timer.monotonic() - start;
-            assert(elapsed >= delay);
+            const elapsed = timer.monotonic().duration_since(start);
+            assert(elapsed.ns >= delay);
         }
 
         fn notify(self: *Context) void {

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -163,7 +163,7 @@ pub const IO = struct {
         while (timeouts_iterator.next()) |completion| {
 
             // NOTE: We could cache `now` above the loop but monotonic() should be cheap to call.
-            const now = self.time_os.time().monotonic();
+            const now = self.time_os.time().monotonic().ns;
             const expires = completion.operation.timeout.expires;
 
             // NOTE: remove() could be O(1) here with a doubly-linked-list
@@ -662,7 +662,7 @@ pub const IO = struct {
             completion,
             .timeout,
             .{
-                .expires = self.time_os.time().monotonic() + nanoseconds,
+                .expires = self.time_os.time().monotonic().ns + nanoseconds,
             },
             struct {
                 fn do_operation(_: anytype) TimeoutError!void {

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -294,7 +294,7 @@ test "timeout" {
         fn run_test() !void {
             var time_os: TimeOS = .{};
             const timer = time_os.time();
-            const start_time = timer.monotonic();
+            const start_time = timer.monotonic().ns;
             var self: Context = .{
                 .timer = timer,
                 .io = try IO.init(32, 0),
@@ -331,7 +331,7 @@ test "timeout" {
             _ = completion;
             _ = result catch @panic("timeout error");
 
-            if (self.stop_time == 0) self.stop_time = self.timer.monotonic();
+            if (self.stop_time == 0) self.stop_time = self.timer.monotonic().ns;
             self.count += 1;
         }
     }.run_test();
@@ -376,8 +376,8 @@ test "event" {
             assert(self.count == events_count);
 
             // Make sure at least some time has passed.
-            const elapsed = timer.monotonic() - start;
-            assert(elapsed >= delay);
+            const elapsed = timer.monotonic().duration_since(start);
+            assert(elapsed.ns >= delay);
         }
 
         fn trigger_event(self: *Context) void {

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -151,7 +151,7 @@ pub const IO = struct {
         var timeouts_iterator = self.timeouts.iterate();
         while (timeouts_iterator.next()) |completion| {
             // Lazily get the current time.
-            const now = current_time orelse self.time_os.time().monotonic();
+            const now = current_time orelse self.time_os.time().monotonic().ns;
             current_time = now;
 
             // Move the completion to completed if it expired.
@@ -1019,7 +1019,7 @@ pub const IO = struct {
             callback,
             completion,
             .timeout,
-            .{ .deadline = self.time_os.time().monotonic() + nanoseconds },
+            .{ .deadline = self.time_os.time().monotonic().ns + nanoseconds },
             struct {
                 fn do_operation(ctx: Completion.Context, op: anytype) TimeoutError!void {
                     _ = ctx;

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -231,7 +231,7 @@ pub fn StorageType(comptime IO: type) type {
                 .offset = offset_in_storage,
                 .target_max = buffer.len,
                 .zone = zone,
-                .start = self.tracer.time.monotonic_instant(),
+                .start = self.tracer.time.monotonic(),
             };
 
             self.start_read(read, null);
@@ -257,7 +257,7 @@ pub fn StorageType(comptime IO: type) type {
 
                 self.tracer.timing(
                     .{ .storage_read = .{ .zone = read.zone } },
-                    self.tracer.time.monotonic_instant().duration_since(read.start.?),
+                    self.tracer.time.monotonic().duration_since(read.start.?),
                 );
 
                 read.callback(read);
@@ -401,7 +401,7 @@ pub fn StorageType(comptime IO: type) type {
                 .buffer = buffer,
                 .offset = offset_in_storage,
                 .zone = zone,
-                .start = self.tracer.time.monotonic_instant(),
+                .start = self.tracer.time.monotonic(),
             };
 
             self.start_write(write);
@@ -466,7 +466,7 @@ pub fn StorageType(comptime IO: type) type {
             if (write.buffer.len == 0) {
                 self.tracer.timing(
                     .{ .storage_write = .{ .zone = write.zone } },
-                    self.tracer.time.monotonic_instant().duration_since(write.start.?),
+                    self.tracer.time.monotonic().duration_since(write.start.?),
                 );
 
                 write.callback(write);

--- a/src/time.zig
+++ b/src/time.zig
@@ -26,12 +26,8 @@ pub const Time = struct {
     /// Always use a monotonic timestamp if the goal is to measure elapsed time.
     /// This clock is not affected by discontinuous jumps in the system time, for example if the
     /// system administrator manually changes the clock.
-    pub fn monotonic(self: Time) u64 {
-        return self.vtable.monotonic(self.context);
-    }
-
-    pub fn monotonic_instant(self: Time) Instant {
-        return Instant{ .ns = self.monotonic() };
+    pub fn monotonic(self: Time) Instant {
+        return .{ .ns = self.vtable.monotonic(self.context) };
     }
 
     /// A timestamp to measure real (i.e. wall clock) time, meaningful across systems, and reboots.
@@ -179,8 +175,8 @@ pub const TimeOS = struct {
 test "Time monotonic smoke" {
     var time_os: TimeOS = .{};
     const time = time_os.time();
-    const instant_1 = time.monotonic_instant();
-    const instant_2 = time.monotonic_instant();
+    const instant_1 = time.monotonic();
+    const instant_2 = time.monotonic();
     assert(instant_1.duration_since(instant_1).ns == 0);
     assert(instant_2.duration_since(instant_1).ns >= 0);
 }
@@ -194,20 +190,20 @@ pub const Timer = struct {
     pub fn init(time: Time) Timer {
         return .{
             .time = time,
-            .started = time.monotonic_instant(),
+            .started = time.monotonic(),
         };
     }
 
     /// Reads the timer value since start or the last reset.
     pub fn read(self: *Timer) stdx.Duration {
-        const current = self.time.monotonic_instant();
+        const current = self.time.monotonic();
         assert(current.ns >= self.started.ns);
         return current.duration_since(self.started);
     }
 
     /// Resets the timer.
     pub fn reset(self: *Timer) void {
-        const current = self.time.monotonic_instant();
+        const current = self.time.monotonic();
         assert(current.ns >= self.started.ns);
         self.started = current;
     }

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -214,7 +214,7 @@ pub fn init(
         .events_metric = events_metric,
         .events_timing = events_timing,
 
-        .time_start = time.monotonic_instant(),
+        .time_start = time.monotonic(),
     };
 }
 
@@ -264,7 +264,7 @@ pub fn start(tracer: *Tracer, event: Event) void {
     const event_timing = event.as(EventTiming);
     const stack = event_tracing.stack();
 
-    const time_now = tracer.time.monotonic_instant();
+    const time_now = tracer.time.monotonic();
 
     assert(tracer.events_started[stack] == null);
     tracer.events_started[stack] = time_now;
@@ -321,7 +321,7 @@ pub fn stop(tracer: *Tracer, event: Event) void {
     const stack = event_tracing.stack();
 
     const event_start = tracer.events_started[stack].?;
-    const event_end = tracer.time.monotonic_instant();
+    const event_end = tracer.time.monotonic();
     const event_duration = event_end.duration_since(event_start);
 
     assert(tracer.events_started[stack] != null);
@@ -348,7 +348,7 @@ pub fn stop(tracer: *Tracer, event: Event) void {
 pub fn cancel(tracer: *Tracer, event_tag: Event.Tag) void {
     const stack_base = EventTracing.stack_bases.get(event_tag);
     const cardinality = EventTracing.stack_limits.get(event_tag);
-    const event_end = tracer.time.monotonic_instant();
+    const event_end = tracer.time.monotonic();
     for (stack_base..stack_base + cardinality) |stack| {
         if (tracer.events_started[stack]) |_| {
             log.debug("{}: {s}: cancel", .{ tracer.process_id, @tagName(event_tag) });

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -475,7 +475,7 @@ pub fn ClientType(
             }
 
             const ping_timestamp_monotonic = pong.header.ping_timestamp_monotonic;
-            const pong_timestamp_monotonic = self.time.monotonic();
+            const pong_timestamp_monotonic = self.time.monotonic().ns;
             if (ping_timestamp_monotonic <= pong_timestamp_monotonic) {
                 self.replica_round_trip_times_ns[pong.header.replica] =
                     pong_timestamp_monotonic - ping_timestamp_monotonic;
@@ -637,7 +637,7 @@ pub fn ClientType(
                 .cluster = self.cluster,
                 .release = self.release,
                 .client = self.id,
-                .ping_timestamp_monotonic = self.time.monotonic(),
+                .ping_timestamp_monotonic = self.time.monotonic().ns,
             };
 
             self.send_header_to_replicas(ping.frame_const());

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4291,7 +4291,7 @@ pub fn ReplicaType(
                 if (self.commit_stage == .check_prepare) {
                     self.commit_stage = .prefetch;
 
-                    self.commit_started = self.clock.time.monotonic();
+                    self.commit_started = self.clock.monotonic();
                     self.trace.start(.{ .replica_commit = .{
                         .stage = self.commit_stage,
                         .op = self.commit_prepare.?.header.op,
@@ -5126,7 +5126,7 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op < self.op_checkpoint_next_trigger());
 
-            const commit_completion_time_local = self.clock.time.monotonic()
+            const commit_completion_time_local = self.clock.monotonic()
                 .duration_since(self.commit_started.?);
             self.commit_started = null;
             if (commit_completion_time_local.to_ms() >
@@ -7208,7 +7208,7 @@ pub fn ReplicaType(
                 self.pulse_timeout.reset();
             }
 
-            self.routing.op_prepare(message.header.op, self.clock.time.monotonic());
+            self.routing.op_prepare(message.header.op, self.clock.monotonic());
             self.pipeline.queue.push_prepare(message);
             self.on_prepare(message);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1821,7 +1821,7 @@ pub fn ReplicaType(
 
             const m0 = message.header.ping_timestamp_monotonic;
             const t1: i64 = @bitCast(message.header.pong_timestamp_wall);
-            const m2 = self.clock.monotonic();
+            const m2 = self.clock.monotonic().ns;
 
             self.clock.learn(message.header.replica, m0, t1, m2);
             if (self.clock.round_trip_time_median_ns()) |rtt_ns| {
@@ -2152,7 +2152,7 @@ pub fn ReplicaType(
             self.routing.op_prepare_ok(
                 message.header.op,
                 message.header.replica,
-                self.clock.monotonic_instant(),
+                self.clock.monotonic(),
             );
 
             const prepare = self.pipeline.queue.prepare_by_prepare_ok(message) orelse {
@@ -3457,7 +3457,7 @@ pub fn ReplicaType(
                 .release = self.release,
                 .checkpoint_id = self.superblock.working.checkpoint_id(),
                 .checkpoint_op = self.op_checkpoint(),
-                .ping_timestamp_monotonic = self.clock.monotonic(),
+                .ping_timestamp_monotonic = self.clock.monotonic().ns,
                 .route = ping_route,
                 .release_count = releases.count,
             };
@@ -4291,7 +4291,7 @@ pub fn ReplicaType(
                 if (self.commit_stage == .check_prepare) {
                     self.commit_stage = .prefetch;
 
-                    self.commit_started = self.clock.time.monotonic_instant();
+                    self.commit_started = self.clock.time.monotonic();
                     self.trace.start(.{ .replica_commit = .{
                         .stage = self.commit_stage,
                         .op = self.commit_prepare.?.header.op,
@@ -5126,7 +5126,7 @@ pub fn ReplicaType(
             assert(self.commit_prepare.?.header.op == self.commit_min);
             assert(self.commit_prepare.?.header.op < self.op_checkpoint_next_trigger());
 
-            const commit_completion_time_local = self.clock.time.monotonic_instant()
+            const commit_completion_time_local = self.clock.time.monotonic()
                 .duration_since(self.commit_started.?);
             self.commit_started = null;
             if (commit_completion_time_local.to_ms() >
@@ -7208,7 +7208,7 @@ pub fn ReplicaType(
                 self.pulse_timeout.reset();
             }
 
-            self.routing.op_prepare(message.header.op, self.clock.time.monotonic_instant());
+            self.routing.op_prepare(message.header.op, self.clock.time.monotonic());
             self.pipeline.queue.push_prepare(message);
             self.on_prepare(message);
 
@@ -11163,7 +11163,7 @@ pub fn ReplicaType(
                 .view = self.view,
                 .commit = self.commit_max,
                 .commit_checksum = latest_committed_entry,
-                .timestamp_monotonic = self.clock.monotonic(),
+                .timestamp_monotonic = self.clock.monotonic().ns,
                 .checkpoint_op = self.superblock.working.vsr_state.checkpoint.header.op,
                 .checkpoint_id = self.superblock.working.checkpoint_id(),
             }));


### PR DESCRIPTION
The Instant/Duration types seem to be a success, so there's no need to keep both the raw and the type variant around. I'd even say that `.monotonic().ns` is a strict improvement by itself!