### PR TITLE
[StateMachine] Remove the comptime config.

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -297,10 +297,7 @@ pub fn AOFType(comptime IO: type) type {
 
         pub const ReplayClient = struct {
             const Storage = vsr.storage.StorageType(IO);
-            const StateMachine = vsr.state_machine.StateMachineType(
-                Storage,
-                constants.state_machine_config,
-            );
+            const StateMachine = vsr.state_machine.StateMachineType(Storage);
             const Client = vsr.ClientType(StateMachine, MessageBus);
 
             client: *Client,

--- a/src/cdc/amqp/types.zig
+++ b/src/cdc/amqp/types.zig
@@ -25,7 +25,7 @@ pub const ConnectionProperties = struct {
         .product = "TigerBeetle",
         .version = std.fmt.comptimePrint(
             "{}",
-            .{vsr.constants.state_machine_config.release},
+            .{vsr.constants.config.process.release},
         ),
         // By convention, "platform" refers to the programming language.
         // e.g., Erlang, Java, Go, etc.

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -12,10 +12,7 @@ const Time = vsr.time.Time;
 const Storage = vsr.storage.StorageType(IO);
 const MessagePool = vsr.message_pool.MessagePool;
 const MessageBus = vsr.message_bus.MessageBusClient;
-const StateMachine = vsr.state_machine.StateMachineType(
-    Storage,
-    vsr.constants.state_machine_config,
-);
+const StateMachine = vsr.state_machine.StateMachineType(Storage);
 const Client = vsr.ClientType(StateMachine, MessageBus);
 const TimestampRange = vsr.lsm.TimestampRange;
 const tb = vsr.tigerbeetle;
@@ -491,13 +488,13 @@ pub const Runner = struct {
                                         assert(TimestampRange.valid(progress_tracker.timestamp));
 
                                         // Downgrading the CDC job is not allowed.
-                                        if (vsr.constants.state_machine_config.release.value <
+                                        if (vsr.constants.config.process.release.value <
                                             progress_tracker.release.value)
                                         {
                                             fatal("The last event was published using a newer " ++
                                                 "release (event={} current={}).", .{
                                                 progress_tracker.release,
-                                                vsr.constants.state_machine_config.release,
+                                                vsr.constants.config.process.release,
                                             });
                                         }
 
@@ -861,7 +858,7 @@ pub const Runner = struct {
                     assert(events.len > 0);
                     break :progress .{
                         .timestamp = events[events.len - 1].timestamp,
-                        .release = vsr.constants.state_machine_config.release,
+                        .release = vsr.constants.config.process.release,
                     };
                 };
                 self.amqp_client.publish_enqueue(.{

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -3,12 +3,11 @@ const std = @import("std");
 pub const vsr = @import("../../vsr.zig");
 pub const exports = @import("tb_client_exports.zig");
 
-const constants = @import("../../constants.zig");
 const IO = @import("../../io.zig").IO;
 const Storage = @import("../../storage.zig").StorageType(IO);
 const MessageBus = @import("../../message_bus.zig").MessageBusClient;
 const StateMachineType = @import("../../state_machine.zig").StateMachineType;
-const StateMachine = StateMachineType(Storage, constants.state_machine_config);
+const StateMachine = StateMachineType(Storage);
 
 pub const InitError = @import("tb_client/context.zig").InitError;
 pub const InitParameters = @import("tb_client/context.zig").InitParameters;

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -14,7 +14,7 @@ const QueryFilter = tb.QueryFilter;
 
 const vsr = @import("vsr");
 const Storage = vsr.storage.StorageType(vsr.io.IO);
-const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
+const StateMachine = vsr.state_machine.StateMachineType(Storage);
 const Operation = StateMachine.Operation;
 const constants = vsr.constants;
 const stdx = vsr.stdx;

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -3,11 +3,9 @@ const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
 const assert = std.debug.assert;
 
-const constants = vsr.constants;
 const IO = vsr.io.IO;
-
 const Storage = vsr.storage.StorageType(IO);
-const StateMachine = vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
+const StateMachine = vsr.state_machine.StateMachineType(Storage);
 const tb = vsr.tigerbeetle;
 
 /// VSR type mappings: these will always be the same regardless of state machine.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -758,18 +758,6 @@ pub const clock_synchronization_window_min_ms = config.process.clock_synchroniza
 /// If a window expires because of this then it is likely that the clock epoch will also be expired.
 pub const clock_synchronization_window_max_ms = config.process.clock_synchronization_window_max_ms;
 
-pub const StateMachineConfig = struct {
-    release: vsr.Release,
-    message_body_size_max: comptime_int,
-    lsm_compaction_ops: comptime_int,
-};
-
-pub const state_machine_config = StateMachineConfig{
-    .release = config.process.release,
-    .message_body_size_max = message_body_size_max,
-    .lsm_compaction_ops = lsm_compaction_ops,
-};
-
 /// TigerBeetle uses asserts proactively, unless they severely degrade performance. For production,
 /// 5% slow down might be deemed critical, tests tolerate slowdowns up to 5x. Tests should be
 /// reasonably fast to make deterministic simulation effective. `constants.verify` disambiguate the

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -16,8 +16,7 @@ const tb = @import("../tigerbeetle.zig");
 const TimeSim = @import("../testing/time.zig").TimeSim;
 const Account = @import("../tigerbeetle.zig").Account;
 const Storage = @import("../testing/storage.zig").Storage;
-const StateMachine = @import("../state_machine.zig")
-    .StateMachineType(Storage, constants.state_machine_config);
+const StateMachine = @import("../state_machine.zig").StateMachineType(Storage);
 const Reservation = @import("../vsr/free_set.zig").Reservation;
 const GridType = @import("../vsr/grid.zig").GridType;
 const ScanRangeType = @import("../lsm/scan_range.zig").ScanRangeType;
@@ -132,7 +131,7 @@ const Environment = struct {
 
         env.scan_lookup_buffer = try gpa.alloc(
             tb.Account,
-            StateMachine.machine_constants.batch_max.create_accounts,
+            StateMachine.batch_max.create_accounts,
         );
 
         env.forest = undefined;

--- a/src/lsm/forest_table_iterator.zig
+++ b/src/lsm/forest_table_iterator.zig
@@ -194,7 +194,7 @@ fn TreeTableIteratorType(comptime Tree: type) type {
 test "ForestTableIterator: refAllDecls" {
     const Storage = @import("../testing/storage.zig").Storage;
     const StateMachineType = @import("../testing/state_machine.zig").StateMachineType;
-    const StateMachine = StateMachineType(Storage, constants.state_machine_config);
+    const StateMachine = StateMachineType(Storage);
 
     std.testing.refAllDecls(ForestTableIteratorType(StateMachine.Forest));
 }

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -8,10 +8,7 @@ const IO = vsr.io.IO;
 const Time = vsr.time.Time;
 const StaticAllocator = @import("static_allocator.zig");
 const Storage = vsr.storage.StorageType(IO);
-const StateMachine = vsr.state_machine.StateMachineType(
-    Storage,
-    constants.state_machine_config,
-);
+const StateMachine = vsr.state_machine.StateMachineType(Storage);
 const MessagePool = vsr.message_pool.MessagePool;
 const RingBufferType = stdx.RingBufferType;
 

--- a/src/repl/parser.zig
+++ b/src/repl/parser.zig
@@ -5,10 +5,7 @@ const vsr = @import("../vsr.zig");
 const constants = vsr.constants;
 const IO = vsr.io.IO;
 const Storage = vsr.storage.StorageType(IO);
-const StateMachine = vsr.state_machine.StateMachineType(
-    Storage,
-    constants.state_machine_config,
-);
+const StateMachine = vsr.state_machine.StateMachineType(Storage);
 const tb = vsr.tigerbeetle;
 
 const Terminal = @import("terminal.zig").Terminal;
@@ -292,7 +289,7 @@ pub const Parser = struct {
                 .timestamp_max = 0,
                 .limit = StateMachine.operation_result_max(
                     operation_comptime.state_machine_op(),
-                    StateMachine.machine_constants.message_body_size_max,
+                    constants.message_body_size_max,
                 ),
                 .flags = .{
                     .credits = true,
@@ -312,7 +309,7 @@ pub const Parser = struct {
                 .timestamp_max = 0,
                 .limit = StateMachine.operation_result_max(
                     operation_comptime.state_machine_op(),
-                    StateMachine.machine_constants.message_body_size_max,
+                    constants.message_body_size_max,
                 ),
                 .flags = .{
                     .reversed = false,
@@ -887,7 +884,7 @@ test "parser.zig: Parser account filter successfully" {
                 .timestamp_max = 0,
                 .limit = StateMachine.operation_result_max(
                     .get_account_transfers,
-                    StateMachine.machine_constants.message_body_size_max,
+                    constants.message_body_size_max,
                 ),
                 .flags = .{
                     .credits = true,
@@ -965,7 +962,7 @@ test "parser.zig: Parser query filter successfully" {
                 .timestamp_max = 0,
                 .limit = StateMachine.operation_result_max(
                     .query_transfers,
-                    StateMachine.machine_constants.message_body_size_max,
+                    constants.message_body_size_max,
                 ),
                 .flags = .{
                     .reversed = false,

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -692,10 +692,7 @@ const VSRContext = struct {
     const MessagePool = vsr.message_pool.MessagePool;
     const Message = MessagePool.Message;
     const Storage = vsr.storage.StorageType(vsr.io.IO);
-    const StateMachine = vsr.state_machine.StateMachineType(
-        Storage,
-        vsr.constants.state_machine_config,
-    );
+    const StateMachine = vsr.state_machine.StateMachineType(Storage);
     const Client = vsr.ClientType(
         StateMachine,
         vsr.message_bus.MessageBusClient,
@@ -741,7 +738,7 @@ const VSRContext = struct {
         self.buffer = try gpa.alloc(tb.ChangeEvent, StateMachine.operation_result_max(
             .get_change_events,
             @divFloor(
-                StateMachine.machine_constants.message_body_size_max,
+                vsr.constants.message_body_size_max,
                 @sizeOf(tb.ChangeEvent),
             ),
         ));

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -8,7 +8,6 @@ const assert = std.debug.assert;
 const maybe = stdx.maybe;
 const log = std.log.scoped(.test_auditor);
 
-const constants = @import("../constants.zig");
 const tb = @import("../tigerbeetle.zig");
 const IdPermutation = @import("../testing/id.zig").IdPermutation;
 const TimestampRange = @import("../lsm/timestamp_range.zig").TimestampRange;
@@ -16,7 +15,7 @@ const TimestampRange = @import("../lsm/timestamp_range.zig").TimestampRange;
 const PriorityQueue = std.PriorityQueue;
 const Storage = @import("../testing/storage.zig").Storage;
 const StateMachine =
-    @import("../state_machine.zig").StateMachineType(Storage, constants.state_machine_config);
+    @import("../state_machine.zig").StateMachineType(Storage);
 
 pub const CreateAccountResultSet = std.enums.EnumSet(tb.CreateAccountResult);
 // TODO(zig): See `Ordered` comments.
@@ -24,8 +23,8 @@ pub const CreateTransferResultSet = std.enums.EnumSet(tb.CreateTransferResult.Or
 
 /// Batch sizes apply to both `create` and `lookup` operations.
 /// (More ids would fit in the `lookup` request, but then the response wouldn't fit.)
-const accounts_batch_size_max = StateMachine.machine_constants.batch_max.create_accounts;
-const transfers_batch_size_max = StateMachine.machine_constants.batch_max.create_transfers;
+const accounts_batch_size_max = StateMachine.batch_max.create_accounts;
+const transfers_batch_size_max = StateMachine.batch_max.create_transfers;
 
 const InFlightKey = struct {
     client_index: usize,

--- a/src/state_machine/workload.zig
+++ b/src/state_machine/workload.zig
@@ -263,10 +263,10 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
             options: Options,
         ) !Workload {
             assert(options.accounts_batch_size_span + options.accounts_batch_size_min <=
-                AccountingStateMachine.machine_constants.batch_max.create_accounts);
+                AccountingStateMachine.batch_max.create_accounts);
             assert(options.accounts_batch_size_span >= 1);
             assert(options.transfers_batch_size_span + options.transfers_batch_size_min <=
-                AccountingStateMachine.machine_constants.batch_max.create_transfers);
+                AccountingStateMachine.batch_max.create_transfers);
             assert(options.transfers_batch_size_span >= 1);
 
             var auditor = try Auditor.init(allocator, prng, options.auditor_options);
@@ -372,7 +372,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                 self.options.batch_size_limit,
             );
             assert(result_max > 0);
-            assert(AccountingStateMachine.machine_constants.message_body_size_max >=
+            assert(constants.message_body_size_max >=
                 result_size * result_max);
 
             if (!AccountingStateMachine.operation_is_multi_batch(operation)) {
@@ -428,9 +428,7 @@ pub fn WorkloadType(comptime AccountingStateMachine: type) type {
                 const reply_message_size: u32 =
                     ((result_count + result_count_expected) * result_size) +
                     reply_trailer_size;
-                if (reply_message_size >
-                    AccountingStateMachine.machine_constants.message_body_size_max)
-                {
+                if (reply_message_size > constants.message_body_size_max) {
                     // For operations that produce 1:1 result per event
                     // (e.g., `create_*` and `lookup_*`), this was already validated
                     // when checking if `event_count` fits within the multi-batch request.
@@ -1990,9 +1988,7 @@ fn OptionsType(comptime StateMachine: type, comptime Action: type, comptime Look
             client_count: usize,
             in_flight_max: usize,
         }) Options {
-            assert(
-                options.batch_size_limit <= StateMachine.machine_constants.message_body_size_max,
-            );
+            assert(options.batch_size_limit <= constants.message_body_size_max);
 
             const batch_create_accounts_limit = @min(
                 StateMachine.operation_event_max(
@@ -2005,8 +2001,7 @@ fn OptionsType(comptime StateMachine: type, comptime Action: type, comptime Look
                 ),
             );
             assert(batch_create_accounts_limit > 0);
-            assert(batch_create_accounts_limit <=
-                StateMachine.machine_constants.batch_max.create_accounts);
+            assert(batch_create_accounts_limit <= StateMachine.batch_max.create_accounts);
 
             const batch_create_transfers_limit = @min(
                 StateMachine.operation_event_max(
@@ -2019,8 +2014,7 @@ fn OptionsType(comptime StateMachine: type, comptime Action: type, comptime Look
                 ),
             );
             assert(batch_create_transfers_limit > 0);
-            assert(batch_create_transfers_limit <=
-                StateMachine.machine_constants.batch_max.create_transfers);
+            assert(batch_create_transfers_limit <= StateMachine.batch_max.create_transfers);
             return .{
                 .batch_size_limit = options.batch_size_limit,
                 .multi_batch_per_request_limit = options.multi_batch_per_request_limit,

--- a/src/state_machine_fuzz.zig
+++ b/src/state_machine_fuzz.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const vsr = @import("vsr.zig");
+const constants = vsr.constants;
 const stdx = @import("stdx");
 
 const tb = @import("tigerbeetle.zig");
@@ -43,14 +44,14 @@ pub fn main(allocator: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
     const request_buffer = try allocator.alignedAlloc(
         u8,
         16,
-        TestContext.message_body_size_max,
+        constants.message_body_size_max,
     );
     defer allocator.free(request_buffer);
 
     const reply_buffer = try allocator.alignedAlloc(
         u8,
         16,
-        TestContext.message_body_size_max,
+        constants.message_body_size_max,
     );
     defer allocator.free(reply_buffer);
 

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -115,12 +115,14 @@ pub const TestContext = struct {
         ctx.grid = try fixtures.init_grid(allocator, &ctx.trace, &ctx.superblock, .{});
         errdefer ctx.grid.deinit(allocator);
 
+        const batch_size_limit = 30 * @max(@sizeOf(Account), @sizeOf(Transfer));
+        assert(batch_size_limit <= constants.message_body_size_max);
         try ctx.state_machine.init(
             allocator,
             ctx.time_sim.time(),
             &ctx.grid,
             .{
-                .batch_size_limit = constants.message_body_size_max,
+                .batch_size_limit = batch_size_limit,
                 .lsm_forest_compaction_block_count = StateMachine.Forest.Options
                     .compaction_block_count_min,
                 .lsm_forest_node_count = 1,

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -5,11 +5,10 @@ const mem = std.mem;
 
 const stdx = @import("stdx");
 const maybe = stdx.maybe;
-const MiB = stdx.MiB;
 
-const constants = @import("constants.zig");
 const tb = @import("tigerbeetle.zig");
 const vsr = @import("vsr.zig");
+const constants = vsr.constants;
 
 const MultiBatchEncoder = vsr.multi_batch.MultiBatchEncoder;
 const MultiBatchDecoder = vsr.multi_batch.MultiBatchDecoder;
@@ -44,14 +43,7 @@ pub const TestContext = struct {
     const Grid = @import("vsr/grid.zig").GridType(Storage);
     const fixtures = @import("testing/fixtures.zig");
 
-    pub const StateMachine = StateMachineType(Storage, .{
-        .release = vsr.Release.minimum,
-        // Overestimate the batch size because the test never compacts.
-        .message_body_size_max = TestContext.message_body_size_max,
-        .lsm_compaction_ops = constants.lsm_compaction_ops,
-    });
-
-    pub const message_body_size_max = 64 * @max(@sizeOf(Account), @sizeOf(Transfer));
+    pub const StateMachine = StateMachineType(Storage);
 
     pub const Operation = enum {
         create_accounts,
@@ -128,7 +120,7 @@ pub const TestContext = struct {
             ctx.time_sim.time(),
             &ctx.grid,
             .{
-                .batch_size_limit = message_body_size_max,
+                .batch_size_limit = constants.message_body_size_max,
                 .lsm_forest_compaction_block_count = StateMachine.Forest.Options
                     .compaction_block_count_min,
                 .lsm_forest_node_count = 1,
@@ -174,7 +166,7 @@ pub const TestContext = struct {
         operation: TestContext.StateMachine.Operation,
         input_buffer: []align(16) u8,
         input_size: u32,
-        output_buffer: *align(16) [message_body_size_max]u8,
+        output_buffer: *align(16) [constants.message_body_size_max]u8,
     ) []const u8 {
         const message_body: []align(16) const u8 = message_body: {
             if (!TestContext.StateMachine.operation_is_multi_batch(operation)) {
@@ -258,7 +250,7 @@ pub const TestContext = struct {
         op: u64,
         operation: TestContext.StateMachine.Operation,
         message_body_used: []align(16) const u8,
-        output_buffer: *align(16) [message_body_size_max]u8,
+        output_buffer: *align(16) [constants.message_body_size_max]u8,
     ) usize {
         const timestamp = context.state_machine.prepare_timestamp;
         context.busy = true;
@@ -634,7 +626,7 @@ fn check_version(
 
     var request = std.ArrayListAligned(u8, 16).init(allocator);
     defer request.deinit();
-    try request.ensureTotalCapacity(TestContext.message_body_size_max);
+    try request.ensureTotalCapacity(constants.message_body_size_max);
 
     var reply = std.ArrayListAligned(u8, 16).init(allocator);
     defer reply.deinit();
@@ -954,7 +946,7 @@ fn check_version(
                 const reply_actual_buffer = try allocator.alignedAlloc(
                     u8,
                     16,
-                    TestContext.message_body_size_max,
+                    constants.message_body_size_max,
                 );
                 defer allocator.free(reply_actual_buffer);
                 const payload_size: u32 = @intCast(request.items.len);
@@ -965,7 +957,7 @@ fn check_version(
                     operation_actual,
                     request.items,
                     payload_size,
-                    reply_actual_buffer[0..TestContext.message_body_size_max],
+                    reply_actual_buffer[0..constants.message_body_size_max],
                 );
 
                 switch (operation_actual) {
@@ -1202,6 +1194,7 @@ test "create_transfers/lookup_transfers" {
         // `credit_account_not_found` is a transient error, T2 cannot be reused:
         \\ transfer   T2 A1 A9    9   _  _  _  _    _ L9 C1   _ PEN   _   _   _   _ _  _   _   _ _ credit_account_not_found
         \\ transfer   T2 A1 A3  123   _  _  _  _    _ L1 C1   _ _     _   _   _   _ _  _   _   _ _ id_already_failed
+        \\ commit create_transfers
         \\
         \\ transfer   T3 A1 A2    1   _  _  _  _    _ L9 C1   _ PEN   _   _   _   _ _  _   _   _ _ accounts_must_have_the_same_ledger
         \\ transfer   T3 A1 A3    1   _  _  _  _    _ L9 C1   _ PEN   _   _   _   _ _  _   _   _ _ transfer_must_have_the_same_ledger_as_accounts
@@ -1220,6 +1213,7 @@ test "create_transfers/lookup_transfers" {
         \\ transfer   T4 A1 A3  123   _  _  _  _    _ L1 C1   _ _     _   _   _   _ _  _   _   _ _ id_already_failed
         \\
         \\ transfer   T5 A1 A3  123   _  _  _  _    1 L1 C1   _ PEN   _   _   _   _ _  _   _   _ _ ok
+        \\ commit create_transfers
 
         // Ensure that idempotence is checked first:
         \\ transfer   T5 A1 A3  123   _  _  _  _    1 L2 C1   _ PEN   _   _   _   _ _  _ _ _ _ exists_with_different_ledger
@@ -1304,6 +1298,8 @@ test "create/lookup 2-phase transfers" {
         \\ transfer T102 A8 A9   16  -0 U2 U2 U2   50 L6 C7   _   _   _ VOI   _   _  _ _ _ _ _ pending_id_must_not_be_int_max
         \\ transfer T102 A8 A9   16 102 U2 U2 U2   50 L6 C7   _   _   _ VOI   _   _  _ _ _ _ _ pending_id_must_be_different
         \\ transfer T102 A8 A9   16 103 U2 U2 U2   50 L6 C7   _   _   _ VOI   _   _  _ _ _ _ _ timeout_reserved_for_pending_transfer
+        \\ commit create_transfers
+
         // `pending_transfer_not_found` is a transient error, T102 cannot be reused:
         \\ transfer T102 A8 A9   16 103 U2 U2 U2    _ L6 C7   _   _   _ VOI   _   _  _ _ _ _ _ pending_transfer_not_found
         \\ transfer T102 A1 A2   13   _ U1 U1 U1    _ L1 C1   _   _   _   _   _   _  _ _ _ _ _ id_already_failed
@@ -1319,6 +1315,7 @@ test "create/lookup 2-phase transfers" {
         \\ transfer T103 A1 A2   15  T3 U1 U1 U1    _ L1 C1   _   _   _ VOI   _   _  _ _ _ _ _ ok
         \\ transfer T104 A1 A2   13  T3 U1 U1 U1    _ L1 C1   _   _ POS   _   _   _  _ _ _ _ _ pending_transfer_already_voided
         \\ transfer T104 A1 A2   15  T4 U1 U1 U1    _ L1 C1   _   _   _ VOI   _   _  _ _ _ _ _ pending_transfer_expired
+        \\ commit create_transfers
 
         // Transfers posted/voided with optional fields must not raise `exists_with_different_*`.
         // But transfers posted with posted.amount≠pending.amount may return
@@ -2831,55 +2828,47 @@ test "get_change_events" {
 // Sanity test to check the maximum batch size on a 1MiB message.
 // For a comprehensive test of all operations, see the `input_valid` test.
 test "StateMachine: batch_elements_max" {
-    // TODO: Zig 0.13.0 lazy compilation allowed creating a state machine
-    // with `test_min` config and a 1MiB message. With Zig 0.14.1, many
-    // assertions are hit during compile time.
-    // We should either move this test to another non-testing binary or isolate
-    // the code in another type that doesn’t require creating the state machine.
-    if (true) return error.SkipZigTest;
-    // 1MiB message:
-    const message_body_size_max = (1 * MiB) - @sizeOf(vsr.Header);
+    const StateMachine = StateMachineType(TestContext.Storage);
 
-    const StateMachine = StateMachineType(TestContext.Storage, .{
-        .release = vsr.Release.minimum,
-        .message_body_size_max = message_body_size_max,
-        .lsm_compaction_ops = constants.lsm_compaction_ops,
-    });
+    const events_max: u32 = @divExact(
+        constants.message_body_size_max,
+        @max(@sizeOf(Account), @sizeOf(Transfer)),
+    );
 
     // No multi-batch encode.
-    try testing.expectEqual(@as(u32, 8190), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max, StateMachine.operation_event_max(
         .deprecated_create_accounts_unbatched,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
-    try testing.expectEqual(@as(u32, 8190), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max, StateMachine.operation_event_max(
         .deprecated_lookup_accounts_unbatched,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
-    try testing.expectEqual(@as(u32, 8190), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max, StateMachine.operation_event_max(
         .deprecated_create_transfers_unbatched,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
-    try testing.expectEqual(@as(u32, 8190), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max, StateMachine.operation_event_max(
         .deprecated_lookup_transfers_unbatched,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
 
     // Multi-batch encoded (the size corresponding to one element is occupied by the trailer).
-    try testing.expectEqual(@as(u32, 8189), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max - 1, StateMachine.operation_event_max(
         .create_accounts,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
-    try testing.expectEqual(@as(u32, 8189), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max - 1, StateMachine.operation_event_max(
         .lookup_accounts,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
-    try testing.expectEqual(@as(u32, 8189), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max - 1, StateMachine.operation_event_max(
         .create_transfers,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
-    try testing.expectEqual(@as(u32, 8189), StateMachine.operation_event_max(
+    try testing.expectEqual(events_max - 1, StateMachine.operation_event_max(
         .lookup_transfers,
-        message_body_size_max,
+        constants.message_body_size_max,
     ));
 }
 
@@ -2887,7 +2876,7 @@ test "StateMachine: batch_elements_max" {
 // the former single-batch format.
 test "StateMachine: input_valid" {
     const allocator = std.testing.allocator;
-    const input = try allocator.alignedAlloc(u8, 16, 2 * TestContext.message_body_size_max);
+    const input = try allocator.alignedAlloc(u8, 16, 2 * constants.message_body_size_max);
     defer allocator.free(input);
 
     const build_input = struct {
@@ -2970,7 +2959,7 @@ test "StateMachine: input_valid" {
             .event_count = event_max + 1,
             .operation = operation,
         });
-        if (too_much_data.len < TestContext.message_body_size_max) {
+        if (too_much_data.len < constants.message_body_size_max) {
             try std.testing.expect(!context.state_machine.input_valid(
                 operation,
                 too_much_data,
@@ -2987,7 +2976,7 @@ test "StateMachine: input_valid" {
 // number of results that can fit in the reply message.
 test "StateMachine: query multi-batch input_valid" {
     const allocator = std.testing.allocator;
-    const input = try allocator.alignedAlloc(u8, 16, 2 * TestContext.message_body_size_max);
+    const input = try allocator.alignedAlloc(u8, 16, 2 * constants.message_body_size_max);
     defer allocator.free(input);
 
     var context: TestContext = undefined;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -66,7 +66,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
         pub const Tracer = Storage.Tracer;
         pub const SuperBlock = vsr.SuperBlockType(Storage);
         pub const MessageBus = @import("cluster/message_bus.zig").MessageBus;
-        pub const StateMachine = StateMachineType(Storage, constants.state_machine_config);
+        pub const StateMachine = StateMachineType(Storage);
         pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, AOF);
         pub const ReplicaReformat =
             vsr.ReplicaReformatType(StateMachine, MessageBus, Storage);

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -7,10 +7,7 @@ const constants = @import("../constants.zig");
 const GrooveType = @import("../lsm/groove.zig").GrooveType;
 const ForestType = @import("../lsm/forest.zig").ForestType;
 
-pub fn StateMachineType(
-    comptime Storage: type,
-    comptime config: constants.StateMachineConfig,
-) type {
+pub fn StateMachineType(comptime Storage: type) type {
     return struct {
         const StateMachine = @This();
         const Grid = @import("../vsr/grid.zig").GridType(Storage);
@@ -26,10 +23,6 @@ pub fn StateMachineType(
 
             return vsr.Operation.to(StateMachine, operation);
         }
-
-        pub const machine_constants = struct {
-            pub const message_body_size_max = config.message_body_size_max;
-        };
 
         pub fn EventType(comptime _: Operation) type {
             return u8; // Must be non-zero-sized for sliceAsBytes().
@@ -213,7 +206,7 @@ pub fn StateMachineType(
             timestamp: u64,
             operation: Operation,
             input: []align(16) const u8,
-            output: *align(16) [machine_constants.message_body_size_max]u8,
+            output: *align(16) [constants.message_body_size_max]u8,
         ) usize {
             assert(op != 0);
 
@@ -283,7 +276,6 @@ pub fn StateMachineType(
 fn WorkloadType(comptime StateMachine: type) type {
     return struct {
         const Workload = @This();
-        const constants = StateMachine.machine_constants;
 
         prng: *stdx.PRNG,
         options: Options,

--- a/src/testing/vortex/workload.zig
+++ b/src/testing/vortex/workload.zig
@@ -30,7 +30,6 @@
 const std = @import("std");
 const stdx = @import("stdx");
 const tb = @import("../../tigerbeetle.zig");
-const constants = @import("../../constants.zig");
 const StateMachineType = @import("../../state_machine.zig").StateMachineType;
 const RingBufferType = stdx.RingBufferType;
 const TestingStorage = @import("../storage.zig").Storage;
@@ -39,7 +38,7 @@ const ratio = stdx.PRNG.ratio;
 const log = std.log.scoped(.workload);
 const assert = std.debug.assert;
 const testing = std.testing;
-const StateMachine = StateMachineType(TestingStorage, constants.state_machine_config);
+const StateMachine = StateMachineType(TestingStorage);
 
 const events_count_max = 8189;
 const pending_transfers_count_max = 1024;

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -3,7 +3,7 @@ const stdx = @import("stdx");
 const constants = @import("../../constants.zig");
 const StateMachineType = @import("../../state_machine.zig").StateMachineType;
 const TestingStorage = @import("../storage.zig").Storage;
-const StateMachine = StateMachineType(TestingStorage, constants.state_machine_config);
+const StateMachine = StateMachineType(TestingStorage);
 
 // We could have used the idiomatic Zig API exposed by `vsr.tb_client`,
 // but we want to test the actual FFI exposed by `libtb_client`.

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -24,8 +24,7 @@ const AOF = vsr.aof.AOFType(IO);
 
 const MessageBus = vsr.message_bus.MessageBusReplica;
 const MessagePool = vsr.message_pool.MessagePool;
-pub const StateMachine =
-    vsr.state_machine.StateMachineType(Storage, constants.state_machine_config);
+pub const StateMachine = vsr.state_machine.StateMachineType(Storage);
 pub const Grid = vsr.GridType(Storage);
 
 const Client = vsr.ClientType(StateMachine, vsr.message_bus.MessageBusClient);


### PR DESCRIPTION
Replace specialization over `StateMachineConfig` with the global `constants`.
