### PR TITLE
compaction: tighten interface

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -255,17 +255,14 @@ pub fn ResourcePoolType(comptime Grid: type) type {
     };
 }
 
-pub fn CompactionType(
-    comptime Table: type,
-    comptime Tree: type,
-    comptime Storage: type,
-) type {
+pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
     return struct {
         const Compaction = @This();
 
         const Grid = GridType(Storage);
         const ResourcePool = ResourcePoolType(Grid);
 
+        const Table = Tree.Table;
         const Manifest = ManifestType(Table, Storage);
         const TableInfo = TableInfoType(Table);
         const TableInfoReference = Manifest.TableInfoReference;

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -54,7 +54,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         const KeyRange = Manifest.KeyRange;
 
         const CompactionType = @import("compaction.zig").CompactionType;
-        pub const Compaction = CompactionType(Table, Tree, Storage);
+        pub const Compaction = CompactionType(Tree, Storage);
 
         pub const LookupMemoryResult = union(enum) {
             negative,


### PR DESCRIPTION
CompactionType currently relies on comptime Storage, Table and Tree types. However, Table can be obtained via Tree, so we can remove the explicit Table parameter.