### PR TITLE
aof: stat the aof on checkpoint and reopen if not there

### DIFF
--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -123,6 +123,11 @@ pub fn aof_blocking_stat(path: []const u8) std.fs.Dir.StatFileError!std.fs.File.
     return std.fs.cwd().statFile(path);
 }
 
+pub fn aof_blocking_fstat(fd: posix.fd_t) std.fs.Dir.StatError!std.fs.File.Stat {
+    const file = std.fs.File{ .handle = fd };
+    return file.stat();
+}
+
 pub fn aof_blocking_open(dir_fd: posix.fd_t, path: []const u8) !posix.fd_t {
     assert(!std.fs.path.isAbsolute(path));
 

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -118,3 +118,32 @@ pub fn aof_blocking_close(fd: posix.fd_t) void {
     const file = std.fs.File{ .handle = fd };
     file.close();
 }
+
+pub fn aof_blocking_stat(path: []const u8) std.fs.Dir.StatFileError!std.fs.File.Stat {
+    return std.fs.cwd().statFile(path);
+}
+
+pub fn aof_blocking_open(dir_fd: posix.fd_t, path: []const u8) !posix.fd_t {
+    assert(!std.fs.path.isAbsolute(path));
+
+    const dir = std.fs.Dir{ .fd = dir_fd };
+
+    const file = try dir.createFile(path, .{
+        .read = true,
+        .truncate = false,
+        .exclusive = false,
+        .lock = .exclusive,
+    });
+
+    try file.sync();
+
+    // We cannot fsync the directory handle on Windows.
+    // We have no way to open a directory with write access.
+    if (builtin.os.tag != .windows) {
+        try std.posix.fsync(dir_fd);
+    }
+
+    try file.seekFromEnd(0);
+
+    return file.handle;
+}

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -1075,6 +1075,10 @@ pub const IO = struct {
         return common.aof_blocking_stat(path);
     }
 
+    pub fn aof_blocking_fstat(_: *IO, fd: fd_t) std.fs.Dir.StatError!std.fs.File.Stat {
+        return common.aof_blocking_fstat(fd);
+    }
+
     pub fn aof_blocking_open(io: *IO, path: []const u8) !fd_t {
         stdx.maybe(std.fs.path.isAbsolute(path));
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -1070,4 +1070,20 @@ pub const IO = struct {
     pub fn aof_blocking_close(_: *IO, fd: fd_t) void {
         return common.aof_blocking_close(fd);
     }
+
+    pub fn aof_blocking_stat(_: *IO, path: []const u8) std.fs.Dir.StatFileError!std.fs.File.Stat {
+        return common.aof_blocking_stat(path);
+    }
+
+    pub fn aof_blocking_open(io: *IO, path: []const u8) !fd_t {
+        stdx.maybe(std.fs.path.isAbsolute(path));
+
+        const dir_path = std.fs.path.dirname(path) orelse ".";
+        const dir_fd = try IO.open_dir(dir_path);
+        defer io.aof_blocking_close(dir_fd);
+
+        const file_path = std.fs.path.basename(path);
+
+        return common.aof_blocking_open(dir_fd, file_path);
+    }
 };

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1836,6 +1836,22 @@ pub const IO = struct {
         return common.aof_blocking_close(fd);
     }
 
+    pub fn aof_blocking_stat(_: *IO, path: []const u8) std.fs.Dir.StatFileError!std.fs.File.Stat {
+        return common.aof_blocking_stat(path);
+    }
+
+    pub fn aof_blocking_open(io: *IO, path: []const u8) !fd_t {
+        stdx.maybe(std.fs.path.isAbsolute(path));
+
+        const dir_path = std.fs.path.dirname(path) orelse ".";
+        const dir_fd = try IO.open_dir(dir_path);
+        defer io.aof_blocking_close(dir_fd);
+
+        const file_path = std.fs.path.basename(path);
+
+        return common.aof_blocking_open(dir_fd, file_path);
+    }
+
     fn erase_types(
         comptime Context: type,
         comptime Result: type,

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1840,6 +1840,10 @@ pub const IO = struct {
         return common.aof_blocking_stat(path);
     }
 
+    pub fn aof_blocking_fstat(_: *IO, fd: fd_t) std.fs.Dir.StatError!std.fs.File.Stat {
+        return common.aof_blocking_fstat(fd);
+    }
+
     pub fn aof_blocking_open(io: *IO, path: []const u8) !fd_t {
         stdx.maybe(std.fs.path.isAbsolute(path));
 

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1434,6 +1434,22 @@ pub const IO = struct {
     pub fn aof_blocking_close(_: *IO, fd: fd_t) void {
         return common.aof_blocking_close(fd);
     }
+
+    pub fn aof_blocking_stat(_: *IO, path: []const u8) std.fs.Dir.StatFileError!std.fs.File.Stat {
+        return common.aof_blocking_stat(path);
+    }
+
+    pub fn aof_blocking_open(io: *IO, path: []const u8) !fd_t {
+        stdx.maybe(std.fs.path.isAbsolute(path));
+
+        const dir_path = std.fs.path.dirname(path) orelse ".";
+        const dir_fd = try IO.open_dir(dir_path);
+        defer io.aof_blocking_close(dir_fd);
+
+        const file_path = std.fs.path.basename(path);
+
+        return common.aof_blocking_open(dir_fd, file_path);
+    }
 };
 
 // TODO: use posix.getsockoptError when fixed for windows in stdlib.

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1439,6 +1439,10 @@ pub const IO = struct {
         return common.aof_blocking_stat(path);
     }
 
+    pub fn aof_blocking_fstat(_: *IO, fd: fd_t) std.fs.Dir.StatError!std.fs.File.Stat {
+        return common.aof_blocking_fstat(fd);
+    }
+
     pub fn aof_blocking_open(io: *IO, path: []const u8) !fd_t {
         stdx.maybe(std.fs.path.isAbsolute(path));
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -409,7 +409,8 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
                 aof.* = AOF{
                     .io = aof_io,
-                    .file_descriptor = 0,
+                    .path = "test.aof",
+                    .fd = 0,
                 };
                 errdefer for (cluster.aofs[0..i]) |*aof_| aof_.deinit(allocator);
             }

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -303,6 +303,10 @@ pub const IO = struct {
         return error.Unexpected;
     }
 
+    pub fn aof_blocking_fstat(_: *IO, _: fd_t) std.fs.Dir.StatError!std.fs.File.Stat {
+        return error.Unexpected;
+    }
+
     pub fn aof_blocking_open(_: *IO, _: []const u8) !fd_t {
         return error.Unexpected;
     }

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -299,6 +299,14 @@ pub const IO = struct {
         return target.len;
     }
 
+    pub fn aof_blocking_stat(_: *IO, _: []const u8) std.fs.Dir.StatFileError!std.fs.File.Stat {
+        return error.Unexpected;
+    }
+
+    pub fn aof_blocking_open(_: *IO, _: []const u8) !fd_t {
+        return error.Unexpected;
+    }
+
     pub fn reset(self: *IO) void {
         self.completed.reset();
     }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -257,14 +257,7 @@ fn command_start(
     defer message_pool.deinit(gpa);
 
     var aof: ?AOF = if (args.aof_file) |*aof_file| blk: {
-        const aof_dir = std.fs.path.dirname(aof_file.const_slice()) orelse ".";
-        const aof_dir_fd = try IO.open_dir(aof_dir);
-        defer std.posix.close(aof_dir_fd);
-
-        break :blk try AOF.init(io, .{
-            .dir_fd = aof_dir_fd,
-            .relative_path = std.fs.path.basename(aof_file.const_slice()),
-        });
+        break :blk try AOF.init(io, aof_file.const_slice());
     } else null;
     defer if (aof != null) aof.?.close();
 


### PR DESCRIPTION
This adds the ability to rotate AOF files without having to use signals. Instead, you can `mv` the old AOF out of the way, and tigerbeetle will continue writing to it until checkpoint, upon which it'll notice and reopen the original path.

The main reason behind this is to allow trimming AOF sizes without having to interrupt the cluster.

When the cluster hits a checkpoint, it'll `stat` the path, see there's no file there anymore, and reopen a new fd, giving a clean rotation.

The _safe_ way to rotate and backup is thus:
```bash
$ mv current.aof old.aof
$ # Wait for current.aof to be recreated, or wait for the lock to be released on old.aof - this is NB!
$ s3 cp old.aof s3://my-backup/
```

The middle step is load bearing! Before it happens, tigerbeetle is still writing in to the same file descriptor (which now points to old.aof), so old.aof _is not_ safe to copy or delete. You can also check old.aof is not `flock`'d to make sure.

It's also incorrect to try and recreate `current.aof` yourself; this will cause tigerbeetle to miss the rotation and keep on writing into `old.aof`.

There's no way to rotate other than waiting for a checkpoint - this is to keep things simple. If it's a very lightly loaded cluster, you can pulse no-ops or similar through to force one.