### PR TITLE
table_memory: exploit that composite keys are already sorted by time.

### DIFF
--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -26,6 +26,7 @@ const mem = std.mem;
 const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");
+const composite_key = @import("composite_key.zig");
 const binary_search = @import("binary_search.zig");
 const stdx = @import("stdx");
 const maybe = stdx.maybe;
@@ -595,9 +596,45 @@ pub fn TableMemoryType(comptime Table: type) type {
             assert(values.len == values_scratch.len);
             assert(offset <= values.len);
 
-            stdx.radix_sort(Key, Value, key_from_value, values[offset..], values_scratch[offset..]);
+            // This fast path assumes that timestamps are strictly monotonically increasing.
+            if (comptime composite_key.is_composite_key(Value) and
+                @FieldType(Value, "field") != void)
+            {
+                switch (@FieldType(Value, "field")) {
+                    // There are only timestamps, which are already sorted.
+                    void => {},
+                    else => {
+                        // We only need to sort by prefix assuming:
+                        // (1) the sort is stable.
+                        // (2) timestamps are ordered.
+                        const Prefix = @FieldType(Value, "field");
+                        comptime assert(@typeInfo(Prefix) == .int);
 
+                        const prefix_from_value = struct {
+                            inline fn prefix_from_value(key: *const Value) Prefix {
+                                return key.field;
+                            }
+                        }.prefix_from_value;
+                        stdx.radix_sort(
+                            Prefix,
+                            Value,
+                            prefix_from_value,
+                            values[offset..],
+                            values_scratch[offset..],
+                        );
+                    },
+                }
+            } else {
+                stdx.radix_sort(
+                    Key,
+                    Value,
+                    key_from_value,
+                    values[offset..],
+                    values_scratch[offset..],
+                );
+            }
             // Deduplicate values in streaming fashion.
+            // We still need to deduplicate because of Tombstones.
             var dedup_sink = DedupSink.init(values[offset..]);
             for (values[offset..]) |value| {
                 dedup_sink.push(value);


### PR DESCRIPTION
This PR leverages the fact that entries within a batch are already ordered by timestamp. 
Specifically, it relies on:
(1) The existing chronological order of timestamps.
(2) The stability of radix sort.  Because radix sort is stable, when two entries have the same prefix:
- Their relative order remains unchanged.
- The original timestamp ordering is preserved automatically.
- We don’t need to explicitly include the timestamp in the sort key.

This approach ignores the padding and avoids unnecessary memory copies during radix passes for `timestamps`.

This gives quite a nice performance boost from 604k to 634k TPS in our default benchmark.  

Edit: We still need to de-duplicate due to tombstones. The tombstone bit is masked out when computing the key, so a value and its tombstone generate the same key. As a result, the sequence is not strictly monotonic yet, and we need to eliminate tombstones.
