### PR TITLE
stdx: use idiomatic comptime error messages

### DIFF
--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -295,8 +295,7 @@ fn assert_valid_value_type(comptime T: type) void {
             return;
         }
 
-        @compileLog("unsupported type", T);
-        unreachable;
+        @compileError("flags: unsupported type: " ++ @typeName(T));
     }
 }
 

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -939,8 +939,8 @@ pub fn array_print(
         var args_worst_case: Args = undefined;
         for (ArgsStruct.fields, 0..) |field, index| {
             const arg_worst_case = switch (field.type) {
-                u64 => std.math.maxInt(field.type),
-                else => @compileError("array_print: unhandled type"),
+                u8, u16, u32, u64, u128 => std.math.maxInt(field.type),
+                else => @compileError("array_print: unsupported type: " ++ @typeName(field.type)),
             };
             args_worst_case[index] = arg_worst_case;
         }


### PR DESCRIPTION
TIL about @typeName (thanks, ChatGPT), let's use it! Example error message:

```
λ ../zig/zig build check
check
└─ zig build-exe tigerbeetle Debug aarch64-macos 1 errors
src/stdx/flags.zig:298:9: error: flags: unsupported type: net.Address
        @compileError("flags: unsupported type: " ++ @typeName(T));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/stdx/flags.zig:170:44: note: called from here
                    assert_valid_value_type(optional.child);
                    ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```