### PR TITLE
AOF: Deterministic AOF recovery

### DIFF
--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -51,25 +51,29 @@ echo ''
 echo 'Testing recovery...'
 ./tigerbeetle format --cluster=0 --replica=0 --replica-count=2 a1/aof-test.tigerbeetle >> ./aof.log 2>&1
 ./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --aof-file=a1/aof-test.tigerbeetle.aof --experimental a1/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+r1=$!
 ./tigerbeetle format --cluster=0 --replica=1 --replica-count=2 a2/aof-test.tigerbeetle >> ./aof.log 2>&1
 ./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --aof --experimental a2/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+r2=$!
 
 sleep 1
 ./zig/zig build aof -- recover --cluster=0 --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
 sleep 10 # Give replicas time to settle.
-kill %2 %3
+kill $r1 $r2
 
 echo ""
 echo "Recovering a second time, to test determinism."
 
 ./tigerbeetle format --cluster=0 --replica=0 --replica-count=2 b1/aof-test.tigerbeetle >> ./aof.log 2>&1
 ./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --experimental b1/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+r1=$!
 ./tigerbeetle format --cluster=0 --replica=1 --replica-count=2 b2/aof-test.tigerbeetle >> ./aof.log 2>&1
 ./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --experimental b2/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+r2=$!
 
 ./zig/zig build aof -- recover --cluster=0 --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
 sleep 10 # Give replicas time to settle.
-kill %4 %5
+kill $r1 $r2
 
 echo ""
 echo "Running 'zig build aof -- debug a{1,2}/aof-test.tigerbeetle.aof' to check recovered AOF..."

--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -8,11 +8,19 @@ fi
 
 ./zig/zig build install -Drelease
 
-rm -f aof.log
+# Be careful to use a benchmark-specific filenames so that we don't erase a real data file:
+cleanup() {
+    rm -f aof-test.tigerbeetle
+    rm -f aof-test.tigerbeetle.aof
+    rm -f aof.log
+    rm -f {a1,a2,b1,b2}/aof-test.tigerbeetle{,.aof}
+    rmdir {a1,a2,b1,b2} 2>/dev/null || true
+}
+cleanup
 
 function onerror {
     if [ "$?" == "0" ]; then
-        rm aof.log
+        cleanup
     else
         echo
         echo "============================================================="
@@ -25,65 +33,63 @@ function onerror {
 }
 trap onerror EXIT
 
-# Be careful to use a benchmark-specific filename so that we don't erase a real data file:
-rm -f aof-test.tigerbeetle
-rm -f aof-test.tigerbeetle.aof
-
+echo "Running benchmark to populate AOF..."
 ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 aof-test.tigerbeetle > aof.log 2>&1
 ./tigerbeetle start --cache-grid=256MiB --addresses=3000 --aof --experimental aof-test.tigerbeetle >> aof.log 2>&1 &
-
-# Wait for replicas to start, listen and connect:
-sleep 1
-
-echo "Running benchmark to populate AOF..."
 ./tigerbeetle benchmark --addresses=3000 --transfer-count=400000 >> aof.log 2>&1
+kill %1
 
 echo ""
 echo "Running 'zig build aof -- debug aof-test.tigerbeetle.aof' to check AOF..."
 data_checksum_src=$(./zig/zig build aof -- debug aof-test.tigerbeetle.aof 2>&1 | tee -a aof.log | grep 'Data checksum chain:')
 echo "${data_checksum_src}"
 
+mkdir a1 a2 b1 b2
+
+echo ''
+echo 'Testing recovery...'
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=2 a1/aof-test.tigerbeetle >> ./aof.log 2>&1
+./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --aof-file=a1/aof-test.tigerbeetle.aof --experimental a1/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+./tigerbeetle format --cluster=0 --replica=1 --replica-count=2 a2/aof-test.tigerbeetle >> ./aof.log 2>&1
+./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --aof --experimental a2/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+
+sleep 1
+./zig/zig build aof -- recover --cluster=0 --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
+sleep 10 # Give replicas time to settle.
+kill %2 %3
+
 echo ""
-echo "Clearing cluster, and testing recovery"
-kill %1
-sleep 1
+echo "Recovering a second time, to test determinism."
 
-rm -rf 1 2
-
-mkdir 1 && cd 1
-../tigerbeetle format --cluster=0 --replica=0 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle start --cache-grid=256MiB --addresses=3001,3002 --aof-file="aof-test.tigerbeetle.aof" --experimental --aof-recovery aof-test.tigerbeetle >> ../aof.log 2>&1 &
-cd ..
-
-mkdir 2 && cd 2
-../tigerbeetle format --cluster=0 --replica=1 --replica-count=2 aof-test.tigerbeetle >> ../aof.log 2>&1
-../tigerbeetle start --cache-grid=256MiB --addresses=3001,3002 --aof --experimental --aof-recovery aof-test.tigerbeetle >> ../aof.log 2>&1 &
-cd ..
-
-# mkdir 3 && cd 3
-# ../tigerbeetle format --cluster=0 --replica=2 --replica-count=3 aof-test.tigerbeetle >> aof.log 2>&1
-# ../tigerbeetle start --addresses=3001,3002,3003 aof-test.tigerbeetle >> aof.log 2>&1 &
-# cd ..
-
-sleep 1
+./tigerbeetle format --cluster=0 --replica=0 --replica-count=2 b1/aof-test.tigerbeetle >> ./aof.log 2>&1
+./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --experimental b1/aof-test.tigerbeetle >> ./aof.log 2>&1 &
+./tigerbeetle format --cluster=0 --replica=1 --replica-count=2 b2/aof-test.tigerbeetle >> ./aof.log 2>&1
+./tigerbeetle start --aof-recovery --cache-grid=256MiB --addresses=3001,3002 --experimental b2/aof-test.tigerbeetle >> ./aof.log 2>&1 &
 
 ./zig/zig build aof -- recover --cluster=0 --addresses=3001,3002 aof-test.tigerbeetle.aof >> aof.log 2>&1
-
-# Give replicas time to settle.
-sleep 10
+sleep 10 # Give replicas time to settle.
+kill %4 %5
 
 echo ""
-echo "Running 'zig build aof -- debug {1,2}/aof-test.tigerbeetle.aof' to check recovered AOF..."
-data_checksum_recovered_1=$(./zig/zig build aof -- debug 1/aof-test.tigerbeetle.aof 2>&1 | tee -a aof.log | grep 'Data checksum chain:')
+echo "Running 'zig build aof -- debug a{1,2}/aof-test.tigerbeetle.aof' to check recovered AOF..."
+data_checksum_recovered_1=$(./zig/zig build aof -- debug a1/aof-test.tigerbeetle.aof 2>&1 | tee -a aof.log | grep 'Data checksum chain:')
 echo "1: ${data_checksum_recovered_1}"
-data_checksum_recovered_2=$(./zig/zig build aof -- debug 2/aof-test.tigerbeetle.aof 2>&1 | tee -a aof.log | grep 'Data checksum chain:')
+data_checksum_recovered_2=$(./zig/zig build aof -- debug a2/aof-test.tigerbeetle.aof 2>&1 | tee -a aof.log | grep 'Data checksum chain:')
 echo "2: ${data_checksum_recovered_2}"
-# data_checksum_recovered_3=$(./zig/zig build aof -- debug 3/aof-test.tigerbeetle.aof 2>&1 | tee -a aof.log | grep 'Data checksum chain:')
-# echo "3: ${data_checksum_recovered_3}"
 
 if [ "${data_checksum_src}" != "${data_checksum_recovered_1}" ] || [ "${data_checksum_src}" != "${data_checksum_recovered_2}" ]; then
     echo "Mismatch in data checksums!"
     exit 1
 fi
 
-rm -rf 1 2
+echo
+echo 'Running "tigerbeetle inspect" to compare superblocks...'
+superblock_a=$(./tigerbeetle inspect superblock ./a1/aof-test.tigerbeetle 2>/dev/null)
+superblock_b=$(./tigerbeetle inspect superblock ./b1/aof-test.tigerbeetle 2>/dev/null)
+if [ "$superblock_a" != "$superblock_b" ]; then
+    echo "Mismatch in recovery determinism."
+    exit 1
+fi
+
+echo
+echo 'Success!'

--- a/.github/ci/test_aof.sh
+++ b/.github/ci/test_aof.sh
@@ -29,7 +29,8 @@ function onerror {
         cat aof.log
     fi
 
-    kill $(jobs -p) 2> /dev/null
+    kill $(jobs -p) 2> /dev/null || true
+    wait
 }
 trap onerror EXIT
 

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -16,6 +16,11 @@ const MiB = stdx.MiB;
 
 const log = std.log.scoped(.aof);
 
+pub const std_options: std.Options = .{
+    .log_level = .info,
+    .logFn = stdx.log_with_timestamp,
+};
+
 const magic_number: u128 = 0xbcd8d3fee406119ed192c4f4c4fc82;
 
 pub const AOFEntry = extern struct {
@@ -284,10 +289,10 @@ pub fn AOFType(comptime IO: type) type {
                 if (last_entry.?.header().checksum != checksum) {
                     return error.ChecksumMismatch;
                 }
-                log.debug("validated all aof entries. last entry checksum {x:0>32} matches " ++
+                log.info("validated all aof entries. last entry checksum {x:0>32} matches " ++
                     " supplied {x:0>32}", .{ last_entry.?.header().checksum, checksum });
             } else {
-                log.debug("validated present aof entries.", .{});
+                log.info("validated present aof entries.", .{});
             }
         }
 


### PR DESCRIPTION
### Determinism

Register the AOF recovery client with a deterministic client id and timestamp. This ensures that the recovered data file is deterministic. (Specifically the "live" parts of the data file. Grid block padding may differ.)

Note that the AOF-recovered-data-file is _not_ identical to the original data file! (Among other reasons, AOF recovery doesn't replay queries or client registration.)

<details>
<summary>Test script</summary>

```
#!/bin/sh -eu

dir=./tmp
mkdir -p ./tmp

zig build -Drelease

echo "format A"
./tigerbeetle format --replica-count=1 --cluster=0 --replica=0 "$dir"/A.tigerbeetle
./tigerbeetle start --addresses=3000 --experimental --aof-file="$dir"/A.aof "$dir"/A.tigerbeetle &
pid=$!

./tigerbeetle benchmark --addresses=3000
kill "$pid"

echo "format B"
./tigerbeetle format --replica-count=1 --cluster=0 --replica=0 "$dir"/B.tigerbeetle
./tigerbeetle start --addresses=3000 --experimental --aof-recovery "$dir"/B.tigerbeetle &
pid=$!

echo recover B
zig build aof -- recover --cluster=0 --addresses=3000 "$dir"/A.aof
kill "$pid"

echo "format C"
./tigerbeetle format --replica-count=1 --cluster=0 --replica=0 "$dir"/C.tigerbeetle
./tigerbeetle start --addresses=3000 --experimental --aof-recovery "$dir"/C.tigerbeetle &
pid=$!

echo recover C
zig build aof -- recover --cluster=0 --addresses=3000 "$dir"/A.aof
kill "$pid"

printf "sha256sum(A's superblock): %s\n" "$(./tigerbeetle inspect superblock tmp/A.tigerbeetle 2>/dev/null | sha256sum)"
printf "sha256sum(B's superblock): %s\n" "$(./tigerbeetle inspect superblock tmp/B.tigerbeetle 2>/dev/null | sha256sum)"
printf "sha256sum(C's superblock): %s\n" "$(./tigerbeetle inspect superblock tmp/C.tigerbeetle 2>/dev/null | sha256sum)"
```

</details>

```
sha256sum(A's superblock): 09689e4214f57c1f60584eb0e0ecad220b99b4d3b2a4a76728205ac61d5396df  -
sha256sum(B's superblock): 9f56fb6007b85a335afb236bdeaf94cd120de5c98e9938b78af0ccc8e84c0503  -
sha256sum(C's superblock): 9f56fb6007b85a335afb236bdeaf94cd120de5c98e9938b78af0ccc8e84c0503  -
```

### Timestamp Strictness

Right now in AOF recovery mode, we allow the client to send an explicit request timestamp, but they can still pass 0 to get the usual behavior (in which the primary assigns the timestamp).

In this commit, we tighten this, to require non-zero timestamps for all messages during AOF recovery.

This means that in order for an AOF-recovered cluster to start handling client requests, it must be restarted without `--aof-recovery`. This seems safer, since otherwise an accidental non-aof-recovery request could interfere with the AOF recovery.
