### PR TITLE
CFO: Clone + modify devhubdb even without token

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -486,9 +486,8 @@ fn run_fuzzers(
         assert(running_count == options.concurrency);
 
         if (iteration_push) {
-            if (options.devhub_token) |token| {
-                try upload_results(shell, gpa, token, seeds.items, seed_logs.items);
-            } else {
+            try upload_results(shell, gpa, options.devhub_token, seeds.items, seed_logs.items);
+            if (options.devhub_token == null) {
                 log.info("skipping upload, no token", .{});
                 for (seeds.items) |seed_record| {
                     const seed_record_json = try std.json.stringifyAlloc(
@@ -999,13 +998,15 @@ fn run_fuzzers_start_fuzzer(shell: *Shell, options: struct {
 fn upload_results(
     shell: *Shell,
     gpa: std.mem.Allocator,
-    token: []const u8,
+    token: ?[]const u8,
     seeds_new: []const SeedRecord,
     seeds_new_logs: []const ?[]const u8,
 ) !void {
     assert(seeds_new.len == seeds_new_logs.len);
 
-    log.info("uploading {} seeds", .{seeds_new.len});
+    if (token) |_| {
+        log.info("uploading {} seeds", .{seeds_new.len});
+    }
 
     _ = try shell.cwd.deleteTree("./devhubdb");
     try shell.exec(
@@ -1013,7 +1014,9 @@ fn upload_results(
         \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb.git
         \\  devhubdb
     , .{
-        .token = token,
+        // Even when no token is provided, clone and modify the (local) devhubdb so that it is easy
+        // to test CFO changes.
+        .token = token orelse "",
     });
     try shell.pushd("./devhubdb");
     defer shell.popd();
@@ -1068,11 +1071,15 @@ fn upload_results(
         try shell.exec("git add ./fuzzing/data.json", .{});
         try shell.git_env_setup(.{ .use_hostname = true });
         try shell.exec("git commit -m 🌱", .{});
-        if (shell.exec("git push", .{})) {
-            log.info("seeds updated", .{});
+        if (token) |_| {
+            if (shell.exec("git push", .{})) {
+                log.info("seeds updated", .{});
+                break;
+            } else |_| {
+                log.info("conflict, retrying", .{});
+            }
+        } else {
             break;
-        } else |_| {
-            log.info("conflict, retrying", .{});
         }
     } else {
         log.err("can't push new data to devhub", .{});


### PR DESCRIPTION
Even when the `DEVHUBDB_PAT` environment variable is not provided, still clone and update the (local copy of the) devhubdb.

This simplifies local testing of CFO changes, particularly when there is a devhubdb impact (e.g. vortex logs).