### PR TITLE
vopr: fast storage & network in liveness mode for fast convergence

### DIFF
--- a/src/testing/cluster/network.zig
+++ b/src/testing/cluster/network.zig
@@ -132,6 +132,8 @@ pub const Network = struct {
     pub fn transition_to_liveness_mode(network: *Network, core: Core) void {
         assert(core.count() > 0);
 
+        network.packet_simulator.options.one_way_delay_min = .ms(1);
+        network.packet_simulator.options.one_way_delay_mean = .ms(1);
         network.packet_simulator.options.packet_loss_probability = Ratio.zero();
         network.packet_simulator.options.packet_replay_probability = Ratio.zero();
         network.packet_simulator.options.partition_probability = Ratio.zero();

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -921,6 +921,10 @@ pub const Storage = struct {
     }
 
     pub fn transition_to_liveness_mode(storage: *Storage) void {
+        storage.options.write_latency_mean = .ms(1);
+        storage.options.write_latency_min = .ms(1);
+        storage.options.read_latency_mean = .ms(1);
+        storage.options.read_latency_min = .ms(1);
         storage.options.read_fault_probability = Ratio.zero();
         storage.options.write_fault_probability = Ratio.zero();
         storage.options.write_misdirect_probability = Ratio.zero();


### PR DESCRIPTION
Resolves `sudo ./zig/zig build vopr -Drelease -- 12595886967519354417` which fails with `panic: block found in core`, but only because the cluster is slow to converge during liveness mode. 

This PR speeds up convergence, by making disk IO & message delivery faster -- 1ms. This is reasonable since the purpose of liveness mode is to check _whether_ a cluster can converge given steady state, where there are no new storage corruptions, process crashes and network partitions, _not_ how fast it converges. Thereafter, liveness mode also asserts that if a cluster can't converge, it is due to correlated faults that render the cluster irrecoverable. 