### PR TITLE
bus: follow up refactors

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -25,12 +25,13 @@ pub fn MessageBusType(comptime IO: type) type {
     };
 
     return struct {
+        const Address = std.net.Address;
         const MessageBus = @This();
 
         pool: *MessagePool,
         io: *IO,
 
-        configuration: []const std.net.Address,
+        configuration: []const Address,
 
         process: ProcessID,
         /// Prefix for log messages.
@@ -42,7 +43,7 @@ pub fn MessageBusType(comptime IO: type) type {
         ///
         /// This allows passing port 0 as an address for the OS to pick an open port for us
         /// in a TOCTOU immune way and logging the resulting port number.
-        accept_address: ?std.net.Address = null,
+        accept_address: ?Address = null,
         accept_completion: IO.Completion = undefined,
         /// The connection reserved for the currently in progress accept operation.
         /// This is non-null exactly when an accept operation is submitted.
@@ -81,7 +82,7 @@ pub fn MessageBusType(comptime IO: type) type {
         prng: stdx.PRNG,
 
         pub const Options = struct {
-            configuration: []const std.net.Address,
+            configuration: []const Address,
             io: *IO,
             clients_limit: ?usize = null,
         };

--- a/src/message_bus_fuzz.zig
+++ b/src/message_bus_fuzz.zig
@@ -324,7 +324,7 @@ const Node = struct {
     id: u8,
 
     fn send_message(node: *Node, target: u8, message: *Message) void {
-        if (target < node.message_bus.configuration.len) {
+        if (target < node.message_bus.replicas_addresses.len) {
             node.message_bus.send_message_to_replica(target, message);
         } else {
             assert(node.message_bus.process == .replica);


### PR DESCRIPTION
- Add `MessageBus.Address`, don't assume it is `std.net.Address`
- `MessageBus` now owns `[]Address`, for simpler lifetimes and to allow for changing addresses
- use `u32` for tracking message sizes