### PR TITLE
vsr: embrace commit and repair concurrency

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7432,18 +7432,6 @@ pub fn ReplicaType(
             // Request and repair any missing, dirty, or faulty prepares.
             self.repair_prepares();
 
-            if (header_break != null and header_break.?.op_max > self.op_checkpoint()) {
-                return;
-            }
-
-            // The hash chain is anchored at both ends: `self.op` and `self.op_checkpoint`.
-            // It is safe to start committing.
-            // The replica might still be repairing headers and prepares before the checkpoint.
-            assert(self.valid_hash_chain_between(
-                @min(self.op_checkpoint() + 1, self.op),
-                self.op,
-            ));
-
             if (self.commit_min < self.commit_max) {
                 // Try to the commit prepares we already have, even if we don't have all of them.
                 // This helps when a replica is recovering from a crash and has a mostly intact


### PR DESCRIPTION
As part of https://github.com/tigerbeetle/tigerbeetle/pull/2625 and https://github.com/tigerbeetle/tigerbeetle/pull/2627, we relaxed the preconditions for header repair (`repair_header`) and commit (`commit_start_journal`), to check the hash chain up till the head op _only if_ there is a view mismatch between the op being repaired/committed, and the head op. 

Turns out there is _also_ a precondition in `repair` which checks for a valid hash chain between `self.op_checkpoint()` → `self.op` before committing. This PR removes that precondition, and instead freely initiates commit, so that the below optimization in `commit_start_journal` applies to commits initiated through repair as well:

```C
                // Assuming that the head op is correct, it is definitely safe to commit the next
                // prepare if it is from the same view as the head --- the primary for that view
                // made sure that the hash chain is valid. If it is from the different view, we
                // additionally verify ourselves that the hash-chain is not broken
                const valid_hash_chain_or_same_view = self.valid_hash_chain(@src()) or
                    (self.status == .normal and
                        header.view == self.journal.header_with_op(self.op).?.view);
```

