### PR TITLE
CFO: Don't crash so much

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -679,15 +679,14 @@ fn run_fuzzers_prepare_tasks(tasks: *Tasks, shell: *Shell, gh_token: ?[]const u8
     defer tasks.verify();
 
     for ([2]SeedRecord.Template.Branch{ .main, .release }) |branch| {
-        if (branch == .release and gh_token == null) continue;
-
-        const working_directory = if (gh_token == null)
+        // Fuzz in-place when no token is specified, for testing coordinated fuzzer changes.
+        // But also fuzz on the release branch, to make sure CFO doesn't break on older branches.
+        const local_branch = branch == .main and gh_token == null;
+        const working_directory = if (local_branch)
             "."
         else
             try shell.fmt("./working/{s}", .{@tagName(branch)});
-        const commit = if (gh_token == null)
-            // Fuzz in-place when no token is specified, as a convenient shortcut for local
-            // debugging.
+        const commit = if (local_branch)
             try run_fuzzers_commit_info(shell)
         else commit: {
             try shell.cwd.makePath(working_directory);
@@ -940,7 +939,7 @@ fn run_fuzzers_start_fuzzer(shell: *Shell, options: struct {
     };
     assert(exe.len > 0);
 
-    log.debug("will start '{s}'", .{command});
+    log.debug("will start '{s}' ({s})", .{ command, options.working_directory });
 
     const log_path = if (options.fuzzer.capture_logs())
         try shell.fmt("{s}_{d}.log", .{ @tagName(options.fuzzer), options.seed })


### PR DESCRIPTION
Try to make CFO less fragile:

- Test release branch even without a `gh_token`. (We only need to token to retrieve the PR list.)
    - When https://github.com/tigerbeetle/tigerbeetle/pull/3462 merged it broke CFO because `release`'s vortex didn't have the `--log` flag added by that PR. Vortex would crash, and then CFO would fail to read the log file and crash.
    - And I didn't find this during my local testing because I wasn't testing with a `gh_token`.
- Don't crash CFO if vortex didn't create its log file.
    - Instead, we record the seed, just without an accompanying log.
    - When possible, CFO should be resilient to its fuzzer's mistakes!

I recommend reviewing the commits separately.