### PR TITLE
Scripts/Release: Work around apk bug

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -908,6 +908,9 @@ fn publish_docker(shell: *Shell, info: VersionInfo) !void {
             .{
                 .stdin_slice =
                 \\FROM alpine:latest
+                // TODO Remove this workaround once the Alpine 3.23.1 is published.
+                // (See https://hub.docker.com/_/alpine).
+                \\RUN apk upgrade --scripts=no apk-tools
                 \\RUN apk add --no-cache tini
                 \\ARG TARGETARCH
                 \\COPY tigerbeetle-${TARGETARCH} /tigerbeetle


### PR DESCRIPTION
Work around release bug due to https://gitlab.alpinelinux.org/alpine/aports/-/issues/17775

(I tested this by building the dockerfile locally.)