### PR TITLE
fix mislabelled transfers/accounts/balances in snippets

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -593,7 +593,7 @@ var filter = new QueryFilter
     Ledger = 0, // No filter by Ledger.
     TimestampMin = 0, // No filter by Timestamp.
     TimestampMax = 0, // No filter by Timestamp.
-    Limit = 10, // Limit to ten balances at most.
+    Limit = 10, // Limit to ten accounts at most.
     Flags = QueryFilterFlags.Reversed, // Sort by timestamp in reverse-chronological order.
 };
 
@@ -620,7 +620,7 @@ var filter = new QueryFilter
     Ledger = 0, // No filter by Ledger
     TimestampMin = 0, // No filter by Timestamp.
     TimestampMax = 0, // No filter by Timestamp.
-    Limit = 10, // Limit to ten balances at most.
+    Limit = 10, // Limit to ten transfers at most.
     Flags = QueryFilterFlags.Reversed, // Sort by timestamp in reverse-chronological order.
 };
 

--- a/src/clients/dotnet/samples/walkthrough/Program.cs
+++ b/src/clients/dotnet/samples/walkthrough/Program.cs
@@ -393,7 +393,7 @@ using (var client = new Client(clusterID, addresses))
             Ledger = 0, // No filter by Ledger.
             TimestampMin = 0, // No filter by Timestamp.
             TimestampMax = 0, // No filter by Timestamp.
-            Limit = 10, // Limit to ten balances at most.
+            Limit = 10, // Limit to ten accounts at most.
             Flags = QueryFilterFlags.Reversed, // Sort by timestamp in reverse-chronological order.
         };
 
@@ -414,7 +414,7 @@ using (var client = new Client(clusterID, addresses))
             Ledger = 0, // No filter by Ledger
             TimestampMin = 0, // No filter by Timestamp.
             TimestampMax = 0, // No filter by Timestamp.
-            Limit = 10, // Limit to ten balances at most.
+            Limit = 10, // Limit to ten transfers at most.
             Flags = QueryFilterFlags.Reversed, // Sort by timestamp in reverse-chronological order.
         };
 

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -589,7 +589,7 @@ filter := QueryFilter{
 	Ledger:       0,  // No filter by Ledger
 	TimestampMin: 0,  // No filter by Timestamp.
 	TimestampMax: 0,  // No filter by Timestamp.
-	Limit:        10, // Limit to ten balances at most.
+	Limit:        10, // Limit to ten accounts at most.
 	Flags: QueryFilterFlags{
 		Reversed: true, // Sort by timestamp in reverse-chronological order.
 	}.ToUint32(),
@@ -617,7 +617,7 @@ filter := QueryFilter{
 	Ledger:       0,  // No filter by Ledger.
 	TimestampMin: 0,  // No filter by Timestamp.
 	TimestampMax: 0,  // No filter by Timestamp.
-	Limit:        10, // Limit to ten balances at most.
+	Limit:        10, // Limit to ten transfers at most.
 	Flags: QueryFilterFlags{
 		Reversed: true, // Sort by timestamp in reverse-chronological order.
 	}.ToUint32(),

--- a/src/clients/go/samples/walkthrough/main.go
+++ b/src/clients/go/samples/walkthrough/main.go
@@ -354,7 +354,7 @@ func main() {
 			Ledger:       0,  // No filter by Ledger
 			TimestampMin: 0,  // No filter by Timestamp.
 			TimestampMax: 0,  // No filter by Timestamp.
-			Limit:        10, // Limit to ten balances at most.
+			Limit:        10, // Limit to ten accounts at most.
 			Flags: QueryFilterFlags{
 				Reversed: true, // Sort by timestamp in reverse-chronological order.
 			}.ToUint32(),
@@ -375,7 +375,7 @@ func main() {
 			Ledger:       0,  // No filter by Ledger.
 			TimestampMin: 0,  // No filter by Timestamp.
 			TimestampMax: 0,  // No filter by Timestamp.
-			Limit:        10, // Limit to ten balances at most.
+			Limit:        10, // Limit to ten transfers at most.
 			Flags: QueryFilterFlags{
 				Reversed: true, // Sort by timestamp in reverse-chronological order.
 			}.ToUint32(),

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -658,7 +658,7 @@ filter.setCode(1); // Filter by Code.
 filter.setLedger(0); // No filter by Ledger.
 filter.setTimestampMin(0); // No filter by Timestamp.
 filter.setTimestampMax(0); // No filter by Timestamp.
-filter.setLimit(10); // Limit to ten balances at most.
+filter.setLimit(10); // Limit to ten accounts at most.
 filter.setReversed(true); // Sort by timestamp in reverse-chronological order.
 
 AccountBatch accounts = client.queryAccounts(filter);
@@ -683,7 +683,7 @@ filter.setCode(1); // Filter by Code.
 filter.setLedger(0); // No filter by Ledger.
 filter.setTimestampMin(0); // No filter by Timestamp.
 filter.setTimestampMax(0); // No filter by Timestamp.
-filter.setLimit(10); // Limit to ten balances at most.
+filter.setLimit(10); // Limit to ten transfers at most.
 filter.setReversed(true); // Sort by timestamp in reverse-chronological order.
 
 TransferBatch transfers = client.queryTransfers(filter);

--- a/src/clients/java/samples/walkthrough/src/main/java/Main.java
+++ b/src/clients/java/samples/walkthrough/src/main/java/Main.java
@@ -374,7 +374,7 @@ public final class Main {
                 filter.setLedger(0); // No filter by Ledger.
                 filter.setTimestampMin(0); // No filter by Timestamp.
                 filter.setTimestampMax(0); // No filter by Timestamp.
-                filter.setLimit(10); // Limit to ten balances at most.
+                filter.setLimit(10); // Limit to ten accounts at most.
                 filter.setReversed(true); // Sort by timestamp in reverse-chronological order.
 
                 AccountBatch accounts = client.queryAccounts(filter);
@@ -391,7 +391,7 @@ public final class Main {
                 filter.setLedger(0); // No filter by Ledger.
                 filter.setTimestampMin(0); // No filter by Timestamp.
                 filter.setTimestampMax(0); // No filter by Timestamp.
-                filter.setLimit(10); // Limit to ten balances at most.
+                filter.setLimit(10); // Limit to ten transfers at most.
                 filter.setReversed(true); // Sort by timestamp in reverse-chronological order.
 
                 TransferBatch transfers = client.queryTransfers(filter);

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -614,7 +614,7 @@ const filter = {
   code: 0, // No filter by Code.
   timestamp_min: 0n, // No filter by Timestamp.
   timestamp_max: 0n, // No filter by Timestamp.
-  limit: 10, // Limit to ten balances at most.
+  limit: 10, // Limit to ten transfers at most.
   flags: AccountFilterFlags.debits | // Include transfer from the debit side.
     AccountFilterFlags.credits | // Include transfer from the credit side.
     AccountFilterFlags.reversed, // Sort by timestamp in reverse-chronological order.
@@ -675,7 +675,7 @@ const query_filter = {
   ledger: 0, // No filter by Ledger.
   timestamp_min: 0n, // No filter by Timestamp.
   timestamp_max: 0n, // No filter by Timestamp.
-  limit: 10, // Limit to ten balances at most.
+  limit: 10, // Limit to ten accounts at most.
   flags: QueryFilterFlags.reversed, // Sort by timestamp in reverse-chronological order.
 };
 
@@ -701,7 +701,7 @@ const query_filter = {
   ledger: 0, // No filter by Ledger.
   timestamp_min: 0n, // No filter by Timestamp.
   timestamp_max: 0n, // No filter by Timestamp.
-  limit: 10, // Limit to ten balances at most.
+  limit: 10, // Limit to ten transfers at most.
   flags: QueryFilterFlags.reversed, // Sort by timestamp in reverse-chronological order.
 };
 

--- a/src/clients/node/samples/walkthrough/main.js
+++ b/src/clients/node/samples/walkthrough/main.js
@@ -412,7 +412,7 @@ async function main() {
       code: 0, // No filter by Code.
       timestamp_min: 0n, // No filter by Timestamp.
       timestamp_max: 0n, // No filter by Timestamp.
-      limit: 10, // Limit to ten balances at most.
+      limit: 10, // Limit to ten transfers at most.
       flags: AccountFilterFlags.debits | // Include transfer from the debit side.
         AccountFilterFlags.credits | // Include transfer from the credit side.
         AccountFilterFlags.reversed, // Sort by timestamp in reverse-chronological order.
@@ -452,7 +452,7 @@ async function main() {
       ledger: 0, // No filter by Ledger.
       timestamp_min: 0n, // No filter by Timestamp.
       timestamp_max: 0n, // No filter by Timestamp.
-      limit: 10, // Limit to ten balances at most.
+      limit: 10, // Limit to ten accounts at most.
       flags: QueryFilterFlags.reversed, // Sort by timestamp in reverse-chronological order.
     };
 
@@ -470,7 +470,7 @@ async function main() {
       ledger: 0, // No filter by Ledger.
       timestamp_min: 0n, // No filter by Timestamp.
       timestamp_max: 0n, // No filter by Timestamp.
-      limit: 10, // Limit to ten balances at most.
+      limit: 10, // Limit to ten transfers at most.
       flags: QueryFilterFlags.reversed, // Sort by timestamp in reverse-chronological order.
     };
 

--- a/src/clients/python/README.md
+++ b/src/clients/python/README.md
@@ -586,7 +586,7 @@ filter = tb.AccountFilter(
     code=0, # No filter by Code.
     timestamp_min=0, # No filter by Timestamp.
     timestamp_max=0, # No filter by Timestamp.
-    limit=10, # Limit to ten balances at most.
+    limit=10, # Limit to ten transfers at most.
     flags=tb.AccountFilterFlags.DEBITS | # Include transfer from the debit side.
     tb.AccountFilterFlags.CREDITS | # Include transfer from the credit side.
     tb.AccountFilterFlags.REVERSED, # Sort by timestamp in reverse-chronological order.
@@ -647,7 +647,7 @@ query_filter = tb.QueryFilter(
     ledger=0, # No filter by Ledger.
     timestamp_min=0, # No filter by Timestamp.
     timestamp_max=0, # No filter by Timestamp.
-    limit=10, # Limit to ten balances at most.
+    limit=10, # Limit to ten accounts at most.
     flags=tb.QueryFilterFlags.REVERSED, # Sort by timestamp in reverse-chronological order.
 )
 
@@ -673,7 +673,7 @@ query_filter = tb.QueryFilter(
     ledger=0, # No filter by Ledger.
     timestamp_min=0, # No filter by Timestamp.
     timestamp_max=0, # No filter by Timestamp.
-    limit=10, # Limit to ten balances at most.
+    limit=10, # Limit to ten transfers at most.
     flags=tb.QueryFilterFlags.REVERSED, # Sort by timestamp in reverse-chronological order.
 )
 

--- a/src/clients/python/samples/walkthrough/main.py
+++ b/src/clients/python/samples/walkthrough/main.py
@@ -400,7 +400,7 @@ with tb.ClientSync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000
             code=0, # No filter by Code.
             timestamp_min=0, # No filter by Timestamp.
             timestamp_max=0, # No filter by Timestamp.
-            limit=10, # Limit to ten balances at most.
+            limit=10, # Limit to ten transfers at most.
             flags=tb.AccountFilterFlags.DEBITS | # Include transfer from the debit side.
             tb.AccountFilterFlags.CREDITS | # Include transfer from the credit side.
             tb.AccountFilterFlags.REVERSED, # Sort by timestamp in reverse-chronological order.
@@ -442,7 +442,7 @@ with tb.ClientSync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000
             ledger=0, # No filter by Ledger.
             timestamp_min=0, # No filter by Timestamp.
             timestamp_max=0, # No filter by Timestamp.
-            limit=10, # Limit to ten balances at most.
+            limit=10, # Limit to ten accounts at most.
             flags=tb.QueryFilterFlags.REVERSED, # Sort by timestamp in reverse-chronological order.
         )
 
@@ -461,7 +461,7 @@ with tb.ClientSync(cluster_id=0, replica_addresses=os.getenv("TB_ADDRESS", "3000
             ledger=0, # No filter by Ledger.
             timestamp_min=0, # No filter by Timestamp.
             timestamp_max=0, # No filter by Timestamp.
-            limit=10, # Limit to ten balances at most.
+            limit=10, # Limit to ten transfers at most.
             flags=tb.QueryFilterFlags.REVERSED, # Sort by timestamp in reverse-chronological order.
         )
 


### PR DESCRIPTION
I noticed that these comments were labelled wrong on the Python client, and sure enough they were wrong on all clients!