### PR TITLE
compaction: reserve grid blocks per half bar

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -153,8 +153,8 @@ const ConfigProcess = struct {
 const ConfigCluster = struct {
     cache_line_size: comptime_int = 64,
     clients_max: u32,
-    pipeline_prepare_queue_max: u32 = 8,
-    view_change_headers_suffix_max: u32 = 8 + 1,
+    pipeline_prepare_queue_max: u32 = 16,
+    view_change_headers_suffix_max: u32 = 16 + 1,
     quorum_replication_max: u8 = 3,
     journal_slot_count: u32 = 1024,
     message_size_max: u32 = 1 * MiB,

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -659,39 +659,14 @@ pub fn ManifestLogType(comptime Storage: type) type {
             }
         }
 
-        /// `compact` does not close a partial block; that is only necessary during `checkpoint`.
-        ///
-        /// The (production) block size is large, so the number of blocks compacted per half-bar is
-        /// relatively small (e.g. ~4). We read them in sequence rather than parallel to spread the
-        /// work more evenly across the half-bar's beats.
-        // TODO Make sure block reservation cannot fail — before compaction begins verify that
-        // enough free blocks are available for all reservations.
-        pub fn compact(manifest_log: *ManifestLog, callback: Callback, op: u64) void {
+        pub fn compact_reserve_blocks(manifest_log: *ManifestLog) void {
             assert(manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
             assert(manifest_log.read_callback == null);
             assert(manifest_log.write_callback == null);
             assert(manifest_log.grid_reservation == null);
-            assert(manifest_log.blocks.count ==
-                manifest_log.blocks_closed + @intFromBool(manifest_log.entry_count > 0));
             assert(manifest_log.compact_blocks == null);
-
-            // TODO: Currently manifest compaction is hardcoded to run on the last beat of each
-            // half-bar.
-            // This is because otherwise it would mess with our grid reserve / forfeit ordering,
-            // since we now reserve / forfeit per beat.
-            assert((op + 1) % @divExact(constants.lsm_compaction_ops, 2) == 0);
-
-            manifest_log.grid.trace.start(.compact_manifest);
-
-            if (op < constants.lsm_compaction_ops or
-                manifest_log.superblock.working.vsr_state.op_compacted(op))
-            {
-                manifest_log.read_callback = callback;
-                manifest_log.grid.on_next_tick(compact_tick_callback, &manifest_log.next_tick);
-                return;
-            }
 
             manifest_log.compact_blocks = @min(
                 manifest_log.pace.half_bar_compact_blocks(.{
@@ -707,25 +682,35 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 manifest_log.compact_blocks.? +
                     manifest_log.pace.half_bar_append_blocks_max,
             );
-
-            manifest_log.read_callback = callback;
-            manifest_log.flush(compact_next_block);
         }
 
-        fn compact_tick_callback(next_tick: *Grid.NextTick) void {
-            const manifest_log: *ManifestLog = @alignCast(@fieldParentPtr("next_tick", next_tick));
+        /// `compact` does not close a partial block; that is only necessary during `checkpoint`.
+        ///
+        /// The (production) block size is large, so the number of blocks compacted per half-bar is
+        /// relatively small (e.g. ~4). We read them in sequence rather than parallel to spread the
+        /// work more evenly across the half-bar's beats.
+        // TODO Make sure block reservation cannot fail — before compaction begins verify that
+        // enough free blocks are available for all reservations.
+        pub fn compact(manifest_log: *ManifestLog, callback: Callback, op: u64) void {
+            assert(manifest_log.opened);
+            assert(!manifest_log.reading);
+            assert(!manifest_log.writing);
+            assert(manifest_log.read_callback == null);
             assert(manifest_log.write_callback == null);
-            assert(manifest_log.grid_reservation == null);
-            assert(manifest_log.blocks_closed == 0);
-            assert(manifest_log.blocks.count == 0);
-            assert(manifest_log.entry_count == 0);
-            assert(manifest_log.compact_blocks == null);
+            assert(manifest_log.grid_reservation != null);
+            assert(manifest_log.blocks.count ==
+                manifest_log.blocks_closed + @intFromBool(manifest_log.entry_count > 0));
+            assert(manifest_log.compact_blocks != null);
+            assert(op >= constants.lsm_compaction_ops);
+            assert(!manifest_log.superblock.working.vsr_state.op_compacted(op));
 
-            manifest_log.grid.trace.stop(.compact_manifest);
+            // ManifestLog compaction is lesser work than forest compaction, so we run it only on
+            // the last beat of each half-bar.
+            assert((op + 1) % @divExact(constants.lsm_compaction_ops, 2) == 0);
 
-            const callback = manifest_log.read_callback.?;
-            manifest_log.read_callback = null;
-            callback(manifest_log);
+            manifest_log.grid.trace.start(.compact_manifest);
+            manifest_log.read_callback = callback;
+            manifest_log.flush(compact_next_block);
         }
 
         fn compact_next_block(manifest_log: *ManifestLog) void {

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -399,6 +399,7 @@ const Environment = struct {
         const op = vsr.Checkpoint.checkpoint_after(
             env.manifest_log.superblock.working.vsr_state.checkpoint.header.op,
         );
+        env.manifest_log.compact_reserve_blocks();
         env.manifest_log.compact(
             manifest_log_compact_callback,
             op,

--- a/src/vsr/free_set.zig
+++ b/src/vsr/free_set.zig
@@ -600,6 +600,8 @@ pub const FreeSet = struct {
     pub fn mark_checkpoint_durable(set: *FreeSet) void {
         assert(set.opened);
         assert(!set.checkpoint_durable);
+        assert(set.reservation_count == 0);
+        assert(set.reservation_blocks == 0);
 
         set.checkpoint_durable = true;
 


### PR DESCRIPTION
This PR changes the way forest compactions reserve blocks, to make it so that _all compactions share a single grid reservation that reserves enough blocks for the entire half bar_. Earlier, we made a new grid reservation every beat. To reduce fragmentation, we also need to ensure that ManifestLog reservation is made _before_ the forest reservation (as the former is smaller than the latter), so we now reserve ManifestLog blocks on the first beat of each half bar.

The main _why_ here is that per bar reservations are simpler, beat reservations require more complex accounting, like initialisation to 1 to account for index/value block from last beat, and adding 1 to account for immutable table pacing. 

Additionally (and orthogonally), this PR makes `bar_input_size` and `beat_input_size` as `?u64` instead of `u64`, and they are set to `null` when forest compaction isn't running.