### PR TITLE
segmented array: remove potential ressource leak.

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -348,6 +348,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         }
 
         pub fn reset(forest: *Forest) void {
+            // Components using the node_pool must release all nodes they acquired upon reset.
+            defer assert(forest.node_pool.free.count() == forest.node_pool.free.bit_length);
+
             inline for (std.meta.fields(Grooves)) |field| {
                 @field(forest.grooves, field.name).reset();
             }
@@ -358,7 +361,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             forest.grid.trace.cancel(.scan_tree_level);
 
             forest.manifest_log.reset();
-            forest.node_pool.reset();
             forest.scan_buffer_pool.reset();
             forest.compaction_schedule.reset();
 

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -211,7 +211,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
             for (&manifest.levels, 0..) |*level, i| {
                 errdefer for (manifest.levels[0..i]) |*l| l.deinit(allocator, node_pool);
-                try level.init(allocator);
+                try level.init(allocator, node_pool);
             }
             errdefer for (&manifest.levels) |*level| level.deinit(allocator, node_pool);
         }

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -221,7 +221,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         }
 
         pub fn reset(manifest: *Manifest) void {
-            for (&manifest.levels) |*level| level.reset();
+            for (&manifest.levels) |*level| level.reset(manifest.node_pool);
 
             manifest.* = .{
                 .node_pool = manifest.node_pool,

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -170,17 +170,17 @@ pub fn ManifestLevelType(
         /// TableInfo references.
         generation: u32 = 0,
 
-        pub fn init(level: *ManifestLevel, allocator: mem.Allocator) !void {
+        pub fn init(level: *ManifestLevel, allocator: mem.Allocator, node_pool: *NodePool) !void {
             level.* = .{
                 .keys = undefined,
                 .tables = undefined,
             };
 
             level.keys = try Keys.init(allocator);
-            errdefer level.keys.deinit(allocator, null);
+            errdefer level.keys.deinit(allocator, node_pool);
 
             level.tables = try Tables.init(allocator);
-            errdefer level.tables.deinit(allocator, null);
+            errdefer level.tables.deinit(allocator, node_pool);
         }
 
         pub fn deinit(level: *ManifestLevel, allocator: mem.Allocator, node_pool: *NodePool) void {
@@ -852,7 +852,7 @@ pub fn TestContextType(
             );
             errdefer context.pool.deinit(testing.allocator);
 
-            try context.level.init(testing.allocator);
+            try context.level.init(testing.allocator, &context.pool);
             errdefer context.level.deinit(testing.allocator, &context.pool);
 
             context.reference = std.ArrayList(TableInfo).init(testing.allocator);

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -190,9 +190,9 @@ pub fn ManifestLevelType(
             level.* = undefined;
         }
 
-        pub fn reset(level: *ManifestLevel) void {
-            level.keys.reset();
-            level.tables.reset();
+        pub fn reset(level: *ManifestLevel, node_pool: *NodePool) void {
+            level.keys.reset(node_pool);
+            level.tables.reset(node_pool);
 
             level.* = .{
                 .keys = level.keys,

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -245,7 +245,7 @@ pub fn EnvironmentType(comptime table_count_max_tree: u32, comptime node_size: u
             try env.pool.init(gpa, node_pool_size);
             errdefer env.pool.deinit(gpa);
 
-            try env.level.init(gpa);
+            try env.level.init(gpa, &env.pool);
             errdefer env.level.deinit(gpa, &env.pool);
 
             env.buffer = TableBuffer.init(gpa);

--- a/src/lsm/node_pool.zig
+++ b/src/lsm/node_pool.zig
@@ -51,15 +51,6 @@ pub fn NodePoolType(comptime _node_size: u32, comptime _node_alignment: u13) typ
             pool.free.deinit(allocator);
         }
 
-        pub fn reset(pool: *NodePool) void {
-            pool.free.setRangeValue(.{ .start = 0, .end = pool.free.capacity() }, true);
-
-            pool.* = .{
-                .buffer = pool.buffer,
-                .free = pool.free,
-            };
-        }
-
         pub fn acquire(pool: *NodePool) Node {
             // TODO: To ensure this "unreachable" is never reached, the primary must reject
             // new requests when storage space is too low to fulfill them.

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -147,11 +147,11 @@ fn SegmentedArrayBaseType(
             return array;
         }
 
-        pub fn deinit(array: SegmentedArray, allocator: mem.Allocator, node_pool: ?*NodePool) void {
+        pub fn deinit(array: SegmentedArray, allocator: mem.Allocator, node_pool: *NodePool) void {
             if (options.verify) array.verify();
 
             for (array.nodes[0..array.node_count]) |node| {
-                node_pool.?.release(@ptrCast(@alignCast(node.?)));
+                node_pool.release(@ptrCast(@alignCast(node.?)));
             }
             allocator.free(array.nodes);
             allocator.free(array.indexes);

--- a/src/lsm/segmented_array.zig
+++ b/src/lsm/segmented_array.zig
@@ -157,10 +157,15 @@ fn SegmentedArrayBaseType(
             allocator.free(array.indexes);
         }
 
-        pub fn reset(array: *SegmentedArray) void {
-            @memset(array.nodes, null);
-            array.indexes[0] = 0;
+        pub fn reset(array: *SegmentedArray, node_pool: *NodePool) void {
+            if (options.verify) array.verify();
 
+            for (array.nodes[0..array.node_count]) |node| {
+                node_pool.release(@ptrCast(@alignCast(node.?)));
+            }
+            @memset(array.nodes, null);
+
+            array.indexes[0] = 0;
             array.* = .{
                 .nodes = array.nodes,
                 .indexes = array.indexes,


### PR DESCRIPTION
This PR removes a potential resource leak / footgun in `reset`, where used `Node`s were not returned to the `NodePool`.
In the current codebase, this issue is avoided because `reset` is always paired with `NodePool.reset`, but relying on this coupling is error-prone (especially for future changes).