### PR TITLE
CFO: Run Vortex in CFO

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -57,6 +57,8 @@ async function main_seeds() {
     "https://raw.githubusercontent.com/tigerbeetle/devhubdb/main/fuzzing/data.json";
   const issues_url =
     "https://api.github.com/repos/tigerbeetle/tigerbeetle/issues?per_page=200";
+  const logs_base =
+    "https://raw.githubusercontent.com/tigerbeetle/devhubdb/main/";
 
   const [records, issues] = await Promise.all([
     fetch_json(data_url),
@@ -163,6 +165,7 @@ async function main_seeds() {
     } else if (is_release(record)) {
       commit_extra = "(release)";
     }
+    const log_link = record.log ? ` <a href="${logs_base + record.log}">(log)</a>` : '';
     row_dom.innerHTML = `
           <td>
             <a href="https://github.com/tigerbeetle/tigerbeetle/commit/${record.commit_sha}"><code>${
@@ -173,7 +176,7 @@ async function main_seeds() {
           <td>${pull ? pull.user.login : ""}</td>
           <td><a href="?fuzzer=${record.fuzzer}&commit=${record.commit_sha}">${record.fuzzer}</a></td>
           <td><code onclick="copy_to_clipboard(this)">${record.command}</code></td>
-          <td><time>${format_duration(seed_duration_ms)}</time></td>
+          <td><time>${format_duration(seed_duration_ms)}</time>${log_link}</td>
           <td>
             <time>${format_duration(seed_freshness_ms)} ago</time>
             ${staleness_warning}

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -48,7 +48,7 @@ const CLIArgs = union(enum) {
         \\
         \\  zig build scripts -- changelog
         \\
-        \\  zig build scripts -- cfo [--budget-minutes=<n>] [--hang-minutes=<n>] [--concurrency=<n>]
+        \\  zig build scripts -- cfo [--budget=<duration>] [--refresh=<duration>] [--concurrency=<n>]
         \\
         \\  zig build scripts -- ci [--language=<dotnet|go|rust|java|node|python>] [--validate-release]
         \\                          [--build-docs]

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1261,6 +1261,7 @@ const LogTail = struct {
 
     pub fn deinit(log_tail: *LogTail, gpa: std.mem.Allocator) void {
         log_tail.ring.deinit(gpa);
+        log_tail.* = undefined;
     }
 
     pub fn reset(log_tail: *LogTail) void {

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -544,17 +544,15 @@ const Tasks = struct {
         assert(tasks.list.items.len == tasks.map.count());
         assert(tasks.list.items.len > 0);
 
-        var task_best_runtime_virtual: ?u64 = null;
         var task_best: ?*Task = null;
         for (tasks.list.items) |*task| {
             assert(task.runtime_virtual > 0);
             assert(task.generation <= tasks.generation);
 
             if (task.generation == tasks.generation) {
-                if (task_best_runtime_virtual == null or
-                    task_best_runtime_virtual.? > task.runtime_virtual)
+                if (task_best == null or
+                    task_best.?.runtime_virtual > task.runtime_virtual)
                 {
-                    task_best_runtime_virtual = task.runtime_virtual;
                     task_best = task;
                 }
             }

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1243,10 +1243,7 @@ const SeedRecord = struct {
 
 fn create_log_path(arena: std.mem.Allocator) ![]const u8 {
     const name = std.crypto.random.int(u128);
-    const buffer = try arena.alloc(u8, 256);
-    var stream = std.io.fixedBufferStream(buffer);
-    try stream.writer().print("./fuzzing/logs/{x:0>32}.vopr", .{name});
-    return stream.getWritten();
+    return std.fmt.allocPrint(arena, "./fuzzing/logs/{x:0>32}.vopr", .{name});
 }
 
 // TODO(Zig) This should probably be redone once zig's new reader/writer api's are available.

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -540,6 +540,7 @@ const Tasks = struct {
 
     /// Pick a task to run next.
     /// Returns the task with the minimal virtual runtime.
+    /// Break ties by choosing the task with the greater weight.
     pub fn sample(tasks: *const Tasks) *Task {
         assert(tasks.list.items.len == tasks.map.count());
         assert(tasks.list.items.len > 0);
@@ -551,7 +552,9 @@ const Tasks = struct {
 
             if (task.generation == tasks.generation) {
                 if (task_best == null or
-                    task_best.?.runtime_virtual > task.runtime_virtual)
+                    task_best.?.runtime_virtual > task.runtime_virtual or
+                    (task_best.?.runtime_virtual == task.runtime_virtual and
+                    task_best.?.weight < task.weight))
                 {
                     task_best = task;
                 }

--- a/src/stdx/ring_buffer.zig
+++ b/src/stdx/ring_buffer.zig
@@ -140,6 +140,15 @@ pub fn RingBufferType(
             self.count -= 1;
         }
 
+        pub fn advance_head_many(self: *RingBuffer, discard: u64) void {
+            assert(discard <= self.count);
+            if (self.buffer.len == 0) return;
+
+            self.index += discard;
+            self.index %= self.buffer.len;
+            self.count -= discard;
+        }
+
         pub inline fn retreat_head(self: *RingBuffer) void {
             assert(self.count < self.buffer.len);
 

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -62,6 +62,10 @@ pub const CLIArgs = struct {
     disable_faults: bool = false,
     output_directory: ?[]const u8 = null,
     log_debug: bool = false,
+    positional: struct {
+        /// Vortex is non-deterministic, but providing a seed can still help constrain the scenario.
+        seed: ?u64 = null,
+    },
 };
 
 pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
@@ -101,7 +105,7 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
     log.info("output directory: {s}", .{output_directory});
     log.info("starting test with target runtime of {}", .{args.test_duration});
 
-    const seed = std.crypto.random.int(u64);
+    const seed = args.positional.seed orelse std.crypto.random.int(u64);
     var prng = stdx.PRNG.from_seed(seed);
 
     var network = try faulty_network.Network.listen(

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -82,6 +82,7 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
         });
     } else {
         log.warn("vortex may spawn runaway processes when run on a non-Linux OS", .{});
+        log.warn("vortex may encounter port collisions non-Linux OS", .{});
     }
 
     const shell = try Shell.create(allocator);


### PR DESCRIPTION
Run Vortex in CFO.

- Currently it only fuzzes debug builds (for the replica stack traces) with 3 replicas. Once we have stack traces in release mode I will change it to fuzz release builds instead, for maximum realism.

Since Vortex is non-deterministic, we need to capture the log (suffix) of failed runs:

- Log suffix includes the stack trace.
- The log file is linked from the devhub.
- Logs are stored in `devhubdb/fuzzing/logs/*.vopr`. (`.vopr` since I am used to using that extension for server logs, for syntax highlighting.)
- Currently we only store logs for Vortex runs, but that is configurable in `Fuzzer.capture_logs()`. It might be worth enabling it for VOPR as well, to make it easier to dedup multiple failing seeds.
- When the seed record is dropped from the devhubdb, the corresponding log file is deleted at the same time.
