### PR TITLE
Vortex: Disable "lose" network faults

### DIFF
--- a/src/testing/vortex/constants.zig
+++ b/src/testing/vortex/constants.zig
@@ -5,10 +5,10 @@ pub const vsr = @import("../../constants.zig");
 
 pub const vortex = struct {
     pub const cluster_id = 0;
-    pub const connections_count_max = @divFloor(
-        constants.vsr.clients_max,
-        constants.vsr.replicas_max,
-    );
+    // Maximum number of connections *per replica*.
+    // -1 since replicas don't connect to themselves.
+    // +1 for the single driver/client.
+    pub const connections_count_max = (vsr.replicas_max - 1) + 1;
 
     // We allow the cluster to not make progress processing requests for this amount of time.
     // After that it's considered a test failure.

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -34,19 +34,17 @@ const Faults = struct {
     };
 
     delay: ?Delay = null,
-    lose: ?Ratio = null,
     corrupt: ?Ratio = null,
 
     // Others not implemented: duplication, reordering, rate
 
     pub fn heal(faults: *Faults) void {
         faults.delay = null;
-        faults.lose = null;
         faults.corrupt = null;
     }
 
     pub fn is_healed(faults: *const Faults) bool {
-        return faults.delay == null and faults.lose == null and faults.corrupt == null;
+        return faults.delay == null and faults.corrupt == null;
     }
 };
 
@@ -128,18 +126,6 @@ const Pipe = struct {
         if (pipe.recv_size == 0) {
             // Zero bytes means EOF.
             return pipe.connection.try_close();
-        }
-
-        if (pipe.connection.network.faults.lose) |lose| {
-            if (pipe.connection.network.prng.chance(lose)) {
-                log.debug("losing {d} bytes ({d},{d})", .{
-                    pipe.recv_size,
-                    pipe.connection.replica_index,
-                    pipe.connection.connection_index,
-                });
-                pipe.recv();
-                return;
-            }
         }
 
         if (pipe.connection.network.faults.corrupt) |corrupt| {

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -333,7 +333,6 @@ const Supervisor = struct {
                     replica_pause,
                     replica_resume,
                     network_delay,
-                    network_lose,
                     network_corrupt,
                     network_heal,
                     quiesce,
@@ -346,7 +345,6 @@ const Supervisor = struct {
                     .replica_pause = if (running_replicas.len > 0) 3 else 0,
                     .replica_resume = if (paused_replicas.len > 0) 10 else 0,
                     .network_delay = if (supervisor.network.faults.delay == null) 3 else 0,
-                    .network_lose = if (supervisor.network.faults.lose == null) 3 else 0,
                     .network_corrupt = if (supervisor.network.faults.corrupt == null) 3 else 0,
                     .network_heal = if (!supervisor.network.faults.is_healed()) 10 else 0,
                     .quiesce = if (faulty_replica_count > 0 or
@@ -385,11 +383,6 @@ const Supervisor = struct {
                             .jitter_ms = @min(time_ms, 50),
                         };
                         log.info("injecting network delays: {any}", .{supervisor.network.faults});
-                    },
-                    .network_lose => {
-                        supervisor.network.faults.lose =
-                            ratio(supervisor.prng.range_inclusive(u8, 1, 10), 100);
-                        log.info("injecting network loss: {any}", .{supervisor.network.faults});
                     },
                     .network_corrupt => {
                         supervisor.network.faults.corrupt =


### PR DESCRIPTION
I ran a version of this fix in CFO over the weekend w/o hitting a liveness bug.

### Bug

The vortex liveness bug has two parts:
1. An [asymmetrically-partitioned primary](https://github.com/tigerbeetle/tigerbeetle/pull/3528) which can't receive requests prevents the cluster from making progress, but primary also never abdicates.
2. But vortex doesn't implement asymmetric partitions!

So what is preventing the Vortex's primary from receiving requests?

Consider this sequence of events:

1. Client sends a large (~1MiB) request, to primary.
2. Primary prepares the request...
3. Client retries request (which is still preparing/committing), to replica `X` (where `X` may be either primary or backup).
4. Faulty network truncates the request to `X`. The whole header arrives, but not all of the body.
5. Primary commits + replies to the request.

(Or this can happen via request hedging instead of retries).

At this point:
- Client doesn't need to retry that request anymore.
- `X`'s message buffer has the request's header at the front, but not the whole body. It won't dequeue that message until it has received `header.size` bytes (so that it can check `checksum_body`).
- And if the client now switches to smaller messages, it can take a very long time to hit that. In the mean time, that particular connection is effectively blocked, ignoring incoming messages.
- This same bug can also impact replica-replica connections.
- If it affects too many of the primary's connections simultaneously, then the primary is "asymmetrically partitioned".

### Fix

Remove the truncation ("lose") fault from vortex's networking.

I know we try to ignore TCP's guarantees as much as possible, but I think in this case it is alright. Eventually we may want to buffer messages independently, for a UDP-based transport, to avoid head-of-line blocking. But implementing it now wouldn't actually benefit us while we are on TCP.

### Also

The connection limit change is unrelated.