### PR TITLE
C: ensure public contrat is stated in the header file

### DIFF
--- a/src/clients/c/tb_client.h
+++ b/src/clients/c/tb_client.h
@@ -304,6 +304,18 @@ typedef struct tb_init_parameters_t {
     uint64_t addresses_len;
 } tb_init_parameters_t;
 
+// Per-client callback invoked every time a `tb_client_submit` completes or is canceled.
+// Use `packet->userdata` to identify the specific submission.
+// `result` is null iff `packet->status != TB_PACKET_OK`
+// `result` is only valid for the duration of the callback itself.
+typedef void (*tb_completion_t)(
+    uintptr_t userdata,
+    tb_packet_t* packet,
+    uint64_t timestamp,
+    const uint8_t *result, // nullable
+    uint32_t result_size
+);
+
 // Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_INIT_STATUS tb_client_init(
@@ -313,7 +325,7 @@ TB_INIT_STATUS tb_client_init(
     const char *address_ptr,
     uint32_t address_len,
     uintptr_t completion_ctx,
-    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+    tb_completion_t completion_callback
 );
 
 // Initialize a new TigerBeetle client that echoes back any submitted data.
@@ -324,7 +336,7 @@ TB_INIT_STATUS tb_client_init_echo(
     const char *address_ptr,
     uint32_t address_len,
     uintptr_t completion_ctx,
-    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+    tb_completion_t completion_callback
 );
 
 // Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -130,14 +130,14 @@ pub const ClientInterface = extern struct {
 };
 
 /// The function pointer called by the IO thread when a request is completed or fails.
-/// The memory referenced by `result_ptr` is only valid for the duration of this callback.
+/// The memory referenced by `result` is only valid for the duration of this callback.
 /// `result_ptr` is `null` for unsuccessful requests. See `packet.status` for more details.
 pub const CompletionCallback = *const fn (
     context: usize,
     packet: *Packet.Extern,
     timestamp: u64,
-    result_ptr: ?[*]const u8,
-    result_len: u32,
+    result: ?[*]const u8,
+    result_size: u32,
 ) callconv(.c) void;
 
 pub const InitError = std.mem.Allocator.Error || error{
@@ -855,7 +855,7 @@ pub fn ContextType(
                 packet.phase = .complete;
 
                 // The packet completed with an error.
-                (self.completion_callback)(
+                self.completion_callback(
                     self.completion_context,
                     packet.cast(),
                     0,
@@ -868,7 +868,7 @@ pub fn ContextType(
             // The packet completed normally.
             assert(packet.status == .ok);
             packet.phase = .complete;
-            (self.completion_callback)(
+            self.completion_callback(
                 self.completion_context,
                 packet.cast(),
                 result.timestamp,

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -221,6 +221,18 @@ pub fn main() !void {
     // TODO: use `std.meta.declaractions` and generate with pub + export functions.
     // Zig 0.9.1 has `decl.data.Fn.arg_names` but it's currently/incorrectly a zero-sized slice.
     try buffer.writer().print(
+        \\// Per-client callback invoked every time a `tb_client_submit` completes or is canceled.
+        \\// Use `packet->userdata` to identify the specific submission.
+        \\// `result` is null iff `packet->status != TB_PACKET_OK`
+        \\// `result` is only valid for the duration of the callback itself.
+        \\typedef void (*tb_completion_t)(
+        \\    uintptr_t userdata,
+        \\    tb_packet_t* packet,
+        \\    uint64_t timestamp,
+        \\    const uint8_t *result, // nullable
+        \\    uint32_t result_size
+        \\);
+        \\
         \\// Initialize a new TigerBeetle client which connects to the addresses provided and
         \\// completes submitted packets by invoking the callback with the given context.
         \\TB_INIT_STATUS tb_client_init(
@@ -230,7 +242,7 @@ pub fn main() !void {
         \\    const char *address_ptr,
         \\    uint32_t address_len,
         \\    uintptr_t completion_ctx,
-        \\    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+        \\    tb_completion_t completion_callback
         \\);
         \\
         \\// Initialize a new TigerBeetle client that echoes back any submitted data.
@@ -241,7 +253,7 @@ pub fn main() !void {
         \\    const char *address_ptr,
         \\    uint32_t address_len,
         \\    uintptr_t completion_ctx,
-        \\    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+        \\    tb_completion_t completion_callback
         \\);
         \\
         \\// Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/go/pkg/native/tb_client.h
+++ b/src/clients/go/pkg/native/tb_client.h
@@ -304,6 +304,18 @@ typedef struct tb_init_parameters_t {
     uint64_t addresses_len;
 } tb_init_parameters_t;
 
+// Per-client callback invoked every time a `tb_client_submit` completes or is canceled.
+// Use `packet->userdata` to identify the specific submission.
+// `result` is null iff `packet->status != TB_PACKET_OK`
+// `result` is only valid for the duration of the callback itself.
+typedef void (*tb_completion_t)(
+    uintptr_t userdata,
+    tb_packet_t* packet,
+    uint64_t timestamp,
+    const uint8_t *result, // nullable
+    uint32_t result_size
+);
+
 // Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_INIT_STATUS tb_client_init(
@@ -313,7 +325,7 @@ TB_INIT_STATUS tb_client_init(
     const char *address_ptr,
     uint32_t address_len,
     uintptr_t completion_ctx,
-    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+    tb_completion_t completion_callback
 );
 
 // Initialize a new TigerBeetle client that echoes back any submitted data.
@@ -324,7 +336,7 @@ TB_INIT_STATUS tb_client_init_echo(
     const char *address_ptr,
     uint32_t address_len,
     uintptr_t completion_ctx,
-    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+    tb_completion_t completion_callback
 );
 
 // Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -132,8 +132,8 @@ const NativeClient = struct {
         context_ptr: usize,
         packet: *tb.Packet,
         timestamp: u64,
-        result_ptr: ?[*]const u8,
-        result_len: u32,
+        result: ?[*]const u8,
+        result_size: u32,
     ) callconv(.c) void {
         const jvm: *jni.JavaVM = @ptrFromInt(context_ptr);
 
@@ -152,18 +152,18 @@ const NativeClient = struct {
 
         if (packet_status != .ok) {
             assert(timestamp == 0);
-            assert(result_ptr == null);
-            assert(result_len == 0);
+            assert(result == null);
+            assert(result_size == 0);
         }
 
-        if (result_len > 0) {
+        if (result_size > 0) {
             switch (packet_status) {
-                .ok => if (result_ptr) |ptr| {
+                .ok => if (result) |ptr| {
                     // Copying the reply before returning from the callback.
                     ReflectionHelper.set_reply_buffer(
                         env,
                         request_obj,
-                        ptr[0..@as(usize, @intCast(result_len))],
+                        ptr[0..result_size],
                     );
                 },
                 else => {},

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -257,8 +257,8 @@ fn on_completion(
     completion_ctx: usize,
     packet_extern: *tb_client.Packet,
     timestamp: u64,
-    result_ptr: ?[*]const u8,
-    result_len: u32,
+    result: ?[*]const u8,
+    result_size: u32,
 ) callconv(.c) void {
     _ = timestamp;
 
@@ -277,7 +277,7 @@ fn on_completion(
                     // This is optimal for create_* operations.
                     const reply_buffer: []align(@alignOf(Result)) u8 = global_allocator.realloc(
                         request_buffer,
-                        result_len,
+                        result_size,
                     ) catch {
                         // We can't throw Js exceptions from the native callback.
                         @panic("Failed to allocated the request buffer.");
@@ -286,7 +286,7 @@ fn on_completion(
                     const source = stdx.bytes_as_slice(
                         .exact,
                         Result,
-                        result_ptr.?[0..result_len],
+                        result.?[0..result_size],
                     );
                     const target = stdx.bytes_as_slice(
                         .exact,

--- a/src/clients/rust/assets/tb_client.h
+++ b/src/clients/rust/assets/tb_client.h
@@ -304,6 +304,18 @@ typedef struct tb_init_parameters_t {
     uint64_t addresses_len;
 } tb_init_parameters_t;
 
+// Per-client callback invoked every time a `tb_client_submit` completes or is canceled.
+// Use `packet->userdata` to identify the specific submission.
+// `result` is null iff `packet->status != TB_PACKET_OK`
+// `result` is only valid for the duration of the callback itself.
+typedef void (*tb_completion_t)(
+    uintptr_t userdata,
+    tb_packet_t* packet,
+    uint64_t timestamp,
+    const uint8_t *result, // nullable
+    uint32_t result_size
+);
+
 // Initialize a new TigerBeetle client which connects to the addresses provided and
 // completes submitted packets by invoking the callback with the given context.
 TB_INIT_STATUS tb_client_init(
@@ -313,7 +325,7 @@ TB_INIT_STATUS tb_client_init(
     const char *address_ptr,
     uint32_t address_len,
     uintptr_t completion_ctx,
-    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+    tb_completion_t completion_callback
 );
 
 // Initialize a new TigerBeetle client that echoes back any submitted data.
@@ -324,7 +336,7 @@ TB_INIT_STATUS tb_client_init_echo(
     const char *address_ptr,
     uint32_t address_len,
     uintptr_t completion_ctx,
-    void (*completion_callback)(uintptr_t, tb_packet_t*, uint64_t, const uint8_t*, uint32_t)
+    tb_completion_t completion_callback
 );
 
 // Retrieve the parameters initially passed to `tb_client_init` or `tb_client_init_echo`.

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -1727,15 +1727,15 @@ where
 {
     let (tx, rx) = channel::<CompletionMessage<Event>>();
     let callback: Box<OnCompletion> = Box::new(Box::new(
-        |context, packet, timestamp, result_ptr, result_len| unsafe {
+        |context, packet, timestamp, result, result_size| unsafe {
             let events_len = (*packet).data_size as usize / mem::size_of::<Event>();
             let events = Vec::from_raw_parts((*packet).data as *mut Event, events_len, events_len);
             (*packet).data = ptr::null_mut();
 
             let packet = Packet(Box::from_raw(packet));
 
-            let result = if result_len != 0 {
-                std::slice::from_raw_parts(result_ptr, result_len as usize)
+            let result = if result_size != 0 {
+                std::slice::from_raw_parts(result, result_size as usize)
             } else {
                 &[]
             };

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -108,8 +108,8 @@ pub fn on_complete(
     tb_context: usize,
     tb_packet: [*c]c.tb_packet_t,
     timestamp: u64,
-    result_ptr: [*c]const u8,
-    result_len: u32,
+    result: ?[*]const u8,
+    result_size: u32,
 ) callconv(.c) void {
     _ = tb_context;
     _ = timestamp;
@@ -119,10 +119,10 @@ pub fn on_complete(
     defer context.lock.unlock();
 
     assert(tb_packet.*.status == c.TB_PACKET_OK);
-    assert(result_ptr != null);
+    assert(result != null);
 
-    stdx.copy_disjoint(.exact, u8, context.result[0..result_len], result_ptr[0..result_len]);
-    context.result_size = result_len;
+    stdx.copy_disjoint(.exact, u8, context.result[0..result_size], result.?[0..result_size]);
+    context.result_size = result_size;
     context.completed = true;
     context.condition.signal();
 }


### PR DESCRIPTION
A) introduce type alias for `tb_completion_t` callback in `tb_client.h` B) rename `result_len` to `result_size`

Why A): to be able to name arguments and spell-out the contract in the actual public API (the header file)

Why B): `result_len` is particulary bad, as it can easily mean either the count of objects, or the count of bytes. This is precisely the case for which we invented index-count-offset-size terminology, so its important to use it here. No strong opinion on what to do with `result_ptr`, but 1) `_ptr` is an abbr, 2) it is redundant with type, so I went with the simple soluition of removing the thing.