### PR TITLE
ci: validate client release versions

### DIFF
--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -173,3 +173,28 @@ fn nuget_install(shell: *Shell, options: struct {
         return err;
     }
 }
+
+pub fn release_published_latest(shell: *Shell) ![]const u8 {
+    const DotnetSearch = struct {
+        const SearchResult = struct {
+            const Packages = struct {
+                id: []const u8,
+                latestVersion: []const u8,
+            };
+            packages: []Packages,
+        };
+        searchResult: []SearchResult,
+    };
+
+    const output = try shell.exec_stdout("dotnet package search tigerbeetle --format json", .{});
+    const dotnet_search_results = try std.json.parseFromSliceLeaky(
+        DotnetSearch,
+        shell.arena.allocator(),
+        output,
+        .{ .ignore_unknown_fields = true },
+    );
+
+    assert(std.mem.eql(u8, dotnet_search_results.searchResult[0].packages[0].id, "tigerbeetle"));
+
+    return dotnet_search_results.searchResult[0].packages[0].latestVersion;
+}

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -194,6 +194,9 @@ pub fn release_published_latest(shell: *Shell) ![]const u8 {
         .{ .ignore_unknown_fields = true },
     );
 
+    assert(dotnet_search_results.searchResult.len == 1);
+    assert(dotnet_search_results.searchResult[0].packages.len == 1);
+
     assert(std.mem.eql(u8, dotnet_search_results.searchResult[0].packages[0].id, "tigerbeetle"));
 
     return dotnet_search_results.searchResult[0].packages[0].latestVersion;

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -95,3 +95,14 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     try shell.env.put("CC", zig_cc);
     try shell.exec("go run main.go", .{});
 }
+
+pub fn release_published_latest(shell: *Shell) ![]const u8 {
+    // Returns a list of all versions. Slice on ' v' and offset by 2 to get the raw version number.
+    const output = try shell.exec_stdout(
+        "go list -m -versions github.com/tigerbeetle/tigerbeetle-go",
+        .{},
+    );
+    const last_version = std.mem.lastIndexOf(u8, output, " v").?;
+
+    return output[last_version + 2 ..];
+}

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -97,7 +97,8 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {
-    // Returns a list of all versions. Slice on ' v' and offset by 2 to get the raw version number.
+    // Example output:
+    //  github.com/tigerbeetle/tigerbeetle-go v0.9.149 v0.13.56 v0.13.57
     const output = try shell.exec_stdout(
         "go list -m -versions github.com/tigerbeetle/tigerbeetle-go",
         .{},

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const log = std.log;
 const assert = std.debug.assert;
-const stdx = @import("stdx");
 
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
@@ -164,26 +163,7 @@ pub fn release_published_latest(shell: *Shell) ![]const u8 {
         "=normalizedVersion&sortDirection=desc&page=0&size=1&" ++
         "filter=namespace%3Acom.tigerbeetle%2Cname%3Atigerbeetle-java";
 
-    var client = std.http.Client{ .allocator = shell.gpa };
-    defer client.deinit();
-
-    const uri = try std.Uri.parse(url);
-    var header_buffer: [4 * stdx.KiB]u8 = undefined;
-    var request = try client.open(.GET, uri, .{ .server_header_buffer = &header_buffer });
-    defer request.deinit();
-
-    try request.send();
-    try request.finish();
-    try request.wait();
-
-    if (request.response.status != std.http.Status.ok) {
-        return error.WrongStatusResponse;
-    }
-
-    const response_body_size_max = 32 * stdx.KiB;
-    var response_body_buffer: [response_body_size_max]u8 = undefined;
-    const response_body_len = try request.readAll(&response_body_buffer);
-    const response_body = response_body_buffer[0..response_body_len];
+    const response_body = try shell.http_get(url);
 
     const MavenSearch = struct {
         const Component = struct {

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -159,11 +159,11 @@ fn mvn_update(shell: *Shell) !union(enum) { ok, retry: anyerror } {
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {
-    const url = "https://central.sonatype.com/api/internal/browse/component/versions?sortField" ++
-        "=normalizedVersion&sortDirection=desc&page=0&size=1&" ++
+    const url = "https://central.sonatype.com/api/internal/browse/component/versions?" ++
+        "sortField=normalizedVersion&sortDirection=desc&page=0&size=1&" ++
         "filter=namespace%3Acom.tigerbeetle%2Cname%3Atigerbeetle-java";
 
-    const response_body = try shell.http_get(url);
+    const response_body = try shell.http_get(url, .{});
 
     const MavenSearch = struct {
         const Component = struct {
@@ -180,6 +180,8 @@ pub fn release_published_latest(shell: *Shell) ![]const u8 {
         response_body,
         .{ .ignore_unknown_fields = true },
     );
+
+    assert(maven_search_results.components.len == 1);
 
     assert(std.mem.eql(u8, maven_search_results.components[0].namespace, "com.tigerbeetle"));
     assert(std.mem.eql(u8, maven_search_results.components[0].name, "tigerbeetle-java"));

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -98,3 +98,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     );
     try shell.exec("node main.js", .{});
 }
+
+pub fn release_published_latest(shell: *Shell) ![]const u8 {
+    return try shell.exec_stdout("npm view tigerbeetle-node version", .{});
+}

--- a/src/clients/python/ci.zig
+++ b/src/clients/python/ci.zig
@@ -121,3 +121,11 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     );
     try shell.exec("{tmp_dir}/bin/python3 main.py", .{ .tmp_dir = tmp_dir });
 }
+
+pub fn release_published_latest(shell: *Shell) ![]const u8 {
+    const output = try shell.exec_stdout("python3 -m pip index versions --pre tigerbeetle", .{});
+    const version_start = std.mem.indexOf(u8, output, "(").? + 1;
+    const version_end = std.mem.indexOf(u8, output, ")").?;
+
+    return output[version_start..version_end];
+}

--- a/src/clients/python/ci.zig
+++ b/src/clients/python/ci.zig
@@ -123,7 +123,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {
-    const output = try shell.exec_stdout("python3 -m pip index versions --pre tigerbeetle", .{});
+    const output = try shell.exec_stdout("python3 -m pip index versions tigerbeetle", .{});
     const version_start = std.mem.indexOf(u8, output, "(").? + 1;
     const version_end = std.mem.indexOf(u8, output, ")").?;
 

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -20,6 +20,6 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {
-    _ = shell; // autofix
+    _ = shell;
     return "unimplemented";
 }

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -18,3 +18,8 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     _ = options;
     // todo
 }
+
+pub fn release_published_latest(shell: *Shell) ![]const u8 {
+    _ = shell; // autofix
+    return "unimplemented";
+}

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -413,7 +413,7 @@ fn upload_nyrkio(shell: *Shell, batch: *const MetricBatch) !void {
         [_]*const MetricBatch{batch}, // Nyrkiö needs an _array_ of batches.
         .{},
     );
-    try shell.http_post(url, payload, .{
+    _ = try shell.http_post(url, payload, .{
         .content_type = .json,
         .authorization = try shell.fmt("Bearer {s}", .{token}),
     });

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -905,7 +905,7 @@ pub fn http_post(shell: *Shell, url: []const u8, body: []const u8, options: Http
     defer client.deinit();
 
     const uri = try std.Uri.parse(url);
-    var header_buffer: [4 << 10]u8 = undefined;
+    var header_buffer: [4 * stdx.KiB]u8 = undefined;
     var request = try client.open(.POST, uri, .{ .server_header_buffer = &header_buffer });
     defer request.deinit();
 
@@ -923,7 +923,7 @@ pub fn http_post(shell: *Shell, url: []const u8, body: []const u8, options: Http
     try request.wait();
 
     if (request.response.status != std.http.Status.ok) {
-        const response_body_size_max = 512 << 10;
+        const response_body_size_max = 512 * stdx.KiB;
         var response_body_buffer: [response_body_size_max]u8 = undefined;
         const response_body_len = try request.readAll(&response_body_buffer);
         const response_body = response_body_buffer[0..response_body_len];


### PR DESCRIPTION
Add a check for all published clients (and Docker) to ensure that the latest published release there indeed matches the latest published release of the database on GitHub.

Currently, the GitHub release itself is treated as authoritative, and it should be possible to ensure it is against the source, but that's for a followup!

This aims to detect a situation where a rogue package might have been published to one of the registries by eg a compromised account.