### PR TITLE
IO: allow canceling single operations

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -291,6 +291,28 @@ pub const IO = struct {
         // TODO Cancel in-flight async IO and wait for all completions.
     }
 
+    pub const CancelError = error{
+        NotRunning,
+        NotInterruptable,
+    } || posix.UnexpectedError;
+
+    pub fn cancel(
+        _: *IO,
+        comptime Context: type,
+        _: Context,
+        comptime _: fn (
+            context: Context,
+            completion: *Completion,
+            result: CancelError!void,
+        ) void,
+        _: struct {
+            completion: *Completion,
+            target: *Completion,
+        },
+    ) void {
+        // TODO Cancel in-flight async IO.
+    }
+
     pub const AcceptError = posix.AcceptError || posix.SetSockOptError;
 
     pub fn accept(

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -310,7 +310,7 @@ pub const IO = struct {
             target: *Completion,
         },
     ) void {
-        // TODO Cancel in-flight async IO.
+        @panic("cancelation is not supported on darwin");
     }
 
     pub const AcceptError = posix.AcceptError || posix.SetSockOptError;

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -505,7 +505,6 @@ pub const IO = struct {
                                 },
                                 .AGAIN => error.WouldBlock,
                                 .BADF => error.FileDescriptorInvalid,
-                                .CANCELED => error.Canceled,
                                 .CONNABORTED => error.ConnectionAborted,
                                 .FAULT => unreachable,
                                 .INVAL => error.SocketNotListening,
@@ -651,7 +650,6 @@ pub const IO = struct {
                                     return;
                                 },
                                 .BADF => error.NotOpenForReading,
-                                .CANCELED => error.Canceled,
                                 .CONNRESET => error.ConnectionResetByPeer,
                                 .FAULT => unreachable,
                                 .INVAL => error.Alignment,
@@ -789,7 +787,6 @@ pub const IO = struct {
                                 },
                                 .AGAIN => error.WouldBlock,
                                 .BADF => error.NotOpenForWriting,
-                                .CANCELED => error.Canceled,
                                 .DESTADDRREQ => error.NotConnected,
                                 .DQUOT => error.DiskQuota,
                                 .FAULT => unreachable,
@@ -884,7 +881,6 @@ pub const IO = struct {
         OperationNotSupported,
         PermissionDenied,
         ProtocolFailure,
-        Canceled,
     } || posix.UnexpectedError;
 
     pub fn accept(
@@ -1070,7 +1066,6 @@ pub const IO = struct {
         SystemResources,
         Unseekable,
         ConnectionTimedOut,
-        Canceled,
     } || posix.UnexpectedError;
 
     pub fn read(
@@ -1294,7 +1289,6 @@ pub const IO = struct {
         Unseekable,
         AccessDenied,
         BrokenPipe,
-        Canceled,
     } || posix.UnexpectedError;
 
     pub fn write(

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -858,6 +858,7 @@ test "cancel_all" {
 }
 
 test "cancel_one" {
+    if (builtin.target.os.tag != .linux) return;
     try struct {
         const Context = @This();
 

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -857,7 +857,7 @@ test "cancel_all" {
     }.run_test();
 }
 
-test "cancel_one" {
+test "cancel" {
     if (builtin.target.os.tag != .linux) return;
     try struct {
         const Context = @This();

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -299,6 +299,28 @@ pub const IO = struct {
         // TODO Cancel in-flight async IO and wait for all completions.
     }
 
+    pub const CancelError = error{
+        NotRunning,
+        NotInterruptable,
+    } || posix.UnexpectedError;
+
+    pub fn cancel(
+        _: *IO,
+        comptime Context: type,
+        _: Context,
+        comptime _: fn (
+            context: Context,
+            completion: *Completion,
+            result: CancelError!void,
+        ) void,
+        _: struct {
+            completion: *Completion,
+            target: *Completion,
+        },
+    ) void {
+        // TODO Cancel in-flight async IO.
+    }
+
     pub const AcceptError = posix.AcceptError || posix.SetSockOptError;
 
     pub fn accept(

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -318,7 +318,7 @@ pub const IO = struct {
             target: *Completion,
         },
     ) void {
-        // TODO Cancel in-flight async IO.
+        @panic("cancelation is not supported on windows");
     }
 
     pub const AcceptError = posix.AcceptError || posix.SetSockOptError;

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -338,6 +338,7 @@ pub fn StorageType(comptime IO: type) type {
                     }
                 },
 
+                error.Canceled,
                 error.WouldBlock,
                 error.NotOpenForReading,
                 error.ConnectionResetByPeer,

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -338,7 +338,6 @@ pub fn StorageType(comptime IO: type) type {
                     }
                 },
 
-                error.Canceled,
                 error.WouldBlock,
                 error.NotOpenForReading,
                 error.ConnectionResetByPeer,


### PR DESCRIPTION
Previously, the IO subsystem only allowed to cancel all asynchronous in-flight, this change allows to issue cancel request for individual in-flight operations.