### PR TITLE
Disable `config.verify` in release builds.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -113,7 +113,7 @@ pub fn build(b: *std.Build) !void {
         ),
         .config_verify = b.option(bool, "config_verify", "Enable extra assertions.") orelse
             // If `config_verify` isn't set, disable it for `release` builds; otherwise, enable it.
-            if (mode == .ReleaseSafe) false else true,
+            (mode == .Debug),
         .config_aof_recovery = b.option(
             bool,
             "config-aof-recovery",

--- a/build.zig
+++ b/build.zig
@@ -1011,7 +1011,7 @@ fn build_test_jni(
             // the stack size and causes a SEGV that is handled by Zig's panic handler.
             // https://bugzilla.redhat.com/show_bug.cgi?id=1572811#c7
             //
-            // The workaround is run the tests boolReleaseFast" mode.
+            // The workaround is to run the tests in "ReleaseFast" mode.
             .optimize = if (builtin.os.tag == .windows) .ReleaseFast else options.mode,
         }),
     });

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -7,6 +7,15 @@ const fuzz = @import("./testing/fuzz.zig");
 
 const log = std.log.scoped(.fuzz);
 
+// This enables `constants.verify` for this file.
+pub const vsr_options = .{
+    .config_verify = true,
+    .git_commit = @import("vsr_options").git_commit,
+    .release = @import("vsr_options").release,
+    .release_client_min = @import("vsr_options").release_client_min,
+    .config_aof_recovery = @import("vsr_options").config_aof_recovery,
+};
+
 // NB: this changes values in `constants.zig`!
 pub const tigerbeetle_config = @import("config.zig").configs.test_min;
 comptime {
@@ -57,6 +66,8 @@ const CLIArgs = struct {
 };
 
 pub fn main() !void {
+    comptime assert(constants.verify);
+
     fuzz.limit_ram();
 
     var gpa_allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -43,7 +43,7 @@ pub fn binary_search_values_upsert_index(
     var offset: usize = 0;
     var length: usize = values.len;
     while (length > 1) {
-        if (constants.verify) {
+        {
             assert(offset == 0 or switch (comptime config.mode) {
                 .lower_bound => key_from_value(&values[offset - 1]) < key,
                 .upper_bound => key_from_value(&values[offset - 1]) <= key,
@@ -114,7 +114,7 @@ pub fn binary_search_values_upsert_index(
         length -= half;
     }
 
-    if (constants.verify) {
+    {
         assert(length == 1);
 
         assert(offset == 0 or switch (comptime config.mode) {
@@ -130,7 +130,7 @@ pub fn binary_search_values_upsert_index(
 
     offset += @intFromBool(key_from_value(&values[offset]) < key);
 
-    if (constants.verify) {
+    {
         assert(offset == 0 or switch (config.mode) {
             .lower_bound => key_from_value(&values[offset - 1]) < key,
             .upper_bound => key_from_value(&values[offset - 1]) <= key,
@@ -191,9 +191,7 @@ pub inline fn binary_search_values(
 
     if (exact) {
         const value = &values[index];
-        if (constants.verify) {
-            assert(key == key_from_value(value));
-        }
+        assert(key == key_from_value(value));
         return value;
     } else {
         // TODO: Figure out how to fuzz this without causing asymptotic

--- a/src/lsm/binary_search.zig
+++ b/src/lsm/binary_search.zig
@@ -43,7 +43,7 @@ pub fn binary_search_values_upsert_index(
     var offset: usize = 0;
     var length: usize = values.len;
     while (length > 1) {
-        {
+        if (constants.verify) {
             assert(offset == 0 or switch (comptime config.mode) {
                 .lower_bound => key_from_value(&values[offset - 1]) < key,
                 .upper_bound => key_from_value(&values[offset - 1]) <= key,
@@ -114,7 +114,7 @@ pub fn binary_search_values_upsert_index(
         length -= half;
     }
 
-    {
+    if (constants.verify) {
         assert(length == 1);
 
         assert(offset == 0 or switch (comptime config.mode) {
@@ -130,7 +130,7 @@ pub fn binary_search_values_upsert_index(
 
     offset += @intFromBool(key_from_value(&values[offset]) < key);
 
-    {
+    if (constants.verify) {
         assert(offset == 0 or switch (config.mode) {
             .lower_bound => key_from_value(&values[offset - 1]) < key,
             .upper_bound => key_from_value(&values[offset - 1]) <= key,

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -174,7 +174,7 @@ pub fn CacheMapType(
                     switch (result.updated) {
                         .update => {
                             assert(key_from_value(evicted) == key);
-                            if (constants.verify) assert(!self.stash.contains(value.*));
+                            assert(!self.stash.contains(value.*));
 
                             // There was an eviction because an item was updated,
                             // the evicted item is always its previous version.

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -174,7 +174,7 @@ pub fn CacheMapType(
                     switch (result.updated) {
                         .update => {
                             assert(key_from_value(evicted) == key);
-                            assert(!self.stash.contains(value.*));
+                            if (constants.verify) assert(!self.stash.contains(value.*));
 
                             // There was an eviction because an item was updated,
                             // the evicted item is always its previous version.

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -3,7 +3,6 @@ const assert = std.debug.assert;
 const math = std.math;
 
 const stdx = @import("stdx");
-const constants = @import("../constants.zig");
 
 /// Combines a field (the key prefix) with a timestamp (the primary key).
 /// - To keep alignment, it supports either `u64` or `u128` prefixes (which can be truncated

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -60,7 +60,7 @@ pub fn CompositeKeyType(comptime Field: type) type {
         }
 
         pub inline fn key_from_value(value: *const CompositeKey) Key {
-            if (constants.verify) assert(value.padding == 0);
+            assert(value.padding == 0);
             if (Field == void) {
                 comptime assert(Key == u64);
                 return value.timestamp & ~tombstone_bit;
@@ -75,7 +75,7 @@ pub fn CompositeKeyType(comptime Field: type) type {
         }
 
         pub inline fn tombstone(value: *const CompositeKey) bool {
-            if (constants.verify) assert(value.padding == 0);
+            assert(value.padding == 0);
             return (value.timestamp & tombstone_bit) != 0;
         }
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1319,7 +1319,7 @@ pub fn GrooveType(
             // an object that has changes.
             // Unlike the index trees, the new and old values in the object tree share the same
             // key. Therefore put() is sufficient to overwrite the old value.
-            if (constants.verify) {
+            {
                 const tombstone = ObjectTreeHelper.tombstone;
                 const key_from_value = ObjectTreeHelper.key_from_value;
 

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -989,7 +989,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
         }
 
         fn verify_block(block: BlockPtrConst, checksum: ?u128, address: ?u64) void {
-            if (constants.verify) {
+            {
                 const frame = std.mem.bytesAsValue(vsr.Header, block[0..@sizeOf(vsr.Header)]);
                 assert(frame.valid_checksum());
                 assert(frame.valid_checksum_body(block[@sizeOf(vsr.Header)..frame.size]));

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -6,8 +6,6 @@ const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
 
-const constants = @import("../constants.zig");
-
 const stdx = @import("stdx");
 
 const div_ceil = stdx.div_ceil;

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -7,7 +7,6 @@ const mem = std.mem;
 const meta = std.meta;
 
 const constants = @import("../constants.zig");
-const verify = constants.verify;
 
 const stdx = @import("stdx");
 

--- a/src/lsm/zig_zag_merge.zig
+++ b/src/lsm/zig_zag_merge.zig
@@ -4,7 +4,6 @@ const math = std.math;
 const mem = std.mem;
 
 const stdx = @import("stdx");
-const constants = @import("../constants.zig");
 
 const Direction = @import("../direction.zig").Direction;
 

--- a/src/lsm/zig_zag_merge.zig
+++ b/src/lsm/zig_zag_merge.zig
@@ -77,12 +77,10 @@ pub fn ZigZagMergeIteratorType(
                     const value_other = stream_pop(it.context, @intCast(stream_index));
                     assert(key_from_value(&value_other) == key);
 
-                    if (constants.verify) {
-                        // Differently from K-way merge, there's no precedence between streams
-                        // in Zig-Zag merge. It's assumed that all streams will produce the same
-                        // value during a key intersection.
-                        assert(stdx.equal_bytes(Value, &value, &value_other));
-                    }
+                    // Differently from K-way merge, there's no precedence between streams
+                    // in Zig-Zag merge. It's assumed that all streams will produce the same
+                    // value during a key intersection.
+                    assert(stdx.equal_bytes(Value, &value, &value_other));
                 }
 
                 if (it.key_popped) |previous| {

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -302,11 +302,7 @@ fn build_tigerbeetle_target(
         const output = try shell.exec_stdout("./{exe_name} version --verbose", .{
             .exe_name = exe_name,
         });
-        if (debug) {
-            assert(std.mem.indexOf(u8, output, "process.verify=true") != null);
-        } else {
-            assert(std.mem.indexOf(u8, output, "process.verify=true") == null);
-        }
+        assert(debug == (std.mem.indexOf(u8, output, "process.verify=true") != null));
         const build_mode = if (debug)
             "build.mode=builtin.OptimizeMode.Debug"
         else

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -302,7 +302,11 @@ fn build_tigerbeetle_target(
         const output = try shell.exec_stdout("./{exe_name} version --verbose", .{
             .exe_name = exe_name,
         });
-        assert(std.mem.indexOf(u8, output, "process.verify=true") != null);
+        if (debug) {
+            assert(std.mem.indexOf(u8, output, "process.verify=true") != null);
+        } else {
+            assert(std.mem.indexOf(u8, output, "process.verify=true") == null);
+        }
         const build_mode = if (debug)
             "build.mode=builtin.OptimizeMode.Debug"
         else

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -99,7 +99,6 @@ const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.trace);
 
-const constants = @import("constants.zig");
 const stdx = @import("stdx");
 const KiB = stdx.KiB;
 const Duration = stdx.Duration;

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -428,9 +428,7 @@ pub fn timing(tracer: *Tracer, event_timing: EventTiming, duration: Duration) vo
     const timing_slot = event_timing.slot();
 
     if (tracer.events_timing[timing_slot]) |*event_timing_existing| {
-        if (constants.verify) {
-            assert(std.meta.eql(event_timing_existing.event, event_timing));
-        }
+        assert(std.meta.eql(event_timing_existing.event, event_timing));
 
         const timing_existing = event_timing_existing.values;
         event_timing_existing.values = .{

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -14,7 +14,15 @@ const vsr = @import("vsr.zig");
 const fuzz = @import("./testing/fuzz.zig");
 const Header = vsr.Header;
 
+pub const vsr_options = .{
+    .config_verify = true,
+    .git_commit = @import("vsr_options").git_commit,
+    .release = @import("vsr_options").release,
+    .release_client_min = @import("vsr_options").release_client_min,
+    .config_aof_recovery = @import("vsr_options").config_aof_recovery,
+};
 const vsr_vopr_options = @import("vsr_vopr_options");
+
 const state_machine = vsr_vopr_options.state_machine;
 const StateMachineType = switch (state_machine) {
     .accounting => @import("state_machine.zig").StateMachineType,
@@ -86,6 +94,7 @@ const CLIArgs = struct {
 };
 
 pub fn main() !void {
+    comptime assert(constants.verify);
     // This must be initialized at runtime as stderr is not comptime known on e.g. Windows.
     log_buffer.unbuffered_writer = std.io.getStdErr().writer();
     fuzz.limit_ram();

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1292,7 +1292,7 @@ pub const Headers = struct {
     pub fn dvc_header_type(header: *const Header.Prepare) enum { blank, valid } {
         if (std.meta.eql(header.*, Headers.dvc_blank(header.op))) return .blank;
 
-        if (constants.verify) assert(header.valid_checksum());
+        assert(header.valid_checksum());
         assert(header.command == .prepare);
         assert(header.operation != .reserved);
         assert(header.invalid() == null);

--- a/src/vsr/client_sessions.zig
+++ b/src/vsr/client_sessions.zig
@@ -234,7 +234,7 @@ pub const ClientSessions = struct {
         assert(header.command == .reply);
         const client = header.client;
 
-        defer if (constants.verify) assert(client_sessions.entries_by_client.contains(client));
+        defer assert(client_sessions.entries_by_client.contains(client));
 
         const entry_gop = client_sessions.entries_by_client.getOrPutAssumeCapacity(client);
         if (entry_gop.found_existing) {
@@ -309,7 +309,7 @@ pub const ClientSessions = struct {
         assert(client_sessions.entries[entry_index].header.client == client);
         client_sessions.entries[entry_index] = std.mem.zeroes(Entry);
 
-        if (constants.verify) assert(!client_sessions.entries_by_client.contains(client));
+        assert(!client_sessions.entries_by_client.contains(client));
     }
 
     pub const Iterator = struct {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -11848,7 +11848,7 @@ fn message_body_as_prepare_headers(message: *const Message) []const Header.Prepa
     const headers = message_body_as_headers_unchecked(message);
     var child: ?*const Header.Prepare = null;
     for (headers) |*header| {
-        if (constants.verify) assert(header.valid_checksum());
+        assert(header.valid_checksum());
         assert(header.command == .prepare);
         assert(header.cluster == message.header.cluster);
         assert(header.view <= message.header.view);


### PR DESCRIPTION
Until now, `constants.verify` was enabled even in release builds.
This PR disables `constants.verify` by default in release builds; it can be re-enabled by compiling with `-Dconfig_verify=true`.
In debug builds, `constants.verify` remains enabled by default.

Why this matters:
1. Reduces performance overhead in production.
2. But more importantly, removes the incentive to _avoid_ expensive assertions, since Release builds were penalized by default.  


EDIT: Most previously guarded assertions are now enabled unconditionally; only a handful of expensive O(N) checks remain guarded.

EDIT II: To make the transition smooth we opted to automatically enable `constants.verify` for `vopr`, and `fuzz` (which run in release).