### PR TITLE
tidy: draw a blank after defer.

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -79,6 +79,7 @@ pub const ClientInterface = extern struct {
 
         client.locker.lock();
         defer client.locker.unlock();
+
         const context = client.context.ptr orelse return Error.ClientInvalid;
         client.vtable.ptr.submit_fn(context, packet);
     }
@@ -89,6 +90,7 @@ pub const ClientInterface = extern struct {
 
         client.locker.lock();
         defer client.locker.unlock();
+
         const context = client.context.ptr orelse return Error.ClientInvalid;
         return client.vtable.ptr.completion_context_fn(context);
     }
@@ -100,9 +102,11 @@ pub const ClientInterface = extern struct {
         const context: *anyopaque = context: {
             client.locker.lock();
             defer client.locker.unlock();
+
             if (client.context.ptr == null) return Error.ClientInvalid;
 
             defer client.context.ptr = null;
+
             break :context client.context.ptr.?;
         };
         client.vtable.ptr.deinit_fn(context);
@@ -114,6 +118,7 @@ pub const ClientInterface = extern struct {
 
         client.locker.lock();
         defer client.locker.unlock();
+
         const context = client.context.ptr orelse return Error.ClientInvalid;
         return client.vtable.ptr.init_parameters_fn(context, out_parameters);
     }
@@ -700,6 +705,7 @@ pub fn ContextType(
                 const packet: *Packet = pop: {
                     self.interface.locker.lock();
                     defer self.interface.locker.unlock();
+
                     break :pop self.submitted.pop() orelse return;
                 };
                 self.packet_enqueue(packet);
@@ -717,6 +723,7 @@ pub fn ContextType(
             const empty: bool = empty: {
                 self.interface.locker.lock();
                 defer self.interface.locker.unlock();
+
                 break :empty self.submitted.empty();
             };
             if (!empty) {
@@ -1054,6 +1061,7 @@ test "Locker: contended" {
             while (true) {
                 self.state.locker.lock();
                 defer self.state.locker.unlock();
+
                 if (self.state.counter == increments) break;
                 self.state.counter += 1;
             }

--- a/src/clients/c/tb_client_exports.zig
+++ b/src/clients/c/tb_client_exports.zig
@@ -192,6 +192,7 @@ pub fn register_log_callback(
 ) callconv(.c) tb_register_log_callback_status {
     Logging.global.mutex.lock();
     defer Logging.global.mutex.unlock();
+
     if (Logging.global.callback == null) {
         if (callback_maybe) |callback| {
             Logging.global.callback = callback;

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -160,6 +160,7 @@ pub fn main() !void {
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
+
     const allocator = arena.allocator();
 
     var buffer = std.ArrayList(u8).init(allocator);

--- a/src/clients/c/test.zig
+++ b/src/clients/c/test.zig
@@ -141,6 +141,7 @@ test "tb_client echo" {
     );
 
     defer client.deinit() catch unreachable;
+
     var prng = stdx.PRNG.from_seed(tb_context);
 
     const requests: []RequestContext = try testing.allocator.alloc(
@@ -261,6 +262,7 @@ test "tb_client init" {
                 RequestContextType(0).on_complete,
             );
             defer if (!std.meta.isError(result)) client_out.deinit() catch unreachable;
+
             try testing.expectEqual(expected, result);
         }
     }.action;

--- a/src/clients/java/src/jni_tests.zig
+++ b/src/clients/java/src/jni_tests.zig
@@ -232,6 +232,7 @@ test "JNI: References" {
 
     const obj = env.alloc_object(boolean_class);
     defer env.delete_local_ref(obj);
+
     try testing.expect(obj != null);
     try testing.expect(env.get_object_ref_type(obj) == .local);
 
@@ -311,6 +312,7 @@ test "JNI: AllocObject" {
 
         const obj = env.alloc_object(boolean_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
     }
 
@@ -322,6 +324,7 @@ test "JNI: AllocObject" {
 
         const obj = env.alloc_object(serializable_interface);
         defer env.exception_clear();
+
         try testing.expect(obj == null);
         try testing.expect(env.exception_check() == .jni_true);
     }
@@ -334,6 +337,7 @@ test "JNI: AllocObject" {
 
         const obj = env.alloc_object(calendar_abstract_class);
         defer env.exception_clear();
+
         try testing.expect(obj == null);
         try testing.expect(env.exception_check() == .jni_true);
     }
@@ -368,6 +372,7 @@ test "JNI: IsInstanceOf" {
 
     const obj = env.alloc_object(boolean_class);
     defer env.delete_local_ref(obj);
+
     try testing.expect(obj != null);
 
     try testing.expect(env.is_instance_of(obj, boolean_class) == .jni_true);
@@ -391,6 +396,7 @@ test "JNI: GetFieldId" {
 
     const invalid_field = env.get_field_id(boolean_class, "not_a_valid_field", "I");
     defer env.exception_clear();
+
     try testing.expect(invalid_field == null);
     try testing.expect(env.exception_check() == .jni_true);
 }
@@ -409,6 +415,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(boolean_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_boolean_field(obj, value_field_id);
@@ -432,6 +439,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(byte_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_byte_field(obj, value_field_id);
@@ -455,6 +463,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(char_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_char_field(obj, value_field_id);
@@ -478,6 +487,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(short_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_short_field(obj, value_field_id);
@@ -501,6 +511,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(int_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_int_field(obj, value_field_id);
@@ -524,6 +535,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(long_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_long_field(obj, value_field_id);
@@ -547,6 +559,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(float_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_float_field(obj, value_field_id);
@@ -570,6 +583,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(double_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_double_field(obj, value_field_id);
@@ -593,6 +607,7 @@ test "JNI: Get<Type>Field, Set<Type>Field" {
 
         const obj = env.alloc_object(object_class);
         defer env.delete_local_ref(obj);
+
         try testing.expect(obj != null);
 
         const value_before = env.get_object_field(obj, value_field_id);
@@ -618,6 +633,7 @@ test "JNI: GetMethodId" {
 
     const invalid_method = env.get_method_id(object_class, "invalid_method", "()V");
     defer env.exception_clear();
+
     try testing.expect(invalid_method == null);
     try testing.expect(env.exception_check() == .jni_true);
 }
@@ -890,6 +906,7 @@ test "JNI: GetStaticFieldId" {
 
     const invalid_field_id = env.get_static_field_id(boolean_class, "invalid_field", "J");
     defer env.exception_clear();
+
     try testing.expect(invalid_field_id == null);
     try testing.expect(env.exception_check() == .jni_true);
 }
@@ -1057,6 +1074,7 @@ test "JNI: GetStaticMethodId" {
 
     const invalid_method_id = env.get_static_method_id(boolean_class, "invalid_method", "()J");
     defer env.exception_clear();
+
     try testing.expect(invalid_method_id == null);
     try testing.expect(env.exception_check() == .jni_true);
 }
@@ -1232,6 +1250,7 @@ test "JNI: CallStatic<Type>Method" {
         );
         try testing.expect(env.exception_check() == .jni_false);
         defer env.delete_local_ref(ret);
+
         try testing.expect(env.is_instance_of(ret, class) == .jni_true);
     }
 

--- a/src/docs_website/src/docs.zig
+++ b/src/docs_website/src/docs.zig
@@ -25,6 +25,7 @@ pub fn build(
     var page_buffer: [1 << 16]u8 = undefined;
     var base = try b.build_root.handle.openDir(base_path, .{});
     defer base.close();
+
     const root_page = try content.load(arena, base, &page_buffer);
 
     try tree_install(b, website, output, &search_index, root_page, root_page);

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -292,6 +292,7 @@ pub fn ewah(comptime Word: type) type {
 
             var encoder = encode_chunks(source_words);
             defer assert(encoder.done());
+
             return encoder.encode_chunk(target);
         }
 

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -610,6 +610,7 @@ test "pipe data over socket" {
         fn run() !void {
             const tx_buf = try testing.allocator.alloc(u8, buffer_size);
             defer testing.allocator.free(tx_buf);
+
             const rx_buf = try testing.allocator.alloc(u8, buffer_size);
             defer testing.allocator.free(rx_buf);
 
@@ -788,6 +789,7 @@ test "cancel_all" {
                 // Initialize a file filled with test data.
                 const file_buffer = try allocator.alloc(u8, read_size);
                 defer allocator.free(file_buffer);
+
                 for (file_buffer, 0..) |*b, i| b.* = @intCast(i % 256);
 
                 try std.fs.cwd().writeFile(.{ .sub_path = file_path, .data = file_buffer });
@@ -877,6 +879,7 @@ test "cancel" {
             const allocator = std.testing.allocator;
             var io = try IO.init(32, 0);
             defer io.deinit();
+
             const buffer_size = 512 * KiB;
 
             const buffer: []u8 = try allocator.alloc(u8, buffer_size);

--- a/src/list.zig
+++ b/src/list.zig
@@ -177,6 +177,7 @@ test "DoublyLinkedList fuzz" {
 
     const nodes = try allocator.alloc(Node, nodes_count);
     defer allocator.free(nodes);
+
     for (nodes, 0..) |*node, i| node.* = .{ .id = @intCast(i) };
 
     var nodes_free = try std.DynamicBitSetUnmanaged.initFull(allocator, nodes_count);

--- a/src/lsm/scan_buffer.zig
+++ b/src/lsm/scan_buffer.zig
@@ -106,6 +106,7 @@ pub const ScanBufferPool = struct {
         if (self.scan_buffer_used == constants.lsm_scans_max) return Error.ScansMaxExceeded;
 
         defer self.scan_buffer_used += 1;
+
         return &self.scan_buffers[self.scan_buffer_used];
     }
 

--- a/src/lsm/segmented_array_benchmark.zig
+++ b/src/lsm/segmented_array_benchmark.zig
@@ -95,6 +95,7 @@ test "benchmark: segmented array" {
 
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var node_pool: NodePool = undefined;

--- a/src/lsm/zig_zag_merge.zig
+++ b/src/lsm/zig_zag_merge.zig
@@ -373,6 +373,7 @@ fn TestContextType(comptime streams_max: u32) type {
                     var dummy: [10]Value = .{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
                     const replaced = streams[streams_count - 1];
                     defer streams[streams_count - 1] = replaced;
+
                     streams[streams_count - 1] = &dummy;
                     try merge(streams[0..streams_count], &.{});
                 }
@@ -382,6 +383,7 @@ fn TestContextType(comptime streams_max: u32) type {
                     const empty: [0]Value = .{};
                     const replaced = streams[streams_count - 1];
                     defer streams[streams_count - 1] = replaced;
+
                     streams[streams_count - 1] = &empty;
                     try merge(streams[0..streams_count], &.{});
                 }

--- a/src/multiversion.zig
+++ b/src/multiversion.zig
@@ -729,11 +729,13 @@ pub const MultiversionOS = struct {
                 const suffix = if (builtin.target.os.tag == .windows) ".exe" else "";
                 const temporary_directory = try system_temporary_directory(allocator);
                 defer allocator.free(temporary_directory);
+
                 const filename = try std.fmt.allocPrint(allocator, "{s}-{}" ++ suffix, .{
                     multiversion_uuid,
                     nonce,
                 });
                 defer allocator.free(filename);
+
                 break :blk try std.fs.path.joinZ(allocator, &.{ temporary_directory, filename });
             },
             else => @panic("unsupported platform"),

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -283,6 +283,7 @@ test "Queue: fuzz" {
 
         var items = try gpa.alloc(Item, N);
         defer gpa.free(items);
+
         for (items, 0..) |*item, value| {
             item.* = .{ .value = value, .link = .{} };
         }

--- a/src/repl/parser.zig
+++ b/src/repl/parser.zig
@@ -678,6 +678,7 @@ test "parser.zig: Parser single transfer successfully" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -746,6 +747,7 @@ test "parser.zig: Parser multiple transfers successfully" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -844,6 +846,7 @@ test "parser.zig: Parser single account successfully" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -921,6 +924,7 @@ test "parser.zig: Parser account filter successfully" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -994,6 +998,7 @@ test "parser.zig: Parser query filter successfully" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -1062,6 +1067,7 @@ test "parser.zig: Parser multiple accounts successfully" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -1200,6 +1206,7 @@ test "parser.zig: Parser odd but correct formatting" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -1285,6 +1292,7 @@ test "parser.zig: Handle parsing errors" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(
@@ -1328,6 +1336,7 @@ test "parser.zig: Parser fails for operations not supporting multiple objects" {
     for (vectors) |vector| {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
+
         const allocator = arena.allocator();
 
         var arguments = try std.ArrayListUnmanaged(u8).initCapacity(

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -77,6 +77,7 @@ fn run_protocol_test(gpa: std.mem.Allocator, options: struct { host: std.net.Add
         stdx.unique_u128(),
     });
     defer gpa.free(testing_queue);
+
     context.queue_declare(.{
         .queue = testing_queue, // Creating the queue.
         .passive = false,
@@ -192,6 +193,7 @@ fn run_protocol_test(gpa: std.mem.Allocator, options: struct { host: std.net.Add
         stdx.unique_u128(),
     });
     defer gpa.free(progress_queue);
+
     context.queue_declare(.{
         .queue = progress_queue,
         .passive = false,
@@ -276,6 +278,7 @@ fn run_serialization_test(
         stdx.unique_u128(),
     });
     defer gpa.free(queue);
+
     context.queue_declare(.{
         .queue = queue,
         .passive = false,
@@ -372,6 +375,7 @@ fn run_cdc_test(
     var amqp_context: AmqpContext = undefined;
     try amqp_context.init(gpa);
     defer amqp_context.deinit(gpa);
+
     try amqp_context.connect(options.host);
 
     var arena = std.heap.ArenaAllocator.init(gpa);
@@ -466,6 +470,7 @@ fn run_cdc_test(
         };
         assert(events.len > 0);
         defer timestamp_previous = events[events.len - 1].timestamp;
+
         for (events) |*event| {
             // Keep track of how many transfers will expire:
             switch (event.type) {
@@ -624,6 +629,7 @@ const AmqpContext = struct {
         assert(!self.busy);
         assert(self.message == null);
         defer self.message = null;
+
         self.busy = true;
         self.client.get_message(&get_message_header_callback, options);
         self.wait();

--- a/src/stack.zig
+++ b/src/stack.zig
@@ -144,6 +144,7 @@ test "Stack: fuzz" {
     // Allocate a pool of nodes.
     var items = try allocator.alloc(Item, item_count_max);
     defer allocator.free(items);
+
     for (items, 0..) |*item, i| {
         item.* = Item{ .id = @intCast(i), .link = .{} };
     }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -2721,6 +2721,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         assert(self.scan_lookup_buffer_index <= self.scan_lookup_buffer.len);
                         assert(self.scan_lookup_buffer_index >= scan_size + offset);
                         defer offset += scan_size;
+
                         break :size self.execute_get_account_transfers(
                             batch,
                             self.scan_lookup_buffer[offset..][0..scan_size],
@@ -2732,6 +2733,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         assert(self.scan_lookup_buffer_index <= self.scan_lookup_buffer.len);
                         assert(self.scan_lookup_buffer_index >= scan_size + offset);
                         defer offset += scan_size;
+
                         break :size self.execute_get_account_balances(
                             batch,
                             self.scan_lookup_buffer[offset..][0..scan_size],
@@ -2743,6 +2745,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         assert(self.scan_lookup_buffer_index <= self.scan_lookup_buffer.len);
                         assert(self.scan_lookup_buffer_index >= scan_size + offset);
                         defer offset += scan_size;
+
                         break :size self.execute_query_transfers(
                             batch,
                             self.scan_lookup_buffer[offset..][0..scan_size],
@@ -2754,6 +2757,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         assert(self.scan_lookup_buffer_index <= self.scan_lookup_buffer.len);
                         assert(self.scan_lookup_buffer_index >= scan_size + offset);
                         defer offset += scan_size;
+
                         break :size self.execute_query_accounts(
                             batch,
                             self.scan_lookup_buffer[offset..][0..scan_size],

--- a/src/state_machine/auditor.zig
+++ b/src/state_machine/auditor.zig
@@ -207,6 +207,7 @@ pub const AccountingAuditor = struct {
             },
         }) void {
             defer assert(self.current.count_total() <= self.changes_events_max);
+
             const count: u32 = switch (change) {
                 .transfer => 1,
                 .expiry => |expiry| expiry.expired_count,
@@ -280,6 +281,7 @@ pub const AccountingAuditor = struct {
         fn release_snapshot(self: *ChangesTracker) Counter {
             assert(self.snapshot != null);
             defer self.snapshot = null;
+
             return self.snapshot.?;
         }
     };
@@ -875,6 +877,7 @@ pub fn IteratorForCreateType(comptime Result: type) type {
         ) ?@FieldType(Result, "result") {
             if (self.results.len > 0 and self.results[0].index == event_index) {
                 defer self.results = self.results[1..];
+
                 return self.results[0].result;
             } else {
                 return null;
@@ -898,6 +901,7 @@ pub fn IteratorForLookupType(comptime Result: type) type {
         pub fn take(self: *IteratorForLookup, id: u128) ?*const Result {
             if (self.results.len > 0 and self.results[0].id == id) {
                 defer self.results = self.results[1..];
+
                 return &self.results[0];
             } else {
                 return null;

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -624,6 +624,7 @@ fn check_version(
 
     var request = std.ArrayListAligned(u8, 16).init(allocator);
     defer request.deinit();
+
     try request.ensureTotalCapacity(constants.message_body_size_max);
 
     var reply = std.ArrayListAligned(u8, 16).init(allocator);
@@ -947,6 +948,7 @@ fn check_version(
                     constants.message_body_size_max,
                 );
                 defer allocator.free(reply_actual_buffer);
+
                 const payload_size: u32 = @intCast(request.items.len);
                 request.expandToCapacity();
 

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -723,6 +723,7 @@ test "flags" {
                     @src().file,
                 });
                 defer gpa.free(path_relative);
+
                 const this_file = try std.fs.cwd().realpath(
                     path_relative,
                     flags_exe_buf,

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -670,6 +670,7 @@ test "no floating point please" {
         @src().file,
     });
     defer std.testing.allocator.free(path);
+
     const file_text = try std.fs.cwd().readFileAlloc(std.testing.allocator, path, 64 * KiB);
     defer std.testing.allocator.free(file_text);
 

--- a/src/stdx/ring_buffer.zig
+++ b/src/stdx/ring_buffer.zig
@@ -260,6 +260,7 @@ pub fn RingBufferType(
                 if (it.ring.buffer.len == 0) return null;
                 if (it.count == it.ring.count) return null;
                 defer it.count += 1;
+
                 return &it.ring.buffer[(it.ring.index + it.count) % it.ring.buffer.len];
             }
         };
@@ -279,6 +280,7 @@ pub fn RingBufferType(
                 if (it.ring.buffer.len == 0) return null;
                 if (it.count == it.ring.count) return null;
                 defer it.count += 1;
+
                 return &it.ring.buffer[(it.ring.index + it.count) % it.ring.buffer.len];
             }
         };
@@ -424,6 +426,7 @@ test "RingBuffer: low level interface" {
     const PointerRing = RingBufferType(u32, .slice);
     var pointer_ring = try PointerRing.init(testing.allocator, 2);
     defer pointer_ring.deinit(testing.allocator);
+
     try test_low_level_interface(PointerRing, &pointer_ring);
 }
 

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -989,6 +989,7 @@ const SectorRange = struct {
     fn next(range: *SectorRange) ?usize {
         if (range.min == range.max) return null;
         defer range.min += 1;
+
         return range.min;
     }
 

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -276,6 +276,7 @@ const Connection = struct {
 
         assert(connection.remote_fd == null);
         defer assert(connection.remote_fd != null);
+
         assert(connection.remote_address != null);
 
         const fd = result catch |err| {

--- a/src/testing/vortex/logged_process.zig
+++ b/src/testing/vortex/logged_process.zig
@@ -179,6 +179,7 @@ test "LoggedProcess: starts and stops" {
             @src().file,
         });
         defer allocator.free(path_relative);
+
         const this_file = try std.fs.cwd().realpath(
             path_relative,
             test_exe_buf,

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -103,6 +103,7 @@ pub fn main(allocator: std.mem.Allocator, args: CLIArgs) !void {
             };
         }
     }
+
     log.info("output directory: {s}", .{output_directory});
     log.info("starting test with target runtime of {}", .{args.test_duration});
 

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -52,6 +52,7 @@ test "tidy" {
     dead_files_detector.finish(&errors);
 
     if (errors.count > 0) return error.Untidy;
+
     assert(errors.count == 0);
 }
 

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -150,6 +150,7 @@ const TigerBeetleProcess = struct {
         _ = self.child.wait() catch {};
 
         defer self.* = undefined;
+
         return self.child.resource_usage_statistics;
     }
 };

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -81,6 +81,7 @@ pub fn main(
 
     var message_pools = stdx.BoundedArrayType(MessagePool, constants.clients_max){};
     defer for (message_pools.slice()) |*message_pool| message_pool.deinit(allocator);
+
     for (0..cli_args.clients) |_| {
         message_pools.push(try MessagePool.init(allocator, .client));
     }

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -597,6 +597,7 @@ test "EventMetric slot doesn't have collisions" {
     const allocator = std.testing.allocator;
     var stacks: std.ArrayListUnmanaged(u32) = .{};
     defer stacks.deinit(allocator);
+
     var g: @import("../testing/exhaustigen.zig") = .{};
     while (!g.done()) {
         const event: EventMetric = switch (g.enum_value(EventMetric.Tag)) {
@@ -627,6 +628,7 @@ test "EventTiming slot doesn't have collisions" {
     const allocator = std.testing.allocator;
     var stacks: std.ArrayListUnmanaged(u32) = .{};
     defer stacks.deinit(allocator);
+
     var g: @import("../testing/exhaustigen.zig") = .{};
     while (!g.done()) {
         const event: EventTiming = switch (g.enum_value(Event.Tag)) {

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -80,6 +80,7 @@ const quine =
     \\test quine {
     \\    var arena_instance = std.heap.ArenaAllocator.init(std.testing.allocator);
     \\    defer arena_instance.deinit();
+    \\
     \\    const arena = arena_instance.allocator();
     \\
     \\    // build.zig runs this in the root dir.

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -203,6 +203,7 @@ const MiB = stdx.MiB;
 test quine {
     var arena_instance = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_instance.deinit();
+
     const arena = arena_instance.allocator();
 
     // build.zig runs this in the root dir.

--- a/src/vsr/clock.zig
+++ b/src/vsr/clock.zig
@@ -714,6 +714,7 @@ test "ideal clocks get clamped to cluster time" {
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
+
     const allocator = arena.allocator();
 
     var ideal_constant_drift_clock: ClockUnitTestContainer = undefined;

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -517,6 +517,7 @@ pub fn GridType(comptime Storage: type) type {
             // and also mark the checkpoint as durable.
             assert(!grid.free_set.checkpoint_durable);
             defer assert(grid.free_set.checkpoint_durable);
+
             grid.free_set.mark_checkpoint_durable();
 
             const callback = grid.callback.checkpoint_durable;

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -613,6 +613,7 @@ pub const GridBlocksMissing = struct {
     ) void {
         queue.verify();
         defer if (constants.verify) queue.verify();
+
         assert(queue.state == .sync_jump);
 
         for (tables) |table| {
@@ -655,6 +656,7 @@ pub const GridBlocksMissing = struct {
     fn sync_complete(queue: *GridBlocksMissing, free_set: *const vsr.FreeSet) void {
         queue.verify();
         defer if (constants.verify) queue.verify();
+
         assert(queue.state == .sync_jump);
         assert(free_set.opened);
 
@@ -684,6 +686,7 @@ pub const GridBlocksMissing = struct {
     ) void {
         queue.verify();
         defer if (constants.verify) queue.verify();
+
         assert(queue.state == .repairing);
         assert(queue.faulty_blocks.count() ==
             queue.enqueued_blocks_repair + queue.enqueued_blocks_sync);

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -378,6 +378,7 @@ pub fn GridScrubberType(comptime Forest: type, grid_scrubber_reads_max: comptime
 
             const read = scrubber.reads_done.pop() orelse return null;
             defer scrubber.reads.release(read);
+
             assert(read.done);
 
             const block: BlockId = .{

--- a/src/vsr/multi_batch.zig
+++ b/src/vsr/multi_batch.zig
@@ -505,6 +505,7 @@ test "batch: maximum batches with no elements" {
         buffer_size,
     );
     defer testing.allocator.free(buffer);
+
     const written_bytes = try TestRunner.run(.{
         .prng = &prng,
         .element_size = element_size,
@@ -528,6 +529,7 @@ test "batch: maximum batches with a single element" {
 
     const buffer = try testing.allocator.alignedAlloc(u8, @alignOf(vsr.Header), buffer_size);
     defer testing.allocator.free(buffer);
+
     const written_bytes = try TestRunner.run(.{
         .prng = &prng,
         .element_size = element_size,
@@ -555,6 +557,7 @@ test "batch: maximum elements on a single batch" {
 
     const buffer = try testing.allocator.alignedAlloc(u8, @alignOf(vsr.Header), buffer_size);
     defer testing.allocator.free(buffer);
+
     const written_bytes = try TestRunner.run(.{
         .prng = &prng,
         .element_size = element_size,

--- a/src/vsr/multi_batch_fuzz.zig
+++ b/src/vsr/multi_batch_fuzz.zig
@@ -19,6 +19,7 @@ pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
         message_body_size_max,
     );
     defer gpa.free(buffer_expected);
+
     const buffer_actual = try gpa.alignedAlloc(
         u8,
         @alignOf(vsr.Header),

--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -301,6 +301,7 @@ pub const RepairBudgetGrid = struct {
     pub fn decrement(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) bool {
         budget.assert_invariants();
         defer budget.assert_invariants();
+
         assert(budget.available > 0);
         assert(block_identifier.address > 0);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3442,6 +3442,7 @@ pub fn ReplicaType(
             defer {
                 self.grid_repair_writes.release(write);
             }
+
             log.debug("{}: on_block: repair done address={}", .{
                 self.log_prefix(),
                 grid_write.address,

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -938,6 +938,7 @@ test "Cluster: view_change: lagging replica advances checkpoint during view chan
 
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
+
     var c = t.clients(.{});
     var a0 = t.replica(.A0);
     var b1 = t.replica(.B1);
@@ -1744,6 +1745,7 @@ test "Cluster: view_change: DVC header doesn't match current header in journal" 
 
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
+
     var c = t.clients(.{});
     var a0 = t.replica(.A0);
     var b1 = t.replica(.B1);
@@ -1840,6 +1842,7 @@ test "Cluster: view_change: lagging replica repairs WAL using start_view from po
 
     const t = try TestContext.init(.{ .replica_count = 3 });
     defer t.deinit();
+
     var c = t.clients(.{});
     var a0 = t.replica(.A0);
     var b1 = t.replica(.B1);


### PR DESCRIPTION
This PR introduces a new tidy lint that enforces a blank line after `defer`.
There are a few patterns I allowed explicitly, here, it is best to look at the test cases I added (but one example is a `defer` followed by `errdefer`).

Somewhat surprisingly, this lint uncovered a large number of violations (~90-100) of TigerStyle’s rule: “Use newlines to group resource allocation and deallocation.”

Admittedly many occur in test cases but some are in production code. Some examples are:

```zig
client.locker.lock();
defer client.locker.unlock();
const context = client.context.ptr orelse return Error.ClientInvalid;
```

```zig

const obj = env.alloc_object(serializable_interface);
defer env.exception_clear();
try testing.expect(obj == null);
```
```zig
var base = try b.build_root.handle.openDir(base_path, .{});
defer base.close();
const root_page = try content.load(arena, base, &page_buffer);
```
```zig
const tx_buf = try testing.allocator.alloc(u8, buffer_size);
defer testing.allocator.free(tx_buf);
const rx_buf = try testing.allocator.alloc(u8, buffer_size);
defer testing.allocator.free(rx_buf);
```

```zig
const read = scrubber.reads_done.pop() orelse return null;
defer scrubber.reads.release(read);
assert(read.done);
```

There are a few cases where I’m unsure how this should be handled, so I’ve left the PR in draft state to encourage discussion.

My intuition is that a blank line would not hurt in these cases either. While this is not necessarily about resource allocation, it does introduce non-linear control flow.

```zig
// Negative space: empty stream.
{
    const empty: [0]Value = .{};
    const replaced = streams[streams_count - 1];
    defer streams[streams_count - 1] = replaced;
    streams[streams_count - 1] = &empty;
    try merge(streams[0..streams_count], &.{});
}
```
or this one 
```zig
.query_transfers => size: {
    const scan_size: u32 = result_count * @sizeOf(Transfer);
    assert(self.scan_lookup_buffer_index <= self.scan_lookup_buffer.len);
    assert(self.scan_lookup_buffer_index >= scan_size + offset);
    defer offset += scan_size;
break :size self.execute_query_transfers(
               batch,
               self.scan_lookup_buffer[offset..][0..scan_size],
               encoder_output_buffer,
               );
},
```
Overall, I think it may be worthwhile to have such a lint, as it enforces a stricter and more consistent grouping of resources and highlights non-linear control flow.
