### PR TITLE
benchmark: add `--id-order=tbid`

### DIFF
--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -77,6 +77,12 @@ pub fn main(
         .{ constants.clients_max, cli_args.clients },
     );
 
+    if (cli_args.validate and cli_args.id_order == .tbid) vsr.fatal(
+        .cli,
+        "--validate is incompatible with --id-order=tbid",
+        .{},
+    );
+
     const cluster_id: u128 = 0;
 
     var message_pools = stdx.BoundedArrayType(MessagePool, constants.clients_max){};
@@ -160,18 +166,6 @@ pub fn main(
     });
 
     const use_tbid = cli_args.id_order == .tbid;
-
-    const validate = validate: {
-        if (cli_args.validate and use_tbid) {
-            log.warn(
-                "--validate is incompatible with --id-order=tbid, disabling.",
-                .{},
-            );
-            break :validate false;
-        }
-        break :validate cli_args.validate;
-    };
-
     const account_id_start: ?u128 = if (use_tbid)
         stdx.unique_u128()
     else
@@ -204,7 +198,7 @@ pub fn main(
         .query_count = cli_args.query_count,
         .no_history = cli_args.no_history,
         .imported = cli_args.imported,
-        .validate = validate,
+        .validate = cli_args.validate,
         .print_batch_timings = cli_args.print_batch_timings,
     };
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -565,13 +565,13 @@ pub const Command = union(enum) {
         /// sequential is expected to be the best (since it can take advantage of various
         /// optimizations such as avoiding negative prefetch) while random/reversed can't.
         pub const IdOrder = enum {
-            sequential,
-            random,
-            reversed,
             // Use TBIDs (time-based IDs) for transfers and a random start for account IDs.
             // Avoids ID collisions between benchmark runs against the same cluster.
             // Incompatible with --validate (IDs are not deterministically replayable).
             tbid,
+            sequential,
+            random,
+            reversed,
         };
 
         pub const Distribution = enum {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -564,7 +564,15 @@ pub const Command = union(enum) {
         /// The ID order can affect the results of a benchmark significantly. Specifically,
         /// sequential is expected to be the best (since it can take advantage of various
         /// optimizations such as avoiding negative prefetch) while random/reversed can't.
-        pub const IdOrder = enum { sequential, random, reversed };
+        pub const IdOrder = enum {
+            sequential,
+            random,
+            reversed,
+            // Use TBIDs (time-based IDs) for transfers and a random start for account IDs.
+            // Avoids ID collisions between benchmark runs against the same cluster.
+            // Incompatible with --validate (IDs are not deterministically replayable).
+            tbid,
+        };
 
         pub const Distribution = enum {
             /// Shuffled zipfian numbers where relatively few indexes are selected frequently.


### PR DESCRIPTION
This PR introduces `--id-order=tbid`, which (1) generates a random starting account ID and increments subsequent account IDs from there, and (2) uses TBIDs for transfer IDs.

This has two benefits: (1) benchmark runs no longer collide (or only with very small probability), which is a big quality of life improvement as you can let the cluster run between benchmarks (this only worked with `--id-order=random` which we do not encourage), and (2) we exercise TBIDs in the hot path, yielding more realistic performance numbers and access patterns (e.g., for radix-sort optimizations like skipping common bytes, as well as for compression).

The main downside is that `--validate` is incompatible (we emit a warning) because IDs are no longer deterministically reproducible. Making validation work, would require persisting the generated IDs, which would be quite large. After discussing this with @matklad, we concluded that `--validate` shouldn't block real benchmarking; for correctness we rely on fuzzers, VOPR, etc., so this is a worthwhile tradeoff.

Note: The `--file` flag creates a new data file (it formats it first). To test two runs against the same cluster, you need to start a server and connect via `--addresses`. 