### PR TITLE
io: switch to using `posix.sendto()` instead of `posix.send()`

### DIFF
--- a/src/stdx/unshare.zig
+++ b/src/stdx/unshare.zig
@@ -198,7 +198,7 @@ pub fn linux_ip_link_loopback() !void {
     };
 
     const msg_buf = std.mem.asBytes(&msg);
-    const sent_len = std.posix.send(sock, msg_buf, 0) catch |err| {
+    const sent_len = std.posix.sendto(sock, msg_buf, 0, null, 0) catch |err| {
         log.err("failed to send netlink message: {}", .{err});
         return error.IpLink;
     };

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -214,6 +214,10 @@ fn tidy_banned(source: []const u8) ?[]const u8 {
         return "switch on error to avoid silent anyerror upcast";
     }
 
+    if (std.mem.indexOf(u8, source, "posix." ++ "send(") != null) {
+        return "use posix.sendto() to avoid connection race condition";
+    }
+
     return null;
 }
 


### PR DESCRIPTION
`posix.send()` is a thin wrapper over `posix.sendto()` that has an `unreachable` on various errors that happen if the socket isn't connected.

However, we _want_ to be able to handle those connection errors ourselves! Trying to check the state of the socket before using it is race prone, too.