### PR TITLE
Vortex: Refactor/cleanup; remove tracing

### DIFF
--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -23,13 +23,4 @@ pub const vortex = struct {
         }
         break :brk ports;
     };
-
-    pub const replica_ports_proxied = brk: {
-        var ports: [constants.vsr.replicas_max]u16 = undefined;
-        var replica_num: u16 = 0;
-        while (replica_num < constants.vsr.replicas_max) : (replica_num += 1) {
-            ports[replica_num] = 3000 + replica_num;
-        }
-        break :brk ports;
-    };
 };

--- a/src/testing/vortex/java_driver/ci.zig
+++ b/src/testing/vortex/java_driver/ci.zig
@@ -23,13 +23,10 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         const class_path = class_path_driver ++ ":" ++ base_path ++
             "src/testing/vortex/java_driver/target/vortex-driver-java-0.0.1-SNAPSHOT.jar";
         const driver_command = "java -cp " ++ class_path ++ " Main";
-        const vortex_out_dir = try shell.create_tmp_dir();
-        defer shell.cwd.deleteTree(vortex_out_dir) catch {};
         try shell.exec(
             "{vortex_bin} " ++
                 "supervisor --driver-command={driver_command} " ++
                 "--tigerbeetle-executable={tigerbeetle_bin} " ++
-                "--output-directory={vortex_out_dir} " ++
                 "--replica-count=1 " ++
                 "--disable-faults " ++
                 "--test-duration=1s",
@@ -37,7 +34,6 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,
                 .tigerbeetle_bin = tigerbeetle_bin,
-                .vortex_out_dir = vortex_out_dir,
             },
         );
     } else {

--- a/src/testing/vortex/rust_driver/ci.zig
+++ b/src/testing/vortex/rust_driver/ci.zig
@@ -18,13 +18,10 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         const vortex_bin = base_path ++ "zig-out/bin/vortex";
         const driver_command = base_path ++
             "src/testing/vortex/rust_driver/target/debug/vortex-driver-rust";
-        const vortex_out_dir = try shell.create_tmp_dir();
-        defer shell.cwd.deleteTree(vortex_out_dir) catch {};
         try shell.exec(
             "{vortex_bin} " ++
                 "supervisor --driver-command={driver_command} " ++
                 "--tigerbeetle-executable={tigerbeetle_bin} " ++
-                "--output-directory={vortex_out_dir} " ++
                 "--replica-count=1 " ++
                 "--disable-faults " ++
                 "--test-duration=1s",
@@ -32,7 +29,6 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,
                 .tigerbeetle_bin = tigerbeetle_bin,
-                .vortex_out_dir = vortex_out_dir,
             },
         );
     } else {

--- a/src/vortex.zig
+++ b/src/vortex.zig
@@ -29,13 +29,13 @@ pub const std_options: std.Options = .{
 pub const CLIArgs = union(enum) {
     supervisor: Supervisor.CLIArgs,
     driver: ZigDriver.CLIArgs,
-    workload: DriverArgs,
+    workload: WorkloadArgs,
 };
 
-const DriverArgs = struct {
-    @"cluster-id": u128,
+const WorkloadArgs = struct {
+    cluster_id: u128,
     addresses: []const u8,
-    @"driver-command": []const u8,
+    driver_command: []const u8,
 };
 
 pub fn main() !void {
@@ -76,19 +76,19 @@ pub fn main() !void {
     }
 }
 
-fn start_driver(allocator: std.mem.Allocator, args: DriverArgs) !std.process.Child {
+fn start_driver(allocator: std.mem.Allocator, args: WorkloadArgs) !std.process.Child {
     var argv = std.ArrayList([]const u8).init(allocator);
     defer argv.deinit();
 
-    assert(std.mem.indexOfScalar(u8, args.@"driver-command", '"') == null);
-    var cmd_parts = std.mem.splitScalar(u8, args.@"driver-command", ' ');
+    assert(std.mem.indexOfScalar(u8, args.driver_command, '"') == null);
+    var cmd_parts = std.mem.splitScalar(u8, args.driver_command, ' ');
 
     while (cmd_parts.next()) |part| {
         try argv.append(part);
     }
 
     var cluster_id_argument: [32]u8 = undefined;
-    const cluster_id = try std.fmt.bufPrint(cluster_id_argument[0..], "{d}", .{args.@"cluster-id"});
+    const cluster_id = try std.fmt.bufPrint(cluster_id_argument[0..], "{d}", .{args.cluster_id});
 
     try argv.append(cluster_id);
     try argv.append(args.addresses);


### PR DESCRIPTION
- Bind proxies via port 0 rather than hard-coded ports. I made this change before deciding to keep unshare (and the network namespace). But it actually simplified the code overall, so we may as well keep it.
- Remove Vortex's custom tracing: Previously vortex created a trace file with the various events it injects into the cluster. It is a bunch of extra code and I think for this purpose the logs are superior anyway, since they provide more information and interleave the different replicas as well. And for vortex in cfo I don't want to deal with multiple files, just one for the logs.
- Rename `stop`/`cont` to `pause`/`unpause`. "stop" is too easy to confuse with "terminate". And "cont" is [not a word](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md#naming-things).
- Various other refactors.

I recommend reviewing commit-by-commit.
