### PR TITLE
Bump macOS image due to GHA deprecation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - { os: 'ubuntu-latest-arm64' }
           - { os: 'windows-latest' }
           - { os: 'macos-latest' }
-          - { os: 'macos-13' }
+          - { os: 'macos-14' }
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf false
@@ -82,9 +82,9 @@ jobs:
           - { os: 'macos-latest',   language: 'node',    language_version: '20.x'  }
           - { os: 'macos-latest',   language: 'python',  language_version: '3.13'  }
 
-          - { os: 'macos-13',       language: 'go',      language_version: '1.21'  }
-          - { os: 'macos-13',       language: 'node',    language_version: '20.x'  }
-          - { os: 'macos-13',       language: 'python',  language_version: '3.13'  }
+          - { os: 'macos-14',       language: 'go',      language_version: '1.21'  }
+          - { os: 'macos-14',       language: 'node',    language_version: '20.x'  }
+          - { os: 'macos-14',       language: 'python',  language_version: '3.13'  }
 
           # Limited matrix for Ubuntu ARM - runners are paid and we're not sure of the cost yet.
           - { os: 'ubuntu-latest-arm64',  language: 'dotnet',  language_version: '8.0.x' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - { os: 'ubuntu-latest-arm64' }
           - { os: 'windows-latest' }
           - { os: 'macos-latest' }
-          - { os: 'macos-14' }
+          - { os: 'macos-15-intel' }
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf false
@@ -82,9 +82,9 @@ jobs:
           - { os: 'macos-latest',   language: 'node',    language_version: '20.x'  }
           - { os: 'macos-latest',   language: 'python',  language_version: '3.13'  }
 
-          - { os: 'macos-14',       language: 'go',      language_version: '1.21'  }
-          - { os: 'macos-14',       language: 'node',    language_version: '20.x'  }
-          - { os: 'macos-14',       language: 'python',  language_version: '3.13'  }
+          - { os: 'macos-15-intel',       language: 'go',      language_version: '1.21'  }
+          - { os: 'macos-15-intel',       language: 'node',    language_version: '20.x'  }
+          - { os: 'macos-15-intel',       language: 'python',  language_version: '3.13'  }
 
           # Limited matrix for Ubuntu ARM - runners are paid and we're not sure of the cost yet.
           - { os: 'ubuntu-latest-arm64',  language: 'dotnet',  language_version: '8.0.x' }


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/