### PR TITLE
Scripts/Release: Replace "npm install" with "npm ci"

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -480,7 +480,7 @@ fn build_node(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
         "npm version --no-git-tag-version {tag}",
         .{ .tag = info.tag },
     );
-    try shell.exec("npm install", .{});
+    try shell.exec("npm ci", .{});
     try shell.exec("npm pack --quiet", .{});
 
     try Shell.copy_path(


### PR DESCRIPTION
From npm docs:

> This command is similar to npm install, except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.
> ...
> - If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.
>
> ...
> - It will never write to package.json or any of the package-locks: installs are essentially frozen.

That sounds like what we want for our release script!