### PR TITLE
tracing: WAF counter.

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -798,6 +798,23 @@ pub fn CompactionType(
                 compaction.counters.dropped,
             });
 
+            compaction.grid.trace.count(
+                .{ .compaction_values_physical = .{
+                    .tree = @enumFromInt(compaction.tree.config.id),
+                } },
+                compaction.counters.out,
+            );
+            if (compaction.level_b == 0) {
+                if (compaction.table_info_a.? == .immutable) {
+                    compaction.grid.trace.count(
+                        .{ .compaction_values_logical = .{
+                            .tree = @enumFromInt(compaction.tree.config.id),
+                        } },
+                        compaction.table_info_a.?.immutable.len,
+                    );
+                }
+            }
+
             // Mark the immutable table as flushed, if we were compacting into level 0.
             if (compaction.level_b == 0) {
                 assert(!compaction.tree.table_immutable.mutability.immutable.flushed);

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -107,7 +107,7 @@ const packet_count_max = stdx.div_ceil(
 comptime {
     // Sanity-check:
     assert(packet_count_max > 0);
-    assert(packet_count_max < 256);
+    assert(packet_count_max < 512);
 }
 
 pub const StatsD = struct {


### PR DESCRIPTION
This PR introduces counters that can be used to calculate LSM write amplification. 
It records the logical values that arrive in the immutable table (i.e., before it is flushed to disk) as well as the values that are actually written to disk and stored in the LSM.
