### PR TITLE
k-way: exploit composite keys with prefix optimization.

### DIFF
--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -76,6 +76,10 @@ pub fn CompositeKeyType(comptime Field: type) type {
             return if (Field == void) {} else @truncate(key >> 64);
         }
 
+        pub inline fn key_suffix(key: Key) u64 {
+            return @truncate(key);
+        }
+
         pub inline fn tombstone(value: *const CompositeKey) bool {
             assert(value.padding == 0);
             return (value.timestamp & tombstone_bit) != 0;

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -25,10 +25,16 @@ const maybe = stdx.maybe;
 const math = std.math;
 const mem = std.mem;
 
+const composite_key = @import("composite_key.zig");
 const Direction = @import("../direction.zig").Direction;
 const Pending = error{Pending};
 
-pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) type {
+pub fn TournamentTreeType(
+    comptime Key: type,
+    comptime Value: type,
+    contestants_max: comptime_int,
+) type {
+    // TODO: we could just use the prefix when it is a composite key.
     return struct {
         loser_keys: [node_count_max]Key align(64),
         loser_ids: [node_count_max]u32 align(64),
@@ -163,7 +169,21 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
 
                 const opp_key = tree.loser_keys[idx];
                 const opp_id = tree.loser_ids[idx];
-                const new_wins = beats(new_key, new_id, opp_key, opp_id, direction);
+                const new_wins = new_wins: {
+                    if (comptime composite_key.is_composite_key(Value) and @FieldType(Value, "field") != void) {
+                        const new_prefix = Value.key_prefix(new_key);
+                        const opp_prefix = Value.key_prefix(opp_key);
+                        if (new_prefix == opp_prefix) {
+                            @branchHint(.cold);
+                            const new_suffix = Value.key_suffix(new_key);
+                            const opp_suffix = Value.key_suffix(opp_key);
+                            break :new_wins beats(new_suffix, new_id, opp_suffix, opp_id, direction);
+                        }
+                        break :new_wins beats(new_prefix, new_id, opp_prefix, opp_id, direction);
+                    } else {
+                        break :new_wins beats(new_key, new_id, opp_key, opp_id, direction);
+                    }
+                };
 
                 tree.loser_keys[idx] = stdx.branchless_select(Key, new_wins, opp_key, new_key);
                 tree.loser_ids[idx] = stdx.branchless_select(u32, new_wins, opp_id, new_id);
@@ -182,7 +202,7 @@ pub fn TournamentTreeType(comptime Key: type, contestants_max: comptime_int) typ
         /// In ascending mode, sentinel_key (maxInt) naturally loses on `<` so no
         /// explicit sentinel checks are needed. In descending mode, maxInt would
         /// incorrectly "win" on `>`, so explicit sentinel checks are required.
-        inline fn beats(a_key: Key, a_id: u32, b_key: Key, b_id: u32, direction: Direction) bool {
+        inline fn beats(a_key: anytype, a_id: u32, b_key: anytype, b_id: u32, direction: Direction) bool {
             const id_lt: u1 = @intFromBool(a_id < b_id);
             const keys_eq: u1 = @intFromBool(a_key == b_key);
             const eq_and_id_wins: u1 = keys_eq & id_lt;
@@ -225,7 +245,7 @@ pub fn KWayMergeIteratorType(
         key_popped: ?Key,
         tree: ?Tree,
 
-        const Tree = TournamentTreeType(Key, options.streams_max);
+        const Tree = TournamentTreeType(Key, Value, options.streams_max);
         const KWayMergeIterator = @This();
 
         pub fn init(

--- a/src/lsm/k_way_merge.zig
+++ b/src/lsm/k_way_merge.zig
@@ -25,14 +25,15 @@ const maybe = stdx.maybe;
 const math = std.math;
 const mem = std.mem;
 
-const composite_key = @import("composite_key.zig");
 const Direction = @import("../direction.zig").Direction;
 const Pending = error{Pending};
 
 pub fn TournamentTreeType(
     comptime Key: type,
-    comptime Value: type,
     contestants_max: comptime_int,
+    /// `void` for standard comparison, or a type with
+    /// `key_prefix(Key)` and `key_suffix(Key)` for prefix-key optimization.
+    comptime CompositeKey: type,
 ) type {
     // TODO: we could just use the prefix when it is a composite key.
     return struct {
@@ -170,14 +171,20 @@ pub fn TournamentTreeType(
                 const opp_key = tree.loser_keys[idx];
                 const opp_id = tree.loser_ids[idx];
                 const new_wins = new_wins: {
-                    if (comptime composite_key.is_composite_key(Value) and @FieldType(Value, "field") != void) {
-                        const new_prefix = Value.key_prefix(new_key);
-                        const opp_prefix = Value.key_prefix(opp_key);
+                    if (CompositeKey != void) {
+                        const new_prefix = CompositeKey.key_prefix(new_key);
+                        const opp_prefix = CompositeKey.key_prefix(opp_key);
                         if (new_prefix == opp_prefix) {
                             @branchHint(.cold);
-                            const new_suffix = Value.key_suffix(new_key);
-                            const opp_suffix = Value.key_suffix(opp_key);
-                            break :new_wins beats(new_suffix, new_id, opp_suffix, opp_id, direction);
+                            const new_suffix = CompositeKey.key_suffix(new_key);
+                            const opp_suffix = CompositeKey.key_suffix(opp_key);
+                            break :new_wins beats(
+                                new_suffix,
+                                new_id,
+                                opp_suffix,
+                                opp_id,
+                                direction,
+                            );
                         }
                         break :new_wins beats(new_prefix, new_id, opp_prefix, opp_id, direction);
                     } else {
@@ -202,7 +209,13 @@ pub fn TournamentTreeType(
         /// In ascending mode, sentinel_key (maxInt) naturally loses on `<` so no
         /// explicit sentinel checks are needed. In descending mode, maxInt would
         /// incorrectly "win" on `>`, so explicit sentinel checks are required.
-        inline fn beats(a_key: anytype, a_id: u32, b_key: anytype, b_id: u32, direction: Direction) bool {
+        inline fn beats(
+            a_key: anytype,
+            a_id: u32,
+            b_key: anytype,
+            b_id: u32,
+            direction: Direction,
+        ) bool {
             const id_lt: u1 = @intFromBool(a_id < b_id);
             const keys_eq: u1 = @intFromBool(a_key == b_key);
             const eq_and_id_wins: u1 = keys_eq & id_lt;
@@ -245,7 +258,11 @@ pub fn KWayMergeIteratorType(
         key_popped: ?Key,
         tree: ?Tree,
 
-        const Tree = TournamentTreeType(Key, Value, options.streams_max);
+        const composite_key = @import("composite_key.zig");
+        // Composite keys enable a prefix optimization.
+        const CompositeKey = if (composite_key.is_composite_key(Value) and
+            @FieldType(Value, "field") != void) Value else void;
+        const Tree = TournamentTreeType(Key, options.streams_max, CompositeKey);
         const KWayMergeIterator = @This();
 
         pub fn init(

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -6,6 +6,7 @@ const stdx = @import("stdx");
 const Bench = @import("../testing/bench.zig");
 const Pending = error{Pending};
 const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
+const CompositeKeyType = @import("composite_key.zig").CompositeKeyType;
 
 const streams_count_max = 32;
 const repetitions: usize = 32;
@@ -68,9 +69,6 @@ test "benchmark: k-way-merge" {
     var duration_element = duration_streams;
     duration_element.ns /= (streams_count * stream_length * streams.len);
 
-    bench.report("{} total", .{
-        duration_streams,
-    });
     bench.report("{} per element", .{
         duration_element,
     });
@@ -82,9 +80,9 @@ pub fn prepare_streams(
     arena: std.mem.Allocator,
     streams_count: usize,
     stream_length: usize,
-) !struct { KWayMergeContextType(Value), []Value } {
+) !struct { KWayMergeContextType(Value, Value.key_from_value), []Value } {
     var streams = try arena.alignedAlloc(Value, 64, streams_count * stream_length);
-    var context: KWayMergeContextType(Value) = .{
+    var context: KWayMergeContextType(Value, Value.key_from_value) = .{
         .streams = undefined,
         .streams_count = @intCast(streams_count),
     };
@@ -107,7 +105,7 @@ pub fn prepare_streams(
     return .{ context, output };
 }
 
-fn KWayMergeContextType(comptime Value: type) type {
+fn KWayMergeContextType(comptime Value: type, comptime key_from_value: fn (*const Value) callconv(.@"inline") Value.Key) type {
     return struct {
         const Context = @This();
 
@@ -117,7 +115,7 @@ fn KWayMergeContextType(comptime Value: type) type {
         fn stream_peek(context: *const Context, stream_index: u32) Pending!?Value.Key {
             const stream = context.streams[stream_index];
             if (stream.len == 0) return null;
-            return stream[0].key;
+            return key_from_value(&stream[0]);
         }
 
         fn stream_pop(context: *Context, stream_index: u32) Value {
@@ -130,7 +128,7 @@ fn KWayMergeContextType(comptime Value: type) type {
             const KWayIterator = KWayMergeIteratorType(Context, Value.Key, Value, .{
                 .streams_max = streams_count_max,
                 .deduplicate = false,
-            }, Value.key_from_value, stream_peek, stream_pop);
+            }, key_from_value, stream_peek, stream_pop);
 
             var k_way_iterator = KWayIterator.init(context, context.streams_count, .ascending);
 
@@ -139,6 +137,114 @@ fn KWayMergeContextType(comptime Value: type) type {
             }
         }
     };
+}
+
+const CompositeFieldMode = enum { distinct, same, mixed };
+
+fn prepare_composite_streams(
+    comptime CK: type,
+    comptime mode: CompositeFieldMode,
+    prng: *stdx.PRNG,
+    arena: std.mem.Allocator,
+    streams_count: usize,
+    stream_length: usize,
+) !struct { KWayMergeContextType(CK, CK.key_from_value), []CK } {
+    const tombstone_bit: u64 = 1 << 63;
+    var streams = try arena.alignedAlloc(CK, 64, streams_count * stream_length);
+    var context: KWayMergeContextType(CK, CK.key_from_value) = .{
+        .streams = undefined,
+        .streams_count = @intCast(streams_count),
+    };
+    const output = try arena.alignedAlloc(CK, 64, streams_count * stream_length);
+
+    for (0..streams_count) |stream_id| {
+        const stream_begin = stream_id * stream_length;
+        const stream_end = stream_begin + stream_length;
+        const stream = streams[stream_begin..stream_end];
+
+        for (stream) |*value| {
+            value.field = switch (mode) {
+                .distinct => @intCast(stream_id),
+                .same => 42,
+                // Random field per element from a small set: after sorting,
+                // each stream has groups of same-prefix elements with
+                // transition points at random positions, so the tournament
+                // tree comparison outcomes change unpredictably during merge.
+                .mixed => @intCast(prng.int(u1)),
+            };
+            value.timestamp = prng.int(u64) & ~tombstone_bit;
+            value.padding = 0;
+        }
+
+        std.mem.sort(CK, stream, {}, compositeKeyAsc(CK));
+
+        context.streams[stream_id] = stream;
+    }
+
+    return .{ context, output };
+}
+
+fn compositeKeyAsc(comptime CK: type) fn (void, CK, CK) bool {
+    return struct {
+        fn cmp(_: void, a: CK, b: CK) bool {
+            return CK.key_from_value(&a) < CK.key_from_value(&b);
+        }
+    }.cmp;
+}
+
+test "benchmark: composite k-way-merge" {
+    var bench: Bench = .init();
+    defer bench.deinit();
+
+    const streams_count: usize = @intCast(bench.parameter("streams_count", 4, 32));
+    const stream_length: usize = @intCast(bench.parameter("stream_length", 128, 8192));
+    assert(streams_count <= streams_count_max);
+
+    var prng = stdx.PRNG.from_seed(bench.seed);
+
+    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_instance.deinit();
+
+    const arena = arena_instance.allocator();
+
+    inline for (.{ u64, u128 }) |Field| {
+        const CompositeKey = CompositeKeyType(Field);
+
+        inline for (.{
+            CompositeFieldMode.distinct,
+            CompositeFieldMode.same,
+            CompositeFieldMode.mixed,
+        }) |mode| {
+            const pair = try prepare_composite_streams(
+                CompositeKey,
+                mode,
+                &prng,
+                arena,
+                streams_count,
+                stream_length,
+            );
+
+            var duration_samples: [repetitions]stdx.Duration = undefined;
+
+            for (&duration_samples) |*duration| {
+                var context, const output = pair;
+                bench.start();
+                context.merge(output);
+                duration.* = bench.stop();
+
+                assert(std.sort.isSorted(CompositeKey, output, {}, compositeKeyAsc(CompositeKey)));
+            }
+
+            const duration_total = bench.estimate(&duration_samples);
+            var duration_element = duration_total;
+            duration_element.ns /= (streams_count * stream_length);
+            bench.report("{s}/{s}: {} per element", .{
+                @typeName(Field),
+                @tagName(mode),
+                duration_element,
+            });
+        }
+    }
 }
 
 fn ValueType(comptime KeyType: type, comptime value_size: u32) type {

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -105,7 +105,10 @@ pub fn prepare_streams(
     return .{ context, output };
 }
 
-fn KWayMergeContextType(comptime Value: type, comptime key_from_value: fn (*const Value) callconv(.@"inline") Value.Key) type {
+fn KWayMergeContextType(
+    comptime Value: type,
+    comptime key_from_value: fn (*const Value) callconv(.@"inline") Value.Key,
+) type {
     return struct {
         const Context = @This();
 


### PR DESCRIPTION
This PR exploits the structure of composite keys by comparing the prefix first, if that is not enough, it follows by comparing the suffix.
It provides two main benefits:
(1) Fewer instructions are executed because padding (e.g., in `u128` keys) is ignored.
(2) When the prefixes differ, the comparison can short-circuit early, saving additional instructions.

This reduces P100 latency by ~ 5 ms in our default benchmark.  

This also adds a small micro-benchmark for k-way merge on composite keys.  