### PR TITLE
Test/MessageBus: Fix false positive

### DIFF
--- a/src/message_bus_fuzz.zig
+++ b/src/message_bus_fuzz.zig
@@ -38,7 +38,7 @@ pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
     const messages_max = args.events_max orelse 200;
     // Usually we don't need nearly this many ticks, but certain combinations of errors can make
     // delivering messages quite time consuming.
-    const ticks_max = messages_max * 5_000;
+    const ticks_max = messages_max * 10_000;
 
     var prng = stdx.PRNG.from_seed(args.seed);
 


### PR DESCRIPTION
Failed on:

```
thread 711286 panic: only 195/200 messages delivered
```

...but it just needed more ticks to finish.

Seed: ./zig/zig build fuzz -Drelease -- message_bus 5097211745018781263