### PR TITLE
rust client: Add an eviction test case.

### DIFF
--- a/src/clients/rust/tests/tests.rs
+++ b/src/clients/rust/tests/tests.rs
@@ -1395,7 +1395,6 @@ fn example_lookup_transfers() -> Result<(), Box<dyn std::error::Error>> {
     })
 }
 
-// This is a copy of the Java testClientEvicted case.
 #[test]
 fn client_evicted() -> anyhow::Result<()> {
     const CLIENTS_MAX: usize = 64;


### PR DESCRIPTION
Still working on client eviction. This is one test case that works now, copied from the Java test suite. Adding this for more coverage.

Testing eviction requires a fresh isolated database to avoid evicting other test case clients, so this includes that refactor.