### PR TITLE
VSR: Reserve release 65535.x.x for cluster=0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -929,7 +929,7 @@ fn build_test_integration(
         .stdx_module = options.stdx_module,
         .git_commit = "bee71e0000000000000000000000000000bee71e".*, // Beetle-hash!
         .config_verify = true,
-        .config_release = "0.16.99",
+        .config_release = "65535.0.0",
         .config_release_client_min = "0.16.4",
         .config_aof_recovery = false,
     });

--- a/src/multiversion.zig
+++ b/src/multiversion.zig
@@ -183,6 +183,12 @@ pub const Release = extern struct {
     // Minimum is used for all development builds, to distinguish them from production deployments.
     pub const minimum = Release.from(.{ .major = 0, .minor = 0, .patch = 1 });
 
+    /// The 65535.x.x releases are reserved for cluster=0.
+    /// This way, when testing multiversion binaries (either manually or with the integration tests'
+    /// or Vortex's build) it isn't possible to use the test's multiversion build to upgrade a
+    /// production cluster to non-production code.
+    pub const development_major: u16 = std.math.maxInt(u16);
+
     pub fn from(release_triple: ReleaseTriple) Release {
         return std.mem.bytesAsValue(Release, std.mem.asBytes(&release_triple)).*;
     }

--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -4,7 +4,7 @@ const constants = @This();
 pub const vsr = @import("../../constants.zig");
 
 pub const vortex = struct {
-    pub const cluster_id = 1;
+    pub const cluster_id = 0;
     pub const connections_count_max = @divFloor(
         constants.vsr.clients_max,
         constants.vsr.replicas_max,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -738,6 +738,12 @@ pub fn ReplicaType(
             assert(release_target.value >= self.superblock.working.release_format.value);
             log.info("superblock release={}", .{release_target});
 
+            if (self.superblock.working.cluster != 0) {
+                if (self.release.triple().major == vsr.Release.development_major) {
+                    @panic("Test builds must only be used with test clusters. (cluster=0)");
+                }
+            }
+
             if (release_target.value != self.release.value) {
                 self.release_transition(@src());
                 return;


### PR DESCRIPTION
The `65535.x.x` releases are now reserved for `cluster=0`.

This way, when testing multiversion binaries (either manually or with the integration tests' or (in the near future) Vortex's build) it isn't possible to use the test's multiversion build to upgrade a production cluster to non-production code.

(The reason that our existing development release `0.0.1` is not sufficient for these use cases is that to test upgrades we need a development version which is _higher_ than the real version.)