### PR TITLE
stdx: refactor parse_flag_value

### DIFF
--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -369,6 +369,7 @@ fn parse_value(comptime T: type, flag: []const u8, value: [:0]const u8) T {
         } else |err| switch (err) {
             error.InvalidFlagValue => {
                 const message = diagnostic.?;
+                assert(std.ascii.isLower(message[0]));
                 assert(message[message.len - 1] == ':');
                 fatal("{s}: {s} '{s}'", .{ flag, message, value });
             },
@@ -460,6 +461,129 @@ test flag_name {
 fn flag_name_positional(comptime field: std.builtin.Type.StructField) []const u8 {
     comptime assert(std.mem.indexOfScalar(u8, field.name, '_') == null);
     return "<" ++ field.name ++ ">";
+}
+
+/// Fuzz parse_flag_value function:
+///
+/// - Check that ok cases return a value.
+/// - Check that err cases return an error with a properly formatted diagnostics.
+/// - Check that the diagnostic contains specified substring
+/// - Random tests with the input alphabet seeded from explicit cases.
+/// - Random tests with uniform input.
+pub fn parse_flag_value_fuzz(
+    comptime T: type,
+    parse_flag_value: fn ([]const u8, *?[]const u8) error{InvalidFlagValue}!T,
+    cases: struct {
+        ok: []const struct { []const u8, T },
+        err: []const struct { []const u8, []const u8 },
+    },
+) !void {
+    comptime assert(T.parse_flag_value == parse_flag_value);
+
+    const test_count = 1024;
+    const string_size_max = 32;
+
+    const gpa = std.testing.allocator;
+    var prng = stdx.PRNG.from_seed_testing();
+
+    for (cases.ok) |case| {
+        const string, const want = case;
+        assert(string.len > 0);
+
+        var diagnostic: ?[]const u8 = null;
+        const got = try parse_flag_value(string, &diagnostic);
+        assert(diagnostic == null);
+        try std.testing.expectEqual(want, got);
+    }
+
+    for (cases.err) |case| {
+        const string, const want_message = case;
+        assert(string.len > 0); // Empty value are rejected early.
+
+        var diagnostic: ?[]const u8 = null;
+        if (parse_flag_value(string, &diagnostic)) |value| {
+            std.debug.print("expected an error, got value: input='{s}', value={}", .{
+                string,
+                value,
+            });
+            return error.TestUnexpectedResult;
+        } else |err| switch (err) {
+            error.InvalidFlagValue => {
+                try parse_flag_value_check_diagnostic(string, diagnostic);
+                if (stdx.cut(diagnostic.?, want_message) == null) {
+                    std.debug.print(
+                        "expected diagnostic to contain substring='{s}' diagnostic='{s}'",
+                        .{ want_message, diagnostic.? },
+                    );
+                    return error.TestUnexpectedResult;
+                }
+            },
+        }
+    }
+
+    var corpus: std.ArrayListUnmanaged(u8) = .empty;
+    defer corpus.deinit(gpa);
+
+    for (cases.ok) |case| try corpus.appendSlice(gpa, case[0]);
+    for (cases.err) |case| try corpus.appendSlice(gpa, case[0]);
+    for (0..5) |_| try corpus.append(gpa, prng.int(u8));
+
+    std.mem.sort(u8, corpus.items, {}, std.sort.asc(u8));
+
+    const alphabet = unique(corpus.items);
+
+    var string_buffer: [string_size_max]u8 = @splat(0);
+    for (0..test_count) |_| {
+        const string_size = prng.range_inclusive(usize, 1, string_size_max);
+        const string = string_buffer[0..string_size];
+        assert(string.len > 0);
+        if (prng.boolean()) {
+            for (string) |*c| c.* = alphabet[prng.index(alphabet)];
+        } else {
+            for (string) |*c| c.* = prng.int(u8);
+        }
+
+        var diagnostic: ?[]const u8 = null;
+        if (parse_flag_value(string, &diagnostic)) |_| {
+            assert(diagnostic == null);
+        } else |err| switch (err) {
+            error.InvalidFlagValue => try parse_flag_value_check_diagnostic(string, diagnostic),
+        }
+    }
+}
+
+fn parse_flag_value_check_diagnostic(string: []const u8, diagnostic: ?[]const u8) !void {
+    const message = diagnostic orelse {
+        std.debug.print("expected a diagnostic: string='{s}'", .{string});
+        return error.TestUnexpectedResult;
+    };
+    if (!(message.len > 0 and
+        std.ascii.isLower(message[0]) and
+        message[message.len - 1] == ':'))
+    {
+        std.debug.print("wrong diagnostic format: string='{s}' diagnostic='{s}'", .{
+            string,
+            message,
+        });
+        return error.TestUnexpectedResult;
+    }
+}
+
+fn unique(sorted: []u8) []u8 {
+    assert(sorted.len > 0);
+
+    var count: usize = 1;
+    for (1..sorted.len) |index| {
+        assert(sorted[count - 1] <= sorted[index]);
+        if (sorted[count - 1] == sorted[index]) {
+            // Duplicate! Skip to the next index.
+        } else {
+            sorted[count] = sorted[index];
+            count += 1;
+        }
+    }
+
+    return sorted[0..count];
 }
 
 // CLI parsing makes a liberal use of `fatal`, so testing it within the process is impossible. We

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -50,20 +50,20 @@ pub const Ratio = struct {
     }
 
     pub fn parse_flag_value(
-        value: []const u8,
+        string: []const u8,
         static_diagnostic: *?[]const u8,
     ) error{InvalidFlagValue}!Ratio {
-        assert(value.len > 0);
-        const numerator_string, const denominator_string = stdx.cut(value, "/") orelse {
+        assert(string.len > 0);
+        const string_numerator, const string_denominator = stdx.cut(string, "/") orelse {
             static_diagnostic.* = "expected 'a/b' ratio, but found:";
             return error.InvalidFlagValue;
         };
 
-        const numerator = std.fmt.parseInt(u64, numerator_string, 10) catch {
+        const numerator = std.fmt.parseInt(u64, string_numerator, 10) catch {
             static_diagnostic.* = "invalid numerator:";
             return error.InvalidFlagValue;
         };
-        const denominator = std.fmt.parseInt(u64, denominator_string, 10) catch {
+        const denominator = std.fmt.parseInt(u64, string_denominator, 10) catch {
             static_diagnostic.* = "invalid denominator:";
             return error.InvalidFlagValue;
         };

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1001,7 +1001,7 @@ pub const ByteSize = struct {
 
         const split_index = for (string, 0..) |c, index| {
             if (std.ascii.isDigit(c) or c == '_') {
-                // Numeric string part continues
+                // Numeric part continues.
             } else break index;
         } else string.len;
 

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -994,23 +994,23 @@ pub const ByteSize = struct {
     };
 
     pub fn parse_flag_value(
-        value: []const u8,
+        string: []const u8,
         static_diagnostic: *?[]const u8,
     ) error{InvalidFlagValue}!ByteSize {
-        assert(value.len != 0);
+        assert(string.len != 0);
 
-        const split_index = for (value, 0..) |c, index| {
+        const split_index = for (string, 0..) |c, index| {
             if (std.ascii.isDigit(c) or c == '_') {
-                // Numeric value part continues
+                // Numeric string part continues
             } else break index;
-        } else value.len;
+        } else string.len;
 
-        const value_input = value[0..split_index];
-        const unit_input = value[split_index..];
-        maybe(value_input.len == 0);
-        maybe(unit_input.len == 0);
+        const string_amount = string[0..split_index];
+        const string_unit = string[split_index..];
+        maybe(string_amount.len == 0);
+        maybe(string_unit.len == 0);
 
-        const amount = std.fmt.parseUnsigned(u64, value_input, 10) catch |err| switch (err) {
+        const amount = std.fmt.parseUnsigned(u64, string_amount, 10) catch |err| switch (err) {
             error.Overflow => {
                 static_diagnostic.* = "value exceeds 64-bit unsigned integer:";
                 return error.InvalidFlagValue;
@@ -1021,10 +1021,10 @@ pub const ByteSize = struct {
             },
         };
 
-        const unit = if (unit_input.len == 0)
+        const unit = if (string_unit.len == 0)
             .bytes
         else inline for (comptime std.enums.values(Unit)) |tag| {
-            if (std.ascii.eqlIgnoreCase(unit_input, @tagName(tag))) break tag;
+            if (std.ascii.eqlIgnoreCase(string_unit, @tagName(tag))) break tag;
         } else {
             static_diagnostic.* = "invalid unit in size, needed KiB, MiB, GiB or TiB:";
             return error.InvalidFlagValue;


### PR DESCRIPTION
Wanted to do a quick 5-minute recreational refactor to start the day/week, but got carried away a bit 🤣 

- Use idiomatic signature for parse_flag_value with error union and diagnostic out parameter (https://matklad.github.io/2025/11/06/error-codes-for-control-flow.html). Sorry for not getting this right from the start. 
- Fix error message format when parsing duration to avoid tripping an assert:

```
λ ./zig/zig build run -- benchmark --transfer-batch-delay=nope
thread 10224850 panic: reached unreachable code
/Users/matklad/p/tb/main/zig/lib/std/debug.zig:550:14: 0x100367c93 in assert (tigerbeetle)
    if (!ok) unreachable; // assertion failure
             ^
/Users/matklad/p/tb/main/src/stdx/flags.zig:354:23: 0x10075bb07 in parse_value__anon_168588 (tigerbeetle)
                assert(message[message.len - 1] == ':');
```

- Implement universal fuzzer for all `parse_flag_value`, to catch this sort of thing proactively.
- Touch up all parse_flag_value implementations.
- Fix incorrect comment in ByteSize parsing, revealed by the fuzzer.
- Add a test that durations _don't_ support using `_` as separator (we allow `_` in other places). For durations, I don't think it matters one way or the other, but I just wanted to be explicit here. 
