### PR TITLE
stdx: make duration parsing more conservative

### DIFF
--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1011,7 +1011,7 @@ pub const Duration = struct {
         while (string_remaining.len > 0) {
             const value_size = for (string_remaining, 0..) |character, i| {
                 if (!std.ascii.isDigit(character)) break i;
-            } else return .{ .err = "missing unit; must be one of: y/w/d/h/m/s/ms/us/ns" };
+            } else return .{ .err = "missing unit; must be one of: d/h/m/s/ms/us/ns" };
             if (value_size == 0) return .{ .err = "missing value" };
 
             const value = std.fmt.parseInt(u64, string_remaining[0..value_size], 10) catch |err| {
@@ -1029,17 +1029,18 @@ pub const Duration = struct {
                 .{ .ns = std.time.ns_per_min, .label = "m" },
                 .{ .ns = std.time.ns_per_hour, .label = "h" },
                 .{ .ns = std.time.ns_per_day, .label = "d" },
-                .{ .ns = std.time.ns_per_week, .label = "w" },
-                .{ .ns = std.time.ns_per_day * 365, .label = "y" },
             }) |unit| {
                 if (cut_prefix(string_remaining[value_size..], unit.label)) |suffix| {
-                    duration_ns += unit.ns * value;
+                    duration_ns +|= unit.ns *| value;
                     string_remaining = suffix;
                     break;
                 }
             } else {
-                return .{ .err = "unknown unit; must be one of: y/w/d/h/m/s/ms/us/ns" };
+                return .{ .err = "unknown unit; must be one of: d/h/m/s/ms/us/ns" };
             }
+        }
+        if (duration_ns >= 1_000 * std.time.ns_per_day) {
+            return .{ .err = "duration too large" };
         }
         return .{ .ok = .{ .ns = duration_ns } };
     }
@@ -1079,6 +1080,8 @@ test "Duration.parse_flag_value" {
         "1H",
         "1h2x",
         "1h 2m",
+        "18446744073709551616ns",
+        "1844674407370955161s",
     }) |string| {
         try std.testing.expect(Duration.parse_flag_value(string) == .err);
     }

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1089,15 +1089,15 @@ test "Duration.parse_flag_value" {
 
 test "Duration.parse_flag_value fuzz" {
     const test_count = 1024;
-    const len_max = 32;
+    const input_size_max = 32;
     const alphabet = " \t\n.-e[]0123456789abcdhmuns";
 
     var prng = PRNG.from_seed_testing();
 
-    var input_max: [len_max]u8 = @splat(0);
+    var input_buffer: [input_size_max]u8 = @splat(0);
     for (0..test_count) |_| {
-        const len = prng.int_inclusive(usize, len_max);
-        const input = input_max[0..len];
+        const input_size = prng.int_inclusive(usize, input_size_max);
+        const input = input_buffer[0..input_size];
         for (input) |*c| {
             c.* = alphabet[prng.index(alphabet)];
         }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1077,16 +1077,16 @@ test parse_addresses {
 
 test "parse_addresses: fuzz" {
     const test_count = 1024;
-    const len_max = 32;
+    const input_size_max = 32;
     const alphabet = " \t\n,:[]0123456789abcdefgABCDEFGXx";
 
     var prng = stdx.PRNG.from_seed_testing();
 
-    var input_max: [len_max]u8 = @splat(0);
+    var input_bufer: [input_size_max]u8 = @splat(0);
     var buffer: [3]std.net.Address = undefined;
     for (0..test_count) |_| {
-        const len = prng.int_inclusive(usize, len_max);
-        const input = input_max[0..len];
+        const input_size = prng.int_inclusive(usize, input_size_max);
+        const input = input_bufer[0..input_size];
         for (input) |*c| {
             c.* = alphabet[prng.index(alphabet)];
         }


### PR DESCRIPTION
* remove week and year unit and stick only to SI-defined units. Year in particular is ambigious
* add overflow checking
* arbitrary sanity-bound duration at 1 000 days, to avoid downstream overflows and to catch obvious typos early. We can always relax this later. Only 0.8 sure this is a good idea!