### PR TITLE
ci: fix out of space failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 2147483647 }
       - run: sudo apt-get update && sudo apt-get install -y kcov
+      - run: sudo rm -rf /usr/local/lib/android # Free up disk space for benchmarking.
       - run: ./zig/download.ps1
 
       # Dummy devhub run - checks that all the devhub tests pass in CI. They are run again, in main

--- a/build.zig
+++ b/build.zig
@@ -538,9 +538,6 @@ fn build_ci_script(
 // Hide step's stderr unless it fails, to prevent zig build ci output being dominated by VOPR logs.
 // Sadly, this requires "overriding" Build.Step.Run make function.
 fn hide_stderr(run: *std.Build.Step.Run) void {
-    // Debugging https://github.com/tigerbeetle/tigerbeetle/actions/runs/20034473571/job/57452104427
-    if (true) return;
-
     const b = run.step.owner;
 
     run.addCheck(.{ .expect_term = .{ .Exited = 0 } });


### PR DESCRIPTION
Our data file size after benchmarking is 16GiB, which is a bit over what we can use. Free up the space by removing 15GiB of android

<https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/>