### PR TITLE
forest: fold CompactionSchedule into Forest

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -310,7 +310,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             paused,
         } = .inactive,
 
-        // Bar-scoped fields:
+        // Half-bar-scoped fields:
         // -----------------
 
         /// `op_min` is the first op/beat of this compaction's half-bar.
@@ -358,18 +358,18 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         quotas: struct {
             beat: u64 = 0,
             beat_done: u64 = 0,
-            bar: u64 = 0,
-            bar_done: u64 = 0,
+            half_bar: u64 = 0,
+            half_bar_done: u64 = 0,
 
             fn beat_exhausted(quotas: @This()) bool {
-                assert(quotas.beat_done <= quotas.bar_done);
-                assert(quotas.bar_done <= quotas.bar);
+                assert(quotas.beat_done <= quotas.half_bar_done);
+                assert(quotas.half_bar_done <= quotas.half_bar);
                 return quotas.beat_done >= quotas.beat;
             }
 
-            fn bar_exhausted(quotas: @This()) bool {
-                assert(quotas.bar_done <= quotas.bar);
-                return quotas.bar_done == quotas.bar;
+            fn half_bar_exhausted(quotas: @This()) bool {
+                assert(quotas.half_bar_done <= quotas.half_bar);
+                return quotas.half_bar_done == quotas.half_bar;
             }
         } = .{},
 
@@ -550,9 +550,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         /// - check if compaction is needed at all (if the level_a is full),
         /// - find a table on level_a and the corresponding range on level_b that should be
         ///   compacted,
-        /// - compute the bar quota (just the total number of values in all input tables),
+        /// - compute the half bar quota (just the total number of values in all input tables),
         /// - execute move table optimization if range_b turns out to be empty.
-        pub fn bar_commence(compaction: *Compaction, op: u64) u64 {
+        pub fn half_bar_commence(compaction: *Compaction, op: u64) u64 {
             assert(compaction.idle());
             assert(compaction.block_queues_empty_output());
             assert(compaction.block_queues_empty_input());
@@ -566,8 +566,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             if (compaction.level_b == 0) {
                 // Do not start compaction if the immutable table does not require compaction.
                 if (compaction.tree.table_immutable.mutability.immutable.flushed) {
-                    assert(compaction.quotas.bar == 0);
-                    assert(compaction.quotas.bar_exhausted());
+                    assert(compaction.quotas.half_bar == 0);
+                    assert(compaction.quotas.half_bar_exhausted());
                     log.debug("{s}:{}: bar_commence: immutable table flushed", .{
                         compaction.tree.config.name,
                         compaction.level_b,
@@ -602,8 +602,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         compaction_op_max == op_checkpoint_trigger_next;
 
                     if (!last_half_bar_of_checkpoint) {
-                        assert(compaction.quotas.bar == 0);
-                        assert(compaction.quotas.bar_exhausted());
+                        assert(compaction.quotas.half_bar == 0);
+                        assert(compaction.quotas.half_bar_exhausted());
                         log.debug("{s}:{}: bar_commence: immutable table flush skipped " ++
                             "({}+{}+{} ≤ {})", .{
                             compaction.tree.config.name,
@@ -636,12 +636,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
                 // Do not start compaction if level A does not require compaction.
                 const table_range = compaction.tree.manifest.compaction_table(level_a) orelse {
-                    assert(compaction.quotas.bar == 0);
-                    assert(compaction.quotas.bar_exhausted());
-                    log.debug("{s}:{}: bar_commence: nothing to compact", .{
-                        compaction.tree.config.name,
-                        compaction.level_b,
-                    });
+                    assert(compaction.quotas.half_bar == 0);
+                    assert(compaction.quotas.half_bar_exhausted());
                     return 0;
                 };
 
@@ -669,30 +665,33 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 assert(!compaction.grid.free_set.is_free(table.table_info.address));
             }
 
-            var quota_bar = switch (compaction.table_info_a.?) {
+            var quota_half_bar = switch (compaction.table_info_a.?) {
                 .immutable => compaction.tree.table_immutable.count(),
                 .disk => |table| table.table_info.value_count,
             };
             for (compaction.range_b.?.tables.const_slice()) |*table| {
-                quota_bar += table.table_info.value_count;
+                quota_half_bar += table.table_info.value_count;
             }
             compaction.quotas = .{
                 .beat = 0,
                 .beat_done = 0,
-                .bar = quota_bar,
-                .bar_done = 0,
+                .half_bar = quota_half_bar,
+                .half_bar_done = 0,
             };
 
-            log.debug("{s}:{}: bar_commence: quota_bar_done={} quota_bar={}", .{
-                compaction.tree.config.name,
-                compaction.level_b,
-                compaction.quotas.bar_done,
-                compaction.quotas.bar,
-            });
             compaction.move_table = compaction.table_info_a.? == .disk and
                 compaction.range_b.?.tables.empty();
             compaction.drop_tombstones = compaction.tree.manifest
                 .compaction_must_drop_tombstones(compaction.level_b, &compaction.range_b.?);
+
+            log.debug("{s}:{}: half_bar_commence: quotas: half_bar_done={} half_bar={}" ++
+                " move_table={}", .{
+                compaction.tree.config.name,
+                compaction.level_b,
+                compaction.quotas.half_bar_done,
+                compaction.quotas.half_bar,
+                compaction.move_table,
+            });
 
             // The last level must always drop tombstones.
             if (compaction.level_b == constants.lsm_levels - 1) assert(compaction.drop_tombstones);
@@ -717,30 +716,30 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
                 compaction.quotas.beat = value_count;
                 compaction.quotas.beat_done = value_count;
-                compaction.quotas.bar_done = value_count;
+                compaction.quotas.half_bar_done = value_count;
 
                 assert(compaction.quotas.beat_exhausted());
-                assert(compaction.quotas.bar_exhausted());
+                assert(compaction.quotas.half_bar_exhausted());
 
                 return 0;
             } else {
                 if (compaction.table_info_a.? == .immutable) {
                     compaction.counters.in += compaction.table_info_a.?.immutable.len;
                 }
-                return compaction.quotas.bar;
+                return compaction.quotas.half_bar;
             }
         }
 
         /// Apply the changes that have been accumulated in memory to the manifest and remove any
         /// tables that are now invisible.
-        pub fn bar_complete(compaction: *Compaction) void {
+        pub fn half_bar_complete(compaction: *Compaction) void {
             assert(compaction.idle());
             assert(compaction.block_queues_empty_output());
             assert(compaction.block_queues_empty_input());
 
             assert(compaction.stage == .paused);
             assert(compaction.counters.consistent());
-            assert(compaction.quotas.bar_exhausted());
+            assert(compaction.quotas.half_bar_exhausted());
             // Assert blocks have been released back to the pipeline.
             assert(compaction.table_builder.state == .no_blocks);
             assert(compaction.table_builder_index_block == null);
@@ -758,7 +757,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             if (compaction.table_info_a == null) {
                 assert(compaction.range_b == null);
                 assert(compaction.manifest_entries.count() == 0);
-                assert(compaction.quotas.bar == 0);
+                assert(compaction.quotas.half_bar == 0);
                 if (compaction.level_b == 0) {
                     // Either:
                     // - the immutable table is empty (already flushed), or
@@ -769,7 +768,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             }
             assert(compaction.table_info_a != null);
             assert(compaction.range_b != null);
-            assert(compaction.quotas.bar > 0);
+            assert(compaction.quotas.half_bar > 0);
 
             switch (compaction.table_info_a.?) {
                 .immutable => {},
@@ -900,14 +899,14 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             // We may be carrying over some blocks from the previous beat.
             maybe(compaction.block_queues_empty_input());
 
-            if (compaction.move_table) assert(compaction.quotas.bar_exhausted());
+            if (compaction.move_table) assert(compaction.quotas.half_bar_exhausted());
 
             // Run the compaction up to completion of the bar quota, if possible.
-            const values_remaining = (compaction.quotas.bar - compaction.quotas.bar_done);
+            const values_remaining = (compaction.quotas.half_bar - compaction.quotas.half_bar_done);
 
             compaction.quotas.beat = @min(values_count, values_remaining);
             compaction.quotas.beat_done = 0;
-            assert(compaction.quotas.beat <= compaction.quotas.bar);
+            assert(compaction.quotas.beat <= compaction.quotas.half_bar);
         }
 
         /// The entry point to the actual compaction work for the beat. Called by the forest.
@@ -923,26 +922,31 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             // We may be carrying over some blocks from the previous beat.
             maybe(compaction.block_queues_empty_input());
 
-            if (compaction.move_table) assert(compaction.quotas.bar_exhausted());
+            if (compaction.move_table) assert(compaction.quotas.half_bar_exhausted());
 
-            if (compaction.quotas.bar_exhausted()) {
-                log.debug("{}: {s}:{}: beat_commence: bar quota={} fulfilled, done={}", .{
-                    compaction.grid.superblock.replica_index.?,
-                    compaction.tree.config.name,
-                    compaction.level_b,
-                    compaction.quotas.bar,
-                    compaction.quotas.bar_done,
-                });
+            if (compaction.quotas.half_bar_exhausted()) {
+                if (compaction.quotas.half_bar > 0) {
+                    log.debug("{}: {s}:{}: beat_commence: half_bar quota={} fulfilled, done={}", .{
+                        compaction.grid.superblock.replica_index.?,
+                        compaction.tree.config.name,
+                        compaction.level_b,
+                        compaction.quotas.half_bar,
+                        compaction.quotas.half_bar_done,
+                    });
+                }
+
                 return .ready;
             }
 
             if (compaction.quotas.beat_exhausted()) {
-                log.debug("{s}:{}: beat_commence: beat quota={} fulfilled, done={}", .{
-                    compaction.tree.config.name,
-                    compaction.level_b,
-                    compaction.quotas.beat,
-                    compaction.quotas.beat_done,
-                });
+                if (compaction.quotas.beat > 0) {
+                    log.debug("{s}:{}: beat_commence: beat quota={} fulfilled, done={}", .{
+                        compaction.tree.config.name,
+                        compaction.level_b,
+                        compaction.quotas.beat,
+                        compaction.quotas.beat_done,
+                    });
+                }
                 return .ready;
             }
 
@@ -974,11 +978,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .index_and_value_block => {
                     assert(!compaction.table_builder.index_block_full());
                     assert(!compaction.table_builder.value_block_full());
-                    assert(!compaction.quotas.bar_exhausted());
+                    assert(!compaction.quotas.half_bar_exhausted());
                 },
                 .index_block => {
                     assert(!compaction.table_builder.index_block_full());
-                    assert(!compaction.quotas.bar_exhausted());
+                    assert(!compaction.quotas.half_bar_exhausted());
                 },
             }
 
@@ -998,7 +1002,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(compaction.pool.?.idle());
             maybe(compaction.pool.?.blocks_acquired() > 0);
 
-            if (compaction.quotas.bar_exhausted()) {
+            if (compaction.quotas.half_bar_exhausted()) {
                 assert(compaction.table_builder.state == .no_blocks);
                 assert(compaction.table_builder_value_block == null);
                 assert(compaction.table_builder_index_block == null);
@@ -1015,13 +1019,13 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(compaction.idle());
             assert(pool.idle());
             log.debug("{s}:{}: beat_complete: quota_beat_done={} quota_beat={} " ++
-                "quota_bar_done={} quota_bar={}", .{
+                "quota_half_bar_done={} quota_half_bar={}", .{
                 compaction.tree.config.name,
                 compaction.level_b,
                 compaction.quotas.beat_done,
                 compaction.quotas.beat,
-                compaction.quotas.bar_done,
-                compaction.quotas.bar,
+                compaction.quotas.half_bar_done,
+                compaction.quotas.half_bar,
             });
 
             callback(pool, compaction.tree.config.id, compaction.quotas.beat_done);
@@ -1041,13 +1045,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         // - A single bar of compaction should process only a fraction of the input, so the
         //   processes can be suspended in the middle.
         //
-        // A beat of compaction ends when both:
-        //   - at least quota.bar of input values is consumed,
-        //   - there's no incomplete output value blocks.
-        //
-        // In other words, the only compaction state that gets carried over to the next beat is a
-        // partially full index block. The current beat must end with writing a value block, and the
-        // next beat must start with re-reading level_a and level_b index and value blocks.
+        // A beat of compaction ends when at least quota.beat of input values is consumed.
+        // Partially full output index and value blocks, as well as input index and value blocks
+        // may be carried over to the next beat.
         fn compaction_dispatch(compaction: *Compaction) void {
             switch (compaction.stage) {
                 .beat,
@@ -1237,7 +1237,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     compaction.level_b_value_block.count == 0;
                 const levels_exhausted = level_a_exhausted and level_b_exhausted;
 
-                assert(levels_exhausted == compaction.quotas.bar_exhausted());
+                assert(levels_exhausted == compaction.quotas.half_bar_exhausted());
 
                 if (compaction.table_builder.state == .index_and_value_block) {
                     if (level_a_exhausted and level_b_exhausted) {
@@ -1287,10 +1287,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(compaction.stage == .beat_quota_done);
 
             if (compaction.table_builder.state == .index_and_value_block and
-                (compaction.table_builder.value_block_full() or compaction.quotas.bar_exhausted()))
+                (compaction.table_builder.value_block_full() or
+                    compaction.quotas.half_bar_exhausted()))
             {
                 if (compaction.table_builder.value_block_empty()) {
-                    assert(compaction.quotas.bar_exhausted());
+                    assert(compaction.quotas.half_bar_exhausted());
                     const value_block = compaction.table_builder_value_block.?;
                     compaction.table_builder_value_block = null;
                     compaction.table_builder.state = .index_block;
@@ -1312,10 +1313,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             }
 
             if (compaction.table_builder.state == .index_block and
-                (compaction.table_builder.index_block_full() or compaction.quotas.bar_exhausted()))
+                (compaction.table_builder.index_block_full() or
+                    compaction.quotas.half_bar_exhausted()))
             {
                 if (compaction.table_builder.index_block_empty()) {
-                    assert(compaction.quotas.bar_exhausted());
+                    assert(compaction.quotas.half_bar_exhausted());
                     const index_block = compaction.table_builder_index_block.?;
                     compaction.table_builder_index_block = null;
                     compaction.table_builder.state = .no_blocks;
@@ -1346,11 +1348,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .index_and_value_block => {
                     assert(!compaction.table_builder.index_block_full());
                     assert(!compaction.table_builder.value_block_full());
-                    assert(!compaction.quotas.bar_exhausted());
+                    assert(!compaction.quotas.half_bar_exhausted());
                 },
                 .index_block => {
                     assert(!compaction.table_builder.index_block_full());
-                    assert(!compaction.quotas.bar_exhausted());
+                    assert(!compaction.quotas.half_bar_exhausted());
                 },
             }
 
@@ -1525,7 +1527,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         }
 
         fn merge(compaction: *Compaction, cpu: *ResourcePool.CPU) void {
-            assert(!compaction.quotas.bar_exhausted());
+            assert(!compaction.quotas.half_bar_exhausted());
 
             if (compaction.table_info_a.? == .immutable) {
                 if (compaction.level_a_immutable_stage == .ready) {
@@ -1628,12 +1630,12 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             const consumed_ab = merge_result.consumed_a + merge_result.consumed_b;
 
-            compaction.quotas.bar_done += consumed_ab;
+            compaction.quotas.half_bar_done += consumed_ab;
             compaction.quotas.beat_done += consumed_ab;
 
             compaction.counters.dropped += merge_result.dropped;
 
-            assert(compaction.quotas.bar_done <= compaction.quotas.bar);
+            assert(compaction.quotas.half_bar_done <= compaction.quotas.half_bar);
 
             compaction.merge_advance_position();
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -183,7 +183,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         const Forest = @This();
 
         pub const ManifestLog = ManifestLogType(Storage);
-        const CompactionSchedule = CompactionScheduleType(Forest, Grid);
 
         const Callback = *const fn (*Forest) void;
 
@@ -221,6 +220,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
             pub const compaction_block_count_min: u32 = compaction_block_count_beat_min;
         };
+        const ResourcePool = ResourcePoolType(Grid);
 
         progress: ?union(enum) {
             open: struct { callback: Callback },
@@ -228,17 +228,17 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             compact: struct {
                 op: u64,
                 callback: Callback,
+                trees_beat_input_size: u64 = 0,
+                trees_done: bool,
+                manifest_log_done: bool,
+
+                fn all_done(progress: @This()) bool {
+                    return progress.trees_done and progress.manifest_log_done;
+                }
             },
         } = null,
 
-        compaction_progress: ?struct {
-            trees_done: bool,
-            manifest_log_done: bool,
-
-            fn all_done(compaction_progress: @This()) bool {
-                return compaction_progress.trees_done and compaction_progress.manifest_log_done;
-            }
-        } = null,
+        compact_trees_half_bar_input_size: u64 = 0,
 
         grid: *Grid,
         next_tick: Grid.NextTick = undefined,
@@ -247,7 +247,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         node_pool: NodePool,
         manifest_log: ManifestLog,
 
-        compaction_schedule: CompactionSchedule,
+        resource_pool: ResourcePool,
 
         scan_buffer_pool: ScanBufferPool,
 
@@ -267,7 +267,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 .grooves = undefined,
                 .node_pool = undefined,
                 .manifest_log = undefined,
-                .compaction_schedule = undefined,
+                .resource_pool = undefined,
                 .scan_buffer_pool = undefined,
                 .radix_buffer = undefined,
             };
@@ -306,6 +306,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             forest.radix_buffer = try .init(allocator, radix_buffer_size);
             errdefer forest.radix_buffer.deinit(allocator);
 
+            forest.resource_pool = try ResourcePool.init(allocator, options.compaction_block_count);
+            errdefer forest.resource_pool.deinit(allocator);
+
             inline for (std.meta.fields(Grooves)) |field| {
                 const Groove = field.type;
                 const groove: *Groove = &@field(forest.grooves, field.name);
@@ -321,14 +324,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 grooves_initialized += 1;
             }
 
-            try forest.compaction_schedule.init(
-                allocator,
-                grid,
-                forest,
-                options.compaction_block_count,
-            );
-            errdefer forest.compaction_schedule.deinit(allocator);
-
             try forest.scan_buffer_pool.init(allocator);
             errdefer forest.scan_buffer_pool.deinit(allocator);
         }
@@ -342,10 +337,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
             forest.manifest_log.deinit(allocator);
             forest.node_pool.deinit(allocator);
-
+            forest.resource_pool.deinit(allocator);
             forest.radix_buffer.deinit(allocator);
-
-            forest.compaction_schedule.deinit(allocator);
             forest.scan_buffer_pool.deinit(allocator);
         }
 
@@ -364,7 +357,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
             forest.manifest_log.reset();
             forest.scan_buffer_pool.reset();
-            forest.compaction_schedule.reset();
+            forest.resource_pool.reset();
 
             forest.* = .{
                 // Don't reset the grid – replica is responsible for grid cancellation.
@@ -372,9 +365,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 .grooves = forest.grooves,
                 .node_pool = forest.node_pool,
                 .manifest_log = forest.manifest_log,
-
-                .compaction_schedule = forest.compaction_schedule,
-
+                .resource_pool = forest.resource_pool,
                 .scan_buffer_pool = forest.scan_buffer_pool,
                 .radix_buffer = forest.radix_buffer,
             };
@@ -382,7 +373,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
         pub fn open(forest: *Forest, callback: Callback) void {
             assert(forest.progress == null);
-            assert(forest.compaction_progress == null);
 
             forest.progress = .{ .open = .{ .callback = callback } };
 
@@ -399,7 +389,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         ) void {
             const forest: *Forest = @fieldParentPtr("manifest_log", manifest_log);
             assert(forest.progress.? == .open);
-            assert(forest.compaction_progress == null);
             assert(table.label.level < constants.lsm_levels);
             assert(table.label.event != .remove);
 
@@ -418,7 +407,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         fn manifest_log_open_callback(manifest_log: *ManifestLog) void {
             const forest: *Forest = @fieldParentPtr("manifest_log", manifest_log);
             assert(forest.progress.? == .open);
-            assert(forest.compaction_progress == null);
             forest.verify_tables_recovered();
 
             inline for (std.meta.fields(Grooves)) |field| {
@@ -452,18 +440,15 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                 last_beat,
             });
 
+            // Run trees and manifest log compaction in parallel, join in compact_finish.
             assert(forest.progress == null);
             forest.progress = .{ .compact = .{
                 .op = op,
                 .callback = callback,
-            } };
-
-            // Run trees and manifest log compaction in parallel, join in compact_finish.
-            assert(forest.compaction_progress == null);
-            forest.compaction_progress = .{
                 .trees_done = false,
                 .manifest_log_done = false,
-            };
+                .trees_beat_input_size = 0,
+            } };
 
             // No compactions are run during the absolute first bar, or during
             // the first bar of the checkpoint that we are currently recovering
@@ -471,8 +456,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             if (op < constants.lsm_compaction_ops or
                 forest.grid.superblock.working.vsr_state.op_compacted(op))
             {
-                forest.compaction_progress.?.manifest_log_done = true;
-                forest.compaction_progress.?.trees_done = true;
+                forest.progress.?.compact.manifest_log_done = true;
+                forest.progress.?.compact.trees_done = true;
                 forest.grid.on_next_tick(compact_finish_next_tick, &forest.next_tick);
                 return;
             }
@@ -486,10 +471,10 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             if (last_beat or last_half_beat) {
                 forest.manifest_log.compact(compact_manifest_log_callback, op);
             } else {
-                forest.compaction_progress.?.manifest_log_done = true;
+                forest.progress.?.compact.manifest_log_done = true;
             }
 
-            forest.compaction_schedule.beat_start(compact_trees_callback, op);
+            forest.compact_trees_start();
         }
 
         fn compact_finish_next_tick(next_tick: *Grid.NextTick) void {
@@ -499,13 +484,196 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             forest.compact_finish();
         }
 
-        fn compact_trees_callback(forest: *Forest) void {
+        /// Plans a half-bar's worth of compaction work across all the trees in the
+        /// Forest, and schedules it one beat at a time. Each bar is divided into
+        /// two half bars with `lsm_compaction_ops/2` beats each. Even levels
+        /// (0 → 1, 2 → 4, etc.) are active during the first half bar and odd levels
+        /// (immutable → 0, 1 → 3, etc.) are active during the second half bar.
+        ///
+        /// We now describe the scheduling algorithm. In the description, we refer
+        /// to each (tree, level) combination as a `Compaction`, for example the
+        /// compaction from level 0 → 1 in the Accounts tree.
+        ///
+        /// At the first beat of each half bar:
+        /// 1. Calculate the half-bar quota for each Compaction, which is the total
+        ///    number of bytes that Compaction needs to chew through. We use this as
+        ///    an estimate of time the compaction will take and then slice it into
+        ///    small chunks, to spread it evenly across the beats of the half bar.
+        /// 2. Calculate the half-bar quota for the entire Forest by summing up the
+        ///    aforementioned quotas.
+        ///
+        /// At each beat:
+        /// 1. Calculate the Forest's beat quota by equally dividing the half-bar
+        ///    quota across each beat.
+        /// 2. Resume a suspended Compaction, or start a new one.
+        /// 3. Run active Compaction till either the Forest's beat quota is met,
+        ///    or its half-bar quota is  met. If its the latter, go to step 2.
+        ///    If its the former...
+        /// 4. Suspend active Compaction and finish the beat.
+        pub fn compact_trees_start(forest: *Forest) void {
             assert(forest.progress.? == .compact);
-            assert(forest.compaction_progress != null);
-            assert(!forest.compaction_progress.?.trees_done);
-            forest.compaction_progress.?.trees_done = true;
+            assert(!forest.progress.?.compact.trees_done);
+            assert(forest.progress.?.compact.trees_beat_input_size == 0);
 
-            if (forest.compaction_progress.?.all_done()) {
+            const op = forest.progress.?.compact.op;
+            assert(!forest.grid.superblock.working.vsr_state.op_compacted(op));
+            assert(op >= constants.lsm_compaction_ops);
+
+            const half_bar = @divExact(constants.lsm_compaction_ops, 2);
+            const compaction_beat = op % constants.lsm_compaction_ops;
+
+            const first_beat = compaction_beat == 0;
+            const half_beat = compaction_beat == half_bar;
+
+            if (first_beat or half_beat) {
+                maybe(forest.resource_pool.blocks_acquired() > 0);
+                assert(forest.compact_trees_half_bar_input_size == 0);
+
+                var half_bar_input_size: u64 = 0;
+                for (0..constants.lsm_levels) |level_b| {
+                    if (level_active(.{ .level_b = level_b, .op = op })) {
+                        inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
+                            const tree = Forest.tree_info_for_id(tree_id);
+                            const Value = tree.Tree.Value;
+                            const compaction = forest.compaction_at(level_b, tree_id);
+
+                            const bar_input_values = compaction.half_bar_commence(op);
+
+                            half_bar_input_size += (bar_input_values * @sizeOf(Value));
+                        }
+                    }
+                }
+                forest.compact_trees_half_bar_input_size = half_bar_input_size;
+            }
+
+            const beats_total = half_bar;
+            const beats_done = compaction_beat % half_bar;
+            const beats_remaining = beats_total - beats_done;
+
+            forest.progress.?.compact.trees_beat_input_size = stdx.div_ceil(
+                forest.compact_trees_half_bar_input_size,
+                beats_remaining,
+            );
+
+            forest.compact_trees_reserve_grid_blocks();
+            forest.compact_trees_resume();
+        }
+
+        /// This is akin to a dry run for the actual compaction work that
+        /// is going to happen during this beat, wherein we:
+        /// * Invoke beat_commence on the active compactions to set beat quotas
+        /// * Reserve blocks in the grid for the output of these compactions
+        fn compact_trees_reserve_grid_blocks(forest: *Forest) void {
+            assert(forest.progress.? == .compact);
+            assert(!forest.progress.?.compact.trees_done);
+
+            const op = forest.progress.?.compact.op;
+            // 1 since we may have partially finished index/value blocks from the previous beat.
+            var beat_index_blocks_max: u64 = 1;
+            var beat_value_blocks_max: u64 = 1;
+
+            var beat_input_size = forest.progress.?.compact.trees_beat_input_size;
+            for (0..constants.lsm_levels) |level_b| {
+                if (level_active(.{ .level_b = level_b, .op = op })) {
+                    inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
+                        const tree = Forest.tree_info_for_id(tree_id);
+                        const compaction = forest.compaction_at(level_b, tree_id);
+
+                        const Value = tree.Tree.Value;
+                        const Table = tree.Tree.Table;
+
+                        compaction.beat_commence(
+                            stdx.div_ceil(beat_input_size, @sizeOf(Value)),
+                        );
+
+                        // The +1 is for imperfections in pacing our immutable table, which
+                        // might cause us to overshoot by a single block (limited to 1 due
+                        // to how the immutable table values are consumed.)
+                        const beat_value_blocks = stdx.div_ceil(
+                            compaction.quotas.beat,
+                            Table.layout.block_value_count_max,
+                        ) + 1;
+                        const beat_index_blocks = stdx.div_ceil(
+                            beat_value_blocks,
+                            Table.value_block_count_max,
+                        );
+                        beat_value_blocks_max += beat_value_blocks;
+                        beat_index_blocks_max += beat_index_blocks;
+
+                        beat_input_size -|= (compaction.quotas.beat * @sizeOf(Value));
+                    }
+                }
+            }
+            assert(beat_input_size == 0);
+
+            assert(forest.resource_pool.grid_reservation == null);
+            forest.resource_pool.grid_reservation = forest.grid.reserve(
+                beat_value_blocks_max + beat_index_blocks_max,
+            );
+        }
+
+        fn compact_trees_resume(forest: *Forest) void {
+            assert(forest.resource_pool.grid_reservation != null);
+
+            if (forest.progress.?.compact.trees_beat_input_size == 0) {
+                if (forest.resource_pool.grid_reservation) |reservation| {
+                    forest.grid.forfeit(reservation);
+                    forest.resource_pool.grid_reservation = null;
+                }
+
+                forest.grid.on_next_tick(compact_trees_finish_callback, &forest.next_tick);
+                return;
+            }
+
+            const op = forest.progress.?.compact.op;
+            for (0..constants.lsm_levels) |level_b| {
+                if (level_active(.{ .level_b = level_b, .op = op })) {
+                    inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
+                        const compaction = forest.compaction_at(level_b, tree_id);
+
+                        const resumed = compaction.compaction_dispatch_enter(.{
+                            .callback = compact_trees_resume_callback,
+                            .pool = &forest.resource_pool,
+                        });
+
+                        switch (resumed) {
+                            .pending => return,
+                            .ready => {},
+                        }
+                    }
+                }
+            }
+        }
+
+        fn compact_trees_resume_callback(
+            pool: *ResourcePool,
+            tree_id: u16,
+            values_consumed: u64,
+        ) void {
+            const forest: *Forest = @fieldParentPtr("resource_pool", pool);
+
+            switch (Forest.tree_id_cast(tree_id)) {
+                inline else => |id| {
+                    const Value = Forest.tree_info_for_id(id).Tree.Value;
+                    const input_bytes_consumed = values_consumed * @sizeOf(Value);
+                    forest.compact_trees_half_bar_input_size -= input_bytes_consumed;
+                    forest.progress.?.compact.trees_beat_input_size -|= input_bytes_consumed;
+                },
+            }
+            forest.compact_trees_resume();
+        }
+
+        fn compact_trees_finish_callback(next_tick: *Grid.NextTick) void {
+            const forest: *Forest = @alignCast(
+                @fieldParentPtr("next_tick", next_tick),
+            );
+            assert(forest.progress.? == .compact);
+            assert(forest.progress.?.compact.trees_beat_input_size == 0);
+            assert(!forest.progress.?.compact.trees_done);
+
+            forest.progress.?.compact.trees_done = true;
+
+            if (forest.progress.?.compact.all_done()) {
                 forest.compact_finish();
             }
         }
@@ -514,22 +682,20 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             const forest: *Forest = @fieldParentPtr("manifest_log", manifest_log);
 
             assert(forest.progress.? == .compact);
-            assert(forest.compaction_progress != null);
-            assert(!forest.compaction_progress.?.manifest_log_done);
-            forest.compaction_progress.?.manifest_log_done = true;
+            assert(!forest.progress.?.compact.manifest_log_done);
+            forest.progress.?.compact.manifest_log_done = true;
 
-            if (forest.compaction_progress.?.all_done()) {
+            if (forest.progress.?.compact.all_done()) {
                 forest.compact_finish();
             }
         }
 
         fn compact_finish(forest: *Forest) void {
             assert(forest.progress.? == .compact);
-            assert(forest.compaction_progress != null);
-            assert(forest.compaction_progress.?.trees_done);
-            assert(forest.compaction_progress.?.manifest_log_done);
-            assert(forest.compaction_schedule.pool.idle());
-            assert(forest.compaction_schedule.pool.blocks_acquired() <=
+            assert(forest.progress.?.compact.trees_done);
+            assert(forest.progress.?.compact.manifest_log_done);
+            assert(forest.resource_pool.idle());
+            assert(forest.resource_pool.blocks_acquired() <=
                 compaction_block_count_beat_min);
 
             forest.verify_table_extents();
@@ -551,11 +717,11 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     if (level_active(.{ .level_b = level_b, .op = op })) {
                         inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
                             const compaction =
-                                forest.compaction_schedule.compaction_at(level_b, tree_id);
+                                forest.compaction_at(level_b, tree_id);
 
                             // Apply the changes to the manifest. This will run at the target
                             // compaction beat that is requested.
-                            if (last_beat or last_half_beat) compaction.bar_complete();
+                            if (last_beat or last_half_beat) compaction.half_bar_complete();
                         }
                     }
                 }
@@ -567,10 +733,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
             }
 
             if (last_beat or last_half_beat) {
-                if (forest.compaction_schedule.bar_input_size) |bar_input_size| {
-                    assert(bar_input_size == 0);
-                    forest.compaction_schedule.bar_input_size = null;
-                }
+                assert(forest.compact_trees_half_bar_input_size == 0);
 
                 // On the last beat of the bar, make sure that manifest log compaction is finished.
                 forest.manifest_log.compact_end();
@@ -594,14 +757,20 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
             const callback = forest.progress.?.compact.callback;
             forest.progress = null;
-            forest.compaction_progress = null;
 
             callback(forest);
         }
 
+        fn compaction_at(
+            forest: *Forest,
+            level_b: usize,
+            comptime tree_id: Forest.TreeID,
+        ) *Forest.TreeForIdType(tree_id).Compaction {
+            return &forest.tree_for_id(tree_id).compactions[level_b];
+        }
+
         pub fn checkpoint(forest: *Forest, callback: Callback) void {
             assert(forest.progress == null);
-            assert(forest.compaction_progress == null);
             forest.grid.assert_only_repairing();
             forest.verify_table_extents();
 
@@ -628,7 +797,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         fn checkpoint_manifest_log_callback(manifest_log: *ManifestLog) void {
             const forest: *Forest = @fieldParentPtr("manifest_log", manifest_log);
             assert(forest.progress.? == .checkpoint);
-            assert(forest.compaction_progress == null);
             forest.verify_table_extents();
             forest.verify_tables_recovered();
 
@@ -883,248 +1051,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
 
             return compaction_blocks_released_pipeline_max +
                 manifest_log_blocks_released_pipeline_max;
-        }
-    };
-}
-
-/// Plans a bar's worth of compaction work across all the trees in the Forest, and schedules it
-/// one beat at a time. Each bar is divided into two half bars with `lsm_compaction_ops/2` beats
-/// each. Even levels (0 → 1, 2 → 4, etc.) are active during the first half bar and odd levels
-/// (immutable → 0, 1 → 3, etc.) are active during the second half bar.
-///
-/// We now describe the scheduling algorithm. In the description, we refer to each (tree, level)
-/// combination as a `Compaction`, for example the compaction from level 0 → 1 in the Accounts tree.
-///
-/// At the first beat of each half bar:
-/// 1. Calculate the half-bar quota for each Compaction, which is the total number of bytes that
-///    Compaction needs to chew through. We use this as an estimate of time the compaction will take
-///    and then slice it into small chunks, to spread it evenly across the beats of the half bar.
-/// 2. Calculate the half-bar quota for the entire Forest by summing up the aforementioned quotas.
-///
-/// At each beat:
-/// 1. Calculate the Forest's beat quota by equally dividing the half-bar quota across each beat.
-/// 2. Resume a suspended Compaction, or start a new one.
-/// 3. Run active Compaction till either the Forest's beat quota is met, or its half-bar quota is
-///    met. If its the latter, go to step 2. If its the former...
-/// 4. Suspend active Compaction and finish the beat.
-fn CompactionScheduleType(comptime Forest: type, comptime Grid: type) type {
-    return struct {
-        grid: *Grid,
-        forest: *Forest,
-        pool: ResourcePool,
-        next_tick: Grid.NextTick = undefined,
-        callback: ?*const fn (*Forest) void = null,
-        bar_input_size: ?u64 = null,
-        beat_input_size: ?u64 = null,
-
-        const CompactionSchedule = @This();
-        const ResourcePool = ResourcePoolType(Grid);
-
-        pub fn init(
-            self: *CompactionSchedule,
-            allocator: mem.Allocator,
-            grid: *Grid,
-            forest: *Forest,
-            block_count: u32,
-        ) !void {
-            assert(block_count >= compaction_block_count_beat_min);
-
-            self.* = .{ .grid = grid, .forest = forest, .pool = undefined };
-            self.pool = try ResourcePool.init(allocator, block_count);
-            errdefer self.pool.deinit(allocator);
-        }
-
-        pub fn deinit(self: *CompactionSchedule, allocator: mem.Allocator) void {
-            self.pool.deinit(allocator);
-        }
-
-        pub fn reset(self: *CompactionSchedule) void {
-            self.pool.reset();
-
-            self.* = .{ .grid = self.grid, .forest = self.forest, .pool = self.pool };
-        }
-
-        pub fn beat_start(self: *CompactionSchedule, callback: Forest.Callback, op: u64) void {
-            assert(self.pool.idle());
-            assert(self.pool.grid_reservation == null);
-
-            assert(self.callback == null);
-            assert(op >= constants.lsm_compaction_ops);
-            assert(!self.grid.superblock.working.vsr_state.op_compacted(op));
-            assert(self.beat_input_size == null);
-
-            self.beat_input_size = 0;
-            self.callback = callback;
-
-            const half_bar = @divExact(constants.lsm_compaction_ops, 2);
-            const compaction_beat = op % constants.lsm_compaction_ops;
-
-            const first_beat = compaction_beat == 0;
-            const half_beat = compaction_beat == half_bar;
-
-            if (first_beat or half_beat) {
-                assert(self.pool.blocks_acquired() == 0);
-                assert(self.bar_input_size == null);
-
-                var bar_input_size: u64 = 0;
-                for (0..constants.lsm_levels) |level_b| {
-                    if (level_active(.{ .level_b = level_b, .op = op })) {
-                        inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
-                            const tree = Forest.tree_info_for_id(tree_id);
-                            const Value = tree.Tree.Value;
-                            const compaction = self.compaction_at(level_b, tree_id);
-
-                            assert(
-                                self.pool.blocks_free() >=
-                                    // Input index & value blocks may be carried to the next beat.
-                                    compaction.level_a_index_block.buffer.len +
-                                        compaction.level_a_value_block.buffer.len +
-                                        compaction.level_b_index_block.buffer.len +
-                                        compaction.level_b_value_block.buffer.len +
-                                        // At least one output index & value block.
-                                        (1 + 1),
-                            );
-                            const bar_input_values = compaction.bar_commence(op);
-
-                            bar_input_size += (bar_input_values * @sizeOf(Value));
-                        }
-                    }
-                }
-                self.bar_input_size = bar_input_size;
-            }
-
-            const beats_total = half_bar;
-            const beats_done = compaction_beat % half_bar;
-            const beats_remaining = beats_total - beats_done;
-
-            self.beat_input_size = stdx.div_ceil(self.bar_input_size.?, beats_remaining);
-
-            // This is akin to a dry run for the actual compaction work that is going to happen
-            // during this beat, wherein we:
-            // * Invoke beat_commence on the active compactions to set beat quotas
-            // * Reserve blocks in the grid for the output of these compactions
-            {
-                // 1 since we may have partially finished index/value blocks from the previous beat.
-                var beat_index_blocks_max: u64 = 1;
-                var beat_value_blocks_max: u64 = 1;
-
-                var beat_input_size = self.beat_input_size.?;
-                for (0..constants.lsm_levels) |level_b| {
-                    if (level_active(.{ .level_b = level_b, .op = op })) {
-                        inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
-                            const tree = Forest.tree_info_for_id(tree_id);
-                            const compaction = self.compaction_at(level_b, tree_id);
-
-                            const Value = tree.Tree.Value;
-                            const Table = tree.Tree.Table;
-
-                            compaction.beat_commence(
-                                stdx.div_ceil(beat_input_size, @sizeOf(Value)),
-                            );
-
-                            // The +1 is for imperfections in pacing our immutable table, which
-                            // might cause us to overshoot by a single block (limited to 1 due
-                            // to how the immutable table values are consumed.)
-                            const beat_value_blocks = stdx.div_ceil(
-                                compaction.quotas.beat,
-                                Table.layout.block_value_count_max,
-                            ) + 1;
-                            const beat_index_blocks = stdx.div_ceil(
-                                beat_value_blocks,
-                                Table.value_block_count_max,
-                            );
-                            beat_value_blocks_max += beat_value_blocks;
-                            beat_index_blocks_max += beat_index_blocks;
-
-                            beat_input_size -|= (compaction.quotas.beat * @sizeOf(Value));
-                        }
-                    }
-                }
-                assert(beat_input_size == 0);
-                self.pool.grid_reservation = self.grid.reserve(
-                    beat_value_blocks_max + beat_index_blocks_max,
-                );
-            }
-
-            self.beat_resume();
-        }
-
-        fn beat_resume(self: *CompactionSchedule) void {
-            assert(self.callback != null);
-            assert(self.pool.grid_reservation != null);
-
-            if (self.beat_input_size == 0) {
-                self.beat_finish();
-                return;
-            }
-
-            const op = self.forest.progress.?.compact.op;
-
-            for (0..constants.lsm_levels) |level_b| {
-                if (level_active(.{ .level_b = level_b, .op = op })) {
-                    inline for (comptime std.enums.values(Forest.TreeID)) |tree_id| {
-                        const compaction = self.compaction_at(level_b, tree_id);
-
-                        const resumed = compaction.compaction_dispatch_enter(.{
-                            .pool = &self.pool,
-                            .callback = beat_resume_callback,
-                        });
-
-                        switch (resumed) {
-                            .pending => return,
-                            .ready => {},
-                        }
-                    }
-                }
-            }
-        }
-
-        fn beat_resume_callback(pool: *ResourcePool, tree_id: u16, values_consumed: u64) void {
-            const self: *CompactionSchedule = @fieldParentPtr("pool", pool);
-            assert(self.callback != null);
-
-            switch (Forest.tree_id_cast(tree_id)) {
-                inline else => |id| {
-                    const Value = Forest.tree_info_for_id(id).Tree.Value;
-                    const input_bytes_consumed = values_consumed * @sizeOf(Value);
-                    self.bar_input_size.? -= input_bytes_consumed;
-                    self.beat_input_size.? -|= input_bytes_consumed;
-                },
-            }
-
-            self.beat_resume();
-        }
-
-        fn beat_finish(self: *CompactionSchedule) void {
-            assert(self.callback != null);
-
-            assert(self.bar_input_size.? >= 0);
-            assert(self.beat_input_size == 0);
-            self.beat_input_size = null;
-
-            if (self.pool.grid_reservation) |reservation| {
-                self.grid.forfeit(reservation);
-                self.pool.grid_reservation = null;
-            }
-
-            self.grid.on_next_tick(beat_finish_next_tick, &self.next_tick);
-        }
-
-        fn beat_finish_next_tick(next_tick: *Grid.NextTick) void {
-            const self: *CompactionSchedule = @alignCast(
-                @fieldParentPtr("next_tick", next_tick),
-            );
-            const callback = self.callback.?;
-            self.callback = null;
-            callback(self.forest);
-        }
-
-        fn compaction_at(
-            self: *CompactionSchedule,
-            level_b: usize,
-            comptime tree_id: Forest.TreeID,
-        ) *Forest.TreeForIdType(tree_id).Compaction {
-            return &self.forest.tree_for_id(tree_id).compactions[level_b];
         }
     };
 }

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -311,10 +311,10 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             var beat_index_blocks_max: u64 = 1;
 
             for (compactions_slice) |compaction| {
-                if (first_beat or half_beat) _ = compaction.bar_commence(op);
+                if (first_beat or half_beat) _ = compaction.half_bar_commence(op);
 
                 const input_values_remaining_bar =
-                    compaction.quotas.bar - compaction.quotas.bar_done;
+                    compaction.quotas.half_bar - compaction.quotas.half_bar_done;
                 const input_values_remaining_beat =
                     stdx.div_ceil(input_values_remaining_bar, beats_remaining);
 
@@ -364,7 +364,7 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
                 }
 
                 for (compactions_slice) |compaction| {
-                    compaction.bar_complete();
+                    compaction.half_bar_complete();
                 }
 
                 if (op >= constants.lsm_compaction_ops) {


### PR DESCRIPTION
Makes the following refactors in compaction:
* Remove CompactionSchedule and maintains the logic at the Forest level.
* Rename all instances of bar -> half_bar (for example bar_commence is
now half_bar_commence), as the former is imprecise.
* Remove debug logs that log "nothing to compact" in `bar_commence`,
for levels of the tree that don't yet require compaction, as it gets quite noisy.
Now, we only log for levels that are active and entail some meaningful compaction work.