### PR TITLE
node: don't discard high 16 bits of timestamp

### DIFF
--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -189,7 +189,7 @@ export function id(): bigint {
   idLastBuffer.setUint32(4, randomHi32 & 0xFFFFFFFF, littleEndian)
   idLastBuffer.setUint16(8, randomHi16, littleEndian) // No need to mask since checked above.
   idLastBuffer.setUint16(10, timestamp & 0xFFFF, littleEndian) // timestamp lo.
-  idLastBuffer.setUint32(12, (timestamp >>> 16) & 0xFFFFFFFF, littleEndian) // timestamp hi.
+  idLastBuffer.setUint32(12, (timestamp / 0x10000) | 0, littleEndian) // timestamp hi.
 
   // Then return the buffer's contents as a little-endian u128 bigint.
   const lo = idLastBuffer.getBigUint64(0, littleEndian)


### PR DESCRIPTION
Closes https://github.com/tigerbeetle/tigerbeetle/issues/3315

In JavaScript, numbers are 64 bit floating points (double). Integers up to 2**53 are represented precisely, and Date.now() is guaranteed to return such an integer.

However, bitwise operations like `&` or `>>>` are defined to operate on low 32 bits only:

```
> 0xFFFF_FFFF_FFFF.toString(16)
'ffffffffffff'
> (0xFFFF_FFFF_FFFF >>> 32).toString(16)
'ffffffff'
> (0xFFFF_FFFF_FFFF >> 32).toString(16)
'-1'
```

To get to the higher 32 bits of the 48 bit timestamp, we instead divide and round, which is guaranteed to get the correct result: division is subtraction in the exponent, and rounding is exactly the bitshift we are looking for.

Kudos to edible-programs for discovering the issue and suggesting a fix.

I also tried alternative implementation that is somewhat simpler:

```
let idLastTimestamp: number = 0; // 48 bits here, a number is fine.
let idLastRandom: bigint = 0n; // 80 bits, need bigint.

// These are two references to the same buffer.
// We only need the `Uint8Array` because in Node.js 24, but not earlier, `crypto.randomFillSync`
// rejects `DataView` typed arguments.
const idBuffer = new DataView(new ArrayBuffer(16));
const idBufferArray = new Uint8Array(
    idBuffer.buffer, idBuffer.byteOffset, idBuffer.byteLength
);
export function id(): bigint {
  // Ensure timestamp monotonically increases and generate a new random on each new timestamp.
  const timestamp = Date.now();
  if (timestamp <= idLastTimestamp) {
    idLastRandom += 1n;
    if (idLastRandom == (1n << 80n)) {
      throw new Error('random bits overflow on monotonic increment')
    }
  } else {
    idLastTimestamp = timestamp;
    randomFillSync(idBufferArray);
    idLastRandom = (idBuffer.getBigInt64(0) << 16n) | (idBuffer.getBigInt64(8) & 0xFFFFn);
  }
  if (idLastRandom >= (1n << 80n)) throw new Error("assertion error");
  const timestampMask = ((1n << 40n) - 1n)
  const timestampBits = (BigInt(idLastTimestamp) & timestampMask) << 80n;
  return timestampBits | idLastRandom;
}
```

But it was also somewhat slower, and, given that I wasn't able to get rid of array buffers completely, I opted for a local fix for now.