### PR TITLE
vsr: restore assert for syncing replica in replace_header

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -8337,7 +8337,7 @@ pub fn ReplicaType(
 
             if (self.op_checkpoint() < header.op and header.op <= self.commit_min) {
                 if (self.journal.header_with_op(header.op)) |_| {
-                    assert(self.journal.has_header(header));
+                    assert(self.syncing == .updating_checkpoint or self.journal.has_header(header));
                 }
             }
 


### PR DESCRIPTION
This PR resolves the following failing seed: `./zig/zig build vopr -Drelease -Dvopr-state-machine=testing -- 6283830614359312224`, which trips an overzealous assert in `replace_header` under the following scenario:

1. R receives a SV message
2. R finds that repair may be stuck, commit_min hasn't advanced in a long time (`repair_stuck` returns True)
3. R transitions to state sync, accepts headers from the future checkpoint (in `start_view_set_journal`) , advances its commit_min, begins updating its superblock
4. R receives another SV, but this time `repair_stuck` returns `False`, as we advance our commit_min before we begin updating our superblock
5. R invokes `start_view_set_journal`, accepts headers from the future checkpoint (in `replace_header`), which asserts that the header for a committed op (if it exists) must match the header in the SV message. 
6. 💥

https://github.com/tigerbeetle/tigerbeetle/blob/dafb825b1cbb2dc7342ac485707f2c4e0c702523/src/vsr/replica.zig#L8338-L8342


The reason why this failure showed up right now is because https://github.com/tigerbeetle/tigerbeetle/pull/3294 refactored the corresponding assertm and changed it from `assert(self.syncing == .updating_checkpoint or self.journal.has_header(header));` → ` assert(self.journal.has_header(header));`. This PR restores the old assert.