### PR TITLE
tb-objcopy: no more llvm-objcopy 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -79,6 +79,15 @@ pub fn build(b: *std.Build) !void {
         .docs = b.step("docs", "Build docs"),
         .fuzz = b.step("fuzz", "Run non-VOPR fuzzers"),
         .fuzz_build = b.step("fuzz:build", "Build non-VOPR fuzzers"),
+        .objcopy_fuzz = b.step("objcopy:fuzz", "Run tb_objcopy differential fuzzer"),
+        .objcopy_fuzz_roundtrip = b.step(
+            "objcopy:fuzz:roundtrip",
+            "Run tb_objcopy roundtrip fuzzer (no llvm dependency)",
+        ),
+        .objcopy_fuzz_build = b.step(
+            "objcopy:fuzz:build",
+            "Build tb_objcopy differential fuzzer",
+        ),
         .run = b.step("run", "Run TigerBeetle"),
         .ci = b.step("ci", "Run the full suite of CI checks"),
         .scripts = b.step("scripts", "Free form automation scripts"),
@@ -141,7 +150,7 @@ pub fn build(b: *std.Build) !void {
         .llvm_objcopy = b.option(
             []const u8,
             "llvm-objcopy",
-            "Use this llvm-objcopy instead of downloading one",
+            "Use this objcopy binary instead of the in-tree tb_objcopy wrapper",
         ),
         .print_exe = b.option(
             bool,
@@ -292,6 +301,14 @@ pub fn build(b: *std.Build) !void {
         .vsr_options_test = vsr_options_test,
         .target = target,
         .mode = mode,
+        .print_exe = build_options.print_exe,
+    });
+    build_objcopy_fuzz(b, .{
+        .objcopy_fuzz = build_steps.objcopy_fuzz,
+        .objcopy_fuzz_roundtrip = build_steps.objcopy_fuzz_roundtrip,
+        .objcopy_fuzz_build = build_steps.objcopy_fuzz_build,
+    }, .{
+        .llvm_objcopy = build_options.llvm_objcopy,
         .print_exe = build_options.print_exe,
     });
 
@@ -485,6 +502,18 @@ fn build_ci(
     }
     if (default or mode == .fuzz) {
         build_ci_step(b, step_ci, .{ "fuzz", "--", "smoke" });
+        build_ci_step(b, step_ci, .{
+            "objcopy:fuzz",
+            "--",
+            "--iterations=50",
+            "--seed=1",
+        });
+        build_ci_step(b, step_ci, .{
+            "objcopy:fuzz",
+            "--",
+            "--iterations=50",
+            "--seed=2",
+        });
         inline for (.{ "testing", "accounting" }) |state_machine| {
             build_ci_step(b, step_ci, .{
                 "vopr",
@@ -737,7 +766,10 @@ fn build_tigerbeetle_executable_multiversion(b: *std.Build, options: struct {
     if (options.llvm_objcopy) |path| {
         build_multiversion.addArg(b.fmt("--llvm-objcopy={s}", .{path}));
     } else {
-        build_multiversion.addPrefixedFileArg("--llvm-objcopy=", fetch_objcopy(b));
+        build_multiversion.addPrefixedFileArg(
+            "--llvm-objcopy=",
+            build_tb_objcopy_wrapper(b),
+        );
     }
     if (options.target.result.os.tag == .macos) {
         build_multiversion.addArg("--target=macos");
@@ -782,6 +814,24 @@ fn build_tigerbeetle_executable_multiversion(b: *std.Build, options: struct {
     else
         "tigerbeetle";
     return build_multiversion.addPrefixedOutputFileArg("--output=", basename);
+}
+
+fn build_tigerbeetle_executable_get_objcopy_reference(b: *std.Build) std.Build.LazyPath {
+    return fetch_objcopy(b);
+}
+
+fn build_tb_objcopy_wrapper(b: *std.Build) std.Build.LazyPath {
+    const stdx_module = b.createModule(.{ .root_source_file = b.path("src/stdx/stdx.zig") });
+    const objcopy = b.addExecutable(.{
+        .name = "tb_objcopy",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tb_objcopy.zig"),
+            .target = resolve_target(b, null) catch @panic("unsupported host"),
+            .optimize = .ReleaseSafe,
+        }),
+    });
+    objcopy.root_module.addImport("stdx", stdx_module);
+    return objcopy.getEmittedBin();
 }
 
 fn build_aof(
@@ -1115,6 +1165,52 @@ fn build_fuzz(
     const fuzz_run = b.addRunArtifact(fuzz_exe);
     if (b.args) |args| fuzz_run.addArgs(args);
     steps.fuzz.dependOn(&fuzz_run.step);
+}
+
+fn build_objcopy_fuzz(
+    b: *std.Build,
+    steps: struct {
+        objcopy_fuzz: *std.Build.Step,
+        objcopy_fuzz_roundtrip: *std.Build.Step,
+        objcopy_fuzz_build: *std.Build.Step,
+    },
+    options: struct {
+        llvm_objcopy: ?[]const u8,
+        print_exe: bool,
+    },
+) void {
+    const stdx_module = b.createModule(.{ .root_source_file = b.path("src/stdx/stdx.zig") });
+    const objcopy_fuzz = b.addExecutable(.{
+        .name = "tb_objcopy_fuzz",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tb_objcopy_fuzz.zig"),
+            .target = resolve_target(b, null) catch @panic("unsupported host"),
+            .optimize = .ReleaseSafe,
+        }),
+    });
+    objcopy_fuzz.root_module.addImport("stdx", stdx_module);
+
+    steps.objcopy_fuzz_build.dependOn(print_or_install(b, objcopy_fuzz, options.print_exe));
+
+    const run_objcopy_fuzz = b.addRunArtifact(objcopy_fuzz);
+    run_objcopy_fuzz.addArg(b.fmt("--zig-exe={s}", .{b.graph.zig_exe}));
+    run_objcopy_fuzz.addPrefixedFileArg("--tb-objcopy=", build_tb_objcopy_wrapper(b));
+    if (options.llvm_objcopy) |path| {
+        run_objcopy_fuzz.addArg(b.fmt("--llvm-objcopy={s}", .{path}));
+    } else {
+        run_objcopy_fuzz.addPrefixedFileArg(
+            "--llvm-objcopy=",
+            build_tigerbeetle_executable_get_objcopy_reference(b),
+        );
+    }
+    if (b.args) |args| run_objcopy_fuzz.addArgs(args);
+    steps.objcopy_fuzz.dependOn(&run_objcopy_fuzz.step);
+
+    const run_objcopy_fuzz_roundtrip = b.addRunArtifact(objcopy_fuzz);
+    run_objcopy_fuzz_roundtrip.addArg(b.fmt("--zig-exe={s}", .{b.graph.zig_exe}));
+    run_objcopy_fuzz_roundtrip.addPrefixedFileArg("--tb-objcopy=", build_tb_objcopy_wrapper(b));
+    if (b.args) |args| run_objcopy_fuzz_roundtrip.addArgs(args);
+    steps.objcopy_fuzz_roundtrip.dependOn(&run_objcopy_fuzz_roundtrip.step);
 }
 
 fn build_scripts(

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -59,6 +59,7 @@ pub fn main() !void {
 
     const has_section_changes = cli_has_section_changes(&cli);
     if (!has_section_changes and is_pe(input)) {
+        assert(is_valid_pe(input)); // Fast-path copy is only valid for real PE/COFF files.
         try std.fs.cwd().writeFile(.{
             .sub_path = cli.output,
             .data = input,
@@ -187,6 +188,14 @@ fn is_elf(bytes: []const u8) bool {
 // Check DOS/PE magic prefix.
 fn is_pe(bytes: []const u8) bool {
     return bytes.len >= 2 and std.mem.eql(u8, bytes[0..2], "MZ");
+}
+
+// Validate enough PE structure to distinguish real PE/COFF from generic MZ files.
+fn is_valid_pe(bytes: []const u8) bool {
+    if (bytes.len < 0x40) return false;
+    const pe_header_offset = std.mem.readInt(u32, bytes[0x3c..][0..4], .little);
+    if (pe_header_offset + 4 + 20 > bytes.len) return false;
+    return std.mem.eql(u8, bytes[pe_header_offset..][0..4], "PE\x00\x00");
 }
 
 const ElfSection = struct {
@@ -388,14 +397,9 @@ fn elf_apply_string_table(
     gpa: std.mem.Allocator,
     sections: *std.ArrayList(ElfSection),
 ) !usize {
-    var shstr_index: ?usize = null;
-    for (sections.items, 0..) |section, i| {
-        if (std.mem.eql(u8, section.name, ".shstrtab")) {
-            shstr_index = i;
-            break;
-        }
-    }
-    assert(shstr_index != null); // `.shstrtab` must exist in valid ELF output.
+    const shstr_index: usize = for (sections.items, 0..) |section, i| {
+        if (std.mem.eql(u8, section.name, ".shstrtab")) break i;
+    } else unreachable; // `.shstrtab` must exist in valid ELF output.
 
     // LLVM sorts and suffix-deduplicates names before materializing `.shstrtab`.
     const name_offsets, const shstr_bytes = try elf_build_string_table(gpa, sections.items);
@@ -405,11 +409,11 @@ fn elf_apply_string_table(
         section.header.sh_name = name_offsets[i];
     }
     // Ownership is transferred to the section list and used by the final writer.
-    sections.items[shstr_index.?].data = shstr_bytes;
-    sections.items[shstr_index.?].data_owned = true;
-    sections.items[shstr_index.?].header.sh_size = shstr_bytes.len;
+    sections.items[shstr_index].data = shstr_bytes;
+    sections.items[shstr_index].data_owned = true;
+    sections.items[shstr_index].header.sh_size = shstr_bytes.len;
 
-    return shstr_index.?;
+    return shstr_index;
 }
 
 // Recompute section file offsets after add/remove/replace operations.
@@ -688,6 +692,17 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
     const new_section_count: u16 = @intCast(sections.items.len);
     const new_size_of_image = std.mem.alignForward(u32, next_va, section_alignment);
     const output_size: usize = @intCast(next_raw);
+    const new_section_table_end = section_table_offset + sections.items.len * section_header_size;
+    var first_section_raw_offset = output_size;
+    for (sections.items) |section| {
+        if (section.size_of_raw_data == 0) continue;
+        first_section_raw_offset = @min(
+            first_section_raw_offset,
+            @as(usize, @intCast(section.pointer_to_raw_data)),
+        );
+    }
+    // Added section headers must not overlap any section raw payload.
+    assert(new_section_table_end <= first_section_raw_offset);
 
     var output = try gpa.alloc(u8, output_size);
     @memset(output, 0);
@@ -734,7 +749,6 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
         }
     }
     const old_section_table_end = section_table_offset + section_count * section_header_size;
-    const new_section_table_end = section_table_offset + sections.items.len * section_header_size;
     if (new_section_table_end < old_section_table_end and old_section_table_end <= output.len) {
         @memset(output[new_section_table_end..old_section_table_end], 0);
         if (builtin.mode == .Debug) {

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -199,6 +199,36 @@ const ElfSection = struct {
     added: bool,
 };
 
+// ELF64 layout used by this tool:
+//
+//     +------------------------------+
+// 0x0 | Elf64_Ehdr                   |
+//     |   e_ident = 0x7F 'E' 'L' 'F' |
+//     |   EI_CLASS = ELFCLASS64      |
+//     |   EI_DATA  = ELFDATA2LSB     |
+//     |   e_shoff -> section table   |
+//     +------------------------------+
+//     | section payload bytes        |
+//     +------------------------------+
+//     | Elf64_Shdr[e_shnum]          |
+//     +------------------------------+
+//
+// Section header entry (64 bytes):
+//
+//     +0x00 sh_name
+//     +0x04 sh_type
+//     +0x08 sh_flags
+//     +0x10 sh_addr
+//     +0x18 sh_offset
+//     +0x20 sh_size
+//     +0x28 sh_link / sh_info
+//     +0x30 sh_addralign
+//     +0x38 sh_entsize
+//
+// Assumptions:
+// 1. No extended numbering (`e_shnum != 0` and `e_shstrndx != SHN_XINDEX`).
+// 2. `.shstrtab` exists as a normal section and is rebuilt LLVM-style.
+// 3. Only section table and section payload bytes are rewritten.
 // Apply the requested section edits to an ELF input and emit rewritten bytes.
 fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
     assert(input.len >= @sizeOf(elf.Elf64_Ehdr)); // ELF header must be present.
@@ -559,6 +589,44 @@ const PESection = struct {
     added: bool,
 };
 
+// PE32+ layout used by this tool:
+//
+//     +------------------------------+
+// 0x00| DOS header ("MZ")            |
+//     |   e_lfanew @ 0x3C            |
+//     +------------------------------+
+//     | ... DOS stub ...             |
+//     +------------------------------+
+// e_lf| "PE\\0\\0" signature          |
+// anew| COFF header (20 bytes)       |
+//     | Optional header (PE32+)      |
+//     |   Magic = 0x20B              |
+//     |   SectionAlignment           |
+//     |   FileAlignment              |
+//     |   SizeOfHeaders              |
+//     +------------------------------+
+//     | Section table (40-byte rows) |
+//     +------------------------------+
+//     | Section raw data             |
+//     +------------------------------+
+//
+// Section header row (40 bytes):
+//
+//     +0x00 Name[8]
+//     +0x08 VirtualSize
+//     +0x0C VirtualAddress
+//     +0x10 SizeOfRawData
+//     +0x14 PointerToRawData
+//     +0x18 PointerToRelocations
+//     +0x1C PointerToLinenumbers
+//     +0x20 NumberOfRelocations
+//     +0x22 NumberOfLinenumbers
+//     +0x24 Characteristics
+//
+// Assumptions:
+// 1. Little-endian PE32+ only.
+// 2. Machine is x86_64 or aarch64.
+// 3. Header region is preserved up to `SizeOfHeaders`.
 // Apply the requested section edits to a PE/COFF input and emit rewritten bytes.
 fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
     assert(input.len >= 0x40); // DOS stub + `e_lfanew` must be present.

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -1,0 +1,789 @@
+//! Minimal native objcopy implementation used by multiversion builds.
+//! Supports only the subset of flags used in this repository.
+
+const std = @import("std");
+const elf = std.elf;
+const stdx = @import("stdx");
+const assert = std.debug.assert;
+
+const Section = enum {
+    tb_mvb,
+    tb_mvh,
+
+    fn name(section: Section) []const u8 {
+        return switch (section) {
+            .tb_mvb => ".tb_mvb",
+            .tb_mvh => ".tb_mvh",
+        };
+    }
+};
+
+const AddSection = struct {
+    section: Section,
+    path: []const u8,
+    bytes: []const u8 = "",
+};
+
+const CLI = struct {
+    source: []const u8 = "",
+    output: []const u8 = "",
+    add_sections: [2]?AddSection = .{ null, null },
+    remove_sections: [2]bool = .{ false, false },
+};
+
+pub fn main() !void {
+    var gpa_state: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    defer if (gpa_state.deinit() != .ok) @panic("memory leaked");
+
+    const gpa = gpa_state.allocator();
+
+    var arguments = try std.process.argsWithAllocator(gpa);
+    defer arguments.deinit();
+
+    var cli = try parse_cli_args(&arguments);
+    const source_file_mode = (try std.fs.cwd().statFile(cli.source)).mode;
+
+    for (cli.add_sections, 0..) |maybe_add, i| {
+        if (maybe_add == null) continue;
+        var add = maybe_add.?;
+        add.bytes = try std.fs.cwd().readFileAlloc(gpa, add.path, std.math.maxInt(usize));
+        cli.add_sections[i] = add;
+    }
+    defer for (cli.add_sections) |maybe_add| {
+        if (maybe_add) |add| gpa.free(add.bytes);
+    };
+
+    const input = try std.fs.cwd().readFileAlloc(gpa, cli.source, std.math.maxInt(usize));
+    defer gpa.free(input);
+
+    const has_section_changes = cli_has_section_changes(&cli);
+    if (!has_section_changes and is_pe(input)) {
+        try std.fs.cwd().writeFile(.{
+            .sub_path = cli.output,
+            .data = input,
+            .flags = .{ .mode = source_file_mode },
+        });
+        return;
+    }
+
+    const output = if (is_elf(input))
+        try transform_elf(gpa, input, &cli)
+    else if (is_pe(input))
+        try transform_pe(gpa, input, &cli)
+    else
+        return error.UnsupportedFormat;
+    defer gpa.free(output);
+
+    try std.fs.cwd().writeFile(.{
+        .sub_path = cli.output,
+        .data = output,
+        .flags = .{ .mode = source_file_mode },
+    });
+}
+
+// Parse the supported objcopy CLI subset and normalize in-place output mode.
+fn parse_cli_args(arguments: *std.process.ArgIterator) !CLI {
+    _ = arguments.next() orelse return error.InvalidArguments;
+
+    var cli: CLI = .{};
+    var positional_argument_count: usize = 0;
+    while (arguments.next()) |argument| {
+        if (std.mem.eql(u8, argument, "--enable-deterministic-archives") or
+            std.mem.eql(u8, argument, "--keep-undefined"))
+        {
+            continue;
+        }
+
+        if (try parse_option_value(arguments, argument, "--add-section")) |value| {
+            try parse_add_section(&cli, value);
+            continue;
+        }
+
+        if (try parse_option_value(arguments, argument, "--remove-section")) |value| {
+            try parse_remove_section(&cli, value);
+            continue;
+        }
+
+        if (try parse_option_value(arguments, argument, "--set-section-flags")) |value| {
+            try validate_section_flags(value);
+            continue;
+        }
+
+        if (std.mem.startsWith(u8, argument, "-")) return error.InvalidArguments;
+
+        positional_argument_count += 1;
+        switch (positional_argument_count) {
+            1 => cli.source = argument,
+            2 => cli.output = argument,
+            else => return error.InvalidArguments,
+        }
+    }
+
+    if (positional_argument_count == 0) return error.InvalidArguments;
+    if (positional_argument_count == 1) cli.output = cli.source;
+    return cli;
+}
+
+// Parse `--option value` and `--option=value` forms into a single value.
+fn parse_option_value(
+    arguments: *std.process.ArgIterator,
+    argument: []const u8,
+    comptime option_name: []const u8,
+) !?[]const u8 {
+    if (std.mem.eql(u8, argument, option_name)) {
+        return arguments.next() orelse error.InvalidArguments;
+    }
+    return stdx.cut_prefix(argument, option_name ++ "=");
+}
+
+// Return whether any section add/remove operation was requested.
+fn cli_has_section_changes(cli: *const CLI) bool {
+    for (cli.add_sections) |add| if (add != null) return true;
+    for (cli.remove_sections) |remove| if (remove) return true;
+    return false;
+}
+
+// Parse one `--add-section` entry and store it by logical section id.
+fn parse_add_section(cli: *CLI, value: []const u8) !void {
+    const section_name, const path = stdx.cut(value, "=") orelse return error.InvalidArguments;
+    const section = section_parse(section_name) orelse return error.InvalidArguments;
+    if (path.len == 0) return error.InvalidArguments;
+
+    const index = @intFromEnum(section);
+    cli.add_sections[index] = .{ .section = section, .path = path };
+}
+
+// Parse one `--remove-section` entry.
+fn parse_remove_section(cli: *CLI, value: []const u8) !void {
+    const section = section_parse(value) orelse return error.InvalidArguments;
+    cli.remove_sections[@intFromEnum(section)] = true;
+}
+
+// Accept only the exact section flags combination used by TigerBeetle builds.
+fn validate_section_flags(value: []const u8) !void {
+    const section_name, const flags = stdx.cut(value, "=") orelse return error.InvalidArguments;
+    const section = section_parse(section_name) orelse return error.InvalidArguments;
+    _ = section;
+    if (!std.mem.eql(u8, flags, "contents,noload,readonly")) return error.InvalidArguments;
+}
+
+// Map known section names into the internal section enum.
+fn section_parse(name: []const u8) ?Section {
+    if (std.mem.eql(u8, name, ".tb_mvb")) return .tb_mvb;
+    if (std.mem.eql(u8, name, ".tb_mvh")) return .tb_mvh;
+    return null;
+}
+
+// Check ELF magic prefix.
+fn is_elf(bytes: []const u8) bool {
+    return bytes.len >= 4 and std.mem.eql(u8, bytes[0..4], "\x7fELF");
+}
+
+// Check DOS/PE magic prefix.
+fn is_pe(bytes: []const u8) bool {
+    return bytes.len >= 2 and std.mem.eql(u8, bytes[0..2], "MZ");
+}
+
+const ElfSection = struct {
+    header: elf.Elf64_Shdr,
+    name: []const u8,
+    data: []const u8,
+    data_owned: bool,
+    old_offset: usize,
+    old_size: usize,
+    added: bool,
+};
+
+// Apply the requested section edits to an ELF input and emit rewritten bytes.
+fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
+    if (input.len < @sizeOf(elf.Elf64_Ehdr)) return error.InvalidELF;
+
+    var elf_header = std.mem.bytesAsValue(elf.Elf64_Ehdr, input[0..@sizeOf(elf.Elf64_Ehdr)]).*;
+    if (!std.mem.eql(u8, elf_header.e_ident[0..4], elf.MAGIC)) return error.InvalidELF;
+    if (elf_header.e_ident[elf.EI_CLASS] != elf.ELFCLASS64) return error.UnsupportedELF;
+    if (elf_header.e_ident[elf.EI_DATA] != elf.ELFDATA2LSB) return error.UnsupportedELF;
+    if (elf_header.e_shentsize != @sizeOf(elf.Elf64_Shdr)) return error.InvalidELF;
+
+    const section_headers_offset: usize = @intCast(elf_header.e_shoff);
+    const section_headers_count: usize = elf_header.e_shnum;
+    if (section_headers_offset + section_headers_count * @sizeOf(elf.Elf64_Shdr) > input.len) {
+        return error.InvalidELF;
+    }
+
+    if (elf_header.e_shstrndx >= section_headers_count) return error.InvalidELF;
+    const section_name_table_header = std.mem.bytesAsValue(
+        elf.Elf64_Shdr,
+        input[section_headers_offset + elf_header.e_shstrndx * @sizeOf(elf.Elf64_Shdr) ..][0..@sizeOf(
+            elf.Elf64_Shdr,
+        )],
+    ).*;
+    const section_name_table_offset: usize = @intCast(section_name_table_header.sh_offset);
+    const section_name_table_size: usize = @intCast(section_name_table_header.sh_size);
+    if (section_name_table_offset + section_name_table_size > input.len) return error.InvalidELF;
+    const section_name_table = input[section_name_table_offset..][0..section_name_table_size];
+
+    var sections, const section_data_end_max_original = try elf_collect_sections(gpa, input, cli, .{
+        .section_headers_offset = section_headers_offset,
+        .section_headers_count = section_headers_count,
+        .section_name_table = section_name_table,
+    });
+    defer sections.deinit();
+    defer for (sections.items) |section| {
+        if (section.name.len > 0) gpa.free(section.name);
+        if (section.data_owned) gpa.free(section.data);
+    };
+
+    try elf_apply_add_sections(gpa, &sections, cli, section_data_end_max_original);
+    const section_name_table_index = try elf_apply_string_table(gpa, &sections);
+
+    // Keep existing section data offsets as stable as possible and shift only the tail.
+    const section_data_end_max = elf_relayout_sections(sections.items);
+
+    const section_headers_offset_new = std.mem.alignForward(usize, section_data_end_max, 8);
+    elf_header.e_shoff = section_headers_offset_new;
+    elf_header.e_shnum = @intCast(sections.items.len);
+    elf_header.e_shstrndx = @intCast(section_name_table_index);
+
+    return try elf_write_output(gpa, input, elf_header, sections.items, section_data_end_max);
+}
+
+// Read ELF section headers/data, filtering removed sections.
+fn elf_collect_sections(
+    gpa: std.mem.Allocator,
+    input: []const u8,
+    cli: *const CLI,
+    options: struct {
+        section_headers_offset: usize,
+        section_headers_count: usize,
+        section_name_table: []const u8,
+    },
+) !struct { std.ArrayList(ElfSection), usize } {
+    var sections = std.ArrayList(ElfSection).init(gpa);
+    var data_end_max: usize = 0;
+
+    for (0..options.section_headers_count) |i| {
+        const shdr = std.mem.bytesAsValue(
+            elf.Elf64_Shdr,
+            input[options.section_headers_offset + i * @sizeOf(elf.Elf64_Shdr) ..][0..@sizeOf(
+                elf.Elf64_Shdr,
+            )],
+        ).*;
+        if (shdr.sh_name >= options.section_name_table.len) return error.InvalidELF;
+        const name = std.mem.sliceTo(
+            @as([*:0]const u8, @ptrCast(options.section_name_table.ptr + shdr.sh_name)),
+            0,
+        );
+        if (section_parse(name)) |section| {
+            if (cli.remove_sections[@intFromEnum(section)]) continue;
+        }
+
+        const data = blk: {
+            if (shdr.sh_type == elf.SHT_NOBITS or shdr.sh_size == 0) break :blk "";
+            const offset: usize = @intCast(shdr.sh_offset);
+            const size: usize = @intCast(shdr.sh_size);
+            if (offset + size > input.len) return error.InvalidELF;
+            break :blk input[offset..][0..size];
+        };
+        const name_owned = if (name.len > 0) try gpa.dupe(u8, name) else "";
+        try sections.append(.{
+            .header = shdr,
+            .name = name_owned,
+            .data = data,
+            .data_owned = false,
+            .old_offset = @intCast(shdr.sh_offset),
+            .old_size = data.len,
+            .added = false,
+        });
+        if (shdr.sh_type != elf.SHT_NOBITS and data.len > 0) {
+            data_end_max = @max(data_end_max, @as(usize, @intCast(shdr.sh_offset)) + data.len);
+        }
+    }
+
+    return .{ sections, data_end_max };
+}
+
+// Append requested ELF sections, replacing same-name sections when present.
+fn elf_apply_add_sections(
+    gpa: std.mem.Allocator,
+    sections: *std.ArrayList(ElfSection),
+    cli: *const CLI,
+    data_end_max: usize,
+) !void {
+    for (cli.add_sections) |maybe_add| {
+        if (maybe_add == null) continue;
+        const add = maybe_add.?;
+        // Replace existing section (if any) with same name to match `remove + add` behavior.
+        var existing_index: ?usize = null;
+        for (sections.items, 0..) |section, i| {
+            if (std.mem.eql(u8, section.name, add.section.name())) {
+                existing_index = i;
+                break;
+            }
+        }
+        if (existing_index) |index| {
+            const removed = sections.orderedRemove(index);
+            if (removed.name.len > 0) gpa.free(removed.name);
+            if (removed.data_owned) gpa.free(removed.data);
+        }
+
+        try sections.append(.{
+            .header = .{
+                .sh_name = 0,
+                .sh_type = elf.SHT_PROGBITS,
+                .sh_flags = 0,
+                .sh_addr = 0,
+                .sh_offset = 0,
+                .sh_size = @intCast(add.bytes.len),
+                .sh_link = 0,
+                .sh_info = 0,
+                .sh_addralign = 1,
+                .sh_entsize = 0,
+            },
+            .name = try gpa.dupe(u8, add.section.name()),
+            .data = add.bytes,
+            .data_owned = false,
+            .old_offset = data_end_max,
+            .old_size = 0,
+            .added = true,
+        });
+    }
+}
+
+// Rebuild `.shstrtab` and patch each section header `sh_name`.
+fn elf_apply_string_table(
+    gpa: std.mem.Allocator,
+    sections: *std.ArrayList(ElfSection),
+) !usize {
+    var shstr_index: ?usize = null;
+    for (sections.items, 0..) |section, i| {
+        if (std.mem.eql(u8, section.name, ".shstrtab")) {
+            shstr_index = i;
+            break;
+        }
+    }
+    if (shstr_index == null) return error.InvalidELF;
+
+    // LLVM sorts and suffix-deduplicates names before materializing `.shstrtab`.
+    const name_offsets, const shstr_bytes = try elf_build_string_table(gpa, sections.items);
+    defer gpa.free(name_offsets);
+
+    for (sections.items, 0..) |*section, i| {
+        section.header.sh_name = name_offsets[i];
+    }
+    // Ownership is transferred to the section list and used by the final writer.
+    sections.items[shstr_index.?].data = shstr_bytes;
+    sections.items[shstr_index.?].data_owned = true;
+    sections.items[shstr_index.?].header.sh_size = shstr_bytes.len;
+
+    return shstr_index.?;
+}
+
+// Recompute section file offsets after add/remove/replace operations.
+fn elf_relayout_sections(sections: []ElfSection) usize {
+    var delta: i64 = 0;
+    var max_data_end: usize = 0;
+    for (sections) |*section| {
+        if (section.header.sh_type == elf.SHT_NOBITS or section.header.sh_size == 0) continue;
+        const section_align = if (section.header.sh_addralign == 0)
+            1
+        else
+            section.header.sh_addralign;
+        const base: i64 = @as(i64, @intCast(section.old_offset)) + delta;
+        const aligned: usize = std.mem.alignForward(
+            usize,
+            @intCast(base),
+            @intCast(section_align),
+        );
+        const aligned_delta: i64 = @as(i64, @intCast(aligned)) - base;
+        delta += aligned_delta;
+        section.header.sh_offset = aligned;
+
+        const old_size: i64 = @intCast(section.old_size);
+        const new_size: i64 = @intCast(section.data.len);
+        delta += new_size - old_size;
+        section.old_offset = aligned;
+        max_data_end = @max(max_data_end, aligned + section.data.len);
+    }
+    return max_data_end;
+}
+
+// Materialize final ELF bytes including data payloads and the section table.
+fn elf_write_output(
+    gpa: std.mem.Allocator,
+    input: []const u8,
+    elf_header: elf.Elf64_Ehdr,
+    sections: []const ElfSection,
+    max_data_end: usize,
+) ![]u8 {
+    const section_headers_offset_new: usize = @intCast(elf_header.e_shoff);
+
+    const output_size = section_headers_offset_new + sections.len * @sizeOf(elf.Elf64_Shdr);
+    var output = try gpa.alloc(u8, output_size);
+    @memset(output, 0);
+
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        output[0..@min(output.len, input.len)],
+        input[0..@min(output.len, input.len)],
+    );
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        output[0..@sizeOf(elf.Elf64_Ehdr)],
+        std.mem.asBytes(&elf_header),
+    );
+
+    for (sections) |section| {
+        if (section.header.sh_type == elf.SHT_NOBITS or section.header.sh_size == 0) continue;
+        const section_data_offset: usize = @intCast(section.header.sh_offset);
+        if (section_data_offset + section.data.len > output.len) return error.InvalidELF;
+        stdx.copy_disjoint(
+            .exact,
+            u8,
+            output[section_data_offset..][0..section.data.len],
+            section.data,
+        );
+    }
+    if (max_data_end < section_headers_offset_new) {
+        @memset(output[max_data_end..section_headers_offset_new], 0);
+    }
+
+    for (sections, 0..) |section, i| {
+        const section_header_offset = section_headers_offset_new + i * @sizeOf(elf.Elf64_Shdr);
+        stdx.copy_disjoint(
+            .exact,
+            u8,
+            output[section_header_offset..][0..@sizeOf(elf.Elf64_Shdr)],
+            std.mem.asBytes(&section.header),
+        );
+    }
+
+    return output;
+}
+
+// Build LLVM-compatible `.shstrtab` bytes and per-section name offsets.
+fn elf_build_string_table(
+    gpa: std.mem.Allocator,
+    sections: []const ElfSection,
+) !struct { []u32, []u8 } {
+    var unique_names = std.ArrayList([]const u8).init(gpa);
+    defer unique_names.deinit();
+
+    var offset_by_name = std.StringHashMap(u32).init(gpa);
+    defer offset_by_name.deinit();
+
+    try unique_names.append("");
+    try offset_by_name.put("", 0);
+    for (sections) |section| {
+        if (offset_by_name.get(section.name) == null) {
+            try unique_names.append(section.name);
+            try offset_by_name.put(section.name, 0);
+        }
+    }
+
+    std.sort.heap([]const u8, unique_names.items, {}, struct {
+        fn char_tail_at(s: []const u8, pos: usize) i16 {
+            if (pos >= s.len) return -1;
+            return @intCast(s[s.len - 1 - pos]);
+        }
+
+        fn less_than(_: void, a: []const u8, b: []const u8) bool {
+            var pos: usize = 0;
+            while (true) : (pos += 1) {
+                const ca = char_tail_at(a, pos);
+                const cb = char_tail_at(b, pos);
+                if (ca == cb) {
+                    if (ca == -1) return false;
+                    continue;
+                }
+                // Same ordering as LLVM's multikeySort partition `C > Pivot`.
+                return ca > cb;
+            }
+        }
+    }.less_than);
+
+    var size: usize = 1;
+    var previous: []const u8 = "";
+    for (unique_names.items) |name| {
+        if (std.mem.endsWith(u8, previous, name)) {
+            const pos = size - name.len - 1;
+            try offset_by_name.put(name, @intCast(pos));
+            continue;
+        }
+        const offset: u32 = @intCast(size);
+        try offset_by_name.put(name, offset);
+        size += name.len + 1;
+        previous = name;
+    }
+    try offset_by_name.put("", 0);
+
+    var table = try gpa.alloc(u8, size);
+    @memset(table, 0);
+    var it = offset_by_name.iterator();
+    while (it.next()) |entry| {
+        const name = entry.key_ptr.*;
+        const offset = entry.value_ptr.*;
+        if (name.len == 0) continue;
+        stdx.copy_disjoint(.exact, u8, table[offset..][0..name.len], name);
+    }
+
+    var offsets = try gpa.alloc(u32, sections.len);
+    for (sections, 0..) |section, i| {
+        offsets[i] = offset_by_name.get(section.name).?;
+    }
+
+    return .{ offsets, table };
+}
+
+const PESection = struct {
+    name: [8]u8,
+    virtual_size: u32,
+    virtual_address: u32,
+    size_of_raw_data: u32,
+    pointer_to_raw_data: u32,
+    pointer_to_relocations: u32,
+    pointer_to_linenumbers: u32,
+    number_of_relocations: u16,
+    number_of_linenumbers: u16,
+    characteristics: u32,
+    data: []const u8,
+    added: bool,
+};
+
+// Apply the requested section edits to a PE/COFF input and emit rewritten bytes.
+fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
+    if (input.len < 0x40) return error.InvalidPE;
+    const pe_header_offset = std.mem.readInt(u32, input[0x3c..][0..4], .little);
+    if (pe_header_offset + 4 + 20 > input.len) return error.InvalidPE;
+    if (!std.mem.eql(u8, input[pe_header_offset..][0..4], "PE\x00\x00")) return error.InvalidPE;
+
+    const coff_offset = pe_header_offset + 4;
+    const section_count = std.mem.readInt(u16, input[coff_offset + 2 ..][0..2], .little);
+    const optional_header_size = std.mem.readInt(u16, input[coff_offset + 16 ..][0..2], .little);
+    const optional_header_offset = coff_offset + 20;
+    const section_table_offset = optional_header_offset + optional_header_size;
+    const section_header_size = 40;
+    if (section_table_offset + section_count * section_header_size > input.len) {
+        return error.InvalidPE;
+    }
+
+    const section_alignment = std.mem.readInt(
+        u32,
+        input[optional_header_offset + 32 ..][0..4],
+        .little,
+    );
+    const file_alignment = std.mem.readInt(
+        u32,
+        input[optional_header_offset + 36 ..][0..4],
+        .little,
+    );
+    const size_of_headers = std.mem.readInt(
+        u32,
+        input[optional_header_offset + 60 ..][0..4],
+        .little,
+    );
+    if (section_alignment == 0 or file_alignment == 0) return error.InvalidPE;
+
+    var sections = try pe_collect_sections(gpa, input, cli, .{
+        .section_table_offset = section_table_offset,
+        .section_header_size = section_header_size,
+        .section_count = section_count,
+    });
+    defer sections.deinit();
+
+    try pe_apply_add_sections(&sections, cli);
+    const next_raw, const next_va = pe_layout_sections(
+        sections.items,
+        file_alignment,
+        section_alignment,
+    );
+
+    const new_section_count: u16 = @intCast(sections.items.len);
+    const new_size_of_image = std.mem.alignForward(u32, next_va, section_alignment);
+    const output_size: usize = @intCast(next_raw);
+
+    var output = try gpa.alloc(u8, output_size);
+    @memset(output, 0);
+    // LLVM only preserves the PE header region, not stale data from removed section payloads.
+    const headers_copy_len: usize = @min(@min(output.len, input.len), size_of_headers);
+    stdx.copy_disjoint(.exact, u8, output[0..headers_copy_len], input[0..headers_copy_len]);
+
+    std.mem.writeInt(u16, output[coff_offset + 2 ..][0..2], new_section_count, .little);
+    std.mem.writeInt(u32, output[optional_header_offset + 56 ..][0..4], new_size_of_image, .little);
+
+    for (sections.items, 0..) |section, i| {
+        const section_header_offset = section_table_offset + i * section_header_size;
+        if (section_header_offset + section_header_size > output.len) return error.InvalidPE;
+        stdx.copy_disjoint(.exact, u8, output[section_header_offset..][0..8], &section.name);
+
+        inline for ([_]struct { field_offset: usize, field_value: u32 }{
+            .{ .field_offset = 8, .field_value = section.virtual_size },
+            .{ .field_offset = 12, .field_value = section.virtual_address },
+            .{ .field_offset = 16, .field_value = section.size_of_raw_data },
+            .{ .field_offset = 20, .field_value = section.pointer_to_raw_data },
+            .{ .field_offset = 24, .field_value = section.pointer_to_relocations },
+            .{ .field_offset = 28, .field_value = section.pointer_to_linenumbers },
+            .{ .field_offset = 36, .field_value = section.characteristics },
+        }) |field| {
+            std.mem.writeInt(
+                u32,
+                output[section_header_offset + field.field_offset ..][0..4],
+                field.field_value,
+                .little,
+            );
+        }
+
+        inline for ([_]struct { field_offset: usize, field_value: u16 }{
+            .{ .field_offset = 32, .field_value = section.number_of_relocations },
+            .{ .field_offset = 34, .field_value = section.number_of_linenumbers },
+        }) |field| {
+            std.mem.writeInt(
+                u16,
+                output[section_header_offset + field.field_offset ..][0..2],
+                field.field_value,
+                .little,
+            );
+        }
+    }
+    const old_section_table_end = section_table_offset + section_count * section_header_size;
+    const new_section_table_end = section_table_offset + sections.items.len * section_header_size;
+    if (new_section_table_end < old_section_table_end and old_section_table_end <= output.len) {
+        @memset(output[new_section_table_end..old_section_table_end], 0);
+    }
+
+    for (sections.items) |section| {
+        if (section.size_of_raw_data == 0) continue;
+        const raw_ptr: usize = @intCast(section.pointer_to_raw_data);
+        if (raw_ptr + section.data.len > output.len) return error.InvalidPE;
+        stdx.copy_disjoint(.exact, u8, output[raw_ptr..][0..section.data.len], section.data);
+    }
+
+    assert(output.len == output_size);
+    return output;
+}
+
+// Read PE section headers/data, filtering removed sections.
+fn pe_collect_sections(
+    gpa: std.mem.Allocator,
+    input: []const u8,
+    cli: *const CLI,
+    options: struct {
+        section_table_offset: usize,
+        section_header_size: usize,
+        section_count: usize,
+    },
+) !std.ArrayList(PESection) {
+    var sections = std.ArrayList(PESection).init(gpa);
+
+    for (0..options.section_count) |i| {
+        const section_header_offset = options.section_table_offset + i * options.section_header_size;
+        var name: [8]u8 = undefined;
+        stdx.copy_disjoint(.exact, u8, &name, input[section_header_offset..][0..8]);
+
+        const section_name = std.mem.sliceTo(&name, 0);
+        if (section_parse(section_name)) |section| {
+            if (cli.remove_sections[@intFromEnum(section)]) continue;
+        }
+
+        const raw_size = std.mem.readInt(u32, input[section_header_offset + 16 ..][0..4], .little);
+        const raw_ptr = std.mem.readInt(u32, input[section_header_offset + 20 ..][0..4], .little);
+        const data = blk: {
+            if (raw_size == 0) break :blk "";
+            if (raw_ptr + raw_size > input.len) return error.InvalidPE;
+            break :blk input[raw_ptr..][0..raw_size];
+        };
+
+        var section: PESection = .{
+            .name = name,
+            .virtual_size = 0,
+            .virtual_address = 0,
+            .size_of_raw_data = raw_size,
+            .pointer_to_raw_data = raw_ptr,
+            .pointer_to_relocations = 0,
+            .pointer_to_linenumbers = 0,
+            .number_of_relocations = 0,
+            .number_of_linenumbers = 0,
+            .characteristics = 0,
+            .data = data,
+            .added = false,
+        };
+        inline for ([_]struct { field_name: []const u8, field_offset: usize }{
+            .{ .field_name = "virtual_size", .field_offset = 8 },
+            .{ .field_name = "virtual_address", .field_offset = 12 },
+            .{ .field_name = "pointer_to_relocations", .field_offset = 24 },
+            .{ .field_name = "pointer_to_linenumbers", .field_offset = 28 },
+            .{ .field_name = "characteristics", .field_offset = 36 },
+        }) |field| {
+            @field(section, field.field_name) = std.mem.readInt(
+                u32,
+                input[section_header_offset + field.field_offset ..][0..4],
+                .little,
+            );
+        }
+        inline for ([_]struct { field_name: []const u8, field_offset: usize }{
+            .{ .field_name = "number_of_relocations", .field_offset = 32 },
+            .{ .field_name = "number_of_linenumbers", .field_offset = 34 },
+        }) |field| {
+            @field(section, field.field_name) = std.mem.readInt(
+                u16,
+                input[section_header_offset + field.field_offset ..][0..2],
+                .little,
+            );
+        }
+        try sections.append(section);
+    }
+    return sections;
+}
+
+// Append requested PE sections with TigerBeetle's expected section attributes.
+fn pe_apply_add_sections(sections: *std.ArrayList(PESection), cli: *const CLI) !void {
+    for (cli.add_sections) |maybe_add| {
+        if (maybe_add == null) continue;
+        const add = maybe_add.?;
+        var name: [8]u8 = @splat(0);
+        stdx.copy_disjoint(.exact, u8, name[0..add.section.name().len], add.section.name());
+        try sections.append(.{
+            .name = name,
+            .virtual_size = @intCast(add.bytes.len),
+            .virtual_address = 0,
+            .size_of_raw_data = 0,
+            .pointer_to_raw_data = 0,
+            .pointer_to_relocations = 0,
+            .pointer_to_linenumbers = 0,
+            .number_of_relocations = 0,
+            .number_of_linenumbers = 0,
+            .characteristics = 0x40000800, // MEM_READ | LNK_REMOVE
+            .data = add.bytes,
+            .added = true,
+        });
+    }
+}
+
+// Compute raw/file and virtual layout for all PE sections.
+fn pe_layout_sections(
+    sections: []PESection,
+    file_alignment: u32,
+    section_alignment: u32,
+) struct { u32, u32 } {
+    var next_raw: u32 = 0;
+    var next_va: u32 = 0;
+    for (sections) |*section| {
+        if (section.added) {
+            section.size_of_raw_data = @intCast(std.mem.alignForward(
+                usize,
+                section.data.len,
+                file_alignment,
+            ));
+            section.pointer_to_raw_data = std.mem.alignForward(u32, next_raw, file_alignment);
+            section.virtual_address = std.mem.alignForward(u32, next_va, section_alignment);
+        }
+        next_raw = section.pointer_to_raw_data + section.size_of_raw_data;
+        next_va = section.virtual_address + std.mem.alignForward(
+            u32,
+            @max(section.virtual_size, section.size_of_raw_data),
+            section_alignment,
+        );
+    }
+    return .{ next_raw, next_va };
+}

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -211,11 +211,11 @@ fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]
     }
 
     if (elf_header.e_shstrndx >= section_headers_count) return error.InvalidELF;
+    const section_name_table_header_offset =
+        section_headers_offset + elf_header.e_shstrndx * @sizeOf(elf.Elf64_Shdr);
     const section_name_table_header = std.mem.bytesAsValue(
         elf.Elf64_Shdr,
-        input[section_headers_offset + elf_header.e_shstrndx * @sizeOf(elf.Elf64_Shdr) ..][0..@sizeOf(
-            elf.Elf64_Shdr,
-        )],
+        input[section_name_table_header_offset..][0..@sizeOf(elf.Elf64_Shdr)],
     ).*;
     const section_name_table_offset: usize = @intCast(section_name_table_header.sh_offset);
     const section_name_table_size: usize = @intCast(section_name_table_header.sh_size);
@@ -677,7 +677,8 @@ fn pe_collect_sections(
     var sections = std.ArrayList(PESection).init(gpa);
 
     for (0..options.section_count) |i| {
-        const section_header_offset = options.section_table_offset + i * options.section_header_size;
+        const section_header_offset = options.section_table_offset + i *
+            options.section_header_size;
         var name: [8]u8 = undefined;
         stdx.copy_disjoint(.exact, u8, &name, input[section_header_offset..][0..8]);
 

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -36,9 +36,9 @@ pub fn main() !void {
     var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_allocator.deinit();
 
-    const gpa = arena_allocator.allocator();
+    const arena = arena_allocator.allocator();
 
-    var arguments = try std.process.argsWithAllocator(gpa);
+    var arguments = try std.process.argsWithAllocator(arena);
 
     var cli = try parse_cli_args(&arguments);
     const source_file_mode = (try std.fs.cwd().statFile(cli.source)).mode;
@@ -46,11 +46,11 @@ pub fn main() !void {
     for (cli.add_sections, 0..) |maybe_add, i| {
         if (maybe_add == null) continue;
         var add = maybe_add.?;
-        add.bytes = try std.fs.cwd().readFileAlloc(gpa, add.path, std.math.maxInt(usize));
+        add.bytes = try std.fs.cwd().readFileAlloc(arena, add.path, std.math.maxInt(usize));
         cli.add_sections[i] = add;
     }
 
-    const input = try std.fs.cwd().readFileAlloc(gpa, cli.source, std.math.maxInt(usize));
+    const input = try std.fs.cwd().readFileAlloc(arena, cli.source, std.math.maxInt(usize));
 
     const has_section_changes = cli_has_section_changes(&cli);
     if (!has_section_changes and is_pe(input)) {
@@ -65,9 +65,9 @@ pub fn main() !void {
 
     const output = blk: {
         if (is_elf(input)) {
-            break :blk try transform_elf(gpa, input, &cli);
+            break :blk try transform_elf(arena, input, &cli);
         } else if (is_pe(input)) {
-            break :blk try transform_pe(gpa, input, &cli);
+            break :blk try transform_pe(arena, input, &cli);
         } else unreachable;
     };
 
@@ -230,7 +230,7 @@ const ElfSection = struct {
 // 2. `.shstrtab` exists as a normal section and is rebuilt LLVM-style.
 // 3. Only section table and section payload bytes are rewritten.
 // Apply the requested section edits to an ELF input and emit rewritten bytes.
-fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
+fn transform_elf(arena: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
     assert(input.len >= @sizeOf(elf.Elf64_Ehdr)); // ELF header must be present.
 
     var elf_header = std.mem.bytesAsValue(elf.Elf64_Ehdr, input[0..@sizeOf(elf.Elf64_Ehdr)]).*;
@@ -260,13 +260,18 @@ fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]
     assert(section_name_table_offset + section_name_table_size <= input.len);
     const section_name_table = input[section_name_table_offset..][0..section_name_table_size];
 
-    var sections, const section_data_end_max_original = try elf_collect_sections(gpa, input, cli, .{
-        .section_headers = section_headers,
-        .section_name_table = section_name_table,
-    });
+    var sections, const section_data_end_max_original = try elf_collect_sections(
+        arena,
+        input,
+        cli,
+        .{
+            .section_headers = section_headers,
+            .section_name_table = section_name_table,
+        },
+    );
 
-    try elf_apply_add_sections(gpa, &sections, cli, section_data_end_max_original);
-    const section_name_table_index = try elf_apply_string_table(gpa, &sections);
+    try elf_apply_add_sections(arena, &sections, cli, section_data_end_max_original);
+    const section_name_table_index = try elf_apply_string_table(arena, &sections);
 
     // Keep existing section data offsets as stable as possible and shift only the tail.
     const section_data_end_max = elf_relayout_sections(sections.items);
@@ -276,12 +281,12 @@ fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]
     elf_header.e_shnum = @intCast(sections.items.len);
     elf_header.e_shstrndx = @intCast(section_name_table_index);
 
-    return try elf_write_output(gpa, input, elf_header, sections.items, section_data_end_max);
+    return try elf_write_output(arena, input, elf_header, sections.items, section_data_end_max);
 }
 
 // Read ELF section headers/data, filtering removed sections.
 fn elf_collect_sections(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     input: []const u8,
     cli: *const CLI,
     options: struct {
@@ -289,7 +294,7 @@ fn elf_collect_sections(
         section_name_table: []const u8,
     },
 ) !struct { std.ArrayList(ElfSection), usize } {
-    var sections = std.ArrayList(ElfSection).init(gpa);
+    var sections = std.ArrayList(ElfSection).init(arena);
     var data_end_max: usize = 0;
 
     for (options.section_headers) |shdr| {
@@ -313,7 +318,7 @@ fn elf_collect_sections(
             assert(offset + size <= input.len); // Section payload must fit in file bytes.
             break :blk input[offset..][0..size];
         };
-        const name_owned = if (name.len > 0) try gpa.dupe(u8, name) else "";
+        const name_owned = if (name.len > 0) try arena.dupe(u8, name) else "";
         try sections.append(.{
             .header = shdr,
             .name = name_owned,
@@ -333,7 +338,7 @@ fn elf_collect_sections(
 
 // Append requested ELF sections, replacing same-name sections when present.
 fn elf_apply_add_sections(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     sections: *std.ArrayList(ElfSection),
     cli: *const CLI,
     data_end_max: usize,
@@ -366,7 +371,7 @@ fn elf_apply_add_sections(
                 .sh_addralign = 1,
                 .sh_entsize = 0,
             },
-            .name = try gpa.dupe(u8, add.section.name()),
+            .name = try arena.dupe(u8, add.section.name()),
             .data = add.bytes,
             .data_owned = false,
             .old_offset = data_end_max,
@@ -378,7 +383,7 @@ fn elf_apply_add_sections(
 
 // Rebuild `.shstrtab` and patch each section header `sh_name`.
 fn elf_apply_string_table(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     sections: *std.ArrayList(ElfSection),
 ) !usize {
     const shstr_index: usize = for (sections.items, 0..) |section, i| {
@@ -386,7 +391,7 @@ fn elf_apply_string_table(
     } else unreachable; // `.shstrtab` must exist in valid ELF output.
 
     // LLVM sorts and suffix-deduplicates names before materializing `.shstrtab`.
-    const name_offsets, const shstr_bytes = try elf_build_string_table(gpa, sections.items);
+    const name_offsets, const shstr_bytes = try elf_build_string_table(arena, sections.items);
 
     for (sections.items, 0..) |*section, i| {
         section.header.sh_name = name_offsets[i];
@@ -430,7 +435,7 @@ fn elf_relayout_sections(sections: []ElfSection) usize {
 
 // Materialize final ELF bytes including data payloads and the section table.
 fn elf_write_output(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     input: []const u8,
     elf_header: elf.Elf64_Ehdr,
     sections: []const ElfSection,
@@ -439,7 +444,7 @@ fn elf_write_output(
     const section_headers_offset_new: usize = @intCast(elf_header.e_shoff);
 
     const output_size = section_headers_offset_new + sections.len * @sizeOf(elf.Elf64_Shdr);
-    var output = try gpa.alloc(u8, output_size);
+    var output = try arena.alloc(u8, output_size);
     @memset(output, 0);
 
     stdx.copy_disjoint(
@@ -489,12 +494,12 @@ fn elf_write_output(
 
 // Build LLVM-compatible `.shstrtab` bytes and per-section name offsets.
 fn elf_build_string_table(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     sections: []const ElfSection,
 ) !struct { []u32, []u8 } {
-    var unique_names = std.ArrayList([]const u8).init(gpa);
+    var unique_names = std.ArrayList([]const u8).init(arena);
 
-    var offset_by_name = std.StringHashMap(u32).init(gpa);
+    var offset_by_name = std.StringHashMap(u32).init(arena);
 
     try unique_names.append("");
     try offset_by_name.put("", 0);
@@ -541,7 +546,7 @@ fn elf_build_string_table(
     }
     try offset_by_name.put("", 0);
 
-    var table = try gpa.alloc(u8, size);
+    var table = try arena.alloc(u8, size);
     @memset(table, 0);
     var it = offset_by_name.iterator();
     while (it.next()) |entry| {
@@ -551,7 +556,7 @@ fn elf_build_string_table(
         stdx.copy_disjoint(.exact, u8, table[offset..][0..name.len], name);
     }
 
-    var offsets = try gpa.alloc(u32, sections.len);
+    var offsets = try arena.alloc(u32, sections.len);
     for (sections, 0..) |section, i| {
         offsets[i] = offset_by_name.get(section.name).?;
     }
@@ -613,7 +618,7 @@ const PESection = struct {
 // 2. Machine is x86_64 or aarch64.
 // 3. Header region is preserved up to `SizeOfHeaders`.
 // Apply the requested section edits to a PE/COFF input and emit rewritten bytes.
-fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
+fn transform_pe(arena: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
     assert(input.len >= 0x40); // DOS stub + `e_lfanew` must be present.
     const pe_header_offset = std.mem.readInt(u32, input[0x3c..][0..4], .little);
     assert(pe_header_offset + 4 + 20 <= input.len); // PE signature + COFF header.
@@ -656,7 +661,7 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
     );
     assert(section_alignment > 0 and file_alignment > 0); // Required for alignment math.
 
-    var sections = try pe_collect_sections(gpa, input, cli, .{
+    var sections = try pe_collect_sections(arena, input, cli, .{
         .section_table_offset = section_table_offset,
         .section_header_size = section_header_size,
         .section_count = section_count,
@@ -684,7 +689,7 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
     // Added section headers must not overlap any section raw payload.
     assert(new_section_table_end <= first_section_raw_offset);
 
-    var output = try gpa.alloc(u8, output_size);
+    var output = try arena.alloc(u8, output_size);
     @memset(output, 0);
     // LLVM only preserves the PE header region, not stale data from removed section payloads.
     const headers_copy_len: usize = @min(@min(output.len, input.len), size_of_headers);
@@ -750,7 +755,7 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
 
 // Read PE section headers/data, filtering removed sections.
 fn pe_collect_sections(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     input: []const u8,
     cli: *const CLI,
     options: struct {
@@ -759,7 +764,7 @@ fn pe_collect_sections(
         section_count: usize,
     },
 ) !std.ArrayList(PESection) {
-    var sections = std.ArrayList(PESection).init(gpa);
+    var sections = std.ArrayList(PESection).init(arena);
 
     for (0..options.section_count) |i| {
         const section_header_offset = options.section_table_offset + i *

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -2,6 +2,7 @@
 //! Supports only the subset of flags used in this repository.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const elf = std.elf;
 const stdx = @import("stdx");
 const assert = std.debug.assert;
@@ -66,12 +67,16 @@ pub fn main() !void {
         return;
     }
 
-    const output = if (is_elf(input))
-        try transform_elf(gpa, input, &cli)
-    else if (is_pe(input))
-        try transform_pe(gpa, input, &cli)
-    else
-        return error.UnsupportedFormat;
+    const output = blk: {
+        if (is_elf(input)) {
+            break :blk try transform_elf(gpa, input, &cli);
+        } else if (is_pe(input)) {
+            break :blk try transform_pe(gpa, input, &cli);
+        } else {
+            assert(false); // TigerBeetle multiversion inputs are always ELF or PE.
+            unreachable;
+        }
+    };
     defer gpa.free(output);
 
     try std.fs.cwd().writeFile(.{
@@ -196,35 +201,37 @@ const ElfSection = struct {
 
 // Apply the requested section edits to an ELF input and emit rewritten bytes.
 fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
-    if (input.len < @sizeOf(elf.Elf64_Ehdr)) return error.InvalidELF;
+    assert(input.len >= @sizeOf(elf.Elf64_Ehdr)); // ELF header must be present.
 
     var elf_header = std.mem.bytesAsValue(elf.Elf64_Ehdr, input[0..@sizeOf(elf.Elf64_Ehdr)]).*;
-    if (!std.mem.eql(u8, elf_header.e_ident[0..4], elf.MAGIC)) return error.InvalidELF;
-    if (elf_header.e_ident[elf.EI_CLASS] != elf.ELFCLASS64) return error.UnsupportedELF;
-    if (elf_header.e_ident[elf.EI_DATA] != elf.ELFDATA2LSB) return error.UnsupportedELF;
-    if (elf_header.e_shentsize != @sizeOf(elf.Elf64_Shdr)) return error.InvalidELF;
+    assert(std.mem.eql(u8, elf_header.e_ident[0..4], elf.MAGIC)); // Input is ELF.
+    assert(elf_header.e_ident[elf.EI_CLASS] == elf.ELFCLASS64); // 64-bit only.
+    assert(elf_header.e_ident[elf.EI_DATA] == elf.ELFDATA2LSB); // Little-endian only.
+    assert(elf_header.e_shentsize == @sizeOf(elf.Elf64_Shdr)); // 64-bit section headers.
+    assert(elf_header.e_shnum != 0); // No ELF extended section numbering.
+    assert(elf_header.e_shstrndx != elf.SHN_HIRESERVE); // No SHN_XINDEX indirection.
 
     const section_headers_offset: usize = @intCast(elf_header.e_shoff);
     const section_headers_count: usize = elf_header.e_shnum;
-    if (section_headers_offset + section_headers_count * @sizeOf(elf.Elf64_Shdr) > input.len) {
-        return error.InvalidELF;
-    }
-
-    if (elf_header.e_shstrndx >= section_headers_count) return error.InvalidELF;
-    const section_name_table_header_offset =
-        section_headers_offset + elf_header.e_shstrndx * @sizeOf(elf.Elf64_Shdr);
-    const section_name_table_header = std.mem.bytesAsValue(
+    // Section header table must fit in file bytes.
+    assert(section_headers_offset + section_headers_count * @sizeOf(elf.Elf64_Shdr) <= input.len);
+    const section_headers = stdx.bytes_as_slice(
+        .exact,
         elf.Elf64_Shdr,
-        input[section_name_table_header_offset..][0..@sizeOf(elf.Elf64_Shdr)],
-    ).*;
+        input[section_headers_offset..][0 .. section_headers_count * @sizeOf(elf.Elf64_Shdr)],
+    );
+
+    // Section name table index must reference a real section.
+    assert(elf_header.e_shstrndx < section_headers_count);
+    const section_name_table_header = section_headers[elf_header.e_shstrndx];
     const section_name_table_offset: usize = @intCast(section_name_table_header.sh_offset);
     const section_name_table_size: usize = @intCast(section_name_table_header.sh_size);
-    if (section_name_table_offset + section_name_table_size > input.len) return error.InvalidELF;
+    // `.shstrtab` payload must fit in file bytes.
+    assert(section_name_table_offset + section_name_table_size <= input.len);
     const section_name_table = input[section_name_table_offset..][0..section_name_table_size];
 
     var sections, const section_data_end_max_original = try elf_collect_sections(gpa, input, cli, .{
-        .section_headers_offset = section_headers_offset,
-        .section_headers_count = section_headers_count,
+        .section_headers = section_headers,
         .section_name_table = section_name_table,
     });
     defer sections.deinit();
@@ -253,26 +260,23 @@ fn elf_collect_sections(
     input: []const u8,
     cli: *const CLI,
     options: struct {
-        section_headers_offset: usize,
-        section_headers_count: usize,
+        section_headers: []const elf.Elf64_Shdr,
         section_name_table: []const u8,
     },
 ) !struct { std.ArrayList(ElfSection), usize } {
     var sections = std.ArrayList(ElfSection).init(gpa);
     var data_end_max: usize = 0;
 
-    for (0..options.section_headers_count) |i| {
-        const shdr = std.mem.bytesAsValue(
-            elf.Elf64_Shdr,
-            input[options.section_headers_offset + i * @sizeOf(elf.Elf64_Shdr) ..][0..@sizeOf(
-                elf.Elf64_Shdr,
-            )],
-        ).*;
-        if (shdr.sh_name >= options.section_name_table.len) return error.InvalidELF;
-        const name = std.mem.sliceTo(
-            @as([*:0]const u8, @ptrCast(options.section_name_table.ptr + shdr.sh_name)),
+    for (options.section_headers) |shdr| {
+        assert(shdr.sh_name < options.section_name_table.len);
+        const name_offset: usize = @intCast(shdr.sh_name);
+        const name_end = std.mem.indexOfScalarPos(
+            u8,
+            options.section_name_table,
+            name_offset,
             0,
-        );
+        ) orelse unreachable;
+        const name = options.section_name_table[name_offset..name_end];
         if (section_parse(name)) |section| {
             if (cli.remove_sections[@intFromEnum(section)]) continue;
         }
@@ -281,7 +285,7 @@ fn elf_collect_sections(
             if (shdr.sh_type == elf.SHT_NOBITS or shdr.sh_size == 0) break :blk "";
             const offset: usize = @intCast(shdr.sh_offset);
             const size: usize = @intCast(shdr.sh_size);
-            if (offset + size > input.len) return error.InvalidELF;
+            assert(offset + size <= input.len); // Section payload must fit in file bytes.
             break :blk input[offset..][0..size];
         };
         const name_owned = if (name.len > 0) try gpa.dupe(u8, name) else "";
@@ -361,7 +365,7 @@ fn elf_apply_string_table(
             break;
         }
     }
-    if (shstr_index == null) return error.InvalidELF;
+    assert(shstr_index != null); // `.shstrtab` must exist in valid ELF output.
 
     // LLVM sorts and suffix-deduplicates names before materializing `.shstrtab`.
     const name_offsets, const shstr_bytes = try elf_build_string_table(gpa, sections.items);
@@ -437,7 +441,8 @@ fn elf_write_output(
     for (sections) |section| {
         if (section.header.sh_type == elf.SHT_NOBITS or section.header.sh_size == 0) continue;
         const section_data_offset: usize = @intCast(section.header.sh_offset);
-        if (section_data_offset + section.data.len > output.len) return error.InvalidELF;
+        // Rewritten section payload must fit in output buffer.
+        assert(section_data_offset + section.data.len <= output.len);
         stdx.copy_disjoint(
             .exact,
             u8,
@@ -447,6 +452,9 @@ fn elf_write_output(
     }
     if (max_data_end < section_headers_offset_new) {
         @memset(output[max_data_end..section_headers_offset_new], 0);
+        if (builtin.mode == .Debug) {
+            assert(stdx.zeroed(output[max_data_end..section_headers_offset_new]));
+        }
     }
 
     for (sections, 0..) |section, i| {
@@ -553,20 +561,30 @@ const PESection = struct {
 
 // Apply the requested section edits to a PE/COFF input and emit rewritten bytes.
 fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u8 {
-    if (input.len < 0x40) return error.InvalidPE;
+    assert(input.len >= 0x40); // DOS stub + `e_lfanew` must be present.
     const pe_header_offset = std.mem.readInt(u32, input[0x3c..][0..4], .little);
-    if (pe_header_offset + 4 + 20 > input.len) return error.InvalidPE;
-    if (!std.mem.eql(u8, input[pe_header_offset..][0..4], "PE\x00\x00")) return error.InvalidPE;
+    assert(pe_header_offset + 4 + 20 <= input.len); // PE signature + COFF header.
+    assert(std.mem.eql(u8, input[pe_header_offset..][0..4], "PE\x00\x00")); // PE/COFF only.
 
     const coff_offset = pe_header_offset + 4;
+    const machine = std.mem.readInt(u16, input[coff_offset..][0..2], .little);
+    assert(machine == 0x8664 or machine == 0xaa64); // PE32+ x86_64 or aarch64 only.
     const section_count = std.mem.readInt(u16, input[coff_offset + 2 ..][0..2], .little);
     const optional_header_size = std.mem.readInt(u16, input[coff_offset + 16 ..][0..2], .little);
     const optional_header_offset = coff_offset + 20;
+    // Optional header must fit in file bytes.
+    assert(optional_header_offset + optional_header_size <= input.len);
+    assert(optional_header_size >= 64); // We read fields through SizeOfHeaders.
+    const optional_header_magic = std.mem.readInt(
+        u16,
+        input[optional_header_offset..][0..2],
+        .little,
+    );
+    assert(optional_header_magic == 0x20b); // PE32+ only (reject PE32).
     const section_table_offset = optional_header_offset + optional_header_size;
     const section_header_size = 40;
-    if (section_table_offset + section_count * section_header_size > input.len) {
-        return error.InvalidPE;
-    }
+    // Section table must fit in file bytes.
+    assert(section_table_offset + section_count * section_header_size <= input.len);
 
     const section_alignment = std.mem.readInt(
         u32,
@@ -583,7 +601,7 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
         input[optional_header_offset + 60 ..][0..4],
         .little,
     );
-    if (section_alignment == 0 or file_alignment == 0) return error.InvalidPE;
+    assert(section_alignment > 0 and file_alignment > 0); // Required for alignment math.
 
     var sections = try pe_collect_sections(gpa, input, cli, .{
         .section_table_offset = section_table_offset,
@@ -614,7 +632,8 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
 
     for (sections.items, 0..) |section, i| {
         const section_header_offset = section_table_offset + i * section_header_size;
-        if (section_header_offset + section_header_size > output.len) return error.InvalidPE;
+        // Rewritten section header must fit in output buffer.
+        assert(section_header_offset + section_header_size <= output.len);
         stdx.copy_disjoint(.exact, u8, output[section_header_offset..][0..8], &section.name);
 
         inline for ([_]struct { field_offset: usize, field_value: u32 }{
@@ -650,16 +669,20 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
     const new_section_table_end = section_table_offset + sections.items.len * section_header_size;
     if (new_section_table_end < old_section_table_end and old_section_table_end <= output.len) {
         @memset(output[new_section_table_end..old_section_table_end], 0);
+        if (builtin.mode == .Debug) {
+            assert(stdx.zeroed(output[new_section_table_end..old_section_table_end]));
+        }
     }
 
     for (sections.items) |section| {
         if (section.size_of_raw_data == 0) continue;
         const raw_ptr: usize = @intCast(section.pointer_to_raw_data);
-        if (raw_ptr + section.data.len > output.len) return error.InvalidPE;
+        // Section raw bytes must fit in output buffer.
+        assert(raw_ptr + section.data.len <= output.len);
         stdx.copy_disjoint(.exact, u8, output[raw_ptr..][0..section.data.len], section.data);
     }
 
-    assert(output.len == output_size);
+    assert(output.len == output_size); // Allocated output length must match computed final size.
     return output;
 }
 
@@ -691,7 +714,7 @@ fn pe_collect_sections(
         const raw_ptr = std.mem.readInt(u32, input[section_header_offset + 20 ..][0..4], .little);
         const data = blk: {
             if (raw_size == 0) break :blk "";
-            if (raw_ptr + raw_size > input.len) return error.InvalidPE;
+            assert(raw_ptr + raw_size <= input.len); // Section raw bytes must fit in input file.
             break :blk input[raw_ptr..][0..raw_size];
         };
 

--- a/src/tb_objcopy.zig
+++ b/src/tb_objcopy.zig
@@ -33,13 +33,12 @@ const CLI = struct {
 };
 
 pub fn main() !void {
-    var gpa_state: std.heap.GeneralPurposeAllocator(.{}) = .{};
-    defer if (gpa_state.deinit() != .ok) @panic("memory leaked");
+    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_allocator.deinit();
 
-    const gpa = gpa_state.allocator();
+    const gpa = arena_allocator.allocator();
 
     var arguments = try std.process.argsWithAllocator(gpa);
-    defer arguments.deinit();
 
     var cli = try parse_cli_args(&arguments);
     const source_file_mode = (try std.fs.cwd().statFile(cli.source)).mode;
@@ -50,12 +49,8 @@ pub fn main() !void {
         add.bytes = try std.fs.cwd().readFileAlloc(gpa, add.path, std.math.maxInt(usize));
         cli.add_sections[i] = add;
     }
-    defer for (cli.add_sections) |maybe_add| {
-        if (maybe_add) |add| gpa.free(add.bytes);
-    };
 
     const input = try std.fs.cwd().readFileAlloc(gpa, cli.source, std.math.maxInt(usize));
-    defer gpa.free(input);
 
     const has_section_changes = cli_has_section_changes(&cli);
     if (!has_section_changes and is_pe(input)) {
@@ -73,12 +68,8 @@ pub fn main() !void {
             break :blk try transform_elf(gpa, input, &cli);
         } else if (is_pe(input)) {
             break :blk try transform_pe(gpa, input, &cli);
-        } else {
-            assert(false); // TigerBeetle multiversion inputs are always ELF or PE.
-            unreachable;
-        }
+        } else unreachable;
     };
-    defer gpa.free(output);
 
     try std.fs.cwd().writeFile(.{
         .sub_path = cli.output,
@@ -273,11 +264,6 @@ fn transform_elf(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]
         .section_headers = section_headers,
         .section_name_table = section_name_table,
     });
-    defer sections.deinit();
-    defer for (sections.items) |section| {
-        if (section.name.len > 0) gpa.free(section.name);
-        if (section.data_owned) gpa.free(section.data);
-    };
 
     try elf_apply_add_sections(gpa, &sections, cli, section_data_end_max_original);
     const section_name_table_index = try elf_apply_string_table(gpa, &sections);
@@ -364,9 +350,7 @@ fn elf_apply_add_sections(
             }
         }
         if (existing_index) |index| {
-            const removed = sections.orderedRemove(index);
-            if (removed.name.len > 0) gpa.free(removed.name);
-            if (removed.data_owned) gpa.free(removed.data);
+            _ = sections.orderedRemove(index);
         }
 
         try sections.append(.{
@@ -403,7 +387,6 @@ fn elf_apply_string_table(
 
     // LLVM sorts and suffix-deduplicates names before materializing `.shstrtab`.
     const name_offsets, const shstr_bytes = try elf_build_string_table(gpa, sections.items);
-    defer gpa.free(name_offsets);
 
     for (sections.items, 0..) |*section, i| {
         section.header.sh_name = name_offsets[i];
@@ -510,10 +493,8 @@ fn elf_build_string_table(
     sections: []const ElfSection,
 ) !struct { []u32, []u8 } {
     var unique_names = std.ArrayList([]const u8).init(gpa);
-    defer unique_names.deinit();
 
     var offset_by_name = std.StringHashMap(u32).init(gpa);
-    defer offset_by_name.deinit();
 
     try unique_names.append("");
     try offset_by_name.put("", 0);
@@ -680,7 +661,6 @@ fn transform_pe(gpa: std.mem.Allocator, input: []const u8, cli: *const CLI) ![]u
         .section_header_size = section_header_size,
         .section_count = section_count,
     });
-    defer sections.deinit();
 
     try pe_apply_add_sections(&sections, cli);
     const next_raw, const next_va = pe_layout_sections(

--- a/src/tb_objcopy_fuzz.zig
+++ b/src/tb_objcopy_fuzz.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const stdx = @import("stdx");
+const fuzz = @import("./testing/fuzz.zig");
+const log = std.log.scoped(.tb_objcopy_fuzz);
 
 const CLIArgs = struct {
     zig_exe: []const u8,
@@ -10,7 +12,8 @@ const CLIArgs = struct {
     tmp: []const u8 = "/tmp",
 };
 
-const edge_lengths = [_]usize{
+// Stress N-1/N/N+1 boundaries around common alignment and page-size cutoffs.
+const boundary_lengths = [_]usize{
     1,   2,   7,   8,    15,   16,   31,   32,   63,   64,   127,  128,  255,  256,
     511, 512, 513, 1023, 1024, 1025, 2047, 2048, 2049, 4095, 4096, 4097, 8191,
 };
@@ -24,7 +27,9 @@ pub fn main() !void {
     var arguments = try std.process.argsWithAllocator(gpa);
 
     const command_line = stdx.flags(&arguments, CLIArgs);
-    var prng = stdx.PRNG.from_seed(command_line.seed orelse std.crypto.random.int(u64));
+    const seed = command_line.seed orelse std.crypto.random.int(u64);
+    log.info("seed={d} iterations={d}", .{ seed, command_line.iterations });
+    var prng = stdx.PRNG.from_seed(seed);
 
     var tmp_dir_name_buffer: [64]u8 = undefined;
     const tmp_dir_name = try std.fmt.bufPrint(
@@ -70,7 +75,12 @@ fn run_case(
     fixture: []const u8,
     iteration: usize,
 ) !void {
-    const case_dir = try std.fmt.allocPrint(gpa, "{s}/case-{d}", .{ tmp_dir, iteration });
+    const fixture_name = std.fs.path.basename(fixture);
+    const case_dir = try std.fmt.allocPrint(
+        gpa,
+        "{s}/case-{d}-{s}",
+        .{ tmp_dir, iteration, fixture_name },
+    );
 
     try std.fs.cwd().makePath(case_dir);
     defer std.fs.cwd().deleteTree(case_dir) catch {};
@@ -239,8 +249,10 @@ fn random_bytes_file(
 }
 
 fn fuzz_length(prng: *stdx.PRNG, index: usize) usize {
-    if (index < edge_lengths.len) return edge_lengths[index];
-    return 1 + prng.int_inclusive(usize, 8191);
+    if (index < boundary_lengths.len) return boundary_lengths[index];
+    // Keep broad coverage while biasing toward small payloads used most often in practice.
+    if (prng.boolean()) return 1 + prng.int_inclusive(usize, 8191);
+    return @min(1 + fuzz.random_int_exponential(prng, usize, 512), @as(usize, 8191));
 }
 
 fn run_tool(

--- a/src/tb_objcopy_fuzz.zig
+++ b/src/tb_objcopy_fuzz.zig
@@ -1,0 +1,383 @@
+const std = @import("std");
+const stdx = @import("stdx");
+
+const CLIArgs = struct {
+    zig_exe: []const u8,
+    tb_objcopy: []const u8,
+    llvm_objcopy: ?[]const u8 = null,
+    iterations: usize = 100,
+    seed: ?u64 = null,
+    tmp: []const u8 = "/tmp",
+};
+
+const edge_lengths = [_]usize{
+    1,   2,   7,   8,    15,   16,   31,   32,   63,   64,   127,  128,  255,  256,
+    511, 512, 513, 1023, 1024, 1025, 2047, 2048, 2049, 4095, 4096, 4097, 8191,
+};
+
+pub fn main() !void {
+    var gpa_state: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    defer if (gpa_state.deinit() != .ok) @panic("memory leaked");
+
+    const gpa = gpa_state.allocator();
+
+    var arguments = try std.process.argsWithAllocator(gpa);
+    defer arguments.deinit();
+
+    const command_line = stdx.flags(&arguments, CLIArgs);
+    var prng = std.Random.DefaultPrng.init(command_line.seed orelse std.crypto.random.int(u64));
+    const random = prng.random();
+
+    var tmp_dir_name_buffer: [64]u8 = undefined;
+    const tmp_dir_name = try std.fmt.bufPrint(
+        &tmp_dir_name_buffer,
+        "{s}/tb_objcopy_fuzz_{d}",
+        .{ command_line.tmp, random.int(u64) },
+    );
+    try std.fs.cwd().makePath(tmp_dir_name);
+    defer std.fs.cwd().deleteTree(tmp_dir_name) catch {};
+
+    const fixture_elf = try build_linux_fixture(gpa, command_line, tmp_dir_name);
+    defer gpa.free(fixture_elf);
+
+    try build_windows_fixture(gpa, command_line, tmp_dir_name);
+
+    const fixture_pe = try std.fmt.allocPrint(gpa, "{s}/fixture.exe", .{tmp_dir_name});
+    defer gpa.free(fixture_pe);
+
+    var fixtures = std.ArrayList([]const u8).init(gpa);
+    defer fixtures.deinit();
+
+    try fixtures.append(fixture_elf);
+    if (std.fs.cwd().access(fixture_pe, .{})) |_| {
+        try fixtures.append(fixture_pe);
+    } else |_| {}
+
+    for (0..command_line.iterations) |iteration| {
+        for (fixtures.items) |fixture| {
+            try run_case(gpa, random, command_line, tmp_dir_name, fixture, iteration);
+        }
+    }
+}
+
+fn run_case(
+    gpa: std.mem.Allocator,
+    random: std.Random,
+    command_line: CLIArgs,
+    tmp_dir: []const u8,
+    fixture: []const u8,
+    iteration: usize,
+) !void {
+    const case_dir = try std.fmt.allocPrint(gpa, "{s}/case-{d}", .{ tmp_dir, iteration });
+    defer gpa.free(case_dir);
+
+    try std.fs.cwd().makePath(case_dir);
+    defer std.fs.cwd().deleteTree(case_dir) catch {};
+
+    const body_data = try random_bytes_file(
+        gpa,
+        random,
+        case_dir,
+        "body.bin",
+        fuzz_length(random, iteration * 3),
+    );
+    defer gpa.free(body_data.path);
+
+    const header_data = try random_bytes_file(
+        gpa,
+        random,
+        case_dir,
+        "header.bin",
+        fuzz_length(random, iteration * 3 + 1),
+    );
+    defer gpa.free(header_data.path);
+
+    const header_replacement_data = try random_bytes_file(
+        gpa,
+        random,
+        case_dir,
+        "header_replacement.bin",
+        fuzz_length(random, iteration * 3 + 2),
+    );
+    defer gpa.free(header_replacement_data.path);
+
+    const tb_copy = try std.fmt.allocPrint(gpa, "{s}/tb_copy.bin", .{case_dir});
+    defer gpa.free(tb_copy);
+
+    const tb_working = try std.fmt.allocPrint(gpa, "{s}/tb_working.bin", .{case_dir});
+    defer gpa.free(tb_working);
+
+    const llvm_working = try std.fmt.allocPrint(gpa, "{s}/llvm_working.bin", .{case_dir});
+    defer gpa.free(llvm_working);
+
+    const tb_removed = try std.fmt.allocPrint(gpa, "{s}/tb_removed.bin", .{case_dir});
+    defer gpa.free(tb_removed);
+
+    const llvm_removed = try std.fmt.allocPrint(gpa, "{s}/llvm_removed.bin", .{case_dir});
+    defer gpa.free(llvm_removed);
+
+    try run_tool(gpa, command_line.tb_objcopy, &.{
+        "--enable-deterministic-archives",
+        fixture,
+        tb_copy,
+    });
+    try run_tool(gpa, command_line.tb_objcopy, &.{
+        "--enable-deterministic-archives",
+        tb_copy,
+        tb_working,
+    });
+
+    if (command_line.llvm_objcopy) |llvm_objcopy| {
+        try run_tool(gpa, llvm_objcopy, &.{
+            "--enable-deterministic-archives",
+            fixture,
+            llvm_working,
+        });
+        try assert_equal_stage(gpa, tb_copy, llvm_working, "copy", case_dir);
+    }
+
+    const add_mvb = try std.fmt.allocPrint(gpa, ".tb_mvb={s}", .{body_data.path});
+    defer gpa.free(add_mvb);
+
+    const add_mvh = try std.fmt.allocPrint(gpa, ".tb_mvh={s}", .{header_data.path});
+    defer gpa.free(add_mvh);
+
+    try run_tool(gpa, command_line.tb_objcopy, &.{
+        "--enable-deterministic-archives",
+        "--keep-undefined",
+        "--add-section",
+        add_mvb,
+        "--set-section-flags",
+        ".tb_mvb=contents,noload,readonly",
+        "--add-section",
+        add_mvh,
+        "--set-section-flags",
+        ".tb_mvh=contents,noload,readonly",
+        tb_working,
+    });
+    if (command_line.llvm_objcopy) |llvm_objcopy| {
+        try run_tool(gpa, llvm_objcopy, &.{
+            "--enable-deterministic-archives",
+            "--keep-undefined",
+            "--add-section",
+            add_mvb,
+            "--set-section-flags",
+            ".tb_mvb=contents,noload,readonly",
+            "--add-section",
+            add_mvh,
+            "--set-section-flags",
+            ".tb_mvh=contents,noload,readonly",
+            llvm_working,
+        });
+        try assert_equal_stage(gpa, tb_working, llvm_working, "add", case_dir);
+    }
+
+    const add_mvh_replacement = try std.fmt.allocPrint(
+        gpa,
+        ".tb_mvh={s}",
+        .{header_replacement_data.path},
+    );
+    defer gpa.free(add_mvh_replacement);
+
+    try run_tool(gpa, command_line.tb_objcopy, &.{
+        "--enable-deterministic-archives",
+        "--keep-undefined",
+        "--remove-section",
+        ".tb_mvh",
+        "--add-section",
+        add_mvh_replacement,
+        "--set-section-flags",
+        ".tb_mvh=contents,noload,readonly",
+        tb_working,
+    });
+    if (command_line.llvm_objcopy) |llvm_objcopy| {
+        try run_tool(gpa, llvm_objcopy, &.{
+            "--enable-deterministic-archives",
+            "--keep-undefined",
+            "--remove-section",
+            ".tb_mvh",
+            "--add-section",
+            add_mvh_replacement,
+            "--set-section-flags",
+            ".tb_mvh=contents,noload,readonly",
+            llvm_working,
+        });
+        try assert_equal_stage(gpa, tb_working, llvm_working, "header replace", case_dir);
+    }
+
+    try run_tool(gpa, command_line.tb_objcopy, &.{
+        "--enable-deterministic-archives",
+        "--keep-undefined",
+        "--remove-section",
+        ".tb_mvb",
+        "--remove-section",
+        ".tb_mvh",
+        tb_working,
+        tb_removed,
+    });
+    if (command_line.llvm_objcopy) |llvm_objcopy| {
+        try run_tool(gpa, llvm_objcopy, &.{
+            "--enable-deterministic-archives",
+            "--keep-undefined",
+            "--remove-section",
+            ".tb_mvb",
+            "--remove-section",
+            ".tb_mvh",
+            llvm_working,
+            llvm_removed,
+        });
+        try assert_equal_stage(gpa, tb_removed, llvm_removed, "remove", case_dir);
+    }
+    try assert_equal_stage(gpa, tb_removed, tb_copy, "roundtrip remove", case_dir);
+}
+
+const RandomBytesFile = struct {
+    path: []const u8,
+};
+
+fn random_bytes_file(
+    gpa: std.mem.Allocator,
+    random: std.Random,
+    dir: []const u8,
+    name: []const u8,
+    length_bytes: usize,
+) !RandomBytesFile {
+    const path = try std.fmt.allocPrint(gpa, "{s}/{s}", .{ dir, name });
+    const bytes = try gpa.alloc(u8, length_bytes);
+    defer gpa.free(bytes);
+
+    random.bytes(bytes);
+    try std.fs.cwd().writeFile(.{
+        .sub_path = path,
+        .data = bytes,
+    });
+    return .{ .path = path };
+}
+
+fn fuzz_length(random: std.Random, index: usize) usize {
+    if (index < edge_lengths.len) return edge_lengths[index];
+    return 1 + random.uintAtMost(usize, 8191);
+}
+
+fn run_tool(
+    gpa: std.mem.Allocator,
+    executable_path: []const u8,
+    arguments: []const []const u8,
+) !void {
+    var argv = std.ArrayList([]const u8).init(gpa);
+    defer argv.deinit();
+
+    try argv.append(executable_path);
+    for (arguments) |argument| try argv.append(argument);
+
+    var child = std.process.Child.init(argv.items, gpa);
+    const term = try child.spawnAndWait();
+    if (term != .Exited or term.Exited != 0) return error.ToolFailed;
+}
+
+fn build_linux_fixture(
+    gpa: std.mem.Allocator,
+    command_line: CLIArgs,
+    tmp_dir: []const u8,
+) ![]const u8 {
+    const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
+    defer gpa.free(source_path);
+
+    try std.fs.cwd().writeFile(.{
+        .sub_path = source_path,
+        .data =
+        \\pub fn main() void {}
+        ,
+    });
+
+    const output_path = try std.fmt.allocPrint(gpa, "{s}/fixture", .{tmp_dir});
+    const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
+    defer gpa.free(emit_bin_arg);
+
+    var child = std.process.Child.init(&.{
+        command_line.zig_exe,
+        "build-exe",
+        source_path,
+        "-O",
+        "ReleaseSafe",
+        "-fstrip",
+        "--zig-lib-dir",
+        "zig/lib",
+        "--cache-dir",
+        ".zig-cache",
+        "--global-cache-dir",
+        ".zig-cache",
+        emit_bin_arg,
+    }, gpa);
+    const term = try child.spawnAndWait();
+    if (term != .Exited or term.Exited != 0) return error.FixtureBuildFailed;
+    return output_path;
+}
+
+fn assert_equal_files(gpa: std.mem.Allocator, a: []const u8, b: []const u8) !void {
+    const a_bytes = try std.fs.cwd().readFileAlloc(gpa, a, std.math.maxInt(usize));
+    defer gpa.free(a_bytes);
+
+    const b_bytes = try std.fs.cwd().readFileAlloc(gpa, b, std.math.maxInt(usize));
+    defer gpa.free(b_bytes);
+
+    if (!std.mem.eql(u8, a_bytes, b_bytes)) return error.BytesMismatch;
+}
+
+fn assert_equal_stage(
+    gpa: std.mem.Allocator,
+    got: []const u8,
+    want: []const u8,
+    stage: []const u8,
+    case_dir: []const u8,
+) !void {
+    assert_equal_files(gpa, got, want) catch |err| {
+        std.log.err("mismatch after {s} in {s}", .{ stage, case_dir });
+        return err;
+    };
+}
+
+fn build_windows_fixture(
+    gpa: std.mem.Allocator,
+    command_line: CLIArgs,
+    tmp_dir: []const u8,
+) !void {
+    const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
+    defer gpa.free(source_path);
+
+    try std.fs.cwd().writeFile(.{
+        .sub_path = source_path,
+        .data =
+        \\pub fn main() void {}
+        ,
+    });
+
+    const output_path = try std.fmt.allocPrint(gpa, "{s}/fixture.exe", .{tmp_dir});
+    defer gpa.free(output_path);
+
+    const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
+    defer gpa.free(emit_bin_arg);
+
+    var child = std.process.Child.init(&.{
+        command_line.zig_exe,
+        "build-exe",
+        source_path,
+        "-O",
+        "ReleaseSafe",
+        "-fstrip",
+        "-target",
+        "x86_64-windows",
+        "--zig-lib-dir",
+        "zig/lib",
+        "--cache-dir",
+        ".zig-cache",
+        "--global-cache-dir",
+        ".zig-cache",
+        emit_bin_arg,
+    }, gpa);
+    const term = try child.spawnAndWait();
+    if (term != .Exited or term.Exited != 0) {
+        // PE coverage is optional in local environments where cross-linking may be unavailable.
+        return;
+    }
+}

--- a/src/tb_objcopy_fuzz.zig
+++ b/src/tb_objcopy_fuzz.zig
@@ -39,18 +39,16 @@ pub fn main() !void {
     const fixture_elf = try build_linux_fixture(gpa, command_line, tmp_dir_name);
     defer gpa.free(fixture_elf);
 
-    try build_windows_fixture(gpa, command_line, tmp_dir_name);
-
     const fixture_pe = try std.fmt.allocPrint(gpa, "{s}/fixture.exe", .{tmp_dir_name});
     defer gpa.free(fixture_pe);
+
+    try build_windows_fixture(gpa, command_line, tmp_dir_name, fixture_pe);
 
     var fixtures = std.ArrayList([]const u8).init(gpa);
     defer fixtures.deinit();
 
     try fixtures.append(fixture_elf);
-    if (std.fs.cwd().access(fixture_pe, .{})) |_| {
-        try fixtures.append(fixture_pe);
-    } else |_| {}
+    try fixtures.append(fixture_pe);
 
     for (0..command_line.iterations) |iteration| {
         for (fixtures.items) |fixture| {
@@ -340,6 +338,7 @@ fn build_windows_fixture(
     gpa: std.mem.Allocator,
     command_line: CLIArgs,
     tmp_dir: []const u8,
+    output_path: []const u8,
 ) !void {
     const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
     defer gpa.free(source_path);
@@ -350,9 +349,6 @@ fn build_windows_fixture(
         \\pub fn main() void {}
         ,
     });
-
-    const output_path = try std.fmt.allocPrint(gpa, "{s}/fixture.exe", .{tmp_dir});
-    defer gpa.free(output_path);
 
     const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
     defer gpa.free(emit_bin_arg);
@@ -375,8 +371,5 @@ fn build_windows_fixture(
         emit_bin_arg,
     }, gpa);
     const term = try child.spawnAndWait();
-    if (term != .Exited or term.Exited != 0) {
-        // PE coverage is optional in local environments where cross-linking may be unavailable.
-        return;
-    }
+    if (term != .Exited or term.Exited != 0) return error.FixtureBuildFailed;
 }

--- a/src/tb_objcopy_fuzz.zig
+++ b/src/tb_objcopy_fuzz.zig
@@ -22,9 +22,9 @@ pub fn main() !void {
     var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_allocator.deinit();
 
-    const gpa = arena_allocator.allocator();
+    const arena = arena_allocator.allocator();
 
-    var arguments = try std.process.argsWithAllocator(gpa);
+    var arguments = try std.process.argsWithAllocator(arena);
 
     const command_line = stdx.flags(&arguments, CLIArgs);
     const seed = command_line.seed orelse std.crypto.random.int(u64);
@@ -40,13 +40,13 @@ pub fn main() !void {
     try std.fs.cwd().makePath(tmp_dir_name);
     defer std.fs.cwd().deleteTree(tmp_dir_name) catch {};
 
-    const fixture_elf = try build_linux_fixture(gpa, command_line, tmp_dir_name);
+    const fixture_elf = try build_linux_fixture(arena, command_line, tmp_dir_name);
 
-    const fixture_pe = try std.fmt.allocPrint(gpa, "{s}/fixture.exe", .{tmp_dir_name});
+    const fixture_pe = try std.fmt.allocPrint(arena, "{s}/fixture.exe", .{tmp_dir_name});
 
-    try build_windows_fixture(gpa, command_line, tmp_dir_name, fixture_pe);
+    try build_windows_fixture(arena, command_line, tmp_dir_name, fixture_pe);
 
-    var fixtures = std.ArrayList([]const u8).init(gpa);
+    var fixtures = std.ArrayList([]const u8).init(arena);
     try fixtures.append(fixture_elf);
     try fixtures.append(fixture_pe);
 
@@ -68,7 +68,7 @@ pub fn main() !void {
 }
 
 fn run_case(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     prng: *stdx.PRNG,
     command_line: CLIArgs,
     tmp_dir: []const u8,
@@ -77,7 +77,7 @@ fn run_case(
 ) !void {
     const fixture_name = std.fs.path.basename(fixture);
     const case_dir = try std.fmt.allocPrint(
-        gpa,
+        arena,
         "{s}/case-{d}-{s}",
         .{ tmp_dir, iteration, fixture_name },
     );
@@ -86,7 +86,7 @@ fn run_case(
     defer std.fs.cwd().deleteTree(case_dir) catch {};
 
     const body_data = try random_bytes_file(
-        gpa,
+        arena,
         prng,
         case_dir,
         "body.bin",
@@ -94,7 +94,7 @@ fn run_case(
     );
 
     const header_data = try random_bytes_file(
-        gpa,
+        arena,
         prng,
         case_dir,
         "header.bin",
@@ -102,43 +102,43 @@ fn run_case(
     );
 
     const header_replacement_data = try random_bytes_file(
-        gpa,
+        arena,
         prng,
         case_dir,
         "header_replacement.bin",
         fuzz_length(prng, iteration * 3 + 2),
     );
 
-    const tb_copy = try std.fmt.allocPrint(gpa, "{s}/tb_copy.bin", .{case_dir});
-    const tb_working = try std.fmt.allocPrint(gpa, "{s}/tb_working.bin", .{case_dir});
-    const llvm_working = try std.fmt.allocPrint(gpa, "{s}/llvm_working.bin", .{case_dir});
-    const tb_removed = try std.fmt.allocPrint(gpa, "{s}/tb_removed.bin", .{case_dir});
-    const llvm_removed = try std.fmt.allocPrint(gpa, "{s}/llvm_removed.bin", .{case_dir});
+    const tb_copy = try std.fmt.allocPrint(arena, "{s}/tb_copy.bin", .{case_dir});
+    const tb_working = try std.fmt.allocPrint(arena, "{s}/tb_working.bin", .{case_dir});
+    const llvm_working = try std.fmt.allocPrint(arena, "{s}/llvm_working.bin", .{case_dir});
+    const tb_removed = try std.fmt.allocPrint(arena, "{s}/tb_removed.bin", .{case_dir});
+    const llvm_removed = try std.fmt.allocPrint(arena, "{s}/llvm_removed.bin", .{case_dir});
 
-    try run_tool(gpa, command_line.tb_objcopy, &.{
+    try run_tool(arena, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
         fixture,
         tb_copy,
     });
-    try run_tool(gpa, command_line.tb_objcopy, &.{
+    try run_tool(arena, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
         tb_copy,
         tb_working,
     });
 
     if (command_line.llvm_objcopy) |llvm_objcopy| {
-        try run_tool(gpa, llvm_objcopy, &.{
+        try run_tool(arena, llvm_objcopy, &.{
             "--enable-deterministic-archives",
             fixture,
             llvm_working,
         });
-        try assert_equal_stage(gpa, tb_copy, llvm_working, "copy", case_dir);
+        try assert_equal_stage(arena, tb_copy, llvm_working, "copy", case_dir);
     }
 
-    const add_mvb = try std.fmt.allocPrint(gpa, ".tb_mvb={s}", .{body_data.path});
-    const add_mvh = try std.fmt.allocPrint(gpa, ".tb_mvh={s}", .{header_data.path});
+    const add_mvb = try std.fmt.allocPrint(arena, ".tb_mvb={s}", .{body_data.path});
+    const add_mvh = try std.fmt.allocPrint(arena, ".tb_mvh={s}", .{header_data.path});
 
-    try run_tool(gpa, command_line.tb_objcopy, &.{
+    try run_tool(arena, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
         "--keep-undefined",
         "--add-section",
@@ -152,7 +152,7 @@ fn run_case(
         tb_working,
     });
     if (command_line.llvm_objcopy) |llvm_objcopy| {
-        try run_tool(gpa, llvm_objcopy, &.{
+        try run_tool(arena, llvm_objcopy, &.{
             "--enable-deterministic-archives",
             "--keep-undefined",
             "--add-section",
@@ -165,16 +165,16 @@ fn run_case(
             ".tb_mvh=contents,noload,readonly",
             llvm_working,
         });
-        try assert_equal_stage(gpa, tb_working, llvm_working, "add", case_dir);
+        try assert_equal_stage(arena, tb_working, llvm_working, "add", case_dir);
     }
 
     const add_mvh_replacement = try std.fmt.allocPrint(
-        gpa,
+        arena,
         ".tb_mvh={s}",
         .{header_replacement_data.path},
     );
 
-    try run_tool(gpa, command_line.tb_objcopy, &.{
+    try run_tool(arena, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
         "--keep-undefined",
         "--remove-section",
@@ -186,7 +186,7 @@ fn run_case(
         tb_working,
     });
     if (command_line.llvm_objcopy) |llvm_objcopy| {
-        try run_tool(gpa, llvm_objcopy, &.{
+        try run_tool(arena, llvm_objcopy, &.{
             "--enable-deterministic-archives",
             "--keep-undefined",
             "--remove-section",
@@ -197,10 +197,10 @@ fn run_case(
             ".tb_mvh=contents,noload,readonly",
             llvm_working,
         });
-        try assert_equal_stage(gpa, tb_working, llvm_working, "header replace", case_dir);
+        try assert_equal_stage(arena, tb_working, llvm_working, "header replace", case_dir);
     }
 
-    try run_tool(gpa, command_line.tb_objcopy, &.{
+    try run_tool(arena, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
         "--keep-undefined",
         "--remove-section",
@@ -211,7 +211,7 @@ fn run_case(
         tb_removed,
     });
     if (command_line.llvm_objcopy) |llvm_objcopy| {
-        try run_tool(gpa, llvm_objcopy, &.{
+        try run_tool(arena, llvm_objcopy, &.{
             "--enable-deterministic-archives",
             "--keep-undefined",
             "--remove-section",
@@ -221,9 +221,9 @@ fn run_case(
             llvm_working,
             llvm_removed,
         });
-        try assert_equal_stage(gpa, tb_removed, llvm_removed, "remove", case_dir);
+        try assert_equal_stage(arena, tb_removed, llvm_removed, "remove", case_dir);
     }
-    try assert_equal_stage(gpa, tb_removed, tb_copy, "roundtrip remove", case_dir);
+    try assert_equal_stage(arena, tb_removed, tb_copy, "roundtrip remove", case_dir);
 }
 
 const RandomBytesFile = struct {
@@ -231,14 +231,14 @@ const RandomBytesFile = struct {
 };
 
 fn random_bytes_file(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     prng: *stdx.PRNG,
     dir: []const u8,
     name: []const u8,
     length_bytes: usize,
 ) !RandomBytesFile {
-    const path = try std.fmt.allocPrint(gpa, "{s}/{s}", .{ dir, name });
-    const bytes = try gpa.alloc(u8, length_bytes);
+    const path = try std.fmt.allocPrint(arena, "{s}/{s}", .{ dir, name });
+    const bytes = try arena.alloc(u8, length_bytes);
 
     prng.fill(bytes);
     try std.fs.cwd().writeFile(.{
@@ -256,27 +256,27 @@ fn fuzz_length(prng: *stdx.PRNG, index: usize) usize {
 }
 
 fn run_tool(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     executable_path: []const u8,
     arguments: []const []const u8,
 ) !void {
-    var argv = std.ArrayList([]const u8).init(gpa);
+    var argv = std.ArrayList([]const u8).init(arena);
     defer argv.deinit();
 
     try argv.append(executable_path);
     for (arguments) |argument| try argv.append(argument);
 
-    var child = std.process.Child.init(argv.items, gpa);
+    var child = std.process.Child.init(argv.items, arena);
     const term = try child.spawnAndWait();
     if (term != .Exited or term.Exited != 0) return error.ToolFailed;
 }
 
 fn build_linux_fixture(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     command_line: CLIArgs,
     tmp_dir: []const u8,
 ) ![]const u8 {
-    const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
+    const source_path = try std.fmt.allocPrint(arena, "{s}/fixture.zig", .{tmp_dir});
 
     try std.fs.cwd().writeFile(.{
         .sub_path = source_path,
@@ -285,8 +285,8 @@ fn build_linux_fixture(
         ,
     });
 
-    const output_path = try std.fmt.allocPrint(gpa, "{s}/fixture", .{tmp_dir});
-    const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
+    const output_path = try std.fmt.allocPrint(arena, "{s}/fixture", .{tmp_dir});
+    const emit_bin_arg = try std.fmt.allocPrint(arena, "-femit-bin={s}", .{output_path});
 
     var child = std.process.Child.init(&.{
         command_line.zig_exe,
@@ -302,40 +302,40 @@ fn build_linux_fixture(
         "--global-cache-dir",
         ".zig-cache",
         emit_bin_arg,
-    }, gpa);
+    }, arena);
     const term = try child.spawnAndWait();
     if (term != .Exited or term.Exited != 0) return error.FixtureBuildFailed;
     return output_path;
 }
 
-fn assert_equal_files(gpa: std.mem.Allocator, a: []const u8, b: []const u8) !void {
-    const a_bytes = try std.fs.cwd().readFileAlloc(gpa, a, std.math.maxInt(usize));
+fn assert_equal_files(arena: std.mem.Allocator, a: []const u8, b: []const u8) !void {
+    const a_bytes = try std.fs.cwd().readFileAlloc(arena, a, std.math.maxInt(usize));
 
-    const b_bytes = try std.fs.cwd().readFileAlloc(gpa, b, std.math.maxInt(usize));
+    const b_bytes = try std.fs.cwd().readFileAlloc(arena, b, std.math.maxInt(usize));
 
     if (!std.mem.eql(u8, a_bytes, b_bytes)) return error.BytesMismatch;
 }
 
 fn assert_equal_stage(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     got: []const u8,
     want: []const u8,
     stage: []const u8,
     case_dir: []const u8,
 ) !void {
-    assert_equal_files(gpa, got, want) catch |err| {
+    assert_equal_files(arena, got, want) catch |err| {
         std.log.err("mismatch after {s} in {s}", .{ stage, case_dir });
         return err;
     };
 }
 
 fn build_windows_fixture(
-    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     command_line: CLIArgs,
     tmp_dir: []const u8,
     output_path: []const u8,
 ) !void {
-    const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
+    const source_path = try std.fmt.allocPrint(arena, "{s}/fixture.zig", .{tmp_dir});
 
     try std.fs.cwd().writeFile(.{
         .sub_path = source_path,
@@ -344,7 +344,7 @@ fn build_windows_fixture(
         ,
     });
 
-    const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
+    const emit_bin_arg = try std.fmt.allocPrint(arena, "-femit-bin={s}", .{output_path});
 
     var child = std.process.Child.init(&.{
         command_line.zig_exe,
@@ -362,7 +362,7 @@ fn build_windows_fixture(
         "--global-cache-dir",
         ".zig-cache",
         emit_bin_arg,
-    }, gpa);
+    }, arena);
     const term = try child.spawnAndWait();
     if (term != .Exited or term.Exited != 0) return error.FixtureBuildFailed;
 }

--- a/src/tb_objcopy_fuzz.zig
+++ b/src/tb_objcopy_fuzz.zig
@@ -16,13 +16,12 @@ const edge_lengths = [_]usize{
 };
 
 pub fn main() !void {
-    var gpa_state: std.heap.GeneralPurposeAllocator(.{}) = .{};
-    defer if (gpa_state.deinit() != .ok) @panic("memory leaked");
+    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_allocator.deinit();
 
-    const gpa = gpa_state.allocator();
+    const gpa = arena_allocator.allocator();
 
     var arguments = try std.process.argsWithAllocator(gpa);
-    defer arguments.deinit();
 
     const command_line = stdx.flags(&arguments, CLIArgs);
     var prng = stdx.PRNG.from_seed(command_line.seed orelse std.crypto.random.int(u64));
@@ -37,22 +36,28 @@ pub fn main() !void {
     defer std.fs.cwd().deleteTree(tmp_dir_name) catch {};
 
     const fixture_elf = try build_linux_fixture(gpa, command_line, tmp_dir_name);
-    defer gpa.free(fixture_elf);
 
     const fixture_pe = try std.fmt.allocPrint(gpa, "{s}/fixture.exe", .{tmp_dir_name});
-    defer gpa.free(fixture_pe);
 
     try build_windows_fixture(gpa, command_line, tmp_dir_name, fixture_pe);
 
     var fixtures = std.ArrayList([]const u8).init(gpa);
-    defer fixtures.deinit();
-
     try fixtures.append(fixture_elf);
     try fixtures.append(fixture_pe);
 
     for (0..command_line.iterations) |iteration| {
         for (fixtures.items) |fixture| {
-            try run_case(gpa, &prng, command_line, tmp_dir_name, fixture, iteration);
+            var case_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer case_arena.deinit();
+
+            try run_case(
+                case_arena.allocator(),
+                &prng,
+                command_line,
+                tmp_dir_name,
+                fixture,
+                iteration,
+            );
         }
     }
 }
@@ -66,7 +71,6 @@ fn run_case(
     iteration: usize,
 ) !void {
     const case_dir = try std.fmt.allocPrint(gpa, "{s}/case-{d}", .{ tmp_dir, iteration });
-    defer gpa.free(case_dir);
 
     try std.fs.cwd().makePath(case_dir);
     defer std.fs.cwd().deleteTree(case_dir) catch {};
@@ -78,7 +82,6 @@ fn run_case(
         "body.bin",
         fuzz_length(prng, iteration * 3),
     );
-    defer gpa.free(body_data.path);
 
     const header_data = try random_bytes_file(
         gpa,
@@ -87,7 +90,6 @@ fn run_case(
         "header.bin",
         fuzz_length(prng, iteration * 3 + 1),
     );
-    defer gpa.free(header_data.path);
 
     const header_replacement_data = try random_bytes_file(
         gpa,
@@ -96,22 +98,12 @@ fn run_case(
         "header_replacement.bin",
         fuzz_length(prng, iteration * 3 + 2),
     );
-    defer gpa.free(header_replacement_data.path);
 
     const tb_copy = try std.fmt.allocPrint(gpa, "{s}/tb_copy.bin", .{case_dir});
-    defer gpa.free(tb_copy);
-
     const tb_working = try std.fmt.allocPrint(gpa, "{s}/tb_working.bin", .{case_dir});
-    defer gpa.free(tb_working);
-
     const llvm_working = try std.fmt.allocPrint(gpa, "{s}/llvm_working.bin", .{case_dir});
-    defer gpa.free(llvm_working);
-
     const tb_removed = try std.fmt.allocPrint(gpa, "{s}/tb_removed.bin", .{case_dir});
-    defer gpa.free(tb_removed);
-
     const llvm_removed = try std.fmt.allocPrint(gpa, "{s}/llvm_removed.bin", .{case_dir});
-    defer gpa.free(llvm_removed);
 
     try run_tool(gpa, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
@@ -134,10 +126,7 @@ fn run_case(
     }
 
     const add_mvb = try std.fmt.allocPrint(gpa, ".tb_mvb={s}", .{body_data.path});
-    defer gpa.free(add_mvb);
-
     const add_mvh = try std.fmt.allocPrint(gpa, ".tb_mvh={s}", .{header_data.path});
-    defer gpa.free(add_mvh);
 
     try run_tool(gpa, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
@@ -174,7 +163,6 @@ fn run_case(
         ".tb_mvh={s}",
         .{header_replacement_data.path},
     );
-    defer gpa.free(add_mvh_replacement);
 
     try run_tool(gpa, command_line.tb_objcopy, &.{
         "--enable-deterministic-archives",
@@ -241,7 +229,6 @@ fn random_bytes_file(
 ) !RandomBytesFile {
     const path = try std.fmt.allocPrint(gpa, "{s}/{s}", .{ dir, name });
     const bytes = try gpa.alloc(u8, length_bytes);
-    defer gpa.free(bytes);
 
     prng.fill(bytes);
     try std.fs.cwd().writeFile(.{
@@ -278,7 +265,6 @@ fn build_linux_fixture(
     tmp_dir: []const u8,
 ) ![]const u8 {
     const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
-    defer gpa.free(source_path);
 
     try std.fs.cwd().writeFile(.{
         .sub_path = source_path,
@@ -289,7 +275,6 @@ fn build_linux_fixture(
 
     const output_path = try std.fmt.allocPrint(gpa, "{s}/fixture", .{tmp_dir});
     const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
-    defer gpa.free(emit_bin_arg);
 
     var child = std.process.Child.init(&.{
         command_line.zig_exe,
@@ -313,10 +298,8 @@ fn build_linux_fixture(
 
 fn assert_equal_files(gpa: std.mem.Allocator, a: []const u8, b: []const u8) !void {
     const a_bytes = try std.fs.cwd().readFileAlloc(gpa, a, std.math.maxInt(usize));
-    defer gpa.free(a_bytes);
 
     const b_bytes = try std.fs.cwd().readFileAlloc(gpa, b, std.math.maxInt(usize));
-    defer gpa.free(b_bytes);
 
     if (!std.mem.eql(u8, a_bytes, b_bytes)) return error.BytesMismatch;
 }
@@ -341,7 +324,6 @@ fn build_windows_fixture(
     output_path: []const u8,
 ) !void {
     const source_path = try std.fmt.allocPrint(gpa, "{s}/fixture.zig", .{tmp_dir});
-    defer gpa.free(source_path);
 
     try std.fs.cwd().writeFile(.{
         .sub_path = source_path,
@@ -351,7 +333,6 @@ fn build_windows_fixture(
     });
 
     const emit_bin_arg = try std.fmt.allocPrint(gpa, "-femit-bin={s}", .{output_path});
-    defer gpa.free(emit_bin_arg);
 
     var child = std.process.Child.init(&.{
         command_line.zig_exe,

--- a/src/tb_objcopy_fuzz.zig
+++ b/src/tb_objcopy_fuzz.zig
@@ -25,14 +25,13 @@ pub fn main() !void {
     defer arguments.deinit();
 
     const command_line = stdx.flags(&arguments, CLIArgs);
-    var prng = std.Random.DefaultPrng.init(command_line.seed orelse std.crypto.random.int(u64));
-    const random = prng.random();
+    var prng = stdx.PRNG.from_seed(command_line.seed orelse std.crypto.random.int(u64));
 
     var tmp_dir_name_buffer: [64]u8 = undefined;
     const tmp_dir_name = try std.fmt.bufPrint(
         &tmp_dir_name_buffer,
         "{s}/tb_objcopy_fuzz_{d}",
-        .{ command_line.tmp, random.int(u64) },
+        .{ command_line.tmp, prng.int(u64) },
     );
     try std.fs.cwd().makePath(tmp_dir_name);
     defer std.fs.cwd().deleteTree(tmp_dir_name) catch {};
@@ -55,14 +54,14 @@ pub fn main() !void {
 
     for (0..command_line.iterations) |iteration| {
         for (fixtures.items) |fixture| {
-            try run_case(gpa, random, command_line, tmp_dir_name, fixture, iteration);
+            try run_case(gpa, &prng, command_line, tmp_dir_name, fixture, iteration);
         }
     }
 }
 
 fn run_case(
     gpa: std.mem.Allocator,
-    random: std.Random,
+    prng: *stdx.PRNG,
     command_line: CLIArgs,
     tmp_dir: []const u8,
     fixture: []const u8,
@@ -76,28 +75,28 @@ fn run_case(
 
     const body_data = try random_bytes_file(
         gpa,
-        random,
+        prng,
         case_dir,
         "body.bin",
-        fuzz_length(random, iteration * 3),
+        fuzz_length(prng, iteration * 3),
     );
     defer gpa.free(body_data.path);
 
     const header_data = try random_bytes_file(
         gpa,
-        random,
+        prng,
         case_dir,
         "header.bin",
-        fuzz_length(random, iteration * 3 + 1),
+        fuzz_length(prng, iteration * 3 + 1),
     );
     defer gpa.free(header_data.path);
 
     const header_replacement_data = try random_bytes_file(
         gpa,
-        random,
+        prng,
         case_dir,
         "header_replacement.bin",
-        fuzz_length(random, iteration * 3 + 2),
+        fuzz_length(prng, iteration * 3 + 2),
     );
     defer gpa.free(header_replacement_data.path);
 
@@ -237,7 +236,7 @@ const RandomBytesFile = struct {
 
 fn random_bytes_file(
     gpa: std.mem.Allocator,
-    random: std.Random,
+    prng: *stdx.PRNG,
     dir: []const u8,
     name: []const u8,
     length_bytes: usize,
@@ -246,7 +245,7 @@ fn random_bytes_file(
     const bytes = try gpa.alloc(u8, length_bytes);
     defer gpa.free(bytes);
 
-    random.bytes(bytes);
+    prng.fill(bytes);
     try std.fs.cwd().writeFile(.{
         .sub_path = path,
         .data = bytes,
@@ -254,9 +253,9 @@ fn random_bytes_file(
     return .{ .path = path };
 }
 
-fn fuzz_length(random: std.Random, index: usize) usize {
+fn fuzz_length(prng: *stdx.PRNG, index: usize) usize {
     if (index < edge_lengths.len) return edge_lengths[index];
-    return 1 + random.uintAtMost(usize, 8191);
+    return 1 + prng.int_inclusive(usize, 8191);
 }
 
 fn run_tool(

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -1238,6 +1238,8 @@ const DeadFilesDetector = struct {
             "search_index_writer.zig",
             "service_worker_writer.zig",
             "single_page_writer.zig",
+            "tb_objcopy.zig",
+            "tb_objcopy_fuzz.zig",
             "tb_client_header.zig",
             "unit_tests.zig",
             "vopr.zig",


### PR DESCRIPTION
This PR removes llvm-objcopy as a dependency by implementing the subset of objcopy functionality we rely on in-tree. It also adds a fuzzer with two modes: (1) a round-trip check, and (2) differential testing against llvm-objcopy to ensure the produced output is byte-for-byte identical.

```
Differential (requires LLVM):
./zig/zig build objcopy:fuzz -- --iterations=20

Round-trip only (no LLVM dependency):
./zig/zig build objcopy:fuzz:roundtrip -- --iterations=20
```
