### PR TITLE
Review scan_lookup

### DIFF
--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -653,8 +653,12 @@ const Environment = struct {
                 env.forest.grooves.things.scan_builder.reset();
             }
 
-            const query_results_max =
-                env.prng.range_inclusive(usize, 1, env.scan_lookup_buffer.len);
+            const query_results_max: u32 = env.prng.range_inclusive(
+                u32,
+                1,
+                @intCast(env.scan_lookup_buffer.len),
+            );
+            assert(query_results_max > 0);
             const query_results = results: {
                 const scan = env.scan_from_condition(query_spec, timestamp_previous);
                 env.scan_lookup = ScanLookup.init(&env.forest.grooves.things, scan);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1704,6 +1704,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         self.batch_size_limit,
                     ),
                 );
+                assert(limit > 0);
                 assert(scan_buffer.len >= limit);
                 scan_lookup.read(
                     scan_buffer[0..limit],
@@ -1823,6 +1824,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                                 self.batch_size_limit,
                             ),
                         );
+                        assert(limit > 0);
                         assert(scan_buffer.len >= limit);
                         scan_lookup.read(
                             scan_buffer[0..limit],
@@ -2073,6 +2075,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         self.batch_size_limit,
                     ),
                 );
+                assert(limit > 0);
                 assert(scan_buffer.len >= limit);
                 scan_lookup.read(
                     scan_buffer[0..limit],
@@ -2163,6 +2166,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         self.batch_size_limit,
                     ),
                 );
+                assert(limit > 0);
                 assert(scan_buffer.len >= limit);
                 scan_lookup.read(
                     scan_buffer[0..limit],
@@ -2445,6 +2449,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 // Limiting the buffer size according to the query limit.
                 // TODO: Prevent clients from setting the limit larger than the buffer size.
                 const limit = @min(filter.limit, limit_max);
+                assert(limit > 0);
                 assert(scan_buffer.len >= limit);
                 scan_lookup.read(
                     scan_buffer[0..limit],


### PR DESCRIPTION
- Use `u32` instead of `usize`
- Use naming convention `count` and `index`
- Assert limit should be > 0 (it's validated before prefetch)

Ref https://github.com/tigerbeetle/tigerbeetle/pull/3317#pullrequestreview-3376495930