### PR TITLE
[CDC] Timeout on network partitions.

### DIFF
--- a/docs/operating/cdc.md
+++ b/docs/operating/cdc.md
@@ -57,6 +57,16 @@ Here what the arguments mean:
   Must be greater than zero.<br>
   Optional. No limit if omitted.
 
+* `--amqp-timeout-seconds` the maximum time, in seconds, to wait for a reply from
+  the AMQP server. If exceeded, the process exits with a non-zero code.<br>
+  Must be greater than 0.<br>
+  Optional. Defaults to `30` seconds if omitted.
+
+* `--tigerbeetle-timeout-seconds` the maximum time, in seconds, to wait for a reply from
+  the TigerBeetle cluster. If exceeded, the process exits with a non-zero code.<br>
+  Must be greater than 0.<br>
+  Optional. Defaults to `30` seconds if omitted.
+
 * `--timestamp-last` overrides the last published timestamp, resuming from this point.<br>
   This is a TigerBeetle timestamp with nanosecond precision.<br>
   Optional. If omitted, the last acknowledged timestamp is used.

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -30,14 +30,14 @@ pub const Runner = struct {
 
     const constants = struct {
         const tick_ms = vsr.constants.tick_ms;
-        const idle_interval: stdx.Duration = .seconds(1);
-        const amqp_timeout: stdx.Duration = .seconds(30);
-        const tigerbeetle_timeout: stdx.Duration = .seconds(30);
-
         const app_id = "tigerbeetle";
         const progress_tracker_queue = "tigerbeetle.internal.progress";
         const locker_queue = "tigerbeetle.internal.locker";
-        const event_count_max: u32 = Operation.get_change_events.result_max(
+
+        const idle_interval_default: stdx.Duration = .seconds(1);
+        const amqp_timeout_default: stdx.Duration = .seconds(30);
+        const tigerbeetle_timeout_default: stdx.Duration = .seconds(30);
+        const event_count_max_default: u32 = Operation.get_change_events.result_max(
             vsr.constants.message_body_size_max,
         );
     };
@@ -156,25 +156,25 @@ pub const Runner = struct {
         const idle_interval: stdx.Duration = if (options.idle_interval_ms) |value|
             .ms(value)
         else
-            constants.idle_interval;
+            constants.idle_interval_default;
         assert(idle_interval.ns > 0);
 
         const event_count_max: u32 = if (options.event_count_max) |event_count_max|
-            @min(event_count_max, constants.event_count_max)
+            @min(event_count_max, constants.event_count_max_default)
         else
-            constants.event_count_max;
+            constants.event_count_max_default;
         assert(event_count_max > 0);
 
         const amqp_timeout: stdx.Duration = if (options.amqp_timeout_seconds) |value|
             .seconds(value)
         else
-            constants.amqp_timeout;
+            constants.amqp_timeout_default;
         assert(amqp_timeout.ns > 0);
 
         const tigerbeetle_timeout: stdx.Duration = if (options.tigerbeetle_timeout_seconds) |value|
             .seconds(value)
         else
-            constants.tigerbeetle_timeout;
+            constants.tigerbeetle_timeout_default;
         assert(tigerbeetle_timeout.ns > 0);
 
         const publish_exchange: []const u8 = options.publish_exchange orelse "";
@@ -960,7 +960,7 @@ pub const Runner = struct {
         self.vsr_client_timeout.tick();
         if (self.vsr_client_timeout.fired()) {
             const timeout: stdx.Duration = .ms(self.vsr_client_timeout.ticks * constants.tick_ms);
-            fatal("Timed out: no reply from the TigerBeetle cluster after {}.", .{timeout});
+            fatal("Timed out: no reply from the TigerBeetle cluster within {}.", .{timeout});
         }
     }
 };
@@ -1153,7 +1153,7 @@ const DualBuffer = struct {
 
     pub fn init(allocator: std.mem.Allocator, event_count: u32) !DualBuffer {
         assert(event_count > 0);
-        assert(event_count <= Runner.constants.event_count_max);
+        assert(event_count <= Runner.constants.event_count_max_default);
 
         const buffer_1 = try allocator.alloc(tb.ChangeEvent, event_count);
         errdefer allocator.free(buffer_1);
@@ -1546,7 +1546,7 @@ test "amqp: RateLimit" {
 }
 
 test "amqp: DualBuffer" {
-    const event_count_max = Runner.constants.event_count_max;
+    const event_count_max = Runner.constants.event_count_max_default;
 
     var prng = stdx.PRNG.from_seed_testing();
     var dual_buffer = try DualBuffer.init(testing.allocator, event_count_max);

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -4,7 +4,6 @@ const log = std.log.scoped(.amqp);
 const vsr = @import("../vsr.zig");
 const assert = std.debug.assert;
 const maybe = vsr.stdx.maybe;
-const fatal = @import("amqp/protocol.zig").fatal;
 
 const stdx = vsr.stdx;
 const tb = vsr.tigerbeetle;
@@ -31,11 +30,10 @@ pub const Runner = struct {
 
     const constants = struct {
         const tick_ms = vsr.constants.tick_ms;
-        const idle_interval_ns: u63 = 1 * std.time.ns_per_s;
-        const reply_timeout_ticks = @divExact(
-            30 * std.time.ms_per_s,
-            constants.tick_ms,
-        );
+        const idle_interval: stdx.Duration = .seconds(1);
+        const amqp_timeout: stdx.Duration = .seconds(30);
+        const tigerbeetle_timeout: stdx.Duration = .seconds(30);
+
         const app_id = "tigerbeetle";
         const progress_tracker_queue = "tigerbeetle.internal.progress";
         const locker_queue = "tigerbeetle.internal.locker";
@@ -46,11 +44,12 @@ pub const Runner = struct {
 
     io: IO,
     idle_completion: IO.Completion = undefined,
-    idle_interval_ns: u63,
+    idle_interval: stdx.Duration,
     event_count_max: u32,
 
     message_pool: MessagePool,
     vsr_client: Client,
+    vsr_client_timeout: vsr.Timeout,
     buffer: DualBuffer,
 
     amqp_client: amqp.Client,
@@ -139,6 +138,14 @@ pub const Runner = struct {
             /// Limits the number of requests per second.
             /// Must be greater than zero.
             requests_per_second_limit: ?u32,
+            /// Overrides the timeout, in seconds,
+            /// for receiving a reply from the AMQP server.
+            /// Must be greater than zero.
+            amqp_timeout_seconds: ?u32,
+            /// Overrides the timeout, in seconds,
+            /// for receiving a reply from the TigerBeetle cluster.
+            /// Must be greater than zero.
+            tigerbeetle_timeout_seconds: ?u32,
             /// Indicates whether to recover the last timestamp published on the state
             /// tracker queue, or override it with a user-defined value.
             recovery_mode: StateRecoveryMode,
@@ -146,17 +153,29 @@ pub const Runner = struct {
     ) !void {
         assert(options.addresses.len > 0);
 
-        const idle_interval_ns: u63 = if (options.idle_interval_ms) |value|
-            @intCast(@as(u64, value) * std.time.ns_per_ms)
+        const idle_interval: stdx.Duration = if (options.idle_interval_ms) |value|
+            .ms(value)
         else
-            constants.idle_interval_ns;
-        assert(idle_interval_ns > 0);
+            constants.idle_interval;
+        assert(idle_interval.ns > 0);
 
         const event_count_max: u32 = if (options.event_count_max) |event_count_max|
             @min(event_count_max, constants.event_count_max)
         else
             constants.event_count_max;
         assert(event_count_max > 0);
+
+        const amqp_timeout: stdx.Duration = if (options.amqp_timeout_seconds) |value|
+            .seconds(value)
+        else
+            constants.amqp_timeout;
+        assert(amqp_timeout.ns > 0);
+
+        const tigerbeetle_timeout: stdx.Duration = if (options.tigerbeetle_timeout_seconds) |value|
+            .seconds(value)
+        else
+            constants.tigerbeetle_timeout;
+        assert(tigerbeetle_timeout.ns > 0);
 
         const publish_exchange: []const u8 = options.publish_exchange orelse "";
         const publish_routing_key: []const u8 = options.publish_routing_key orelse "";
@@ -188,7 +207,7 @@ pub const Runner = struct {
         errdefer self.buffer.deinit(allocator);
 
         self.* = .{
-            .idle_interval_ns = idle_interval_ns,
+            .idle_interval = idle_interval,
             .event_count_max = event_count_max,
             .publish_exchange = publish_exchange,
             .publish_routing_key = publish_routing_key,
@@ -204,6 +223,7 @@ pub const Runner = struct {
             .buffer = dual_buffer,
             .message_pool = undefined,
             .vsr_client = undefined,
+            .vsr_client_timeout = undefined,
             .amqp_client = undefined,
         };
 
@@ -248,11 +268,23 @@ pub const Runner = struct {
         );
         errdefer self.vsr_client.deinit(allocator);
 
+        self.vsr_client_timeout = .{
+            .name = "vsr_client_timeout",
+            .id = self.vsr_client.id,
+            .after = stdx.div_ceil(
+                tigerbeetle_timeout.to_ms(),
+                constants.tick_ms,
+            ),
+        };
+
         self.amqp_client = try amqp.Client.init(allocator, .{
             .io = &self.io,
             .message_count_max = self.event_count_max,
             .message_body_size_max = Message.json_string_size_max,
-            .reply_timeout_ticks = constants.reply_timeout_ticks,
+            .reply_timeout_ticks = stdx.div_ceil(
+                amqp_timeout.to_ms(),
+                constants.tick_ms,
+            ),
         });
         errdefer self.amqp_client.deinit(allocator);
 
@@ -579,6 +611,8 @@ pub const Runner = struct {
 
         // Register the VSR client as the last step to avoid unnecessarily joining the cluster
         // in case the CDC fails due to connectivity or configuration issues with the AMQP server.
+        assert(!self.vsr_client_timeout.ticking);
+        self.vsr_client_timeout.start();
         self.vsr_client.register(
             &struct {
                 fn callback(
@@ -588,6 +622,10 @@ pub const Runner = struct {
                     const runner: *Runner = @ptrFromInt(@as(usize, @intCast(user_data)));
                     assert(runner.connected.amqp);
                     assert(!runner.connected.vsr);
+
+                    assert(runner.vsr_client_timeout.ticking);
+                    runner.vsr_client_timeout.stop();
+
                     log.info("VSR client registered.", .{});
                     runner.vsr_client.batch_size_limit = result.batch_size_limit;
                     runner.connected.vsr = true;
@@ -680,6 +718,8 @@ pub const Runner = struct {
                     .timestamp_max = 0,
                 };
 
+                assert(!self.vsr_client_timeout.ticking);
+                self.vsr_client_timeout.start();
                 self.vsr_client.request(
                     &produce_request_callback,
                     @intFromPtr(self),
@@ -712,7 +752,7 @@ pub const Runner = struct {
                         }
                     }.callback,
                     &self.idle_completion,
-                    self.idle_interval_ns,
+                    @intCast(self.idle_interval.ns),
                 );
             },
         }
@@ -729,6 +769,9 @@ pub const Runner = struct {
         assert(timestamp != 0);
         const runner: *Runner = @ptrFromInt(@as(usize, @intCast(context)));
         assert(runner.producer == .request);
+
+        assert(runner.vsr_client_timeout.ticking);
+        runner.vsr_client_timeout.stop();
 
         const source: []const tb.ChangeEvent = stdx.bytes_as_slice(.exact, tb.ChangeEvent, result);
         const target: []tb.ChangeEvent = runner.buffer.get_producer_buffer();
@@ -913,8 +956,24 @@ pub const Runner = struct {
         self.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms) catch unreachable;
 
         self.metrics.tick();
+
+        self.vsr_client_timeout.tick();
+        if (self.vsr_client_timeout.fired()) {
+            const timeout: stdx.Duration = .ms(self.vsr_client_timeout.ticks * constants.tick_ms);
+            fatal("Timed out: no reply from the TigerBeetle cluster after {}.", .{timeout});
+        }
     }
 };
+
+/// Terminates the process with non-zero exit code.
+/// Similar to `vsr.fatal`, but not logged in the `vsr` scope.
+fn fatal(comptime format: []const u8, args: anytype) noreturn {
+    log.err(format, args);
+
+    const status = vsr.FatalReason.cli.exit_status();
+    assert(status != 0);
+    std.process.exit(status);
+}
 
 /// Rate limit to throttle the maximum number of requests to TigerBeetle within a time period.
 pub const RateLimit = struct {

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -49,6 +49,9 @@ pub fn main(_: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
         try run_serialization_test(gpa, .{
             .host = rabbit_mq.host,
         });
+        try run_timeout_test(gpa, .{
+            .host = rabbit_mq.host,
+        });
         try run_cdc_test(gpa, .{
             .host = rabbit_mq.host,
             .transfer_count = cli_args.transfer_count,
@@ -532,6 +535,75 @@ fn run_cdc_test(
     }));
 }
 
+fn run_timeout_test(
+    gpa: std.mem.Allocator,
+    options: struct {
+        host: std.net.Address,
+    },
+) !void {
+    var amqp_context: AmqpContext = undefined;
+    try amqp_context.init(gpa);
+    defer amqp_context.deinit(gpa);
+
+    try amqp_context.connect(options.host);
+
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+
+    var time_os: vsr.time.TimeOS = .{};
+    const time = &time_os.time();
+
+    const queue = try std.fmt.allocPrint(arena.allocator(), "queue_{}", .{
+        stdx.unique_u128(),
+    });
+    amqp_context.queue_declare(.{
+        .queue = queue,
+        .passive = false,
+        .durable = true,
+        .exclusive = false,
+        .auto_delete = false,
+        .arguments = .{},
+    });
+
+    var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
+        .development = false,
+    });
+
+    const shell = try Shell.create(gpa);
+    defer shell.destroy();
+
+    // Starting the CDC job with a 1s timeout for the TigerBeetle cluster:
+    var cdc_job = try shell.spawn(
+        .{},
+        "{tigerbeetle} amqp " ++
+            "--cluster=0 --addresses={addresses} " ++
+            "--host=127.0.0.1:{port} --vhost=/ --user=guest --password=guest " ++
+            "--publish-routing-key={queue} " ++
+            "--idle-interval-ms={idle_interval_ms} " ++
+            "--tigerbeetle-timeout-seconds={tigerbeetle_timeout_seconds}",
+        .{
+            .tigerbeetle = tmp_beetle.tigerbeetle_exe,
+            .addresses = tmp_beetle.port_str,
+            .port = options.host.getPort(),
+            .queue = queue,
+            .idle_interval_ms = 1,
+            .tigerbeetle_timeout_seconds = 1,
+        },
+    );
+    defer _ = cdc_job.kill() catch undefined;
+
+    const started = time.monotonic();
+
+    // Kills the TigerBeetle cluster and waits for the CDC job to time out.
+    tmp_beetle.deinit(gpa);
+    const result = try cdc_job.wait();
+
+    const elapsed = time.monotonic().duration_since(started);
+
+    try testing.expectEqual(@as(u8, 1), result.Exited);
+    try testing.expect(elapsed.to_ms() > 1000);
+}
+
 const AmqpContext = struct {
     const Message = struct {
         header: amqp.GetMessagePropertiesResult,
@@ -764,7 +836,7 @@ const VSRContext = struct {
         defer self.event_count = null;
 
         const filter: tb.ChangeEventsFilter = .{
-            .limit = std.math.maxInt(u32),
+            .limit = @intCast(self.event_buffer.len),
             .timestamp_min = timestamp_min,
             .timestamp_max = 0,
         };

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -1321,7 +1321,7 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         if (amqp_timeout_seconds == 0) {
             vsr.fatal(
                 .cli,
-                "--amqp-timeout-ms must not be zero.",
+                "--amqp-timeout-seconds must not be zero.",
                 .{},
             );
         }
@@ -1331,7 +1331,7 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         if (tigerbeetle_timeout_seconds == 0) {
             vsr.fatal(
                 .cli,
-                "--tigerbeetle-timeout-ms must not be zero.",
+                "--tigerbeetle-timeout-seconds must not be zero.",
                 .{},
             );
         }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -322,6 +322,8 @@ const CLIArgs = union(enum) {
         event_count_max: ?u32 = null,
         idle_interval_ms: ?u32 = null,
         requests_per_second_limit: ?u32 = null,
+        amqp_timeout_seconds: ?u32 = null,
+        tigerbeetle_timeout_seconds: ?u32 = null,
         timestamp_last: ?u64 = null,
         verbose: bool = false,
     };
@@ -674,6 +676,8 @@ pub const Command = union(enum) {
         event_count_max: ?u32,
         idle_interval_ms: ?u32,
         requests_per_second_limit: ?u32,
+        amqp_timeout_seconds: ?u32,
+        tigerbeetle_timeout_seconds: ?u32,
         timestamp_last: ?u64,
         log_debug: bool,
     };
@@ -1303,6 +1307,36 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         }
     }
 
+    if (amqp.idle_interval_ms) |idle_interval_ms| {
+        if (idle_interval_ms == 0) {
+            vsr.fatal(
+                .cli,
+                "--idle-interval-ms must not be zero.",
+                .{},
+            );
+        }
+    }
+
+    if (amqp.amqp_timeout_seconds) |amqp_timeout_seconds| {
+        if (amqp_timeout_seconds == 0) {
+            vsr.fatal(
+                .cli,
+                "--amqp-timeout-ms must not be zero.",
+                .{},
+            );
+        }
+    }
+
+    if (amqp.tigerbeetle_timeout_seconds) |tigerbeetle_timeout_seconds| {
+        if (tigerbeetle_timeout_seconds == 0) {
+            vsr.fatal(
+                .cli,
+                "--tigerbeetle-timeout-ms must not be zero.",
+                .{},
+            );
+        }
+    }
+
     return .{
         .addresses = addresses,
         .cluster = amqp.cluster,
@@ -1316,6 +1350,8 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
         .idle_interval_ms = amqp.idle_interval_ms,
         .requests_per_second_limit = amqp.requests_per_second_limit,
         .timestamp_last = amqp.timestamp_last,
+        .amqp_timeout_seconds = amqp.amqp_timeout_seconds,
+        .tigerbeetle_timeout_seconds = amqp.tigerbeetle_timeout_seconds,
         .log_debug = amqp.verbose,
     };
 }

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -610,6 +610,8 @@ fn command_amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !
             .event_count_max = args.event_count_max,
             .idle_interval_ms = args.idle_interval_ms,
             .requests_per_second_limit = args.requests_per_second_limit,
+            .amqp_timeout_seconds = args.amqp_timeout_seconds,
+            .tigerbeetle_timeout_seconds = args.tigerbeetle_timeout_seconds,
             .recovery_mode = if (args.timestamp_last) |timestamp_last|
                 .{ .override = timestamp_last }
             else


### PR DESCRIPTION
Adds the `tigerbeetle_timeout_seconds` CLI argument. The CDC job exits with code == 1 if the TigerBeetle cluster does not reply before the timeout, giving the operator the opportunity to log the error and diagnose any connectivity issue.

For symmetry, it also exposes `amqp_timeout_seconds` as a CLI option (it was previously fixed at 30s). The behavior regarding the AMQP timeout is unchanged.

Also implements tests for the TigerBeetle timeout.

The AMQP timeout cannot be trivially tested because, unlike the TigerBeetle client, the AMQP client closes when the TCP connection is severed.