### PR TITLE
Log the rest of superblock checksums in hex

### DIFF
--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -1325,12 +1325,12 @@ pub fn SuperBlockType(comptime Storage: type) type {
                         "commit_min={[commit_min]} " ++
                         "commit_max={[commit_max]} log_view={[log_view]} view={[view]} " ++
                         "sync_op_min={[sync_op_min]} sync_op_max={[sync_op_max]} " ++
-                        "manifest_oldest_checksum={[manifest_oldest_checksum]} " ++
+                        "manifest_oldest_checksum={[manifest_oldest_checksum]x:0>32} " ++
                         "manifest_oldest_address={[manifest_oldest_address]} " ++
-                        "manifest_newest_checksum={[manifest_newest_checksum]} " ++
+                        "manifest_newest_checksum={[manifest_newest_checksum]x:0>32} " ++
                         "manifest_newest_address={[manifest_newest_address]} " ++
                         "manifest_block_count={[manifest_block_count]} " ++
-                        "snapshots_block_checksum={[snapshots_block_checksum]} " ++
+                        "snapshots_block_checksum={[snapshots_block_checksum]x:0>32} " ++
                         "snapshots_block_address={[snapshots_block_address]}",
                     .{
                         .replica = superblock.replica_index,
@@ -1525,7 +1525,7 @@ pub fn SuperBlockType(comptime Storage: type) type {
                 "{[commit_min_checksum_new]x:0>32} " ++
                 "log_view={[log_view_old]}..{[log_view_new]} " ++
                 "view={[view_old]}..{[view_new]} " ++
-                "head={[head_old]}..{[head_new]?}", .{
+                "head={[head_old]x:0>32}..{[head_new]x:0>32}", .{
                 .replica = superblock.replica_index,
                 .caller = @tagName(context.caller),
 
@@ -1546,9 +1546,9 @@ pub fn SuperBlockType(comptime Storage: type) type {
 
                 .head_old = superblock.staging.view_headers().slice[0].checksum,
                 .head_new = if (context.view_headers) |*headers|
-                    @as(?u128, headers.array.get(0).checksum)
+                    headers.array.get(0).checksum
                 else
-                    null,
+                    0,
             });
         }
     };


### PR DESCRIPTION
This PR is a followup for #3439 to address missing hex checksum logging in `superblock.zig`.