### PR TITLE
Devhub: assert: throw Error, not String

### DIFF
--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -17,7 +17,7 @@ window.onload = () =>
 function assert(condition) {
   if (!condition) {
     alert("Assertion failed");
-    throw "Assertion failed";
+    throw new Error("Assertion failed");
   }
 }
 


### PR DESCRIPTION
On assertion failure, throw an `Error` rather than a string, so that we get a stack trace in the console.