### PR TITLE
routing: sometimes test fully random codes

### DIFF
--- a/src/vsr/routing.zig
+++ b/src/vsr/routing.zig
@@ -480,6 +480,9 @@ test route_decode {
                 if (prng.chance(ratio(1, 20))) {
                     code ^= prng.bit(u64);
                 }
+                if (prng.chance(ratio(1, 20))) {
+                    code = prng.int(u64);
+                }
 
                 var routing = Routing.init(.{
                     .replica = prng.int_inclusive(u8, replica_count - 1),


### PR DESCRIPTION
Our existing generation tries hard to generte codes on the boundary between valid and invalid, but it arguably tries too hard --- some encodings are impossible to genreate.

Fix that by using completely random bytes once in a while.