### PR TITLE
CLI: Add runtime `--aof-recovery` flag

### DIFF
--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -6,9 +6,6 @@ if [ ! -f "zig/zig" ]; then
     ./zig/download.sh
 fi
 
-./zig/zig build install -Dconfig-aof-recovery=true -Drelease
-mv zig-out/bin/tigerbeetle tigerbeetle-aof-recovery
-
 ./zig/zig build install -Drelease
 
 rm -f aof.log
@@ -54,18 +51,18 @@ sleep 1
 rm -rf 1 2
 
 mkdir 1 && cd 1
-../tigerbeetle-aof-recovery format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof-file="aof-test.tigerbeetle.aof" --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
+../tigerbeetle format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
+../tigerbeetle start --cache-grid=256MiB --addresses=3001,3002 --aof-file="aof-test.tigerbeetle.aof" --experimental --aof-recovery aof-test.tigerbeetle >> ../aof.log 2>&1 &
 cd ..
 
 mkdir 2 && cd 2
-../tigerbeetle-aof-recovery format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle-aof-recovery start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental aof-test.tigerbeetle >> ../aof.log 2>&1 &
+../tigerbeetle format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
+../tigerbeetle start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental --aof-recovery aof-test.tigerbeetle >> ../aof.log 2>&1 &
 cd ..
 
 # mkdir 3 && cd 3
-# ../tigerbeetle-aof-recovery format --cluster=0 --replica=2 --replica-count=3 aof-test.tigerbeetle >> aof.log 2>&1
-# ../tigerbeetle-aof-recovery start --addresses=3001,3002,3003 aof-test.tigerbeetle >> aof.log 2>&1 &
+# ../tigerbeetle format --cluster=0 --replica=2 --replica-count=3 aof-test.tigerbeetle >> aof.log 2>&1
+# ../tigerbeetle start --addresses=3001,3002,3003 aof-test.tigerbeetle >> aof.log 2>&1 &
 # cd ..
 
 sleep 1

--- a/build.zig
+++ b/build.zig
@@ -114,11 +114,6 @@ pub fn build(b: *std.Build) !void {
         .config_verify = b.option(bool, "config_verify", "Enable extra assertions.") orelse
             // If `config_verify` isn't set, disable it for `release` builds; otherwise, enable it.
             (mode == .Debug),
-        .config_aof_recovery = b.option(
-            bool,
-            "config-aof-recovery",
-            "Enable AOF Recovery mode.",
-        ) orelse false,
         .config_release = b.option([]const u8, "config-release", "Release triple."),
         .config_release_client_min = b.option(
             []const u8,
@@ -164,7 +159,6 @@ pub fn build(b: *std.Build) !void {
         .config_verify = build_options.config_verify,
         .config_release = build_options.config_release,
         .config_release_client_min = build_options.config_release_client_min,
-        .config_aof_recovery = build_options.config_aof_recovery,
     });
 
     const tb_client = build_tb_client(b, .{
@@ -348,7 +342,6 @@ fn build_vsr_module(b: *std.Build, options: struct {
     config_verify: bool,
     config_release: ?[]const u8,
     config_release_client_min: ?[]const u8,
-    config_aof_recovery: bool,
 }) struct { *std.Build.Step.Options, *std.Build.Module } {
     // Ideally, we would return _just_ the module here, and keep options an implementation detail.
     // However, currently Zig makes it awkward to provide multiple entry points for a module:
@@ -365,7 +358,6 @@ fn build_vsr_module(b: *std.Build, options: struct {
         "release_client_min",
         options.config_release_client_min,
     );
-    vsr_options.addOption(bool, "config_aof_recovery", options.config_aof_recovery);
 
     const vsr_module = b.createModule(.{
         .root_source_file = b.path("src/vsr.zig"),
@@ -933,7 +925,6 @@ fn build_test_integration(
         .config_verify = true,
         .config_release = "65535.0.0",
         .config_release_client_min = "0.16.4",
-        .config_aof_recovery = false,
     });
     const tigerbeetle_previous = download_release(b, "latest", options.target, options.mode);
     const tigerbeetle = build_tigerbeetle_executable_multiversion(b, .{

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -330,6 +330,7 @@ pub fn AOFType(comptime IO: type) type {
                         .id = stdx.unique_u128(),
                         .cluster = 0,
                         .replica_count = @intCast(addresses.len),
+                        .aof_recovery = true,
                         .message_bus_options = .{
                             .configuration = addresses,
                             .io = io,

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -238,6 +238,7 @@ pub const Runner = struct {
                 .id = stdx.unique_u128(),
                 .cluster = options.cluster_id,
                 .replica_count = @intCast(options.addresses.len),
+                .aof_recovery = false,
                 .message_bus_options = .{ .configuration = options.addresses, .io = &self.io },
             },
         );

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -305,6 +305,7 @@ pub fn ContextType(
                     .id = context.client_id,
                     .cluster = cluster_id,
                     .replica_count = context.addresses.count_as(u8),
+                    .aof_recovery = false,
                     .message_bus_options = .{
                         .configuration = context.addresses.const_slice(),
                         .io = &context.io,

--- a/src/clients/c/tb_client/echo_client.zig
+++ b/src/clients/c/tb_client/echo_client.zig
@@ -41,11 +41,13 @@ pub fn EchoClientType(comptime MessageBus: type) type {
                     client: *EchoClient,
                     eviction: *const Message.Eviction,
                 ) void = null,
+                aof_recovery: bool,
             },
         ) !EchoClient {
             _ = allocator;
             _ = options.replica_count;
             _ = options.message_bus_options;
+            assert(!options.aof_recovery);
 
             return EchoClient{
                 .id = options.id,

--- a/src/config.zig
+++ b/src/config.zig
@@ -23,7 +23,6 @@ const BuildOptions = struct {
     git_commit: ?[40]u8,
     release: ?[]const u8,
     release_client_min: ?[]const u8,
-    config_aof_recovery: bool,
 };
 
 // Allow setting build-time config either via `build.zig` `Options`, or via a struct in the root
@@ -140,7 +139,6 @@ const ConfigProcess = struct {
     grid_scrubber_cycle_ms: u64 = std.time.ms_per_day * 180,
     grid_scrubber_interval_ms_min: u64 = std.time.ms_per_s / 20,
     grid_scrubber_interval_ms_max: u64 = std.time.ms_per_s * 10,
-    aof_recovery: bool = false,
     multiversion_binary_platform_size_max: u64 = 64 * MiB,
     multiversion_poll_interval_ms: u64 = 1000,
 };
@@ -303,7 +301,6 @@ pub const configs = struct {
         base.process.release = release;
         base.process.release_client_min = release_client_min;
         base.process.git_commit = build_options.git_commit;
-        base.process.aof_recovery = build_options.config_aof_recovery;
         base.process.verify = build_options.config_verify;
 
         assert(base.process.release.value >= base.process.release_client_min.value);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -779,10 +779,6 @@ pub const clock_synchronization_window_max_ms = config.process.clock_synchroniza
 /// only during unit tests of the data structure.
 pub const verify = config.process.verify;
 
-/// Place us in a special recovery state, where we accept timestamps passed in to us. Used to
-/// replay our AOF.
-pub const aof_recovery = config.process.aof_recovery;
-
 /// The maximum number of bytes to use for compaction blocks.
 pub const compaction_block_memory_size_max = std.math.maxInt(u32) * block_size;
 

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -13,7 +13,6 @@ pub const vsr_options = .{
     .git_commit = @import("vsr_options").git_commit,
     .release = @import("vsr_options").release,
     .release_client_min = @import("vsr_options").release_client_min,
-    .config_aof_recovery = @import("vsr_options").config_aof_recovery,
 };
 
 // NB: this changes values in `constants.zig`!

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -344,7 +344,7 @@ test "help/version smoke" {
         .{ .command = "{tigerbeetle} --help", .substring = "tigerbeetle repl" },
         .{ .command = "{tigerbeetle} inspect --help", .substring = "tables --tree" },
         .{ .command = "{tigerbeetle} version", .substring = "TigerBeetle version" },
-        .{ .command = "{tigerbeetle} version --verbose", .substring = "process.aof_recovery=" },
+        .{ .command = "{tigerbeetle} version --verbose", .substring = "process.backoff_max_ms=" },
     }) |check| {
         const output = try shell.exec_stdout(check.command, .{ .tigerbeetle = tigerbeetle });
         try std.testing.expect(output.len > 0);

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -76,6 +76,7 @@ const Environment = struct {
         .cache_entries_transfers = cache_entries_max,
         .cache_entries_transfers_pending = cache_entries_max,
         .log_trace = true,
+        .aof_recovery = false,
     });
 
     const free_set_fragments_max = 2048;

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -677,6 +677,7 @@ pub fn ReplType(comptime MessageBus: type) type {
                     .id = client_id,
                     .cluster = options.cluster_id,
                     .replica_count = @intCast(options.addresses.len),
+                    .aof_recovery = false,
                     .message_bus_options = .{
                         .configuration = options.addresses,
                         .io = io,

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -725,6 +725,7 @@ const VSRContext = struct {
                 .id = stdx.unique_u128(),
                 .cluster = 0,
                 .replica_count = 1,
+                .aof_recovery = false,
                 .message_bus_options = .{
                     .configuration = &.{address},
                     .io = &self.io,

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -130,6 +130,7 @@ pub const TestContext = struct {
                 .cache_entries_transfers = 0,
                 .cache_entries_transfers_pending = 0,
                 .log_trace = true,
+                .aof_recovery = false,
             },
         );
         errdefer ctx.state_machine.deinit(allocator);

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -331,6 +331,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                         .id = client_id_permutation.encode(i + client_id_permutation_shift),
                         .cluster = options.cluster.cluster_id,
                         .replica_count = options.cluster.replica_count,
+                        .aof_recovery = false,
                         .message_bus_options = .{ .network = network },
                         .eviction_callback = client_on_eviction,
                     },
@@ -737,6 +738,7 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
                     .node_count = cluster.options.replica_count + cluster.options.standby_count,
                     .pipeline_requests_limit = cluster.replica_pipeline_requests_limit,
                     .aof = &cluster.aofs[replica_index],
+                    .aof_recovery = false,
                     // TODO Test restarting with a higher storage limit.
                     .storage_size_limit = cluster.options.storage_size_limit,
                     .nonce = options.nonce,

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -100,6 +100,7 @@ pub fn main(
                 .id = stdx.unique_u128(),
                 .cluster = cluster_id,
                 .replica_count = @intCast(addresses.len),
+                .aof_recovery = false,
                 .message_bus_options = .{ .configuration = addresses, .io = io },
             },
         ));

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -105,6 +105,10 @@ const CLIArgs = union(enum) {
         /// setting aof_file to '<data file path>.aof'.
         aof: bool = false,
 
+        /// AOF recovery mode: accept timestamps passed by the client.
+        /// Only enable this when recovering cluster from AOF.
+        aof_recovery: bool = false,
+
         @"--": void,
         path: []const u8,
     };
@@ -537,6 +541,7 @@ pub const Command = union(enum) {
         experimental: bool,
         replicate_star: bool,
         aof_file: ?Path,
+        aof_recovery: bool,
         path: []const u8,
         log_debug: bool,
         log_trace: bool,
@@ -1063,6 +1068,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
         .trace = start.trace,
         .replicate_star = start.replicate_star,
         .aof_file = aof_file,
+        .aof_recovery = start.aof_recovery,
         .path = start.path,
         .log_debug = start.log_debug,
         .log_trace = start.log_trace,

--- a/src/tigerbeetle/inspect_integrity.zig
+++ b/src/tigerbeetle/inspect_integrity.zig
@@ -209,6 +209,7 @@ fn init(
             .cache_entries_transfers_pending = 0,
 
             .log_trace = false,
+            .aof_recovery = false,
         }),
     );
     errdefer integrity.forest.deinit(gpa);

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -311,7 +311,7 @@ fn command_start(
             });
             break :blk .single_release(constants.config.process.release);
         }
-        if (constants.aof_recovery) {
+        if (args.aof_recovery) {
             log.info("multiversioning: upgrades disabled due to aof_recovery.", .{});
             break :blk .single_release(constants.config.process.release);
         }
@@ -356,6 +356,7 @@ fn command_start(
             .pipeline_requests_limit = args.pipeline_requests_limit,
             .storage_size_limit = args.storage_size_limit,
             .aof = if (aof != null) &aof.? else null,
+            .aof_recovery = args.aof_recovery,
             .nonce = nonce,
             .timeout_prepare_ticks = args.timeout_prepare_ticks,
             .timeout_grid_repair_message_ticks = args.timeout_grid_repair_message_ticks,
@@ -368,6 +369,7 @@ fn command_start(
                 .cache_entries_transfers = args.cache_transfers,
                 .cache_entries_transfers_pending = args.cache_transfers_pending,
                 .log_trace = args.log_trace,
+                .aof_recovery = args.aof_recovery,
             },
             .message_bus_options = .{
                 .configuration = args.addresses.const_slice(),
@@ -425,10 +427,10 @@ fn command_start(
         replica.message_bus.accept_address.?,
     });
 
-    if (constants.aof_recovery) {
+    if (args.aof_recovery) {
         log.warn(
             "{}: started in AOF recovery mode. This is potentially dangerous - if it's" ++
-                " unexpected, please recompile TigerBeetle with -Dconfig-aof-recovery=false.",
+                " unexpected, please rerun without --aof-recovery flag.",
             .{replica.replica},
         );
     }
@@ -518,6 +520,7 @@ fn command_reformat(
             .id = stdx.unique_u128(),
             .cluster = args.cluster,
             .replica_count = args.replica_count,
+            .aof_recovery = false,
 
             .message_bus_options = .{
                 .configuration = args.addresses.const_slice(),

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -19,7 +19,6 @@ pub const vsr_options = .{
     .git_commit = @import("vsr_options").git_commit,
     .release = @import("vsr_options").release,
     .release_client_min = @import("vsr_options").release_client_min,
-    .config_aof_recovery = @import("vsr_options").config_aof_recovery,
 };
 const vsr_vopr_options = @import("vsr_vopr_options");
 
@@ -408,6 +407,7 @@ fn options_swarm(prng: *stdx.PRNG) Simulator.Options {
                 .cache_entries_transfers = if (prng.boolean()) 256 else 0,
                 .cache_entries_transfers_pending = if (prng.boolean()) 256 else 0,
                 .log_trace = true,
+                .aof_recovery = false,
             },
         },
         .replicate_options = .{
@@ -535,6 +535,7 @@ fn options_performance(prng: *stdx.PRNG) Simulator.Options {
                 .cache_entries_transfers = 0,
                 .cache_entries_transfers_pending = 0,
                 .log_trace = true,
+                .aof_recovery = false,
             },
         },
     };

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -63,6 +63,8 @@ pub fn ClientType(
         /// The number of replicas in the cluster.
         replica_count: u8,
 
+        aof_recovery: bool,
+
         /// Only tests should ever override the release.
         release: vsr.Release = constants.config.process.release,
 
@@ -133,6 +135,7 @@ pub fn ClientType(
                 id: u128,
                 cluster: u128,
                 replica_count: u8,
+                aof_recovery: bool,
                 message_bus_options: MessageBus.Options,
                 /// When eviction_callback is null, the client will panic on eviction.
                 ///
@@ -162,6 +165,7 @@ pub fn ClientType(
                 .id = options.id,
                 .cluster = options.cluster,
                 .replica_count = options.replica_count,
+                .aof_recovery = options.aof_recovery,
                 .request_completion_timer = .init(time),
                 .request_timeout = .{
                     .name = "request_timeout",
@@ -357,13 +361,13 @@ pub fn ClientType(
             assert(message.header.session == 0);
             assert(message.header.request == 0);
 
-            if (!constants.aof_recovery) {
+            if (!self.aof_recovery) {
                 assert(message.header.operation == .noop or
                     !message.header.operation.vsr_reserved());
             }
 
             // TODO: Re-investigate this state for AOF as it currently traps.
-            // assert(message.header.timestamp == 0 or constants.aof_recovery);
+            // assert(message.header.timestamp == 0 or self.aof_recovery);
 
             message.header.request = self.request_number;
             self.request_number += 1;

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -633,7 +633,6 @@ pub const Header = extern struct {
             assert(self.command == .request);
             if (self.release.value == 0) return "release == 0";
             if (self.parent_padding != 0) return "parent_padding != 0";
-            if (self.timestamp != 0 and !constants.aof_recovery) return "timestamp != 0";
             switch (self.operation) {
                 .reserved => return "operation == .reserved",
                 .root => return "operation == .root",


### PR DESCRIPTION
For AOF recovery, replace the compile-time `-Dconfig-aof-recovery=false` setting with a runtime CLI `--aof-recovery` flag.

This simplifies both recovery and testing.