### PR TITLE
Reapply "ci: Bump Rust version to 1.71"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         include:
           - { os: 'ubuntu-latest',  language: 'dotnet',  language_version: '8.0.x' }
           - { os: 'ubuntu-latest',  language: 'go',      language_version: '1.21'  }
-          - { os: 'ubuntu-latest',  language: 'rust',    language_version: '1.68'  }
+          - { os: 'ubuntu-latest',  language: 'rust',    language_version: '1.71'  }
           - { os: 'ubuntu-latest',  language: 'rust',    language_version: 'stable' }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '11'    }
           - { os: 'ubuntu-latest',  language: 'java',    language_version: '21'    }


### PR DESCRIPTION
This reverts commit e37b4edec1ce2cb22e86f95ad824547494c4b4f0.

https://github.com/rust-lang/futures-rs/pull/2989
https://github.com/tigerbeetle/tigerbeetle/pull/3515#issuecomment-3883818502