### PR TITLE
[Rust client]Support for Cargo build from Git

### DIFF
--- a/src/clients/rust/build.rs
+++ b/src/clients/rust/build.rs
@@ -81,7 +81,7 @@ fn build_tigerbeetle(manifest_dir: &str) -> anyhow::Result<()> {
 
     let tigerbeetle_root = format!("{manifest_dir}/../../..");
     let zig_compiler = if cfg!(unix) {
-        let zig_path = format!("{tigerbeetle_root}/zig/zig");
+        let mut zig_path = format!("{tigerbeetle_root}/zig/zig");
         if !fs::exists(&zig_path)? {
             // Fallback to the system zig if installed
             match Command::new("which").arg("zig").output() {


### PR DESCRIPTION
# Problem

To install rust client with cargo build form git as the official build has not been updated fails with you have to run You may need to run zig/download.ps1."

# Solution

To default to use the installed zig.

