### PR TITLE
bus: make SendQueue size a runtime parameter

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -1083,7 +1083,7 @@ pub fn MessageBusType(comptime IO: type, comptime process_type: vsr.ProcessType)
                 assert(connection.state == .terminating);
 
                 result catch |err| {
-                    log.warn("{}: on_closing: to={} {}", .{ bus.id, connection.peer, err });
+                    log.warn("{}: on_close: to={} {}", .{ bus.id, connection.peer, err });
                 };
 
                 // Reset the connection to its initial state.


### PR DESCRIPTION
Before this commit Bus.Connection closes over `process_type` parameter to define the inline size (`@sizeOf`) of the send Queue. After, the send queue has a runtime-know capacity. The memory for all send queues of all connections is allocated as a single contagious chunk, and each individual connection points into that slice.

The motivation is two-fold. First, I want to make MessageBus not parametrized at comptime by process type: we include both replcia and client busses into the binary (client for benchmark and repl), and it doesn't make sense to have two copies of the same code! And sizing of SendQueue is the biggest problem to removal of comptime here, which can be tackled separately.

Second, making queue size runtime makes it possible to have a _per connection_ limit! And we actually should take advantage of that, to make sure that client connections are limited by 2 messages on the send queue. Right now replica sets send_queue_size to 4 for _all_ connections, which wastes 128 MiB.

An alternative implementation would keep send queue as a conservatively sized array and add an extra limit field to connection. I considered that, but I like the slice approach more. When we do per-connection limit, we can still _statically_ give each connection a slice of 4 messages, and then we can set send_queue.buffer.len to 4 or 2 when allocating connection. But both that and removal of comptime parametrization are future work!