### PR TITLE
Vortex: Depend on TB executable in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1227,6 +1227,16 @@ fn build_vortex_executable(
         tb_client.linkSystemLibrary("advapi32");
     }
 
+    const tigerbeetle = build_tigerbeetle_executable(b, .{
+        .vsr_module = options.vsr_module,
+        .vsr_options = options.vsr_options,
+        .target = options.target,
+        .mode = options.mode,
+    });
+
+    const vortex_options = b.addOptions();
+    vortex_options.addOptionPath("tigerbeetle_exe", tigerbeetle.getEmittedBin());
+
     const vortex = b.addExecutable(.{
         .name = "vortex",
         .root_module = b.createModule(.{
@@ -1241,6 +1251,7 @@ fn build_vortex_executable(
     vortex.linkLibrary(tb_client);
     vortex.addIncludePath(options.tb_client_header.dirname());
     vortex.root_module.addOptions("vsr_options", options.vsr_options);
+    vortex.root_module.addOptions("vortex_options", vortex_options);
     return vortex;
 }
 

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -459,12 +459,8 @@ test "vortex smoke" {
     defer shell.destroy();
 
     try shell.exec(
-        "{vortex_exe} supervisor --test-duration=1s " ++
-            "--replica-count=1 --tigerbeetle-executable={tigerbeetle}",
-        .{
-            .vortex_exe = vortex_exe,
-            .tigerbeetle = tigerbeetle,
-        },
+        "{vortex_exe} supervisor --test-duration=1s --replica-count=1",
+        .{ .vortex_exe = vortex_exe },
     );
 }
 

--- a/src/testing/vortex/java_driver/ci.zig
+++ b/src/testing/vortex/java_driver/ci.zig
@@ -16,7 +16,6 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     // NB: This expects the vortex bin to be available.
     if (builtin.target.os.tag == .linux) {
         const base_path = "../../../../";
-        const tigerbeetle_bin = base_path ++ "zig-out/bin/tigerbeetle";
         const vortex_bin = base_path ++ "zig-out/bin/vortex";
         const class_path_driver = base_path ++
             "src/clients/java/target/tigerbeetle-java-0.0.1-SNAPSHOT.jar";
@@ -26,14 +25,12 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         try shell.exec(
             "{vortex_bin} " ++
                 "supervisor --driver-command={driver_command} " ++
-                "--tigerbeetle-executable={tigerbeetle_bin} " ++
                 "--replica-count=1 " ++
                 "--disable-faults " ++
                 "--test-duration=1s",
             .{
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,
-                .tigerbeetle_bin = tigerbeetle_bin,
             },
         );
     } else {

--- a/src/testing/vortex/rust_driver/ci.zig
+++ b/src/testing/vortex/rust_driver/ci.zig
@@ -14,21 +14,18 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     // NB: This expects the vortex bin to be available.
     if (builtin.target.os.tag == .linux) {
         const base_path = "../../../../";
-        const tigerbeetle_bin = base_path ++ "zig-out/bin/tigerbeetle";
         const vortex_bin = base_path ++ "zig-out/bin/vortex";
         const driver_command = base_path ++
             "src/testing/vortex/rust_driver/target/debug/vortex-driver-rust";
         try shell.exec(
             "{vortex_bin} " ++
                 "supervisor --driver-command={driver_command} " ++
-                "--tigerbeetle-executable={tigerbeetle_bin} " ++
                 "--replica-count=1 " ++
                 "--disable-faults " ++
                 "--test-duration=1s",
             .{
                 .vortex_bin = vortex_bin,
                 .driver_command = driver_command,
-                .tigerbeetle_bin = tigerbeetle_bin,
             },
         );
     } else {


### PR DESCRIPTION
This gives Vortex a default binary to test against -- a build of the current repo -- which is almost always what you want. It's more convenient for locally testing against vortex, and also for the CFO.

(A downside to this approach is that the running the integration tests now compiled TB an extra time.)

In the future this build will be a multiversion executable, so that Vortex can test upgrades.

I considered building from within `supervisor.zig` (rather than `build.zig`), since that would give us the ability to customize it at "runtime". I'm still on the fence about this but decided to err on the side of keeping compilation in `build.zig`.

