### PR TITLE
lsm: One radix buffer to rule them all.

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -291,14 +291,14 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             };
 
             const radix_buffer_size: usize = comptime blk: {
-                var max_size: usize = 0;
+                var size_max: usize = 0;
                 for (std.enums.values(_TreeID)) |tree_id| {
                     const tree = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];
                     const size = tree.Tree.Table.value_count_max * @sizeOf(tree.Tree.Value);
                     assert(size > 0);
-                    max_size = @max(max_size, size);
+                    size_max = @max(size_max, size);
                 }
-                break :blk max_size;
+                break :blk size_max;
             };
 
             forest.radix_buffer = try .init(allocator, radix_buffer_size);

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -14,7 +14,7 @@ const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_no
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
 const ManifestLogPace = @import("manifest_log.zig").Pace;
 
-const RadixBuffer = @import("radix_buffer.zig").RadixBuffer;
+const ScratchMemory = @import("scratch_memory.zig").ScratchMemory;
 const ScanBufferPool = @import("scan_buffer.zig").ScanBufferPool;
 const ResourcePoolType = @import("compaction.zig").ResourcePoolType;
 const snapshot_min_for_table_output = @import("compaction.zig").snapshot_min_for_table_output;
@@ -179,18 +179,15 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
     const Grid = GridType(_Storage);
 
-    const radix_scratch_size: usize, const radix_scratch_alignment: usize = comptime blk: {
+    const radix_scratch_size: usize = comptime blk: {
         var max_size: usize = 0;
-        var max_alignment: usize = 0;
 
         for (std.enums.values(_TreeID)) |tree_id| {
             const tree = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];
             const size = tree.Tree.Table.value_count_max * @sizeOf(tree.Tree.Value);
-            const alignment = @alignOf(tree.Tree.Value);
             max_size = @max(max_size, size);
-            max_alignment = @max(max_alignment, alignment);
         }
-        break :blk .{ max_size, max_alignment };
+        break :blk max_size;
     };
 
     return struct {
@@ -263,7 +260,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
         scan_buffer_pool: ScanBufferPool,
 
-        radix_scratch: RadixBuffer,
+        radix_scratch: ScratchMemory,
 
         pub fn init(
             forest: *Forest,
@@ -281,10 +278,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 .manifest_log = undefined,
                 .compaction_schedule = undefined,
                 .scan_buffer_pool = undefined,
-                .radix_scratch = .{
-                    .buffer = undefined,
-                    .in_use = false,
-                },
+                .radix_scratch = undefined,
             };
 
             // TODO: look into using lsm_table_size_max for the node_count.
@@ -307,9 +301,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 }
             };
 
-            forest.radix_scratch.buffer =
-                try allocator.alignedAlloc(u8, radix_scratch_alignment, radix_scratch_size);
-            errdefer allocator.free(forest.radix_scratch.buffer);
+            forest.radix_scratch = try ScratchMemory.init(allocator, radix_scratch_size);
+            errdefer forest.radix_scratch.deinit(allocator);
 
             inline for (std.meta.fields(Grooves)) |field| {
                 const Groove = field.type;
@@ -348,10 +341,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             forest.manifest_log.deinit(allocator);
             forest.node_pool.deinit(allocator);
 
-            // This matches the allocation alignment.
-            allocator.free(
-                @as([]align(radix_scratch_alignment) u8, @alignCast(forest.radix_scratch.buffer)),
-            );
+            forest.radix_scratch.deinit(allocator);
 
             forest.compaction_schedule.deinit(allocator);
             forest.scan_buffer_pool.deinit(allocator);

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -249,7 +249,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
         scan_buffer_pool: ScanBufferPool,
 
-        radix_scratch: ScratchMemory,
+        radix_buffer: ScratchMemory,
 
         pub fn init(
             forest: *Forest,
@@ -267,7 +267,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 .manifest_log = undefined,
                 .compaction_schedule = undefined,
                 .scan_buffer_pool = undefined,
-                .radix_scratch = undefined,
+                .radix_buffer = undefined,
             };
 
             // TODO: look into using lsm_table_size_max for the node_count.
@@ -290,7 +290,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 }
             };
 
-            const radix_scratch_size: usize = comptime blk: {
+            const radix_buffer_size: usize = comptime blk: {
                 var max_size: usize = 0;
                 for (std.enums.values(_TreeID)) |tree_id| {
                     const tree = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];
@@ -301,8 +301,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 break :blk max_size;
             };
 
-            forest.radix_scratch = try .init(allocator, radix_scratch_size);
-            errdefer forest.radix_scratch.deinit(allocator);
+            forest.radix_buffer = try .init(allocator, radix_buffer_size);
+            errdefer forest.radix_buffer.deinit(allocator);
 
             inline for (std.meta.fields(Grooves)) |field| {
                 const Groove = field.type;
@@ -313,7 +313,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     allocator,
                     &forest.node_pool,
                     grid,
-                    &forest.radix_scratch,
+                    &forest.radix_buffer,
                     groove_options,
                 );
                 grooves_initialized += 1;
@@ -341,7 +341,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             forest.manifest_log.deinit(allocator);
             forest.node_pool.deinit(allocator);
 
-            forest.radix_scratch.deinit(allocator);
+            forest.radix_buffer.deinit(allocator);
 
             forest.compaction_schedule.deinit(allocator);
             forest.scan_buffer_pool.deinit(allocator);
@@ -372,7 +372,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 .compaction_schedule = forest.compaction_schedule,
 
                 .scan_buffer_pool = forest.scan_buffer_pool,
-                .radix_scratch = forest.radix_scratch,
+                .radix_buffer = forest.radix_buffer,
             };
         }
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -179,17 +179,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
     const Grid = GridType(_Storage);
 
-    const radix_scratch_size: usize = comptime blk: {
-        var max_size: usize = 0;
-
-        for (std.enums.values(_TreeID)) |tree_id| {
-            const tree = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];
-            const size = tree.Tree.Table.value_count_max * @sizeOf(tree.Tree.Value);
-            max_size = @max(max_size, size);
-        }
-        break :blk max_size;
-    };
-
     return struct {
         const Forest = @This();
 
@@ -299,6 +288,17 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     const groove: *Groove = &@field(forest.grooves, field.name);
                     groove.deinit(allocator);
                 }
+            };
+
+            const radix_scratch_size: usize = comptime blk: {
+                var max_size: usize = 0;
+                for (std.enums.values(_TreeID)) |tree_id| {
+                    const tree = _tree_infos[@intFromEnum(tree_id) - _tree_infos[0].tree_id];
+                    const size = tree.Tree.Table.value_count_max * @sizeOf(tree.Tree.Value);
+                    assert(size > 0);
+                    max_size = @max(max_size, size);
+                }
+                break :blk max_size;
             };
 
             forest.radix_scratch = try ScratchMemory.init(allocator, radix_scratch_size);

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -179,7 +179,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
     const Grid = GridType(_Storage);
 
-    const sort_buffer_size: usize, const sort_buffer_alignment: usize = comptime blk: {
+    const radix_scratch_size: usize, const radix_scratch_alignment: usize = comptime blk: {
         var max_size: usize = 0;
         var max_alignment: usize = 0;
 
@@ -307,11 +307,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 }
             };
 
-            forest.radix_scratch.buffer = try allocator.alignedAlloc(
-                u8,
-                sort_buffer_alignment,
-                sort_buffer_size,
-            );
+            forest.radix_scratch.buffer =
+                try allocator.alignedAlloc(u8, radix_scratch_alignment, radix_scratch_size);
             errdefer allocator.free(forest.radix_scratch.buffer);
 
             inline for (std.meta.fields(Grooves)) |field| {
@@ -353,7 +350,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
             // This matches the allocation alignment.
             allocator.free(
-                @as([]align(sort_buffer_alignment) u8, @alignCast(forest.radix_scratch.buffer)),
+                @as([]align(radix_scratch_alignment) u8, @alignCast(forest.radix_scratch.buffer)),
             );
 
             forest.compaction_schedule.deinit(allocator);

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -301,7 +301,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 break :blk max_size;
             };
 
-            forest.radix_scratch = try ScratchMemory.init(allocator, radix_scratch_size);
+            forest.radix_scratch = try .init(allocator, radix_scratch_size);
             errdefer forest.radix_scratch.deinit(allocator);
 
             inline for (std.meta.fields(Grooves)) |field| {

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -19,7 +19,7 @@ const ScopeCloseMode = @import("tree.zig").ScopeCloseMode;
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
 const ScanBuilderType = @import("scan_builder.zig").ScanBuilderType;
 
-const RadixBuffer = @import("radix_buffer.zig").RadixBuffer;
+const ScratchMemory = @import("scratch_memory.zig").ScratchMemory;
 
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 
@@ -610,7 +610,7 @@ pub fn GrooveType(
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
-            radix_scratch: *RadixBuffer,
+            radix_scratch: *ScratchMemory,
             options: Options,
         ) !void {
             assert(options.tree_options_object.batch_value_count_limit *

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -19,6 +19,8 @@ const ScopeCloseMode = @import("tree.zig").ScopeCloseMode;
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
 const ScanBuilderType = @import("scan_builder.zig").ScanBuilderType;
 
+const RadixBuffer = @import("radix_buffer.zig").RadixBuffer;
+
 const snapshot_latest = @import("tree.zig").snapshot_latest;
 
 fn ObjectTreeHelperType(comptime Object: type) type {
@@ -608,6 +610,7 @@ pub fn GrooveType(
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
+            radix_scratch: *RadixBuffer,
             options: Options,
         ) !void {
             assert(options.tree_options_object.batch_value_count_limit *
@@ -656,6 +659,7 @@ pub fn GrooveType(
                 allocator,
                 node_pool,
                 grid,
+                radix_scratch,
                 .{
                     .id = @field(groove_options.ids, "timestamp"),
                     .name = ObjectTree.tree_name(),
@@ -668,6 +672,7 @@ pub fn GrooveType(
                 allocator,
                 node_pool,
                 grid,
+                radix_scratch,
                 .{
                     .id = @field(groove_options.ids, "id"),
                     .name = ObjectTree.tree_name() ++ ".id",
@@ -694,6 +699,7 @@ pub fn GrooveType(
                     allocator,
                     node_pool,
                     grid,
+                    radix_scratch,
                     .{
                         .id = @field(groove_options.ids, field.name),
                         .name = ObjectTree.tree_name() ++ "." ++ field.name,

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -615,6 +615,7 @@ pub fn GrooveType(
         ) !void {
             assert(options.tree_options_object.batch_value_count_limit *
                 constants.lsm_compaction_ops <= ObjectTree.Table.value_count_max);
+            assert(radix_scratch.state == .free);
 
             groove.* = .{
                 .grid = grid,

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -610,12 +610,12 @@ pub fn GrooveType(
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
-            radix_scratch: *ScratchMemory,
+            radix_buffer: *ScratchMemory,
             options: Options,
         ) !void {
             assert(options.tree_options_object.batch_value_count_limit *
                 constants.lsm_compaction_ops <= ObjectTree.Table.value_count_max);
-            assert(radix_scratch.state == .free);
+            assert(radix_buffer.state == .free);
 
             groove.* = .{
                 .grid = grid,
@@ -660,7 +660,7 @@ pub fn GrooveType(
                 allocator,
                 node_pool,
                 grid,
-                radix_scratch,
+                radix_buffer,
                 .{
                     .id = @field(groove_options.ids, "timestamp"),
                     .name = ObjectTree.tree_name(),
@@ -673,7 +673,7 @@ pub fn GrooveType(
                 allocator,
                 node_pool,
                 grid,
-                radix_scratch,
+                radix_buffer,
                 .{
                     .id = @field(groove_options.ids, "id"),
                     .name = ObjectTree.tree_name() ++ ".id",
@@ -700,7 +700,7 @@ pub fn GrooveType(
                     allocator,
                     node_pool,
                     grid,
-                    radix_scratch,
+                    radix_buffer,
                     .{
                         .id = @field(groove_options.ids, field.name),
                         .name = ObjectTree.tree_name() ++ "." ++ field.name,

--- a/src/lsm/radix_buffer.zig
+++ b/src/lsm/radix_buffer.zig
@@ -1,0 +1,4 @@
+pub const RadixBuffer = struct {
+    buffer: []u8,
+    in_use: bool,
+};

--- a/src/lsm/radix_buffer.zig
+++ b/src/lsm/radix_buffer.zig
@@ -1,4 +1,0 @@
-pub const RadixBuffer = struct {
-    buffer: []u8,
-    in_use: bool,
-};

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -9,6 +9,8 @@ state: enum { free, busy },
 pub const ScratchMemory = @This();
 
 pub fn init(gpa: std.mem.Allocator, size: usize) !ScratchMemory {
+    assert(size > 0);
+
     var scratch: ScratchMemory = .{
         .buffer = undefined,
         .state = .free,

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -57,7 +57,7 @@ test "ScratchMemory basic" {
     const gpa = testing.allocator;
     const size = @sizeOf(u64) * 10;
 
-    var scratch = try ScratchMemory.init(
+    var scratch: ScratchMemory = try .init(
         gpa,
         size,
     );

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -1,0 +1,74 @@
+//! ScratchMemory is a TODO
+const std = @import("std");
+const stdx = @import("stdx");
+const assert = std.debug.assert;
+
+buffer: []align(std.heap.page_size_min) u8,
+state: enum { free, busy },
+
+pub const ScratchMemory = @This();
+
+pub fn init(gpa: std.mem.Allocator, size: usize) !ScratchMemory {
+    var scratch: ScratchMemory = .{
+        .buffer = undefined,
+        .state = .free,
+    };
+
+    scratch.buffer = try gpa.alignedAlloc(u8, std.heap.page_size_min, size);
+    errdefer gpa.free(scratch.buffer);
+
+    return scratch;
+}
+
+pub fn deinit(scratch: *ScratchMemory, gpa: std.mem.Allocator) void {
+    assert(scratch.state == .free);
+    gpa.free(scratch.buffer);
+}
+
+pub fn acquire(scratch: *ScratchMemory, T: type, count: usize) []T {
+    assert(scratch.state == .free);
+    assert(count * @sizeOf(T) <= scratch.buffer.len);
+    // A pointer with a larger alignment can be cast into one with a smaller alignment.
+    assert(@alignOf(T) <= std.heap.page_size_min);
+    defer assert(scratch.state == .busy);
+
+    scratch.state = .busy;
+    const scratch_size = count * @sizeOf(T);
+    const scratch_typed = stdx.bytes_as_slice(
+        .exact,
+        T,
+        scratch.buffer[0..scratch_size],
+    );
+    assert(std.mem.isAligned(@intFromPtr(scratch_typed.ptr), @alignOf(T)));
+    return scratch_typed;
+}
+
+pub fn release(scratch: *ScratchMemory, T: type, slice: []T) void {
+    assert(scratch.state == .busy);
+    assert(std.mem.isAligned(@intFromPtr(slice.ptr), @alignOf(T)));
+    defer assert(scratch.state == .free);
+
+    scratch.state = .free;
+}
+
+test "ScratchMemory basic" {
+    const testing = std.testing;
+
+    const gpa = testing.allocator;
+    const size = @sizeOf(u64) * 10;
+
+    var scratch = try ScratchMemory.init(
+        gpa,
+        size,
+    );
+    defer scratch.deinit(gpa);
+
+    const slice = scratch.acquire(u64, 10);
+
+    for (0..10) |n| {
+        const ptr = &slice[n];
+        try testing.expect(std.mem.isAligned(@intFromPtr(ptr), @alignOf(u64)));
+        ptr.* = n;
+    }
+    scratch.release(u64, slice);
+}

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -32,10 +32,10 @@ pub fn deinit(scratch: *ScratchMemory, gpa: std.mem.Allocator) void {
 }
 
 pub fn acquire(scratch: *ScratchMemory, T: type, count: usize) []T {
+    // A pointer with a larger alignment can be cast into one with a smaller alignment.
+    comptime assert(@alignOf(T) < std.heap.page_size_min);
     assert(scratch.state == .free);
     assert(count * @sizeOf(T) <= scratch.buffer.len);
-    // A pointer with a larger alignment can be cast into one with a smaller alignment.
-    assert(@alignOf(T) <= std.heap.page_size_min);
     defer assert(scratch.state == .busy);
 
     scratch.state = .busy;
@@ -50,6 +50,7 @@ pub fn acquire(scratch: *ScratchMemory, T: type, count: usize) []T {
 }
 
 pub fn release(scratch: *ScratchMemory, T: type, slice: []T) void {
+    comptime assert(@alignOf(T) < std.heap.page_size_min);
     assert(scratch.state == .busy);
     assert(std.mem.isAligned(@intFromPtr(slice.ptr), @alignOf(T)));
     defer assert(scratch.state == .free);

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -1,4 +1,8 @@
-//! ScratchMemory is a TODO
+//! ScratchMemory is a page-aligned scratch buffer meant for situations where a buffer is required
+//! (e.g., radix sort) and can be shared between components.
+//! The buffer is page-aligned so that smaller alignments are trivially satisfied. See:
+//! https://ziglang.org/documentation/0.7.0/#Alignment
+//!
 const std = @import("std");
 const stdx = @import("stdx");
 const assert = std.debug.assert;

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -1,7 +1,7 @@
 //! ScratchMemory is a page-aligned scratch buffer meant for situations where a buffer is required
 //! (e.g., radix sort) and can be shared between components.
 //! The buffer is page-aligned so that smaller alignments are trivially satisfied. See:
-//! https://ziglang.org/documentation/0.7.0/#Alignment
+//! https://ziglang.org/documentation/0.14.1/#Alignment
 //!
 const std = @import("std");
 const stdx = @import("stdx");

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -29,6 +29,7 @@ pub fn init(gpa: std.mem.Allocator, size: usize) !ScratchMemory {
 pub fn deinit(scratch: *ScratchMemory, gpa: std.mem.Allocator) void {
     assert(scratch.state == .free);
     gpa.free(scratch.buffer);
+    scratch.* = undefined;
 }
 
 pub fn acquire(scratch: *ScratchMemory, T: type, count: usize) []T {

--- a/src/lsm/scratch_memory.zig
+++ b/src/lsm/scratch_memory.zig
@@ -53,6 +53,8 @@ pub fn acquire(scratch: *ScratchMemory, T: type, count: usize) []T {
 pub fn release(scratch: *ScratchMemory, T: type, slice: []T) void {
     comptime assert(@alignOf(T) < std.heap.page_size_min);
     assert(scratch.state == .busy);
+    assert(@intFromPtr(slice.ptr) == @intFromPtr(scratch.buffer.ptr));
+    assert(slice.len * @sizeOf(T) <= scratch.buffer.len);
     assert(std.mem.isAligned(@intFromPtr(slice.ptr), @alignOf(T)));
     defer assert(scratch.state == .free);
 

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -58,7 +58,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             mutable: struct {
                 // This buffer is shared between all `Tables` for the radix sort.
                 // It is passed down from the forest.
-                radix_scratch: *ScratchMemory,
+                radix_buffer: *ScratchMemory,
             },
             immutable: struct {
                 // An empty table has nothing to flush.
@@ -305,7 +305,7 @@ pub fn TableMemoryType(comptime Table: type) type {
         pub fn init(
             table: *TableMemory,
             allocator: mem.Allocator,
-            radix_scratch: *ScratchMemory,
+            radix_buffer: *ScratchMemory,
             mutability: std.meta.Tag(Mutability),
             name: []const u8,
             options: struct {
@@ -313,7 +313,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             },
         ) !void {
             assert(options.value_count_limit <= Table.value_count_max);
-            assert(radix_scratch.state == .free);
+            assert(radix_buffer.state == .free);
 
             table.* = .{
                 .value_context = .{
@@ -321,7 +321,7 @@ pub fn TableMemoryType(comptime Table: type) type {
                 },
                 .mutability = switch (mutability) {
                     .mutable => .{ .mutable = .{
-                        .radix_scratch = radix_scratch,
+                        .radix_buffer = radix_buffer,
                     } },
                     .immutable => .{ .immutable = .{} },
                 },
@@ -343,7 +343,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             const mutability: Mutability = switch (table.mutability) {
                 .immutable => .{ .immutable = .{} },
                 .mutable => .{ .mutable = .{
-                    .radix_scratch = table.mutability.mutable.radix_scratch,
+                    .radix_buffer = table.mutability.mutable.radix_buffer,
                 } },
             };
 
@@ -576,15 +576,15 @@ pub fn TableMemoryType(comptime Table: type) type {
             assert(offset == 0 or offset == table.value_context.run_tracker.last().?.max);
             assert(offset <= table.count());
 
-            const radix_scratch_values = table.mutability.mutable.radix_scratch.acquire(
+            const radix_buffer_values = table.mutability.mutable.radix_buffer.acquire(
                 Value,
                 table.count(),
             );
-            defer table.mutability.mutable.radix_scratch.release(Value, radix_scratch_values);
+            defer table.mutability.mutable.radix_buffer.release(Value, radix_buffer_values);
 
             const target_count = sort_suffix_from_offset(
                 table.values_used(),
-                radix_scratch_values,
+                radix_buffer_values,
                 offset,
             );
             table.value_context.count = target_count;
@@ -662,12 +662,12 @@ const TestHelper = struct {
         comptime TableType: type,
         gpa: std.mem.Allocator,
         value_count_limit: u32,
-        radix_scratch: *ScratchMemory,
+        radix_buffer: *ScratchMemory,
     ) !TableType {
         var table_immutable: TableType = undefined;
         try table_immutable.init(
             gpa,
-            radix_scratch,
+            radix_buffer,
             .immutable,
             "immutable",
             .{ .value_count_limit = value_count_limit },
@@ -679,12 +679,12 @@ const TestHelper = struct {
         comptime TableType: type,
         gpa: std.mem.Allocator,
         value_count_limit: u32,
-        radix_scratch: *ScratchMemory,
+        radix_buffer: *ScratchMemory,
     ) !TableType {
         var table_mutable: TableType = undefined;
         try table_mutable.init(
             gpa,
-            radix_scratch,
+            radix_buffer,
             .mutable,
             "mutable",
             .{ .value_count_limit = value_count_limit },
@@ -704,14 +704,14 @@ test "table_memory: merge and absorb (last wins across streams)" {
 
     const alloc = testing.allocator;
 
-    var radix_scratch: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
-    defer radix_scratch.deinit(alloc);
+    var radix_buffer: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
+    defer radix_buffer.deinit(alloc);
 
     var table_immutable: TableMemory = try TestHelper.create_table_immutable(
         TableMemory,
         alloc,
         Table.value_count_max,
-        &radix_scratch,
+        &radix_buffer,
     );
     defer table_immutable.deinit(alloc);
 
@@ -719,7 +719,7 @@ test "table_memory: merge and absorb (last wins across streams)" {
         TableMemory,
         alloc,
         Table.value_count_max,
-        &radix_scratch,
+        &radix_buffer,
     );
     defer table_mutable.deinit(alloc);
 
@@ -763,14 +763,14 @@ test "table_memory: compact and deduplicate across runs" {
 
     const alloc = testing.allocator;
 
-    var radix_scratch: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
-    defer radix_scratch.deinit(alloc);
+    var radix_buffer: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
+    defer radix_buffer.deinit(alloc);
 
     var table_immutable: TableMemory = try TestHelper.create_table_immutable(
         TableMemory,
         alloc,
         Table.value_count_max,
-        &radix_scratch,
+        &radix_buffer,
     );
     defer table_immutable.deinit(alloc);
 
@@ -778,7 +778,7 @@ test "table_memory: compact and deduplicate across runs" {
         TableMemory,
         alloc,
         Table.value_count_max,
-        &radix_scratch,
+        &radix_buffer,
     );
     defer table_mutable.deinit(alloc);
 
@@ -815,14 +815,14 @@ test "table_memory (secondary): annhiliation yields zero after deduplicate" {
 
     const alloc = testing.allocator;
 
-    var radix_scratch: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
-    defer radix_scratch.deinit(alloc);
+    var radix_buffer: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
+    defer radix_buffer.deinit(alloc);
 
     var table_immutable: TableMemory = try TestHelper.create_table_immutable(
         TableMemory,
         alloc,
         Table.value_count_max,
-        &radix_scratch,
+        &radix_buffer,
     );
     defer table_immutable.deinit(alloc);
 
@@ -830,7 +830,7 @@ test "table_memory (secondary): annhiliation yields zero after deduplicate" {
         TableMemory,
         alloc,
         Table.value_count_max,
-        &radix_scratch,
+        &radix_buffer,
     );
     defer table_mutable.deinit(alloc);
 

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -305,8 +305,8 @@ pub fn TableMemoryType(comptime Table: type) type {
         pub fn init(
             table: *TableMemory,
             allocator: mem.Allocator,
-            mutability: std.meta.Tag(Mutability),
             radix_scratch: *ScratchMemory,
+            mutability: std.meta.Tag(Mutability),
             name: []const u8,
             options: struct {
                 value_count_limit: u32,
@@ -666,8 +666,8 @@ const TestHelper = struct {
         var table_immutable: TableType = undefined;
         try table_immutable.init(
             gpa,
-            .immutable,
             radix_scratch,
+            .immutable,
             "immutable",
             .{ .value_count_limit = value_count_limit },
         );
@@ -683,8 +683,8 @@ const TestHelper = struct {
         var table_mutable: TableType = undefined;
         try table_mutable.init(
             gpa,
-            .mutable,
             radix_scratch,
+            .mutable,
             "mutable",
             .{ .value_count_limit = value_count_limit },
         );

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -582,18 +582,18 @@ pub fn TableMemoryType(comptime Table: type) type {
                 assert(!table.mutability.mutable.radix_scratch.in_use);
             }
 
-            const sort_buffer_size = @sizeOf(Value) * Table.value_count_max;
-            const sort_buffer_values = stdx.bytes_as_slice(
+            const radix_scratch_size = @sizeOf(Value) * Table.value_count_max;
+            const radix_scratch_values = stdx.bytes_as_slice(
                 .exact,
                 Value,
-                table.mutability.mutable.radix_scratch.buffer[0..sort_buffer_size],
+                table.mutability.mutable.radix_scratch.buffer[0..radix_scratch_size],
             );
-            assert(@as(usize, @intFromPtr(sort_buffer_values.ptr)) % @alignOf(Value) == 0);
-            assert(sort_buffer_values.len == table.values.len);
+            assert(@as(usize, @intFromPtr(radix_scratch_values.ptr)) % @alignOf(Value) == 0);
+            assert(radix_scratch_values.len == table.values.len);
 
             const target_count = sort_suffix_from_offset(
                 table.values_used(),
-                sort_buffer_values[0..table.count()],
+                radix_scratch_values[0..table.count()],
                 offset,
             );
             table.value_context.count = target_count;

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -313,6 +313,7 @@ pub fn TableMemoryType(comptime Table: type) type {
             },
         ) !void {
             assert(options.value_count_limit <= Table.value_count_max);
+            assert(radix_scratch.state == .free);
 
             table.* = .{
                 .value_context = .{

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -588,6 +588,7 @@ pub fn TableMemoryType(comptime Table: type) type {
                 Value,
                 table.mutability.mutable.radix_scratch.buffer[0..sort_buffer_size],
             );
+            assert(@as(usize, @intFromPtr(sort_buffer_values.ptr)) % @alignOf(Value) == 0);
             assert(sort_buffer_values.len == table.values.len);
 
             const target_count = sort_suffix_from_offset(

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -703,7 +703,7 @@ test "table_memory: merge and absorb (last wins across streams)" {
 
     const alloc = testing.allocator;
 
-    var radix_scratch = try ScratchMemory.init(alloc, Table.value_count_max * @sizeOf(Value));
+    var radix_scratch: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
     defer radix_scratch.deinit(alloc);
 
     var table_immutable: TableMemory = try TestHelper.create_table_immutable(
@@ -762,7 +762,7 @@ test "table_memory: compact and deduplicate across runs" {
 
     const alloc = testing.allocator;
 
-    var radix_scratch = try ScratchMemory.init(alloc, Table.value_count_max * @sizeOf(Value));
+    var radix_scratch: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
     defer radix_scratch.deinit(alloc);
 
     var table_immutable: TableMemory = try TestHelper.create_table_immutable(
@@ -814,7 +814,7 @@ test "table_memory (secondary): annhiliation yields zero after deduplicate" {
 
     const alloc = testing.allocator;
 
-    var radix_scratch = try ScratchMemory.init(alloc, Table.value_count_max * @sizeOf(Value));
+    var radix_scratch: ScratchMemory = try .init(alloc, Table.value_count_max * @sizeOf(Value));
     defer radix_scratch.deinit(alloc);
 
     var table_immutable: TableMemory = try TestHelper.create_table_immutable(

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -12,6 +12,7 @@ const schema = @import("schema.zig");
 const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_node_size, 16);
 const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
+const RadixBuffer = @import("radix_buffer.zig").RadixBuffer;
 
 pub const ScopeCloseMode = enum { persist, discard };
 
@@ -103,6 +104,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
+            radix_scratch: *RadixBuffer,
             config: Config,
             options: Options,
         ) !void {
@@ -126,12 +128,12 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 .compactions = undefined,
             };
 
-            try tree.table_mutable.init(allocator, .mutable, config.name, .{
+            try tree.table_mutable.init(allocator, .mutable, radix_scratch, config.name, .{
                 .value_count_limit = value_count_limit,
             });
             errdefer tree.table_mutable.deinit(allocator);
 
-            try tree.table_immutable.init(allocator, .immutable, config.name, .{
+            try tree.table_immutable.init(allocator, .immutable, radix_scratch, config.name, .{
                 .value_count_limit = value_count_limit,
             });
             errdefer tree.table_immutable.deinit(allocator);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -111,6 +111,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             assert(grid.superblock.opened);
             assert(config.id != 0); // id=0 is reserved.
             assert(config.name.len > 0);
+            assert(radix_scratch.state == .free);
 
             const value_count_limit =
                 options.batch_value_count_limit * constants.lsm_compaction_ops;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -104,14 +104,14 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
-            radix_scratch: *ScratchMemory,
+            radix_buffer: *ScratchMemory,
             config: Config,
             options: Options,
         ) !void {
             assert(grid.superblock.opened);
             assert(config.id != 0); // id=0 is reserved.
             assert(config.name.len > 0);
-            assert(radix_scratch.state == .free);
+            assert(radix_buffer.state == .free);
 
             const value_count_limit =
                 options.batch_value_count_limit * constants.lsm_compaction_ops;
@@ -129,12 +129,12 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 .compactions = undefined,
             };
 
-            try tree.table_mutable.init(allocator, radix_scratch, .mutable, config.name, .{
+            try tree.table_mutable.init(allocator, radix_buffer, .mutable, config.name, .{
                 .value_count_limit = value_count_limit,
             });
             errdefer tree.table_mutable.deinit(allocator);
 
-            try tree.table_immutable.init(allocator, radix_scratch, .immutable, config.name, .{
+            try tree.table_immutable.init(allocator, radix_buffer, .immutable, config.name, .{
                 .value_count_limit = value_count_limit,
             });
             errdefer tree.table_immutable.deinit(allocator);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -128,12 +128,12 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 .compactions = undefined,
             };
 
-            try tree.table_mutable.init(allocator, .mutable, radix_scratch, config.name, .{
+            try tree.table_mutable.init(allocator, radix_scratch, .mutable, config.name, .{
                 .value_count_limit = value_count_limit,
             });
             errdefer tree.table_mutable.deinit(allocator);
 
-            try tree.table_immutable.init(allocator, .immutable, radix_scratch, config.name, .{
+            try tree.table_immutable.init(allocator, radix_scratch, .immutable, config.name, .{
                 .value_count_limit = value_count_limit,
             });
             errdefer tree.table_immutable.deinit(allocator);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -12,7 +12,7 @@ const schema = @import("schema.zig");
 const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_node_size, 16);
 const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
-const RadixBuffer = @import("radix_buffer.zig").RadixBuffer;
+const ScratchMemory = @import("scratch_memory.zig").ScratchMemory;
 
 pub const ScopeCloseMode = enum { persist, discard };
 
@@ -104,7 +104,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             allocator: mem.Allocator,
             node_pool: *NodePool,
             grid: *Grid,
-            radix_scratch: *RadixBuffer,
+            radix_scratch: *ScratchMemory,
             config: Config,
             options: Options,
         ) !void {

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -203,6 +203,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.pool = try ResourcePool.init(gpa, block_count);
             defer env.pool.deinit(gpa);
 
+            env.sort_scratch.in_use = false;
             env.sort_scratch.buffer = try gpa.alignedAlloc(
                 u8,
                 @alignOf(Value),

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -145,7 +145,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         scan_results_count: u32,
         scan_results_model: []Value,
         compaction_exhausted: bool = false,
-        sort_scratch: RadixBuffer,
+        radix_scratch: RadixBuffer,
 
         pool: ResourcePool,
 
@@ -203,13 +203,13 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.pool = try ResourcePool.init(gpa, block_count);
             defer env.pool.deinit(gpa);
 
-            env.sort_scratch.in_use = false;
-            env.sort_scratch.buffer = try gpa.alignedAlloc(
+            env.radix_scratch.in_use = false;
+            env.radix_scratch.buffer = try gpa.alignedAlloc(
                 u8,
                 @alignOf(Value),
                 value_count_max * @sizeOf(Value),
             );
-            defer gpa.free(@as([]align(@alignOf(Value)) u8, @alignCast(env.sort_scratch.buffer)));
+            defer gpa.free(@as([]align(@alignOf(Value)) u8, @alignCast(env.radix_scratch.buffer)));
 
             try env.open_then_apply(gpa, fuzz_ops);
         }
@@ -247,7 +247,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             // The first checkpoint is trivially durable.
             env.grid.free_set.mark_checkpoint_durable();
 
-            try env.tree.init(gpa, &env.node_pool, &env.grid, &env.sort_scratch, .{
+            try env.tree.init(gpa, &env.node_pool, &env.grid, &env.radix_scratch, .{
                 .id = 1,
                 .name = "Key.Value",
             }, .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -145,7 +145,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         scan_results_count: u32,
         scan_results_model: []Value,
         compaction_exhausted: bool = false,
-        radix_scratch: ScratchMemory,
+        radix_buffer: ScratchMemory,
 
         pool: ResourcePool,
 
@@ -203,8 +203,8 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.pool = try ResourcePool.init(gpa, block_count);
             defer env.pool.deinit(gpa);
 
-            env.radix_scratch = try .init(gpa, value_count_max * @sizeOf(Value));
-            defer env.radix_scratch.deinit(gpa);
+            env.radix_buffer = try .init(gpa, value_count_max * @sizeOf(Value));
+            defer env.radix_buffer.deinit(gpa);
 
             try env.open_then_apply(gpa, fuzz_ops);
         }
@@ -242,7 +242,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             // The first checkpoint is trivially durable.
             env.grid.free_set.mark_checkpoint_durable();
 
-            try env.tree.init(gpa, &env.node_pool, &env.grid, &env.radix_scratch, .{
+            try env.tree.init(gpa, &env.node_pool, &env.grid, &env.radix_buffer, .{
                 .id = 1,
                 .name = "Key.Value",
             }, .{

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -203,7 +203,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.pool = try ResourcePool.init(gpa, block_count);
             defer env.pool.deinit(gpa);
 
-            env.radix_scratch = try ScratchMemory.init(gpa, value_count_max);
+            env.radix_scratch = try .init(gpa, value_count_max);
             defer env.radix_scratch.deinit(gpa);
 
             try env.open_then_apply(gpa, fuzz_ops);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -203,7 +203,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.pool = try ResourcePool.init(gpa, block_count);
             defer env.pool.deinit(gpa);
 
-            env.radix_scratch = try .init(gpa, value_count_max);
+            env.radix_scratch = try .init(gpa, value_count_max * @sizeOf(Value));
             defer env.radix_scratch.deinit(gpa);
 
             try env.open_then_apply(gpa, fuzz_ops);

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -22,6 +22,7 @@ comptime {
     _ = @import("lsm/k_way_merge.zig");
     _ = @import("lsm/manifest_level.zig");
     _ = @import("lsm/node_pool.zig");
+    _ = @import("lsm/scratch_memory.zig");
     _ = @import("lsm/segmented_array.zig");
     _ = @import("lsm/segmented_array_benchmark.zig");
     _ = @import("lsm/set_associative_cache.zig");


### PR DESCRIPTION
Previously, each table owned its own radix sort buffer. 
This PR centralizes the buffer in `forest.zig` so it’s shared across all tables and safes a decent amount of memory.

I implemented it multiple times with different designs and I think this was the best one for multiple reasons: 

- It’s a storage-layer concern; keeping it out of the state machine preserves proper separation of responsibilities. The buffer now lives in the forest and is shared from there.
- This is the most direct implementation. It avoids passing the buffer through via parameters (including scan paths via the state machine).
- The naming reflects that it is tied to the radix sort, which makes grepping and maintainability easier, e.g., if we would change radix sort to an inplace sort etc. 
