### PR TITLE
ci: Bump Rust version to 1.71

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         include:
           - { os: 'ubuntu-latest',  language: 'dotnet',  language_version: '8.0.x' }
           - { os: 'ubuntu-latest',  language: 'go',      language_version: '1.21'  }
-          - { os: 'ubuntu-latest',  language: 'rust',    language_version: '1.68'  }
+          - { os: 'ubuntu-latest',  language: 'rust',    language_version: '1.71'  }
           - { os: 'ubuntu-latest',  language: 'rust',    language_version: 'stable' }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '11'    }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '21'    }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Subscribe to the [tracking issue #2231](https://github.com/tigerbeetle/tigerbeetle/issues/2231)
 to receive notifications about breaking changes!
 
-## TigerBeetle 0.16.71
+## TigerBeetle 0.16.72
 
 Released: 2026-02-06
 


### PR DESCRIPTION
A new version of a transitive Rust dependency was published that bumped their minimum Rust version to 1.71, breaking our CI that uses 1.68.

Here's what it looks like:

```
  Downloaded memchr v2.8.0
  Downloaded futures-sink v0.3.31
error: package `unicode-ident v1.0.23` cannot be built because it requires rustc 1.71 or newer, while the currently active rustc version is 1.68.2
Either upgrade to rustc 1.71 or newer, or use
cargo update -p unicode-ident@1.0.23 --precise ver
where `ver` is the latest version of `unicode-ident` supporting rustc 1.68.2
++++

rust ci: 5m51.083s
2026-02-10 20:45:00.175Z error: ExecNonZeroExitStatus
/home/runner/work/tigerbeetle/tigerbeetle/src/shell.zig:569:42: 0x1307b57 in exec_inner (scripts)
        .Exited => |code| if (code != 0) return error.ExecNonZeroExitStatus,
```

This is just a quick fix to unbreak CI.