### PR TITLE
terminal: remove needless use of bounded array

### DIFF
--- a/src/repl/parser.zig
+++ b/src/repl/parser.zig
@@ -480,7 +480,6 @@ const null_terminal = Terminal{
     .stdin = undefined,
     .stderr = null,
     .stdout = null,
-    .buffer_in = undefined,
 };
 
 test "parser.zig: Parser single transfer successfully" {

--- a/src/stdx/bounded_array.zig
+++ b/src/stdx/bounded_array.zig
@@ -80,10 +80,6 @@ pub fn BoundedArrayType(comptime T: type, comptime buffer_capacity: usize) type 
             array.inner.appendSliceAssumeCapacity(items);
         }
 
-        pub inline fn writer(self: *BoundedArray) Inner.Writer {
-            return self.inner.writer();
-        }
-
         pub inline fn swap_remove(array: *BoundedArray, index: usize) T {
             return array.inner.swapRemove(index);
         }


### PR DESCRIPTION
It's totally fine to allocate 256 byte buffer on the stack. In Zig 0.15, we won't need even that, and should be able to read directly from self.stdin's buffer.

And `fn writer` on `BoundedArray` is a weird API which doesn't really belong there, so good riddance!