### PR TITLE
Binary search benchmark: reduce noise and improve reproducibility.

### DIFF
--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -86,7 +86,7 @@ fn run_benchmark(
     comptime layout: Layout,
     search_count: u64,
     page_buffer: []u8,
-    allocator: std.mem.Allocator,
+    arena: std.mem.Allocator,
     prng: *stdx.PRNG,
 ) !void {
     const V = ValueType(layout);
@@ -99,12 +99,10 @@ fn run_benchmark(
     assert(page_count > 0);
     if (page_count > 1024 * 1024) @panic("page_count too large");
 
-    const page_picker = try allocator.alloc(usize, page_count);
-    defer allocator.free(page_picker);
+    const page_picker = try arena.alloc(usize, page_count);
     shuffled_index(prng, page_picker);
 
-    const value_picker = try allocator.alloc(usize, layout.values_count);
-    defer allocator.free(value_picker);
+    const value_picker = try arena.alloc(usize, layout.values_count);
     shuffled_index(prng, value_picker);
 
     var page_alloc = std.heap.FixedBufferAllocator.init(page_buffer);

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -141,7 +141,7 @@ fn run_benchmark(
     std.mem.doNotOptimizeAway(checksum);
 
     std.sort.block(stdx.Duration, &duration_samples, {}, stdx.Duration.sort.asc);
-    const result = duration_samples[2]; // discard the fastest two, report the 3rd fastest.
+    const result = duration_samples[2]; // Discard the fastest two, report the 3rd fastest.
 
     bench.report(body_fmt, .{
         scenario_name,

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -45,13 +45,8 @@ test "benchmark: binary search" {
 
     const blob_size = bench.parameter("blob_size", MiB, GiB);
     const searches = bench.parameter("searches", 500, 20_000);
-    // Benchmarks require a fixed seed for reproducibility; smoke mode may use a random seed.
-    const seed = bench.parameter(
-        "seed",
-        std.crypto.random.intRangeLessThan(u64, 0, std.math.maxInt(u64)),
-        std.math.maxInt(u64),
-    );
-    var prng = stdx.PRNG.from_seed(seed);
+
+    var prng = stdx.PRNG.from_seed(bench.seed);
 
     bench.report("WT: Wall time/search", .{});
 

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -43,15 +43,15 @@ test "benchmark: binary search" {
     var bench: Bench = .init();
     defer bench.deinit();
 
+    bench.report("WT: Wall time/search", .{});
+
     const blob_size = bench.parameter("blob_size", MiB, GiB);
     const searches = bench.parameter("searches", 500, 20_000);
 
     var prng = stdx.PRNG.from_seed(bench.seed);
-
-    bench.report("WT: Wall time/search", .{});
-
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
+
     const blob = try arena.allocator().alignedAlloc(u8, 64, blob_size);
     var checksum: u64 = 0;
 

--- a/src/testing/bench.zig
+++ b/src/testing/bench.zig
@@ -58,17 +58,23 @@ const Duration = stdx.Duration;
 const Instant = stdx.Instant;
 const TimeOS = @import("../time.zig").TimeOS;
 
+const seed_benchmark: u64 = 42;
+
 const mode: enum { smoke, benchmark } =
     // See build.zig for how this is ultimately determined.
     if (@import("test_options").benchmark) .benchmark else .smoke;
 
+seed: u64,
 time: TimeOS = .{},
 instant_start: ?Instant = null,
 
 const Bench = @This();
 
 pub fn init() Bench {
-    return .{};
+    return .{
+        // Benchmarks require a fixed seed for reproducibility; smoke mode uses a random seed.
+        .seed = if (mode == .benchmark) seed_benchmark else std.testing.random_seed,
+    };
 }
 
 pub fn deinit(bench: *Bench) void {


### PR DESCRIPTION
This PR reduces noise in our binary search benchmark to make potential performance regressions easier to detect.

The benchmark now focuses only on scenarios that matter. Previously, it covered many additional cases, some of which are not relevant in our code, which introduced unnecessary noise.
To further stabilize the results, the benchmark now collects multiple samples, discards the two fastest runs, and reports the third-best result. While this may seem unintuitive, it follows a best practice to mitigate system noise and transient effects as most benchmark distributions are log-normal ( [see](https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/) and  [here](https://github.com/travisdowns/uarch-bench)).

The benchmark also uses a fixed random seed for each benchmark run, improving reproducibility. (The smoke benchmark still uses a random seed.) Finally, an 8 MB allocation was moved from the stack to the heap.

P.S. I want to create a few more benchmarks with @matklad's nice benchmark harness in the next few days.