### PR TITLE
Vortex: Detect crashed replicas quickly

### DIFF
--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1119,6 +1119,19 @@ test "fastrange not modulo" {
     ).diff_fmt("{d}", .{distribution});
 }
 
+/// `status` is a waitpid() status result.
+pub fn term_from_status(status: u32) std.process.Child.Term {
+    const Term = std.process.Child.Term;
+    return if (std.posix.W.IFEXITED(status))
+        Term{ .Exited = std.posix.W.EXITSTATUS(status) }
+    else if (std.posix.W.IFSIGNALED(status))
+        Term{ .Signal = std.posix.W.TERMSIG(status) }
+    else if (std.posix.W.IFSTOPPED(status))
+        Term{ .Stopped = std.posix.W.STOPSIG(status) }
+    else
+        Term{ .Unknown = status };
+}
+
 comptime {
     _ = @import("aegis.zig");
     _ = @import("bit_set.zig");

--- a/src/testing/vortex/logged_process.zig
+++ b/src/testing/vortex/logged_process.zig
@@ -67,7 +67,7 @@ pub fn spawn(
         struct {
             fn poll_broken_pipe(stdin: std.fs.File, process: *LoggedProcess) void {
                 while (process.state() == .running) {
-                    std.time.sleep(1 * std.time.ns_per_s);
+                    std.time.sleep(50 * std.time.ns_per_ms);
                     _ = stdin.write(&.{1}) catch |err| {
                         switch (err) {
                             error.WouldBlock => {}, // still running

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -16,13 +16,11 @@
 //!
 //!     $ zig build test:integration -- "vortex smoke"
 //!
-//! If you need more control, you can run this program directly. Using `unshare` is recommended to
-//! be sure all child processes are killed, and to get network sandboxing.
+//! If you need more control, you can run this program directly.
 //!
 //!     $ zig build
 //!     $ zig build vortex:build
-//!     $ unshare --net --fork --map-root-user --pid bash -c 'ip link set up dev lo ; \
-//!         ./zig-out/bin/vortex supervisor --tigerbeetle-executable=./zig-out/bin/tigerbeetle'
+//!     $ ./zig-out/bin/vortex supervisor --tigerbeetle-executable=./zig-out/bin/tigerbeetle
 //!
 //! Other options:
 //!

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -308,9 +308,7 @@ const Supervisor = struct {
                 }
             }
 
-            if (now < sleep_deadline) continue;
-
-            if (!supervisor.disable_faults) {
+            if (sleep_deadline < now and !supervisor.disable_faults) {
                 const Action = enum {
                     sleep,
                     replica_terminate,

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -146,7 +146,7 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
             .datafile = datafile,
         }) catch |err| {
             log.err("failed formatting datafile: {}", .{err});
-            std.process.exit(1);
+            return error.SetupFailed;
         };
 
         var replica_ports: [constants.vsr.replicas_max]u16 = undefined;
@@ -420,7 +420,7 @@ const Supervisor = struct {
                                         "{}: replica terminated unexpectedly with signal {d}",
                                         .{ index, signal },
                                     );
-                                    std.process.exit(1);
+                                    return error.TestFailed;
                                 },
                             }
                         },
@@ -457,7 +457,7 @@ const Supervisor = struct {
                     std.posix.SIG.KILL => log.info("workload terminated as requested", .{}),
                     else => {
                         log.err("workload exited unexpectedly with signal {d}", .{signal});
-                        std.process.exit(1);
+                        return error.TestFailed;
                     },
                 }
             },

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -409,13 +409,13 @@ const Supervisor = struct {
             // Check for replicas that have exited.
             for (supervisor.replicas, 0..) |replica, replica_index| {
                 if (replica.state() != .terminated) {
-                    if (replica.process.?.wait_nonblocking()) |code| {
+                    if (replica.process.?.wait_nonblocking()) |term| {
                         // Replicas shouldn't exit on their own, even with code=0.
-                        maybe(code == 0);
+                        maybe(std.meta.eql(term, .{ .Exited = 0 }));
 
                         log.err(
-                            "{}: replica terminated unexpectedly with code {d}",
-                            .{ replica_index, code },
+                            "{}: replica terminated unexpectedly with {}",
+                            .{ replica_index, term },
                         );
                         return error.TestFailed;
                     }


### PR DESCRIPTION
## Overview

Ideally any replica panic would immediately cause Vortex to stop the test and exit with a failure.

This is a step in that direction, bringing the delay down from ~20s to ~2s.

I recommend reviewing commit-by-commit.

### Check for crashed replicas during "sleep"

During vortex's main loop, we are often "sleeping" for 1-10s intervals. This isn't a real sleep, it just means we are ticking IO but not injecting any faults.

Previously during this interval vortex didn't check for crashed replicas. Now it does.

### Remove threading

Instead of using an extra thread writing to stdin per child process to detect replica termination, use `waitpid()` with `NOHANG`.

This _slightly_ improves the time it takes to detect that a child process has died.

But more importantly, it is a lot simpler.

## Remaining delay

I had hoped to solve the panic-exit delay completely, but didn't manage it.

The supervisor can only detect replica failure on panic. There is a noticeable delay (with systemd-coredump running) -- 1-4 seconds -- between when a replica prints "panic" + stack trace and when the process actually exits. My theory is that this is the process dumping core. (This is even with systemd-coredump configured to not save coredumps.)

I _think_ that the delay is because it actually still dumps core, it's just that the dump is not saved.
(Aside: If my theory is right, the cfo is paying the same "core dump tax" on fuzzer failures, even though we don't collect those core dumps either.)

Things I tried, which didn't work:
- `_ = try std.posix.prctl(std.posix.PR.SET_DUMPABLE, .{0});`
- `try std.posix.setrlimit(std.posix.rlimit_resource.CORE, .{ .cur = 0, .max = 0 });`
- Zeroing out the `/proc/self/coredump_filter` mask.

