### PR TITLE
CLI: Fix multiversion polling warnings

### DIFF
--- a/src/multiversion.zig
+++ b/src/multiversion.zig
@@ -921,13 +921,12 @@ pub const MultiversionOS = struct {
     }
 
     pub fn timeout_start(self: *MultiversionOS, replica_index: u8) void {
+        // Checking for new binaries on disk after the replica has been opened is only
+        // supported on Linux.
+        comptime assert(builtin.target.os.tag == .linux);
         assert(!self.timeout.ticking);
-        if (builtin.target.os.tag != .linux) {
-            // Checking for new binaries on disk after the replica has been opened is only
-            // supported on Linux.
-            return;
-        }
         assert(self.timeout.id == 0);
+
         self.timeout.id = replica_index;
         self.timeout.start();
         log.debug("enabled automatic on-disk version detection.", .{});

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -393,13 +393,13 @@ fn command_start(
             log.info("multiversioning: upgrade polling disabled due to --development.", .{});
         } else {
             multiversion_os.?.timeout_start(replica.replica);
-        }
 
-        if (args.experimental) {
-            log.warn("multiversioning: upgrade polling and --experimental enabled - " ++
-                "make sure to check CLI argument compatibility before upgrading.", .{});
-            log.warn("If the cluster upgrades automatically, and incompatible experimental " ++
-                "CLI arguments are set, it will crash.", .{});
+            if (args.experimental) {
+                log.warn("multiversioning: upgrade polling and --experimental enabled - " ++
+                    "make sure to check CLI argument compatibility before upgrading.", .{});
+                log.warn("If the cluster upgrades automatically, and incompatible experimental " ++
+                    "CLI arguments are set, it will crash.", .{});
+            }
         }
     }
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -389,7 +389,11 @@ fn command_start(
     };
 
     if (multiversion_os != null) {
-        if (args.development) {
+        if (builtin.target.os.tag != .linux) {
+            // Checking for new binaries on disk after the replica has been opened is only
+            // supported on Linux.
+            log.info("multiversioning: upgrade polling disabled; only available on Linux", .{});
+        } else if (args.development) {
             log.info("multiversioning: upgrade polling disabled due to --development.", .{});
         } else {
             multiversion_os.?.timeout_start(replica.replica);


### PR DESCRIPTION
When `--development` is used at the same time as `--experimental`, polling is disabled, so don't warn about it being enabled with `--experimental`.

Also warn that polling is disabled on non-linux OS's.