### PR TITLE
[tb_client] Rework how eviction is signaled.

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -984,8 +984,13 @@ pub fn ContextType(
             assert(thread_caller == .user);
 
             const self: *Context = @ptrCast(@alignCast(context));
+
+            // Copy the thread handle here, since stopping the I/O thread deinitializes
+            // the context and invalidates the `self` pointer.
+            const thread = self.thread;
+            defer thread.join();
+
             self.signal.stop();
-            self.thread.join();
         }
 
         fn vtable_init_parameters_fn(context: *anyopaque, out_parameters: *InitParameters) void {

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -985,6 +985,14 @@ public class IntegrationTest {
                 } catch (RequestException requestException) {
                     assertEquals(PacketStatus.ClientEvicted.value, requestException.getStatus());
                 }
+
+                // The client is deinitialized after it learns it was evicted.
+                // Reusing an evicted client must return a "ClientShutdown" error.
+                try {
+                    client_evict.lookupAccounts(new IdBatch(UInt128.id()));
+                    assert false;
+                } catch (ClientClosedException clientClosedException) {
+                }
             }
         }
     }


### PR DESCRIPTION
- Lock the interface to avoid race conditions when checking `signal.status()` and `eviction_reason`.

- Unify how eviction and shutdown are notified. Pending requests receive the `eviction_reason` callback; subsequent requests fail with the standard “shutdown” error.

- Assert that all functions run on the I/O thread, except for the vtable function pointers, which must be called from the user thread.

Ref: https://github.com/tigerbeetle/tigerbeetle/pull/3373
