### PR TITLE
stdx: handle zero ratios better

### DIFF
--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -480,7 +480,7 @@ pub fn parse_flag_value_fuzz(
 ) !void {
     comptime assert(T.parse_flag_value == parse_flag_value);
 
-    const test_count = 1024;
+    const test_count = 50_000;
     const string_size_max = 32;
 
     const gpa = std.testing.allocator;


### PR DESCRIPTION
- Print zero ratio as `0`
- Parse `0` as a ratio
- Return error for `0/0`
- Bump fuzz iteration count! The test does find the bug with 1 000 000 iterations, but we haven't seen it before, which means that our iteration count is probably too small. The test still completes in 100ms with 50k iterations.

  Note that `1/0` and such didn't crush, as do check that nom <= denom, `0/0` was the single problematic input.
