### PR TITLE
lsm: increase the level of abstraction when handling directions

### DIFF
--- a/src/direction.zig
+++ b/src/direction.zig
@@ -1,3 +1,25 @@
+const std = @import("std");
+const stdx = @import("stdx");
+const assert = std.debug.assert;
+const maybe = stdx.maybe;
+const Elem = std.meta.Elem;
+
+const binary_search = @import("lsm/binary_search.zig");
+
+/// Tree LSM is a sorted array with a monocle and a top hat.
+///
+/// We want to iterate it in both directions:
+/// - For CDC, you want to learn about all new objects with timestamp>thershold.
+/// - For paginated timelines, you want to learn about past objects with timestamp<thersold.
+///
+/// Sadly, this can't be implemented via just a single branch near the end of the system, we need to
+/// change a whole bunch of `<` to `>` throughout the stack.
+///
+/// Direction encapsulate the logic of "if ascending use < if descending use >". The mnemonic is
+/// that usual comparison is horizontal along a number line, but Direciton-aware is vertical.
+///
+/// In other words, `key_min` and `key_max` track natural ordering, while `key_lower` and
+/// `key_upper` are direction-aware.
 pub const Direction = enum(u1) {
     ascending = 0,
     descending = 1,
@@ -7,5 +29,92 @@ pub const Direction = enum(u1) {
             .ascending => .descending,
             .descending => .ascending,
         };
+    }
+
+    pub inline fn cmp(
+        d: Direction,
+        a: anytype,
+        comptime op: enum { @"<", @"<=" },
+        b: @TypeOf(a),
+    ) bool {
+        return switch (op) {
+            .@"<" => switch (d) {
+                .ascending => a < b,
+                .descending => a > b,
+            },
+            .@"<=" => switch (d) {
+                .ascending => a <= b,
+                .descending => a >= b,
+            },
+        };
+    }
+
+    pub inline fn lower(d: Direction, a: anytype, b: @TypeOf(a)) @TypeOf(a) {
+        return if (d.cmp(a, .@"<", b)) a else b;
+    }
+
+    pub inline fn upper(d: Direction, a: anytype, b: @TypeOf(a)) @TypeOf(a) {
+        return if (d.cmp(a, .@"<", b)) b else a;
+    }
+
+    pub inline fn slice_peek(d: Direction, slice: anytype) *const Elem(@TypeOf(slice)) {
+        assert(slice.len > 0);
+        return switch (d) {
+            .ascending => &slice[0],
+            .descending => &slice[slice.len - 1],
+        };
+    }
+
+    pub inline fn slice_pop(
+        d: Direction,
+        slice: anytype,
+    ) struct { Elem(@TypeOf(slice)), @TypeOf(slice) } {
+        assert(slice.len > 0);
+        return switch (d) {
+            .ascending => .{ slice[0], slice[1..] },
+            .descending => .{ slice[slice.len - 1], slice[0 .. slice.len - 1] },
+        };
+    }
+
+    pub inline fn slice_lower_bound(
+        direction: Direction,
+        comptime Key: type,
+        comptime Value: type,
+        comptime key_from_value: fn (*const Value) callconv(.@"inline") Key,
+        slice: []const Value,
+        key: Key,
+    ) []const Value {
+        maybe(slice.len == 0);
+        switch (direction) {
+            .ascending => {
+                const start = binary_search.binary_search_values_upsert_index(
+                    Key,
+                    Value,
+                    key_from_value,
+                    slice,
+                    key,
+                    .{ .mode = .lower_bound },
+                );
+
+                return if (start == slice.len) &.{} else slice[start..];
+            },
+            .descending => {
+                const end = end: {
+                    const index = binary_search.binary_search_values_upsert_index(
+                        Key,
+                        Value,
+                        key_from_value,
+                        slice,
+                        key,
+                        .{ .mode = .upper_bound },
+                    );
+                    break :end index + @intFromBool(
+                        index < slice.len and key_from_value(&slice[index]) <= key,
+                    );
+                };
+
+                return if (end == 0) &.{} else slice[0..end];
+            },
+        }
     }
 };

--- a/src/direction.zig
+++ b/src/direction.zig
@@ -6,7 +6,7 @@ const Elem = std.meta.Elem;
 
 const binary_search = @import("lsm/binary_search.zig");
 
-/// Tree LSM is a sorted array with a monocle and a top hat.
+/// LSM Tree is a sorted array with a monocle and a top hat.
 ///
 /// We want to iterate it in both directions:
 /// - For CDC, you want to learn about all new objects with timestamp>threshold.

--- a/src/direction.zig
+++ b/src/direction.zig
@@ -9,8 +9,8 @@ const binary_search = @import("lsm/binary_search.zig");
 /// Tree LSM is a sorted array with a monocle and a top hat.
 ///
 /// We want to iterate it in both directions:
-/// - For CDC, you want to learn about all new objects with timestamp>thershold.
-/// - For paginated timelines, you want to learn about past objects with timestamp<thersold.
+/// - For CDC, you want to learn about all new objects with timestamp>threshold.
+/// - For paginated timelines, you want to learn about past objects with timestamp<threshold.
 ///
 /// Sadly, this can't be implemented via just a single branch near the end of the system, we need to
 /// change a whole bunch of `<` to `>` throughout the stack.

--- a/src/direction.zig
+++ b/src/direction.zig
@@ -16,7 +16,7 @@ const binary_search = @import("lsm/binary_search.zig");
 /// change a whole bunch of `<` to `>` throughout the stack.
 ///
 /// Direction encapsulate the logic of "if ascending use < if descending use >". The mnemonic is
-/// that usual comparison is horizontal along a number line, but Direciton-aware is vertical.
+/// that usual comparison is horizontal along a number line, but Direction-aware is vertical.
 ///
 /// In other words, `key_min` and `key_max` track natural ordering, while `key_lower` and
 /// `key_upper` are direction-aware.

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -482,10 +482,10 @@ pub fn ScanType(
 
                     if (comptime is_composite_key(Value)) {
                         const prefix = prefix: {
-                            const prefix_min = Value.key_prefix(scan_impl.key_min);
-                            const prefix_max = Value.key_prefix(scan_impl.key_max);
-                            assert(prefix_min == prefix_max);
-                            break :prefix prefix_min;
+                            const prefix_lower = Value.key_prefix(scan_impl.key_lower);
+                            const prefix_upper = Value.key_prefix(scan_impl.key_upper);
+                            assert(prefix_lower == prefix_upper);
+                            break :prefix prefix_lower;
                         };
                         scan_impl.probe(Value.key_from_value(&.{
                             .field = prefix,
@@ -496,7 +496,7 @@ pub fn ScanType(
                         comptime assert(Groove.IdTree != void);
 
                         // Scans over the IdTree cannot probe for a next timestamp.
-                        assert(scan_impl.key_min == scan_impl.key_max);
+                        assert(scan_impl.key_lower == scan_impl.key_upper);
                     }
                 },
             }
@@ -516,12 +516,12 @@ pub fn ScanType(
                     if (comptime is_composite_key(Value)) {
                         // Secondary indexes can only produce results sorted by timestamp if
                         // scanning over the same key prefix.
-                        assert(Value.key_prefix(scan_impl.key_min) ==
-                            Value.key_prefix(scan_impl.key_max));
+                        assert(Value.key_prefix(scan_impl.key_lower) ==
+                            Value.key_prefix(scan_impl.key_upper));
                     } else {
                         comptime assert(tag == .id);
                         comptime assert(Groove.IdTree != void);
-                        assert(scan_impl.key_min == scan_impl.key_max);
+                        assert(scan_impl.key_lower == scan_impl.key_upper);
                     }
 
                     return scan_impl.direction;

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -267,10 +267,7 @@ fn ScanMergeType(
                             // 2. k_way_merge₁ relays 11 to its streams (tree₁ + zig_zag_merge₂).
                             // 3. Probing zig_zag_merge₂ with 12 trips the assert, because tree₃ has
                             //    already produced a higher key (11 < 12).
-                            switch (self.direction) {
-                                .ascending => maybe(key_popped < timestamp),
-                                .descending => maybe(key_popped > timestamp),
-                            }
+                            maybe(self.direction.cmp(key_popped, .@"<", timestamp));
                         }
 
                         // Once the underlying streams have been changed, the merge iterator needs


### PR DESCRIPTION
Tree LSM is a sorted array with a monocle and a top hat.

We want to iterate it in both directions:
- For CDC, you want to learn about all new objects with timestamp>thershold.
- For paginated timelines, you want to learn about past objects with timestamp<thersold.

Sadly, this can't be implemented via just a single branch near the end of the system, we need to
change a whole bunch of `<` to `>` throughout the stack.

Direction encapsulate the logic of "if ascending use < if descending use >". The mnemonic is
that usual comparison is horizontal along a number line, but Direciton-aware is vertical.

In other words, `key_min` and `key_max` track natural ordering, while `key_lower` and
`key_upper` are direction-aware.
