### PR TITLE
build: work around poor GitHub avilability harder

### DIFF
--- a/src/build/fetch.zig
+++ b/src/build/fetch.zig
@@ -48,10 +48,11 @@ pub fn main() !void {
         try std.fs.cwd().makePath(tmp_dir);
 
         const curl_output = path_join(arena, &.{ tmp_dir, url_file_name });
-        _ = try exec(arena, &(.{"curl"} ++ .{
-            "--location",       url,
+        _ = try exec(arena, &(.{
+            "curl",             "--retry-all-errors",
             "--retry",          "5",
             "--retry-max-time", "120",
+            "--location",       url,
             "--output",         curl_output,
         }));
         break :hash try exec(arena, &.{ zig, "fetch", curl_output });


### PR DESCRIPTION
```
+- fetch https://github.com/tigerbeetle/dependencies/releases/download/18.1.8/llvm-objcopy-x86_64-windows.zip failure
error: running { curl, --location, https://github.com/tigerbeetle/dependencies/releases/download/18.1.8/llvm-objcopy-x86_64-windows.zip, --retry, 5, --retry-max-time, 120, --output, C:\Users\runneradmin\AppData\Local\zig\tmp\d74870326b186bf5/llvm-objcopy-x86_64-windows.zip }: process.Child.Term{ .Exited = 52 }
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (52) Empty reply from server
```