### PR TITLE
rust client: Use `--cache-grid` to reduce memory in tests.

### DIFF
--- a/src/clients/rust/tests/tests.rs
+++ b/src/clients/rust/tests/tests.rs
@@ -79,6 +79,7 @@ impl TestDb {
             // magic address 0: tell us the port to use,
             // shutdown when stdin closes
             "--addresses=0",
+            "--cache-grid=128MiB",
             &database_name,
         ])
         .stdin(Stdio::piped())


### PR DESCRIPTION
Reduces the singleton database's memory from 3GB to 2.1GB. Every bit helps on my laptop.