### PR TITLE
rust/ci: disable client validation

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -22,9 +22,11 @@ jobs:
         with:
           ref: release
       # Run on the latest tag. The release branch is ahead of release tag over the weekend.
+      # NB: Temporarily overriden to cb22/release-validate-override - make sure to revert back
+      # before the next release!
       - run: |
           TAG=$(gh release list --limit 1 | cut -f1)
-          git fetch origin $TAG && git switch -d FETCH_HEAD
+          git fetch origin cb22/release-validate-override && git switch -d FETCH_HEAD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -30,35 +30,40 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     version: []const u8,
     tigerbeetle: []const u8,
 }) !void {
-    const tmp_dir = try shell.create_tmp_dir();
-    defer shell.cwd.deleteTree(tmp_dir) catch {};
+    _ = shell;
+    _ = gpa;
+    _ = options;
+    // The Rust client is not yet published.
 
-    try shell.pushd(tmp_dir);
-    defer shell.popd();
+    // const tmp_dir = try shell.create_tmp_dir();
+    // defer shell.cwd.deleteTree(tmp_dir) catch {};
 
-    var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
-        .development = true,
-        .prebuilt = options.tigerbeetle,
-    });
-    defer tmp_beetle.deinit(gpa);
-    errdefer tmp_beetle.log_stderr();
+    // try shell.pushd(tmp_dir);
+    // defer shell.popd();
 
-    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
+    // var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
+    //     .development = true,
+    //     .prebuilt = options.tigerbeetle,
+    // });
+    // defer tmp_beetle.deinit(gpa);
+    // errdefer tmp_beetle.log_stderr();
 
-    // Create a new Rust project to test the published crate
-    try shell.exec("cargo init --name test_tigerbeetle", .{});
+    // try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
-    // Add tigerbeetle dependency to Cargo.toml
-    try shell.exec("cargo add tigerbeetle@{version}", .{ .version = options.version });
-    try shell.exec("cargo add futures@0.3", .{});
+    // // Create a new Rust project to test the published crate
+    // try shell.exec("cargo init --name test_tigerbeetle", .{});
 
-    try Shell.copy_path(
-        shell.project_root,
-        "src/clients/rust/samples/basic/src/main.rs",
-        shell.cwd,
-        "src/main.rs",
-    );
-    try shell.exec("cargo run", .{});
+    // // Add tigerbeetle dependency to Cargo.toml
+    // try shell.exec("cargo add tigerbeetle@{version}", .{ .version = options.version });
+    // try shell.exec("cargo add futures@0.3", .{});
+
+    // try Shell.copy_path(
+    //     shell.project_root,
+    //     "src/clients/rust/samples/basic/src/main.rs",
+    //     shell.cwd,
+    //     "src/main.rs",
+    // );
+    // try shell.exec("cargo run", .{});
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {


### PR DESCRIPTION
Release validation itself is run from `main`, but then checks out a branch. Override this, to be the branch of this PR.

This means that this branch must stay around after the PR is merged.