### PR TITLE
Clarified documentation on closing accounts and two-phase transfers

### DIFF
--- a/docs/coding/recipes/close-account.md
+++ b/docs/coding/recipes/close-account.md
@@ -6,7 +6,7 @@ another account.
 
 Additionally, it may be desirable to forbid further transfers on this account (i.e. at the end of
 an accounting period, upon account termination, or even temporarily freezing the account for audit
-purposes.
+purposes). This doesn't affect existing [pending transfers](../two-phase-transfers.md) which can still time out but can't be posted or voided.
 
 ### Example
 

--- a/docs/coding/recipes/close-account.md
+++ b/docs/coding/recipes/close-account.md
@@ -6,7 +6,9 @@ another account.
 
 Additionally, it may be desirable to forbid further transfers on this account (i.e. at the end of
 an accounting period, upon account termination, or even temporarily freezing the account for audit
-purposes). This doesn't affect existing [pending transfers](../two-phase-transfers.md) which can still time out but can't be posted or voided.
+purposes).
+This doesn't affect existing [pending transfers](../two-phase-transfers.md), which can still time
+out but can’t be posted or voided.
 
 ### Example
 


### PR DESCRIPTION
Hello, 

When an account is being closed and all net debit/credit is being moved to another account and further transactions are being forbidden, the net debit/credit can still change by expiring two-phase transfers. 

This behavior makes sense but was suprising to me, so I have added a sentence to the documentation.