### PR TITLE
flags: make positional DSL more natural

### DIFF
--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -59,10 +59,10 @@ const FuzzersEnum = std.meta.FieldEnum(@TypeOf(Fuzzers));
 
 const CLIArgs = struct {
     events_max: ?usize = null,
-    positional: struct {
-        fuzzer: FuzzersEnum,
-        seed: ?u64 = null,
-    },
+
+    @"--": void,
+    fuzzer: FuzzersEnum,
+    seed: ?u64 = null,
 };
 
 pub fn main() !void {
@@ -104,9 +104,9 @@ pub fn main() !void {
 
     const cli_args = stdx.flags(&args, CLIArgs);
 
-    switch (cli_args.positional.fuzzer) {
+    switch (cli_args.fuzzer) {
         .smoke => {
-            assert(cli_args.positional.seed == null);
+            assert(cli_args.seed == null);
             assert(cli_args.events_max == null);
             try main_smoke(gpa);
         },
@@ -158,13 +158,13 @@ fn main_smoke(gpa: std.mem.Allocator) !void {
 }
 
 fn main_single(gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
-    assert(cli_args.positional.fuzzer != .smoke);
+    assert(cli_args.fuzzer != .smoke);
 
-    const seed = cli_args.positional.seed orelse std.crypto.random.int(u64);
+    const seed = cli_args.seed orelse std.crypto.random.int(u64);
     log.info("Fuzz seed = {}", .{seed});
 
     var timer = try std.time.Timer.start();
-    switch (cli_args.positional.fuzzer) {
+    switch (cli_args.fuzzer) {
         .smoke => unreachable,
         .canary => {
             if (seed % 100 == 0) {

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -201,24 +201,7 @@ fn parse_flags(args: *std.process.ArgIterator, comptime Flags: type) Flags {
         }
     }
 
-    // Would use std.enums.EnumFieldStruct(Flags, u32, 0) here but Flags is a Struct not an Enum.
-    var counts: Counts: {
-        var count_fields = std.meta.fields(Flags)[0..std.meta.fields(Flags).len].*;
-        for (&count_fields) |*field| {
-            field.type = u32;
-            field.alignment = @alignOf(u32);
-            field.default_value_ptr = @ptrCast(&@as(u32, 0));
-        }
-        break :Counts @Type(.{
-            .@"struct" = .{
-                .layout = .auto,
-                .fields = &count_fields,
-                .decls = &.{},
-                .is_tuple = false,
-            },
-        });
-    } = .{};
-
+    var counts: std.enums.EnumFieldStruct(std.meta.FieldEnum(Flags), u32, 0) = .{};
     var result: Flags = undefined;
     var parsed_positional = false;
     next_arg: while (args.next()) |arg| {

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -998,6 +998,13 @@ test "flags" {
         \\
     ));
 
+    try t.check(&.{ "pos", "--", "x", "y" }, snap(@src(),
+        \\status: 1
+        \\stderr:
+        \\error: unexpected argument: '--'
+        \\
+    ));
+
     try t.check(&.{ "pos", "--flak", "x", "y" }, snap(@src(),
         \\status: 1
         \\stderr:

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -62,10 +62,10 @@ pub const CLIArgs = struct {
     disable_faults: bool = false,
     output_directory: ?[]const u8 = null,
     log_debug: bool = false,
-    positional: struct {
-        /// Vortex is non-deterministic, but providing a seed can still help constrain the scenario.
-        seed: ?u64 = null,
-    },
+
+    @"--": void,
+    /// Vortex is non-deterministic, but providing a seed can still help constrain the scenario.
+    seed: ?u64 = null,
 };
 
 pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
@@ -106,7 +106,7 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
     log.info("output directory: {s}", .{output_directory});
     log.info("starting test with target runtime of {}", .{args.test_duration});
 
-    const seed = args.positional.seed orelse std.crypto.random.int(u64);
+    const seed = args.seed orelse std.crypto.random.int(u64);
     var prng = stdx.PRNG.from_seed(seed);
 
     var network = try faulty_network.Network.listen(

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -23,23 +23,22 @@ const events_buffer_size_max = size: {
 };
 
 pub const CLIArgs = struct {
-    positional: struct {
-        @"cluster-id": u128,
-        addresses: []const u8,
-    },
+    @"--": void,
+    @"cluster-id": u128,
+    addresses: []const u8,
 };
 
 pub fn main(_: std.mem.Allocator, args: CLIArgs) !void {
-    log.info("addresses: {s}", .{args.positional.addresses});
+    log.info("addresses: {s}", .{args.addresses});
 
-    const cluster_id = args.positional.@"cluster-id";
+    const cluster_id = args.@"cluster-id";
 
     var tb_client: c.tb_client_t = undefined;
     const init_status = c.tb_client_init(
         &tb_client,
         std.mem.asBytes(&cluster_id),
-        args.positional.addresses.ptr,
-        @intCast(args.positional.addresses.len),
+        args.addresses.ptr,
+        @intCast(args.addresses.len),
         0,
         on_complete,
     );

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -836,7 +836,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
                 .{flag_name},
             );
         }
-    }
+    } else unreachable;
 
     const groove_config = StateMachine.Forest.groove_config;
     const AccountsValuesCache = groove_config.accounts.ObjectsCache.Cache;

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -88,9 +88,8 @@ const CLIArgs = struct {
     replica_missing_until_request: ?u32 = null,
     requests_max: ?u32 = null,
 
-    positional: struct {
-        seed: ?[]const u8 = null,
-    },
+    @"--": void,
+    seed: ?[]const u8 = null,
 };
 
 pub fn main() !void {
@@ -128,7 +127,7 @@ pub fn main() !void {
 
     const seed_random = std.crypto.random.int(u64);
     const seed = seed_from_arg: {
-        const seed_argument = cli_args.positional.seed orelse break :seed_from_arg seed_random;
+        const seed_argument = cli_args.seed orelse break :seed_from_arg seed_random;
         break :seed_from_arg vsr.testing.parse_seed(seed_argument);
     };
 


### PR DESCRIPTION
Right now the DSL for defining positional arguments leaks into use-site, as you need to type `args.positional.foo`. After this commit, just `args.foo` works (and you can also name you flag "positional"), if you like.

```zig
const CLIArgs = struct {
    events_max: ?usize = null,
    positional: struct {
        fuzzer: FuzzersEnum,
        seed: ?u64 = null,
    },
};
```

=>

```zig
const CLIArgs = struct {
    events_max: ?usize = null,

    @"--": void,
    fuzzer: FuzzersEnum,
    seed: ?u64 = null,
};
```

@"--" is chosen as a mnemonic, because it often is used at runtime to signify the end of non-positional arguments.