### PR TITLE
Binary search benchmark: fix precedence.

### DIFF
--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -127,7 +127,7 @@ const Layout = struct {
 
 fn ValueType(comptime layout: Layout) type {
     return struct {
-        pub const max_key = 1 << (8 * layout.key_size) - 1;
+        pub const max_key = (1 << (8 * layout.key_size)) - 1;
         pub const Key = math.IntFittingRange(0, max_key);
         const Value = @This();
         key: Key,


### PR DESCRIPTION
This PR fixes the `max_key` calculation in the binary benchmark so that the full key range is possible.