### PR TITLE
io: add metric to track time spent on cpu work

### DIFF
--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -3,6 +3,8 @@ const builtin = @import("builtin");
 const std = @import("std");
 const posix = std.posix;
 
+const stdx = @import("stdx");
+
 const assert = std.debug.assert;
 
 const is_linux = builtin.target.os.tag == .linux;
@@ -153,3 +155,35 @@ pub fn aof_blocking_open(dir_fd: posix.fd_t, path: []const u8) !posix.fd_t {
 
     return file.handle;
 }
+
+pub const Stats = struct {
+    const Tracer = @import("../trace.zig").Tracer;
+    const Timings = struct {
+        time_callbacks: stdx.Duration = .ms(0),
+        time_run_for_ns: stdx.Duration = .ms(0),
+
+        pub fn time_since(now: Timings, earlier: Timings) Timings {
+            assert(now.time_callbacks.ns >= earlier.time_callbacks.ns);
+            assert(now.time_run_for_ns.ns >= earlier.time_run_for_ns.ns);
+
+            return .{
+                .time_callbacks = now.time_callbacks.subtract(earlier.time_callbacks),
+                .time_run_for_ns = now.time_run_for_ns.subtract(earlier.time_run_for_ns),
+            };
+        }
+    };
+
+    now: Timings = .{},
+    earlier: Timings = .{},
+    tracer: ?*Tracer = null,
+
+    pub fn trace(stats: *Stats) void {
+        if (stats.tracer) |tracer| {
+            const timings_delta = stats.now.time_since(stats.earlier);
+            stats.earlier = stats.now;
+
+            tracer.timing(.loop_run_for_ns, timings_delta.time_run_for_ns);
+            tracer.timing(.loop_callbacks, timings_delta.time_callbacks);
+        }
+    }
+};

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -15,6 +15,7 @@ const DirectIO = @import("../io.zig").DirectIO;
 pub const IO = struct {
     pub const TCPOptions = common.TCPOptions;
     pub const ListenOptions = common.ListenOptions;
+    pub const Stats = common.Stats;
 
     kq: fd_t,
     event_id: Event = 0,
@@ -23,6 +24,8 @@ pub const IO = struct {
     timeouts: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_timeouts" }),
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
     io_pending: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_pending" }),
+
+    stats: common.Stats = .{},
 
     pub fn init(entries: u12, flags: u32) !IO {
         _ = entries;
@@ -48,6 +51,11 @@ pub const IO = struct {
     /// The `nanoseconds` argument is a u63 to allow coercion to the i64 used
     /// in the __kernel_timespec struct.
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
+        defer self.stats.trace();
+
+        var timer = try std.time.Timer.start();
+        defer self.stats.now.time_run_for_ns.ns += timer.read();
+
         var timed_out = false;
         var completion: Completion = undefined;
         const on_timeout = struct {
@@ -127,9 +135,12 @@ pub const IO = struct {
 
         var completed = self.completed;
         self.completed.reset();
+
+        var timer = try std.time.Timer.start();
         while (completed.pop()) |completion| {
             (completion.callback)(self, completion);
         }
+        self.stats.now.time_callbacks.ns += timer.read();
     }
 
     fn flush_io(self: *IO, events: []posix.Kevent) usize {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -21,6 +21,7 @@ const maybe = stdx.maybe;
 pub const IO = struct {
     pub const TCPOptions = common.TCPOptions;
     pub const ListenOptions = common.ListenOptions;
+    pub const Stats = common.Stats;
     const CompletionList = DoublyLinkedListType(Completion, .awaiting_back, .awaiting_next);
 
     ring: IO_Uring,
@@ -59,6 +60,8 @@ pub const IO = struct {
         // All operations have been canceled.
         done,
     } = .inactive,
+
+    stats: common.Stats = .{},
 
     pub fn init(entries: u12, flags: u32) !IO {
         // Detect the linux version to ensure that we support all io_uring ops used.
@@ -118,6 +121,10 @@ pub const IO = struct {
     /// in the kernel_timespec struct.
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         assert(self.cancel_all_status != .done);
+        defer self.stats.trace();
+
+        var timer = try std.time.Timer.start();
+        defer self.stats.now.time_run_for_ns.ns += timer.read();
 
         // We must use the same clock source used by io_uring (CLOCK_MONOTONIC) since we specify the
         // timeout below as an absolute value. Otherwise, we may deadlock if the clock sources are
@@ -170,6 +177,8 @@ pub const IO = struct {
             while (copy.pop()) |completion| self.enqueue(completion);
         }
 
+        var timer = try std.time.Timer.start();
+
         // Run completions only after all completions have been flushed:
         // Loop until all completions are processed. Calls to complete() may queue more work
         // and extend the duration of the loop, but this is fine as it 1) executes completions
@@ -200,6 +209,8 @@ pub const IO = struct {
                 .done => unreachable,
             }
         }
+
+        self.stats.now.time_callbacks.ns += timer.read();
 
         // At this point, unqueued could have completions either by 1) those who didn't get an SQE
         // during the popping of unqueued or 2) completion.complete() which start new IO. These

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -15,12 +15,15 @@ const DirectIO = @import("../io.zig").DirectIO;
 pub const IO = struct {
     pub const TCPOptions = common.TCPOptions;
     pub const ListenOptions = common.ListenOptions;
+    pub const Stats = common.Stats;
 
     iocp: os.windows.HANDLE,
     time_os: TimeOS = .{},
     io_pending: usize = 0,
     timeouts: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_timeouts" }),
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
+
+    stats: common.Stats = .{},
 
     pub fn init(entries: u12, flags: u32) !IO {
         _ = entries;
@@ -51,6 +54,11 @@ pub const IO = struct {
     }
 
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
+        defer self.stats.trace();
+
+        var timer = try std.time.Timer.start();
+        defer self.stats.now.time_run_for_ns.ns += timer.read();
+
         const Callback = struct {
             fn on_timeout(
                 timed_out: *bool,
@@ -136,12 +144,15 @@ pub const IO = struct {
         // as the callbacks could potentially submit more completions.
         var completed = self.completed;
         self.completed.reset();
+
+        var timer = try std.time.Timer.start();
         while (completed.pop()) |completion| {
             (completion.callback)(Completion.Context{
                 .io = self,
                 .completion = completion,
             });
         }
+        self.stats.now.time_callbacks.ns += timer.read();
     }
 
     fn flush_timeouts(self: *IO) ?u64 {

--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -69,6 +69,12 @@ pub const Duration = struct {
         }
     };
 
+    pub fn subtract(longer: Duration, shorter: Duration) Duration {
+        assert(longer.ns >= shorter.ns);
+        const difference_ns = longer.ns - shorter.ns;
+        return .{ .ns = difference_ns };
+    }
+
     // Human readable format like `1.123s`.
     // NB: this is a lossy operation, durations are rounded to look nice.
     pub fn format(

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -501,15 +501,13 @@ fn command_start(
         }
     }
 
+    // Enable tracing for the event loop. Internally, it'll emit its statistics every time
+    // run_for_ns() is called.
+    io.stats.tracer = tracer;
+
     while (true) {
         replica.tick();
-
-        {
-            tracer.start(.loop_run_for_ns);
-            defer tracer.stop(.loop_run_for_ns);
-
-            try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
-        }
+        try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
 }
 

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -149,6 +149,7 @@ pub const Event = union(enum) {
 
     loop_run_for_ns,
     loop_tick,
+    loop_callbacks,
 
     pub const Tag = std.meta.Tag(Event);
 
@@ -227,6 +228,7 @@ pub const EventTiming = union(Event.Tag) {
 
     loop_run_for_ns,
     loop_tick,
+    loop_callbacks,
 
     pub const slot_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = enum_count(CommitStage.Tag),
@@ -253,6 +255,7 @@ pub const EventTiming = union(Event.Tag) {
         .client_request_round_trip = enum_count(Operation),
         .loop_run_for_ns = 1,
         .loop_tick = 1,
+        .loop_callbacks = 1,
     });
 
     pub const slot_bases = array: {
@@ -389,6 +392,7 @@ pub const EventTracing = union(Event.Tag) {
 
     loop_run_for_ns,
     loop_tick,
+    loop_callbacks,
 
     pub const stack_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = 1,
@@ -415,6 +419,7 @@ pub const EventTracing = union(Event.Tag) {
         .client_request_round_trip = 1,
         .loop_run_for_ns = 1,
         .loop_tick = 1,
+        .loop_callbacks = 1,
     });
 
     pub const stack_bases = array: {
@@ -497,7 +502,7 @@ pub const EventTracing = union(Event.Tag) {
     // captured, but no per trace logs or JSON will be emitted.
     pub fn aggregate_only(event: *const EventTracing) bool {
         return switch (event.*) {
-            .loop_run_for_ns, .loop_tick => true,
+            .loop_run_for_ns, .loop_tick, .loop_callbacks => true,
             else => false,
         };
     }
@@ -768,6 +773,7 @@ test "EventTiming slot doesn't have collisions" {
             } },
             .loop_run_for_ns => .loop_run_for_ns,
             .loop_tick => .loop_tick,
+            .loop_callbacks => .loop_callbacks,
         };
         try stacks.append(allocator, event.slot());
     }


### PR DESCRIPTION
Specifically, this tracks all the time spent executing callbacks.

It returns the value from `flush()` up to `run_for_ns()` and then actually tracks it in `main()`. It clutters our main loop a little more, but I'm not sure introducing our existing tracer directly into IO would be a good idea either...