### PR TITLE
Build: Include correct release number in vortex driver

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -235,8 +235,8 @@ pub fn build(b: *std.Build) !void {
     }, .{
         .stdx_module = stdx_module,
         .tb_client_header = tb_client.header,
-        .vsr_module_test = vsr_module_test,
-        .vsr_options_test = vsr_options_test,
+        .vsr_module = vsr_module,
+        .vsr_options = vsr_options,
         .target = target,
         .mode = mode,
         .print_exe = build_options.print_exe,
@@ -1228,8 +1228,8 @@ fn build_vortex_driver_zig(
     options: struct {
         tb_client_header: std.Build.LazyPath,
         stdx_module: *std.Build.Module,
-        vsr_module_test: *std.Build.Module,
-        vsr_options_test: *std.Build.Step.Options,
+        vsr_module: *std.Build.Module,
+        vsr_options: *std.Build.Step.Options,
         target: std.Build.ResolvedTarget,
         mode: std.builtin.OptimizeMode,
         print_exe: bool,
@@ -1247,8 +1247,8 @@ fn build_vortex_driver_zig(
     tb_client.linkLibC();
     tb_client.pie = true;
     tb_client.bundle_compiler_rt = true;
-    tb_client.root_module.addImport("vsr", options.vsr_module_test);
-    tb_client.root_module.addOptions("vsr_options", options.vsr_options_test);
+    tb_client.root_module.addImport("vsr", options.vsr_module);
+    tb_client.root_module.addOptions("vsr_options", options.vsr_options);
     if (options.target.result.os.tag == .windows) {
         tb_client.linkSystemLibrary("ws2_32");
         tb_client.linkSystemLibrary("advapi32");
@@ -1267,7 +1267,7 @@ fn build_vortex_driver_zig(
     vortex_driver.linkLibrary(tb_client);
     vortex_driver.addIncludePath(options.tb_client_header.dirname());
     vortex_driver.root_module.addImport("stdx", options.stdx_module);
-    vortex_driver.root_module.addImport("vsr", options.vsr_module_test);
+    vortex_driver.root_module.addImport("vsr", options.vsr_module);
 
     const install_step = print_or_install(b, vortex_driver, options.print_exe);
     steps.vortex_driver_zig_build.dependOn(install_step);

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -672,7 +672,7 @@ const Workload = struct {
         const argv = &.{
             vortex_path,
             "workload",
-            std.fmt.comptimePrint("--cluster-id={d}", .{constants.vortex.cluster_id}),
+            std.fmt.comptimePrint("--cluster={d}", .{constants.vortex.cluster_id}),
             arg_addresses,
             driver_command_arg,
         };

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -24,7 +24,7 @@ const events_buffer_size_max = size: {
 
 pub const CLIArgs = struct {
     @"--": void,
-    @"cluster-id": u128,
+    cluster: u128,
     addresses: []const u8,
 };
 
@@ -40,14 +40,12 @@ pub fn main() !void {
     defer args_iterator.deinit();
 
     const args = stdx.flags(&args_iterator, CLIArgs);
-
-    const cluster_id = args.@"cluster-id";
     log.info("addresses: {s}", .{args.addresses});
 
     var tb_client: c.tb_client_t = undefined;
     const init_status = c.tb_client_init(
         &tb_client,
-        std.mem.asBytes(&cluster_id),
+        std.mem.asBytes(&args.cluster),
         args.addresses.ptr,
         @intCast(args.addresses.len),
         0,

--- a/src/vortex.zig
+++ b/src/vortex.zig
@@ -31,7 +31,7 @@ pub const CLIArgs = union(enum) {
 };
 
 const WorkloadArgs = struct {
-    cluster_id: u128,
+    cluster: u128,
     addresses: []const u8,
     driver_command: []const u8,
 };
@@ -84,10 +84,10 @@ fn start_driver(allocator: std.mem.Allocator, args: WorkloadArgs) !std.process.C
         try argv.append(part);
     }
 
-    var cluster_id_argument: [32]u8 = undefined;
-    const cluster_id = try std.fmt.bufPrint(cluster_id_argument[0..], "{d}", .{args.cluster_id});
+    var cluster_argument: [32]u8 = undefined;
+    const cluster = try std.fmt.bufPrint(cluster_argument[0..], "{d}", .{args.cluster});
 
-    try argv.append(cluster_id);
+    try argv.append(cluster);
     try argv.append(args.addresses);
 
     var child = std.process.Child.init(argv.items, allocator);


### PR DESCRIPTION
Vortex zig driver releases are not being tagged with the correct release number, instead always `65535.0.0`!

Also change the vortex driver API to use `--cluster` instead of `--cluster-id` at the same time, since those old driver builds can't be used anyway.