### PR TITLE
vsr: promote some logs from debug -> info/warn

### DIFF
--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -338,7 +338,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
             ))[0..constants.journal_iops_write_max];
             errdefer allocator.free(write_headers_sectors);
 
-            log.debug("{}: slot_count={} size={} headers_size={} prepares_size={}", .{
+            log.info("{}: slot_count={} size={} headers_size={} prepares_size={}", .{
                 replica,
                 slot_count,
                 std.fmt.fmtIntSizeBin(write_ahead_log_zone_size),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1023,7 +1023,7 @@ pub fn ReplicaType(
             assert(!self.grid.blocks_missing.repairing_tables());
             self.assert_free_set_consistent();
 
-            log.debug("{}: state_machine_open_callback: sync_ops={}..{}", .{
+            log.info("{}: state_machine_open_callback: sync_ops={}..{}", .{
                 self.log_prefix(),
                 self.superblock.working.vsr_state.sync_op_min,
                 self.superblock.working.vsr_state.sync_op_max,
@@ -1456,7 +1456,7 @@ pub fn ReplicaType(
             };
             self.routing.view_change(self.view);
 
-            log.debug("{}: init: replica_count={} quorum_view_change={} quorum_replication={} " ++
+            log.info("{}: init: replica_count={} quorum_view_change={} quorum_replication={} " ++
                 "release={}", .{
                 self.log_prefix(),
                 self.replica_count,
@@ -2555,7 +2555,7 @@ pub fn ReplicaType(
                 });
                 return;
             }
-            log.debug("{}: on_start_view_change: view={} quorum received (replicas={b:0>6})", .{
+            log.info("{}: on_start_view_change: view={} quorum received (replicas={b:0>6})", .{
                 self.log_prefix(),
                 self.view,
                 self.start_view_change_from_all_replicas.bits,
@@ -2635,7 +2635,7 @@ pub fn ReplicaType(
                 .complete_valid => |*quorum_headers| quorum_headers.next().?.op,
             };
 
-            log.debug("{}: on_do_view_change: view={} quorum received", .{
+            log.info("{}: on_do_view_change: view={} quorum received", .{
                 self.log_prefix(),
                 self.view,
             });
@@ -2688,7 +2688,7 @@ pub fn ReplicaType(
                     }
                 } else unreachable;
 
-                log.mark.debug("{}: on_do_view_change: lagging primary; forfeiting " ++
+                log.mark.warn("{}: on_do_view_change: lagging primary; forfeiting " ++
                     "(view={}..{} checkpoint={}..{})", .{
                     self.log_prefix(),
                     self.view,
@@ -3667,7 +3667,7 @@ pub fn ReplicaType(
             self.primary_abdicate_timeout.reset();
             if (self.solo()) return;
 
-            log.debug("{}: on_primary_abdicate_timeout: abdicating (view={})", .{
+            log.warn("{}: on_primary_abdicate_timeout: abdicating (view={})", .{
                 self.log_prefix(),
                 self.view,
             });
@@ -3853,7 +3853,7 @@ pub fn ReplicaType(
                 };
                 assert(!self.grid.free_set.is_free(fault.block_address));
 
-                log.debug("{}: on_grid_scrub_timeout: fault found: " ++
+                log.warn("{}: on_grid_scrub_timeout: fault found: " ++
                     "block_address={} block_checksum={x:0>32} block_type={s}", .{
                     self.log_prefix(),
                     fault.block_address,
@@ -9976,7 +9976,7 @@ pub fn ReplicaType(
             assert(self.view_headers.command == .start_view);
             defer assert(self.log_view >= self.superblock.working.vsr_state.checkpoint.header.view);
 
-            log.debug(
+            log.info(
                 "{}: transition_to_normal_from_recovering_head_status: view={}..{} backup",
                 .{
                     self.log_prefix(),


### PR DESCRIPTION
The motivation for promoting logs from debug to info/warn here is to ensure the following are visible to the operators without them enabling debug logs:
  * Anomalous behaviour (like primary abdication, scrubber finding faulty block, replica forfeiting view change)
  * State transitions (like transition to recovering head status)
  * Events *within* an important or unexpected state like view change, state sync, initialization, repair (like receiving a SVC/DVC quorum in view change, the progress of state sync, parameters at startup)

Another principle is ensuring that the info logs aren't too noisy, so we avoid logging anything at the per-request level (like prepare, execute, compact). Repair would currently be too noisy to log, but eventually we also want to log WAL repairs.
