### PR TITLE
rust: remove syn from testing dependency tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         include:
           - { os: 'ubuntu-latest',  language: 'dotnet',  language_version: '8.0.x' }
           - { os: 'ubuntu-latest',  language: 'go',      language_version: '1.21'  }
-          - { os: 'ubuntu-latest',  language: 'rust',    language_version: '1.71'  }
+          - { os: 'ubuntu-latest',  language: 'rust',    language_version: '1.68'  }
           - { os: 'ubuntu-latest',  language: 'rust',    language_version: 'stable' }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '11'    }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '21'    }

--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -28,4 +28,4 @@ anyhow = "1.0.93"
 
 [dev-dependencies]
 anyhow = "1.0.93"
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["executor"] }

--- a/src/clients/rust/samples/basic/Cargo.toml
+++ b/src/clients/rust/samples/basic/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["executor"] }
 tigerbeetle.path = "../.."

--- a/src/clients/rust/samples/two-phase-many/Cargo.toml
+++ b/src/clients/rust/samples/two-phase-many/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 tokio.version = "=1.38.1"
-tokio.features = ["macros", "rt-multi-thread"]
+tokio.features = ["rt-multi-thread"]
 tigerbeetle.path = "../.."

--- a/src/clients/rust/samples/two-phase-many/src/main.rs
+++ b/src/clients/rust/samples/two-phase-many/src/main.rs
@@ -45,8 +45,15 @@ async fn assert_account_balances(
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(main_async())
+}
+
+async fn main_async() -> Result<(), Box<dyn std::error::Error>> {
     let port = std::env::var("TB_ADDRESS").unwrap_or_else(|_| "3000".to_string());
     let client = tb::Client::new(0, &port)?;
 

--- a/src/clients/rust/samples/two-phase/Cargo.toml
+++ b/src/clients/rust/samples/two-phase/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 tokio.version = "=1.38.1"
-tokio.features = ["macros", "rt-multi-thread"]
+tokio.features = ["rt-multi-thread"]
 tigerbeetle.path = "../.."

--- a/src/clients/rust/samples/two-phase/src/main.rs
+++ b/src/clients/rust/samples/two-phase/src/main.rs
@@ -1,7 +1,14 @@
 use tigerbeetle as tb;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(main_async())
+}
+
+async fn main_async() -> Result<(), Box<dyn std::error::Error>> {
     let port = std::env::var("TB_ADDRESS").unwrap_or_else(|_| "3000".to_string());
     let client = tb::Client::new(0, &port)?;
 

--- a/src/clients/rust/samples/walkthrough/Cargo.toml
+++ b/src/clients/rust/samples/walkthrough/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["executor"] }
 tigerbeetle.path = "../.."

--- a/src/testing/vortex/rust_driver/Cargo.toml
+++ b/src/testing/vortex/rust_driver/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 tigerbeetle.path = "../../../clients/rust"
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["executor"] }
 anyhow = "1.0.93"


### PR DESCRIPTION
syn (proc macros) is a particularly heavy dep, and we don't _really_ need it.