### PR TITLE
Devhub: Use phony release number for phony release build

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -117,9 +117,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     const build_time_ms, const executable_size_bytes = blk: {
         timer.reset();
         try shell.project_root.deleteTree(".zig-cache/tmp/devhub_cache");
-        try shell.exec_zig("build -Drelease install" ++
-            " --cache-dir .zig-cache/tmp/devhub_cache/project" ++
-            " --global-cache-dir .zig-cache/tmp/devhub_cache/global", .{});
+        try shell.exec_zig("build -Drelease install", .{});
         defer shell.project_root.deleteFile("tigerbeetle") catch unreachable;
 
         break :blk .{
@@ -366,7 +364,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     };
 
     for (batch.metrics) |metric| {
-        std.log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
+        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
     }
 
     upload_run(shell, &batch) catch |err| {

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -365,6 +365,10 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         },
     };
 
+    for (batch.metrics) |metric| {
+        std.log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
+    }
+
     upload_run(shell, &batch) catch |err| {
         log.err("failed to upload devhubdb metrics: {}", .{err});
     };
@@ -372,10 +376,6 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
     upload_nyrkio(shell, &batch) catch |err| {
         log.err("failed to upload Nyrkiö metrics: {}", .{err});
     };
-
-    for (batch.metrics) |metric| {
-        std.log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
-    }
 }
 
 fn get_measurement(

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -116,8 +116,10 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
 
     const build_time_ms, const executable_size_bytes = blk: {
         timer.reset();
-        try shell.project_root.deleteTree(".zig-cache");
-        try shell.exec_zig("build -Drelease install", .{});
+        try shell.project_root.deleteTree(".zig-cache/tmp/devhub_cache");
+        try shell.exec_zig("build -Drelease install" ++
+            " --cache-dir .zig-cache/tmp/devhub_cache/project" ++
+            " --global-cache-dir .zig-cache/tmp/devhub_cache/global", .{});
         defer shell.project_root.deleteFile("tigerbeetle") catch unreachable;
 
         break :blk .{

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -81,17 +81,16 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     var changelog_iteratator = changelog.ChangelogIterator.init(changelog_text);
     const release, const release_multiversion, const changelog_body = blk: {
         if (cli_args.no_changelog) {
+            assert(cli_args.devhub);
+            assert(!cli_args.publish);
+
             var last_release = changelog_iteratator.next_changelog().?;
             while (last_release.release == null) {
                 last_release = changelog_iteratator.next_changelog().?;
             }
 
             break :blk .{
-                multiversion.Release.from(.{
-                    .major = last_release.release.?.triple().major,
-                    .minor = last_release.release.?.triple().minor,
-                    .patch = last_release.release.?.triple().patch + 1,
-                }),
+                multiversion.Release.from(.{ .major = 65535, .minor = 0, .patch = 0 }),
                 last_release.release.?,
                 "",
             };


### PR DESCRIPTION
- Use a phony release number for the phony release build.
- ~Don't delete `.zig-cache` -- instead, use a different cache for the timed build.~
- Move devhub's metrics logging prior to the upload, to make local testing more convenient.
