### PR TITLE
routing: spring cleaning

### DIFF
--- a/src/testing/exhaustigen.zig
+++ b/src/testing/exhaustigen.zig
@@ -89,6 +89,21 @@ pub fn int_inclusive(g: *Gen, Int: type, bound: Int) Int {
     return @intCast(g.gen(@intCast(bound)));
 }
 
+pub fn range_inclusive(g: *Gen, Int: type, min: Int, max: Int) Int {
+    comptime assert(@typeInfo(Int).int.signedness == .unsigned);
+    assert(min <= max);
+    return min + g.int_inclusive(Int, max - min);
+}
+
+pub fn shuffle(g: *Gen, T: type, slice: []T) void {
+    if (slice.len <= 1) return;
+
+    for (0..slice.len - 1) |i| {
+        const j = g.range_inclusive(u64, i, slice.len - 1);
+        std.mem.swap(T, &slice[i], &slice[j]);
+    }
+}
+
 pub fn index(g: *Gen, slice: anytype) usize {
     assert(slice.len > 0);
     return g.int_inclusive(usize, slice.len - 1);

--- a/src/vsr/routing.zig
+++ b/src/vsr/routing.zig
@@ -72,7 +72,7 @@ experiment_chance: Ratio = ratio(1, 20),
 
 history: [history_max]OpHistory,
 
-// A permutation of replicas, where the middle replica is the primary.
+/// A permutation of replicas, where the middle replica is the primary.
 pub const Route = struct {
     replicas: [constants.replicas_max]u8,
     count: u8,
@@ -152,7 +152,7 @@ pub const Route = struct {
         return true;
     }
 
-    // Encode a root as a u64
+    // Encode a root as a u64.
     // Routes are communicated in pings, which have u64 space in the message header.
     pub fn encode(route: Route) u64 {
         comptime assert(constants.replicas_max <= @sizeOf(u64));
@@ -206,7 +206,12 @@ pub const Route = struct {
         assert(replica < route.count);
         assert(route.valid(view, route.count));
 
-        // We need to return at most two "neightbours" in replication topology.
+        // We need to return at most two "neighbours" in replication topology.
+        // Assume that the route is as follows, with view=7:
+        //
+        //     0 2 1 3 5 4
+        //         ^ primary
+        //
         // Assume that the route is as follows, with view=7
         //
         //     0 2 1 3 5 4


### PR DESCRIPTION
A bunch of behavior-preserving refactors from IronBeetle!

- Replace usages of BoundedArray with a dedicated named struct with mehtods.
- Refactor next_hop to separately handle backup replciation and standby replication.
- Teach exhaustigen to shuffle (copy code from PRNG)
- In positive route encoding test, use exhaustigen instead of a loop to select replica count.
- In negative route decoding test, use std.testing.random_seed instead of hard-coded seed.