### PR TITLE
fix: prefer rejecting zero client id in message bus over assert

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -684,7 +684,7 @@ pub fn MessageBusType(comptime IO: type) type {
                     });
                 },
                 .client => |client_id| {
-                    assert(client_id != 0);
+                    if (client_id == 0) return false;
 
                     // Allowed transitions:
                     // * unknown        → client
@@ -718,7 +718,7 @@ pub fn MessageBusType(comptime IO: type) type {
                 },
 
                 .client_likely => |client_id| {
-                    assert(client_id != 0);
+                    if (client_id == 0) return false;
                     switch (connection.peer) {
                         .unknown => {
                             // If the peer transitions from unknown -> client_likely, either


### PR DESCRIPTION
this PR simply prefers an early return instead of an assert in the case `client_id==0` 

my understanding that `recv_update_peer` does not expect client_id to be 0 however a user can send a checksum'ed request that will cause the service to crash.

#### steps to reproduce
```bash
# get latest
curl -Lo tigerbeetle.zip https://mac.tigerbeetle.com && unzip tigerbeetle.zip && ./tigerbeetle version

# format
./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 --development ./0_0.tigerbeetle

# run
./tigerbeetle start --addresses=3000 ./0_0.tigerbeetle
# service should be running
```

now in another terminal send this payload

```python
import socket

# NOTE: checksum was precomputed for cluster ID 0 using vendored aegis impl from
# https://github.com/ziglang/zig/blob/0.13.0/lib/std/crypto/aegis.zig
PAYLOAD = (
    # Base Header fields
    b"\x14\x11\xe8\x17\xd2\x7a\x8e\xba\xac\x35\xc4\x89\x24\x04\xcd\xea"  # checksum: u128
    + b"\x00" * 16  # checksum_padding: u128
    + b"\x83\xcc\x60\x0d\xc4\xe3\xe7\xe6\x2d\x40\x55\x82\x61\x74\xf1\x49"  # checksum_body: u128 - for empty body
    + b"\x00" * 16  # checksum_body_padding: u128
    + b"\x00" * 16  # nonce_reserved: u128
    + b"\x00" * 16  # cluster: u128 = 0
    + b"\x00\x01\x00\x00"  # size: u32 = 256
    + b"\x00" * 4  # epoch: u32 = 0
    + b"\x00" * 4  # view: u32 = 0
    + b"\x01\x00\x00\x00"  # release: u32 = 1
    + b"\x00\x00"  # protocol: u16 = 0
    + b"\x05"  # command: u8 = 5 (.request)
    + b"\x00"  # replica: u8 = 0
    + b"\x00" * 12  # reserved_frame: [12]u8
    # Request-specific fields
    + b"\x00" * 16  # parent: u128 = 0
    + b"\x00" * 16  # parent_padding: u128
    + b"\x00" * 16  # client: u128 = 0 (triggers assert!)
    + b"\x00" * 8  # session: u64 = 0
    + b"\x00" * 8  # timestamp: u64 = 0
    + b"\x00" * 4  # request: u32 = 0
    + b"\x05"  # operation: u8 = 5
    + b"\x00" * 3  # previous_request_latency_padding: [3]u8
    + b"\x00" * 4  # previous_request_latency: u32 = 0
    + b"\x00" * 52  # reserved: [52]u8
)

host = "127.0.0.1"
port = 3000
s = socket.socket(); 
s.connect((host, port)); 
s.send(PAYLOAD); 
s.close()
print(f"Sent {len(PAYLOAD)}B -> {host}:{port}")
```

and the service will crash

```txt
thread 24423971 panic: reached unreachable code
Unable to dump stack trace: debug info stripped
[1]    73250 abort      ./tigerbeetle start --addresses=3000 ./0_0.tigerbeetle
```

note: this also appears to work when following the start commands for a multi replica cluster shown here https://docs.tigerbeetle.com/operating/deploying/#deploying and when specifying a non zero cluster id (to avoid development specific paths)

#### error log

when building from source the crash shows

```
thread 24130127 panic: reached unreachable code
/Users/drbh/Projects/tigerbeetle/zig/lib/std/debug.zig:550:14: 0x10451fc93 in assert (tigerbeetle)
    if (!ok) unreachable; // assertion failure
             ^
/Users/drbh/Projects/tigerbeetle/src/message_bus.zig:721:27: 0x104caacb7 in recv_update_peer (tigerbeetle)
                    assert(client_id != 0);
                          ^
/Users/drbh/Projects/tigerbeetle/src/message_bus.zig:612:49: 0x104c40a8f in recv_callback (tigerbeetle)
                        if (bus.recv_update_peer(connection, header.peer_type())) {
                                                ^
/Users/drbh/Projects/tigerbeetle/src/io/darwin.zig:269:32: 0x104beb9c3 in on_complete (tigerbeetle)
                return callback(
                               ^
/Users/drbh/Projects/tigerbeetle/src/io/darwin.zig:131:34: 0x1045bf4ff in flush (tigerbeetle)
            (completion.callback)(self, completion);
                                 ^
/Users/drbh/Projects/tigerbeetle/src/io/darwin.zig:78:27: 0x1045ccf9b in run_for_ns (tigerbeetle)
            try self.flush(true);
                          ^
/Users/drbh/Projects/tigerbeetle/src/tigerbeetle/main.zig:506:30: 0x1046b7327 in command_start (tigerbeetle)
            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
                             ^
/Users/drbh/Projects/tigerbeetle/src/tigerbeetle/main.zig:157:44: 0x1046baf7b in main (tigerbeetle)
                .start => try command_start(gpa, &io, time, &tracer, &storage, args),
                                           ^
/Users/drbh/Projects/tigerbeetle/zig/lib/std/start.zig:660:37: 0x1046bbd0b in main (tigerbeetle)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x187f41d53 in ??? (???)
???:?:?: 0x0 in ??? (???)
[1]    82916 abort      ./zig-out/bin/tigerbeetle start --addresses=3000 ./0_0.tigerbeetle
```

this lead me to prefer an early return rather than an assert on user input. The included change appears to resolve the bug when testing locally.

note: I found this issue after playing with/testing Tigerbeetle and I may be missing some important context. I'm more than happy to make any changes or amend this PR in any way that is more helpful

Thanks for the awesome project!

