### PR TITLE
rust: fix the build for old rustc

### DIFF
--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -28,4 +28,4 @@ anyhow = "1.0.93"
 
 [dev-dependencies]
 anyhow = "1.0.93"
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["executor"] }


### PR DESCRIPTION
This removes syn from dependency tree, and it stoped building: https://github.com/tigerbeetle/tigerbeetle/actions/runs/21865092561/job/63104087514#step:12:37

This hopefully will unbreak CI!