### PR TITLE
ci: debug failures

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -538,6 +538,9 @@ fn build_ci_script(
 // Hide step's stderr unless it fails, to prevent zig build ci output being dominated by VOPR logs.
 // Sadly, this requires "overriding" Build.Step.Run make function.
 fn hide_stderr(run: *std.Build.Step.Run) void {
+    // Debugging https://github.com/tigerbeetle/tigerbeetle/actions/runs/20034473571/job/57452104427
+    if (true) return;
+
     const b = run.step.owner;
 
     run.addCheck(.{ .expect_term = .{ .Exited = 0 } });


### PR DESCRIPTION
https://github.com/tigerbeetle/tigerbeetle/actions/runs/20034473571/job/57452104427

Apparently our devhub task produces more than 10MiB output _sometimes_? 