### PR TITLE
CI: Publish to npm via trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,6 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
-          NODE_AUTH_TOKEN: ${{ secrets.TIGERBEETLE_NODE_PUBLISH_KEY }}
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
     permissions:
       packages: write
       contents: write
+      # Required for OIDC.
+      # See: https://docs.npmjs.com/trusted-publishers
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - uses: actions/setup-python@v4

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -835,13 +835,6 @@ fn publish_node(shell: *Shell, info: VersionInfo) !void {
 
     assert(try shell.dir_exists("zig-out/dist/node"));
 
-    // `NODE_AUTH_TOKEN` env var doesn't have a special meaning in npm. It does have special meaning
-    // in GitHub Actions, which adds a literal
-    //
-    //    //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-    //
-    // to the .npmrc file (that is, node config file itself supports env variables).
-    _ = try shell.env_get("NODE_AUTH_TOKEN");
     try shell.exec("npm publish {package}", .{
         .package = try shell.fmt("zig-out/dist/node/tigerbeetle-node-{s}.tgz", .{
             info.tag,


### PR DESCRIPTION
Trusted publishers is the recommended (i.e. most secure) method of publishing npm packages from github actions. See https://docs.npmjs.com/trusted-publishers and the [upcoming changes to npm publish tokens](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/) for background.

"Trusted publishers" requires at least npm 11.5.1. We could install that manually via `npm install -g npm@latest` (or similar) but instead I'm bumping the node version we use for releases from 18.x to 24.x, since that will give us a new enough version of npm by default.

<details>
<summary>Screenshot of trusted publisher configuration on the npm side</summary>

<img width="805" height="595" alt="2025-10-15T10:48:07,646385741-07:00" src="https://github.com/user-attachments/assets/1888a700-7324-406c-aee5-34d2bdec5afc" />

</details>

After we have successfully published a release via this method, I will revoke + remove the existing token, and also change the package permission to forbid token access.