### PR TITLE
k-way-merge benchmark.

### DIFF
--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -134,8 +134,7 @@ fn run_benchmark(
         duration.ns /= search_count;
     }
 
-    std.sort.block(stdx.Duration, &duration_samples, {}, stdx.Duration.sort.asc);
-    const result = duration_samples[2]; // Discard the fastest two, report the 3rd fastest.
+    const result = bench.estimate(&duration_samples);
 
     bench.report(body_fmt, .{
         scenario_name,

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -149,10 +149,11 @@ fn KWayMergeContextType(comptime Value: type) type {
 
 fn ValueType(comptime KeyType: type, comptime value_size: u32) type {
     return struct {
-        const Value = @This();
-        const Key = KeyType;
         key: Key,
         body: [value_size - @sizeOf(Key)]u8,
+
+        const Key = KeyType;
+        const Value = @This();
 
         comptime {
             assert(@sizeOf(Value) == value_size);

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -35,19 +35,19 @@ test "benchmark: k-way-merge" {
 
     var prng = stdx.PRNG.from_seed(bench.seed);
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
+    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_instance.deinit();
 
-    const allocator = arena.allocator();
+    const arena = arena_instance.allocator();
 
     const streams = .{
-        try prepare_streams(Values[0], &prng, allocator, streams_count, stream_length),
-        try prepare_streams(Values[1], &prng, allocator, streams_count, stream_length),
-        try prepare_streams(Values[2], &prng, allocator, streams_count, stream_length),
-        try prepare_streams(Values[3], &prng, allocator, streams_count, stream_length),
-        try prepare_streams(Values[4], &prng, allocator, streams_count, stream_length),
-        try prepare_streams(Values[5], &prng, allocator, streams_count, stream_length),
-        try prepare_streams(Values[6], &prng, allocator, streams_count, stream_length),
+        try prepare_streams(Values[0], &prng, arena, streams_count, stream_length),
+        try prepare_streams(Values[1], &prng, arena, streams_count, stream_length),
+        try prepare_streams(Values[2], &prng, arena, streams_count, stream_length),
+        try prepare_streams(Values[3], &prng, arena, streams_count, stream_length),
+        try prepare_streams(Values[4], &prng, arena, streams_count, stream_length),
+        try prepare_streams(Values[5], &prng, arena, streams_count, stream_length),
+        try prepare_streams(Values[6], &prng, arena, streams_count, stream_length),
     };
     comptime assert(streams.len == Values.len);
 

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -64,8 +64,7 @@ test "benchmark: k-way-merge" {
         }
     }
 
-    std.sort.block(stdx.Duration, &duration_samples, {}, stdx.Duration.sort.asc);
-    const duration_streams = duration_samples[2]; //Discard the fastest two.
+    const duration_streams = bench.estimate(&duration_samples);
     var duration_element = duration_streams;
     duration_element.ns /= (streams_count * stream_length * streams.len);
 
@@ -127,16 +126,11 @@ fn KWayMergeContextType(comptime Value: type) type {
             return stream[0];
         }
 
-        fn stream_precedence(context: *const Context, a: u32, b: u32) bool {
-            _ = context;
-            return a > b;
-        }
-
         fn merge(context: *Context, output: []Value) void {
             const KWayIterator = KWayMergeIteratorType(Context, Value.Key, Value, .{
                 .streams_max = streams_count_max,
                 .deduplicate = false,
-            }, Value.key_from_value, stream_peek, stream_pop, stream_precedence);
+            }, Value.key_from_value, stream_peek, stream_pop);
 
             var k_way_iterator = KWayIterator.init(context, context.streams_count, .ascending);
 

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -140,9 +140,8 @@ fn KWayMergeContextType(comptime Value: type) type {
 
             var k_way_iterator = KWayIterator.init(context, context.streams_count, .ascending);
 
-            var index: usize = 0;
-            while (k_way_iterator.pop() catch unreachable) |value| : (index += 1) {
-                output[index] = value;
+            for (output) |*slot| {
+                slot.* = (k_way_iterator.pop() catch unreachable).?;
             }
         }
     };

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -49,7 +49,7 @@ test "benchmark: k-way-merge" {
         try prepare_streams(Values[5], &prng, allocator, streams_count, stream_length),
         try prepare_streams(Values[6], &prng, allocator, streams_count, stream_length),
     };
-    assert(streams.len == Values.len);
+    comptime assert(streams.len == Values.len);
 
     var checksum: u64 = 0;
     var duration_samples: [repetitions]stdx.Duration = undefined;

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -10,8 +10,6 @@ const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
 const streams_count_max = 32;
 const repetitions: usize = 32;
 
-const body_fmt = "K={:_>2} L={:_>3} WT={}";
-
 // Those Values are close to the real-world use case.
 const Values = .{
     ValueType(u64, 128),
@@ -26,8 +24,6 @@ const Values = .{
 test "benchmark: k-way-merge" {
     var bench: Bench = .init();
     defer bench.deinit();
-
-    bench.report("WT: Wall time/merged element", .{});
 
     const streams_count: usize = @intCast(bench.parameter("streams_count", 4, 32));
     const stream_length: usize = @intCast(bench.parameter("stream_length", 128, 8192));
@@ -70,12 +66,15 @@ test "benchmark: k-way-merge" {
     }
 
     std.sort.block(stdx.Duration, &duration_samples, {}, stdx.Duration.sort.asc);
-    const result = duration_samples[2]; // Discard the fastest two, report the 3rd fastest.
+    const duration_streams = duration_samples[2]; // Discard the fastest two, report the 3rd fastest.
+    var duration_element = duration_streams;
+    duration_element.ns /= (streams_count * stream_length * streams.len);
 
-    bench.report(body_fmt, .{
-        streams_count,
-        stream_length,
-        result,
+    bench.report("{} total", .{
+        duration_streams,
+    });
+    bench.report("{} per element", .{
+        duration_element,
     });
 }
 

--- a/src/testing/bench.zig
+++ b/src/testing/bench.zig
@@ -128,6 +128,16 @@ pub fn stop(bench: *Bench) Duration {
     return elapsed;
 }
 
+// Sort the durations and return the third-fastest sample (discarding the two fastest outliers)
+// to get a more stable estimate, assuming benchmark timings are roughly log-normal.
+// E.g. see https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/
+pub fn estimate(bench: *const Bench, durations: []Duration) Duration {
+    assert(durations.len >= 8); // Ensure that we have enough samples to get a meaningful result.
+    _ = bench;
+    std.sort.block(stdx.Duration, durations, {}, stdx.Duration.sort.asc);
+    return durations[2];
+}
+
 pub fn report(_: *const Bench, comptime fmt: []const u8, args: anytype) void {
     switch (mode) {
         .smoke => {},

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -20,6 +20,7 @@ comptime {
     _ = @import("lsm/forest.zig");
     _ = @import("lsm/forest_table_iterator.zig");
     _ = @import("lsm/k_way_merge.zig");
+    _ = @import("lsm/k_way_merge_benchmark.zig");
     _ = @import("lsm/manifest_level.zig");
     _ = @import("lsm/node_pool.zig");
     _ = @import("lsm/scratch_memory.zig");


### PR DESCRIPTION
This PR adds a k-way merge microbenchmark to detect performance regressions.

I validated that the benchmark reliably catches regressions in two ways:

(1) replacing our `swap_nodes` function with `std.mem.swap`:  
With our  `swap_nodes`:
K=32 L=8192 WT=30.938ms

With `std.mem.swap`: 
K=32 L=8192 WT=113.458ms

(2) removed branchless comparison resulted in: 
K=32 L=8192 WT=52.547ms 
Which would be again a major regression.

The benchmark runs multiple iterations and reports an (almost) best-case result, which makes it highly stable and well suited for regression detection. Runtime noise is often log-normally distributed, so best-case or near-best-case measurements tend to be more representative for microbenchmarks (see: https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/).
This PR is stacked on top of #3434 , so we should wait for that to land first and then I will assign a reviewer :-).