### PR TITLE
compaction: prefetch index blocks.

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -69,10 +69,11 @@ pub const compaction_tables_output_max = compaction_tables_input_max;
 /// The minimum number of blocks required for a single beat of a single compaction.
 ///
 /// Compaction needs to carry over the output index block and all input blocks to the next beat:
-/// One index and one value block for the output table, one index block for the two input tables,
-/// and `lsm_compaction_queue_read_max/2` value blocks for the two input tables.
+/// One index and one value block for the output table, one index block for level A, two index
+/// blocks for level B (to allow prefetching), and `lsm_compaction_queue_read_max/2` value blocks
+/// for the two input tables.
 pub const compaction_block_count_beat_min: u32 =
-    (1 + 1) + (1 + 1) + constants.lsm_compaction_queue_read_max;
+    (1 + 1) + (1 + 2) + constants.lsm_compaction_queue_read_max;
 
 const half_bar_beat_count = @divExact(constants.lsm_compaction_ops, 2);
 
@@ -441,7 +442,7 @@ pub fn CompactionType(
         }) = .{ .buffer = undefined },
 
         level_b_index_block: RingBufferType(*ResourcePool.Block, .{
-            .array = 1,
+            .array = 2, // Prefetch next table's index block
         }) = .{ .buffer = undefined },
 
         level_b_value_block: RingBufferType(*ResourcePool.Block, .{


### PR DESCRIPTION
This PR increases the index-block queue size from 1 to 2 to enable prefetching during compaction.

Index blocks introduce a data dependency: we have to read the index block from disk before we can schedule any corresponding value-block reads. With a queue size of 2, we prefetch the next index block already and overlap it with the current compaction work.  

End-to-end impact: 

Before:
```
load accepted = 528962 tx/s
batch latency p1   = 4 ms
batch latency p50  = 12 ms
batch latency p99  = 73 ms
batch latency p100 = 79 ms
```
After:  
```
load accepted = 535182 tx/s
batch latency p1   = 4 ms
batch latency p50  = 11 ms
batch latency p99  = 71 ms
batch latency p100 = 73 ms
```

Note: 2 seems to be the sweet spot, 3 does not increase performance more.