### PR TITLE
CFO: Supervisor trap signals instead of unshare

### DIFF
--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -6,6 +6,12 @@
 
 set -eu
 
+# When the supervisor is killed or interrupted, kill all processes in the process group.
+# (In particular, this will kill all descendent processes that have not changed groups.)
+#
+# We must unset the trap before killing, otherwise the signal will recurse and we segfault.
+trap 'trap - SIGINT SIGTERM EXIT; kill 0' SIGINT SIGTERM EXIT
+
 git --version
 
 while true
@@ -24,6 +30,9 @@ do
         git fetch
         git switch --discard-changes --detach origin/main
         ./zig/download.sh
-        unshare --user --pid --fork ./zig/zig build -Drelease scripts -- cfo
+        # Run via `&`/`wait` rather than running directly, to ensure that it runs in the background,
+        # but still allows signal processing, so that `kill`ing the supervisor doesn't just stall.
+        ./zig/zig build scripts -- cfo &
+        wait "$!"
     ) || sleep 10 # Be resilient to cfo bugs and network errors, but avoid busy-loop retries.
 done


### PR DESCRIPTION
## Context

Previously, the CFO supervisor script used `unshare` so that when the supervisor is stopped, all descendent processes (the cfo, fuzzers, fuzzer compilations) are all killed.

There are a couple issues with this approach:
1. Vortex needs unshare as well, unshare can't be nested, and we want to run Vortex within CFO.
    - Vortex needs unshare for the same process-cleanup reason, and additionally to get a private network namespace.
2. Our current `unshare` approach in `cfo_supervisor.sh` doesn't actually work how we want!
    - If you ctrl-c the `cfo_supervisor.sh`, then it works as expected.
    - But if you `kill` the `cfo_supervisor.sh` process, then the cfo and fuzzers just keep running.
    - (Once their time budget runs out they would exit, but that is as long as an hour away!)
    - I think for `unshare` to work exactly how we want, it would need to _actually_ be the top-level process in the tree, not just spawned from within the bash script.
    - We might make that work via something like `exec unshare ... cfo_supervisor.sh` -- i.e. supervisor exec's itself and uses a branch to determine whether we are actually already in unshare. But that seems like a hack, and also doesn't solve the Vortex conflict.

## Fix

So instead, `cfo_supervisor.sh` traps the EXIT/INT/TERM signals, and on receiving them, kills all processes in the process group (`kill 0`).

This works as expected in the ctrl-c case, and also if the supervisor is killed.

Caveats with this approach:
- `kill -9` of the cfo supervisor won't clean up the descendants.
- If the supervisor is stopped (via `SIGSTOP`) and _then_ killed, the cleanup function is not called, so the descendants keep running.

## Alternatives

- `prctl(PR_SET_PDEATHSIG, SIGTERM);`
  - This lets a child process terminate when its parent dies. (It needs to be paired with a `if (getppid() == 1) exit()` to avoid a race condition.)
  - However, it is not inherited by child processes. CFO spawns the zig compiler, which wouldn't be using this flag.
- cgroups
  - This is an alternative to using the default process group, but still depends on a `trap` to trigger cleanup.
- Do nothing.
  - This works with ctrl-c, but leaves descendants running if you `kill` it.