### PR TITLE
The byte order fallacy

### DIFF
--- a/docs/coding/data-modeling.md
+++ b/docs/coding/data-modeling.md
@@ -197,16 +197,18 @@ advantage of LSM optimizations, which leads to higher database throughput.
 
 TigerBeetle clients include an `id()` function to generate IDs using the recommended scheme.
 
-TigerBeetle IDs consist of:
+TigerBeetle ID is a 128-bit number where:
 
-- 48 bits of (millisecond) timestamp (high-order bits)
-- 80 bits of randomness (low-order bits)
+- the high 48 bits are a millisecond timestamp
+- the low 80 bits are random
+
+```
+id = (timestamp << 80) | random
+```
 
 When creating multiple objects during the same millisecond, we increment the random bytes rather
-than generating new random bytes. Furthermore, it is important that IDs are stored in little-endian
-with the random bytes as the lower-order bits and the timestamp as the higher-order bits. These
-details ensure that a sequence of objects have strictly increasing IDs according to the server,
-which improves database optimization.
+than generating new random bytes. These details ensure that a sequence of objects have strictly
+increasing IDs according to the server, which improves database optimization.
 
 Similar to ULIDs and UUIDv7s, these IDs have the following benefits:
 

--- a/src/clients/python/src/tigerbeetle/client.py
+++ b/src/clients/python/src/tigerbeetle/client.py
@@ -73,10 +73,7 @@ class _IDGenerator:
 
         randomness = os.urandom(10)
 
-        return int.from_bytes(
-            time_ms.to_bytes(6, "big") + randomness,
-            "big",
-        )
+        return (time_ms << 80) | int.from_bytes(randomness, "little")
 
 # Module-level singleton instance.
 _id_generator = _IDGenerator()


### PR DESCRIPTION
TBID is an `u128` number. How exactly that number is stored in memory is
immaterial. In other words, we care about _bit_ layout, not _byte_
layout here.

A hypothetical big-endian Go client should still compute the id as `time
<< 80 | randomness`, and the low-level code tha writes that ID into a
TigerBeetle network message should do the byte swap.

A classic post comes to mind: https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html