### PR TITLE
ci: attempt to reduce java flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
       - if: matrix.language == 'java'
         uses: actions/setup-java@v4
-        with: { java-version: "${{ matrix.language_version }}", distribution: 'temurin' }
+        with: { java-version: "${{ matrix.language_version }}", distribution: 'temurin', cache: 'maven'}
 
       - if: matrix.language == 'node'
         uses: actions/setup-node@v4


### PR DESCRIPTION
* https://github.com/actions/setup-java?tab=readme-ov-file#caching-maven-dependencies
* https://github.com/tigerbeetle/tigerbeetle/actions/runs/20722050611/job/59488099481

My hypothesis is that setting this `cache` should reduce the number of hits against maven central repo, which should reduce the number of 500 we see.

Intentionally not enabling this for release/release-validate workflows.