### PR TITLE
java: simplify retry logic for validate_release

### DIFF
--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -117,45 +117,22 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     // Retry the download for 45 minutes, passing `--update-snapshots` to thwart local negative
     // caching.
     for (0..9) |_| {
-        if (try mvn_update(shell) == .ok) break;
-        log.warn("waiting for 5 minutes for the {s} version to appear in maven cental", .{
-            options.version,
-        });
-        std.time.sleep(5 * std.time.ns_per_min);
-    } else {
-        switch (try mvn_update(shell)) {
-            .ok => {},
-            .retry => |err| {
-                log.err("package is not available in maven central", .{});
-                return err;
-            },
+        if (shell.exec("mvn package --update-snapshots", .{})) {
+            break;
+        } else |_| {
+            log.warn("waiting for 5 minutes for the {s} version to appear in maven cental", .{
+                options.version,
+            });
+            std.time.sleep(5 * std.time.ns_per_min);
         }
+    } else {
+        shell.exec("mvn package --update-snapshots", .{}) catch |err| {
+            log.err("package is not available in maven central", .{});
+            return err;
+        };
     }
 
     try shell.exec("mvn exec:java", .{});
-}
-
-fn mvn_update(shell: *Shell) !union(enum) { ok, retry: anyerror } {
-    if (shell.exec("mvn package --update-snapshots", .{})) {
-        return .ok;
-    } else |err| {
-        // Re-run immediately to capture stdout (sic) to check if the failure is indeed due to
-        // the package missing from the registry.
-        const exec_result = try shell.exec_raw("mvn package --update-snapshots", .{});
-        switch (exec_result.term) {
-            .Exited => |code| if (code == 0) return .ok,
-            else => {},
-        }
-
-        const package_missing = std.mem.indexOf(
-            u8,
-            exec_result.stdout,
-            "Could not resolve dependencies",
-        ) != null;
-        if (package_missing) return .{ .retry = err };
-
-        return err;
-    }
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {


### PR DESCRIPTION
Before, validate_release() used to try and distinguish between an ~unrelated maven failure, and the package actually not being available.

However, due to GitHub / Maven flakes, this fails too often. Simplify it to always retry, much like the Python validate_release().