### PR TITLE
Vortex: Add rust instructions; simplify java instructions

### DIFF
--- a/src/testing/vortex/java_driver/README.md
+++ b/src/testing/vortex/java_driver/README.md
@@ -5,15 +5,10 @@ This implements a driver for Vortex, using the Java client.
 Run the following to test with this driver:
 
 ```
-./zig/zig build -Drelease install
-./zig/zig build -Drelease vortex:build
-./zig/zig build clients:java -Drelease
+./zig/zig build clients:java
 (cd src/clients/java && mvn package)
 (cd src/testing/vortex/java_driver && mvn package)
 CLASS_PATH="src/clients/java/target/tigerbeetle-java-0.0.1-SNAPSHOT.jar"
 CLASS_PATH="${CLASS_PATH}:src/testing/vortex/java_driver/target/vortex-driver-java-0.0.1-SNAPSHOT.jar"
-    zig-out/bin/vortex supervisor \
-        --tigerbeetle-executable=./zig-out/bin/tigerbeetle \
-        --test-duration=1m \
-        --driver-command=java\ -cp\ $CLASS_PATH\ Main
+    zig build vortex -- supervisor --driver-command=java\ -cp\ $CLASS_PATH\ Main
 ```

--- a/src/testing/vortex/rust_driver/README.md
+++ b/src/testing/vortex/rust_driver/README.md
@@ -1,0 +1,13 @@
+# Vortex Rust Driver
+
+This implements a driver for Vortex, using the Rust client.
+
+Run the following to test with this driver:
+
+```
+./zig/zig build clients:rust
+(cd src/clients/rust && cargo build)
+(cd src/testing/vortex/rust_driver && cargo build)
+zig build vortex -- supervisor \
+    --driver-command='./src/testing/vortex/rust_driver/target/debug/vortex-driver-rust'
+```


### PR DESCRIPTION
Vortex can build its own tigerbeetle binary if one isn't supplied.

The default run duration is 1 minute already, so no need to specify it.