### PR TITLE
state_machine: use op # as snapshot for queries

### DIFF
--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -813,12 +813,7 @@ pub fn GrooveType(
 
         /// Must be called directly before the state machine begins queuing ids for prefetch.
         /// When `snapshot` is null, prefetch from the current snapshot.
-        pub fn prefetch_setup(groove: *Groove, snapshot: ?u64) void {
-            // We currently don't have anything that uses or tests snapshots. Leave this
-            // here as a warning that they're not fully tested yet.
-            assert(snapshot == null);
-
-            const snapshot_target = snapshot orelse snapshot_latest;
+        pub fn prefetch_setup(groove: *Groove, snapshot_target: u64) void {
             assert(snapshot_target <= snapshot_latest);
 
             groove.prefetch_snapshot = snapshot_target;

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -812,9 +812,8 @@ pub fn GrooveType(
         }
 
         /// Must be called directly before the state machine begins queuing ids for prefetch.
-        /// When `snapshot` is null, prefetch from the current snapshot.
         pub fn prefetch_setup(groove: *Groove, snapshot_target: u64) void {
-            assert(snapshot_target <= snapshot_latest);
+            assert(snapshot_target < snapshot_latest);
 
             groove.prefetch_snapshot = snapshot_target;
             assert(groove.prefetch_keys.count() == 0);

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -319,9 +319,9 @@ pub fn ManifestLevelType(
         /// Our key range keeps track of tables that are visible to snapshot_latest, so it cannot
         /// be relied upon for queries to older snapshots.
         pub fn key_range_contains(level: *const ManifestLevel, snapshot: u64, key: Key) bool {
-            // TODO We currently assume that the snapshot passed in is the latest snapshot. This
-            // must be changed when persistent snapshots are implemented.
-            _ = snapshot;
+            // TODO We currently assume that the snapshot passed in is the latest snapshot.
+            // This must be changed when persistent snapshots are implemented.
+            assert(snapshot < lsm.snapshot_latest);
             return level.key_range_latest.contains(key);
         }
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -319,11 +319,10 @@ pub fn ManifestLevelType(
         /// Our key range keeps track of tables that are visible to snapshot_latest, so it cannot
         /// be relied upon for queries to older snapshots.
         pub fn key_range_contains(level: *const ManifestLevel, snapshot: u64, key: Key) bool {
-            if (snapshot == lsm.snapshot_latest) {
-                return level.key_range_latest.contains(key);
-            } else {
-                return true;
-            }
+            // TODO We currently assume that the snapshot passed in is the latest snapshot. This
+            // must be changed when persistent snapshots are implemented.
+            _ = snapshot;
+            return level.key_range_latest.contains(key);
         }
 
         pub const Visibility = enum {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -717,6 +717,7 @@ const Environment = struct {
         const scan_buffer_pool = &env.forest.scan_buffer_pool;
         const things_groove = &env.forest.grooves.things;
         const scan_builder: *ThingsGroove.ScanBuilder = &things_groove.scan_builder;
+        const snapshot = env.op;
 
         var stack = stdx.BoundedArrayType(*Scan, query_scans_max){};
         for (query_spec.query.const_slice()) |query_part| {
@@ -734,7 +735,7 @@ const Environment = struct {
                         inline else => |comptime_index| scan_builder.scan_prefix(
                             comptime_index,
                             scan_buffer_pool.acquire_assume_capacity(),
-                            env.op,
+                            snapshot,
                             field.value,
                             timestamp_range,
                             query_spec.direction,

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -179,8 +179,8 @@ pub fn ScanLookupType(
                 self.object_count = self.object_count.? + 1;
 
                 const objects = &self.groove.objects;
-                // TODO We currently assume that the snapshot passed in is the latest snapshot. This
-                // must be changed when persistent snapshots are implemented.
+                // TODO We currently assume that the snapshot passed in is the current snapshot.
+                // This must be changed when persistent snapshots are implemented.
                 if (objects.table_mutable.get(timestamp) orelse
                     objects.table_immutable.get(timestamp)) |object|
                 {

--- a/src/lsm/scan_lookup.zig
+++ b/src/lsm/scan_lookup.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const snapshot_latest = @import("tree.zig").snapshot_latest;
-
 const GridType = @import("../vsr/grid.zig").GridType;
 
 pub const ScanLookupStatus = enum {
@@ -181,12 +179,11 @@ pub fn ScanLookupType(
                 self.object_count = self.object_count.? + 1;
 
                 const objects = &self.groove.objects;
+                // TODO We currently assume that the snapshot passed in is the latest snapshot. This
+                // must be changed when persistent snapshots are implemented.
                 if (objects.table_mutable.get(timestamp) orelse
                     objects.table_immutable.get(timestamp)) |object|
                 {
-                    // TODO(batiati) Handle this properly when we implement snapshot queries.
-                    assert(self.scan.snapshot() == snapshot_latest);
-
                     // Object present in table mutable/immutable,
                     // continue the loop to fetch the next one.
                     self.object_buffer.?[worker.object_index.?] = object.*;

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -181,8 +181,8 @@ pub fn ScanTreeType(
             assert(key_min <= key_max);
 
             const table_mutable_values: []const Value = blk: {
-                // TODO We currently assume that the snapshot passed in is the latest snapshot. This
-                // must be changed when persistent snapshots are implemented.
+                // TODO We currently assume that the snapshot passed in is the current snapshot.
+                // This must be changed when persistent snapshots are implemented.
                 tree.table_mutable.sort();
                 const values = tree.table_mutable.values_used();
                 const range = binary_search.binary_search_values_range(

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -5,7 +5,6 @@ const assert = std.debug.assert;
 const stdx = @import("stdx");
 const maybe = stdx.maybe;
 const constants = @import("../constants.zig");
-const snapshot_latest = @import("tree.zig").snapshot_latest;
 const schema = @import("schema.zig");
 const binary_search = @import("binary_search.zig");
 const k_way_merge = @import("k_way_merge.zig");
@@ -182,8 +181,8 @@ pub fn ScanTreeType(
             assert(key_min <= key_max);
 
             const table_mutable_values: []const Value = blk: {
-                if (snapshot != snapshot_latest) break :blk &.{};
-
+                // TODO We currently assume that the snapshot passed in is the latest snapshot. This
+                // must be changed when persistent snapshots are implemented.
                 tree.table_mutable.sort();
                 const values = tree.table_mutable.values_used();
                 const range = binary_search.binary_search_values_range(

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -804,7 +804,7 @@ pub fn generate_fuzz_ops(
         // Maybe do some gets.
         .get = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
         // Maybe do some scans.
-        .scan = if (prng.boolean()) 0 else 0,
+        .scan = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
     };
     log.info("fuzz_op_weights = {:.2}", .{fuzz_op_weights});
 

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -65,6 +65,7 @@ const Value = packed struct(u128) {
 const FuzzOpTag = std.meta.Tag(FuzzOp);
 const FuzzOp = union(enum) {
     const Scan = struct {
+        snapshot: u64,
         min: u64,
         max: u64,
         direction: Direction,
@@ -84,7 +85,6 @@ const FuzzOp = union(enum) {
 const batch_size_max = constants.message_size_max - @sizeOf(vsr.Header);
 const commit_entries_max = @divFloor(batch_size_max, @sizeOf(Value));
 const value_count_max = constants.lsm_compaction_ops * commit_entries_max;
-const snapshot_latest = @import("tree.zig").snapshot_latest;
 const table_count_max = @import("tree.zig").table_count_max;
 
 const node_count = 1024;
@@ -449,7 +449,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.superblock_checkpoint, .fuzzing);
         }
 
-        pub fn get(env: *Environment, key: u64) ?Value {
+        pub fn get(env: *Environment, key: u64, snapshot: u64) ?Value {
             env.change_state(.fuzzing, .tree_lookup);
             env.lookup_value = null;
 
@@ -459,7 +459,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 env.tree.lookup_from_levels_storage(.{
                     .callback = get_callback,
                     .context = &env.lookup_context,
-                    .snapshot = snapshot_latest,
+                    .snapshot = snapshot,
                     .key = key,
                     .level_min = 0,
                 });
@@ -476,14 +476,20 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.tree_lookup, .fuzzing);
         }
 
-        pub fn scan(env: *Environment, key_min: u64, key_max: u64, direction: Direction) []Value {
+        pub fn scan(
+            env: *Environment,
+            key_min: u64,
+            key_max: u64,
+            direction: Direction,
+            snapshot: u64,
+        ) []Value {
             assert(key_min <= key_max);
 
             env.change_state(.fuzzing, .scan_tree);
             env.scan_tree = ScanTree.init(
                 &env.tree,
                 &env.scan_buffer,
-                snapshot_latest,
+                snapshot,
                 key_min,
                 key_max,
                 direction,
@@ -585,7 +591,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     },
                     .get => |key| {
                         // Get account from lsm.
-                        const tree_value = env.get(key);
+                        const tree_value = env.get(key, fuzz_op_index);
 
                         // Compare result to model.
                         const model_value = model.get(key);
@@ -607,6 +613,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 scan_range.min,
                 scan_range.max,
                 scan_range.direction,
+                scan_range.snapshot,
             );
 
             const model_values = model.scan(
@@ -797,7 +804,7 @@ pub fn generate_fuzz_ops(
         // Maybe do some gets.
         .get = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
         // Maybe do some scans.
-        .scan = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
+        .scan = if (prng.boolean()) 0 else 0,
     };
     log.info("fuzz_op_weights = {:.2}", .{fuzz_op_weights});
 
@@ -844,6 +851,7 @@ pub fn generate_fuzz_ops(
                         .min = min,
                         .max = max,
                         .direction = direction,
+                        .snapshot = op,
                     },
                 };
             },

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -11,7 +11,6 @@ const maybe = stdx.maybe;
 const constants = @import("constants.zig");
 const tb = @import("tigerbeetle.zig");
 const vsr = @import("vsr.zig");
-const snapshot_latest = @import("lsm/tree.zig").snapshot_latest;
 const ScopeCloseMode = @import("lsm/tree.zig").ScopeCloseMode;
 const WorkloadType = @import("state_machine/workload.zig").WorkloadType;
 const GrooveType = @import("lsm/groove.zig").GrooveType;
@@ -231,6 +230,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         commit_timestamp: u64,
         forest: Forest,
 
+        prefetch_snapshot: ?u64 = null,
         prefetch_operation: ?Operation = null,
         prefetch_input: ?[]const u8 = null,
         prefetch_callback: ?*const fn (*StateMachine) void = null,
@@ -757,6 +757,7 @@ pub fn StateMachineType(comptime Storage: type) type {
 
             self.* = .{
                 .batch_size_limit = options.batch_size_limit,
+                .prefetch_snapshot = 0,
                 .prefetch_timestamp = 0,
                 .prepare_timestamp = 0,
                 .commit_timestamp = 0,
@@ -1054,6 +1055,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             self: *StateMachine,
             callback: *const fn (*StateMachine) void,
             op: u64,
+            snapshot: u64,
             operation: Operation,
             message_body_used: []align(16) const u8,
         ) void {
@@ -1087,14 +1089,15 @@ pub fn StateMachineType(comptime Storage: type) type {
                 break :input body_decoder.payload;
             };
 
+            self.prefetch_snapshot = snapshot;
             self.prefetch_operation = operation;
             self.prefetch_input = prefetch_input;
             self.prefetch_callback = callback;
 
             // TODO(Snapshots) Pass in the target snapshot.
-            self.forest.grooves.accounts.prefetch_setup(null);
-            self.forest.grooves.transfers.prefetch_setup(null);
-            self.forest.grooves.transfers_pending.prefetch_setup(null);
+            self.forest.grooves.accounts.prefetch_setup(snapshot);
+            self.forest.grooves.transfers.prefetch_setup(snapshot);
+            self.forest.grooves.transfers_pending.prefetch_setup(snapshot);
 
             // Prefetch starts timing for an operation.
             self.metrics.timer.reset();
@@ -1145,9 +1148,10 @@ pub fn StateMachineType(comptime Storage: type) type {
             assert(self.scan_lookup == .null);
 
             const callback = self.prefetch_callback.?;
+            self.prefetch_callback = null;
+            self.prefetch_snapshot = null;
             self.prefetch_operation = null;
             self.prefetch_input = null;
-            self.prefetch_callback = null;
 
             callback(self);
         }
@@ -1682,7 +1686,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 scan_conditions.push(scan_builder.scan_prefix(
                     .debit_account_id,
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                    snapshot_latest,
+                    self.prefetch_snapshot.?,
                     filter.account_id,
                     timestamp_range,
                     direction,
@@ -1694,7 +1698,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 scan_conditions.push(scan_builder.scan_prefix(
                     .credit_account_id,
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                    snapshot_latest,
+                    self.prefetch_snapshot.?,
                     filter.account_id,
                     timestamp_range,
                     direction,
@@ -1721,7 +1725,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                     scan_conditions.push(scan_builder.scan_prefix(
                         filter_field,
                         self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                        snapshot_latest,
+                        self.prefetch_snapshot.?,
                         filter_value,
                         timestamp_range,
                         direction,
@@ -1997,7 +2001,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                     scan_conditions.push(groove.scan_builder.scan_prefix(
                         std.enums.nameCast(std.meta.FieldEnum(Groove.IndexTrees), index),
                         self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                        snapshot_latest,
+                        self.prefetch_snapshot.?,
                         @field(filter, @tagName(index)),
                         timestamp_range,
                         direction,
@@ -2012,7 +2016,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 // It will be implemented as part of the query executor.
                 groove.scan_builder.scan_timestamp(
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                    snapshot_latest,
+                    self.prefetch_snapshot.?,
                     timestamp_range,
                     direction,
                 ),
@@ -2301,7 +2305,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             scan_lookup.init(
                 &self.forest.grooves.account_events.objects,
                 self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                snapshot_latest,
+                self.prefetch_snapshot.?,
                 timestamp_range,
             );
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1062,6 +1062,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             // NB: This function should never accept `client_release` as an argument.
             // Any public API changes must be introduced explicitly as a new `operation` number.
             assert(op > 0);
+            assert(op <= snapshot);
             assert(self.prefetch_operation == null);
             assert(self.prefetch_input == null);
             assert(self.prefetch_callback == null);
@@ -1144,6 +1145,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         fn prefetch_finish(self: *StateMachine) void {
             assert(self.prefetch_operation != null);
             assert(self.prefetch_input != null);
+            assert(self.prefetch_snapshot != null);
             assert(self.prefetch_context == .null);
             assert(self.scan_lookup == .null);
 

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -256,6 +256,7 @@ pub const TestContext = struct {
         context.state_machine.prefetch(
             TestContext.callback,
             op,
+            op,
             operation,
             message_body_used,
         );

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -184,18 +184,20 @@ pub fn StateMachineType(comptime Storage: type) type {
             state_machine: *StateMachine,
             callback: *const fn (*StateMachine) void,
             op: u64,
+            snapshot: u64,
             operation: Operation,
             input: []align(16) const u8,
         ) void {
             _ = operation;
             _ = input;
+            _ = op;
 
             assert(state_machine.callback == null);
             state_machine.callback = callback;
 
             // TODO(Snapshots) Pass in the target snapshot.
-            state_machine.forest.grooves.things.prefetch_setup(null);
-            state_machine.forest.grooves.things.prefetch_enqueue(op);
+            state_machine.forest.grooves.things.prefetch_setup(snapshot);
+            state_machine.forest.grooves.things.prefetch_enqueue(snapshot);
             state_machine.forest.grooves.things.prefetch(
                 prefetch_callback,
                 &state_machine.prefetch_context,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4658,11 +4658,22 @@ pub fn ReplicaType(
                 @panic("Cannot commit prepare; batch limit too low.");
             }
 
+            // If we crash and recover from a checkpoint, use trigger+1 as the snapshot to query
+            // the LSM tree. This is because the checkpoint contains output tables from the
+            // compaction in the last bar before trigger, which creates tables with
+            // snapshot_min=trigger+1. Otherwise, we use the op number as the snapshot, as it is
+            // guaranteed to be the latest snapshot.
+            const snapshot = if (self.superblock.working.vsr_state.op_compacted(prepare.header.op))
+                vsr.Checkpoint.trigger_for_checkpoint(self.op_checkpoint()).? + 1
+            else
+                prepare.header.op;
+
             if (StateMachine.Operation.from_vsr(prepare.header.operation)) |prepare_operation| {
                 self.state_machine.prefetch_timestamp = prepare.header.timestamp;
                 self.state_machine.prefetch(
                     commit_prefetch_callback,
                     prepare.header.op,
+                    snapshot,
                     prepare_operation,
                     prepare.body_used(),
                 );


### PR DESCRIPTION
Each table in the LSM has `snapshot_min` & `snapshot_max`, which defines the snapshots to which that table is visible. In other words, if a snapshot between a table T's `snapshot_min` & `snapshot_max` is used to query the LSM, then T is visible to that snapshot. 
```C
        pub fn visible(table: *const TreeTableInfo, snapshot: u64) bool {
            assert(table.address != 0);
            assert(table.snapshot_min <= table.snapshot_max);
            assert(snapshot <= snapshot_latest);

            return table.snapshot_min <= snapshot and snapshot <= table.snapshot_max;
        }
```

Currently, tables that are not deleted all have `snapshot_max=math.maxInt(u64)`, and are queried for visibility using `snapshot_latest`, which is `math.maxInt(u64) - 1;`. There are broadly two code paths along which the LSM is queried, both of which use `snapshot_latest`:
* Queries
* Compaction


This PR changes this behaviour, such that:
* Queries now use `VSR op number` to query tables in the LSM
* Compaction _still_ uses `snapshot_latest`

Now, under normal processing, this just works as the `VSR op number` is guaranteed to be greater than any `snapshot_min` that has been ever assigned to a table, and also less than `snapshot_max=math.maxInt(u64)` for visible tables. 

However, this doesn't work as trivially for the scenario where a replica crashes and restarts. This is because in that scenario, the checkpoint that we recover from would contain tables with `snapshot_min=checkpoint_trigger + 1` (created in compaction during the final bar before checkpoint_trigger). On the other hand, we replay the log starting `checkpoint + 1`, since the changes from `(checkpoint, checkpoint_trigger]` are not included in the on-disk checkpoint, as they are still in the in-memory component of the LSM. Therefore, ops between `(checkpoint, checkpoint_trigger]`  must use `checkpoint_trigger + 1` as the snapshot the query the database, so they are able to observe the tables created by the final bar of compaction between checkpoint trigger.