### PR TITLE
bench: implement micro-benchmarking harness

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -850,6 +850,16 @@ fn build_test(
         mode: std.builtin.OptimizeMode,
     },
 ) !void {
+    const test_options = b.addOptions();
+    // Benchmark run in two modes.
+    // - ./zig/zig build test
+    // - ./zig/zig build -Drelease test -- "benchmark: name"
+    // The former uses small parameter values and is silent.
+    // The latter is the real benchmark, which prints the output.
+    test_options.addOption(bool, "benchmark", for (b.args orelse &.{}) |arg| {
+        if (std.mem.indexOf(u8, arg, "benchmark") != null) break true;
+    } else false);
+
     const stdx_unit_tests = b.addTest(.{
         .name = "test-stdx",
         .root_module = b.createModule(.{
@@ -870,6 +880,7 @@ fn build_test(
     });
     unit_tests.root_module.addImport("stdx", options.stdx_module);
     unit_tests.root_module.addOptions("vsr_options", options.vsr_options);
+    unit_tests.root_module.addOptions("test_options", test_options);
 
     steps.test_unit_build.dependOn(&b.addInstallArtifact(stdx_unit_tests, .{}).step);
     steps.test_unit_build.dependOn(&b.addInstallArtifact(unit_tests, .{}).step);

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -1,22 +1,17 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const math = std.math;
-const builtin = @import("builtin");
 
 const stdx = @import("stdx");
+const MiB = stdx.MiB;
+const GiB = stdx.GiB;
+
+const Bench = @import("../testing/bench.zig");
 
 const binary_search_keys_upsert_index =
     @import("./binary_search.zig").binary_search_keys_upsert_index;
 const binary_search_values_upsert_index =
     @import("./binary_search.zig").binary_search_values_upsert_index;
-
-const log = std.log;
-
-const GiB = 1 << 30;
-
-// Bump these up if you want to use this as a real benchmark rather than as a test.
-const blob_size = @divExact(GiB, 1024);
-const searches = 5_000;
 
 const kv_types = .{
     .{ .key_size = @sizeOf(u64), .value_size = 128 },
@@ -26,12 +21,16 @@ const kv_types = .{
 };
 
 const values_per_page = .{ 128, 256, 512, 1024, 2 * 1024, 4 * 1024, 8 * 1024 };
-const body_fmt = "K={:_>2}B V={:_>3}B N={:_>4} {s}{s}: WT={:_>6}ns UT={:_>6}ns";
+const body_fmt = "K={:_>2}B V={:_>3}B N={:_>4} {s}{s}: WT={}";
 
 test "benchmark: binary search" {
-    log.info("Samples: {}", .{searches});
-    log.info("WT: Wall time/search", .{});
-    log.info("UT: utime time/search", .{});
+    var bench: Bench = .init();
+    defer bench.deinit();
+
+    const blob_size = bench.parameter("blob_size", MiB, GiB);
+    const searches = bench.parameter("searches", 5_000, 500_000);
+
+    bench.report("WT: Wall time/search", .{});
 
     const seed = std.crypto.random.int(u64);
     var prng = stdx.PRNG.from_seed(seed);
@@ -45,29 +44,39 @@ test "benchmark: binary search" {
 
     inline for (kv_types) |kv| {
         inline for (values_per_page) |values_count| {
-            try run_benchmark(.{
-                .blob_size = blob_size,
+            try run_benchmark(&bench, .{
                 .key_size = kv.key_size,
                 .value_size = kv.value_size,
                 .values_count = values_count,
-                .searches = searches,
-            }, blob, &prng);
+            }, searches, blob, &prng);
         }
     }
 }
 
-fn run_benchmark(comptime layout: Layout, blob: []u8, prng: *stdx.PRNG) !void {
-    assert(blob.len == layout.blob_size);
+fn run_benchmark(
+    bench: *Bench,
+    comptime layout: Layout,
+    search_count: u64,
+    blob: []u8,
+    prng: *stdx.PRNG,
+) !void {
     const V = ValueType(layout);
     const K = V.Key;
     const Page = struct {
         values: [layout.values_count]V,
     };
-    const page_count = layout.blob_size / @sizeOf(Page);
+    const page_count = @divFloor(blob.len, @sizeOf(Page));
+    assert(page_count > 0);
+    const page_count_max = 1024 * 1024;
+    if (page_count > page_count_max) @panic("page_count too large");
 
     // Search pages and keys in random order.
-    const page_picker = shuffled_index(page_count, prng);
-    const value_picker = shuffled_index(layout.values_count, prng);
+    var page_picker_buffer: [page_count_max]usize = undefined;
+    const page_picker = page_picker_buffer[0..page_count];
+    shuffled_index(prng, page_picker);
+
+    var value_picker: [layout.values_count]usize = undefined;
+    shuffled_index(prng, value_picker[0..]);
 
     // Generate 1GiB worth of 24KiB pages.
     var blob_alloc = std.heap.FixedBufferAllocator.init(blob);
@@ -78,10 +87,9 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, prng: *stdx.PRNG) !void {
     }
 
     inline for (&.{ true, false }) |prefetch| {
-        var benchmark = try Benchmark.begin();
-        var i: usize = 0;
+        bench.start();
         var v: usize = 0;
-        while (i < layout.searches) : (i += 1) {
+        for (0..search_count) |i| {
             const target = value_picker[v % value_picker.len];
             const page = &pages[page_picker[i % page_picker.len]];
             const hit = page.values[
@@ -98,25 +106,23 @@ fn run_benchmark(comptime layout: Layout, blob: []u8, prng: *stdx.PRNG) !void {
             assert(hit.key == target);
             if (i % pages.len == 0) v += 1;
         }
-        const result = try benchmark.end(layout.searches);
-        log.info(body_fmt, .{
+        var result_per_search = bench.stop();
+        result_per_search.ns /= search_count;
+        bench.report(body_fmt, .{
             layout.key_size,
             layout.value_size,
             layout.values_count,
             if (prefetch) "P" else "_",
             "B",
-            result.wall_time,
-            result.utime,
+            result_per_search,
         });
     }
 }
 
 const Layout = struct {
-    blob_size: usize, // bytes allocated for all pages
     key_size: usize, // bytes per key
     value_size: usize, // bytes per value
     values_count: usize, // values per page
-    searches: usize,
 };
 
 fn ValueType(comptime layout: Layout) type {
@@ -138,62 +144,8 @@ fn ValueType(comptime layout: Layout) type {
     };
 }
 
-const BenchmarkResult = struct {
-    wall_time: u64, // nanoseconds
-    utime: u64, // nanoseconds
-};
-
-const Benchmark = struct {
-    timer: std.time.Timer,
-    utime_ns: u128,
-
-    fn begin() !Benchmark {
-        const timer = try std.time.Timer.start();
-        return Benchmark{
-            .timer = timer,
-            .utime_ns = utime_nanos(),
-        };
-    }
-
-    fn end(self: *Benchmark, samples: usize) !BenchmarkResult {
-        const utime_now = utime_nanos();
-        return BenchmarkResult{
-            .wall_time = self.timer.read() / samples,
-            .utime = @intCast((utime_now - self.utime_ns) / samples),
-        };
-    }
-
-    fn utime_nanos() u128 {
-        if (builtin.os.tag == .windows) {
-            var creation_time: std.os.windows.FILETIME = undefined;
-            var exit_time: std.os.windows.FILETIME = undefined;
-            var kernel_time: std.os.windows.FILETIME = undefined;
-            var user_time: std.os.windows.FILETIME = undefined;
-
-            if (stdx.windows.GetProcessTimes(
-                std.os.windows.kernel32.GetCurrentProcess(),
-                &creation_time,
-                &exit_time,
-                &kernel_time,
-                &user_time,
-            ) == std.os.windows.FALSE) {
-                std.debug.panic("GetProcessTimes(): {}", .{std.os.windows.kernel32.GetLastError()});
-            }
-
-            const utime100ns = (@as(u64, user_time.dwHighDateTime) << 32) | user_time.dwLowDateTime;
-            return utime100ns * 100;
-        }
-
-        const utime_tv = std.posix.getrusage(std.posix.rusage.SELF).utime;
-        return (@as(u128, @intCast(utime_tv.sec)) * std.time.ns_per_s) +
-            (@as(u32, @intCast(utime_tv.usec)) * std.time.ns_per_us);
-    }
-};
-
 // shuffle([0,1,…,n-1])
-fn shuffled_index(comptime n: usize, prng: *stdx.PRNG) [n]usize {
-    var indices: [n]usize = undefined;
-    for (&indices, 0..) |*i, j| i.* = j;
-    prng.shuffle(usize, indices[0..]);
-    return indices;
+fn shuffled_index(prng: *stdx.PRNG, indices: []usize) void {
+    for (indices, 0..) |*i, j| i.* = j;
+    prng.shuffle(usize, indices);
 }

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -36,6 +36,7 @@ pub const MiB = 1 << 20;
 pub const GiB = 1 << 30;
 pub const TiB = 1 << 40;
 pub const PiB = 1 << 50;
+// pub const NiB = "Some people say my love cannot be true";
 
 comptime {
     assert(KiB == 1024);

--- a/src/testing/bench.zig
+++ b/src/testing/bench.zig
@@ -1,0 +1,130 @@
+//! Micro benchmarking harness.
+//!
+//! Goals:
+//! - relative (comparative) benchmarking,
+//! - manual checks when refactoring/optimizing/upgrading compiler,
+//! - no benchmark bitrot.
+//!
+//! Non-goals:
+//! - absolute benchmarking,
+//! - continious benchmarking,
+//! - automatic regression detection.
+//!
+//! If you run
+//!     $ ./zig/zig build test
+//! the benchmarks are run in "test" mode which uses small inputs, finishes quickly, and doesn't
+//! print anything to stdout.
+//!
+//! If you run
+//!     $ ./zig/zig build -Drelease test -- "benchmark: binary search"
+//! the benchmark is run for real, with a large input, longer runtime, and results on stderr.
+//! The `benchmark` in the test name is the secret code to unlock benchmarking code.
+
+test "benchmark: API tutorial" { // `benchmark:` in the name is important!
+    var bench: Bench = .init();
+    defer bench.deinit();
+
+    // Parameters are named, and have two default values.
+    // The small value is used in tests, to prevent bitrot.
+    // The large value is the canonical when running benchmark "for real".
+    // You can pass custom values via env variables:
+    //    $ a=92 ./zig/zig build test -- "benchmark: tutorial"
+    const a = bench.parameter("a", 1, 1_000);
+    const b = bench.parameter("b", 2, 2_000);
+
+    bench.start(); // Built-in timer.
+    const c = a + b;
+    const elapsed = bench.stop();
+
+    // Always print a "hash" of the run:
+    // - to prevent compiler from optimizing the code away,
+    // - to prevent YOU from "optimizing" the code by changing semantics.
+    bench.report("hash: {}", .{c});
+    // Print the time, and any other metrics you find important.
+    bench.report("elapsed: {}", .{elapsed});
+
+    // NB: print as little as possible, because humans read slowly.
+    // It's the job of benchmark author to optimize for conciseness.
+
+    // You can compile individual benchmark  via
+    //   ./zig/zig build test:unit:build -- "benchmark: binary search"
+    // and use the resulting biniary with perf/hyperfine/poop.
+}
+
+const std = @import("std");
+const assert = std.debug.assert;
+const stdx = @import("stdx");
+const Duration = stdx.Duration;
+const Instant = stdx.Instant;
+const TimeOS = @import("../time.zig").TimeOS;
+
+const mode: enum { smoke, benchmark } =
+    // See build.zig for how this is ultimateely determined.
+    if (@import("test_options").benchmark) .benchmark else .smoke;
+
+time: TimeOS = .{},
+instant_start: ?Instant = null,
+
+const Bench = @This();
+
+pub fn init() Bench {
+    return .{};
+}
+
+pub fn deinit(bench: *Bench) void {
+    assert(bench.instant_start == null);
+    bench.* = undefined;
+}
+
+pub fn parameter(
+    b: *const Bench,
+    comptime name: []const u8,
+    value_smoke: u64,
+    value_benchmark: u64,
+) u64 {
+    assert(value_smoke < value_benchmark);
+    const value = parameter_fallible(name, value_smoke, value_benchmark) catch |err| switch (err) {
+        error.InvalidCharacter, error.Overflow => @panic("invalid benchmark parameter value"),
+    };
+    b.report("{s}={}", .{ name, value });
+    return value;
+}
+
+fn parameter_fallible(
+    comptime name: []const u8,
+    value_smoke: u64,
+    value_benchmark: u64,
+) std.fmt.ParseIntError!u64 {
+    assert(value_smoke < value_benchmark);
+    return switch (mode) {
+        .smoke => value_smoke,
+        .benchmark => std.process.parseEnvVarInt(name, u64, 10) catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return value_benchmark,
+            else => |e| return e,
+        },
+    };
+}
+
+pub fn start(bench: *Bench) void {
+    assert(bench.instant_start == null);
+    defer assert(bench.instant_start != null);
+
+    bench.instant_start = bench.time.time().monotonic();
+}
+
+pub fn stop(bench: *Bench) Duration {
+    assert(bench.instant_start != null);
+    defer assert(bench.instant_start == null);
+
+    const instant_stop = bench.time.time().monotonic();
+    const elapsed = instant_stop.duration_since(bench.instant_start.?);
+    bench.instant_start = null;
+    return elapsed;
+}
+
+pub fn report(_: *const Bench, comptime fmt: []const u8, args: anytype) void {
+    switch (mode) {
+        .smoke => {},
+        .benchmark => std.debug.print(fmt ++ "\n", args),
+    }
+}

--- a/src/testing/bench.zig
+++ b/src/testing/bench.zig
@@ -7,7 +7,7 @@
 //!
 //! Non-goals:
 //! - absolute benchmarking,
-//! - continious benchmarking,
+//! - continuous benchmarking,
 //! - automatic regression detection.
 //!
 //! If you run
@@ -48,7 +48,7 @@ test "benchmark: API tutorial" { // `benchmark:` in the name is important!
 
     // You can compile individual benchmark  via
     //   ./zig/zig build test:unit:build -- "benchmark: binary search"
-    // and use the resulting biniary with perf/hyperfine/poop.
+    // and use the resulting binary with perf/hyperfine/poop.
 }
 
 const std = @import("std");
@@ -59,7 +59,7 @@ const Instant = stdx.Instant;
 const TimeOS = @import("../time.zig").TimeOS;
 
 const mode: enum { smoke, benchmark } =
-    // See build.zig for how this is ultimateely determined.
+    // See build.zig for how this is ultimately determined.
     if (@import("test_options").benchmark) .benchmark else .smoke;
 
 time: TimeOS = .{},

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -43,6 +43,7 @@ comptime {
     _ = @import("state_machine.zig");
     _ = @import("state_machine_fuzz.zig");
     _ = @import("state_machine_tests.zig");
+    _ = @import("testing/bench.zig");
     _ = @import("testing/exhaustigen.zig");
     _ = @import("testing/id.zig");
     _ = @import("testing/marks.zig");


### PR DESCRIPTION
We have a bunch of benchmarks here and there, but they are somewhat
bitrotted. The big idea behind this module is to fix that by providing
two sets of parameters:

- one to run the benchmark quickly during the tests,
- the other to the benchmark "for real"

I've only updated the binary search benchmark as a proof of concept, but
it would be a great exercise to go through our existing benchmarks and
refresh them!