### PR TITLE
docs: fix link to Viewstamped Replication paper

### DIFF
--- a/docs/concepts/safety.md
+++ b/docs/concepts/safety.md
@@ -26,7 +26,7 @@ might fail catastrophically (e.g. due to a fire in the data center). Primary/bac
 ad-hoc failover can lose data due to split-brain.
 
 To avoid these pitfalls, TigerBeetle implements pioneering
-[Viewstamped Replication](http://pmg.csail.mit.edu/papers/vr-revisited.pdf) and consensus algorithm,
+[Viewstamped Replication](https://dl.acm.org/doi/epdf/10.1145/62546.62549) and consensus algorithm,
 that guarantees correct, automatic failover. It's worth emphasizing that consensus proper needs only
 be engaged during actual failover. During the normal operation, the cost of consensus is just the
 cost of replication, which is further minimized because of

--- a/docs/concepts/safety.md
+++ b/docs/concepts/safety.md
@@ -26,7 +26,7 @@ might fail catastrophically (e.g. due to a fire in the data center). Primary/bac
 ad-hoc failover can lose data due to split-brain.
 
 To avoid these pitfalls, TigerBeetle implements pioneering
-[Viewstamped Replication](https://dl.acm.org/doi/epdf/10.1145/62546.62549) and consensus algorithm,
+[Viewstamped Replication](https://dspace.mit.edu/bitstream/handle/1721.1/71763/MIT-CSAIL-TR-2012-021.pdf) and consensus algorithm,
 that guarantees correct, automatic failover. It's worth emphasizing that consensus proper needs only
 be engaged during actual failover. During the normal operation, the cost of consensus is just the
 cost of replication, which is further minimized because of


### PR DESCRIPTION
The previous link would first return an SSL error in a modern browser, and then even if the risk was accepted, the server would return a 403 Forbidden.

A [2013 news post on the CSAIL website] linked to the ACM page. I opted to link directly to the rendered PDF.

[2013 news post on the CSAIL website]: https://www.csail.mit.edu/news/liskov-honored-sigops-hall-fame-award