### PR TITLE
Vortex: Refactor/cleanup

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -422,7 +422,7 @@ test "vortex smoke" {
     defer shell.destroy();
 
     try shell.exec(
-        "{vortex_exe} supervisor --test-duration-seconds=1 " ++
+        "{vortex_exe} supervisor --test-duration=1s " ++
             "--replica-count=1 --tigerbeetle-executable={tigerbeetle}",
         .{
             .vortex_exe = vortex_exe,

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1001,6 +1001,48 @@ pub const Duration = struct {
     ) !void {
         try std.fmt.fmtDuration(duration.ns).format(fmt, options, writer);
     }
+
+    pub fn parse_flag_value(string: []const u8) union(enum) { ok: Duration, err: []const u8 } {
+        if (string.len == 0) return .{ .err = "expected a duration, but found nothing" };
+
+        var duration_ns: u64 = 0;
+
+        var string_remaining = string;
+        while (string_remaining.len > 0) {
+            const value_size = for (string_remaining, 0..) |character, i| {
+                if (!std.ascii.isDigit(character)) break i;
+            } else return .{ .err = "missing unit; must be one of: y/w/d/h/m/s/ms/us/ns" };
+            if (value_size == 0) return .{ .err = "missing value" };
+
+            const value = std.fmt.parseInt(u64, string_remaining[0..value_size], 10) catch |err| {
+                switch (err) {
+                    error.Overflow => return .{ .err = "integer overflow" },
+                    error.InvalidCharacter => unreachable,
+                }
+            };
+
+            for ([_]struct { ns: u64, label: []const u8 }{
+                .{ .ns = 1, .label = "ns" },
+                .{ .ns = std.time.ns_per_us, .label = "us" },
+                .{ .ns = std.time.ns_per_ms, .label = "ms" },
+                .{ .ns = std.time.ns_per_s, .label = "s" },
+                .{ .ns = std.time.ns_per_min, .label = "m" },
+                .{ .ns = std.time.ns_per_hour, .label = "h" },
+                .{ .ns = std.time.ns_per_day, .label = "d" },
+                .{ .ns = std.time.ns_per_week, .label = "w" },
+                .{ .ns = std.time.ns_per_day * 365, .label = "y" },
+            }) |unit| {
+                if (cut_prefix(string_remaining[value_size..], unit.label)) |suffix| {
+                    duration_ns += unit.ns * value;
+                    string_remaining = suffix;
+                    break;
+                }
+            } else {
+                return .{ .err = "unknown unit; must be one of: y/w/d/h/m/s/ms/us/ns" };
+            }
+        }
+        return .{ .ok = .{ .ns = duration_ns } };
+    }
 };
 
 test "Instant/Duration" {
@@ -1017,6 +1059,29 @@ test "Instant/Duration" {
     assert(Duration.ms(1).ns == std.time.ns_per_ms);
     assert(Duration.seconds(1).ns == std.time.ns_per_s);
     assert(Duration.minutes(1).ns == std.time.ns_per_min);
+}
+
+test "Duration.parse_flag_value" {
+    for ([_]struct { []const u8, u64 }{
+        .{ "1h", std.time.ns_per_hour },
+        .{ "1m", std.time.ns_per_min },
+        .{ "1h2m", std.time.ns_per_hour + 2 * std.time.ns_per_min },
+        .{ "1ms2us3ns", std.time.ns_per_ms + 2 * std.time.ns_per_us + 3 },
+    }) |pair| {
+        try std.testing.expectEqual(Duration.parse_flag_value(pair.@"0").ok.ns, pair.@"1");
+    }
+
+    for ([_][]const u8{
+        "",
+        "h",
+        "1",
+        "h1",
+        "1H",
+        "1h2x",
+        "1h 2m",
+    }) |string| {
+        try std.testing.expect(Duration.parse_flag_value(string) == .err);
+    }
 }
 
 /// DateTime in UTC, intended primarily for logging.

--- a/src/testing/vortex/java_driver/README.md
+++ b/src/testing/vortex/java_driver/README.md
@@ -14,6 +14,6 @@ CLASS_PATH="src/clients/java/target/tigerbeetle-java-0.0.1-SNAPSHOT.jar"
 CLASS_PATH="${CLASS_PATH}:src/testing/vortex/java_driver/target/vortex-driver-java-0.0.1-SNAPSHOT.jar"
     zig-out/bin/vortex supervisor \
         --tigerbeetle-executable=./zig-out/bin/tigerbeetle \
-        --test-duration-seconds=60 \
+        --test-duration=1m \
         --driver-command=java\ -cp\ $CLASS_PATH\ Main
 ```

--- a/src/testing/vortex/java_driver/ci.zig
+++ b/src/testing/vortex/java_driver/ci.zig
@@ -32,7 +32,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 "--output-directory={vortex_out_dir} " ++
                 "--replica-count=1 " ++
                 "--disable-faults " ++
-                "--test-duration-seconds=1",
+                "--test-duration=1s",
             .{
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,

--- a/src/testing/vortex/logged_process.zig
+++ b/src/testing/vortex/logged_process.zig
@@ -197,12 +197,16 @@ pub const main =
     if (@import("root") != @This()) {} else struct {
         fn main() !void {
             while (true) {
-                _ = try std.io.getStdErr().write("yep\n");
+                try std.io.getStdOut().writeAll("yep\n");
             }
         }
     }.main;
 
 test "LoggedProcess: starts and stops" {
+    if (builtin.os.tag != .linux) {
+        return error.SkipZigTest;
+    }
+
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
     defer assert(gpa.deinit() == .ok);
@@ -256,7 +260,7 @@ test "LoggedProcess: starts and stops" {
 
     const argv: []const []const u8 = &.{test_exe};
 
-    var process = try LoggedProcess.spawn(allocator, argv);
+    var process = try LoggedProcess.spawn(allocator, argv, .{});
     defer process.destroy(allocator);
 
     std.time.sleep(10 * std.time.ns_per_ms);

--- a/src/testing/vortex/logged_process.zig
+++ b/src/testing/vortex/logged_process.zig
@@ -266,28 +266,3 @@ test "LoggedProcess: starts and stops" {
     std.time.sleep(10 * std.time.ns_per_ms);
     _ = try process.terminate();
 }
-
-/// Formats the ports as comma-separated. Caller owns slice after successful return.
-pub fn comma_separate_ports(allocator: std.mem.Allocator, ports: []const u16) ![]const u8 {
-    assert(ports.len > 0);
-
-    var out = std.ArrayList(u8).init(allocator);
-    errdefer out.deinit();
-
-    const writer = out.writer();
-
-    try std.fmt.format(writer, "{d}", .{ports[0]});
-    for (ports[1..]) |port| {
-        try writer.writeByte(',');
-        try std.fmt.format(writer, "{d}", .{port});
-    }
-
-    return out.toOwnedSlice();
-}
-
-test comma_separate_ports {
-    const formatted = try comma_separate_ports(std.testing.allocator, &.{ 3000, 3001, 3002 });
-    defer std.testing.allocator.free(formatted);
-
-    try std.testing.expectEqualStrings("3000,3001,3002", formatted);
-}

--- a/src/testing/vortex/rust_driver/ci.zig
+++ b/src/testing/vortex/rust_driver/ci.zig
@@ -27,7 +27,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 "--output-directory={vortex_out_dir} " ++
                 "--replica-count=1 " ++
                 "--disable-faults " ++
-                "--test-duration-seconds=1",
+                "--test-duration=1s",
             .{
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -170,17 +170,13 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
         try trace.process_name_assign(@field(vortex_process_ids, field.name), field.name);
     }
 
-    if (args.test_duration_seconds % std.time.s_per_min == 0) {
-        log.info(
-            "starting test with target runtime of {d}m",
-            .{@divExact(args.test_duration_seconds, std.time.s_per_min)},
-        );
-    } else {
-        log.info(
-            "starting test with target runtime of {d}s",
-            .{args.test_duration_seconds},
-        );
-    }
+    log.info(
+        "starting test with target runtime of {d}m{d}s",
+        .{
+            @divFloor(args.test_duration_seconds, std.time.s_per_min),
+            args.test_duration_seconds % std.time.s_per_min,
+        },
+    );
 
     const seed = std.crypto.random.int(u64);
     var prng = stdx.PRNG.from_seed(seed);

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -485,7 +485,7 @@ const Supervisor = struct {
                     .replica_terminate => {
                         const pick =
                             running_replicas[supervisor.prng.index(running_replicas)];
-                        log.info("terminating replica {d}", .{pick.index});
+                        log.info("{}: terminating replica", .{pick.index});
                         try supervisor.trace.write(.{
                             .name = .terminated,
                             .process_id = pick.index,
@@ -496,7 +496,7 @@ const Supervisor = struct {
                     .replica_restart => {
                         const pick =
                             terminated_replicas[supervisor.prng.index(terminated_replicas)];
-                        log.info("restarting replica {d}", .{pick.index});
+                        log.info("{}: restarting replica", .{pick.index});
                         try supervisor.trace.write(.{
                             .name = .terminated,
                             .process_id = pick.index,
@@ -507,7 +507,7 @@ const Supervisor = struct {
                     .replica_stop => {
                         const pick =
                             running_replicas[supervisor.prng.index(running_replicas)];
-                        log.info("stopping replica {d}", .{pick.index});
+                        log.info("{}: stopping replica", .{pick.index});
                         try supervisor.trace.write(.{
                             .name = .stopped,
                             .process_id = pick.index,
@@ -518,7 +518,7 @@ const Supervisor = struct {
                     .replica_resume => {
                         const pick =
                             stopped_replicas[supervisor.prng.index(stopped_replicas)];
-                        log.info("resuming replica {d}", .{pick.index});
+                        log.info("{}: resuming replica", .{pick.index});
                         try supervisor.trace.write(.{
                             .name = .stopped,
                             .process_id = pick.index,
@@ -644,7 +644,7 @@ const Supervisor = struct {
                                 std.posix.SIG.KILL => {},
                                 else => {
                                     log.err(
-                                        "replica {d} terminated unexpectedly with signal {d}",
+                                        "{}: replica terminated unexpectedly with signal {d}",
                                         .{ index, signal },
                                     );
                                     std.process.exit(1);
@@ -652,7 +652,10 @@ const Supervisor = struct {
                             }
                         },
                         else => {
-                            log.err("unexpected replica result: {any}", .{replica_result});
+                            log.err(
+                                "{} unexpected replica result: {any}",
+                                .{ index, replica_result },
+                            );
                             return error.TestFailed;
                         },
                     }
@@ -678,15 +681,9 @@ const Supervisor = struct {
         switch (workload_result) {
             .Signal => |signal| {
                 switch (signal) {
-                    std.posix.SIG.KILL => log.info(
-                        "workload terminated as requested",
-                        .{},
-                    ),
+                    std.posix.SIG.KILL => log.info("workload terminated as requested", .{}),
                     else => {
-                        log.err(
-                            "workload exited unexpectedly with signal {d}",
-                            .{signal},
-                        );
+                        log.err("workload exited unexpectedly with signal {d}", .{signal});
                         std.process.exit(1);
                     },
                 }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -46,6 +46,8 @@ comptime {
     _ = @import("testing/id.zig");
     _ = @import("testing/marks.zig");
     _ = @import("testing/table.zig");
+    _ = @import("testing/vortex/logged_process.zig");
+    _ = @import("testing/vortex/supervisor.zig");
     _ = @import("tidy.zig");
     _ = @import("time.zig");
     _ = @import("trace.zig");
@@ -157,7 +159,6 @@ const quine =
     \\        if (std.mem.eql(u8, entry_path, "unit_tests.zig")) continue;
     \\        if (std.mem.eql(u8, entry_path, "integration_tests.zig")) continue;
     \\        if (std.mem.startsWith(u8, entry_path, "stdx/")) continue;
-    \\        if (std.mem.startsWith(u8, entry_path, "testing/vortex/")) continue;
     \\        if (std.mem.startsWith(u8, entry_path, "clients/") and
     \\            !std.mem.startsWith(u8, entry_path, "clients/c")) continue;
     \\        if (std.mem.eql(u8, entry_path, "clients/c/tb_client_header_test.zig")) continue;
@@ -281,7 +282,6 @@ fn unit_test_files(arena: std.mem.Allocator, src_dir: std.fs.Dir) ![]const []con
         if (std.mem.eql(u8, entry_path, "unit_tests.zig")) continue;
         if (std.mem.eql(u8, entry_path, "integration_tests.zig")) continue;
         if (std.mem.startsWith(u8, entry_path, "stdx/")) continue;
-        if (std.mem.startsWith(u8, entry_path, "testing/vortex/")) continue;
         if (std.mem.startsWith(u8, entry_path, "clients/") and
             !std.mem.startsWith(u8, entry_path, "clients/c")) continue;
         if (std.mem.eql(u8, entry_path, "clients/c/tb_client_header_test.zig")) continue;


### PR DESCRIPTION
Miscellaneous cleanup and refactoring of Vortex.

In particular:

- Use `Shell` to spawn `tigerbeetle format` and create directories.
- Simplify + improve logging.
- Enable unit tests, which weren't previously being run. And fix them, since they didn't compile before.
- Remove some dead code.

I recommend reviewing commit-by-commit.