### PR TITLE
allocator: enable transparent huge pages on linux.

### DIFF
--- a/src/stdx/huge_page_allocator.zig
+++ b/src/stdx/huge_page_allocator.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+const page_allocator_vtable = std.heap.page_allocator.vtable;
+
+/// Like `std.heap.page_allocator`, but on Linux applies `MADV_HUGEPAGE` to
+/// allocated regions so that the kernel may back them with 2 MiB transparent
+/// huge pages, reducing TLB pressure for large allocations.
+///
+/// Only `alloc` is intercepted. `resize` and `remap` inherit the VMA flags
+/// (including `VM_HUGEPAGE`) set on the original mapping, so they need no
+/// additional `madvise` call.
+///
+/// On non-Linux targets this is identical to `std.heap.page_allocator`.
+pub const huge_page_allocator: Allocator = .{
+    .ptr = undefined,
+    .vtable = if (builtin.target.os.tag == .linux) &vtable else page_allocator_vtable,
+};
+
+const vtable: Allocator.VTable = .{
+    .alloc = alloc,
+    .resize = page_allocator_vtable.resize,
+    .remap = page_allocator_vtable.remap,
+    .free = page_allocator_vtable.free,
+};
+
+fn alloc(context: *anyopaque, n: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+    const ptr = page_allocator_vtable.alloc(context, n, alignment, ra) orelse return null;
+    // This is just a hint, so if it fails we can safely ignore it.
+    std.posix.madvise(@alignCast(ptr), n, std.posix.MADV.HUGEPAGE) catch {};
+    return ptr;
+}
+
+const testing = std.testing;
+
+test "huge_page_allocator: basic alloc and free" {
+    const slice = try huge_page_allocator.alloc(u8, 4096);
+    defer huge_page_allocator.free(slice);
+
+    @memset(slice, 0xab);
+    try testing.expectEqual(@as(u8, 0xab), slice[0]);
+}
+
+test "huge_page_allocator: large THP-eligible allocation" {
+    // 4 MiB — large enough for THP promotion on Linux.
+    const size = 4 * 1024 * 1024;
+    const slice = try huge_page_allocator.alloc(u8, size);
+    defer huge_page_allocator.free(slice);
+
+    @memset(slice, 0xcd);
+    try testing.expectEqual(@as(u8, 0xcd), slice[size - 1]);
+}
+
+test "huge_page_allocator: as ArenaAllocator backing" {
+    var arena = std.heap.ArenaAllocator.init(huge_page_allocator);
+    defer arena.deinit();
+
+    const alloc1 = try arena.allocator().alloc(u8, 1024);
+    const alloc2 = try arena.allocator().alloc(u8, 2048);
+    @memset(alloc1, 1);
+    @memset(alloc2, 2);
+    try testing.expectEqual(@as(u8, 1), alloc1[0]);
+    try testing.expectEqual(@as(u8, 2), alloc2[0]);
+}

--- a/src/stdx/huge_page_allocator.zig
+++ b/src/stdx/huge_page_allocator.zig
@@ -32,7 +32,7 @@ fn alloc(context: *anyopaque, n: usize, alignment: std.mem.Alignment, ra: usize)
     const ptr = page_allocator_vtable.alloc(context, n, alignment, ra) orelse return null;
     // This is just a hint, so if it fails we can safely ignore it.
     std.posix.madvise(@alignCast(ptr), n, std.posix.MADV.HUGEPAGE) catch {
-        log.warn("Transparent Huge Pages (TPH) are disabled.", .{});
+        log.warn("Transparent Huge Pages (THP) are disabled.", .{});
     };
     return ptr;
 }

--- a/src/stdx/huge_page_allocator.zig
+++ b/src/stdx/huge_page_allocator.zig
@@ -32,7 +32,7 @@ fn alloc(context: *anyopaque, n: usize, alignment: std.mem.Alignment, ra: usize)
     const ptr = page_allocator_vtable.alloc(context, n, alignment, ra) orelse return null;
     // This is just a hint, so if it fails we can safely ignore it.
     std.posix.madvise(@alignCast(ptr), n, std.posix.MADV.HUGEPAGE) catch {
-        log.warn("Transparent Huge Pages  (TPH) are disabled.", .{});
+        log.warn("Transparent Huge Pages (TPH) are disabled.", .{});
     };
     return ptr;
 }

--- a/src/stdx/huge_page_allocator.zig
+++ b/src/stdx/huge_page_allocator.zig
@@ -17,7 +17,7 @@ const page_allocator_vtable = std.heap.page_allocator.vtable;
 ///
 /// On non-Linux targets this is identical to `std.heap.page_allocator`.
 pub const huge_page_allocator: Allocator = .{
-    .ptr = undefined,
+    .ptr = std.heap.page_allocator.ptr,
     .vtable = if (builtin.target.os.tag == .linux) &vtable else page_allocator_vtable,
 };
 

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -16,6 +16,8 @@ pub const Snap = @import("testing/snaptest.zig").Snap;
 pub const ZipfianGenerator = @import("zipfian.zig").ZipfianGenerator;
 pub const ZipfianShuffled = @import("zipfian.zig").ZipfianShuffled;
 
+pub const huge_page_allocator = @import("huge_page_allocator.zig").huge_page_allocator;
+
 pub const aegis = @import("vendored/aegis.zig");
 pub const dbg = @import("debug.zig").dbg;
 pub const flags = @import("flags.zig").parse;
@@ -1144,6 +1146,7 @@ pub fn term_from_status(status: u32) std.process.Child.Term {
 }
 
 comptime {
+    _ = @import("huge_page_allocator.zig");
     _ = @import("vendored/aegis.zig");
     _ = @import("bit_set.zig");
     _ = @import("bounded_array.zig");

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -63,7 +63,7 @@ pub const std_options: std.Options = .{
 pub fn main() !void {
     if (builtin.os.tag == .windows) try vsr.multiversion.wait_for_parent_to_exit();
 
-    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena_instance = std.heap.ArenaAllocator.init(stdx.huge_page_allocator);
     defer arena_instance.deinit();
 
     // Arena is an implementation detail, all memory must be freed.


### PR DESCRIPTION
The default `page_allocator` we use to back our arena does not enable transparent huge pages (THP) on Linux. Unfortunately, this is suboptimal for TigerBeetle: we see high TLB pressure and many TLB load misses.

This PR introduces a minimal wrapper to enable huge pages on Linux. From what I’ve seen, it’s sufficient to set the appropriate flags on the initial mapping; subsequent remaps inherit those flags.

I tested this in the benchmark, and it now successfully allocates using THP (`--cache-grid=32GiB`).

Before 
```
AnonHugePages:         0 kB

load accepted = 607364 tx/s
batch latency p1   = 4 ms
batch latency p50  = 10 ms
batch latency p99  = 69 ms
batch latency p100 = 73 ms
```

After 
```
AnonHugePages:  35598336 kB

load accepted = 630465 tx/s
batch latency p1   = 4 ms
batch latency p50  = 9 ms
batch latency p99  = 65 ms
batch latency p100 = 67 ms
```