### PR TITLE
vopr: relax condition for truncating acked ops

### DIFF
--- a/src/testing/cluster/state_checker.zig
+++ b/src/testing/cluster/state_checker.zig
@@ -181,20 +181,7 @@ pub fn StateCheckerType(comptime Client: type, comptime Replica: type) type {
                 return;
             }
 
-            if (replica.status != .recovering_head) {
-                const head_max = &state_checker.replica_head_max[replica_index];
-                const wal_prepares = replica.superblock.storage.wal_prepares();
-                const head_max_journal =
-                    wal_prepares[head_max.op % constants.journal_slot_count].header;
-
-                assert(replica.view > head_max.view or
-                    (replica.view == head_max.view and (replica.op >= head_max.op or
-                        // The last acked prepare may have been truncated through a view change,
-                        // replaced by a prepare from a newer view, and the replica may have crashed
-                        // before making this new view durable in the superblock. Such prepares are
-                        // then truncated on startup.
-                        head_max.view < head_max_journal.view)));
-            }
+            assert(replica.view >= state_checker.replica_head_max[replica_index].view);
 
             const commit_root_op = replica.superblock.working.vsr_state.checkpoint.header.op;
             const commit_root = replica.superblock.working.vsr_state.checkpoint.header.checksum;


### PR DESCRIPTION
Fixes `./zig/zig build vopr -Drelease -- 6194329035882799185` on the release branch. This is a case where a backup:


1. Accepts a new prepare with op=48 in view=440, and prepare_oks it
2. Replaces it with an old prepare with op=48 in view=441
3. Crashes while view=441 is being made durable
4. Restarts into view=440, and truncates the old prepare on startup (as it has an older view=439)
5. Our state checker thinks that we've truncated a prepare that has been prepare_ok'd and crashes

```C
            if (replica.status != .recovering_head) {
                const head_max = &state_checker.replica_head_max[replica_index];
                const wal_prepares = replica.superblock.storage.wal_prepares();
                const head_max_journal =
                    wal_prepares[head_max.op % constants.journal_slot_count].header;

                assert(replica.view > head_max.view or
                    (replica.view == head_max.view and (replica.op >= head_max.op or
                        // The last acked prepare may have been truncated through a view change,
                        // replaced by a prepare from a newer view, and the replica may have crashed
                        // before making this new view durable in the superblock. Such prepares are
                        // then truncated on startup.
                        head_max.view < head_max_journal.view)));
            }
```

In other words, it turns out that `(replica.view == head_max.view and (replica.op >= head_max.op or head_max.view < head_max_journal.view))` is too strict as well!