### PR TITLE
vsr: fault detector

### DIFF
--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -56,6 +56,13 @@ pub const Duration = struct {
         return .{ .ns = @max(lhs.ns, rhs.ns) };
     }
 
+    pub fn clamp(duration: Duration, clamp_min: Duration, clamp_max: Duration) Duration {
+        assert(clamp_min.ns <= clamp_max.ns);
+        if (duration.ns < clamp_min.ns) return clamp_min;
+        if (duration.ns > clamp_max.ns) return clamp_max;
+        return duration;
+    }
+
     pub const sort = struct {
         pub fn asc(ctx: void, lhs: Duration, rhs: Duration) bool {
             return std.sort.asc(u64)(ctx, lhs.ns, rhs.ns);

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -59,6 +59,7 @@ comptime {
     _ = @import("vsr/checksum.zig");
     _ = @import("vsr/checksum_benchmark.zig");
     _ = @import("vsr/clock.zig");
+    _ = @import("vsr/fault_detector.zig");
     _ = @import("vsr/free_set.zig");
     _ = @import("vsr/grid_scrubber.zig");
     _ = @import("vsr/journal.zig");

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -71,6 +71,7 @@ pub const FreeSet = @import("vsr/free_set.zig").FreeSet;
 pub const CheckpointTrailerType = @import("vsr/checkpoint_trailer.zig").CheckpointTrailerType;
 pub const GridScrubberType = @import("vsr/grid_scrubber.zig").GridScrubberType;
 pub const Routing = @import("vsr/routing.zig");
+pub const FaultDetector = @import("vsr/fault_detector.zig");
 pub const CountingAllocator = @import("counting_allocator.zig");
 
 /// The version of our Viewstamped Replication protocol in use, including customizations.

--- a/src/vsr/fault_detector.zig
+++ b/src/vsr/fault_detector.zig
@@ -71,7 +71,7 @@ pub fn signal(detector: *FaultDetector, now: Instant) void {
 /// * red    --- signaler is likely dead
 ///
 /// On yellow, the primary injects a Commit.
-/// On red, a backup send SV.
+/// On red, a backup sends SV.
 ///
 /// Rough model:
 /// - Random delays, but 2X delay is suspicious.
@@ -233,7 +233,7 @@ test "FaultDetector: smoothing" {
                 // gradually converges to 500 ms, right?
                 //
                 // Wrong! Implementing this test to double-check "obviously correct" logic showed
-                // that the interval does expands from 100ms to 250ms, but then gets stuck!
+                // that the interval expands from 100ms to 250ms, but then gets stuck!
                 // Here's the picture. Originally we start with an idle cluster where only commits
                 // are pulsed periodically:
                 //

--- a/src/vsr/fault_detector.zig
+++ b/src/vsr/fault_detector.zig
@@ -1,0 +1,279 @@
+//! FaultDetector estimates the probability that the primary crashed.
+//! It is implemented as a pure algorithm in a "sans-io" style.
+//!
+//! Intuition: imagine looking from a window at the street below and trying to guess whether the
+//! nearest traffic light (not directly visible) is red or green. If you see the cars going, it
+//! definitely was green recently. If there are no cars, it could be that the light is red, or that
+//! you are out of peak hour and there are no cars at all. So, a reasonable algorithm is to note
+//! the average interarrival time over a sliding window, and signal "red" when there's a suspicious
+//! absence of cars, relative to recent history. Note latency-throughput interaction: if the cars
+//! are frequent, but there's a large distance between your window and the traffic light, you notice
+//! red very quickly, but only after "wave edge" reaches you.
+//!
+//! Applying to TigerBeetle, let's consider the case where the cluster is under stable load and
+//! prepares are flowing regularly. In this case, a backup uses a sliding window to compute current
+//! rate of prepares, and sounds an alarm (StartViewChange) if the flow stops.
+//!
+//! To solve the case of an idle cluster, primary broadcasts Commit messages periodically, which are
+//! interchangeable with Prepare messages as a signal that the primary is alive.
+//!
+//! Another complication is that prepare load can be bursty. If the load ramps up quickly, the
+//! primary is seen as extremely alive, which is OK. However, if the load is cut off exogenously
+//! (because the client finished a batch job, not because the primary crashed), this will look like
+//! a dead primary. To solve this, primary uses central-bank style algorithm, where it injects extra
+//! Commit messages to keep prepare rate relatively stable in the short run.
+
+const std = @import("std");
+const stdx = @import("stdx");
+const assert = std.debug.assert;
+const Instant = stdx.Instant;
+const Duration = stdx.Duration;
+
+interval_min: Duration,
+interval_max: Duration,
+
+signal_last: Instant,
+interval_ewma: Duration,
+
+const FaultDetector = @This();
+
+pub fn init(options: struct {
+    now: Instant,
+    interval_min: Duration,
+    interval_max: Duration,
+}) FaultDetector {
+    assert(options.interval_min.ns < options.interval_max.ns);
+    // Sanity check and overflow protection for ewma.
+    assert(options.interval_max.ns <= 10 * std.time.ns_per_hour);
+    return .{
+        .interval_min = options.interval_min,
+        .interval_max = options.interval_max,
+
+        .signal_last = options.now,
+        .interval_ewma = options.interval_max,
+    };
+}
+
+pub fn signal(detector: *FaultDetector, now: Instant) void {
+    const past = detector.signal_last;
+    assert(past.ns <= now.ns);
+    const interval = now.duration_since(past)
+        // Clamp first, then ewma_add, to avoid overflows.
+        .clamp(detector.interval_min, detector.interval_max);
+
+    detector.interval_ewma = ewma_add_duration(detector.interval_ewma, interval);
+    detector.signal_last = now;
+}
+
+/// Is the signal overdue?
+/// * green  --- signal is on time
+/// * yellow --- signal seems delayed/lost
+/// * red    --- signaler is likely dead
+///
+/// On yellow, the primary injects a Commit.
+/// On red, a backup send SV.
+///
+/// Rough model:
+/// - Random delays, but 2X delay is suspicious.
+/// - An individual signal can get lost.
+/// Either of the above suggests 2X+some as a cutoff point for a fault.
+/// We round up to 3X cutoff for red, and 1.5X cutoff for yellow.
+///
+/// An alternative approach would be to build a probabilistic model of the prepare/commit arrival
+/// process, and then compute the actual probability of primary being dead using Bayes' rule. We
+/// don't do that, because we don't know the actual underlying model. A simple rule like the above
+/// will not give us the optimal answer, but it should work in variety of different contexts!
+pub fn tardy(detector: *FaultDetector, now: Instant) enum { green, yellow, red } {
+    const past = detector.signal_last;
+    assert(past.ns <= now.ns);
+    const interval = now.duration_since(past);
+
+    if (interval.ns *| 2 <= detector.interval_ewma.ns * 3) { // interval <= 1.5 * interval_ewma
+        return .green;
+    }
+    assert(interval.ns >= detector.interval_ewma.ns);
+    if (interval.ns <= detector.interval_ewma.ns * 3) {
+        return .yellow;
+    }
+    assert(interval.ns > detector.interval_ewma.ns);
+    return .red;
+}
+
+pub fn reset(detector: *FaultDetector, now: Instant) void {
+    const past = detector.signal_last;
+    assert(past.ns <= now.ns);
+    detector.* = FaultDetector.init(.{
+        .now = now,
+        .interval_min = detector.interval_min,
+        .interval_max = detector.interval_max,
+    });
+}
+
+fn ewma_add_duration(old: Duration, new: Duration) Duration {
+    return .{
+        .ns = @divFloor((old.ns * 4) + new.ns, 5),
+    };
+}
+
+test "FaultDetector: smoke" {
+    // Test that computed ewma interval tracks actual interval,
+    // clamped to limits.
+    var now: Instant = .{ .ns = 1_000 };
+    var detector = FaultDetector.init(.{
+        .now = now,
+        .interval_min = .ms(100),
+        .interval_max = .ms(2_000),
+    });
+    assert(detector.tardy(now) == .green);
+    assert(detector.interval_ewma.to_ms() == 2_000);
+
+    for (0..100) |_| {
+        now = now.add(.ms(200));
+        detector.signal(now);
+    }
+    now = now.add(.ms(200));
+    assert(detector.tardy(now) == .green);
+    assert(detector.interval_ewma.to_ms() == 200);
+
+    now = now.add(.ms(200));
+    assert(detector.tardy(now) == .yellow);
+
+    now = now.add(.ms(250));
+    assert(detector.tardy(now) == .red);
+
+    for (0..100) |_| {
+        now = now.add(.ms(1_000));
+        detector.signal(now);
+    }
+    now = now.add(.ms(1_000));
+    assert(detector.tardy(now) == .green);
+    assert(detector.interval_ewma.to_ms() == 999);
+
+    for (0..100) |_| {
+        now = now.add(.ms(10));
+        detector.signal(now);
+    }
+    now = now.add(.ms(10));
+    assert(detector.tardy(now) == .green);
+    assert(detector.interval_ewma.to_ms() == 100);
+
+    for (0..100) |_| {
+        now = now.add(.ms(10_000));
+        detector.signal(now);
+    }
+    now = now.add(.ms(10_000));
+    assert(detector.tardy(now) == .red);
+    assert(detector.interval_ewma.to_ms() == 1_999);
+}
+
+test "FaultDetector: smoothing" {
+    // Check that, after a burst of prepares is abruptly ended,
+    // the primary can gradually reduce the arrival interval,
+    // without triggering a view change.
+    var now: Instant = .{ .ns = 1_000 };
+    var primary = FaultDetector.init(.{
+        .now = now,
+        .interval_min = .ms(50),
+        .interval_max = .ms(2_000),
+    });
+
+    const backup_delay: Duration = .ms(100);
+    var backup = FaultDetector.init(.{
+        .now = now,
+        .interval_min = .ms(50),
+        .interval_max = .ms(2_000),
+    });
+
+    const commit_interval: Duration = .ms(500);
+    const request_interval: Duration = .ms(100);
+
+    var commit_last = now;
+    var request_last = now;
+
+    for (0..1_000) |_| {
+        now = now.add(.ms(10)); // Advance by one tick.
+
+        // Primary broadcasts commit message every 500ms.
+        if (now.duration_since(commit_last).ns > commit_interval.ns) {
+            commit_last = now;
+            primary.signal(now);
+            backup.signal(now.add(backup_delay));
+        }
+        assert(primary.tardy(now) == .green);
+
+        // Primary converts a request into prepare every 100ms.
+        if (now.duration_since(request_last).ns > request_interval.ns) {
+            request_last = now;
+            primary.signal(now);
+            backup.signal(now.add(backup_delay));
+        }
+        assert(backup.tardy(now.add(backup_delay)) == .green);
+    }
+    assert(primary.interval_ewma.to_ms() == 95);
+    assert(backup.interval_ewma.to_ms() == 95);
+
+    for (0..1_000) |_| {
+        now = now.add(.ms(10)); // Advance by one tick.
+
+        if (now.duration_since(commit_last).ns > commit_interval.ns) {
+            commit_last = now;
+            primary.signal(now);
+            backup.signal(now.add(backup_delay));
+        }
+        switch (primary.tardy(now)) {
+            .green => {},
+            .yellow => {
+                // Stay awhile and listen, wanderer, the story of the next line.
+                //
+                // The original implementation in replica.zig didn't have the equivalent. In other
+                // words, the primary was always sending a commit message every 500 ms, and then
+                // additionally injecting a "bonus" commit whenever fault detector flashed yellow.
+                // That is, when the delay since last commit/prepare exceeded 1.5X of the current
+                // interval. Because 1.5 > 1, it should be the case that the ewma of the interval
+                // gradually converges to 500 ms, right?
+                //
+                // Wrong! Implementing this test to double-check "obviously correct" logic showed
+                // that the interval does expands from 100ms to 250ms, but then gets stuck!
+                // Here's the picture. Originally we start with an idle cluster where only commits
+                // are pulsed periodically:
+                //
+                // C       C       C       C       C
+                //
+                // Then the load starts, and we get a lot of prepares in between:
+                //
+                // C P P P C P P P C P P P C P P P C
+                //
+                // Then, the load cuts off, but the primary starts Injecting extra commits to
+                // keep the interval:
+                //
+                // C I I I C I I   C   I   C ....
+                //
+                // The frequency of injected commits goes down to just one, but then gets stuck:
+                //
+                // C     I C     I C     I C     I C
+                //
+                // Both the first and the last lines are fixed points. For the first line, the ewma
+                // is 500ms and no commits are injected. For the last line, the ewma is 250ms, and
+                // at 250*1.5=350ms after the last C, an I gets injected.
+                //
+                // More generally, if we are currently injecting one extra message, we need to
+                // tolerate at least 2X injection delay to get to zero extra messages, _if_ we keep
+                // a steady pace of heartbeat commits. This means that delay to detect a crashed
+                // primary needs to grow proportionally more, and that feels like too much of a lag.
+                // Instead, we let go of the constraint of keeping the heartbeat steady, and skip
+                // the next normal beat whenever we inject one.
+                commit_last = now;
+
+                primary.signal(now);
+                backup.signal(now.add(backup_delay));
+            },
+            .red => unreachable,
+        }
+        switch (backup.tardy(now.add(backup_delay))) {
+            .green, .yellow => {},
+            .red => unreachable,
+        }
+    }
+    assert(primary.interval_ewma.to_ms() == 499);
+    assert(backup.interval_ewma.to_ms() == 499);
+}

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -539,8 +539,8 @@ pub fn ReplicaType(
         commit_message_timeout: Timeout,
 
         /// Fault detector that treats fresh prepare and commit messages as liveness signal.
-        /// Backups use it to trigger start_view messages.
-        /// The primary injects extra smoothing commit messages when requests stop abruptly.
+        /// - Backups use it to trigger start_view_change messages.
+        /// - Primary uses it to inject extra smoothing commit messages when requests stop abruptly.
         commit_fault: vsr.FaultDetector,
 
         /// The number of ticks before resetting the SVC quorum.

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -538,11 +538,10 @@ pub fn ReplicaType(
         /// (status=normal primary)
         commit_message_timeout: Timeout,
 
-        /// The number of ticks without a heartbeat.
-        /// Reset any time the backup receives a heartbeat from the primary.
-        /// Triggers SVC messages. If an SVC quorum is achieved, we will kick off a view-change.
-        /// (status=normal backup)
-        normal_heartbeat_timeout: Timeout,
+        /// Fault detector that treats fresh prepare and commit messages as liveness signal.
+        /// Backups use it to trigger start_view messages.
+        /// The primary injects extra smoothing commit messages when requests stop abruptly.
+        commit_fault: vsr.FaultDetector,
 
         /// The number of ticks before resetting the SVC quorum.
         /// (status=normal|view-change, SVC quorum contains message from ANY OTHER replica)
@@ -1362,11 +1361,14 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 500 / constants.tick_ms,
                 },
-                .normal_heartbeat_timeout = Timeout{
-                    .name = "normal_heartbeat_timeout",
-                    .id = replica_index,
-                    .after = 5_000 / constants.tick_ms,
-                },
+                .commit_fault = vsr.FaultDetector.init(.{
+                    .now = self.clock.monotonic(),
+                    .interval_min = .ms(100),
+                    // The interval converges to commit_message_timeout regardless of the network
+                    // latency, but the initial interval after view change must encompass the worst
+                    // expected network delay.
+                    .interval_max = .ms(2_000),
+                }),
                 .start_view_change_window_timeout = Timeout{
                     .name = "start_view_change_window_timeout",
                     .id = replica_index,
@@ -1532,6 +1534,10 @@ pub fn ReplicaType(
                     self.syncing == .updating_checkpoint);
             }
 
+            if (self.status == .normal and !self.standby()) {
+                self.tick_normal_heartbeat_fault();
+            }
+
             self.clock.tick();
             self.message_bus.tick();
             self.multiversion.tick();
@@ -1541,7 +1547,6 @@ pub fn ReplicaType(
                 .{ &self.prepare_timeout, on_prepare_timeout },
                 .{ &self.primary_abdicate_timeout, on_primary_abdicate_timeout },
                 .{ &self.commit_message_timeout, on_commit_message_timeout },
-                .{ &self.normal_heartbeat_timeout, on_normal_heartbeat_timeout },
                 .{ &self.start_view_change_window_timeout, on_start_view_change_window_timeout },
                 .{ &self.start_view_change_message_timeout, on_start_view_change_message_timeout },
                 .{ &self.view_change_status_timeout, on_view_change_status_timeout },
@@ -1571,6 +1576,53 @@ pub fn ReplicaType(
 
             // None of the on_timeout() functions above should send a message to this replica.
             assert(self.loopback_queue == null);
+        }
+
+        fn tick_normal_heartbeat_fault(self: *Replica) void {
+            assert(self.status == .normal);
+            assert(self.backup() or self.primary());
+            assert(self.commit_fault.interval_min.to_ms() > 2 * constants.tick_ms);
+            assert(self.commit_fault.interval_ewma.to_ms() > 2 * constants.tick_ms);
+
+            const now = self.clock.monotonic();
+            const tardy = self.commit_fault.tardy(now);
+            if (tardy == .green) return; // Everything is fine!
+
+            if (self.primary()) {
+                if (tardy == .red) {
+                    // Can only happen if there's an abnormal delay between ticks.
+                    log.warn(
+                        "{}: tick_normal_heartbeat_fault: tick delayed (interval={} delay={})",
+                        .{
+                            self.replica,
+                            self.commit_fault.interval_ewma,
+                            now.duration_since(self.commit_fault.signal_last),
+                        },
+                    );
+                }
+                // See FaultDetector smoothing test for why resetting the timeout is critical here.
+                self.commit_message_timeout.reset();
+                self.send_commit();
+            } else {
+                assert(self.backup());
+                if (tardy == .yellow) {
+                    // A slight delay which could be caused by a natural drop in the load,
+                    // so wait some more for a Commit message from the primary.
+                } else {
+                    log.warn(
+                        "{}: tick_normal_heartbeat_fault: heartbeat lost (interval={} delay={})",
+                        .{
+                            self.replica,
+                            self.commit_fault.interval_ewma,
+                            now.duration_since(self.commit_fault.signal_last),
+                        },
+                    );
+                    self.send_start_view_change();
+                    self.commit_fault.signal(now);
+                }
+            }
+            // Avoid busy-looping:
+            assert(self.commit_fault.tardy(self.clock.monotonic()) != .red);
         }
 
         /// Called by the MessageBus to deliver a message to the replica.
@@ -1974,6 +2026,9 @@ pub fn ReplicaType(
             // the prepare, thereby breaking the replication chain.
             if (message.header.op > self.commit_min and !self.journal.has_prepare(message.header)) {
                 self.replicate(message);
+                if (message.header.op > self.op) {
+                    self.commit_fault.signal(self.clock.monotonic());
+                }
             } else {
                 log.warn("{}: on_prepare: not replicating op={} commit_min={} present={}", .{
                     self.log_prefix(),
@@ -2341,7 +2396,7 @@ pub fn ReplicaType(
             // Old/duplicate heartbeats don't count.
             if (self.heartbeat_timestamp < message.header.timestamp_monotonic) {
                 self.heartbeat_timestamp = message.header.timestamp_monotonic;
-                self.normal_heartbeat_timeout.reset();
+                self.commit_fault.signal(self.clock.monotonic());
                 if (!self.standby()) {
                     self.start_view_change_from_all_replicas.unset(self.replica);
                 }
@@ -3621,20 +3676,6 @@ pub fn ReplicaType(
             assert(self.commit_min == self.commit_max);
 
             self.send_commit();
-        }
-
-        fn on_normal_heartbeat_timeout(self: *Replica) void {
-            assert(self.status == .normal);
-            assert(self.backup());
-            self.normal_heartbeat_timeout.reset();
-
-            if (self.solo()) return;
-
-            log.debug("{}: on_normal_heartbeat_timeout: heartbeat lost (view={})", .{
-                self.log_prefix(),
-                self.view,
-            });
-            self.send_start_view_change();
         }
 
         fn on_start_view_change_window_timeout(self: *Replica) void {
@@ -5243,9 +5284,9 @@ pub fn ReplicaType(
         // at the same random backup. This improves logical availability in the case where the
         // the primary → client link is down. If it doesn't work, we have a fallback where a
         // backup directly replies to client requests (see `ignore_request_message`).
-        // Selecting a random backup as opposed to using a determistic function also guards us from
-        // subtle resonance issues wherein the same backup replies to the same client every time.
-        // This could happen if `active client count % replica count == 0`, and these clients'
+        // Selecting a random backup as opposed to using a deterministic function also guards us
+        // from subtle resonance issues wherein the same backup replies to the same client every
+        // time. This could happen if `active client count % replica count == 0`, and these clients'
         // requests arrive at the primary in the same order every time.
         fn execute_op_reply_to_client(self: *Replica, op: u64) bool {
             if (self.replica == self.primary_index(self.view)) return true;
@@ -9815,7 +9856,6 @@ pub fn ReplicaType(
 
             assert(!self.prepare_timeout.ticking);
             assert(!self.primary_abdicate_timeout.ticking);
-            assert(!self.normal_heartbeat_timeout.ticking);
             assert(!self.start_view_change_message_timeout.ticking);
             assert(!self.start_view_change_window_timeout.ticking);
             assert(!self.commit_message_timeout.ticking);
@@ -9854,10 +9894,10 @@ pub fn ReplicaType(
             assert(self.log_view >= self.superblock.working.vsr_state.checkpoint.header.view);
 
             self.status = .normal;
+            self.commit_fault.reset(self.clock.monotonic());
 
             assert(!self.prepare_timeout.ticking);
             assert(!self.primary_abdicate_timeout.ticking);
-            assert(!self.normal_heartbeat_timeout.ticking);
             assert(!self.start_view_change_message_timeout.ticking);
             assert(!self.start_view_change_window_timeout.ticking);
             assert(!self.commit_message_timeout.ticking);
@@ -9904,7 +9944,6 @@ pub fn ReplicaType(
                 );
 
                 self.ping_timeout.start();
-                self.normal_heartbeat_timeout.start();
                 self.start_view_change_message_timeout.start();
                 self.journal_repair_timeout.start();
                 self.journal_repair_budget_timeout.start();
@@ -9937,6 +9976,8 @@ pub fn ReplicaType(
             );
 
             self.status = .normal;
+            self.commit_fault.reset(self.clock.monotonic());
+
             if (self.log_view == view_new) {
                 // Recovering to the same view we lost the head in.
                 assert(self.view == view_new);
@@ -9952,7 +9993,6 @@ pub fn ReplicaType(
             assert(self.backup());
             assert(!self.prepare_timeout.ticking);
             assert(!self.primary_abdicate_timeout.ticking);
-            assert(!self.normal_heartbeat_timeout.ticking);
             assert(!self.start_view_change_window_timeout.ticking);
             assert(!self.commit_message_timeout.ticking);
             assert(!self.view_change_status_timeout.ticking);
@@ -9963,7 +10003,6 @@ pub fn ReplicaType(
             assert(!self.upgrade_timeout.ticking);
 
             self.ping_timeout.start();
-            self.normal_heartbeat_timeout.start();
             self.start_view_change_message_timeout.start();
             self.journal_repair_budget_timeout.start();
             self.journal_repair_timeout.start();
@@ -9983,6 +10022,7 @@ pub fn ReplicaType(
             assert(self.view_headers.command == .start_view);
 
             self.status = .normal;
+            self.commit_fault.reset(self.clock.monotonic());
 
             if (self.primary()) {
                 log.info(
@@ -9991,7 +10031,6 @@ pub fn ReplicaType(
                 );
 
                 assert(!self.prepare_timeout.ticking);
-                assert(!self.normal_heartbeat_timeout.ticking);
                 assert(!self.primary_abdicate_timeout.ticking);
                 assert(!self.repair_sync_timeout.ticking);
                 assert(!self.pulse_timeout.ticking);
@@ -10029,7 +10068,6 @@ pub fn ReplicaType(
                 });
 
                 assert(!self.prepare_timeout.ticking);
-                assert(!self.normal_heartbeat_timeout.ticking);
                 assert(!self.primary_abdicate_timeout.ticking);
                 assert(!self.repair_sync_timeout.ticking);
                 assert(!self.upgrade_timeout.ticking);
@@ -10050,7 +10088,6 @@ pub fn ReplicaType(
 
                 self.ping_timeout.start();
                 self.commit_message_timeout.stop();
-                self.normal_heartbeat_timeout.start();
                 self.start_view_change_window_timeout.stop();
                 self.start_view_change_message_timeout.start();
                 self.view_change_status_timeout.stop();
@@ -10138,7 +10175,6 @@ pub fn ReplicaType(
 
             self.ping_timeout.start();
             self.commit_message_timeout.stop();
-            self.normal_heartbeat_timeout.stop();
             self.start_view_change_window_timeout.stop();
             self.start_view_change_message_timeout.start();
             self.view_change_status_timeout.start();
@@ -11236,6 +11272,7 @@ pub fn ReplicaType(
             assert(self.primary());
             assert(self.commit_min == self.commit_max);
 
+            self.commit_fault.signal(self.clock.monotonic());
             if (self.primary_abdicating) {
                 assert(self.primary_abdicate_timeout.ticking);
 


### PR DESCRIPTION
FaultDetector estimates the probability that the primary crashed.
It is implemented as a pure algorithm in a "sans-io" style.

Intuition: imagine looking from a window at the street below and trying to guess whether the
nearest traffic light (not directly visible) is red or green. If you see the cars going, it
definitely was green recently. If there are no cars, it could be that the light is red, or that
you are out of peak hour and there are no cars at all. So, a reasonable algorithm is to note
the average interarrival time over a sliding window, and signal "red" when there's a suspicious
absence of cars, relative to recent history. Note latency-throughput interaction: if the cars
are frequent, but there's a large distance between your window and the traffic light, you notice
red very quickly, but only after "wave edge" reaches you.

Applying to TigerBeetle, let's consider the case where the cluster is under stable load and
prepares are flowing regularly. In this case, a backup uses a sliding window to compute current
rate of prepares, and sounds an alarm (StartViewChange) if the flow stops.

To solve the case of an idle cluster, primary broadcasts Commit messages periodically, which are
interchangeable with Prepare messages as a signal that the primary is alive.

Another complication is that prepare load can be bursty. If the load ramps up quickly, the
primary is seen as extremely alive, which is OK. However, if the load is cut off exogenously
(because the client finished a batch job, not because the primary crashed), this will look like
a dead primary. To solve this, primary uses central-bank style algorithm, where it injects extra
Commit messages to keep prepare rate relatively stable in the short run.

Here are the results of an ad-hoc kill the primary experiment, the p100 of a batch

```
baseline-normal-0        221 ms
baseline-normal-1        221 ms

baseline-viewchange-0    4554 ms :(
baseline-viewchange-1    4718 ms :(

tigerbeetle-normal-0     221 ms
tigerbeetle-normal-1     223 ms

tigerbeetle-viewchange-0 443 ms  :)
tigerbeetle-viewchange-1 391 ms  :)
```

Experiment setup:

```ts
import $, { CommandChild, Path } from "jsr:@david/dax@0.44.2";

async function main() {
    // await $`box create 7`;

    await $`./zig/zig build -Drelease -Dtarget=x86_64-linux`;
    await $`box sync 0-6 ./tigerbeetle`;
    await $`box sync 0-6 ./baseline`;

    for (const attempt of [0, 1]) {
        for (const tigerbeetle of ["baseline", "tigerbeetle"]) {
            for (const mode of ["normal" as Mode, "viewchange" as Mode]) {
                await $`box run 0-6 pkill tigerbeetle`.noThrow();
                await $`box run 0-6 pkill baseline`.noThrow();

                const resultfile = $.path(
                    `./${tigerbeetle}-${mode}-${attempt}`,
                );
                await bench(tigerbeetle, mode, resultfile);
            }
        }
    }
}

type Mode = "normal" | "viewchange";
async function bench(
    tigerbeetle: string,
    mode: Mode,
    resultfile: Path,
) {
    await $`box run 0-5 rm 0_${"??"}.tigerbeetle`.noThrow();
    await $`box run 0-5 ./${tigerbeetle} format --cluster=0 --replica-count=6 --replica=${"??"} 0_${"??"}.tigerbeetle`;

    const replicas = range(6).map((it) =>
        $`box run ${it}
            ./${tigerbeetle} start --addresses=${"?0-5?"} 0_${"??"}.tigerbeetle &> logs/${it}.log`
            .noThrow()
            .spawn()
    );

    await $.sleep("10s"); // Wait for initial viewchange.

    await Promise.all([
        $`box run 6 ./${tigerbeetle} benchmark --addresses=${"?0-5?"} --id-order=tbid > ${resultfile}`,
        (async () => {
            if (mode === "viewchange") {
                await $.sleep("20s");
                console.log("REDRUM");
                await $`box run 1 pkill ${tigerbeetle}`;
            }
        })(),
    ]);
    console.log("finishing...");
    await $`box run 0-6 pkill ${tigerbeetle}`.noThrow();
    replicas.forEach((it) => it.kill());
    await Promise.all(replicas);
    console.log("finished");
}
```