### PR TITLE
Fix the testing statemachine

### DIFF
--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -25,6 +25,14 @@ pub fn StateMachineType(comptime Storage: type) type {
                 return u8; // Must be non-zero-sized for sliceAsBytes().
             }
 
+            pub fn result_size(_: Operation) u32 {
+                return @sizeOf(u8);
+            }
+
+            pub fn event_size(_: Operation) u32 {
+                return @sizeOf(u8);
+            }
+
             pub fn from_vsr(operation: vsr.Operation) ?Operation {
                 if (operation.vsr_reserved()) return null;
                 return vsr.Operation.to(Operation, operation);


### PR DESCRIPTION
Ref commit https://github.com/tigerbeetle/tigerbeetle/pull/3344/commits/cc84ac6c07e96971853cb46cc3e15e9d74db44b7

```
./zig/zig build vopr -Drelease -Dvopr-state-machine=testing
vopr
└─ run vopr
   └─ zig build-exe vopr ReleaseSafe x86_64-linux 1 errors
src/vopr.zig:364:60: error: no field or member function named 'event_size' in 'testing.state_machine.StateMachineType(testing.storage.Storage).Operation'
            event_size_max = @max(event_size_max, operation.event_size());
                                                  ~~~~~~~~~^~~~~~~~~~~
src/testing/state_machine.zig:17:31: note: enum declared here
        pub const Operation = enum(u8) {
```