### PR TITLE
stdx: less off-by-one prone shuffle implementation

### DIFF
--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -641,10 +641,8 @@ test Reservoir {
 }
 
 pub fn shuffle(prng: *PRNG, T: type, slice: []T) void {
-    if (slice.len <= 1) return;
-
-    for (0..slice.len - 1) |i| {
-        const j = prng.range_inclusive(u64, i, slice.len - 1);
+    for (0..slice.len) |i| {
+        const j = prng.int_inclusive(u64, i);
         std.mem.swap(T, &slice[i], &slice[j]);
     }
 }
@@ -660,7 +658,7 @@ test shuffle {
     }
 
     try snap(@src(),
-        \\g_first_count = 144 expected_value=142
+        \\g_first_count = 152 expected_value=142
     ).diff_fmt("g_first_count = {} expected_value={}", .{ g_first_count, 1000 / 7 });
 }
 

--- a/src/testing/exhaustigen.zig
+++ b/src/testing/exhaustigen.zig
@@ -96,11 +96,24 @@ pub fn range_inclusive(g: *Gen, Int: type, min: Int, max: Int) Int {
 }
 
 pub fn shuffle(g: *Gen, T: type, slice: []T) void {
-    if (slice.len <= 1) return;
-
-    for (0..slice.len - 1) |i| {
-        const j = g.range_inclusive(u64, i, slice.len - 1);
+    for (0..slice.len) |i| {
+        const j = g.int_inclusive(u64, i);
         std.mem.swap(T, &slice[i], &slice[j]);
+    }
+}
+
+test shuffle {
+    var n_factorial: u32 = 1;
+    inline for (0..5) |n| {
+        var g: Gen = .{};
+        var count: u32 = 0;
+        while (!g.done()) {
+            var array: [n]u8 = @splat(0);
+            g.shuffle(u8, &array);
+            count += 1;
+        }
+        assert(count == n_factorial);
+        n_factorial *= (n + 1);
     }
 }
 


### PR DESCRIPTION
Hat tip to https://dotat.at/@/2025-12-25-shuffle.html

Turns out that there are two ways you can think about generating a permutation of, say, N Christmas Tree toys:

* You can have a pile of toys, and at each step draw one toy from the pile and append it to the list. The induction invariant here is that at step k you have a k-permutation of the original set of N elements.
* Altenrnatively, you can first arrange the toys from the most beautiful to the ugliest one, and maintain the invariant that on step k, you have a permutation of the first k most beautiful toys. The way you do it is that you first apeend the next toy, and then swap it with another toy from the permutatoin (probably with itself).

I originally implemented the first version, as its the first thing that comes to mind, but I like the second one more:

- you need less `-1`s,
- you don't need to special-case empty arrays (though that comes at a cost of an extra swap),
- the loop invariant is more natural (as my prof told me, the only thing you need k-permutations for is deriving a formula for combinations)

Also, add exhaustigen test here to double-check that we indeed got all possible linear toy arrangements!