### PR TITLE
k-way-merge: remove `stream_precedence`.

### DIFF
--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -99,7 +99,6 @@ fn ScanMergeType(
             key_from_value,
             merge_stream_peek,
             merge_stream_pop,
-            merge_stream_precedence,
         );
 
         const ZigZagMergeIterator = ZigZagMergeIteratorType(
@@ -347,11 +346,6 @@ fn ScanMergeType(
 
             var stream = &self.streams.slice()[stream_index];
             return stream.pop();
-        }
-
-        fn merge_stream_precedence(self: *const ScanMerge, a: u32, b: u32) bool {
-            _ = self;
-            return a < b;
         }
 
         fn merge_stream_probe(


### PR DESCRIPTION
This PR removes the `stream_precedence` interface/configuration. 
Based on the discussion with @matklad in #3438, it turns out we can refactor the few places that currently rely on it and eliminate this knob entirely, which is a nice simplification.