### PR TITLE
lsm: Use Pending!?Value as the canonical stream signature

### DIFF
--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -103,7 +103,7 @@ pub fn KWayMergeIteratorType(
                 const ordered = if (direction == .ascending) a.key < b.key else a.key > b.key;
                 const stabler = (a.key == b.key) and
                     stream_precedence(ctx, a.stream_id, b.stream_id);
-                return ordered or stabler; // “true”  means  a  loses
+                return ordered or stabler; // “true”  means  a wins.
             }
         };
 

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -155,9 +155,7 @@ pub fn KWayMergeIteratorType(
             var contestants: [node_max]Node = @splat(sentinel);
             var contestants_count: u16 = 0;
             for (0..self.streams_count) |id| {
-                const key = stream_peek(self.context, @intCast(id)) catch |err| switch (err) {
-                    error.Pending => return error.Pending,
-                } orelse continue;
+                const key = try stream_peek(self.context, @intCast(id)) orelse continue;
                 contestants[id] = .{ .key = key, .stream_id = @intCast(id), .sentinel = false };
                 contestants_count += 1;
             }
@@ -244,9 +242,7 @@ pub fn KWayMergeIteratorType(
 
         fn next_contender(self: *KWayMergeIterator, stream_id: u32) Pending!Node {
             assert(stream_id < self.streams_count);
-            const next_key = stream_peek(self.context, stream_id) catch |err| switch (err) {
-                error.Pending => return error.Pending,
-            } orelse { // FIXME: simplify these.
+            const next_key = try stream_peek(self.context, stream_id) orelse {
                 self.streams_active -= 1;
                 return sentinel;
             };

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -29,6 +29,7 @@ const math = std.math;
 const mem = std.mem;
 
 const Direction = @import("../direction.zig").Direction;
+const Pending = error{Pending};
 
 const Options = struct {
     streams_max: u32,
@@ -43,13 +44,13 @@ pub fn KWayMergeIteratorType(
     comptime key_from_value: fn (*const Value) callconv(.@"inline") Key,
     /// Peek the next key in the stream identified by stream_index.
     /// For example, peek(stream_index=2) returns user_streams[2][0].
-    /// Returns Drained if the stream was consumed and
+    /// Returns Pending if the stream was consumed and
     /// must be refilled before calling peek() again.
-    /// Returns Empty if the stream was fully consumed and reached the end.
+    /// Returns null if the stream was fully consumed and reached the end.
     comptime stream_peek: fn (
         context: *Context,
         stream_index: u32,
-    ) error{ Empty, Drained }!Key,
+    ) Pending!?Key,
     comptime stream_pop: fn (context: *Context, stream_index: u32) Value,
     /// Returns true if stream A has higher precedence than stream B.
     /// This is used to break ties across streams.
@@ -144,7 +145,7 @@ pub fn KWayMergeIteratorType(
             };
         }
 
-        fn load(self: *KWayMergeIterator) error{Drained}!void {
+        fn load(self: *KWayMergeIterator) Pending!void {
             assert(self.state == .loading);
             assert(self.nodes_count == 0);
             assert(self.tree_height == 0);
@@ -155,9 +156,8 @@ pub fn KWayMergeIteratorType(
             var contestants_count: u16 = 0;
             for (0..self.streams_count) |id| {
                 const key = stream_peek(self.context, @intCast(id)) catch |err| switch (err) {
-                    error.Empty => continue,
-                    error.Drained => return error.Drained,
-                };
+                    error.Pending => return error.Pending,
+                } orelse continue;
                 contestants[id] = .{ .key = key, .stream_id = @intCast(id), .sentinel = false };
                 contestants_count += 1;
             }
@@ -202,7 +202,7 @@ pub fn KWayMergeIteratorType(
             self.state = .iterating;
         }
 
-        pub fn pop(self: *KWayMergeIterator) error{Drained}!?Value {
+        pub fn pop(self: *KWayMergeIterator) Pending!?Value {
             if (self.state == .loading) try self.load();
             assert(self.state == .iterating);
 
@@ -218,7 +218,7 @@ pub fn KWayMergeIteratorType(
             return null;
         }
 
-        fn next(self: *KWayMergeIterator) error{Drained}!?Value {
+        fn next(self: *KWayMergeIterator) Pending!?Value {
             const direction = self.direction;
             const stream_id = self.contender.stream_id;
             assert(!self.contender.sentinel);
@@ -242,14 +242,13 @@ pub fn KWayMergeIteratorType(
             return stream_pop(self.context, self.contender.stream_id);
         }
 
-        fn next_contender(self: *KWayMergeIterator, stream_id: u32) error{Drained}!Node {
+        fn next_contender(self: *KWayMergeIterator, stream_id: u32) Pending!Node {
             assert(stream_id < self.streams_count);
             const next_key = stream_peek(self.context, stream_id) catch |err| switch (err) {
-                error.Drained => return error.Drained,
-                error.Empty => {
-                    self.streams_active -= 1;
-                    return sentinel;
-                },
+                error.Pending => return error.Pending,
+            } orelse { // FIXME: simplify these.
+                self.streams_active -= 1;
+                return sentinel;
             };
             return .{ .key = next_key, .stream_id = stream_id, .sentinel = false };
         }
@@ -309,9 +308,9 @@ fn TestContextType(comptime streams_max: u32) type {
         fn stream_peek(
             context: *const TestContext,
             stream_index: u32,
-        ) error{ Empty, Drained }!u32 {
+        ) Pending!?u32 {
             const stream = context.streams[stream_index];
-            if (stream.len == 0) return error.Empty;
+            if (stream.len == 0) return null;
             return stream[0].key;
         }
 
@@ -485,6 +484,7 @@ test "k_way_merge: unit" {
 
 fn FuzzTestContextType(comptime streams_max: u32) type {
     const testing = std.testing;
+    const ratio = stdx.PRNG.ratio;
 
     return struct {
         const FuzzTestContext = @This();
@@ -500,14 +500,11 @@ fn FuzzTestContextType(comptime streams_max: u32) type {
         fn fuzz_stream_peek(
             context: *const FuzzTestContext,
             stream_index: u32,
-        ) error{ Empty, Drained }!u32 {
-            switch (context.prng.enum_weighted(
-                enum { normal, drained },
-                .{ .normal = 95, .drained = 5 },
-            )) {
-                .normal => return context.inner.stream_peek(stream_index),
-                .drained => return error.Drained,
+        ) Pending!?u32 {
+            if (context.prng.chance(ratio(5, 100))) {
+                return error.Pending;
             }
+            return context.inner.stream_peek(stream_index);
         }
 
         fn stream_pop(context: *FuzzTestContext, stream_index: u32) Value {

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -19,6 +19,15 @@ const TimestampRange = @import("timestamp_range.zig").TimestampRange;
 
 const Error = @import("scan_buffer.zig").Error;
 
+/// Scans work with asynchronous iterators --- streams.
+///
+/// Iterator has       `fn next() ?Item`,
+/// while a stream has `fn next() Pending!?Item`
+///
+/// When a stream returns `error.Pending`, this means that it is unknown
+/// whether a stream has more items or not, and further IO is required.
+const Pending = error{Pending};
+
 /// ScanBuilder is a helper to create and combine scans using
 /// any of the Groove's indexes.
 pub fn ScanBuilderType(
@@ -413,7 +422,7 @@ pub fn ScanType(
             }
         }
 
-        pub fn next(scan: *Scan) error{ReadAgain}!?u64 {
+        pub fn next(scan: *Scan) Pending!?u64 {
             switch (scan.dispatcher) {
                 inline .merge_union,
                 .merge_intersection,

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -196,7 +196,7 @@ pub fn ScanLookupType(
                     timestamp,
                 )) {
                     // Since the scan already found the key,
-                    // we don't expected `negative` here.
+                    // we don't expect `negative` here.
                     .negative => unreachable,
 
                     // Object is cached in memory,

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -164,7 +164,7 @@ pub fn ScanLookupType(
                 }
 
                 const timestamp = self.scan.next() catch |err| switch (err) {
-                    error.ReadAgain => {
+                    error.Pending => {
                         // The scan needs to be buffered again.
                         self.state = .scan;
                         break;

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -49,13 +49,9 @@ fn ScanMergeType(
             scan: *Scan,
             current: ?u64 = null,
 
-            fn peek(
-                self: *MergeScanStream,
-            ) Pending!?u64 { // FIXME:
+            fn peek(self: *MergeScanStream) Pending!?u64 {
                 if (self.current == null) {
-                    self.current = self.scan.next() catch |err| switch (err) {
-                        error.Pending => return error.Pending,
-                    };
+                    self.current = try self.scan.next();
                 }
                 maybe(self.current == null);
                 return self.current;

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -10,6 +10,7 @@ const Direction = @import("../direction.zig").Direction;
 const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
 const ZigZagMergeIteratorType = @import("zig_zag_merge.zig").ZigZagMergeIteratorType;
 const ScanType = @import("scan_builder.zig").ScanType;
+const Pending = error{Pending};
 
 /// Union ∪ operation over an array of non-specialized `Scan` instances.
 /// At a high level, this is an ordered iterator over the set-union of the timestamps of
@@ -50,13 +51,14 @@ fn ScanMergeType(
 
             fn peek(
                 self: *MergeScanStream,
-            ) error{ Empty, Drained }!u64 {
+            ) Pending!?u64 { // FIXME:
                 if (self.current == null) {
                     self.current = self.scan.next() catch |err| switch (err) {
-                        error.ReadAgain => return error.Drained,
+                        error.Pending => return error.Pending,
                     };
                 }
-                return self.current orelse error.Empty;
+                maybe(self.current == null);
+                return self.current;
             }
 
             fn pop(self: *MergeScanStream) u64 {
@@ -218,21 +220,21 @@ fn ScanMergeType(
 
         /// Moves the iterator to the next position and returns its `Value` or `null` if the
         /// iterator has no more values to iterate.
-        /// May return `error.ReadAgain` if the scan needs to be loaded, in this case
+        /// May return `error.Pending` if the scan needs to be loaded, in this case
         /// call `read()` and resume the iteration after the read callback.
-        pub fn next(self: *ScanMerge) error{ReadAgain}!?u64 {
+        pub fn next(self: *ScanMerge) Pending!?u64 {
             switch (self.state) {
                 .idle => {
                     assert(self.merge_iterator == null);
-                    return error.ReadAgain;
+                    return error.Pending;
                 },
                 .seeking => return self.merge_iterator.?.pop() catch |err| switch (err) {
-                    error.Drained => {
+                    error.Pending => {
                         self.state = .needs_data;
-                        return error.ReadAgain;
+                        return error.Pending;
                     },
                 },
-                .needs_data => return error.ReadAgain,
+                .needs_data => return error.Pending,
                 .buffering, .aborted => unreachable,
             }
         }
@@ -334,7 +336,7 @@ fn ScanMergeType(
         fn merge_stream_peek(
             self: *ScanMerge,
             stream_index: u32,
-        ) error{ Empty, Drained }!u64 {
+        ) Pending!?u64 {
             assert(stream_index < self.streams.count());
 
             var stream = &self.streams.slice()[stream_index];

--- a/src/lsm/scan_range.zig
+++ b/src/lsm/scan_range.zig
@@ -2,6 +2,7 @@ const ScanTreeType = @import("scan_tree.zig").ScanTreeType;
 const ScanBuffer = @import("scan_buffer.zig").ScanBuffer;
 
 const Direction = @import("../direction.zig").Direction;
+const Pending = error{Pending};
 
 /// Apply a custom filter and/or stop-condition when scanning a range of values.
 pub const EvaluateNext = enum {
@@ -71,7 +72,7 @@ pub fn ScanRangeType(
             context.callback(context, parent);
         }
 
-        pub fn next(scan: *ScanRange) error{ReadAgain}!?u64 {
+        pub fn next(scan: *ScanRange) Pending!?u64 {
             while (try scan.scan_tree.next()) |value| {
                 if (Tree.Table.tombstone(&value)) continue;
 

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -32,6 +32,7 @@ const maybe = stdx.maybe;
 
 const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
 const ScratchMemory = @import("scratch_memory.zig").ScratchMemory;
+const Pending = error{Pending};
 
 pub fn TableMemoryType(comptime Table: type) type {
     const Key = Table.Key;
@@ -93,11 +94,11 @@ pub fn TableMemoryType(comptime Table: type) type {
             fn stream_peek(
                 context: *const MergeContext,
                 stream_index: u32,
-            ) error{ Empty, Drained }!Key {
+            ) Pending!?Key {
                 // TODO: Enable the asserts once `constants.verify` is disabled on release.
                 //assert(stream_index < context.streams_count);
                 const stream = context.streams[stream_index];
-                if (stream.len == 0) return error.Empty;
+                if (stream.len == 0) return null;
                 return key_from_value(&stream[0]);
             }
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -498,7 +498,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         fn on_scan_read(env: *Environment, scan_tree: *ScanTree) void {
             while (scan_tree.next() catch |err| switch (err) {
-                error.ReadAgain => return scan_tree.read(env, on_scan_read),
+                error.Pending => return scan_tree.read(env, on_scan_read),
             }) |value| {
                 if (env.scan_results_count == scan_results_max) break;
 

--- a/src/lsm/zig_zag_merge.zig
+++ b/src/lsm/zig_zag_merge.zig
@@ -143,7 +143,7 @@ pub fn ZigZagMergeIteratorType(
                             }),
                     );
 
-                    // The keys matches, continuing to the next stream.
+                    // The keys match, continuing to the next stream.
                     if (key == probe_key) continue;
 
                     if (it.key_ahead(.{ .key_after = key, .key_before = probe_key })) {
@@ -196,7 +196,7 @@ pub fn ZigZagMergeIteratorType(
                 if (pending.isSet(stream_index)) {
                     // Probing the pending stream will update the key range for the next read.
                     stream_probe(it.context, @intCast(stream_index), probe_key);
-                    // The stream must remain pending after probed.
+                    // The stream must remain pending after being probed.
                     assert(stream_peek(it.context, @intCast(stream_index)) == Pending.Pending);
                 } else {
                     // At this point, all the buffered streams must have produced a matching key.

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -4793,7 +4793,7 @@ fn ChangeEventsScanLookupType(
             assert(self.state == .scan);
 
             while (scan_tree.next() catch |err| switch (err) {
-                error.ReadAgain => {
+                error.Pending => {
                     self.scan_tree.read({}, &scan_read_callback);
                     return;
                 },


### PR DESCRIPTION
We have several different ways to describe iterator-shaped things:

1. `fn next() ?Value`
2. `fn next() error{ReadAgain}!?Value`
3. `fn next() error{ Empty, Drained }!Value`

The first one is iterator, the second one is what `ScanTree` is doing, and the third one is the API of the kWayMerge 

This PR unifies 2&3 to

```zig
fn next() error{Pending}!?Value
```

Because: 

- We do want to use consistent signature here
- The `!?` version is orthogonal composition of iteration and asynchrony, so we use that
- And we change to `Pending` terminology, as we already use it in `commit_dispatch` to mean "pending some async work". 
