### PR TITLE
AOF: Add `--cluster` flag to `aof recover`

### DIFF
--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -67,7 +67,7 @@ cd ..
 
 sleep 1
 
-./zig/zig build aof -- recover 127.0.0.1:3001,127.0.0.1:3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
+./zig/zig build aof -- recover --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
 
 # Give replicas time to settle.
 sleep 10

--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -67,7 +67,7 @@ cd ..
 
 sleep 1
 
-./zig/zig build aof -- recover --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
+./zig/zig build aof -- recover --cluster=0 --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
 
 # Give replicas time to settle.
 sleep 10

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -835,45 +835,61 @@ test "aof write / read" {
 
 test "aof merge" {}
 
-const usage =
-    \\Usage:
-    \\
-    \\  aof [-h | --help]
-    \\
-    \\  aof recover <addresses> <path>
-    \\
-    \\  aof debug <path>
-    \\
-    \\  aof merge path.aof ... <path.aof n>
-    \\
-    \\
-    \\Commands:
-    \\
-    \\  recover  Recover a recorded AOF file at <path> to a TigerBeetle cluster running
-    \\           at <addresses>. Said cluster must be running with aof_recovery = true
-    \\           and have the same cluster ID as the source. The AOF must have a consistent
-    \\           hash chain, which can be ensured using the `merge` subcommand.
-    \\
-    \\  debug    Print all entries that have been recorded in the AOF file at <path>
-    \\           to stdout. Checksums are verified, and aof will panic if an invalid
-    \\           checksum is encountered, so this can be used to check the validity
-    \\           of an AOF file. Prints a final hash of all data entries in the AOF.
-    \\
-    \\  merge    Walk through multiple AOF files, extracting entries from each one
-    \\           that pass validation, and build a single valid AOF. The first entry
-    \\           of the first specified AOF file will be considered the root hash.
-    \\           Can also be used to merge multiple incomplete AOF files into one,
-    \\           or re-order a single AOF file. Will output to `merged.aof`.
-    \\
-    \\           NB: Make sure to run merge with at least half of the replicas' AOFs,
-    \\           otherwise entries might be lost.
-    \\
-    \\Options:
-    \\
-    \\  -h, --help
-    \\        Print this help message and exit.
-    \\
-;
+const CLIArgs = union(enum) {
+    recover: struct {
+        addresses: []const u8,
+        @"--": void,
+        path: []const u8,
+    },
+    debug: struct {
+        @"--": void,
+        path: []const u8,
+    },
+    merge: struct {
+        @"--": void,
+        // (One or more AOF file paths.)
+    },
+
+    pub const help =
+        \\Usage:
+        \\
+        \\  aof [-h | --help]
+        \\
+        \\  aof recover --addresses=<addresses> <path>
+        \\
+        \\  aof debug <path>
+        \\
+        \\  aof merge -- path.aof ... <path.aof n>
+        \\
+        \\
+        \\Commands:
+        \\
+        \\  recover  Recover a recorded AOF file at <path> to a TigerBeetle cluster running
+        \\           at <addresses>. Said cluster must be running with aof_recovery = true
+        \\           and have the same cluster ID as the source. The AOF must have a consistent
+        \\           hash chain, which can be ensured using the `merge` subcommand.
+        \\
+        \\  debug    Print all entries that have been recorded in the AOF file at <path>
+        \\           to stdout. Checksums are verified, and aof will panic if an invalid
+        \\           checksum is encountered, so this can be used to check the validity
+        \\           of an AOF file. Prints a final hash of all data entries in the AOF.
+        \\
+        \\  merge    Walk through multiple AOF files, extracting entries from each one
+        \\           that pass validation, and build a single valid AOF. The first entry
+        \\           of the first specified AOF file will be considered the root hash.
+        \\           Can also be used to merge multiple incomplete AOF files into one,
+        \\           or re-order a single AOF file. Will output to `merged.aof`.
+        \\
+        \\           NB: Make sure to run merge with at least half of the replicas' AOFs,
+        \\           otherwise entries might be lost.
+        \\
+        \\Options:
+        \\
+        \\  -h, --help
+        \\        Print this help message and exit.
+        \\
+    ;
+};
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -882,34 +898,10 @@ pub fn main() !void {
     var time_os: vsr.time.TimeOS = .{};
     const time = time_os.time();
 
-    var args = try std.process.argsWithAllocator(allocator);
-    defer args.deinit();
+    var args_iterator = try std.process.argsWithAllocator(allocator);
+    defer args_iterator.deinit();
 
-    var action: ?[:0]const u8 = null;
-    var addresses: ?[:0]const u8 = null;
-    var paths: [constants.members_max][:0]const u8 = undefined;
-    var count: usize = 0;
-
-    while (args.next()) |arg| {
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            std.io.getStdOut().writeAll(usage) catch std.posix.exit(1);
-            std.posix.exit(0);
-        }
-
-        if (count == 1) {
-            action = arg;
-        } else if (count == 2 and std.mem.eql(u8, action.?, "recover")) {
-            addresses = arg;
-        } else if (count == 2 and std.mem.eql(u8, action.?, "debug")) {
-            paths[0] = arg;
-        } else if (count == 3 and std.mem.eql(u8, action.?, "recover")) {
-            paths[0] = arg;
-        } else if (count >= 2 and std.mem.eql(u8, action.?, "merge")) {
-            paths[count - 2] = arg;
-        }
-
-        count += 1;
-    }
+    const args = stdx.flags(&args_iterator, CLIArgs);
 
     const target = try allocator.create(AOFEntry);
     defer allocator.destroy(target);
@@ -922,47 +914,57 @@ pub fn main() !void {
     const AOFReplayClient = AOF.ReplayClient;
     const AOFIterator = AOF.Iterator;
 
-    if (action != null and std.mem.eql(u8, action.?, "recover") and count == 4) {
-        var it = try AOFIterator.init(&io, paths[0]);
-        defer it.close();
+    switch (args) {
+        .recover => |command| {
+            var it = try AOFIterator.init(&io, command.path);
+            defer it.close();
 
-        var addresses_buffer: [constants.replicas_max]std.net.Address = undefined;
-        const addresses_parsed = try vsr.parse_addresses(addresses.?, &addresses_buffer);
-        var replay = try AOFReplayClient.init(&io, allocator, time, addresses_parsed);
-        defer replay.deinit(allocator);
+            var addresses_buffer: [constants.replicas_max]std.net.Address = undefined;
+            const addresses_parsed = try vsr.parse_addresses(command.addresses, &addresses_buffer);
+            var replay = try AOFReplayClient.init(&io, allocator, time, addresses_parsed);
+            defer replay.deinit(allocator);
 
-        try replay.replay(&it);
-    } else if (action != null and std.mem.eql(u8, action.?, "debug") and count == 3) {
-        var it = try AOFIterator.init(&io, paths[0]);
-        defer it.close();
+            try replay.replay(&it);
+        },
+        .debug => |command| {
+            var it = try AOFIterator.init(&io, command.path);
+            defer it.close();
 
-        var data_checksum: [32]u8 = undefined;
-        var blake3 = std.crypto.hash.Blake3.init(.{});
+            var data_checksum: [32]u8 = undefined;
+            var blake3 = std.crypto.hash.Blake3.init(.{});
 
-        const stdout = std.io.getStdOut().writer();
-        while (try it.next(target)) |entry| {
-            const header = entry.header();
-            if (!AOFReplayClient.replay_message(header)) continue;
+            const stdout = std.io.getStdOut().writer();
+            while (try it.next(target)) |entry| {
+                const header = entry.header();
+                if (!AOFReplayClient.replay_message(header)) continue;
 
-            try stdout.print("{}\n", .{
-                header,
-            });
+                try stdout.print("{}\n", .{
+                    header,
+                });
 
-            // The body isn't the only important information, there's also the operation
-            // and the timestamp which are in the header. Include those in our hash too.
-            blake3.update(std.mem.asBytes(&header.checksum_body));
-            blake3.update(std.mem.asBytes(&header.timestamp));
-            blake3.update(std.mem.asBytes(&header.operation));
-        }
-        blake3.final(data_checksum[0..]);
-        try stdout.print(
-            "\nData checksum chain: {}\n",
-            .{@as(u128, @bitCast(data_checksum[0..@sizeOf(u128)].*))},
-        );
-    } else if (action != null and std.mem.eql(u8, action.?, "merge") and count >= 2) {
-        try AOF.merge(&io, allocator, paths[0 .. count - 2], "prepared.aof");
-    } else {
-        std.io.getStdOut().writeAll(usage) catch std.posix.exit(1);
-        std.posix.exit(1);
+                // The body isn't the only important information, there's also the operation
+                // and the timestamp which are in the header. Include those in our hash too.
+                blake3.update(std.mem.asBytes(&header.checksum_body));
+                blake3.update(std.mem.asBytes(&header.timestamp));
+                blake3.update(std.mem.asBytes(&header.operation));
+            }
+            blake3.final(data_checksum[0..]);
+            try stdout.print(
+                "\nData checksum chain: {}\n",
+                .{@as(u128, @bitCast(data_checksum[0..@sizeOf(u128)].*))},
+            );
+        },
+        .merge => |_| {
+            var paths: [constants.members_max][:0]const u8 = undefined;
+            var paths_count: u32 = 0;
+            for (&paths) |*path| {
+                path.* = args_iterator.next() orelse break;
+                paths_count += 1;
+            }
+            if (paths_count == 0) vsr.fatal(.cli, "missing paths", .{});
+            if (args_iterator.next()) |_| vsr.fatal(.cli, "too many paths", .{});
+
+            try AOF.merge(&io, allocator, paths[0..paths_count], "prepared.aof");
+        },
     }
 }

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -60,9 +60,8 @@ fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
 ///    start: struct { addresses: []const u8, replica: u32 },
 ///    format: struct {
 ///        verbose: bool = false,
-///        positional: struct {
-///            path: []const u8,
-///        }
+///        @"--": void,
+///        path: []const u8,
 ///    },
 ///
 ///    pub const help =
@@ -73,7 +72,7 @@ fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
 /// const cli_args = parse_commands(&args, CLIArgs);
 /// ```
 ///
-/// `positional` field is treated specially, it designates positional arguments.
+/// `@"--"` field is treated specially, it delineates positional arguments.
 ///
 /// If `pub const help` declaration is present, it is used to implement `-h/--help` argument.
 ///
@@ -433,7 +432,8 @@ fn fields_to_comma_list(comptime E: type) []const u8 {
 
 fn flag_name(comptime field: std.builtin.Type.StructField) []const u8 {
     return comptime blk: {
-        assert(!std.mem.eql(u8, field.name, "positional"));
+        assert(!std.mem.eql(u8, field.name, "-"));
+        assert(!std.mem.eql(u8, field.name, "--"));
 
         var result: []const u8 = "--";
         var index = 0;

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -609,7 +609,7 @@ pub const main =
                 opt: bool = false,
                 option: bool = false,
             },
-            pos: struct {
+            positional: struct {
                 flag: bool = false,
 
                 @"--": void,
@@ -669,7 +669,7 @@ pub const main =
                     try out_stream.print("opt: {}\n", .{values.opt});
                     try out_stream.print("option: {}\n", .{values.option});
                 },
-                .pos => |values| {
+                .positional => |values| {
                     try out_stream.print("p1: {s}\n", .{values.p1});
                     try out_stream.print("p2: {s}\n", .{values.p2});
                     try out_stream.print("p3: {?}\n", .{values.p3});
@@ -837,7 +837,7 @@ test "flags" {
     try t.check(&.{}, snap(@src(),
         \\status: 1
         \\stderr:
-        \\error: subcommand required, expected 'empty', 'prefix', 'pos', 'extended', 'required', 'values', or 'subcommand'
+        \\error: subcommand required, expected 'empty', 'prefix', 'positional', 'extended', 'required', 'values', or 'subcommand'
         \\
     ));
 
@@ -931,7 +931,7 @@ test "flags" {
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "y" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "y" }, snap(@src(),
         \\stdout:
         \\p1: x
         \\p2: y
@@ -941,7 +941,7 @@ test "flags" {
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "y", "1" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "y", "1" }, snap(@src(),
         \\stdout:
         \\p1: x
         \\p2: y
@@ -951,7 +951,7 @@ test "flags" {
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "y", "1", "2" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "y", "1", "2" }, snap(@src(),
         \\stdout:
         \\p1: x
         \\p2: y
@@ -961,56 +961,56 @@ test "flags" {
         \\
     ));
 
-    try t.check(&.{"pos"}, snap(@src(),
+    try t.check(&.{"positional"}, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: <p1>: argument is required
         \\
     ));
 
-    try t.check(&.{ "pos", "x" }, snap(@src(),
+    try t.check(&.{ "positional", "x" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: <p2>: argument is required
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "y", "z" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "y", "z" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: <p3>: expected an integer value, but found 'z' (invalid digit)
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "y", "1", "2", "3" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "y", "1", "2", "3" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: unexpected argument: '3'
         \\
     ));
 
-    try t.check(&.{ "pos", "" }, snap(@src(),
+    try t.check(&.{ "positional", "" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: <p1>: empty argument
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "--flag" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "--flag" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: unexpected trailing option: '--flag'
         \\
     ));
 
-    try t.check(&.{ "pos", "x", "--flag", "y" }, snap(@src(),
+    try t.check(&.{ "positional", "x", "--flag", "y" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: unexpected trailing option: '--flag'
         \\
     ));
 
-    try t.check(&.{ "pos", "--flag", "x", "y" }, snap(@src(),
+    try t.check(&.{ "positional", "--flag", "x", "y" }, snap(@src(),
         \\stdout:
         \\p1: x
         \\p2: y
@@ -1020,14 +1020,14 @@ test "flags" {
         \\
     ));
 
-    try t.check(&.{ "pos", "--", "x", "y" }, snap(@src(),
+    try t.check(&.{ "positional", "--", "x", "y" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: unexpected argument: '--'
         \\
     ));
 
-    try t.check(&.{ "pos", "--flak", "x", "y" }, snap(@src(),
+    try t.check(&.{ "positional", "--flak", "x", "y" }, snap(@src(),
         \\status: 1
         \\stderr:
         \\error: unexpected argument: '--flak'

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -398,7 +398,7 @@ fn tidy_line(file: SourceFile, line: []const u8, line_index: usize, errors: *Err
         if (std.mem.endsWith(u8, file.path, "cdc/runner.zig") and
             std.mem.startsWith(u8, string_value, "{\"timestamp\":")) return;
 
-        // Message fromatting tests.
+        // Message formatting tests.
         if (std.mem.endsWith(u8, file.path, "message_header.zig") and
             std.mem.startsWith(u8, string_value, "Prepare{")) return;
     }

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -401,6 +401,10 @@ fn tidy_line(file: SourceFile, line: []const u8, line_index: usize, errors: *Err
         // Message formatting tests.
         if (std.mem.endsWith(u8, file.path, "message_header.zig") and
             std.mem.startsWith(u8, string_value, "Prepare{")) return;
+
+        // Flag snapshot test.
+        if (std.mem.endsWith(u8, file.path, "flags.zig") and
+            std.mem.startsWith(u8, string_value, "error: subcommand required")) return;
     }
 
     errors.add_long_line(file, line_index);


### PR DESCRIPTION
I recommend reviewing this commit-by-commit, since it is most just a series of yak shaves.

- The end goal is to add a `--cluster` CLI argument to the `aof recover` subcommand, since it was previously hard-coded as `0`.
- AOF recovery script didn't previously use our `flags.zig` for CLI parsing, so adding a new flag is not trivial.
- But one of aof's other subcommands (`merge`) takes a variable number of paths as input, so `flags.zig` needed extending.
- I'm not sure is my solution to that is great though! I abuse our `@"--": void` notation to tell `flags.zig` to ignore the rest of the arguments in the iterator. I had another attempt which added a new `@"...": void` marker instead but that ended up being more complicated.