### PR TITLE
[StateMachine] Extract the Contract

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 
 const constants = @import("constants.zig");
 const vsr = @import("vsr.zig");
+const tb = vsr.tigerbeetle;
 
 const stdx = @import("stdx");
 const MessagePool = vsr.message_pool.MessagePool;
@@ -296,9 +297,7 @@ pub fn AOFType(comptime IO: type) type {
         }
 
         pub const ReplayClient = struct {
-            const Storage = vsr.storage.StorageType(IO);
-            const StateMachine = vsr.state_machine.StateMachineType(Storage);
-            const Client = vsr.ClientType(StateMachine, MessageBus);
+            const Client = vsr.ClientType(tb.Operation, MessageBus);
 
             client: *Client,
             io: *IO,
@@ -410,7 +409,7 @@ pub fn AOFType(comptime IO: type) type {
             /// a lot of time when replaying.
             pub fn replay_message(header: *Header.Prepare) bool {
                 if (header.operation.vsr_reserved()) return false;
-                const state_machine_operation = header.operation.cast(StateMachine);
+                const state_machine_operation = header.operation.cast(tb.Operation);
                 switch (state_machine_operation) {
                     .create_accounts, .create_transfers => return true,
 

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -7,15 +7,14 @@ const maybe = vsr.stdx.maybe;
 const fatal = @import("amqp/protocol.zig").fatal;
 
 const stdx = vsr.stdx;
+const tb = vsr.tigerbeetle;
 const IO = vsr.io.IO;
 const Time = vsr.time.Time;
-const Storage = vsr.storage.StorageType(IO);
 const MessagePool = vsr.message_pool.MessagePool;
 const MessageBus = vsr.message_bus.MessageBusClient;
-const StateMachine = vsr.state_machine.StateMachineType(Storage);
-const Client = vsr.ClientType(StateMachine, MessageBus);
+const Operation = vsr.tigerbeetle.Operation;
+const Client = vsr.ClientType(Operation, MessageBus);
 const TimestampRange = vsr.lsm.TimestampRange;
-const tb = vsr.tigerbeetle;
 
 pub const amqp = @import("amqp.zig");
 
@@ -40,8 +39,7 @@ pub const Runner = struct {
         const app_id = "tigerbeetle";
         const progress_tracker_queue = "tigerbeetle.internal.progress";
         const locker_queue = "tigerbeetle.internal.locker";
-        const event_count_max: u32 = Client.StateMachine.operation_result_max(
-            .get_change_events,
+        const event_count_max: u32 = Operation.get_change_events.result_max(
             vsr.constants.message_body_size_max,
         );
     };
@@ -721,7 +719,7 @@ pub const Runner = struct {
         timestamp: u64,
         result: []u8,
     ) void {
-        const operation = operation_vsr.cast(Client.StateMachine);
+        const operation = operation_vsr.cast(tb.Operation);
         assert(operation == .get_change_events);
         assert(timestamp != 0);
         const runner: *Runner = @ptrFromInt(@as(usize, @intCast(context)));

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -3,11 +3,7 @@ const std = @import("std");
 pub const vsr = @import("../../vsr.zig");
 pub const exports = @import("tb_client_exports.zig");
 
-const IO = @import("../../io.zig").IO;
-const Storage = @import("../../storage.zig").StorageType(IO);
 const MessageBus = @import("../../message_bus.zig").MessageBusClient;
-const StateMachineType = @import("../../state_machine.zig").StateMachineType;
-const StateMachine = StateMachineType(Storage);
 
 pub const InitError = @import("tb_client/context.zig").InitError;
 pub const InitParameters = @import("tb_client/context.zig").InitParameters;
@@ -15,18 +11,18 @@ pub const ClientInterface = @import("tb_client/context.zig").ClientInterface;
 pub const CompletionCallback = @import("tb_client/context.zig").CompletionCallback;
 pub const Packet = @import("tb_client/packet.zig").Packet.Extern;
 pub const PacketStatus = @import("tb_client/packet.zig").Packet.Status;
-pub const Operation = StateMachine.Operation;
+pub const Operation = vsr.tigerbeetle.Operation;
 
 const ContextType = @import("tb_client/context.zig").ContextType;
 const DefaultContext = blk: {
     const ClientType = @import("../../vsr/client.zig").ClientType;
-    const Client = ClientType(StateMachine, MessageBus);
+    const Client = ClientType(Operation, MessageBus);
     break :blk ContextType(Client);
 };
 
 const TestingContext = blk: {
     const EchoClientType = @import("tb_client/echo_client.zig").EchoClientType;
-    const EchoClient = EchoClientType(StateMachine, MessageBus);
+    const EchoClient = EchoClientType(MessageBus);
     break :blk ContextType(EchoClient);
 };
 

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -136,11 +136,7 @@ pub fn EchoClientType(comptime MessageBus: type) type {
             operation: Operation,
             events: []const u8,
         ) void {
-            const event_size: usize = switch (operation) {
-                inline else => |operation_comptime| @sizeOf(
-                    operation_comptime.EventType(),
-                ),
-            };
+            const event_size = operation.event_size();
             assert(events.len <= constants.message_body_size_max);
             assert(events.len % event_size == 0);
 

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -3,9 +3,6 @@ const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
 const assert = std.debug.assert;
 
-const IO = vsr.io.IO;
-const Storage = vsr.storage.StorageType(IO);
-const StateMachine = vsr.state_machine.StateMachineType(Storage);
 const tb = vsr.tigerbeetle;
 
 /// VSR type mappings: these will always be the same regardless of state machine.
@@ -338,20 +335,20 @@ fn ctype_type_name(comptime Type: type) []const u8 {
 
 fn emit_method(
     buffer: *Buffer,
-    comptime operation: StateMachine.Operation,
+    comptime operation: tb.Operation,
     options: struct { is_async: bool },
 ) void {
-    const event_type = comptime if (StateMachine.operation_is_batchable(operation))
-        "list[" ++ zig_to_python(StateMachine.EventType(operation)) ++ "]"
+    const event_type = comptime if (operation.is_batchable())
+        "list[" ++ zig_to_python(operation.EventType()) ++ "]"
     else
-        zig_to_python(StateMachine.EventType(operation));
+        zig_to_python(operation.EventType());
 
     const result_type =
-        comptime "list[" ++ zig_to_python(StateMachine.ResultType(operation)) ++ "]";
+        comptime "list[" ++ zig_to_python(operation.ResultType()) ++ "]";
 
     // For ergonomics, the client allows calling things like .query_accounts(filter) even
     // though the _submit function requires a list for everything. Wrap them here.
-    const event_name_or_list = comptime if (!StateMachine.operation_is_batchable(operation))
+    const event_name_or_list = comptime if (!operation.is_batchable())
         "[" ++ event_name(operation) ++ "]"
     else
         event_name(operation);
@@ -377,8 +374,8 @@ fn emit_method(
             .event_name_or_list = event_name_or_list,
             .prefix_call = if (options.is_async) "await " else "",
             .uppercase_name = to_uppercase(@tagName(operation)),
-            .event_type_c = ctype_type_name(StateMachine.EventType(operation)),
-            .result_type_c = ctype_type_name(StateMachine.ResultType(operation)),
+            .event_type_c = ctype_type_name(operation.EventType()),
+            .result_type_c = ctype_type_name(operation.ResultType()),
         },
     );
 }
@@ -553,7 +550,7 @@ pub fn main() !void {
             \\
         , .{prefix_class});
 
-        const operations: []const StateMachine.Operation = &.{
+        const operations: []const tb.Operation = &.{
             .create_accounts,
             .create_transfers,
             .lookup_accounts,
@@ -576,7 +573,7 @@ pub fn main() !void {
 /// Used by client code generation to make clearer APIs: the name of the Event parameter,
 /// when used as a variable.
 /// Inline function so that `operation` can be known at comptime.
-fn event_name(comptime operation: StateMachine.Operation) []const u8 {
+fn event_name(comptime operation: tb.Operation) []const u8 {
     return switch (operation) {
         .create_accounts => "accounts",
         .create_transfers => "transfers",

--- a/src/repl/parser.zig
+++ b/src/repl/parser.zig
@@ -287,8 +287,7 @@ pub const Parser = struct {
                 .code = 0,
                 .timestamp_min = 0,
                 .timestamp_max = 0,
-                .limit = StateMachine.operation_result_max(
-                    operation_comptime.state_machine_op(),
+                .limit = operation_comptime.state_machine_op().result_max(
                     constants.message_body_size_max,
                 ),
                 .flags = .{
@@ -307,8 +306,7 @@ pub const Parser = struct {
                 .code = 0,
                 .timestamp_min = 0,
                 .timestamp_max = 0,
-                .limit = StateMachine.operation_result_max(
-                    operation_comptime.state_machine_op(),
+                .limit = operation_comptime.state_machine_op().result_max(
                     constants.message_body_size_max,
                 ),
                 .flags = .{
@@ -337,7 +335,7 @@ pub const Parser = struct {
                 }
 
                 const state_machine_op = operation.state_machine_op();
-                if (!StateMachine.operation_is_batchable(state_machine_op)) {
+                if (!state_machine_op.is_batchable()) {
                     try parser.print_current_position();
                     try parser.terminal.print_error(
                         "{s} expects a single {s} but received multiple.\n",
@@ -882,8 +880,7 @@ test "parser.zig: Parser account filter successfully" {
                 .code = 0,
                 .timestamp_min = 0,
                 .timestamp_max = 0,
-                .limit = StateMachine.operation_result_max(
-                    .get_account_transfers,
+                .limit = StateMachine.Operation.get_account_transfers.result_max(
                     constants.message_body_size_max,
                 ),
                 .flags = .{
@@ -960,8 +957,7 @@ test "parser.zig: Parser query filter successfully" {
                 .code = 0,
                 .timestamp_min = 0,
                 .timestamp_max = 0,
-                .limit = StateMachine.operation_result_max(
-                    .query_transfers,
+                .limit = StateMachine.Operation.query_transfers.result_max(
                     constants.message_body_size_max,
                 ),
                 .flags = .{

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -14,8 +14,7 @@ const TimestampRange = @import("../lsm/timestamp_range.zig").TimestampRange;
 
 const PriorityQueue = std.PriorityQueue;
 const Storage = @import("../testing/storage.zig").Storage;
-const StateMachine =
-    @import("../state_machine.zig").StateMachineType(Storage);
+const StateMachine = @import("../state_machine.zig").StateMachineType(Storage);
 
 pub const CreateAccountResultSet = std.enums.EnumSet(tb.CreateAccountResult);
 // TODO(zig): See `Ordered` comments.

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -465,7 +465,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                         action_comptime,
                     );
                     const Event = operation_comptime.EventType();
-                    const event_size: u32 = @sizeOf(Event);
+                    const event_size: u32 = operation_comptime.event_size();
                     const batchable: []Event = self.batch(
                         Event,
                         action_comptime,

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -70,7 +70,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, AOF);
         pub const ReplicaReformat =
             vsr.ReplicaReformatType(StateMachine, MessageBus, Storage);
-        pub const Client = vsr.ClientType(StateMachine, MessageBus);
+        pub const Client = vsr.ClientType(StateMachine.Operation, MessageBus);
         pub const StateChecker = StateCheckerType(Client, Replica);
         pub const ManifestChecker = ManifestCheckerType(StateMachine.Forest);
         pub const JournalChecker = JournalCheckerType(Replica);
@@ -920,7 +920,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                 .request = 0, // Set by client.raw_request.
                 .cluster = client.cluster,
                 .command = .request,
-                .operation = vsr.Operation.from(StateMachine, request_operation),
+                .operation = request_operation.to_vsr(),
                 .size = @intCast(@sizeOf(vsr.Header) + request_body_size),
                 .previous_request_latency = cluster.prng.int(u32),
             };

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -16,21 +16,24 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         pub const Operation = enum(u8) {
             echo = constants.vsr_operations_reserved + 0,
+
+            pub fn EventType(comptime _: Operation) type {
+                return u8; // Must be non-zero-sized for sliceAsBytes().
+            }
+
+            pub fn ResultType(comptime _: Operation) type {
+                return u8; // Must be non-zero-sized for sliceAsBytes().
+            }
+
+            pub fn from_vsr(operation: vsr.Operation) ?Operation {
+                if (operation.vsr_reserved()) return null;
+                return vsr.Operation.to(Operation, operation);
+            }
+
+            pub fn to_vsr(operation: Operation) vsr.Operation {
+                return vsr.Operation.from(Operation, operation);
+            }
         };
-
-        pub fn operation_from_vsr(operation: vsr.Operation) ?Operation {
-            if (operation.vsr_reserved()) return null;
-
-            return vsr.Operation.to(StateMachine, operation);
-        }
-
-        pub fn EventType(comptime _: Operation) type {
-            return u8; // Must be non-zero-sized for sliceAsBytes().
-        }
-
-        pub fn ResultType(comptime _: Operation) type {
-            return u8; // Must be non-zero-sized for sliceAsBytes().
-        }
 
         pub const Options = struct {
             batch_size_limit: u32,

--- a/src/testing/vortex/workload.zig
+++ b/src/testing/vortex/workload.zig
@@ -30,15 +30,13 @@
 const std = @import("std");
 const stdx = @import("stdx");
 const tb = @import("../../tigerbeetle.zig");
-const StateMachineType = @import("../../state_machine.zig").StateMachineType;
+const Operation = tb.Operation;
 const RingBufferType = stdx.RingBufferType;
-const TestingStorage = @import("../storage.zig").Storage;
 const ratio = stdx.PRNG.ratio;
 
 const log = std.log.scoped(.workload);
 const assert = std.debug.assert;
 const testing = std.testing;
-const StateMachine = StateMachineType(TestingStorage);
 
 const events_count_max = 8189;
 const pending_transfers_count_max = 1024;
@@ -147,7 +145,7 @@ fn execute(command: Command, driver: *const DriverStdio) !?Result {
 
 /// State machine operations and Vortex workload commands are not 1:1. This function maps the
 /// enum values from command to operation.
-fn operation_from_command(tag: std.meta.Tag(Command)) StateMachine.Operation {
+fn operation_from_command(tag: std.meta.Tag(Command)) Operation {
     return switch (tag) {
         .create_accounts => .create_accounts,
         .create_transfers => .create_transfers,
@@ -502,14 +500,14 @@ fn FixedSizeBuffersType(Union: type) type {
 
 pub fn send(
     driver: *const DriverStdio,
-    comptime op: StateMachine.Operation,
-    events: []const StateMachine.EventType(op),
+    comptime operation: Operation,
+    events: []const operation.EventType(),
 ) !void {
     assert(events.len <= events_count_max);
 
     const writer = driver.input.writer().any();
 
-    try writer.writeInt(u8, @intFromEnum(op), .little);
+    try writer.writeInt(u8, @intFromEnum(operation), .little);
     try writer.writeInt(u32, @intCast(events.len), .little);
 
     const bytes: []const u8 = std.mem.sliceAsBytes(events);
@@ -518,9 +516,9 @@ pub fn send(
 
 pub fn receive(
     driver: *const DriverStdio,
-    comptime op: StateMachine.Operation,
-    results: []StateMachine.ResultType(op),
-) ![]StateMachine.ResultType(op) {
+    comptime operation: Operation,
+    results: []operation.ResultType(),
+) ![]operation.ResultType() {
     assert(results.len <= events_count_max);
     const reader = driver.output.reader();
 

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -2,8 +2,10 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
-const stdx = @import("stdx");
-const constants = @import("constants.zig");
+const vsr = @import("vsr.zig");
+const constants = vsr.constants;
+const stdx = vsr.stdx;
+const maybe = stdx.maybe;
 
 pub const Account = extern struct {
     id: u128,
@@ -658,6 +660,283 @@ pub const Operation = enum(u8) {
     get_account_balances = constants.vsr_operations_reserved + 15,
     query_accounts = constants.vsr_operations_reserved + 16,
     query_transfers = constants.vsr_operations_reserved + 17,
+
+    pub fn EventType(comptime operation: Operation) type {
+        return switch (operation) {
+            .pulse => void,
+            .create_accounts => Account,
+            .create_transfers => Transfer,
+            .lookup_accounts => u128,
+            .lookup_transfers => u128,
+            .get_account_transfers => AccountFilter,
+            .get_account_balances => AccountFilter,
+            .query_accounts => QueryFilter,
+            .query_transfers => QueryFilter,
+            .get_change_events => ChangeEventsFilter,
+
+            .deprecated_create_accounts_unbatched => Account,
+            .deprecated_create_transfers_unbatched => Transfer,
+            .deprecated_lookup_accounts_unbatched => u128,
+            .deprecated_lookup_transfers_unbatched => u128,
+            .deprecated_get_account_transfers_unbatched => AccountFilter,
+            .deprecated_get_account_balances_unbatched => AccountFilter,
+            .deprecated_query_accounts_unbatched => QueryFilter,
+            .deprecated_query_transfers_unbatched => QueryFilter,
+        };
+    }
+
+    pub fn ResultType(comptime operation: Operation) type {
+        return switch (operation) {
+            .pulse => void,
+            .create_accounts => CreateAccountsResult,
+            .create_transfers => CreateTransfersResult,
+            .lookup_accounts => Account,
+            .lookup_transfers => Transfer,
+            .get_account_transfers => Transfer,
+            .get_account_balances => AccountBalance,
+            .query_accounts => Account,
+            .query_transfers => Transfer,
+            .get_change_events => ChangeEvent,
+
+            .deprecated_create_accounts_unbatched => CreateAccountsResult,
+            .deprecated_create_transfers_unbatched => CreateTransfersResult,
+            .deprecated_lookup_accounts_unbatched => Account,
+            .deprecated_lookup_transfers_unbatched => Transfer,
+            .deprecated_get_account_transfers_unbatched => Transfer,
+            .deprecated_get_account_balances_unbatched => AccountBalance,
+            .deprecated_query_accounts_unbatched => Account,
+            .deprecated_query_transfers_unbatched => Transfer,
+        };
+    }
+
+    /// Inline function so that `operation` can be known at comptime.
+    pub inline fn event_size(operation: Operation) u32 {
+        return switch (operation) {
+            inline else => |operation_comptime| @sizeOf(operation_comptime.EventType()),
+        };
+    }
+
+    /// Inline function so that `operation` can be known at comptime.
+    pub inline fn result_size(operation: Operation) u32 {
+        return switch (operation) {
+            inline else => |operation_comptime| @sizeOf(operation_comptime.ResultType()),
+        };
+    }
+
+    /// Whether the operation supports multiple events per batch.
+    /// If not, multi-batch requests are still supported, but with a single event per batch.
+    pub inline fn is_batchable(operation: Operation) bool {
+        return switch (operation) {
+            // Pulse does not take any input.
+            .pulse => false,
+            // Operations that take multiple events as input:
+            .create_accounts => true,
+            .create_transfers => true,
+            .lookup_accounts => true,
+            .lookup_transfers => true,
+            // Operations that take a single event as input:
+            .get_account_transfers => false,
+            .get_account_balances => false,
+            .query_accounts => false,
+            .query_transfers => false,
+            .get_change_events => false,
+
+            .deprecated_create_accounts_unbatched => true,
+            .deprecated_create_transfers_unbatched => true,
+            .deprecated_lookup_accounts_unbatched => true,
+            .deprecated_lookup_transfers_unbatched => true,
+            .deprecated_get_account_transfers_unbatched => false,
+            .deprecated_get_account_balances_unbatched => false,
+            .deprecated_query_accounts_unbatched => false,
+            .deprecated_query_transfers_unbatched => false,
+        };
+    }
+
+    /// Whether the operation is multi-batch encoded.
+    /// Inline function so that `operation` can be known at comptime.
+    pub inline fn is_multi_batch(operation: Operation) bool {
+        return switch (operation) {
+            .pulse => false,
+
+            .create_accounts,
+            .create_transfers,
+            .lookup_accounts,
+            .lookup_transfers,
+            .get_account_transfers,
+            .get_account_balances,
+            .query_accounts,
+            .query_transfers,
+            => true,
+
+            .get_change_events => false,
+
+            .deprecated_create_accounts_unbatched,
+            .deprecated_create_transfers_unbatched,
+            .deprecated_lookup_accounts_unbatched,
+            .deprecated_lookup_transfers_unbatched,
+            .deprecated_get_account_transfers_unbatched,
+            .deprecated_get_account_balances_unbatched,
+            .deprecated_query_accounts_unbatched,
+            .deprecated_query_transfers_unbatched,
+            => false,
+        };
+    }
+
+    /// The maximum number of events per batch.
+    /// Inline function so that `operation` and `batch_size_limit` can be known at comptime.
+    pub inline fn event_max(operation: Operation, batch_size_limit: u32) u32 {
+        assert(batch_size_limit > 0);
+        assert(batch_size_limit <= constants.message_body_size_max);
+
+        const event_size_bytes: u32 = operation.event_size();
+        maybe(event_size_bytes == 0); // Zeroed event size is allowed.
+        const result_size_bytes: u32 = operation.result_size();
+        assert(result_size_bytes > 0);
+
+        if (!operation.is_multi_batch()) {
+            return if (event_size_bytes == 0)
+                @intCast(@divFloor(constants.message_body_size_max, result_size_bytes))
+            else
+                @min(
+                    @divFloor(batch_size_limit, event_size_bytes),
+                    @divFloor(constants.message_body_size_max, result_size_bytes),
+                );
+        }
+        assert(operation.is_multi_batch());
+
+        const reply_trailer_size_min: u32 = vsr.multi_batch.trailer_total_size(.{
+            .element_size = result_size_bytes,
+            .batch_count = 1,
+        });
+        assert(reply_trailer_size_min > 0);
+        assert(reply_trailer_size_min < batch_size_limit);
+
+        if (event_size_bytes == 0) {
+            return @intCast(@divFloor(
+                constants.message_body_size_max - reply_trailer_size_min,
+                result_size_bytes,
+            ));
+        } else {
+            const request_trailer_size_min: u32 = vsr.multi_batch.trailer_total_size(.{
+                .element_size = event_size_bytes,
+                .batch_count = 1,
+            });
+            assert(request_trailer_size_min > 0);
+            assert(request_trailer_size_min < constants.message_body_size_max);
+
+            return @min(
+                @divFloor(batch_size_limit - request_trailer_size_min, event_size_bytes),
+                @divFloor(
+                    constants.message_body_size_max - reply_trailer_size_min,
+                    result_size_bytes,
+                ),
+            );
+        }
+    }
+
+    /// The maximum number of results per batch.
+    /// If the number of results is defined by the number of events (`is_batchable()`
+    /// is true) then `result_max() == event_max()`.
+    /// Inline function so that `operation` and `batch_size_limit` can be known at comptime.
+    pub inline fn result_max(operation: Operation, batch_size_limit: u32) u32 {
+        assert(batch_size_limit > 0);
+        assert(batch_size_limit <= constants.message_body_size_max);
+        if (operation.is_batchable()) {
+            return operation.event_max(batch_size_limit);
+        }
+        assert(!operation.is_batchable());
+
+        const result_size_bytes = operation.result_size();
+        assert(result_size_bytes > 0);
+
+        if (!operation.is_multi_batch()) {
+            return @intCast(@divFloor(constants.message_body_size_max, result_size_bytes));
+        }
+        assert(operation.is_multi_batch());
+
+        const reply_trailer_size_min: u32 = vsr.multi_batch.trailer_total_size(.{
+            .element_size = result_size_bytes,
+            .batch_count = 1,
+        });
+        return @intCast(@divFloor(
+            constants.message_body_size_max - reply_trailer_size_min,
+            result_size_bytes,
+        ));
+    }
+
+    /// Returns the expected number of results for a given batch.
+    /// For multi-batch requests, this function expects a single, already decoded batch.
+    /// Inline function so that `operation` can be known at comptime.
+    pub inline fn result_count_expected(
+        operation: Operation,
+        batch: []const u8,
+    ) u32 {
+        return switch (operation) {
+            .pulse => 0,
+            inline .create_accounts,
+            .create_transfers,
+            .lookup_accounts,
+            .lookup_transfers,
+            .deprecated_create_accounts_unbatched,
+            .deprecated_create_transfers_unbatched,
+            .deprecated_lookup_accounts_unbatched,
+            .deprecated_lookup_transfers_unbatched,
+            => |operation_comptime| count: {
+                // For these types of operations, each event produces at most one result.
+                comptime assert(operation_comptime.is_batchable());
+
+                // Clients do not validate batch size == 0,
+                // and even the simulator can generate requests with no events.
+                if (batch.len == 0) return 0;
+
+                const event_size_bytes: u32 = @sizeOf(operation_comptime.EventType());
+                comptime assert(event_size_bytes > 0);
+                assert(batch.len % event_size_bytes == 0); // Input has already been validated.
+
+                break :count @intCast(@divExact(batch.len, event_size_bytes));
+            },
+            inline .get_account_transfers,
+            .get_account_balances,
+            .query_accounts,
+            .query_transfers,
+            .deprecated_get_account_transfers_unbatched,
+            .deprecated_get_account_balances_unbatched,
+            .deprecated_query_accounts_unbatched,
+            .deprecated_query_transfers_unbatched,
+            .get_change_events,
+            => |operation_comptime| count: {
+                // For queries, each event produces up to `limit` events.
+                comptime assert(!operation_comptime.is_batchable());
+
+                const Filter = operation_comptime.EventType();
+                comptime assert(@sizeOf(Filter) > 0);
+                assert(batch.len == @sizeOf(Filter));
+                // This function is used by the client,
+                // so the input may come from unaligned memory.
+                maybe(!std.mem.isAligned(@intFromPtr(batch.ptr), @alignOf(Filter)));
+
+                const filter: Filter = std.mem.bytesToValue(Filter, batch);
+                maybe(filter.limit == 0);
+
+                // TODO: Handle `TooMuchData` at the client side instead of capping the limit.
+                break :count @min(
+                    filter.limit,
+                    operation_comptime.result_max(constants.message_body_size_max),
+                );
+            },
+        };
+    }
+
+    pub fn from_vsr(operation: vsr.Operation) ?Operation {
+        if (operation == .pulse) return .pulse;
+        if (operation.vsr_reserved()) return null;
+
+        return vsr.Operation.to(Operation, operation);
+    }
+
+    pub fn to_vsr(operation: Operation) vsr.Operation {
+        return vsr.Operation.from(Operation, operation);
+    }
 };
 
 comptime {

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -795,7 +795,7 @@ pub const Operation = enum(u8) {
 
         if (!operation.is_multi_batch()) {
             return if (event_size_bytes == 0)
-                @intCast(@divFloor(constants.message_body_size_max, result_size_bytes))
+                @divFloor(constants.message_body_size_max, result_size_bytes)
             else
                 @min(
                     @divFloor(batch_size_limit, event_size_bytes),
@@ -812,10 +812,10 @@ pub const Operation = enum(u8) {
         assert(reply_trailer_size_min < batch_size_limit);
 
         if (event_size_bytes == 0) {
-            return @intCast(@divFloor(
+            return @divFloor(
                 constants.message_body_size_max - reply_trailer_size_min,
                 result_size_bytes,
-            ));
+            );
         } else {
             const request_trailer_size_min: u32 = vsr.multi_batch.trailer_total_size(.{
                 .element_size = event_size_bytes,
@@ -850,7 +850,7 @@ pub const Operation = enum(u8) {
         assert(result_size_bytes > 0);
 
         if (!operation.is_multi_batch()) {
-            return @intCast(@divFloor(constants.message_body_size_max, result_size_bytes));
+            return @divFloor(constants.message_body_size_max, result_size_bytes);
         }
         assert(operation.is_multi_batch());
 
@@ -858,10 +858,10 @@ pub const Operation = enum(u8) {
             .element_size = result_size_bytes,
             .batch_count = 1,
         });
-        return @intCast(@divFloor(
+        return @divFloor(
             constants.message_body_size_max - reply_trailer_size_min,
             result_size_bytes,
-        ));
+        );
     }
 
     /// Returns the expected number of results for a given batch.

--- a/src/tigerbeetle.zig
+++ b/src/tigerbeetle.zig
@@ -889,7 +889,7 @@ pub const Operation = enum(u8) {
                 // and even the simulator can generate requests with no events.
                 if (batch.len == 0) return 0;
 
-                const event_size_bytes: u32 = @sizeOf(operation_comptime.EventType());
+                const event_size_bytes: u32 = operation_comptime.event_size();
                 comptime assert(event_size_bytes > 0);
                 assert(batch.len % event_size_bytes == 0); // Input has already been validated.
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -25,7 +25,13 @@ const StateMachine = @import("./main.zig").StateMachine;
 const Grid = @import("./main.zig").Grid;
 const Ratio = stdx.PRNG.Ratio;
 const ByteSize = stdx.ByteSize;
+const Operation = tigerbeetle.Operation;
 const Duration = stdx.Duration;
+
+comptime {
+    // Make sure we are running the Accounting StateMachine.
+    assert(StateMachine.Operation == tigerbeetle.Operation);
+}
 
 const KiB = stdx.KiB;
 const GiB = stdx.GiB;
@@ -131,15 +137,13 @@ const CLIArgs = union(enum) {
         account_distribution: Command.Benchmark.Distribution = .uniform,
         flag_history: bool = false,
         flag_imported: bool = false,
-        account_batch_size: u32 = StateMachine.operation_event_max(
-            .create_accounts,
+        account_batch_size: u32 = Operation.create_accounts.event_max(
             constants.message_body_size_max,
         ),
         transfer_count: u32 = 10_000_000,
         transfer_hot_percent: u32 = 100,
         transfer_pending: bool = false,
-        transfer_batch_size: u32 = StateMachine.operation_event_max(
-            .create_transfers,
+        transfer_batch_size: u32 = Operation.create_transfers.event_max(
             constants.message_body_size_max,
         ),
         transfer_batch_delay: Duration = .ms(0),
@@ -1020,7 +1024,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
             "--cache-transfers",
         ),
         .cache_transfers_pending = parse_cache_size_to_count(
-            StateMachine.TransferPending,
+            vsr.state_machine.TransferPending,
             TransfersPendingValuesCache,
             start.cache_transfers_pending orelse defaults.cache_transfers_pending,
             "--cache-transfers-pending",

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -1328,8 +1328,8 @@ fn print_value(output: std.io.AnyWriter, value: anytype) !void {
     if (Type == u128) return output.print("0x{x:0>32}", .{value});
 
     if (Type == vsr.Operation) {
-        if (value.valid(StateMachine)) {
-            return output.writeAll(value.tag_name(StateMachine));
+        if (value.valid(StateMachine.Operation)) {
+            return output.writeAll(value.tag_name(StateMachine.Operation));
         } else {
             return output.print("{}!", .{@intFromEnum(value)});
         }
@@ -1494,9 +1494,9 @@ const operation_schemas = list: {
     for (std.enums.values(StateMachine.Operation)) |operation| {
         if (operation == .pulse) continue;
         list = list ++ [_]OperationSchema{.{
-            .operation = vsr.Operation.from(StateMachine, operation),
-            .Event = StateMachine.EventType(operation),
-            .Result = StateMachine.ResultType(operation),
+            .operation = operation.to_vsr(),
+            .Event = operation.EventType(),
+            .Result = operation.ResultType(),
         }};
     }
     break :list list;

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -27,7 +27,7 @@ const MessagePool = vsr.message_pool.MessagePool;
 pub const StateMachine = vsr.state_machine.StateMachineType(Storage);
 pub const Grid = vsr.GridType(Storage);
 
-const Client = vsr.ClientType(StateMachine, vsr.message_bus.MessageBusClient);
+const Client = vsr.ClientType(StateMachine.Operation, vsr.message_bus.MessageBusClient);
 pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, AOF);
 const ReplicaReformat =
     vsr.ReplicaReformatType(StateMachine, vsr.message_bus.MessageBusClient, Storage);

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -16,13 +16,13 @@ const MessageBuffer = @import("../message_buffer.zig").MessageBuffer;
 const log = stdx.log.scoped(.client);
 
 pub fn ClientType(
-    comptime StateMachine_: type,
+    comptime StateMachineOperation: type,
     comptime MessageBus: type,
 ) type {
     return struct {
         const Client = @This();
 
-        pub const StateMachine = StateMachine_;
+        pub const Operation = StateMachineOperation;
         pub const Request = struct {
             pub const Callback = *const fn (
                 user_data: u128,
@@ -304,12 +304,12 @@ pub fn ClientType(
             self: *Client,
             callback: Request.Callback,
             user_data: u128,
-            operation: StateMachine.Operation,
+            operation: Operation,
             events: []const u8,
         ) void {
             const event_size: usize = switch (operation) {
                 inline else => |operation_comptime| @sizeOf(
-                    StateMachine.EventType(operation_comptime),
+                    operation_comptime.EventType(),
                 ),
             };
             assert(!self.evicted);
@@ -328,7 +328,7 @@ pub fn ClientType(
                 .cluster = self.cluster,
                 .command = .request,
                 .release = self.release,
-                .operation = vsr.Operation.from(StateMachine, operation),
+                .operation = operation.to_vsr(),
                 .size = @intCast(@sizeOf(Header) + events.len),
                 .previous_request_latency = 0,
             };
@@ -354,7 +354,7 @@ pub fn ClientType(
             assert(message.header.size >= @sizeOf(Header));
             assert(message.header.size <= constants.message_size_max);
             assert(message.header.size <= @sizeOf(Header) + self.batch_size_limit.?);
-            assert(message.header.operation.valid(StateMachine));
+            assert(message.header.operation.valid(Operation));
             assert(message.header.view == 0);
             assert(message.header.parent == 0);
             assert(message.header.session == 0);
@@ -377,7 +377,7 @@ pub fn ClientType(
                 user_data,
                 message.header.request,
                 message.header.size,
-                message.header.operation.tag_name(StateMachine),
+                message.header.operation.tag_name(Operation),
             });
 
             self.request_inflight = .{
@@ -560,7 +560,7 @@ pub fn ClientType(
                 inflight.user_data,
                 reply.header.request,
                 reply.header.size,
-                reply.header.operation.tag_name(StateMachine),
+                reply.header.operation.tag_name(Operation),
             });
 
             assert(reply.header.request_checksum == self.parent);
@@ -577,7 +577,7 @@ pub fn ClientType(
                     inflight.message.header.request,
                     reply.header.op,
                     inflight.message.header.size,
-                    inflight.message.header.operation.tag_name(StateMachine),
+                    inflight.message.header.operation.tag_name(Operation),
                     request_completion_duration.to_ms(),
                 });
             }

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -307,14 +307,11 @@ pub fn ClientType(
             operation: Operation,
             events: []const u8,
         ) void {
-            const event_size: usize = switch (operation) {
-                inline else => |operation_comptime| @sizeOf(
-                    operation_comptime.EventType(),
-                ),
-            };
             assert(!self.evicted);
             assert(self.request_inflight == null);
             assert(self.request_number > 0);
+
+            const event_size = operation.event_size();
             assert(events.len <= constants.message_body_size_max);
             assert(events.len <= self.batch_size_limit.?);
             assert(events.len % event_size == 0);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4653,7 +4653,7 @@ pub fn ReplicaType(
                 @panic("Cannot commit prepare; batch limit too low.");
             }
 
-            if (StateMachine.operation_from_vsr(prepare.header.operation)) |prepare_operation| {
+            if (StateMachine.Operation.from_vsr(prepare.header.operation)) |prepare_operation| {
                 self.state_machine.prefetch_timestamp = prepare.header.timestamp;
                 self.state_machine.prefetch(
                     commit_prefetch_callback,
@@ -5174,7 +5174,7 @@ pub fn ReplicaType(
                     self.log_prefix(),
                     self.commit_prepare.?.header.request,
                     self.commit_prepare.?.header.size,
-                    self.commit_prepare.?.header.operation.tag_name(StateMachine),
+                    self.commit_prepare.?.header.operation.tag_name(StateMachine.Operation),
                     commit_completion_time_local.to_ms(),
                 });
             }
@@ -5196,7 +5196,7 @@ pub fn ReplicaType(
             if (StateMachine.Operation == @import("../tigerbeetle.zig").Operation and
                 self.status == .normal)
             {
-                if (StateMachine.operation_from_vsr(
+                if (StateMachine.Operation.from_vsr(
                     self.commit_prepare.?.header.operation,
                 )) |operation| {
                     self.trace.timing(
@@ -5282,7 +5282,7 @@ pub fn ReplicaType(
                 self.primary_index(self.view) == self.replica,
                 prepare.header.op,
                 prepare.header.checksum,
-                prepare.header.operation.tag_name(StateMachine),
+                prepare.header.operation.tag_name(StateMachine.Operation),
             });
 
             const reply = self.message_bus.get_message(.reply);
@@ -5334,7 +5334,7 @@ pub fn ReplicaType(
                     prepare.header.client,
                     prepare.header.op,
                     prepare.header.timestamp,
-                    prepare.header.operation.cast(StateMachine),
+                    prepare.header.operation.cast(StateMachine.Operation),
                     prepare.body_used(),
                     reply.buffer[@sizeOf(Header)..],
                 ),
@@ -5440,7 +5440,7 @@ pub fn ReplicaType(
                     if (StateMachine.Operation == @import("../tigerbeetle.zig").Operation and
                         self.status == .normal)
                     {
-                        if (StateMachine.operation_from_vsr(
+                        if (StateMachine.Operation.from_vsr(
                             self.commit_prepare.?.header.operation,
                         )) |operation| {
                             self.trace.timing(
@@ -6192,7 +6192,7 @@ pub fn ReplicaType(
             // - client bug
             // - client memory corruption
             // - client/replica version mismatch
-            if (!message.header.operation.valid(StateMachine)) {
+            if (!message.header.operation.valid(StateMachine.Operation)) {
                 log.warn("{}: on_request: ignoring invalid operation (client={} operation={})", .{
                     self.log_prefix(),
                     message.header.client,
@@ -6204,7 +6204,7 @@ pub fn ReplicaType(
                 );
                 return true;
             }
-            if (StateMachine.operation_from_vsr(message.header.operation)) |operation| {
+            if (StateMachine.Operation.from_vsr(message.header.operation)) |operation| {
                 if (!self.state_machine.input_valid(
                     operation,
                     message.body_used(),
@@ -7151,7 +7151,7 @@ pub fn ReplicaType(
                 if (StateMachine.Operation == @import("../tigerbeetle.zig").Operation and
                     self.status == .normal)
                 {
-                    if (StateMachine.operation_from_vsr(
+                    if (StateMachine.Operation.from_vsr(
                         request.message.header.operation,
                     )) |operation| {
                         self.trace.timing(
@@ -7194,7 +7194,7 @@ pub fn ReplicaType(
                 .noop => {},
                 else => {
                     self.state_machine.prepare(
-                        request.message.header.operation.cast(StateMachine),
+                        request.message.header.operation.cast(StateMachine.Operation),
                         request.message.body_used(),
                     );
                 },

--- a/src/vsr/replica_reformat.zig
+++ b/src/vsr/replica_reformat.zig
@@ -33,7 +33,7 @@ pub fn ReplicaReformatType(
     comptime MessageBus: type,
     comptime Storage: type,
 ) type {
-    const Client = vsr.ClientType(StateMachine, MessageBus);
+    const Client = vsr.ClientType(StateMachine.Operation, MessageBus);
     const SuperBlock = vsr.SuperBlockType(Storage);
 
     return struct {


### PR DESCRIPTION
Parametrize code that doesn’t require the concrete StateMachine implementation over `Operation`.

Example
| before | after |
|-----------|---------|
| `const Result = StateMachine.ResultType(operation_comptime);`  | `const Result = operation_comptime.ResultType();` |
|`StateMachine.operation_event_max(operation, batch_size_max)` | `operation.event_max(batch_size_max)`|

Required to implement https://github.com/tigerbeetle/tigerbeetle/pull/3258#issuecomment-3453937166.