### PR TITLE
io/linux: add ZFS compatibility via POSIX pread(64)/pwrite(64) for Linux, tentatively called sync storage mode since these posix calls are blocking

### DIFF
--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -657,6 +657,7 @@ const fsword_t = i64;
 const fsid_t = u64;
 
 pub const TmpfsMagic = 0x01021994;
+pub const ZfsMagic = 0x2fc12fc1;
 pub const StatFs = extern struct {
     f_type: fsword_t,
     f_bsize: fsword_t,


### PR DESCRIPTION
Description-A:

io_uring has known compatibility issues with ZFS (OpenZFS issue #16133) that can cause hangs and potential data corruption. This adds a hybrid I/O mode for Linux where:

- Storage operations (read, write, fsync) use synchronous pread/pwrite
- Network operations continue to use io_uring

The mode is auto-enabled when ZFS is detected via statfs(), or can be forced via TIGERBEETLE_SYNC_STORAGE=1 environment variable.

Rationale: ZFS with mirroring provides transparent self-healing for silent data corruption at the block level - errors that the database cannot detect because the wrong bits came back from storage silently. When a bad block is read, ZFS serves the good copy from the mirror in microseconds. Without this, corruption must bubble up to the DB layer, requiring network round-trips to fetch from replicas - not ideal for a CP system doing real-time financial transactions.

This enables running TigerBeetle on ZFS for users who want:
- End-to-end checksumming below the DB layer
- Transparent local self-healing with mirrors/raidz
- Operational conveniences like snapshots


Description-B:

Adds a hybrid I/O mode for Linux that uses synchronous POSIX `pread`/`pwrite` for storage operations while keeping `io_uring` for network. Auto-enabled when ZFS is detected.

  **Why ZFS compatibility matters:**

  | Recovery Path | Latency | Coordination |
  |--------------|---------|--------------|
  | ZFS mirror self-heal | ~microseconds | None (local) |
  | DB replica fetch | ~milliseconds | Network + consensus |

  For a CP system doing real-time financial transactions, local self-healing is preferable when available.

  **What ZFS provides that the DB can't:**
  - Block-level checksums catch corruption the DB cannot detect (bad RAM, controller bugs, bits flipped in flight)
  - Self-healing with mirrors/raidz serves good data transparently
  - The DB only sees correct data - no error handling path triggered

  ## Changes

  - `src/stdx/stdx.zig`: Add `ZfsMagic` constant (0x2fc12fc1)
  - `src/io/linux.zig`:
    - Add `sync_storage` flag to IO struct
    - Add `fs_is_zfs()` detection via statfs
    - Modify `read()`/`write()`/`fsync()` to use sync path when enabled
    - Auto-detect ZFS in `open_data_file()`
    - Support `TIGERBEETLE_SYNC_STORAGE=1` env var override
    - Add unit tests

  ## Context

  io_uring + ZFS has known issues (OpenZFS #16133 still open). This sidesteps the problem while preserving io_uring benefits for network I/O.

  **Note:** This is a suggested implementation from ZFS enthusiasts, not ZFS or TigerBeetle experts. Happy to iterate!

  ## Test plan

  - [x] Build passes
  - [x] Existing tests pass
  - [x] New unit tests for sync_storage mode
  - [ ] Manual test on ZFS (need Linux + ZFS environment)