### PR TITLE
docs: Fix grammar in Docker upgrade instructions

### DIFF
--- a/docs/operating/upgrading.md
+++ b/docs/operating/upgrading.md
@@ -72,7 +72,7 @@ systemctl restart tigerbeetle # or, however you are managing TigerBeetle.
 
 ## Upgrading Docker-based installations
 If you're running TigerBeetle inside Kubernetes or Docker, update the tag that is pointed to the
-release you wish to upgrade to. Before beginning, it's strongly recommend to have a rolling deploy
+release you wish to upgrade to. Before beginning, it's strongly recommended to have a rolling deploy
 strategy set up.
 
 For example:


### PR DESCRIPTION
Corrected grammatical error in the upgrading instructions.