### PR TITLE
Checksum benchmark.

### DIFF
--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -57,6 +57,7 @@ comptime {
     _ = @import("trace/event.zig");
     _ = @import("vsr.zig");
     _ = @import("vsr/checksum.zig");
+    _ = @import("vsr/checksum_benchmark.zig");
     _ = @import("vsr/clock.zig");
     _ = @import("vsr/free_set.zig");
     _ = @import("vsr/grid_scrubber.zig");

--- a/src/vsr/checksum_benchmark.zig
+++ b/src/vsr/checksum_benchmark.zig
@@ -10,7 +10,7 @@ const MiB = stdx.MiB;
 
 const Bench = @import("../testing/bench.zig");
 
-const repititions = 35;
+const repetitions = 35;
 
 test "benchmark: checksum" {
     var bench: Bench = .init();
@@ -26,7 +26,7 @@ test "benchmark: checksum" {
     const blob = try arena.alignedAlloc(u8, cache_line_size, blob_size);
     prng.fill(blob);
 
-    var duration_samples: [repititions]stdx.Duration = undefined;
+    var duration_samples: [repetitions]stdx.Duration = undefined;
     var checksum_counter: u128 = 0;
 
     for (&duration_samples) |*duration| {
@@ -36,6 +36,8 @@ test "benchmark: checksum" {
     }
 
     const result = bench.estimate(&duration_samples);
+
+    // See "benchmark: API tutorial" to understand why we print out the "hash" of this run.
     bench.report("checksum {x:0>32}", .{checksum_counter});
     bench.report("{} for whole blob", .{result});
 }

--- a/src/vsr/checksum_benchmark.zig
+++ b/src/vsr/checksum_benchmark.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+const cache_line_size = @import("../constants.zig").cache_line_size;
+const checksum = @import("checksum.zig").checksum;
+
+const stdx = @import("stdx");
+
+const KiB = stdx.KiB;
+const MiB = stdx.MiB;
+
+const Bench = @import("../testing/bench.zig");
+
+const repititions = 35;
+
+test "benchmark: checksum" {
+    var bench: Bench = .init();
+    defer bench.deinit();
+
+    const blob_size = bench.parameter("blob_size", KiB, MiB);
+
+    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_instance.deinit();
+
+    const arena = arena_instance.allocator();
+    var prng = stdx.PRNG.from_seed(bench.seed);
+    const blob = try arena.alignedAlloc(u8, cache_line_size, blob_size);
+    prng.fill(blob);
+
+    var duration_samples: [repititions]stdx.Duration = undefined;
+    var checksum_counter: u128 = 0;
+
+    for (&duration_samples) |*duration| {
+        bench.start();
+        checksum_counter +%= checksum(blob);
+        duration.* = bench.stop();
+    }
+
+    const result = bench.estimate(&duration_samples);
+    bench.report("checksum {x:0>32}", .{checksum_counter});
+    bench.report("{} for whole blob", .{result});
+}


### PR DESCRIPTION
This PR adds a checksum microbenchmark to detect performance regressions.

I validated it by rolling back PR #3201.

New:
Size = 1,048,576 B, WT = 63.019 µs

Old:
Size = 1,048,576 B, WT = 122.36 µs

The benchmark runs multiple iterations and reports an (almost) best-case result, which makes it very stable and well suited for regression detection. Runtime noise is often log-normally distributed, making best-case or near-best-case measurements more representative for microbenchmarks (see https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/).

EDIT: This is now a stacked PR on top of #3434. Will ping you @chaitanyabhandari once the other review is complete to save double work :-). 