### PR TITLE
tb_client: Set stack size to 512KiB

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -23,7 +23,9 @@ const Message = MessagePool.Message;
 const Packet = @import("packet.zig").Packet;
 const Signal = @import("signal.zig").Signal;
 
-const io_thread_stack_size = 512 * 1024;
+const KiB = stdx.KiB;
+
+const io_thread_stack_size = 512 * KiB;
 
 pub const InitParameters = extern struct {
     cluster_id: u128,

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -23,6 +23,8 @@ const Message = MessagePool.Message;
 const Packet = @import("packet.zig").Packet;
 const Signal = @import("signal.zig").Signal;
 
+const io_thread_stack_size = 512 * 1024;
+
 pub const InitParameters = extern struct {
     cluster_id: u128,
     client_id: u128,
@@ -351,7 +353,11 @@ pub fn ContextType(
             context.client.register(client_register_callback, @intFromPtr(context));
 
             log.debug("{}: init: spawning thread", .{context.client_id});
-            context.thread = std.Thread.spawn(.{}, Context.io_thread, .{context}) catch |err| {
+            context.thread = std.Thread.spawn(
+                .{ .stack_size = io_thread_stack_size },
+                Context.io_thread,
+                .{context},
+            ) catch |err| {
                 log.err("{}: failed to spawn thread: {s}", .{
                     context.client_id,
                     @errorName(err),


### PR DESCRIPTION
tb_client creates a background thread to pump I/O. This is an unfortunately heavy imposition on the client's process. We should be as intentional as we can about the resources that thread eats up.

Default stack sizes tend to be large and inconsistent across languages and platforms. I haven't looked exactly at what stack sizes we're getting currently, but it could be 8MiB or more depending on platform.

This uses 512KiB which is hopefully more than we need, but I have only done the most basic smoke testing, and its hard to estimate how much stack is actually needed.