### PR TITLE
metrics: track statsd packets and release as a metric

### DIFF
--- a/src/trace.zig
+++ b/src/trace.zig
@@ -389,7 +389,10 @@ pub fn emit_metrics(tracer: *Tracer) void {
     tracer.start(.metrics_emit);
     defer tracer.stop(.metrics_emit);
 
-    tracer.statsd.emit(tracer.events_metric, tracer.events_timing) catch |err| switch (err) {
+    const metrics_statsd_packets = tracer.statsd.emit(
+        tracer.events_metric,
+        tracer.events_timing,
+    ) catch |err| switch (err) {
         error.Busy, error.UnknownProcess => return,
     };
 
@@ -397,6 +400,8 @@ pub fn emit_metrics(tracer: *Tracer) void {
     // Prometheus, this would have to be removed.
     @memset(tracer.events_metric, null);
     @memset(tracer.events_timing, null);
+
+    tracer.gauge(.metrics_statsd_packets, metrics_statsd_packets);
 }
 
 // Timing works by storing the min, max, sum and count of each value provided. The avg is calculated

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -471,6 +471,8 @@ pub const EventMetric = union(enum) {
     grid_cache_misses,
     lsm_nodes_free,
     lsm_manifest_block_count,
+    metrics_statsd_packets,
+    release,
 
     pub const slot_limits = std.enums.EnumArray(Tag, u32).init(.{
         .table_count_visible = enum_count(TreeEnum),
@@ -496,6 +498,8 @@ pub const EventMetric = union(enum) {
         .grid_cache_misses = 1,
         .lsm_nodes_free = 1,
         .lsm_manifest_block_count = 1,
+        .metrics_statsd_packets = 1,
+        .release = 1,
     });
 
     pub const slot_bases = array: {

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -181,7 +181,7 @@ pub const StatsD = struct {
         self: *StatsD,
         events_metric: []const ?EventMetricAggregate,
         events_timing: []const ?EventTimingAggregate,
-    ) error{ Busy, UnknownProcess }!void {
+    ) error{ Busy, UnknownProcess }!u32 {
         const cluster, const replica = switch (self.process_id) {
             .unknown => {
                 log.err("{}: process id unknown; skipping emit", .{self.process_id});
@@ -278,13 +278,15 @@ pub const StatsD = struct {
             if (self.send_in_flight_count >= self.send_completions.len) {
                 // This shouldn't ever happen, but don't allow metrics to kill the system.
                 log.err("{}: insufficient packets to emit any metrics", .{self.process_id});
-                return;
+                return 0;
             }
             const completion = &self.send_completions[self.send_in_flight_count];
             self.send_in_flight_count += 1;
             self.emit_buffer(completion, self.send_buffer[send_offset..][0..send_size]);
             send_offset += send_size;
         }
+
+        return @intCast(send_sizes.count());
     }
 
     fn emit_buffer(self: *StatsD, send_completion: *IO.Completion, send_buffer: []const u8) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3790,6 +3790,7 @@ pub fn ReplicaType(
             self.trace.gauge(.grid_cache_hits, self.grid.cache.metrics.hits);
             self.trace.gauge(.grid_cache_misses, self.grid.cache.metrics.misses);
             self.trace.gauge(.lsm_nodes_free, self.state_machine.forest.node_pool.free.count());
+            self.trace.gauge(.release, self.release.value);
 
             self.trace.gauge(
                 .grid_blocks_acquired,


### PR DESCRIPTION
This adds two new metrics:
- how many statsd packets are actually emitted and,
- the current release (which is a constant).

The first is useful for seeing the load metrics are actually adding to a system, while the second is useful for keeping track of releases on a dashboard.