### PR TITLE
vsr: remove confusing slow request warning

### DIFF
--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -567,18 +567,6 @@ pub fn ClientType(
             assert(reply.header.op == reply.header.commit);
             assert(reply.header.operation == inflight_vsr_operation);
 
-            const request_completion_duration = self.request_completion_timer.read();
-            if (request_completion_duration.to_ms() > constants.client_request_completion_warn_ms) {
-                log.warn("{}: on_reply: slow request, request={} op={} size={} {s} time={}ms", .{
-                    self.id,
-                    inflight.message.header.request,
-                    reply.header.op,
-                    inflight.message.header.size,
-                    inflight.message.header.operation.tag_name(Operation),
-                    request_completion_duration.to_ms(),
-                });
-            }
-
             // The context of this reply becomes the parent of our next request:
             self.parent = reply.header.context;
 


### PR DESCRIPTION
We had added these `slow request` warnings to get observability into commit latency & the client's end-to-end request latency, in the absence of metrics. However, they have often been a source of confusion for users, since this is heavily dependent on the network & disk speed. 

Now, we collect metrics about the `client_request_round_trip` and `replica_request_local`, which serve the same purpose, as well as `replica_commit: struct { stage: CommitStage.Tag }` for granular timing information about each commit stage. 

So, this PR removes the `slow request` warnings.