### PR TITLE
zig: remove needless BoundedArray

### DIFF
--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -45,7 +45,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
         errdefer tmp_beetle.log_stderr();
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("dotnet run", .{});
     }
 
@@ -120,7 +120,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     defer tmp_beetle.deinit(gpa);
     errdefer tmp_beetle.log_stderr();
 
-    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
     try shell.exec("dotnet new console", .{});
 
     // NuGet may take a few minutes to make the new package available for download.

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -60,7 +60,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
         errdefer tmp_beetle.log_stderr();
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("go build main.go", .{});
         try shell.exec("./main" ++ builtin.target.exeFileExt(), .{});
     }
@@ -77,7 +77,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     defer tmp_beetle.deinit(gpa);
     errdefer tmp_beetle.log_stderr();
 
-    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
     try shell.exec("go mod init tbtest", .{});
     try shell.exec("go get github.com/tigerbeetle/tigerbeetle-go@v{version}", .{

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -32,7 +32,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
         errdefer tmp_beetle.log_stderr();
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec(
             \\mvn --batch-mode --file pom.xml --quiet
             \\  package exec:java
@@ -51,7 +51,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     defer tmp_beetle.deinit(gpa);
     errdefer tmp_beetle.log_stderr();
 
-    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
     try shell.cwd.writeFile(.{ .sub_path = "pom.xml", .data = try shell.fmt(
         \\<project>

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -25,7 +25,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
         errdefer tmp_beetle.log_stderr();
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("node ./dist/{tester}", .{ .tester = tester });
     }
 
@@ -41,7 +41,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
         errdefer tmp_beetle.log_stderr();
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("npm install", .{});
         try shell.exec("node main.js", .{});
     }
@@ -84,7 +84,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     defer tmp_beetle.deinit(gpa);
     errdefer tmp_beetle.log_stderr();
 
-    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
     try shell.exec("npm install tigerbeetle-node@{version}", .{
         .version = options.version,

--- a/src/clients/python/ci.zig
+++ b/src/clients/python/ci.zig
@@ -49,7 +49,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         );
         try shell.env.put("TIGERBEETLE_BINARY", tigerbeetle_path);
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("python3 -m pytest tests/", .{});
     }
 
@@ -65,7 +65,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         defer tmp_beetle.deinit(gpa);
         errdefer tmp_beetle.log_stderr();
 
-        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+        try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("python3 main.py", .{});
     }
 
@@ -111,7 +111,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     defer tmp_beetle.deinit(gpa);
     errdefer tmp_beetle.log_stderr();
 
-    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str.slice());
+    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
     try Shell.copy_path(
         shell.project_root,

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -59,7 +59,7 @@ test "repl integration" {
                 \\{tigerbeetle} repl --cluster=0 --addresses={addresses} --command={command}
             , .{
                 .tigerbeetle = context.tigerbeetle_exe,
-                .addresses = context.tmp_beetle.port_str.slice(),
+                .addresses = context.tmp_beetle.port_str,
                 .command = command,
             });
         }

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -409,7 +409,7 @@ fn run_cdc_test(
             "--idle-interval-ms={idle_interval_ms}",
         .{
             .tigerbeetle = tmp_beetle.tigerbeetle_exe,
-            .addresses = tmp_beetle.port_str.slice(),
+            .addresses = tmp_beetle.port_str,
             .port = options.host.getPort(),
             .queue = queue,
             .idle_interval_ms = 1,
@@ -427,7 +427,7 @@ fn run_cdc_test(
             "--transfer-pending",
         .{
             .tigerbeetle = tmp_beetle.tigerbeetle_exe,
-            .addresses = tmp_beetle.port_str.slice(),
+            .addresses = tmp_beetle.port_str,
             .transfer_count = options.transfer_count,
         },
     );


### PR DESCRIPTION
The call site looks nicer when we heap allocate prot_str, and, given that we spawn an entire TigerBeetle here, we shouldn't worry about a single smalloc.