### PR TITLE
k_way_merge: tree-of-losers rewrite (matklad) + performance improvements.

### DIFF
--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -113,10 +113,8 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
         }
 
         pub fn pop_winner(tree: *TournamentTree, entrant: ?Key) void {
-            if (tree.direction == .ascending) {
-                pop_winner_impl(tree, entrant, .ascending);
-            } else {
-                pop_winner_impl(tree, entrant, .descending);
+            switch (tree.direction) {
+                inline else => |direction| pop_winner_impl(tree, entrant, direction),
             }
         }
 

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -36,6 +36,175 @@ const Options = struct {
     deduplicate: bool,
 };
 
+pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) type {
+    return struct {
+        winner: Node,
+        losers: [node_count]Node,
+        tree_height: u16,
+        nodes_count: u16,
+        contestants_left: u16,
+        direction: Direction,
+
+        pub const node_count: u32 = std.math.ceilPowerOfTwoAssert(u32, contestants_max);
+
+        const Node = struct {
+            key: Key,
+            id: u32,
+
+            const id_sentinel = std.math.maxInt(u32);
+            const sentinel: Node = .{
+                // The key itself is not used to determine whether a Node is a sentinel.
+                // This ensures that valid Keys with the maximum value are not treated as sentinels.
+                .key = std.math.maxInt(Key),
+                .id = id_sentinel,
+            };
+
+            // Returns true iff `a` wins over `b` under `direction`.
+            // If keys are equal, `stream_precedence` decides.
+            inline fn beats(
+                a: *const Node,
+                b: *const Node,
+                direction: Direction,
+            ) bool {
+                // A sentinel always loses.
+                if (b.id == id_sentinel) return true;
+                if (a.id == id_sentinel) return false;
+
+                const ordered = if (direction == .ascending) a.key < b.key else a.key > b.key;
+                assert(a.id != b.id);
+                const stabler = (a.key == b.key) and a.id < b.id;
+                return ordered or stabler; // `true` means a wins.
+            }
+        };
+
+        const TournamentTree = @This();
+
+        pub fn init(
+            direction: Direction,
+            contestants: *[node_count]Node,
+            contestant_count: u16,
+        ) TournamentTree {
+            assert(contestant_count <= contestants_max);
+            maybe(contestant_count == 0);
+
+            var contestant_previous: ?*const Node = null;
+            var contestants_left: u16 = 0;
+            for (contestants[0..contestant_count]) |*contestant| {
+                if (contestant.id == Node.id_sentinel) {
+                    // Stream is empty to start with
+                } else {
+                    contestants_left += 1;
+                    if (contestant_previous) |previous| assert(previous.id < contestant.id);
+                    contestant_previous = contestant;
+                }
+            }
+            for (contestants[contestant_count..]) |*contestant| {
+                assert(contestant.id == Node.id_sentinel);
+            }
+
+            var tree: TournamentTree = .{
+                .winner = .sentinel,
+                .losers = @splat(.sentinel),
+                .direction = direction,
+                .tree_height = 0,
+                .nodes_count = 0,
+                .contestants_left = contestants_left,
+            };
+
+            if (contestants_left == 0) return tree;
+
+            const leafs_count =
+                std.math.ceilPowerOfTwo(u16, contestant_count) catch unreachable;
+            const tree_height = std.math.log2(leafs_count);
+            const nodes_count: u16 = leafs_count - 1;
+
+            // Construct the binary tree bottom up.
+            for (0..tree_height) |level| {
+                const level_min = (leafs_count >> @as(u4, @intCast(level + 1))) - 1;
+                const level_max = (leafs_count >> @as(u4, @intCast(level))) - 1;
+
+                for (level_min..level_max, 0..) |loser_index, competitor_index| {
+                    const competitor_a = contestants[competitor_index * 2];
+                    const competitor_b = contestants[competitor_index * 2 + 1];
+
+                    if (competitor_a.beats(&competitor_b, direction)) {
+                        contestants[competitor_index] = competitor_a;
+                        tree.losers[loser_index] = competitor_b;
+                    } else {
+                        contestants[competitor_index] = competitor_b;
+                        tree.losers[loser_index] = competitor_a;
+                    }
+                }
+            }
+
+            // The final winner of the first competition is now in `contestants[0]`
+            tree.winner = contestants[0];
+            tree.nodes_count = nodes_count;
+            tree.tree_height = tree_height;
+
+            return tree;
+        }
+
+        pub fn pop_winner(tree: *TournamentTree, entrant: ?Key) void {
+            const direction = tree.direction;
+            const winner_id = tree.winner.id;
+
+            assert(tree.contestants_left > 0);
+            assert(tree.winner.id != Node.id_sentinel);
+
+            if (entrant == null) tree.contestants_left -= 1;
+            tree.winner = if (entrant) |key|
+                .{ .key = key, .id = tree.winner.id }
+            else
+                .sentinel;
+
+            var opponent_id: usize = tree.nodes_count + winner_id;
+            for (0..tree.tree_height) |_| {
+                opponent_id = (opponent_id - 1) >> 1;
+
+                const opponent = &tree.losers[opponent_id];
+
+                const winner = determine_winner(&tree.winner, opponent, direction);
+
+                swap_nodes(winner, &tree.winner);
+            }
+
+            if (tree.winner.id == Node.id_sentinel) assert(tree.contestants_left == 0);
+        }
+
+        /// Return a pointer to the winner without branching.
+        inline fn determine_winner(
+            contender: *Node,
+            challenger: *Node,
+            direction: Direction,
+        ) *Node {
+            const challenger_wins: bool = challenger.beats(contender, direction);
+            const winner: *Node = select(challenger_wins, challenger, contender);
+            return winner;
+        }
+
+        inline fn select(choose_a: bool, a: *Node, b: *Node) *Node {
+            // Note: The code layout coaxes the compiler to generate branchless code.
+            //       Best do not change it without verifying the generated code.
+            var p = b;
+            if (choose_a) {
+                @branchHint(.unpredictable); // attaches to this branch
+                p = a;
+            }
+            return p;
+        }
+
+        // This custom swap is faster than `std.mem.swap` for our Node struct.
+        inline fn swap_nodes(a: *Node, b: *Node) void {
+            inline for (std.meta.fields(Node)) |field| {
+                const field_value = @field(a, field.name);
+                @field(a, field.name) = @field(b, field.name);
+                @field(b, field.name) = field_value;
+            }
+        }
+    };
+}
+
 pub fn KWayMergeIteratorType(
     comptime Context: type,
     comptime Key: type,
@@ -57,50 +226,14 @@ pub fn KWayMergeIteratorType(
     comptime assert(options.streams_max < std.math.maxInt(@TypeOf(options.streams_max)));
 
     return struct {
-        const KWayMergeIterator = @This();
-
-        const node_max: u32 = std.math.ceilPowerOfTwoAssert(u32, options.streams_max);
-        const stream_id_invalid = std.math.maxInt(@TypeOf(options.streams_max));
-        const sentinel: Node = .{
-            // The key itself is not used to determine whether a Node is a sentinel.
-            // This ensures that valid Keys with the maximum value are not treated as sentinels.
-            .key = std.math.maxInt(Key),
-            .stream_id = stream_id_invalid,
-            .sentinel = true,
-        };
-
-        state: enum { loading, iterating },
-        tree_height: u16,
-        nodes_count: u16,
-        streams_count: u16,
-        streams_active: u16,
         context: *Context,
-        contender: Node,
-        losers: [node_max]Node,
+        streams_count: u16,
         direction: Direction,
         key_popped: ?Key,
+        tree: ?Tree,
 
-        const Node = struct {
-            key: Key,
-            stream_id: u32,
-            sentinel: bool,
-
-            // Returns true iff `a` wins over `b` under `direction`.
-            // If keys are equal, smaller stream_id wins.
-            inline fn beats(
-                a: *const Node,
-                b: *const Node,
-                direction: Direction,
-            ) bool {
-                // A sentinel always loses.
-                if (b.sentinel) return true;
-                if (a.sentinel) return false;
-
-                const ordered = if (direction == .ascending) a.key < b.key else a.key > b.key;
-                const stabler = (a.key == b.key) and (a.stream_id < b.stream_id);
-                return ordered or stabler; // “true”  means  a wins.
-            }
-        };
+        const Tree = TournamentTreeType(Key, options.streams_max);
+        const KWayMergeIterator = @This();
 
         pub fn init(
             context: *Context,
@@ -113,94 +246,47 @@ pub fn KWayMergeIteratorType(
 
             return .{
                 .context = context,
-                .tree_height = 0,
-                .nodes_count = 0,
-                .contender = sentinel,
-                .losers = @splat(sentinel),
                 .key_popped = null,
                 .direction = direction,
-                .streams_active = 0,
                 .streams_count = streams_count,
-                .state = .loading,
+                .tree = null,
             };
         }
 
         pub fn reset(self: *KWayMergeIterator) void {
             self.* = .{
                 .context = self.context,
-                .tree_height = 0,
-                .nodes_count = 0,
-                .contender = sentinel,
-                .losers = @splat(sentinel),
                 .direction = self.direction,
-                .streams_active = self.streams_active,
                 .streams_count = self.streams_count,
-                .state = .loading,
                 .key_popped = self.key_popped,
+                .tree = null,
             };
         }
 
         fn load(self: *KWayMergeIterator) Pending!void {
-            assert(self.state == .loading);
-            assert(self.nodes_count == 0);
-            assert(self.tree_height == 0);
+            assert(self.tree == null);
             errdefer self.reset();
 
             // Collect the non‑empty batches as initial “contestants”.
-            var contestants: [node_max]Node = @splat(sentinel);
-            var contestants_count: u16 = 0;
-            for (0..self.streams_count) |id| {
-                const key = try stream_peek(self.context, @intCast(id)) orelse continue;
-                contestants[id] = .{ .key = key, .stream_id = @intCast(id), .sentinel = false };
-                contestants_count += 1;
+            var contestants: [Tree.node_count]Tree.Node = @splat(.sentinel);
+            for (0..self.streams_count) |id_usize| {
+                const id: u32 = @intCast(id_usize);
+                const key = try stream_peek(self.context, id) orelse continue;
+                contestants[id_usize] = .{ .key = key, .id = id };
             }
 
-            if (contestants_count == 0) {
-                self.streams_active = 0;
-                self.contender = sentinel;
-                self.state = .iterating;
-                return;
-            }
-
-            // Calculate the shape of the binary tree.
-            const leafs_count = std.math.ceilPowerOfTwo(u16, self.streams_count) catch unreachable;
-            const tree_height = std.math.log2(leafs_count);
-            const nodes_count: u16 = leafs_count - 1;
-
-            // Construct the binary tree bottom up.
-            for (0..tree_height) |level| {
-                const level_min = (leafs_count >> @as(u4, @intCast(level + 1))) - 1;
-                const level_max = (leafs_count >> @as(u4, @intCast(level))) - 1;
-
-                for (level_min..level_max, 0..) |loser_index, competitor_index| {
-                    const competitor_a = contestants[competitor_index * 2];
-                    const competitor_b = contestants[competitor_index * 2 + 1];
-
-                    if (competitor_a.beats(&competitor_b, self.direction)) {
-                        contestants[competitor_index] = competitor_a;
-                        self.losers[loser_index] = competitor_b;
-                    } else {
-                        contestants[competitor_index] = competitor_b;
-                        self.losers[loser_index] = competitor_a;
-                    }
-                }
-            }
-
-            // The final winner of the first competition is now in `contestants[0]`
-            self.contender = contestants[0];
-            self.nodes_count = nodes_count;
-            self.streams_active = contestants_count;
-            self.tree_height = tree_height;
-            self.key_popped = self.key_popped;
-            self.state = .iterating;
+            self.tree = Tree.init(self.direction, &contestants, self.streams_count);
         }
 
         pub fn pop(self: *KWayMergeIterator) Pending!?Value {
-            if (self.state == .loading) try self.load();
-            assert(self.state == .iterating);
+            if (self.tree == null) try self.load();
+            assert(self.tree != null);
 
-            while (self.streams_active > 0) {
-                const value = try self.next() orelse return null;
+            while (self.tree.?.contestants_left > 0) {
+                const key = try stream_peek(self.context, self.tree.?.winner.id);
+                self.tree.?.pop_winner(key);
+                if (self.tree.?.contestants_left == 0) return null;
+                const value = stream_pop(self.context, self.tree.?.winner.id);
                 if (options.deduplicate) {
                     const key_next = key_from_value(&value);
                     if (self.key_popped) |key_prev| if (key_next == key_prev) continue;
@@ -209,70 +295,6 @@ pub fn KWayMergeIteratorType(
                 return value;
             }
             return null;
-        }
-
-        fn next(self: *KWayMergeIterator) Pending!?Value {
-            const direction = self.direction;
-            const stream_id = self.contender.stream_id;
-            assert(!self.contender.sentinel);
-
-            self.contender = try self.next_contender(stream_id);
-
-            var opponent_id: usize = self.nodes_count + stream_id;
-            for (0..self.tree_height) |_| {
-                opponent_id = (opponent_id - 1) >> 1;
-
-                const opponent = &self.losers[opponent_id];
-                const winner = determine_winner(&self.contender, opponent, direction);
-                swap_nodes(winner, &self.contender);
-            }
-
-            if (self.contender.sentinel) {
-                assert(self.streams_active == 0);
-                return null;
-            }
-
-            return stream_pop(self.context, self.contender.stream_id);
-        }
-
-        fn next_contender(self: *KWayMergeIterator, stream_id: u32) Pending!Node {
-            assert(stream_id < self.streams_count);
-            const next_key = try stream_peek(self.context, stream_id) orelse {
-                self.streams_active -= 1;
-                return sentinel;
-            };
-            return .{ .key = next_key, .stream_id = stream_id, .sentinel = false };
-        }
-
-        inline fn select(choose_a: bool, a: *Node, b: *Node) *Node {
-            // Note: The code layout coaxes the compiler to generate branchless code.
-            //       Best do not change it without verifying the generated code.
-            var p = b;
-            if (choose_a) {
-                @branchHint(.unpredictable); // attaches to this branch
-                p = a;
-            }
-            return p;
-        }
-
-        /// Return a pointer to the winner without branching.
-        inline fn determine_winner(
-            contender: *Node,
-            challenger: *Node,
-            direction: Direction,
-        ) *Node {
-            const challenger_wins: bool = challenger.beats(contender, direction);
-            const winner: *Node = select(challenger_wins, challenger, contender);
-            return winner;
-        }
-
-        // This custom swap is faster than `std.mem.swap` for our Node struct.
-        inline fn swap_nodes(a: *Node, b: *Node) void {
-            inline for (std.meta.fields(Node)) |f| {
-                const tmp_field = @field(a, f.name);
-                @field(a, f.name) = @field(b, f.name);
-                @field(b, f.name) = tmp_field;
-            }
         }
     };
 }

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -120,7 +120,11 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
             }
         }
 
-        inline fn pop_winner_impl(tree: *TournamentTree, entrant: ?Key, comptime direction: Direction) void {
+        inline fn pop_winner_impl(
+            tree: *TournamentTree,
+            entrant: ?Key,
+            comptime direction: Direction,
+        ) void {
             const winner_id = tree.win_id;
 
             assert(tree.win_id < node_count);
@@ -188,7 +192,6 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
                 return @bitCast(result);
             }
         }
-
     };
 }
 

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -171,31 +171,31 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
             if (tree.win_id == Node.id_sentinel) assert(tree.contestants_left == 0);
         }
 
-        /// Returns 1 if (a_key, a_id) wins over (b_key, b_id), 0 otherwise.
+        /// Returns true if (a_key, a_id) wins over (b_key, b_id).
         /// Sentinels (id_sentinel) always lose. Equal keys broken by id for stability.
         /// In ascending mode, sentinel_key (maxInt) naturally loses on `<` so no
         /// explicit sentinel checks are needed. In descending mode, maxInt would
         /// incorrectly "win" on `>`, so explicit sentinel checks are required.
-        inline fn beats(a_key: Key, a_id: u32, b_key: Key, b_id: u32, direction: Direction) u1 {
+        inline fn beats(a_key: Key, a_id: u32, b_key: Key, b_id: u32, direction: Direction) bool {
             const id_lt: u1 = @intFromBool(a_id < b_id);
             const keys_eq: u1 = @intFromBool(a_key == b_key);
             const eq_and_id_wins: u1 = keys_eq & id_lt;
 
             if (direction == .ascending) {
                 const key_lt: u1 = @intFromBool(a_key < b_key);
-                return key_lt | eq_and_id_wins;
+                return (key_lt | eq_and_id_wins) == 1;
             } else {
                 const key_gt: u1 = @intFromBool(a_key > b_key);
                 const b_is_sentinel: u1 = @intFromBool(b_id == Node.id_sentinel);
                 const a_is_sentinel: u1 = @intFromBool(a_id == Node.id_sentinel);
                 const key_wins: u1 = key_gt | eq_and_id_wins;
-                return b_is_sentinel | ((1 - a_is_sentinel) & key_wins);
+                return (b_is_sentinel | ((1 - a_is_sentinel) & key_wins)) == 1;
             }
         }
 
-        inline fn branchless_select(comptime T: type, flag: u1, a: T, b: T) T {
+        inline fn branchless_select(comptime T: type, flag: bool, a: T, b: T) T {
             @branchHint(.unpredictable);
-            return if (flag == 1) a else b;
+            return if (flag) a else b;
         }
     };
 }

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -210,7 +210,7 @@ pub fn KWayMergeIteratorType(
     comptime stream_pop: fn (context: *Context, stream_index: u32) Value,
 ) type {
     comptime assert(options.streams_max >= 1);
-    comptime assert(options.streams_max <= 1024); // Reasonable upper bound
+    comptime assert(options.streams_max <= 1024); // Reasonable upper bound.
 
     return struct {
         context: *Context,

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -66,7 +66,7 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
             var contestants_left: u16 = 0;
             for (contestants[0..contestant_count]) |*contestant| {
                 if (contestant.id == Node.id_sentinel) {
-                    // Stream is empty to start with
+                    // Stream is empty to begin with.
                 } else {
                     contestants_left += 1;
                     if (contestant_previous) |previous| assert(previous.id < contestant.id);

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -179,7 +179,7 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
                 const mask = @as(T, 0) -% @as(T, flag);
                 return (a & mask) | (b & ~mask);
             } else {
-                const parts = @bitSizeOf(T) / 64;
+                const parts = @divExact(@bitSizeOf(T), 64);
                 const a_parts: [parts]u64 = @bitCast(a);
                 const b_parts: [parts]u64 = @bitCast(b);
                 const mask = @as(u64, 0) -% @as(u64, flag);

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -123,10 +123,6 @@ fn KWayMergeContextType(comptime Value: type) type {
         fn stream_pop(context: *Context, stream_index: u32) Value {
             const stream = context.streams[stream_index];
             context.streams[stream_index] = stream[1..];
-            const ptr: [*]const u8 = @ptrCast(context.streams[stream_index]);
-            @prefetch(ptr, .{ .locality = 3, .cache = .data });
-            // TODO: make data type dependent.
-            @prefetch(ptr + 64, .{ .locality = 3, .cache = .data });
             return stream[0];
         }
 

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -123,6 +123,10 @@ fn KWayMergeContextType(comptime Value: type) type {
         fn stream_pop(context: *Context, stream_index: u32) Value {
             const stream = context.streams[stream_index];
             context.streams[stream_index] = stream[1..];
+            const ptr: [*]const u8 = @ptrCast(context.streams[stream_index]);
+            @prefetch(ptr, .{ .locality = 3, .cache = .data });
+            // TODO: make data type dependent.
+            @prefetch(ptr + 64, .{ .locality = 3, .cache = .data });
             return stream[0];
         }
 

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -286,7 +286,7 @@ fn ScanMergeType(
         }
 
         fn scan_read_callback(context: *Scan.Context, scan: *Scan) void {
-            const self: *ScanMerge = @fieldParentPtr("scan_context", context);
+            const self: *ScanMerge = @alignCast(@fieldParentPtr("scan_context", context));
             assert(self.state == .buffering);
             assert(self.state.buffering.pending_count > 0);
             assert(self.state.buffering.pending_count <= self.streams.count());

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -273,7 +273,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         }
 
         fn manifest_log_open_callback(manifest_log: *ManifestLog) void {
-            const env: *Environment = @fieldParentPtr("manifest_log", manifest_log);
+            const env: *Environment = @alignCast(@fieldParentPtr("manifest_log", manifest_log));
             env.change_state(.manifest_log_open, .fuzzing);
         }
 
@@ -384,12 +384,12 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         }
 
         fn compact_callback(pool: *ResourcePool, _: u16, _: u64) void {
-            const env: *Environment = @fieldParentPtr("pool", pool);
+            const env: *Environment = @alignCast(@fieldParentPtr("pool", pool));
             env.change_state(.tree_compact, .fuzzing);
         }
 
         fn manifest_log_compact_callback(manifest_log: *ManifestLog) void {
-            const env: *Environment = @fieldParentPtr("manifest_log", manifest_log);
+            const env: *Environment = @alignCast(@fieldParentPtr("manifest_log", manifest_log));
             env.change_state(.manifest_log_compact, .fuzzing);
         }
 
@@ -440,12 +440,13 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         }
 
         fn grid_checkpoint_callback(grid: *Grid) void {
-            const env: *Environment = @fieldParentPtr("grid", grid);
+            const env: *Environment = @alignCast(@fieldParentPtr("grid", grid));
             env.change_state(.grid_checkpoint, .superblock_checkpoint);
         }
 
         fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {
-            const env: *Environment = @fieldParentPtr("superblock_context", superblock_context);
+            const env: *Environment =
+                @alignCast(@fieldParentPtr("superblock_context", superblock_context));
             env.change_state(.superblock_checkpoint, .fuzzing);
         }
 
@@ -470,7 +471,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         }
 
         fn get_callback(lookup_context: *Tree.LookupContext, value: ?*const Value) void {
-            const env: *Environment = @fieldParentPtr("lookup_context", lookup_context);
+            const env: *Environment = @alignCast(@fieldParentPtr("lookup_context", lookup_context));
             assert(env.lookup_value == null);
             env.lookup_value = if (value) |val| val.* else null;
             env.change_state(.tree_lookup, .fuzzing);

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -576,7 +576,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             ) *StateMachine {
                 comptime assert(field != .null);
 
-                const context: *PrefetchContext = @alignCast(@fieldParentPtr(@tagName(field), completion));
+                const context: *PrefetchContext =
+                    @alignCast(@fieldParentPtr(@tagName(field), completion));
                 return @alignCast(@fieldParentPtr("prefetch_context", context));
             }
 
@@ -612,7 +613,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             ) *StateMachine {
                 comptime assert(field != .null);
 
-                const context: *ScanLookup = @alignCast(@fieldParentPtr(@tagName(field), completion));
+                const context: *ScanLookup =
+                    @alignCast(@fieldParentPtr(@tagName(field), completion));
                 return @alignCast(@fieldParentPtr("scan_lookup", context));
             }
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -576,8 +576,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             ) *StateMachine {
                 comptime assert(field != .null);
 
-                const context: *PrefetchContext = @fieldParentPtr(@tagName(field), completion);
-                return @fieldParentPtr("prefetch_context", context);
+                const context: *PrefetchContext = @alignCast(@fieldParentPtr(@tagName(field), completion));
+                return @alignCast(@fieldParentPtr("prefetch_context", context));
             }
 
             pub fn get(self: *PrefetchContext, comptime field: Field) *FieldType(field) {
@@ -612,8 +612,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             ) *StateMachine {
                 comptime assert(field != .null);
 
-                const context: *ScanLookup = @fieldParentPtr(@tagName(field), completion);
-                return @fieldParentPtr("scan_lookup", context);
+                const context: *ScanLookup = @alignCast(@fieldParentPtr(@tagName(field), completion));
+                return @alignCast(@fieldParentPtr("scan_lookup", context));
             }
 
             pub fn get(self: *ScanLookup, comptime field: Field) *FieldType(field) {
@@ -893,7 +893,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn forest_open_callback(forest: *Forest) void {
-            const self: *StateMachine = @fieldParentPtr("forest", forest);
+            const self: *StateMachine = @alignCast(@fieldParentPtr("forest", forest));
             assert(self.open_callback != null);
 
             const callback = self.open_callback.?;
@@ -2804,7 +2804,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn compact_finish(forest: *Forest) void {
-            const self: *StateMachine = @fieldParentPtr("forest", forest);
+            const self: *StateMachine = @alignCast(@fieldParentPtr("forest", forest));
             const callback = self.compact_callback.?;
             self.compact_callback = null;
 
@@ -2825,7 +2825,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn checkpoint_finish(forest: *Forest) void {
-            const self: *StateMachine = @fieldParentPtr("forest", forest);
+            const self: *StateMachine = @alignCast(@fieldParentPtr("forest", forest));
             const callback = self.checkpoint_callback.?;
             self.checkpoint_callback = null;
 

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1098,6 +1098,12 @@ pub inline fn fastrange(word: u64, p: u64) u64 {
     return @truncate(ln >> 64);
 }
 
+// For Zig 14.1 the compiler generates branchless code as is: https://godbolt.org/z/hc563WPKP
+pub inline fn branchless_select(comptime T: type, flag: bool, a: T, b: T) T {
+    @branchHint(.unpredictable);
+    return if (flag) a else b;
+}
+
 const snap = Snap.snap_fn("src/stdx");
 
 test fastrange {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3176,7 +3176,7 @@ pub fn ReplicaType(
             reply_: ?*Message.Reply,
             destination_replica: ?u8,
         ) void {
-            const self: *Replica = @fieldParentPtr("client_replies", client_replies);
+            const self: *Replica = @alignCast(@fieldParentPtr("client_replies", client_replies));
             const reply = reply_ orelse {
                 log.debug("{}: on_request_reply: reply not found for replica={} " ++
                     "(op={} checksum={x:0>32})", .{
@@ -4801,7 +4801,7 @@ pub fn ReplicaType(
         }
 
         fn commit_reply_setup_callback(client_replies: *ClientReplies) void {
-            const self: *Replica = @fieldParentPtr("client_replies", client_replies);
+            const self: *Replica = @alignCast(@fieldParentPtr("client_replies", client_replies));
             assert(self.commit_stage == .reply_setup);
             assert(self.commit_prepare != null);
             assert(self.commit_prepare.?.header.op == self.commit_min + 1);
@@ -5156,7 +5156,7 @@ pub fn ReplicaType(
         }
 
         fn commit_checkpoint_superblock_callback(superblock_context: *SuperBlock.Context) void {
-            const self: *Replica = @fieldParentPtr("superblock_context", superblock_context);
+            const self: *Replica = @alignCast(@fieldParentPtr("superblock_context", superblock_context));
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(self.commit_stage == .checkpoint_superblock);
@@ -6575,7 +6575,7 @@ pub fn ReplicaType(
             reply_: ?*Message.Reply,
             destination_replica: ?u8,
         ) void {
-            const self: *Replica = @fieldParentPtr("client_replies", client_replies);
+            const self: *Replica = @alignCast(@fieldParentPtr("client_replies", client_replies));
             assert(reply_header.size > @sizeOf(Header));
             assert(destination_replica == null);
 
@@ -9441,7 +9441,7 @@ pub fn ReplicaType(
         }
 
         fn view_durable_update_callback(context: *SuperBlock.Context) void {
-            const self: *Replica = @fieldParentPtr("superblock_context_view_change", context);
+            const self: *Replica = @alignCast(@fieldParentPtr("superblock_context_view_change", context));
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(!self.view_durable_updating());

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5156,7 +5156,8 @@ pub fn ReplicaType(
         }
 
         fn commit_checkpoint_superblock_callback(superblock_context: *SuperBlock.Context) void {
-            const self: *Replica = @alignCast(@fieldParentPtr("superblock_context", superblock_context));
+            const self: *Replica =
+                @alignCast(@fieldParentPtr("superblock_context", superblock_context));
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(self.commit_stage == .checkpoint_superblock);
@@ -9441,7 +9442,8 @@ pub fn ReplicaType(
         }
 
         fn view_durable_update_callback(context: *SuperBlock.Context) void {
-            const self: *Replica = @alignCast(@fieldParentPtr("superblock_context_view_change", context));
+            const self: *Replica =
+                @alignCast(@fieldParentPtr("superblock_context_view_change", context));
             assert(self.status == .normal or self.status == .view_change or
                 (self.status == .recovering and self.solo()));
             assert(!self.view_durable_updating());


### PR DESCRIPTION
This PR incorporates @matklad’s beautiful rewrite of the Tournament Tree (our `k_way_merge.zig`). I built on top of it with a few performance optimizations. Together, the result is a clean interface that decouples async concerns from the core algorithm, and it’s also a bit faster than the old version.

Old: 17ns per element
New: 13ns per element

There’s an interesting finding around prefetching the next winner in the stream. We should probably address this in a separate PR focused on the tight k-way merge hot loop.

EDIT: end-to-end performance
old:   609472
new: 624943
 