### PR TITLE
CFO: Supervisor must run in non-bash shell

### DIFF
--- a/src/scripts/cfo_supervisor.sh
+++ b/src/scripts/cfo_supervisor.sh
@@ -10,7 +10,7 @@ set -eu
 # (In particular, this will kill all descendent processes that have not changed groups.)
 #
 # We must unset the trap before killing, otherwise the signal will recurse and we segfault.
-trap 'trap - SIGINT SIGTERM EXIT; kill 0' SIGINT SIGTERM EXIT
+trap 'trap - INT TERM EXIT; kill 0' INT TERM EXIT
 
 git --version
 


### PR DESCRIPTION
The `SIG` prefixes for trapping signals are a bashism.

(Also, TIL that our CFO fleet actually uses busybox's shell to run the supervisor script!)

I already deployed this fix to the CFO's, since it was that or rollback.