### PR TITLE
message_bus: gauge metrics at the same cadence as they are emitted

### DIFF
--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -264,7 +264,9 @@ pub fn MessageBusType(comptime IO: type) type {
             assert(bus.process == .replica);
             bus.tick_connect();
             bus.tick_accept(); // Only replicas accept connections from other replicas and clients.
+        }
 
+        pub fn trace_gauge(bus: *MessageBus) void {
             if (bus.trace) |trace| {
                 var counts = std.enums.EnumArray(std.meta.Tag(vsr.Peer), u32).initFill(0);
                 for (bus.connections) |*connection| {

--- a/src/testing/cluster/message_bus.zig
+++ b/src/testing/cluster/message_bus.zig
@@ -54,6 +54,8 @@ pub const MessageBus = struct {
         // so we don't assign bus.* to undefined here.
     }
 
+    pub fn trace_gauge(_: *MessageBus) void {}
+
     pub fn listen(_: *MessageBus) !void {}
 
     pub fn tick(_: *MessageBus) void {}

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3924,6 +3924,8 @@ pub fn ReplicaType(
                 self.superblock.working.vsr_state.checkpoint.manifest_block_count,
             );
 
+            self.message_bus.trace_gauge();
+
             self.trace.emit_metrics();
         }
 


### PR DESCRIPTION
The connection-tracking that we do at the MessageBus level for metrics (added recently in https://github.com/tigerbeetle/tigerbeetle/pull/3484), we do that every tick (10ms), while metrics at the are emitted by the replica every 10 seconds.
```
                .trace_emit_timeout = Timeout{
                    .name = "trace_emit_timeout",
                    .id = replica_index,
                    .after = 10_000 / constants.tick_ms,
                },
```

We now track the connections at the same cadence as they are committed.