### PR TITLE
Add consistent logging of headers and checksums

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -60,15 +60,15 @@ pub const AOFEntry = extern struct {
         // When writing, entries can backtrack / duplicate, so we don't necessarily have a valid
         // chain. Still, log when that happens. The `aof merge` command can generate a consistent
         // file from entries like these.
-        log.debug("from_message: parent {} (should == {?}) our checksum {}", .{
+        log.debug("from_message: parent {x:0>32} (should == {x:0>32}) our checksum {x:0>32}", .{
             message.header.parent,
-            last_checksum.*,
+            last_checksum.* orelse 0,
             message.header.checksum,
         });
         if (last_checksum.* == null or last_checksum.*.? != message.header.parent) {
-            log.info("from_message: parent {}, expected {?} instead", .{
+            log.info("from_message: parent {x:0>32}, expected {x:0>32} instead", .{
                 message.header.parent,
-                last_checksum.*,
+                last_checksum.* orelse 0,
             });
         }
         last_checksum.* = message.header.checksum;
@@ -284,8 +284,8 @@ pub fn AOFType(comptime IO: type) type {
                 if (last_entry.?.header().checksum != checksum) {
                     return error.ChecksumMismatch;
                 }
-                log.debug("validated all aof entries. last entry checksum {} matches " ++
-                    " supplied {}", .{ last_entry.?.header().checksum, checksum });
+                log.debug("validated all aof entries. last entry checksum {x:0>32} matches " ++
+                    " supplied {x:0>32}", .{ last_entry.?.header().checksum, checksum });
             } else {
                 log.debug("validated present aof entries.", .{});
             }
@@ -652,7 +652,7 @@ pub fn AOFType(comptime IO: type) type {
 
                     if (current_parent == null) {
                         try stdout.print(
-                            "The root checksum will be {} from {s}.\n",
+                            "The root checksum will be {x:0>32} from {s}.\n",
                             .{ parent, input_paths[i] },
                         );
                         current_parent = parent;
@@ -739,8 +739,8 @@ pub fn AOFType(comptime IO: type) type {
             }
 
             try stdout.print(
-                "AOF {s} validated. Starting checksum: {?} Ending checksum: {?}\n",
-                .{ output_path, first_checksum, last_checksum },
+                "AOF {s} validated. Starting checksum: {x:0>32} Ending checksum: {x:0>32}\n",
+                .{ output_path, first_checksum orelse 0, last_checksum orelse 0 },
             );
         }
     };

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -394,7 +394,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 }
             }
 
-            log.debug("{}: opened: checksum={} address={} entries={}", .{
+            log.debug("{}: opened: checksum={x:0>32} address={} entries={}", .{
                 manifest_log.superblock.replica_index.?,
                 block_checksum,
                 block_address,
@@ -496,7 +496,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(manifest_log.blocks.count - manifest_log.blocks_closed == 1);
 
             log.debug(
-                "{}: {s}: level={} tree={} checksum={} address={} snapshot={}..{}",
+                "{}: {s}: level={} tree={} checksum={x:0>32} address={} snapshot={}..{}",
                 .{
                     manifest_log.superblock.replica_index.?,
                     @tagName(table.label.event),
@@ -621,7 +621,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 assert(block_schema.entry_count == schema.ManifestNode.entry_count_max);
             }
 
-            log.debug("{}: write_block: checksum={} address={} entries={}", .{
+            log.debug("{}: write_block: checksum={x:0>32} address={} entries={}", .{
                 manifest_log.superblock.replica_index.?,
                 header.checksum,
                 header.address,
@@ -806,7 +806,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 }
             }
 
-            log.debug("{}: compacted: checksum={} address={} free={}/{}", .{
+            log.debug("{}: compacted: checksum={x:0>32} address={} free={}/{}", .{
                 manifest_log.superblock.replica_index.?,
                 oldest_checksum,
                 oldest_address,
@@ -975,7 +975,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
             manifest_log.log_block_checksums.push_assume_capacity(header.checksum);
             manifest_log.log_block_addresses.push_assume_capacity(header.address);
 
-            log.debug("{}: close_block: checksum={} address={} entries={}/{}", .{
+            log.debug("{}: close_block: checksum={x:0>32} address={} entries={}/{}", .{
                 manifest_log.superblock.replica_index.?,
                 header.checksum,
                 header.address,

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -388,6 +388,10 @@ fn tidy_line(file: SourceFile, line: []const u8, line_index: usize, errors: *Err
         // AMQP JSON snapshot test.
         if (std.mem.endsWith(u8, file.path, "cdc/runner.zig") and
             std.mem.startsWith(u8, string_value, "{\"timestamp\":")) return;
+
+        // Message fromatting tests.
+        if (std.mem.endsWith(u8, file.path, "message_header.zig") and
+            std.mem.startsWith(u8, string_value, "Prepare{")) return;
     }
 
     errors.add_long_line(file, line_index);

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -61,6 +61,7 @@ comptime {
     _ = @import("vsr/grid_scrubber.zig");
     _ = @import("vsr/journal.zig");
     _ = @import("vsr/marzullo.zig");
+    _ = @import("vsr/message_header.zig");
     _ = @import("vsr/multi_batch.zig");
     _ = @import("vsr/replica_format.zig");
     _ = @import("vsr/replica_test.zig");

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -1179,7 +1179,7 @@ pub const Simulator = struct {
                 v.value_ptr.set(replica.replica);
 
                 log.debug("{}: core_missing_blocks: " ++
-                    "missing address={} checksum={} corrupt={} (remote read)", .{
+                    "missing address={} checksum={x:0>32} corrupt={} (remote read)", .{
                     replica.replica,
                     faulty_read.address,
                     faulty_read.checksum,
@@ -1198,7 +1198,7 @@ pub const Simulator = struct {
                 v.value_ptr.set(replica.replica);
 
                 log.debug("{}: core_missing_blocks: " ++
-                    "missing address={} checksum={} corrupt={} (GridBlocksMissing)", .{
+                    "missing address={} checksum={x:0>32} corrupt={} (GridBlocksMissing)", .{
                     replica.replica,
                     fault.key_ptr.*,
                     fault.value_ptr.checksum,
@@ -1231,7 +1231,7 @@ pub const Simulator = struct {
                 const block = storage.grid_block(block_missing.address) orelse continue;
                 const block_header = schema.header_from_block(block);
                 if (block_header.checksum == block_missing.checksum) {
-                    log.err("{}: core_missing_blocks: found address={} checksum={}", .{
+                    log.err("{}: core_missing_blocks: found address={} checksum={x:0>32}", .{
                         replica.replica,
                         block_missing.address,
                         block_missing.checksum,

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -653,7 +653,7 @@ pub fn ClientType(
             assert(message.header.checksum == self.parent);
             assert(message.header.session == self.session);
 
-            log.debug("{}: on_request_timeout: resending request={} checksum={}", .{
+            log.debug("{}: on_request_timeout: resending request={} checksum={x:0>32}", .{
                 self.id,
                 message.header.request,
                 message.header.checksum,
@@ -759,7 +759,7 @@ pub fn ClientType(
             // The checksum of this request becomes the parent of our next reply:
             self.parent = message.header.checksum;
 
-            log.debug("{}: send_request_for_the_first_time: request={} checksum={}", .{
+            log.debug("{}: send_request_for_the_first_time: request={} checksum={x:0>32}", .{
                 self.id,
                 message.header.request,
                 message.header.checksum,

--- a/src/vsr/client_replies.zig
+++ b/src/vsr/client_replies.zig
@@ -194,7 +194,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             assert(client_replies.read_reply_sync(slot, session) == null);
 
             const read = client_replies.reads.acquire() orelse {
-                log.debug("{}: read_reply: busy (client={} reply={})", .{
+                log.debug("{}: read_reply: busy (client={} reply={x:0>32})", .{
                     client_replies.replica,
                     session.header.client,
                     session.header.checksum,
@@ -203,7 +203,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
                 return error.Busy;
             };
 
-            log.debug("{}: read_reply: start (client={} reply={})", .{
+            log.debug("{}: read_reply: start (client={} reply={x:0>32})", .{
                 client_replies.replica,
                 session.header.client,
                 session.header.checksum,
@@ -243,7 +243,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             defer client_replies.message_pool.unref(message);
 
             const callback = callback_or_null orelse {
-                log.debug("{}: read_reply: already resolved (client={} reply={})", .{
+                log.debug("{}: read_reply: already resolved (client={} reply={x:0>32})", .{
                     client_replies.replica,
                     header.client,
                     header.checksum,
@@ -254,7 +254,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             if (!message.header.valid_checksum() or
                 !message.header.valid_checksum_body(message.body_used()))
             {
-                log.warn("{}: read_reply: corrupt reply (client={} reply={})", .{
+                log.warn("{}: read_reply: corrupt reply (client={} reply={x:0>32})", .{
                     client_replies.replica,
                     header.client,
                     header.checksum,
@@ -269,7 +269,8 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             // - The read targets a newer reply (that we haven't seen/written yet).
             // - The read targets a reply that we wrote, but was misdirected.
             if (message.header.checksum != header.checksum) {
-                log.warn("{}: read_reply: unexpected header (client={} reply={} found={})", .{
+                log.warn("{}: read_reply: unexpected header " ++
+                    "(client={} reply={x:0>32} found={x:0>32})", .{
                     client_replies.replica,
                     header.client,
                     header.checksum,
@@ -283,7 +284,7 @@ pub fn ClientRepliesType(comptime Storage: type) type {
             assert(message.header.command == .reply);
             assert(message.header.cluster == header.cluster);
 
-            log.debug("{}: read_reply: done (client={} reply={})", .{
+            log.debug("{}: read_reply: done (client={} reply={x:0>32})", .{
                 client_replies.replica,
                 header.client,
                 header.checksum,

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1165,7 +1165,8 @@ pub fn GridType(comptime Storage: type) type {
                 const header =
                     mem.bytesAsValue(vsr.Header.Block, block.*[0..@sizeOf(vsr.Header)]);
                 log.warn(
-                    "{}: {s}: expected address={} checksum={}, found address={} checksum={}",
+                    "{}: {s}: expected address={} checksum={x:0>32}, " ++
+                        "found address={} checksum={x:0>32}",
                     .{
                         grid.superblock.replica_index.?,
                         @tagName(result),
@@ -1289,7 +1290,7 @@ pub fn GridType(comptime Storage: type) type {
                 assert(read_remote_head.callback == .from_local_or_global_storage);
                 assert(read_remote_head.coherent);
 
-                log.debug("{}: read_block: fault: address={} checksum={}", .{
+                log.debug("{}: read_block: fault: address={} checksum={x:0>32}", .{
                     grid.superblock.replica_index.?,
                     read_remote_head.address,
                     read_remote_head.checksum,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -933,8 +933,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
         fn read_prepare_log(journal: *Journal, op: u64, checksum: ?u128, notice: []const u8) void {
             log.info(
-                "{}: read_prepare: op={} checksum={?}: {s}",
-                .{ journal.replica, op, checksum, notice },
+                "{}: read_prepare: op={} checksum={x:0>32}: {s}",
+                .{ journal.replica, op, checksum orelse 0, notice },
             );
         }
 
@@ -1318,7 +1318,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
 
                     if (header.operation != .reserved and !view_range.contains(header.view)) {
                         log.warn("{}: recover_slots: drop header " ++
-                            "view_range={}..{} view={} op={} checksum={}", .{
+                            "view_range={}..{} view={} op={} checksum={x:0>32}", .{
                             journal.replica,
                             view_range.min,
                             view_range.max,
@@ -1751,7 +1751,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(header.command == .prepare);
             assert(header.operation != .reserved);
 
-            log.debug("{}: set_header_as_dirty: op={} checksum={}", .{
+            log.debug("{}: set_header_as_dirty: op={} checksum={x:0>32}", .{
                 journal.replica,
                 header.op,
                 header.checksum,
@@ -2001,7 +2001,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             assert(header.command == .prepare);
             assert(header.operation != .reserved);
 
-            log_fn("{}: write: view={} slot={} op={} len={}: {} {s}", .{
+            log_fn("{}: write: view={} slot={} op={} len={}: {x:0>32} {s}", .{
                 journal.replica,
                 header.view,
                 journal.slot_for_header(header).index,

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1779,10 +1779,14 @@ test "header prints correctly" {
     // Checksums are present, enums are properly formatted and reserved_* + *_padding are omitted
     const formatted = try std.fmt.bufPrint(&buf, "{}", .{prepare});
     try std.testing.expectStringStartsWith(formatted, "Prepare{");
-    try std.testing.expect(std.mem.indexOf(u8, formatted, ".checksum=00000000000000000123456789abcdef").? > 0);
-    try std.testing.expect(std.mem.indexOf(u8, formatted, ".checksum_body=0000000000000000fedcba9876543210").? > 0);
-    try std.testing.expect(std.mem.indexOf(u8, formatted, ".parent=000000000abcdeffedcba00123456789").? > 0);
-    try std.testing.expect(std.mem.indexOf(u8, formatted, ".request_checksum=00000000000000012345678987654321").? > 0);
+    const checksum_field_val = ".checksum=00000000000000000123456789abcdef";
+    try std.testing.expect(std.mem.indexOf(u8, formatted, checksum_field_val).? > 0);
+    const checksum_body_field_val = ".checksum_body=0000000000000000fedcba9876543210";
+    try std.testing.expect(std.mem.indexOf(u8, formatted, checksum_body_field_val).? > 0);
+    const parent_field_val = ".parent=000000000abcdeffedcba00123456789";
+    try std.testing.expect(std.mem.indexOf(u8, formatted, parent_field_val).? > 0);
+    const request_checksum_field_val = ".request_checksum=00000000000000012345678987654321";
+    try std.testing.expect(std.mem.indexOf(u8, formatted, request_checksum_field_val).? > 0);
     try std.testing.expect(std.mem.indexOf(u8, formatted, ".command=prepare").? > 0);
     try std.testing.expect(std.mem.indexOf(u8, formatted, ".operation=pulse").? > 0);
     try std.testing.expect(std.mem.indexOf(u8, formatted, ".reserved_frame=[]").? > 0);

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -1778,10 +1778,7 @@ test "header prints correctly" {
     };
     // Checksums are present, enums are properly formatted and reserved_* + *_padding are omitted
     const formatted = try std.fmt.bufPrint(&buf, "{}", .{prepare});
-    // try std.testing.expectEqualStrings(formatted, "Prepare{");
-
     try std.testing.expectStringStartsWith(formatted, "Prepare{");
-
     try std.testing.expect(std.mem.indexOf(u8, formatted, ".checksum=00000000000000000123456789abcdef").? > 0);
     try std.testing.expect(std.mem.indexOf(u8, formatted, ".checksum_body=0000000000000000fedcba9876543210").? > 0);
     try std.testing.expect(std.mem.indexOf(u8, formatted, ".parent=000000000abcdeffedcba00123456789").? > 0);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1634,7 +1634,7 @@ pub fn ReplicaType(
             switch (header.into_any()) {
                 .prepare => |header_prepare| if (self.journal.writes.available() == 0) {
                     log.warn("{}: on_messages: suspending command=prepare " ++
-                        "op={} view={} checksum={}", .{
+                        "op={} view={} checksum={x:0>32}", .{
                         self.log_prefix(),
                         header_prepare.op,
                         header_prepare.view,
@@ -1647,7 +1647,7 @@ pub fn ReplicaType(
                         self.syncing == .updating_checkpoint)
                     {
                         log.warn("{}: on_messages: suspending command=block " ++
-                            "address={} checksum={}", .{
+                            "address={} checksum={x:0>32}", .{
                             self.log_prefix(),
                             header_block.address,
                             header_block.checksum,
@@ -2140,7 +2140,7 @@ pub fn ReplicaType(
             // We must advance our op and set the header as dirty before replicating and
             // journalling. The primary needs this before its journal is outrun by any
             // prepare_ok quorum:
-            log.debug("{}: on_prepare: advancing: op={}..{} checksum={}..{}", .{
+            log.debug("{}: on_prepare: advancing: op={}..{} checksum={x:0>32}..{x:0>32}", .{
                 self.log_prefix(),
                 self.op,
                 message.header.op,
@@ -2176,7 +2176,7 @@ pub fn ReplicaType(
 
             const prepare = self.pipeline.queue.prepare_by_prepare_ok(message) orelse {
                 // This can be normal, for example, if an old prepare_ok is replayed.
-                log.debug("{}: on_prepare_ok: not preparing op={} checksum={}", .{
+                log.debug("{}: on_prepare_ok: not preparing op={} checksum={x:0>32}", .{
                     self.log_prefix(),
                     message.header.op,
                     message.header.prepare_checksum,
@@ -2219,7 +2219,7 @@ pub fn ReplicaType(
             assert(!prepare.ok_quorum_received);
             prepare.ok_quorum_received = true;
 
-            log.debug("{}: on_prepare_ok: quorum received, context={}", .{
+            log.debug("{}: on_prepare_ok: quorum received, prepare_checksum={x:0>32}", .{
                 self.log_prefix(),
                 prepare.message.header.checksum,
             });
@@ -2989,7 +2989,7 @@ pub fn ReplicaType(
                 message.header.prepare_op,
                 checksum,
             )) |prepare| {
-                log.debug("{}: on_request_prepare: op={} checksum={} reply from pipeline", .{
+                log.debug("{}: on_request_prepare: op={} checksum={x:0>32} reply from pipeline", .{
                     self.log_prefix(),
                     message.header.prepare_op,
                     checksum,
@@ -3020,7 +3020,7 @@ pub fn ReplicaType(
                     },
                 );
             } else {
-                log.debug("{}: on_request_prepare: op={} checksum={} missing", .{
+                log.debug("{}: on_request_prepare: op={} checksum={x:0>32} missing", .{
                     self.log_prefix(),
                     message.header.prepare_op,
                     checksum,
@@ -3042,7 +3042,8 @@ pub fn ReplicaType(
             assert(message.header.command == .prepare);
             assert(destination_replica != self.replica);
 
-            log.debug("{}: on_request_prepare_read: op={} checksum={} sending to replica={}", .{
+            log.debug("{}: on_request_prepare_read: " ++
+                "op={} checksum={x:0>32} sending to replica={}", .{
                 self.log_prefix(),
                 message.header.op,
                 message.header.checksum,
@@ -3123,7 +3124,7 @@ pub fn ReplicaType(
 
             if (entry.header.checksum != message.header.reply_checksum) {
                 log.debug("{}: on_request_reply: ignoring, reply not in table " ++
-                    "(requested={} stored={})", .{
+                    "(requested={x:0>32} stored={x:0>32})", .{
                     self.log_prefix(),
                     message.header.reply_checksum,
                     entry.header.checksum,
@@ -3166,7 +3167,7 @@ pub fn ReplicaType(
             const self: *Replica = @fieldParentPtr("client_replies", client_replies);
             const reply = reply_ orelse {
                 log.debug("{}: on_request_reply: reply not found for replica={} " ++
-                    "(op={} checksum={})", .{
+                    "(op={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     destination_replica.?,
                     reply_header.op,
@@ -3182,7 +3183,8 @@ pub fn ReplicaType(
             assert(reply.header.command == .reply);
             assert(reply.header.checksum == reply_header.checksum);
 
-            log.debug("{}: on_request_reply: sending reply to replica={} (op={} checksum={})", .{
+            log.debug("{}: on_request_reply: sending reply to replica={} " ++
+                "(op={} checksum={x:0>32})", .{
                 self.log_prefix(),
                 destination_replica.?,
                 reply_header.op,
@@ -3253,7 +3255,7 @@ pub fn ReplicaType(
                         read.destination == message.header.replica)
                     {
                         log.debug("{}: on_request_blocks: ignoring block request;" ++
-                            " already reading (destination={} address={} checksum={})", .{
+                            " already reading (destination={} address={} checksum={x:0>32})", .{
                             self.log_prefix(),
                             message.header.replica,
                             request.block_address,
@@ -3275,7 +3277,7 @@ pub fn ReplicaType(
                 };
 
                 log.debug("{}: on_request_blocks: reading block " ++
-                    "(replica={} address={} checksum={})", .{
+                    "(replica={} address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     message.header.replica,
                     request.block_address,
@@ -3317,7 +3319,7 @@ pub fn ReplicaType(
 
             if (result != .valid) {
                 log.debug("{}: on_request_blocks: error: {s}: " ++
-                    "(destination={} address={} checksum={})", .{
+                    "(destination={} address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     @tagName(result),
                     read.destination,
@@ -3327,7 +3329,8 @@ pub fn ReplicaType(
                 return;
             }
 
-            log.debug("{}: on_request_blocks: success: (destination={} address={} checksum={})", .{
+            log.debug("{}: on_request_blocks: success: " ++
+                "(destination={} address={} checksum={x:0>32})", .{
                 self.log_prefix(),
                 read.destination,
                 grid_read.address,
@@ -3354,7 +3357,7 @@ pub fn ReplicaType(
             assert(self.grid_repair_writes.available() > 0);
 
             if (self.release.value < message.header.release.value) {
-                log.debug("{}: on_block: ignoring; release={} (address={} checksum={})", .{
+                log.debug("{}: on_block: ignoring; release={} (address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     message.header.release,
                     message.header.address,
@@ -3366,7 +3369,8 @@ pub fn ReplicaType(
             if (self.grid.callback == .cancel) {
                 assert(self.grid.read_global_queue.empty());
 
-                log.debug("{}: on_block: ignoring; grid is canceling (address={} checksum={})", .{
+                log.debug("{}: on_block: ignoring; grid is canceling " ++
+                    "(address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     message.header.address,
                     message.header.checksum,
@@ -3380,7 +3384,7 @@ pub fn ReplicaType(
             if (grid_fulfill) {
                 assert(!self.grid.free_set.is_free(message.header.address));
 
-                log.debug("{}: on_block: fulfilled address={} checksum={} {s}", .{
+                log.debug("{}: on_block: fulfilled address={} checksum={x:0>32} {s}", .{
                     self.log_prefix(),
                     message.header.address,
                     message.header.checksum,
@@ -3397,7 +3401,7 @@ pub fn ReplicaType(
                 const write_index = self.grid_repair_writes.index(write);
                 const write_block: *BlockPtr = &self.grid_repair_write_blocks[write_index];
 
-                log.debug("{}: on_block: repairing address={} checksum={} {s}", .{
+                log.debug("{}: on_block: repairing address={} checksum={x:0>32} {s}", .{
                     self.log_prefix(),
                     message.header.address,
                     message.header.checksum,
@@ -3428,7 +3432,8 @@ pub fn ReplicaType(
                     self.send_request_blocks();
                 }
             } else {
-                log.debug("{}: on_block: ignoring; block not needed (address={} checksum={})", .{
+                log.debug("{}: on_block: ignoring; block not needed " ++
+                    "(address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     message.header.address,
                     message.header.checksum,
@@ -4554,7 +4559,8 @@ pub fn ReplicaType(
                 }
 
                 if (self.pipeline.cache.prepare_by_op_and_checksum(op, header.checksum)) |prepare| {
-                    log.debug("{}: commit_start_journal: cached prepare op={} checksum={}", .{
+                    log.debug("{}: commit_start_journal: " ++
+                        "cached prepare op={} checksum={x:0>32}", .{
                         self.log_prefix(),
                         op,
                         header.checksum,
@@ -5281,7 +5287,8 @@ pub fn ReplicaType(
                 }
             }
 
-            log.debug("{}: execute_op: executing view={} primary={} op={} checksum={} ({s})", .{
+            log.debug("{}: execute_op: " ++
+                "executing view={} primary={} op={} checksum={x:0>32} ({s})", .{
                 self.log_prefix(),
                 self.view,
                 self.primary_index(self.view) == self.replica,
@@ -6818,7 +6825,7 @@ pub fn ReplicaType(
             assert(header.op <= self.op_prepare_max() or
                 vsr.Checkpoint.durable(self.op_checkpoint_next(), self.commit_max));
 
-            log.debug("{}: jump_to_newer_op: advancing: op={}..{} checksum={}..{}", .{
+            log.debug("{}: jump_to_newer_op: advancing: op={}..{} checksum={x:0>32}..{x:0>32}", .{
                 self.log_prefix(),
                 self.op,
                 header.op - 1,
@@ -7158,7 +7165,7 @@ pub fn ReplicaType(
 
             defer self.message_bus.unref(request.message);
 
-            log.debug("{}: primary_pipeline_prepare: request checksum={} client={}", .{
+            log.debug("{}: primary_pipeline_prepare: request checksum={x:0>32} client={}", .{
                 self.log_prefix(),
                 request.message.header.checksum,
                 request.message.header.client,
@@ -7264,7 +7271,7 @@ pub fn ReplicaType(
             const size_ceil = vsr.sector_ceil(message.header.size);
             assert(stdx.zeroed(message.buffer[message.header.size..size_ceil]));
 
-            log.debug("{}: primary_pipeline_prepare: prepare checksum={} op={}", .{
+            log.debug("{}: primary_pipeline_prepare: prepare checksum={x:0>32} op={}", .{
                 self.log_prefix(),
                 message.header.checksum,
                 message.header.op,
@@ -7622,7 +7629,7 @@ pub fn ReplicaType(
             if (self.syncing == .updating_checkpoint) return false;
 
             if (header.view > self.view) {
-                log.debug("{}: repair_header: op={} checksum={} view={} (newer view)", .{
+                log.debug("{}: repair_header: op={} checksum={x:0>32} view={} (newer view)", .{
                     self.log_prefix(),
                     header.op,
                     header.checksum,
@@ -7632,7 +7639,8 @@ pub fn ReplicaType(
             }
 
             if (header.op > self.op) {
-                log.debug("{}: repair_header: op={} checksum={} (advances hash chain head)", .{
+                log.debug("{}: repair_header: op={} checksum={x:0>32} " ++
+                    "(advances hash chain head)", .{
                     self.log_prefix(),
                     header.op,
                     header.checksum,
@@ -7640,7 +7648,8 @@ pub fn ReplicaType(
                 return false;
             } else if (header.op == self.op and !self.journal.has_header(header)) {
                 assert(self.journal.header_with_op(self.op) != null);
-                log.debug("{}: repair_header: op={} checksum={} (changes hash chain head)", .{
+                log.debug("{}: repair_header: op={} checksum={x:0>32} " ++
+                    "(changes hash chain head)", .{
                     self.log_prefix(),
                     header.op,
                     header.checksum,
@@ -7651,7 +7660,7 @@ pub fn ReplicaType(
             if (header.op < self.op_repair_min()) {
                 // Slots too far back belong to the next wrap of the log.
                 log.debug(
-                    "{}: repair_header: op={} checksum={} (precedes op_repair_min={})",
+                    "{}: repair_header: op={} checksum={x:0>32} (precedes op_repair_min={})",
                     .{ self.log_prefix(), header.op, header.checksum, self.op_repair_min() },
                 );
                 return false;
@@ -7659,14 +7668,14 @@ pub fn ReplicaType(
 
             if (self.journal.has_header(header)) {
                 if (self.journal.has_prepare(header)) {
-                    log.debug("{}: repair_header: op={} checksum={} (checksum clean)", .{
+                    log.debug("{}: repair_header: op={} checksum={x:0>32} (checksum clean)", .{
                         self.log_prefix(),
                         header.op,
                         header.checksum,
                     });
                     return false;
                 } else {
-                    log.debug("{}: repair_header: op={} checksum={} (checksum dirty)", .{
+                    log.debug("{}: repair_header: op={} checksum={x:0>32} (checksum dirty)", .{
                         self.log_prefix(),
                         header.op,
                         header.checksum,
@@ -7678,13 +7687,15 @@ pub fn ReplicaType(
                     // We expect that the same view and op would have had the same checksum.
                     assert(existing.op != header.op);
                     if (existing.op > header.op) {
-                        log.debug("{}: repair_header: op={} checksum={} (same view, newer op)", .{
+                        log.debug("{}: repair_header: op={} checksum={x:0>32} " ++
+                            "(same view, newer op)", .{
                             self.log_prefix(),
                             header.op,
                             header.checksum,
                         });
                     } else {
-                        log.debug("{}: repair_header: op={} checksum={} (same view, older op)", .{
+                        log.debug("{}: repair_header: op={} checksum={x:0>32} " ++
+                            "(same view, older op)", .{
                             self.log_prefix(),
                             header.op,
                             header.checksum,
@@ -7693,14 +7704,14 @@ pub fn ReplicaType(
                 } else {
                     assert(existing.view != header.view);
 
-                    log.debug("{}: repair_header: op={} checksum={} (different view)", .{
+                    log.debug("{}: repair_header: op={} checksum={x:0>32} (different view)", .{
                         self.log_prefix(),
                         header.op,
                         header.checksum,
                     });
                 }
             } else {
-                log.debug("{}: repair_header: op={} checksum={} (gap)", .{
+                log.debug("{}: repair_header: op={} checksum={x:0>32} (gap)", .{
                     self.log_prefix(),
                     header.op,
                     header.checksum,
@@ -7719,7 +7730,8 @@ pub fn ReplicaType(
                 // We cannot replace this op until we are sure that this would not:
                 // 1. undermine any prior prepare_ok guarantee made to the primary, and
                 // 2. leak stale ops back into our in-memory headers (and so into a view change).
-                log.debug("{}: repair_header: op={} checksum={} (disconnected from hash chain)", .{
+                log.debug("{}: repair_header: op={} checksum={x:0>32} " ++
+                    "(disconnected from hash chain)", .{
                     self.log_prefix(),
                     header.op,
                     header.checksum,
@@ -7916,7 +7928,7 @@ pub fn ReplicaType(
 
             const op = self.primary_repair_pipeline_op().?;
             const op_checksum = self.journal.header_with_op(op).?.checksum;
-            log.debug("{}: primary_repair_pipeline_read: op={} checksum={}", .{
+            log.debug("{}: primary_repair_pipeline_read: op={} checksum={x:0>32}", .{
                 self.log_prefix(),
                 op,
                 op_checksum,
@@ -8010,7 +8022,7 @@ pub fn ReplicaType(
                 return;
             }
 
-            log.debug("{}: repair_pipeline_read_callback: op={} checksum={}", .{
+            log.debug("{}: repair_pipeline_read_callback: op={} checksum={x:0>32}", .{
                 self.log_prefix(),
                 prepare.?.header.op,
                 prepare.?.header.checksum,
@@ -8179,7 +8191,7 @@ pub fn ReplicaType(
                 // We may be appending to or repairing the journal concurrently.
                 // We do not want to re-request any of these prepares unnecessarily.
                 if (self.journal.writing(header) == .exact) {
-                    log.debug("{}: repair_prepare: op={} checksum={} (already writing)", .{
+                    log.debug("{}: repair_prepare: op={} checksum={x:0>32} (already writing)", .{
                         self.log_prefix(),
                         op,
                         checksum,
@@ -8211,7 +8223,8 @@ pub fn ReplicaType(
 
                         // This op won't start writing until all ops in the pipeline preceding it
                         // have been written.
-                        log.debug("{}: repair_prepare: op={} checksum={} (serializing append)", .{
+                        log.debug("{}: repair_prepare: op={} checksum={x:0>32} " ++
+                            "(serializing append)", .{
                             self.log_prefix(),
                             op,
                             checksum,
@@ -8221,7 +8234,7 @@ pub fn ReplicaType(
                         return false;
                     }
 
-                    log.debug("{}: repair_prepare: op={} checksum={} (from pipeline)", .{
+                    log.debug("{}: repair_prepare: op={} checksum={x:0>32} (from pipeline)", .{
                         self.log_prefix(),
                         op,
                         checksum,
@@ -8257,7 +8270,8 @@ pub fn ReplicaType(
                 };
 
                 log.debug(
-                    "{}: repair_prepare: op={} checksum={} replica={} latency={}ms ({s}, {s}, {s})",
+                    "{}: repair_prepare: op={} checksum={x:0>32} replica={} latency={}ms " ++
+                        "({s}, {s}, {s})",
                     .{
                         self.log_prefix(),
                         op,
@@ -8536,7 +8550,7 @@ pub fn ReplicaType(
             assert(header.op <= self.op);
 
             if (self.journal.has_prepare(header)) {
-                log.debug("{}: send_prepare_ok: op={} checksum={}", .{
+                log.debug("{}: send_prepare_ok: op={} checksum={x:0>32}", .{
                     self.log_prefix(),
                     header.op,
                     header.checksum,
@@ -9662,7 +9676,7 @@ pub fn ReplicaType(
                     // repair_header() will not repair a header if the hash chain has a gap.
                     if (header.op <= message.header.commit_min) {
                         log.debug(
-                            "{}: on_do_view_change: committed: replica={} op={} checksum={}",
+                            "{}: on_do_view_change: committed: replica={} op={} checksum={x:0>32}",
                             .{
                                 self.log_prefix(),
                                 message.header.replica,
@@ -9707,7 +9721,7 @@ pub fn ReplicaType(
                 const dvc_present = BitSet{ .bits = dvc.header.present_bitset };
                 for (dvc_headers.slice, 0..) |*header, i| {
                     log.debug("{}: {s}: dvc: header: " ++
-                        "replica={} op={} checksum={} nack={} present={} type={s}", .{
+                        "replica={} op={} checksum={x:0>32} nack={} present={} type={s}", .{
                         self.log_prefix(),
                         context,
                         dvc.header.replica,
@@ -9751,7 +9765,7 @@ pub fn ReplicaType(
                     assert(prepare.ok_from_all_replicas.empty());
 
                     log.debug("{}: start_view_as_the_new_primary: pipeline " ++
-                        "(op={} checksum={x} parent={x})", .{
+                        "(op={} checksum={x:0>32} parent={x:0>32})", .{
                         self.log_prefix(),
                         prepare.message.header.op,
                         prepare.message.header.checksum,
@@ -10644,8 +10658,8 @@ pub fn ReplicaType(
                 if (table_info.snapshot_min >= snapshot_from_commit(sync_op_min) and
                     table_info.snapshot_min <= snapshot_from_commit(sync_op_max))
                 {
-                    log.debug("{}: sync_enqueue_tables: " ++
-                        "request address={} checksum={} level={} snapshot_min={} ({}..{})", .{
+                    log.debug("{}: sync_enqueue_tables: request " ++
+                        "address={} checksum={x:0>32} level={} snapshot_min={} ({}..{})", .{
                         self.log_prefix(),
                         table_info.address,
                         table_info.checksum,
@@ -10727,7 +10741,7 @@ pub fn ReplicaType(
             while (self.grid.blocks_missing.reclaim_table()) |table| {
                 log.info(
                     "{}: sync_reclaim_tables: table synced or canceled: " ++
-                        "address={} checksum={} wrote={}/{?}",
+                        "address={} checksum={x:0>32} wrote={}/{?}",
                     .{
                         self.log_prefix(),
                         table.table_info.address,
@@ -11078,7 +11092,7 @@ pub fn ReplicaType(
             assert(message.header.op >= self.op_repair_min());
 
             if (!self.journal.has_header(message.header)) {
-                log.debug("{}: write_prepare: ignoring op={} checksum={} (header changed)", .{
+                log.debug("{}: write_prepare: ignoring op={} checksum={x:0>32} (header changed)", .{
                     self.log_prefix(),
                     message.header.op,
                     message.header.checksum,
@@ -11090,7 +11104,7 @@ pub fn ReplicaType(
                 .none => {},
                 .slot, .exact => |reason| {
                     log.debug(
-                        "{}: write_prepare: ignoring op={} checksum={} (already writing {s})",
+                        "{}: write_prepare: ignoring op={} checksum={x:0>32} (already writing {s})",
                         .{
                             self.log_prefix(),
                             message.header.op,
@@ -11185,7 +11199,7 @@ pub fn ReplicaType(
             for (requests_buffer[0..requests_count]) |*request| {
                 assert(!self.grid.free_set.is_free(request.block_address));
 
-                log.debug("{}: send_request_blocks: request address={} checksum={}", .{
+                log.debug("{}: send_request_blocks: request address={} checksum={x:0>32}", .{
                     self.log_prefix(),
                     request.block_address,
                     request.block_checksum,

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1321,7 +1321,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         "free_set_blocks_released_size={[free_set_blocks_released_size]} " ++
                         "client_sessions_size={[client_sessions_size]} " ++
                         "checkpoint_id={[checkpoint_id]x:0>32} " ++
-                        "commit_min_checksum={[commit_min_checksum]} commit_min={[commit_min]} " ++
+                        "commit_min_checksum={[commit_min_checksum]x:0>32} " ++
+                        "commit_min={[commit_min]} " ++
                         "commit_max={[commit_max]} log_view={[log_view]} view={[view]} " ++
                         "sync_op_min={[sync_op_min]} sync_op_max={[sync_op_max]} " ++
                         "manifest_oldest_checksum={[manifest_oldest_checksum]} " ++
@@ -1363,7 +1364,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                     },
                 );
                 for (superblock.working.view_headers().slice) |*header| {
-                    log.debug("{?}: {s}: vsr_header: op={} checksum={}", .{
+                    log.debug("{?}: {s}: vsr_header: op={} checksum={x:0>32}", .{
                         superblock.replica_index,
                         @tagName(context.caller),
                         header.op,
@@ -1520,7 +1521,8 @@ pub fn SuperBlockType(comptime Storage: type) type {
             log.debug("{[replica]?}: {[caller]s}: " ++
                 "commit_min={[commit_min_old]}..{[commit_min_new]} " ++
                 "commit_max={[commit_max_old]}..{[commit_max_new]} " ++
-                "commit_min_checksum={[commit_min_checksum_old]}..{[commit_min_checksum_new]} " ++
+                "commit_min_checksum={[commit_min_checksum_old]x:0>32}.." ++
+                "{[commit_min_checksum_new]x:0>32} " ++
                 "log_view={[log_view_old]}..{[log_view_new]} " ++
                 "view={[view_old]}..{[view_new]} " ++
                 "head={[head_old]}..{[head_new]?}", .{

--- a/src/vsr/superblock_quorums.zig
+++ b/src/vsr/superblock_quorums.zig
@@ -103,7 +103,8 @@ pub fn QuorumsType(comptime options: Options) type {
 
             for (quorums.slice()) |quorum| {
                 if (quorum.copies.full()) {
-                    log.debug("quorum: checksum={x} parent={x} sequence={} count={} valid={}", .{
+                    log.debug("quorum: checksum={x:0>32} parent={x:0>32} sequence={} count={} " ++
+                        "valid={}", .{
                         quorum.header.checksum,
                         quorum.header.parent,
                         quorum.header.sequence,
@@ -111,7 +112,8 @@ pub fn QuorumsType(comptime options: Options) type {
                         quorum.valid,
                     });
                 } else {
-                    log.warn("quorum: checksum={x} parent={x} sequence={} count={} valid={}", .{
+                    log.warn("quorum: checksum={x:0>32} parent={x:0>32} sequence={} count={} " ++
+                        "valid={}", .{
                         quorum.header.checksum,
                         quorum.header.parent,
                         quorum.header.sequence,
@@ -209,7 +211,7 @@ pub fn QuorumsType(comptime options: Options) type {
             }
 
             if (copy.copy == slot) {
-                log.debug("copy: {}/{}: checksum={x} parent={x} sequence={}", .{
+                log.debug("copy: {}/{}: checksum={x:0>32} parent={x:0>32} sequence={}", .{
                     slot,
                     options.superblock_copies,
                     copy.checksum,
@@ -217,7 +219,8 @@ pub fn QuorumsType(comptime options: Options) type {
                     copy.sequence,
                 });
             } else if (copy.copy >= options.superblock_copies) {
-                log.warn("copy: {}/{}: checksum={x} parent={x} sequence={} corrupt copy={}", .{
+                log.warn("copy: {}/{}: checksum={x:0>32} parent={x:0>32} sequence={} " ++
+                    "corrupt copy={}", .{
                     slot,
                     options.superblock_copies,
                     copy.checksum,
@@ -229,7 +232,8 @@ pub fn QuorumsType(comptime options: Options) type {
                 // If our read was misdirected, we definitely still want to count the copy.
                 // We must just be careful to count it idempotently.
                 log.warn(
-                    "copy: {}/{}: checksum={x} parent={x} sequence={} misdirected from copy={}",
+                    "copy: {}/{}: checksum={x:0>32} parent={x:0>32} sequence={} " ++
+                        "misdirected from copy={}",
                     .{
                         slot,
                         options.superblock_copies,


### PR DESCRIPTION
This PR _attempts_ to solve #760 

This PR introduces (hopefully) consistent logging of checksums across the whole system in 32-places-wide hex and custom logging of data frames' headers.

The headers are formatted using following rules:
1. The data type's name is printed as a simple name dropping fully qualified prefix (i.e. `PrepareOk{ .checksum=...` instead of `vsr.message_header.Header.PrepareOk{ .checksum=...`).
2. Checksums (including the `parent` field) are formatted in hex.
3. `*_reserved` fields are omitted **if** they contain zeroes only.
4. `*_padding` fields and `nonce_reserved` are omitted.
5. `enum` values are printed as a string literal representing their tag name whenever the enum is exhaustive and the value fits within defined enumeration (i.e. `.command = prepare_ok` instead of `.command = vsr.Command.prepare_ok`). Otherwise we fallback to the default enum formatting.