### PR TITLE
compaction: remove write & read stall from the end of beat

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -97,14 +97,14 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         const ResourcePool = @This();
 
         const BlockRead = struct {
-            grid_read: Grid.Read,
-            counters: ?*CompactionCounters,
+            grid_read: Grid.Read = undefined,
+            counters: ?*CompactionCounters = null,
             block: *Block,
             pool: *ResourcePool,
         };
 
         const BlockWrite = struct {
-            grid_write: Grid.Write,
+            grid_write: Grid.Write = undefined,
             block: *Block,
             pool: *ResourcePool,
         };
@@ -515,8 +515,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             var level_a_value_block_iterator = compaction.level_a_value_block.iterator();
             while (level_a_value_block_iterator.next()) |block| {
                 if (block.stage == .read_value_block_done) {
-                    const value_count = Table.value_block_values_used(block.ptr).len;
-                    values_in_flight += value_count;
+                    values_in_flight += Table.value_block_values_used(block.ptr).len;
                 }
             }
             values_in_flight -= compaction.level_a_position.value;
@@ -524,8 +523,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             var level_b_value_block_iterator = compaction.level_b_value_block.iterator();
             while (level_b_value_block_iterator.next()) |block| {
                 if (block.stage == .read_value_block_done) {
-                    const value_count = Table.value_block_values_used(block.ptr).len;
-                    values_in_flight += value_count;
+                    values_in_flight += Table.value_block_values_used(block.ptr).len;
                 }
             }
 
@@ -1386,8 +1384,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .level_b => compaction.range_b.?.tables.get(level_b_index_block_next - 1),
             };
 
-            read.block = index_block;
-            read.pool = compaction.pool.?;
+            read.* = .{
+                .block = index_block,
+                .pool = compaction.pool.?,
+            };
 
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_index_block_callback },
@@ -1400,13 +1400,13 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
         fn read_index_block_callback(grid_read: *Grid.Read, index_block: BlockPtrConst) void {
             const read: *ResourcePool.BlockRead = @fieldParentPtr("grid_read", grid_read);
-            const pool: *ResourcePool = read.pool;
-            const block = read.block;
 
-            assert(block.stage == .read_index_block);
-            stdx.copy_disjoint(.exact, u8, block.ptr, index_block);
-            block.stage = .read_index_block_done;
-            return pool.iop_release(.{ .read = read });
+            assert(read.block.stage == .read_index_block);
+            assert(read.counters == null);
+
+            stdx.copy_disjoint(.exact, u8, read.block.ptr, index_block);
+            read.block.stage = .read_index_block_done;
+            return read.pool.iop_release(.{ .read = read });
         }
 
         fn read_value_block(
@@ -1451,9 +1451,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const value_block_checksum =
                 index_schema.value_checksums_used(index_block.ptr)[value_block_index];
 
-            read.block = value_block;
-            read.pool = compaction.pool.?;
-            read.counters = &compaction.counters;
+            read.* = .{
+                .block = value_block,
+                .pool = compaction.pool.?,
+                .counters = &compaction.counters,
+            };
 
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_value_block_callback },
@@ -1488,16 +1490,13 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
         fn read_value_block_callback(grid_read: *Grid.Read, value_block: BlockPtrConst) void {
             const read: *ResourcePool.BlockRead = @fieldParentPtr("grid_read", grid_read);
-            const pool: *ResourcePool = read.pool;
-            const block = read.block;
 
             read.counters.?.in += Table.value_block_values_used(value_block).len;
-            read.counters = null;
 
-            assert(block.stage == .read_value_block);
-            stdx.copy_disjoint(.exact, u8, block.ptr, value_block);
-            block.stage = .read_value_block_done;
-            return pool.iop_release(.{ .read = read });
+            assert(read.block.stage == .read_value_block);
+            stdx.copy_disjoint(.exact, u8, read.block.ptr, value_block);
+            read.block.stage = .read_value_block_done;
+            return read.pool.iop_release(.{ .read = read });
         }
 
         fn merge(compaction: *Compaction, cpu: *ResourcePool.CPU) void {
@@ -1697,8 +1696,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     if (compaction.level_a_position.value ==
                         Table.value_block_values_used(value_block.ptr).len)
                     {
-                        const popped_value_block = compaction.level_a_value_block.pop();
-                        assert(value_block == popped_value_block);
+                        const value_block_popped = compaction.level_a_value_block.pop();
+                        assert(value_block == value_block_popped);
 
                         compaction.level_a_position.value_block += 1;
                         compaction.level_a_position.value = 0;
@@ -1719,8 +1718,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                             assert(compaction.level_a_position.index_block == 1);
                             compaction.level_a_position.value_block = 0;
 
-                            const popped_index_block = compaction.level_a_index_block.pop().?;
-                            assert(popped_index_block == index_block);
+                            const index_block_popped = compaction.level_a_index_block.pop().?;
+                            assert(index_block_popped == index_block);
                             compaction.read_value_block_release_table(index_block.ptr);
                             index_block.stage = .free;
                             compaction.pool.?.block_release(index_block);
@@ -1741,8 +1740,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 if (compaction.level_b_position.value ==
                     Table.value_block_values_used(value_block.ptr).len)
                 {
-                    const popped_value_block = compaction.level_b_value_block.pop().?;
-                    assert(popped_value_block == value_block);
+                    const value_block_popped = compaction.level_b_value_block.pop().?;
+                    assert(value_block == value_block_popped);
 
                     compaction.level_b_position.value_block += 1;
                     compaction.level_b_position.value = 0;
@@ -1762,8 +1761,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         compaction.level_b_position.index_block += 1;
                         compaction.level_b_position.value_block = 0;
 
-                        const popped_index_block = compaction.level_b_index_block.pop().?;
-                        assert(popped_index_block == index_block);
+                        const index_block_popped = compaction.level_b_index_block.pop().?;
+                        assert(index_block_popped == index_block);
                         compaction.read_value_block_release_table(index_block.ptr);
                         index_block.stage = .free;
 
@@ -1802,8 +1801,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             block.stage = .write_value_block;
 
-            write.block = block;
-            write.pool = compaction.pool.?;
+            write.* = .{
+                .block = block,
+                .pool = compaction.pool.?,
+            };
 
             compaction.grid.create_block(write_block_callback, &write.grid_write, &write.block.ptr);
         }
@@ -1834,21 +1835,22 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             block.stage = .write_index_block;
 
-            write.block = block;
-            write.pool = compaction.pool.?;
+            write.* = .{
+                .block = block,
+                .pool = compaction.pool.?,
+            };
 
             compaction.grid.create_block(write_block_callback, &write.grid_write, &write.block.ptr);
         }
 
         fn write_block_callback(grid_write: *Grid.Write) void {
             const write: *ResourcePool.BlockWrite = @fieldParentPtr("grid_write", grid_write);
-            const pool: *ResourcePool = write.pool;
-            const block = write.block;
 
-            assert(block.stage == .write_value_block or block.stage == .write_index_block);
-            block.stage = .free;
-            pool.block_release(block);
-            return pool.iop_release(.{ .write = write });
+            assert(write.block.stage == .write_value_block or
+                write.block.stage == .write_index_block);
+            write.block.stage = .free;
+            write.pool.block_release(write.block);
+            return write.pool.iop_release(.{ .write = write });
         }
 
         // The three functions below are hot CPU loops doing the actual merging, TigerBeetle's data

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -89,26 +89,24 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         blocks_backing_storage: []Block,
         grid_reservation: ?Grid.Reservation = null,
 
+        iop_release_resume: ?struct {
+            ctx: *anyopaque,
+            callback: *const fn (*anyopaque) void,
+        } = null,
+
         const ResourcePool = @This();
 
         const BlockRead = struct {
             grid_read: Grid.Read,
+            counters: ?*CompactionCounters,
             block: *Block,
-            compaction: *anyopaque,
-
-            fn parent(read: *BlockRead, comptime Compaction: type) *Compaction {
-                return @as(*Compaction, @ptrCast(@alignCast(read.compaction)));
-            }
+            pool: *ResourcePool,
         };
 
         const BlockWrite = struct {
             grid_write: Grid.Write,
             block: *Block,
-            compaction: *anyopaque,
-
-            fn parent(write: *BlockWrite, comptime Compaction: type) *Compaction {
-                return @as(*Compaction, @ptrCast(@alignCast(write.compaction)));
-            }
+            pool: *ResourcePool,
         };
 
         /// While we don't currently have a CPU pool, we already treat CPU as a resource, by storing
@@ -191,6 +189,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         }
 
         pub fn reset(pool: *ResourcePool) void {
+            maybe(pool.iop_release_resume != null);
             pool.* = .{
                 .blocks = StackType(Block).init(.{
                     .capacity = pool.blocks.capacity(),
@@ -198,6 +197,8 @@ pub fn ResourcePoolType(comptime Grid: type) type {
                 }),
                 .blocks_backing_storage = pool.blocks_backing_storage,
             };
+            assert(pool.iop_release_resume == null);
+
             for (pool.blocks_backing_storage) |*block| {
                 block.* = .{
                     .ptr = block.ptr,
@@ -223,6 +224,20 @@ pub fn ResourcePoolType(comptime Grid: type) type {
 
         pub fn blocks_free(pool: *ResourcePool) u32 {
             return pool.blocks.count();
+        }
+
+        fn iop_release(pool: *@This(), kind: union(enum) {
+            read: *BlockRead,
+            write: *BlockWrite,
+            cpu: *CPU,
+        }) void {
+            switch (kind) {
+                .read => |read| pool.reads.release(read),
+                .write => |write| pool.writes.release(write),
+                .cpu => |cpu| pool.cpus.release(cpu),
+            }
+
+            if (pool.iop_release_resume) |options| options.callback(options.ctx);
         }
 
         fn block_acquire(pool: *@This()) ?*Block {
@@ -254,6 +269,16 @@ pub fn ResourcePoolType(comptime Grid: type) type {
         }
     };
 }
+
+pub const CompactionCounters = struct {
+    in: u64 = 0,
+    dropped: u64 = 0, // Tombstones.
+    out: u64 = 0,
+
+    fn consistent(counters: @This()) bool {
+        return counters.out == counters.in - counters.dropped;
+    }
+};
 
 pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
     return struct {
@@ -306,7 +331,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         stage: enum {
             inactive,
             beat,
-            beat_quota_done,
             paused,
         } = .inactive,
 
@@ -338,15 +362,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         ///
         /// Counters obey accounting equation of compaction:
         ///     out = in - dropped
-        counters: struct {
-            in: u64 = 0,
-            dropped: u64 = 0, // Tombstones.
-            out: u64 = 0,
-
-            fn consistent(counters: @This()) bool {
-                return counters.out == counters.in - counters.dropped;
-            }
-        } = .{},
+        counters: CompactionCounters = .{},
 
         /// Quotas track logical progress of compaction, determine pacing and must be deterministic.
         /// Quotas count consumed input values. That is, every time an output block is written,
@@ -378,8 +394,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         level_a_position: Position = .{},
         level_b_position: Position = .{},
 
-        /// Manifest log appends are queued up until bar_complete is explicitly called to ensure
-        /// they are applied deterministically relative to other concurrent compactions.
+        /// Manifest log appends are queued up until `half_bar_complete` is explicitly called
+        /// to ensure they are applied deterministically relative to other concurrent compactions.
         // Worst-case manifest updates:
         // See docs/about/internals/lsm.md "Compaction Table Overlap" for more detail.
         manifest_entries: stdx.BoundedArrayType(struct {
@@ -394,7 +410,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         table_builder_index_block: ?*ResourcePool.Block = null,
         table_builder_value_block: ?*ResourcePool.Block = null,
 
-        // The progress through immutable table is persisted throughout the bar.
+        // The progress through immutable table is persisted throughout the half bar.
         level_a_immutable_stage: enum { ready, merge, exhausted } = .ready,
 
         // Beat-scoped fields:
@@ -446,10 +462,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             .array = @divExact(constants.lsm_compaction_queue_read_max, 2),
         }) = .{ .buffer = undefined },
 
-        output_blocks: RingBufferType(void, .{
-            .array = constants.lsm_compaction_queue_write_max,
-        }) = .{ .buffer = undefined },
-
         pub fn init(tree: *Tree, grid: *Grid, level_b: u8) Compaction {
             assert(level_b < constants.lsm_levels);
 
@@ -474,7 +486,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         /// straightforward as calling counters.consistent() as we do at the end of the bar, since
         /// we may carry over multiple input value blocks, and an output value block over to the
         /// next beat.
-        ///
         ///
         /// Compute values_in, values_dropped, values_out, values_in_flight, and assert:
         ///       values_out + values_in_flight == values_in - values_dropped
@@ -503,13 +514,19 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             var level_a_value_block_iterator = compaction.level_a_value_block.iterator();
             while (level_a_value_block_iterator.next()) |block| {
-                values_in_flight += Table.value_block_values_used(block.ptr).len;
+                if (block.stage == .read_value_block_done) {
+                    const value_count = Table.value_block_values_used(block.ptr).len;
+                    values_in_flight += value_count;
+                }
             }
             values_in_flight -= compaction.level_a_position.value;
 
             var level_b_value_block_iterator = compaction.level_b_value_block.iterator();
             while (level_b_value_block_iterator.next()) |block| {
-                values_in_flight += Table.value_block_values_used(block.ptr).len;
+                if (block.stage == .read_value_block_done) {
+                    const value_count = Table.value_block_values_used(block.ptr).len;
+                    values_in_flight += value_count;
+                }
             }
 
             values_in_flight -= compaction.level_b_position.value;
@@ -520,7 +537,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         pub fn assert_between_bars(compaction: *const Compaction) void {
             assert(compaction.stage == .inactive);
             assert(compaction.idle());
-            assert(compaction.block_queues_empty_output());
             assert(compaction.block_queues_empty_input());
 
             assert(compaction.table_builder.state == .no_blocks);
@@ -533,10 +549,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             return compaction.pool == null and
                 compaction.callback == null and
                 compaction.quotas.beat_exhausted();
-        }
-
-        fn block_queues_empty_output(compaction: *const Compaction) bool {
-            return compaction.output_blocks.empty();
         }
 
         fn block_queues_empty_input(compaction: *const Compaction) bool {
@@ -554,7 +566,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         /// - execute move table optimization if range_b turns out to be empty.
         pub fn half_bar_commence(compaction: *Compaction, op: u64) u64 {
             assert(compaction.idle());
-            assert(compaction.block_queues_empty_output());
             assert(compaction.block_queues_empty_input());
 
             assert(compaction.stage == .inactive);
@@ -702,7 +713,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             }
 
             // Append the entries to the manifest update queue here and now if we're doing
-            // move table. They'll be applied later by bar_complete().
+            // move table. They'll be applied later by half_bar_complete().
             if (compaction.move_table) {
                 const snapshot_max = snapshot_max_for_table_input(compaction.op_min);
                 assert(compaction.table_info_a.?.disk.table_info.snapshot_max >= snapshot_max);
@@ -734,7 +745,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         /// tables that are now invisible.
         pub fn half_bar_complete(compaction: *Compaction) void {
             assert(compaction.idle());
-            assert(compaction.block_queues_empty_output());
             assert(compaction.block_queues_empty_input());
 
             assert(compaction.stage == .paused);
@@ -785,7 +795,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 assert(compaction.grid.free_set.is_released(table.table_info.address));
             }
 
-            log.debug("{s}:{}: bar_complete: " ++
+            log.debug("{s}:{}: half_bar_complete: " ++
                 "values_in={} values_out={} values_dropped={}", .{
                 compaction.tree.config.name,
                 compaction.level_b,
@@ -895,18 +905,22 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         ) void {
             assert(compaction.idle());
             assert(compaction.stage == .paused);
-            assert(compaction.block_queues_empty_output());
             // We may be carrying over some blocks from the previous beat.
             maybe(compaction.block_queues_empty_input());
 
             if (compaction.move_table) assert(compaction.quotas.half_bar_exhausted());
 
-            // Run the compaction up to completion of the bar quota, if possible.
+            // Run the compaction up to completion of the half bar quota, if possible.
             const values_remaining = (compaction.quotas.half_bar - compaction.quotas.half_bar_done);
 
             compaction.quotas.beat = @min(values_count, values_remaining);
             compaction.quotas.beat_done = 0;
             assert(compaction.quotas.beat <= compaction.quotas.half_bar);
+        }
+
+        pub fn compaction_iop_release_callback(ctx: *anyopaque) void {
+            const compaction: *Compaction = @alignCast(@ptrCast(ctx));
+            compaction.compaction_dispatch();
         }
 
         /// The entry point to the actual compaction work for the beat. Called by the forest.
@@ -918,7 +932,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             },
         ) enum { pending, ready } {
             assert(compaction.stage == .paused);
-            assert(compaction.block_queues_empty_output());
             // We may be carrying over some blocks from the previous beat.
             maybe(compaction.block_queues_empty_input());
 
@@ -926,7 +939,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             if (compaction.quotas.half_bar_exhausted()) {
                 if (compaction.quotas.half_bar > 0) {
-                    log.debug("{}: {s}:{}: beat_commence: half_bar quota={} fulfilled, done={}", .{
+                    log.debug("{}: {s}:{}: beat_commence: half bar quota={} fulfilled, done={}", .{
                         compaction.grid.superblock.replica_index.?,
                         compaction.tree.config.name,
                         compaction.level_b,
@@ -940,7 +953,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             if (compaction.quotas.beat_exhausted()) {
                 if (compaction.quotas.beat > 0) {
-                    log.debug("{s}:{}: beat_commence: beat quota={} fulfilled, done={}", .{
+                    log.debug("{}: {s}:{}: beat_commence: beat quota={} fulfilled, done={}", .{
+                        compaction.grid.superblock.replica_index.?,
                         compaction.tree.config.name,
                         compaction.level_b,
                         compaction.quotas.beat,
@@ -957,12 +971,18 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .level_b = compaction.level_b,
             } });
 
-            assert(options.pool.idle());
+            compaction.stage = .beat;
+            compaction.callback = options.callback;
+
+            assert(compaction.pool == null);
             assert(options.pool.grid_reservation != null);
+            assert(options.pool.iop_release_resume == null);
 
             compaction.pool = options.pool;
-            compaction.callback = options.callback;
-            compaction.stage = .beat;
+            compaction.pool.?.iop_release_resume = .{
+                .ctx = compaction,
+                .callback = compaction_iop_release_callback,
+            };
 
             compaction.compaction_dispatch();
             return .pending;
@@ -972,7 +992,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         // deterministic grid reservations, each compaction completes its own beat's work
         // asynchronously
         fn beat_complete(compaction: *Compaction) void {
-            assert(compaction.stage == .beat_quota_done);
+            assert(compaction.stage == .beat);
             switch (compaction.table_builder.state) {
                 .no_blocks => {},
                 .index_and_value_block => {
@@ -993,14 +1013,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 }
             }
 
-            assert(compaction.block_queues_empty_output());
             // We may be carrying over some input blocks to the next beat.
             maybe(compaction.block_queues_empty_input());
 
             compaction.assert_counter_consistency_between_beats();
-
-            assert(compaction.pool.?.idle());
-            maybe(compaction.pool.?.blocks_acquired() > 0);
 
             if (compaction.quotas.half_bar_exhausted()) {
                 assert(compaction.table_builder.state == .no_blocks);
@@ -1014,10 +1030,14 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             compaction.stage = .paused;
             compaction.callback = null;
+
+            assert(compaction.pool.?.iop_release_resume.?.ctx == @as(*anyopaque, compaction));
+            compaction.pool.?.iop_release_resume = null;
             compaction.pool = null;
 
             assert(compaction.idle());
-            assert(pool.idle());
+            maybe(!pool.idle());
+            maybe(pool.blocks_acquired() > 0);
             log.debug("{s}:{}: beat_complete: quota_beat_done={} quota_beat={} " ++
                 "quota_half_bar_done={} quota_half_bar={}", .{
                 compaction.tree.config.name,
@@ -1027,6 +1047,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 compaction.quotas.half_bar_done,
                 compaction.quotas.half_bar,
             });
+
+            compaction.grid.trace.stop(.{ .compact_beat = .{
+                .tree = @enumFromInt(compaction.tree.config.id),
+                .level_b = compaction.level_b,
+            } });
 
             callback(pool, compaction.tree.config.id, compaction.quotas.beat_done);
         }
@@ -1050,9 +1075,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         // may be carried over to the next beat.
         fn compaction_dispatch(compaction: *Compaction) void {
             switch (compaction.stage) {
-                .beat,
-                .beat_quota_done,
-                => {},
+                .beat => {},
                 .inactive,
                 .paused,
                 => unreachable,
@@ -1069,9 +1092,24 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 if (!progressed) break;
                 progressed = false;
 
-                if (compaction.stage == .beat_quota_done) {
-                    // Just wait for all in-flight jobs to complete.
-                    return compaction.compaction_dispatch_beat_quota_done();
+                if (compaction.quotas.beat_exhausted()) {
+                    _ = compaction.flush_table_builder_blocks();
+
+                    const flush_pending = switch (compaction.table_builder.state) {
+                        .index_and_value_block => compaction.quotas.half_bar_exhausted() or
+                            compaction.table_builder.value_block_full(),
+                        .index_block => compaction.quotas.half_bar_exhausted() or
+                            compaction.table_builder.index_block_full(),
+                        .no_blocks => false,
+                    };
+
+                    if (flush_pending) {
+                        assert(compaction.pool.?.writes.executing() > 0);
+                    } else {
+                        compaction.beat_complete();
+                    }
+
+                    return;
                 }
 
                 // To avoid deadlocks, allocate blocks for the table builder first.
@@ -1083,7 +1121,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         compaction.table_builder.set_index_block(block.ptr);
                         compaction.table_builder_index_block = block;
                     } else {
-                        assert(compaction.output_blocks.count > 0);
+                        assert(compaction.pool.?.writes.executing() > 0);
                     }
                 }
 
@@ -1095,7 +1133,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         compaction.table_builder.set_value_block(block.ptr);
                         compaction.table_builder_value_block = block;
                     } else {
-                        assert(compaction.output_blocks.count > 0);
+                        assert(compaction.pool.?.writes.executing() > 0);
                     }
                 }
 
@@ -1129,7 +1167,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                             progressed = true;
                         } else {
                             assert(compaction.level_a_index_block.count > 0 or
-                                compaction.output_blocks.count > 0);
+                                compaction.pool.?.writes.executing() > 0);
                         }
                     }
                 }
@@ -1149,7 +1187,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         progressed = true;
                     } else {
                         assert(compaction.level_b_index_block.count > 0 or
-                            compaction.output_blocks.count > 0);
+                            compaction.pool.?.writes.executing() > 0);
                     }
                 }
 
@@ -1177,7 +1215,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                                     progressed = true;
                                 } else {
                                     assert(compaction.level_a_value_block.count > 0 or
-                                        compaction.output_blocks.count > 0);
+                                        compaction.pool.?.writes.executing() > 0);
                                 }
                             }
                         } else {
@@ -1207,7 +1245,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                                 progressed = true;
                             } else {
                                 assert(compaction.level_b_value_block.count > 0 or
-                                    compaction.output_blocks.count > 0);
+                                    compaction.pool.?.writes.executing() > 0);
                             }
                         }
                     } else {
@@ -1235,14 +1273,13 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 const level_b_exhausted =
                     compaction.level_b_index_block.count == 0 and
                     compaction.level_b_value_block.count == 0;
-                const levels_exhausted = level_a_exhausted and level_b_exhausted;
 
-                assert(levels_exhausted == compaction.quotas.half_bar_exhausted());
+                assert(!level_a_exhausted or !level_b_exhausted);
+                assert(!compaction.quotas.beat_exhausted());
+                assert(!compaction.quotas.half_bar_exhausted());
 
                 if (compaction.table_builder.state == .index_and_value_block) {
-                    if (level_a_exhausted and level_b_exhausted) {
-                        assert(compaction.stage == .beat_quota_done);
-                    } else if ((level_a_exhausted or level_a_ready) and
+                    if ((level_a_exhausted or level_a_ready) and
                         (level_b_exhausted or level_b_ready) and
                         !compaction.table_builder.value_block_full())
                     {
@@ -1254,28 +1291,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     // Write value and index blocks. It is important for correctness that both the
                     // value block and index block are written together. Otherwise, we may end up
                     // overflowing the index block's capacity for value block addresses.
-                    if (compaction.output_blocks.spare_capacity() >= 2) {
-                        if (compaction.table_builder.value_block_full()) {
-                            assert(!compaction.output_blocks.full());
-                            const write = compaction.pool.?.writes.acquire().?;
-                            compaction.write_value_block(write, .{
-                                .address = compaction.grid.acquire(
-                                    compaction.pool.?.grid_reservation.?,
-                                ),
-                            });
-                            progressed = true;
-                        }
-
-                        if (compaction.table_builder.index_block_full()) {
-                            assert(!compaction.output_blocks.full());
-                            const write = compaction.pool.?.writes.acquire().?;
-                            compaction.write_index_block(write, .{
-                                .address = compaction.grid.acquire(
-                                    compaction.pool.?.grid_reservation.?,
-                                ),
-                            });
-                            progressed = true;
-                        }
+                    if (compaction.pool.?.writes.available() >= 2) {
+                        progressed = progressed or compaction.flush_table_builder_blocks();
                     }
                 }
             } else unreachable;
@@ -1283,8 +1300,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(!compaction.pool.?.idle());
         }
 
-        fn compaction_dispatch_beat_quota_done(compaction: *Compaction) void {
-            assert(compaction.stage == .beat_quota_done);
+        fn flush_table_builder_blocks(compaction: *Compaction) bool {
+            var progressed = false;
 
             if (compaction.table_builder.state == .index_and_value_block and
                 (compaction.table_builder.value_block_full() or
@@ -1299,13 +1316,14 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     value_block.stage = .free;
                     compaction.pool.?.block_release(value_block);
                 } else {
-                    if (!compaction.output_blocks.full()) {
-                        const write = compaction.pool.?.writes.acquire().?;
+                    if (compaction.pool.?.writes.acquire()) |write| {
                         compaction.write_value_block(write, .{
                             .address = compaction.grid.acquire(
                                 compaction.pool.?.grid_reservation.?,
                             ),
                         });
+                        progressed = true;
+
                         assert(compaction.table_builder.state == .index_block);
                         assert(compaction.table_builder_value_block == null);
                     }
@@ -1325,13 +1343,14 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     index_block.stage = .free;
                     compaction.pool.?.block_release(index_block);
                 } else {
-                    if (!compaction.output_blocks.full()) {
-                        const write = compaction.pool.?.writes.acquire().?;
+                    if (compaction.pool.?.writes.acquire()) |write| {
                         compaction.write_index_block(write, .{
                             .address = compaction.grid.acquire(
                                 compaction.pool.?.grid_reservation.?,
                             ),
                         });
+                        progressed = true;
+
                         assert(compaction.table_builder.state == .no_blocks);
                         assert(compaction.table_builder_value_block == null);
                         assert(compaction.table_builder_index_block == null);
@@ -1339,56 +1358,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 }
             }
 
-            if (compaction.output_blocks.count > 0) {
-                return;
-            }
-
-            switch (compaction.table_builder.state) {
-                .no_blocks => {},
-                .index_and_value_block => {
-                    assert(!compaction.table_builder.index_block_full());
-                    assert(!compaction.table_builder.value_block_full());
-                    assert(!compaction.quotas.half_bar_exhausted());
-                },
-                .index_block => {
-                    assert(!compaction.table_builder.index_block_full());
-                    assert(!compaction.quotas.half_bar_exhausted());
-                },
-            }
-
-            var level_a_value_block_iterator = compaction.level_a_value_block.iterator();
-            while (level_a_value_block_iterator.next()) |block| {
-                if (block.stage == .read_value_block) return;
-
-                assert(block.stage == .read_value_block_done);
-            }
-
-            var level_a_index_block_iterator = compaction.level_a_index_block.iterator();
-            while (level_a_index_block_iterator.next()) |block| {
-                if (block.stage == .read_index_block) return;
-
-                assert(block.stage == .read_index_block_done);
-            }
-
-            var level_b_value_block_iterator = compaction.level_b_value_block.iterator();
-            while (level_b_value_block_iterator.next()) |block| {
-                if (block.stage == .read_value_block) return;
-
-                assert(block.stage == .read_value_block_done);
-            }
-
-            var level_b_index_block_iterator = compaction.level_b_index_block.iterator();
-            while (level_b_index_block_iterator.next()) |block| {
-                if (block.stage == .read_index_block) return;
-
-                assert(block.stage == .read_index_block_done);
-            }
-
-            compaction.grid.trace.stop(.{ .compact_beat = .{
-                .tree = @enumFromInt(compaction.tree.config.id),
-                .level_b = compaction.level_b,
-            } });
-            compaction.beat_complete();
+            return progressed;
         }
 
         fn read_index_block(
@@ -1401,7 +1371,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 compaction.level_b_position.index_block +
                 @as(u32, @intCast(compaction.level_b_index_block.count));
 
-            assert(compaction.stage == .beat or compaction.stage == .beat_quota_done);
+            assert(compaction.stage == .beat);
             assert(index_block.stage == .read_index_block);
             switch (level) {
                 .level_a => assert(compaction.level_a_position.index_block == 0),
@@ -1415,8 +1385,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .level_a => compaction.table_info_a.?.disk,
                 .level_b => compaction.range_b.?.tables.get(level_b_index_block_next - 1),
             };
+
             read.block = index_block;
-            read.compaction = compaction;
+            read.pool = compaction.pool.?;
+
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_index_block_callback },
                 &read.grid_read,
@@ -1428,14 +1400,13 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
         fn read_index_block_callback(grid_read: *Grid.Read, index_block: BlockPtrConst) void {
             const read: *ResourcePool.BlockRead = @fieldParentPtr("grid_read", grid_read);
-            const compaction: *Compaction = read.parent(Compaction);
+            const pool: *ResourcePool = read.pool;
             const block = read.block;
-            compaction.pool.?.reads.release(read);
 
             assert(block.stage == .read_index_block);
             stdx.copy_disjoint(.exact, u8, block.ptr, index_block);
             block.stage = .read_index_block_done;
-            compaction.compaction_dispatch();
+            return pool.iop_release(.{ .read = read });
         }
 
         fn read_value_block(
@@ -1444,7 +1415,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             read: *ResourcePool.BlockRead,
             value_block: *ResourcePool.Block,
         ) void {
-            assert(compaction.stage == .beat or compaction.stage == .beat_quota_done);
+            assert(compaction.stage == .beat);
             assert(value_block.stage == .read_value_block);
             if (level == .level_a) assert(compaction.table_info_a.? == .disk);
 
@@ -1481,7 +1452,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 index_schema.value_checksums_used(index_block.ptr)[value_block_index];
 
             read.block = value_block;
-            read.compaction = compaction;
+            read.pool = compaction.pool.?;
+            read.counters = &compaction.counters;
+
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_value_block_callback },
                 &read.grid_read,
@@ -1515,15 +1488,16 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
         fn read_value_block_callback(grid_read: *Grid.Read, value_block: BlockPtrConst) void {
             const read: *ResourcePool.BlockRead = @fieldParentPtr("grid_read", grid_read);
-            const compaction: *Compaction = read.parent(Compaction);
+            const pool: *ResourcePool = read.pool;
             const block = read.block;
-            compaction.pool.?.reads.release(read);
+
+            read.counters.?.in += Table.value_block_values_used(value_block).len;
+            read.counters = null;
 
             assert(block.stage == .read_value_block);
             stdx.copy_disjoint(.exact, u8, block.ptr, value_block);
             block.stage = .read_value_block_done;
-            compaction.counters.in += Table.value_block_values_used(block.ptr).len;
-            compaction.compaction_dispatch();
+            return pool.iop_release(.{ .read = read });
         }
 
         fn merge(compaction: *Compaction, cpu: *ResourcePool.CPU) void {
@@ -1554,7 +1528,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         fn merge_callback(next_tick: *Grid.NextTick) void {
             const cpu: *ResourcePool.CPU = @fieldParentPtr("next_tick", next_tick);
             const compaction: *Compaction = cpu.parent(Compaction);
-            compaction.pool.?.cpus.release(cpu);
             assert(compaction.table_builder.state == .index_and_value_block);
 
             compaction.grid.trace.start(.{ .compact_beat_merge = .{
@@ -1645,7 +1618,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .tree = @enumFromInt(compaction.tree.config.id),
                 .level_b = compaction.level_b,
             } });
-            compaction.compaction_dispatch();
+            return compaction.pool.?.iop_release(.{ .cpu = cpu });
         }
 
         fn merge_inputs(compaction: *const Compaction) struct { ?[]const Value, ?[]const Value } {
@@ -1724,7 +1697,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     if (compaction.level_a_position.value ==
                         Table.value_block_values_used(value_block.ptr).len)
                     {
-                        _ = compaction.level_a_value_block.pop();
+                        const popped_value_block = compaction.level_a_value_block.pop();
+                        assert(value_block == popped_value_block);
 
                         compaction.level_a_position.value_block += 1;
                         compaction.level_a_position.value = 0;
@@ -1745,8 +1719,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                             assert(compaction.level_a_position.index_block == 1);
                             compaction.level_a_position.value_block = 0;
 
-                            const popped = compaction.level_a_index_block.pop().?;
-                            assert(popped == index_block);
+                            const popped_index_block = compaction.level_a_index_block.pop().?;
+                            assert(popped_index_block == index_block);
                             compaction.read_value_block_release_table(index_block.ptr);
                             index_block.stage = .free;
                             compaction.pool.?.block_release(index_block);
@@ -1767,7 +1741,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 if (compaction.level_b_position.value ==
                     Table.value_block_values_used(value_block.ptr).len)
                 {
-                    _ = compaction.level_b_value_block.pop().?;
+                    const popped_value_block = compaction.level_b_value_block.pop().?;
+                    assert(popped_value_block == value_block);
+
                     compaction.level_b_position.value_block += 1;
                     compaction.level_b_position.value = 0;
 
@@ -1786,8 +1762,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         compaction.level_b_position.index_block += 1;
                         compaction.level_b_position.value_block = 0;
 
-                        const popped = compaction.level_b_index_block.pop().?;
-                        assert(popped == index_block);
+                        const popped_index_block = compaction.level_b_index_block.pop().?;
+                        assert(popped_index_block == index_block);
                         compaction.read_value_block_release_table(index_block.ptr);
                         index_block.stage = .free;
 
@@ -1802,11 +1778,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             } else {
                 assert(compaction.level_b_position.value == 0); // Level B exhausted.
             }
-
-            if (compaction.quotas.beat_exhausted()) {
-                assert(compaction.stage == .beat);
-                compaction.stage = .beat_quota_done;
-            }
         }
 
         fn write_value_block(
@@ -1817,7 +1788,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const block = compaction.table_builder_value_block.?;
             assert(block.stage == .build_value_block);
             assert(compaction.table_builder.value_block == block.ptr);
-            assert(!compaction.output_blocks.full());
 
             compaction.counters.out += compaction.table_builder.value_count;
             compaction.table_builder.value_block_finish(.{
@@ -1830,11 +1800,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(compaction.table_builder.state == .index_block);
             compaction.table_builder_value_block = null;
 
-            compaction.output_blocks.push_assume_capacity({});
             block.stage = .write_value_block;
 
             write.block = block;
-            write.compaction = compaction;
+            write.pool = compaction.pool.?;
+
             compaction.grid.create_block(write_block_callback, &write.grid_write, &write.block.ptr);
         }
 
@@ -1846,7 +1816,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const block = compaction.table_builder_index_block.?;
             assert(block.stage == .build_index_block);
             assert(compaction.table_builder.index_block == block.ptr);
-            assert(!compaction.output_blocks.full());
 
             const table = compaction.table_builder.index_block_finish(.{
                 .cluster = compaction.grid.superblock.working.cluster,
@@ -1863,28 +1832,23 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .table = table,
             });
 
-            compaction.output_blocks.push_assume_capacity({});
             block.stage = .write_index_block;
 
             write.block = block;
-            write.compaction = compaction;
+            write.pool = compaction.pool.?;
+
             compaction.grid.create_block(write_block_callback, &write.grid_write, &write.block.ptr);
         }
 
         fn write_block_callback(grid_write: *Grid.Write) void {
             const write: *ResourcePool.BlockWrite = @fieldParentPtr("grid_write", grid_write);
-            const compaction: *Compaction = write.parent(Compaction);
+            const pool: *ResourcePool = write.pool;
             const block = write.block;
-            compaction.pool.?.writes.release(write);
 
             assert(block.stage == .write_value_block or block.stage == .write_index_block);
             block.stage = .free;
-            compaction.pool.?.block_release(block);
-
-            const popped = compaction.output_blocks.pop();
-            assert(popped != null);
-
-            compaction.compaction_dispatch();
+            pool.block_release(block);
+            return pool.iop_release(.{ .write = write });
         }
 
         // The three functions below are hot CPU loops doing the actual merging, TigerBeetle's data

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -224,7 +224,15 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
         progress: ?union(enum) {
             open: struct { callback: Callback },
-            checkpoint: struct { callback: Callback },
+            checkpoint: struct {
+                callback: Callback,
+                manifest_log_done: bool,
+                trees_done: bool,
+
+                fn all_done(progress: @This()) bool {
+                    return progress.trees_done and progress.manifest_log_done;
+                }
+            },
             compact: struct {
                 op: u64,
                 callback: Callback,
@@ -430,8 +438,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             assert(@as(usize, @intFromBool(first_beat)) + @intFromBool(last_half_beat) +
                 @intFromBool(half_beat) + @intFromBool(last_beat) <= 1);
 
-            log.debug("entering forest.compact() op={} constants.lsm_compaction_ops={} " ++
+            log.debug("{}: entering forest.compact() op={} constants.lsm_compaction_ops={} " ++
                 "first_beat={} last_half_beat={} half_beat={} last_beat={}", .{
+                forest.grid.superblock.replica_index.?,
                 op,
                 constants.lsm_compaction_ops,
                 first_beat,
@@ -458,7 +467,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             {
                 forest.progress.?.compact.manifest_log_done = true;
                 forest.progress.?.compact.trees_done = true;
-                forest.grid.on_next_tick(compact_finish_next_tick, &forest.next_tick);
+                forest.grid.on_next_tick(compact_finish_callback, &forest.next_tick);
                 return;
             }
 
@@ -475,13 +484,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             }
 
             forest.compact_trees_start();
-        }
-
-        fn compact_finish_next_tick(next_tick: *Grid.NextTick) void {
-            const forest: *Forest = @alignCast(
-                @fieldParentPtr("next_tick", next_tick),
-            );
-            forest.compact_finish();
         }
 
         /// Plans a half-bar's worth of compaction work across all the trees in the
@@ -690,13 +692,18 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             }
         }
 
+        fn compact_finish_callback(next_tick: *Grid.NextTick) void {
+            const forest: *Forest = @alignCast(@fieldParentPtr("next_tick", next_tick));
+            forest.compact_finish();
+        }
+
         fn compact_finish(forest: *Forest) void {
             assert(forest.progress.? == .compact);
             assert(forest.progress.?.compact.trees_done);
             assert(forest.progress.?.compact.manifest_log_done);
-            assert(forest.resource_pool.idle());
+            maybe(forest.resource_pool.idle());
             assert(forest.resource_pool.blocks_acquired() <=
-                compaction_block_count_beat_min);
+                compaction_block_count_beat_min + constants.lsm_compaction_iops_write_max);
 
             forest.verify_table_extents();
 
@@ -704,9 +711,24 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             const op = forest.progress.?.compact.op;
 
             const compaction_beat = op % constants.lsm_compaction_ops;
+
+            const first_beat = compaction_beat == 0;
+            const half_beat = compaction_beat == @divExact(constants.lsm_compaction_ops, 2);
             const last_half_beat = compaction_beat ==
                 @divExact(constants.lsm_compaction_ops, 2) - 1;
             const last_beat = compaction_beat == constants.lsm_compaction_ops - 1;
+
+            log.debug("{}: entering forest.compact_finish() op={} " ++
+                "constants.lsm_compaction_ops={} first_beat={} " ++
+                "last_half_beat={} half_beat={} last_beat={}", .{
+                forest.grid.superblock.replica_index.?,
+                op,
+                constants.lsm_compaction_ops,
+                first_beat,
+                last_half_beat,
+                half_beat,
+                last_beat,
+            });
 
             if (op < constants.lsm_compaction_ops or
                 forest.grid.superblock.working.vsr_state.op_compacted(op))
@@ -769,12 +791,40 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             return &forest.tree_for_id(tree_id).compactions[level_b];
         }
 
+        fn checkpoint_iop_release_callback(ctx: *anyopaque) void {
+            const forest: *Forest = @alignCast(@ptrCast(ctx));
+
+            if (forest.progress == null) return;
+            if (forest.progress.? != .checkpoint) return;
+            if (!forest.resource_pool.idle()) return;
+
+            assert(!forest.progress.?.checkpoint.trees_done);
+            forest.progress.?.checkpoint.trees_done = true;
+            forest.resource_pool.iop_release_resume = null;
+
+            if (forest.progress.?.checkpoint.all_done()) {
+                const callback = forest.progress.?.checkpoint.callback;
+                forest.progress = null;
+                callback(forest);
+            }
+        }
+
         pub fn checkpoint(forest: *Forest, callback: Callback) void {
             assert(forest.progress == null);
-            forest.grid.assert_only_repairing();
             forest.verify_table_extents();
 
-            forest.progress = .{ .checkpoint = .{ .callback = callback } };
+            forest.progress = .{ .checkpoint = .{
+                .callback = callback,
+                .trees_done = forest.resource_pool.idle(),
+                .manifest_log_done = false,
+            } };
+
+            if (!forest.progress.?.checkpoint.trees_done) {
+                forest.resource_pool.iop_release_resume = .{
+                    .ctx = forest,
+                    .callback = checkpoint_iop_release_callback,
+                };
+            }
 
             inline for (std.meta.fields(Grooves)) |field| {
                 @field(forest.grooves, field.name).assert_between_bars();
@@ -800,9 +850,14 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             forest.verify_table_extents();
             forest.verify_tables_recovered();
 
-            const callback = forest.progress.?.checkpoint.callback;
-            forest.progress = null;
-            callback(forest);
+            assert(!forest.progress.?.checkpoint.manifest_log_done);
+            forest.progress.?.checkpoint.manifest_log_done = true;
+
+            if (forest.progress.?.checkpoint.all_done()) {
+                const callback = forest.progress.?.checkpoint.callback;
+                forest.progress = null;
+                callback(forest);
+            }
         }
 
         pub fn tree_id_cast(tree_id: u16) TreeID {

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -793,9 +793,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
         fn checkpoint_iop_release_callback(ctx: *anyopaque) void {
             const forest: *Forest = @alignCast(@ptrCast(ctx));
+            assert(forest.progress.? == .checkpoint);
 
-            if (forest.progress == null) return;
-            if (forest.progress.? != .checkpoint) return;
             if (!forest.resource_pool.idle()) return;
 
             assert(!forest.progress.?.checkpoint.trees_done);

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -3,6 +3,7 @@ const testing = std.testing;
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
+const maybe = stdx.maybe;
 const constants = @import("../constants.zig");
 const fixtures = @import("../testing/fixtures.zig");
 const fuzz = @import("../testing/fuzz.zig");
@@ -144,7 +145,8 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
         scan_results: []Value,
         scan_results_count: u32,
         scan_results_model: []Value,
-        compaction_exhausted: bool = false,
+        checkpoint_grid_done: bool = false,
+        checkpoint_pool_done: bool = false,
         radix_buffer: ScratchMemory,
 
         pool: ResourcePool,
@@ -277,7 +279,23 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.manifest_log_open, .fuzzing);
         }
 
+        fn checkpoint_iop_release_callback(ctx: *anyopaque) void {
+            const env: *Environment = @alignCast(@ptrCast(ctx));
+            if (env.state != .grid_checkpoint) return;
+            if (!env.pool.idle()) return;
+
+            assert(!env.checkpoint_pool_done);
+            env.checkpoint_pool_done = true;
+
+            if (env.checkpoint_grid_done and env.checkpoint_pool_done) {
+                env.change_state(.grid_checkpoint, .superblock_checkpoint);
+            }
+        }
+
         pub fn compact(env: *Environment, op: u64, beats_remaining: u64) void {
+            maybe(!env.pool.idle());
+            maybe(env.pool.blocks_acquired() > 0);
+
             const half_bar = @divExact(constants.lsm_compaction_ops, 2);
             if (op < half_bar) return;
             const compaction_beat = op % constants.lsm_compaction_ops;
@@ -289,11 +307,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             const last_beat = compaction_beat == constants.lsm_compaction_ops - 1;
 
             if (last_beat or last_half_beat) assert(beats_remaining == 1);
-
-            assert(env.pool.idle());
-            if (first_beat or half_beat) {
-                assert(env.pool.blocks_acquired() == 0);
-            }
 
             var compactions_active: [constants.lsm_levels]*Tree.Compaction = undefined;
             var compactions_active_count: usize = 0;
@@ -323,15 +336,17 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 // The +1 is for imperfections in pacing our immutable table, which
                 // might cause us to overshoot by a single block (limited to 1 due
                 // to how the immutable table values are consumed.)
-                beat_value_blocks_max += stdx.div_ceil(
+                const beat_value_blocks = stdx.div_ceil(
                     compaction.quotas.beat,
                     Table.layout.block_value_count_max,
                 ) + 1;
-
-                beat_index_blocks_max += stdx.div_ceil(
-                    beat_value_blocks_max,
+                const beat_index_blocks = stdx.div_ceil(
+                    beat_value_blocks,
                     Table.value_block_count_max,
                 );
+
+                beat_value_blocks_max += beat_value_blocks;
+                beat_index_blocks_max += beat_index_blocks;
             }
 
             env.pool.grid_reservation = env.grid.reserve(
@@ -339,7 +354,6 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             );
 
             for (compactions_slice) |compaction| {
-                assert(env.pool.idle());
                 env.change_state(.fuzzing, .tree_compact);
 
                 switch (compaction.compaction_dispatch_enter(.{
@@ -349,14 +363,11 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                     .pending => env.tick_until_state_change(.tree_compact, .fuzzing),
                     .ready => env.change_state(.tree_compact, .fuzzing),
                 }
-                assert(env.pool.idle());
             }
 
             env.grid.forfeit(env.pool.grid_reservation.?);
 
             if (last_beat or last_half_beat) {
-                assert(env.pool.blocks_acquired() == 0);
-
                 if (op >= constants.lsm_compaction_ops) {
                     env.change_state(.fuzzing, .manifest_log_compact);
                     env.manifest_log.compact(manifest_log_compact_callback, op);
@@ -395,6 +406,16 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         pub fn checkpoint(env: *Environment, op: u64) void {
             env.tree.assert_between_bars();
+
+            env.checkpoint_grid_done = false;
+            env.checkpoint_pool_done = env.pool.idle();
+            if (!env.checkpoint_pool_done) {
+                env.pool.iop_release_resume = .{
+                    .ctx = env,
+                    .callback = checkpoint_iop_release_callback,
+                };
+            }
+            defer env.pool.iop_release_resume = null;
 
             env.change_state(.fuzzing, .grid_checkpoint);
             env.grid.checkpoint(grid_checkpoint_callback);
@@ -441,7 +462,13 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
 
         fn grid_checkpoint_callback(grid: *Grid) void {
             const env: *Environment = @alignCast(@fieldParentPtr("grid", grid));
-            env.change_state(.grid_checkpoint, .superblock_checkpoint);
+
+            assert(!env.checkpoint_grid_done);
+            env.checkpoint_grid_done = true;
+
+            if (env.checkpoint_grid_done and env.checkpoint_pool_done) {
+                env.change_state(.grid_checkpoint, .superblock_checkpoint);
+            }
         }
 
         fn superblock_checkpoint_callback(superblock_context: *SuperBlock.Context) void {

--- a/src/testing/cluster/storage_checker.zig
+++ b/src/testing/cluster/storage_checker.zig
@@ -430,14 +430,24 @@ pub const StorageChecker = struct {
                 assert(open_block_header.address > 0);
                 if (block_address == open_block_header.address) break;
             } else {
-                const block = superblock.storage.grid_block(block_address) orelse {
-                    log.err("{}: checksum_grid: missing block_address={}", .{
-                        superblock.replica_index.?,
+                const block = blk: {
+                    if (read_block_from_write_queues_by_address(
+                        Forest,
+                        forest,
                         block_address,
-                    });
+                    )) |block_write_queue| {
+                        break :blk block_write_queue;
+                    } else if (superblock.storage.grid_block(block_address)) |block_storage| {
+                        break :blk block_storage;
+                    } else {
+                        log.err("{}: checksum_grid: missing block_address={}", .{
+                            superblock.replica_index.?,
+                            block_address,
+                        });
 
-                    blocks_missing += 1;
-                    continue;
+                        blocks_missing += 1;
+                        continue;
+                    }
                 };
 
                 const block_header = schema.header_from_block(block);
@@ -454,5 +464,42 @@ pub const StorageChecker = struct {
         assert(blocks_missing == 0);
 
         return stream.checksum();
+    }
+
+    fn read_block_from_write_queues_by_address(
+        comptime Forest: type,
+        forest: *const Forest,
+        address: u64,
+    ) ?*align(constants.sector_size) const [constants.block_size]u8 {
+        const grid = forest.grid;
+        assert(grid.superblock.opened);
+        assert(grid.callback != .cancel);
+        assert(address > 0);
+
+        var write_queue_iterator = grid.write_queue.iterate();
+        while (write_queue_iterator.next()) |queued_write| {
+            const queued_write_header = std.mem.bytesAsValue(
+                vsr.Header.Block,
+                queued_write.block.*[0..@sizeOf(vsr.Header)],
+            );
+
+            if (address == queued_write_header.address) {
+                return queued_write.block.*;
+            }
+        }
+
+        var write_iops_iterator = grid.write_iops.iterate();
+        while (write_iops_iterator.next()) |iop| {
+            const queued_write_header = std.mem.bytesAsValue(
+                vsr.Header.Block,
+                iop.write.block.*[0..@sizeOf(vsr.Header)],
+            );
+
+            if (address == queued_write_header.address) {
+                return iop.write.block.*;
+            }
+        }
+
+        return null;
     }
 };

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -897,32 +897,6 @@ pub const Storage = struct {
         }
     }
 
-    /// Verify that the storage:
-    /// - contains the given index block
-    /// - contains every value block referenced by the index block
-    pub fn verify_table(storage: *const Storage, index_address: u64, index_checksum: u128) void {
-        assert(index_address > 0);
-
-        const index_block = storage.grid_block(index_address).?;
-        const index_schema = schema.TableIndex.from(index_block);
-        const index_block_header = schema.header_from_block(index_block);
-        assert(index_block_header.address == index_address);
-        assert(index_block_header.checksum == index_checksum);
-        assert(index_block_header.block_type == .index);
-
-        for (
-            index_schema.value_addresses_used(index_block),
-            index_schema.value_checksums_used(index_block),
-        ) |address, checksum| {
-            const value_block = storage.grid_block(address).?;
-            const value_block_header = schema.header_from_block(value_block);
-
-            assert(value_block_header.address == address);
-            assert(value_block_header.checksum == checksum.value);
-            assert(value_block_header.block_type == .value);
-        }
-    }
-
     pub fn transition_to_liveness_mode(storage: *Storage) void {
         storage.options.write_latency_mean = .ms(1);
         storage.options.write_latency_min = .ms(1);

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -476,9 +476,11 @@ const start_defaults_production = StartDefaults{
     .cache_transfers = .{ .value = constants.cache_transfers_size_default },
     .cache_transfers_pending = .{ .value = constants.cache_transfers_pending_size_default },
     .cache_grid = .{ .value = constants.grid_cache_size_default },
+    // Add `lsm_compaction_iops_write_max` to allow pipelining reads of the next
+    // compaction in the beat with the writes of the current compaction.
     .memory_lsm_compaction = .{
-        // By default, add a few extra blocks for beat-scoped work.
-        .value = (lsm_compaction_block_count_min + 16) * constants.block_size,
+        .value = (lsm_compaction_block_count_min +
+            constants.lsm_compaction_iops_write_max) * constants.block_size,
     },
 };
 

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -632,9 +632,10 @@ pub fn GridType(comptime Storage: type) type {
             for (addresses) |address| {
                 assert(address > 0);
 
-                // It's safe to release an address that is being read from, because the superblock
-                // will not allow it to be overwritten before the end of the bar.
-                assert(grid.writing(address, null) != .create);
+                // It's safe to release an address that is being read from or
+                // written to, as it can only be overwritten in the next
+                // checkpoint (when the address is freed and can be reacquired).
+                maybe(grid.writing(address, null) == .create);
 
                 grid.cache.demote(address);
                 grid.free_set.release(address);
@@ -934,12 +935,16 @@ pub fn GridType(comptime Storage: type) type {
         }
 
         /// Fetch the block synchronously from the write queues, if possible.
+        /// Note that we allow the creation of a block (and hence a write to
+        /// an address) to span the entirety of the checkpoint when the write
+        /// was initiated. This is safe to do as this address can only be
+        /// freed and overwritten in the next checkpoint.
         ///
         /// It is possible to read an address while it's being written to, in the
         /// following scenarios:
         /// * Reading a block that is currenly being repaired.
         /// * Reading a block that is currently being created, if it is requested
-        ///   by another replica.
+        ///   by another replica, or by the replica itself.
         fn read_block_from_write_queues(grid: *Grid, address: u64, checksum: u128) ?BlockPtrConst {
             assert(grid.superblock.opened);
             assert(grid.callback != .cancel);
@@ -982,7 +987,7 @@ pub fn GridType(comptime Storage: type) type {
             return block;
         }
 
-        /// Fetch the block synchronously from cache, if possible.
+        /// Fetch the block synchronously from the write queues or grid cache, if possible.
         /// The returned block pointer is only valid until the next Grid write.
         pub fn read_block_from_cache(
             grid: *Grid,
@@ -992,15 +997,21 @@ pub fn GridType(comptime Storage: type) type {
         ) ?BlockPtrConst {
             assert(grid.superblock.opened);
             assert(grid.callback != .cancel);
+            assert(address > 0);
+
             if (options.coherent) {
-                assert(grid.writing(address, null) != .create);
                 assert(!grid.free_set.is_free(address));
                 grid.assert_coherent(address, checksum);
             }
 
-            assert(address > 0);
+            const cache_index = grid.cache.get_index(address) orelse {
+                if (grid.read_block_from_write_queues(address, checksum)) |block| {
+                    grid.assert_coherent(address, checksum);
+                    return block;
+                }
+                return null;
+            };
 
-            const cache_index = grid.cache.get_index(address) orelse return null;
             const cache_block = grid.cache_blocks[cache_index];
 
             const header = schema.header_from_block(cache_block);
@@ -1019,11 +1030,21 @@ pub fn GridType(comptime Storage: type) type {
 
                 return cache_block;
             } else {
+                const write_queue_block = grid.read_block_from_write_queues(address, checksum);
+
+                // For coherent reads, we can only find an old version of the
+                // block in the cache if we either:
+                // * Learnt about a new version of the block via state sync, or
+                // * A new version of that block is currently being written
+                //
+                // This is because we evict the old version of the block from the
+                // cache, as soon as it is written (see `write_block_callback`).
                 if (options.coherent) {
-                    assert(grid.superblock.working.vsr_state.sync_op_max > 0);
+                    assert(grid.superblock.working.vsr_state.sync_op_max > 0 or
+                        write_queue_block != null);
                 }
 
-                if (grid.read_block_from_write_queues(address, checksum)) |block| {
+                if (write_queue_block) |block| {
                     grid.assert_coherent(address, checksum);
                     return block;
                 }
@@ -1047,18 +1068,20 @@ pub fn GridType(comptime Storage: type) type {
             assert(grid.callback != .cancel);
             assert(address > 0);
 
+            // It is possible to read an address while it's being written to
+            // (see `read_block_from_write_queues`).
+            maybe(grid.writing(address, null) == .create);
+
             switch (callback) {
                 .from_local_storage => {
                     maybe(grid.callback == .checkpoint);
-                    // We try to read the block even when it is free — if we recently released it,
-                    // it might be found on disk anyway.
+                    // We try to read the block even when it is free. If we
+                    // recently released it, it might be found on disk anyway.
                     maybe(grid.free_set.is_free(address));
-                    maybe(grid.writing(address, null) == .create);
                 },
                 .from_local_or_global_storage => {
                     assert(grid.callback != .checkpoint);
                     assert(!grid.free_set.is_free(address));
-                    assert(grid.writing(address, null) != .create);
                     grid.assert_coherent(address, checksum);
                 },
             }
@@ -1089,7 +1112,7 @@ pub fn GridType(comptime Storage: type) type {
             assert(grid.callback != .cancel);
             if (read.coherent) {
                 assert(!grid.free_set.is_free(read.address));
-                assert(grid.writing(read.address, null) != .create);
+                maybe(grid.writing(read.address, null) == .create);
             }
 
             assert(read.address > 0);
@@ -1118,8 +1141,14 @@ pub fn GridType(comptime Storage: type) type {
                 }
             }
 
-            // When Read.cache_read is set, the caller of read_block() is responsible for calling
-            // us via next_tick().
+            if (grid.read_block_from_write_queues(read.address, read.checksum)) |block| {
+                grid.assert_coherent(read.address, read.checksum);
+                grid.read_block_resolve(read, .{ .valid = block });
+                return;
+            }
+
+            // When Read.cache_read is set, the caller of read_block()
+            // is responsible for calling us via next_tick().
             if (read.cache_read) {
                 if (grid.read_block_from_cache(
                     read.address,
@@ -1131,12 +1160,14 @@ pub fn GridType(comptime Storage: type) type {
                 }
             }
 
-            // Become the "root" read that's fetching the block for the given address. The fetch
-            // happens asynchronously to avoid stack-overflow and nested cache invalidation.
+            // Become the "root" read that's fetching the block for the
+            // given address. The fetch happens asynchronously to avoid
+            // stack-overflow and nested cache invalidation.
             grid.read_queue.push(read);
 
             // Grab an IOP to resolve the block from storage.
-            // Failure to do so means the read is queued to receive an IOP when one finishes.
+            // Failure to do so means the read is queued to receive an
+            // IOP when one finishes.
             const iop = grid.read_iops.acquire() orelse {
                 grid.read_pending_queue.push(&read.pending);
                 return;
@@ -1149,8 +1180,8 @@ pub fn GridType(comptime Storage: type) type {
             const address = read.address;
             assert(address > 0);
 
-            // We can only update the cache if the Grid is not resolving callbacks with a cache
-            // block.
+            // We can only update the cache if the Grid is not resolving
+            // callbacks with a cache block.
             assert(!grid.read_resolving);
 
             grid.trace.start(.{ .grid_read = .{ .iop = grid.read_iops.index(iop) } });
@@ -1367,6 +1398,51 @@ pub fn GridType(comptime Storage: type) type {
             assert(address > 0);
 
             return (address - 1) * block_size;
+        }
+
+        /// Verify that the storage:
+        /// - contains the given index block
+        /// - contains every value block referenced by the index block
+        pub fn verify_table(grid: *Grid, index_address: u64, index_checksum: u128) void {
+            assert(index_address > 0);
+
+            const TestStorage = @import("../testing/storage.zig").Storage;
+            if (Storage != TestStorage) return;
+
+            const index_block = blk: {
+                if (grid.read_block_from_write_queues(index_address, index_checksum)) |block| {
+                    break :blk block;
+                } else {
+                    break :blk grid.superblock.storage.grid_block(index_address).?;
+                }
+            };
+            const index_schema = schema.TableIndex.from(index_block);
+            const index_block_header = schema.header_from_block(index_block);
+
+            assert(index_block_header.address == index_address);
+            assert(index_block_header.checksum == index_checksum);
+            assert(index_block_header.block_type == .index);
+
+            for (
+                index_schema.value_addresses_used(index_block),
+                index_schema.value_checksums_used(index_block),
+            ) |value_address, value_checksum| {
+                const value_block = blk: {
+                    if (grid.read_block_from_write_queues(
+                        value_address,
+                        value_checksum.value,
+                    )) |block| {
+                        break :blk block;
+                    } else {
+                        break :blk grid.superblock.storage.grid_block(value_address).?;
+                    }
+                };
+                const value_block_header = schema.header_from_block(value_block);
+
+                assert(value_block_header.address == value_address);
+                assert(value_block_header.checksum == value_checksum.value);
+                assert(value_block_header.block_type == .value);
+            }
         }
 
         fn assert_coherent(grid: *const Grid, address: u64, checksum: u128) void {

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -37,7 +37,6 @@ const allocate_block = @import("./grid.zig").allocate_block;
 const GridType = @import("./grid.zig").GridType;
 const BlockPtr = @import("./grid.zig").BlockPtr;
 const ForestTableIteratorType = @import("../lsm/forest_table_iterator.zig").ForestTableIteratorType;
-const TestStorage = @import("../testing/storage.zig").Storage;
 
 pub fn GridScrubberType(comptime Forest: type, grid_scrubber_reads_max: comptime_int) type {
     return struct {
@@ -438,12 +437,10 @@ pub fn GridScrubberType(comptime Forest: type, grid_scrubber_reads_max: comptime
 
             if (tour.* == .table_index) {
                 if (scrubber.tour_tables.?.next(scrubber.forest)) |table_info| {
-                    if (Forest.Storage == TestStorage) {
-                        scrubber.superblock.storage.verify_table(
-                            table_info.address,
-                            table_info.checksum,
-                        );
-                    }
+                    scrubber.forest.grid.verify_table(
+                        table_info.address,
+                        table_info.checksum,
+                    );
 
                     tour.* = .{ .table_value = .{
                         .index_checksum = table_info.checksum,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4967,7 +4967,6 @@ pub fn ReplicaType(
         fn commit_checkpoint_data(self: *Replica) enum { ready, pending } {
             assert(self.commit_stage == .checkpoint_data);
             assert(self.commit_stage.checkpoint_data.count() == 0);
-            self.grid.assert_only_repairing();
 
             const op = self.commit_prepare.?.header.op;
             assert(op == self.commit_min);
@@ -10759,16 +10758,14 @@ pub fn ReplicaType(
 
                     if (self.grid_repair_tables.available() == 0) break;
                 } else {
-                    if (Forest.Storage == TestStorage) {
-                        // Verify that we already have any table that is not within the sync range.
-                        if (table_info.snapshot_min < snapshot_from_commit(sync_op_min) or
-                            table_info.snapshot_min > snapshot_from_commit(sync_op_max_next))
-                        {
-                            self.superblock.storage.verify_table(
-                                table_info.address,
-                                table_info.checksum,
-                            );
-                        }
+                    // Verify that we already have any table that is not within the sync range.
+                    if (table_info.snapshot_min < snapshot_from_commit(sync_op_min) or
+                        table_info.snapshot_min > snapshot_from_commit(sync_op_max_next))
+                    {
+                        self.grid.verify_table(
+                            table_info.address,
+                            table_info.checksum,
+                        );
                     }
                 }
             }


### PR DESCRIPTION
### Summary

Currently, during compaction, we stall at the end every of beat and
wait for all IO to complete (writes of output value and index blocks,
and reads/prefetches of input index/value blocks). Recently, I realized
that there is no fundamental reason for us to stall on the completion of
this IO at the end of the beat, we could just initiate the IO and move on.
In fact, we can actually afford to let the write IO run up till the checkpoint,
and we only need to stall there. In doing so, we would embrace concurrency,
and pipeline the final IO from the current compaction with the sort work at
the end of the beat, and with the read IO of the next compaction.

### Performance

#### Old
```C
[ec2-user@ip-172-31-41-212 tigerbeetle]$ python3 analyze.py benchmark.log
653776 batches in 19735.07 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 271282 tx/s
batch latency p1   = 15 ms
batch latency p50  = 28 ms
batch latency p99  = 116 ms
batch latency p100 = 133 ms
```

#### New

```C
[ec2-user@ip-172-31-36-167 tigerbeetle]$ python3 analyze.py benchmark.log
653779 batches in 18922.94 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 282926 tx/s
batch latency p1   = 15 ms
batch latency p50  = 26 ms
batch latency p99  = 115 ms
batch latency p100 = 140 ms
```


### Traces

We can see via the trace visualization that `grid_write` IO is now 
overlapping  with the `compact_mutable_suffix` CPU work. In contrast,
in the trace visualization of the old code, we can see that we stall on the
`grid_write`  IOs before we start the `compact_mutable_suffix` work:

<details>
<summary>Traces</summary>

### Before

<img width="1278" height="642" alt="Screenshot 2026-03-01 at 8 26 27 AM" src="https://github.com/user-attachments/assets/63883fd1-bbc7-4779-acfb-00cec21c915e" />

### After

<img width="1284" height="696" alt="Screenshot 2026-03-01 at 8 05 15 AM" src="https://github.com/user-attachments/assets/934f0da9-4ae7-4ac5-9c83-b87268840574" />
</details>
