### PR TITLE
rust client: More cleanup and release prep

### DIFF
--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 
 [dependencies]
 bitflags = "2.6.0"
-futures-channel = "0.3.31"
 
 [dev-dependencies]
 futures = { version = "0.3.31", default-features = false, features = ["executor"] }

--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -23,9 +23,5 @@ include = [
 bitflags = "2.6.0"
 futures-channel = "0.3.31"
 
-[build-dependencies]
-anyhow = "1.0.93"
-
 [dev-dependencies]
-anyhow = "1.0.93"
 futures = { version = "0.3.31", default-features = false, features = ["executor"] }

--- a/src/clients/rust/build.rs
+++ b/src/clients/rust/build.rs
@@ -1,6 +1,6 @@
-use std::{env, path::Path};
+use std::{env, error::Error, path::Path};
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
 
     if !Path::new(&format!("{cargo_manifest_dir}/assets/tb_client.h")).try_exists()? {

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const log = std.log;
 
 const Shell = @import("../../shell.zig");
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
@@ -31,43 +32,72 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     version: []const u8,
     tigerbeetle: []const u8,
 }) !void {
-    _ = shell;
-    _ = gpa;
-    _ = options;
-    // The Rust client is not yet published.
+    const tmp_dir = try shell.create_tmp_dir();
+    defer shell.cwd.deleteTree(tmp_dir) catch {};
 
-    // const tmp_dir = try shell.create_tmp_dir();
-    // defer shell.cwd.deleteTree(tmp_dir) catch {};
+    try shell.pushd(tmp_dir);
+    defer shell.popd();
 
-    // try shell.pushd(tmp_dir);
-    // defer shell.popd();
+    try shell.exec("cargo init --name test_tigerbeetle", .{});
 
-    // var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
-    //     .development = true,
-    //     .prebuilt = options.tigerbeetle,
-    // });
-    // defer tmp_beetle.deinit(gpa);
-    // errdefer tmp_beetle.log_stderr();
+    for (0..9) |_| {
+        if (shell.exec("cargo add tigerbeetle@{version}", .{
+            .version = options.version,
+        })) {
+            break;
+        } else |_| {
+            log.warn("waiting for 5 minutes for the {s} version to appear on crates.io", .{
+                options.version,
+            });
+            std.time.sleep(5 * std.time.ns_per_min);
+        }
+    } else {
+        shell.exec("cargo add tigerbeetle@{version}", .{
+            .version = options.version,
+        }) catch |err| {
+            log.err("package is not available on crates.io", .{});
+            return err;
+        };
+    }
 
-    // try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
+    try shell.exec("cargo add futures@0.3", .{});
 
-    // // Create a new Rust project to test the published crate
-    // try shell.exec("cargo init --name test_tigerbeetle", .{});
+    var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
+        .development = true,
+        .prebuilt = options.tigerbeetle,
+    });
+    defer tmp_beetle.deinit(gpa);
+    errdefer tmp_beetle.log_stderr();
 
-    // // Add tigerbeetle dependency to Cargo.toml
-    // try shell.exec("cargo add tigerbeetle@{version}", .{ .version = options.version });
-    // try shell.exec("cargo add futures@0.3", .{});
+    try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
-    // try Shell.copy_path(
-    //     shell.project_root,
-    //     "src/clients/rust/samples/basic/src/main.rs",
-    //     shell.cwd,
-    //     "src/main.rs",
-    // );
-    // try shell.exec("cargo run", .{});
+    try Shell.copy_path(
+        shell.project_root,
+        "src/clients/rust/samples/basic/src/main.rs",
+        shell.cwd,
+        "src/main.rs",
+    );
+    try shell.exec("cargo run", .{});
 }
 
 pub fn release_published_latest(shell: *Shell) ![]const u8 {
-    _ = shell;
-    return "unimplemented";
+    const CratesResponse = struct {
+        crate: struct {
+            max_version: []const u8,
+        },
+    };
+
+    const response_body = try shell.http_get(
+        "https://crates.io/api/v1/crates/tigerbeetle",
+        .{},
+    );
+
+    const crates_result = try std.json.parseFromSliceLeaky(
+        CratesResponse,
+        shell.arena.allocator(),
+        response_body,
+        .{ .ignore_unknown_fields = true },
+    );
+
+    return crates_result.crate.max_version;
 }

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -316,12 +316,12 @@
 //! [The TigerBeetle Reference](https://docs.tigerbeetle.com/reference/).
 
 use bitflags::bitflags;
-use futures_channel::oneshot::{channel, Receiver};
 
-use std::convert::Infallible;
 use std::future::Future;
 use std::os::raw::{c_char, c_void};
 use std::{fmt, mem, ptr};
+
+mod oneshot;
 
 // The generated bindings.
 // These are not part of the public API but are re-exported hidden
@@ -509,7 +509,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
 
             let responses: &[tbc::tb_create_accounts_result_t] = handle_message(&msg)?;
 
@@ -641,7 +641,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
 
             let responses: &[tbc::tb_create_transfers_result_t] = handle_message(&msg)?;
 
@@ -749,7 +749,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
             let responses: &[Account] = handle_message(&msg)?;
             Ok(Vec::from(responses))
         }
@@ -838,7 +838,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
             let responses: &[Transfer] = handle_message(&msg)?;
             Ok(Vec::from(responses))
         }
@@ -871,7 +871,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
             let result: &[Transfer] = handle_message(&msg)?;
 
             Ok(result.to_vec())
@@ -905,7 +905,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
             let result: &[AccountBalance] = handle_message(&msg)?;
 
             Ok(result.to_vec())
@@ -937,7 +937,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
             let result: &[Account] = handle_message(&msg)?;
 
             Ok(result.to_vec())
@@ -969,7 +969,7 @@ impl Client {
         }
 
         async {
-            let msg = rx.await.expect("channel");
+            let msg = rx.await;
             let result: &[Transfer] = handle_message(&msg)?;
 
             Ok(result.to_vec())
@@ -991,7 +991,7 @@ impl Client {
         let client = std::mem::replace(&mut self.client, std::ptr::null_mut());
         let client = SendClient(client);
 
-        let (tx, rx) = channel::<Infallible>();
+        let (tx, rx) = oneshot::channel::<()>();
 
         std::thread::spawn(move || {
             let client = client;
@@ -1001,12 +1001,11 @@ impl Client {
                 assert_eq!(status, tbc::TB_CLIENT_STATUS_TB_CLIENT_OK);
                 std::mem::drop(Box::from_raw(client.0));
             }
-            drop(tx);
+            tx.send(());
         });
 
         async {
-            // wait for the channel to close
-            let _ = rx.await;
+            rx.await;
         }
     }
 }
@@ -1721,35 +1720,21 @@ impl<const N: usize> Default for Reserved<N> {
 fn create_packet<Event>(
     op: u8, // TB_OPERATION
     events: &[Event],
-) -> (Box<tbc::tb_packet_t>, Receiver<CompletionMessage<Event>>)
+) -> (
+    Box<tbc::tb_packet_t>,
+    oneshot::Receiver<CompletionMessage<Event>>,
+)
 where
     Event: Copy + 'static,
 {
-    let (tx, rx) = channel::<CompletionMessage<Event>>();
-    let callback: Box<OnCompletion> = Box::new(Box::new(
-        |context, packet, timestamp, result, result_size| unsafe {
-            let events_len = (*packet).data_size as usize / mem::size_of::<Event>();
-            let events = Vec::from_raw_parts((*packet).data as *mut Event, events_len, events_len);
-            (*packet).data = ptr::null_mut();
+    let (tx, rx) = oneshot::channel::<CompletionMessage<Event>>();
 
-            let packet = Packet(Box::from_raw(packet));
-
-            let result = if result_size != 0 {
-                std::slice::from_raw_parts(result, result_size as usize)
-            } else {
-                &[]
-            };
-            let result = Vec::from(result);
-
-            let _ = tx.send(CompletionMessage {
-                _context: context,
-                packet,
-                _timestamp: timestamp,
-                result,
-                _events: events,
-            });
+    let callback = Box::new(CallbackData {
+        header: CallbackHeader {
+            complete: complete_typed::<Event>,
         },
-    ));
+        sender: tx,
+    });
 
     let mut events: Vec<Event> = events.to_vec();
     assert_eq!(events.len(), events.capacity());
@@ -1812,7 +1797,57 @@ struct CompletionMessage<E> {
     _events: Vec<E>,
 }
 
-type OnCompletion = Box<dyn FnOnce(usize, *mut tbc::tb_packet_t, u64, *const u8, u32)>;
+/// Type-erased header stored in `packet.user_data`.
+///
+/// By using an unsafe type-erased bare function instead a closure here
+/// we avoid double boxing that closure to store it as a thin pointer,
+/// reducing allocations per request by 1.
+///
+/// `on_completion` reads the `complete` function pointer without knowing
+/// the `Event` type and unsafely casts from `CallbackHeader` to the typed
+/// `CallbackData<Event>`.
+#[repr(C)]
+struct CallbackHeader {
+    complete: unsafe fn(*mut CallbackHeader, usize, *mut tbc::tb_packet_t, u64, *const u8, u32),
+}
+
+/// Full callback data, generic over `Event`.
+#[repr(C)]
+struct CallbackData<Event> {
+    header: CallbackHeader,
+    sender: oneshot::Sender<CompletionMessage<Event>>,
+}
+
+unsafe fn complete_typed<Event: Copy + 'static>(
+    header: *mut CallbackHeader,
+    context: usize,
+    packet: *mut tbc::tb_packet_t,
+    timestamp: u64,
+    result: *const u8,
+    result_size: u32,
+) {
+    let callback = Box::from_raw(header as *mut CallbackData<Event>);
+
+    let events_len = (*packet).data_size as usize / mem::size_of::<Event>();
+    let events = Vec::from_raw_parts((*packet).data as *mut Event, events_len, events_len);
+    (*packet).data = ptr::null_mut();
+    let packet = Packet(Box::from_raw(packet));
+
+    let result = if result_size != 0 {
+        std::slice::from_raw_parts(result, result_size as usize)
+    } else {
+        &[]
+    };
+    let result = Vec::from(result);
+
+    callback.sender.send(CompletionMessage {
+        _context: context,
+        packet,
+        _timestamp: timestamp,
+        result,
+        _events: events,
+    });
+}
 
 extern "C" fn on_completion(
     context: usize,
@@ -1822,8 +1857,8 @@ extern "C" fn on_completion(
     result_len: u32,
 ) {
     unsafe {
-        let callback: Box<OnCompletion> = Box::from_raw((*packet).user_data as *mut OnCompletion);
+        let header = (*packet).user_data as *mut CallbackHeader;
         (*packet).user_data = ptr::null_mut();
-        callback(context, packet, timestamp, result_ptr, result_len);
+        ((*header).complete)(header, context, packet, timestamp, result_ptr, result_len);
     }
 }

--- a/src/clients/rust/src/oneshot.rs
+++ b/src/clients/rust/src/oneshot.rs
@@ -1,0 +1,182 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+struct Shared<T> {
+    value: Option<T>,
+    waker: Option<Waker>,
+}
+
+pub struct Sender<T>(Arc<Mutex<Shared<T>>>);
+pub struct Receiver<T>(Arc<Mutex<Shared<T>>>);
+
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Mutex::new(Shared {
+        value: None,
+        waker: None,
+    }));
+    (Sender(shared.clone()), Receiver(shared))
+}
+
+impl<T> Sender<T> {
+    pub fn send(self, value: T) {
+        let mut shared = self.0.lock().unwrap();
+        shared.value = Some(value);
+        if let Some(waker) = shared.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl<T> Future for Receiver<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        let mut shared = self.0.lock().unwrap();
+        if let Some(value) = shared.value.take() {
+            Poll::Ready(value)
+        } else {
+            shared.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{RawWaker, RawWakerVTable};
+
+    // Minimal waker that tracks wake count.
+    fn counting_waker(count: &Arc<AtomicUsize>) -> Waker {
+        let data = Arc::into_raw(count.clone()) as *const ();
+
+        unsafe fn clone(data: *const ()) -> RawWaker {
+            Arc::increment_strong_count(data as *const AtomicUsize);
+            RawWaker::new(data, &VTABLE)
+        }
+        unsafe fn wake(data: *const ()) {
+            let arc = Arc::from_raw(data as *const AtomicUsize);
+            arc.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe fn wake_by_ref(data: *const ()) {
+            let arc = &*(data as *const AtomicUsize);
+            arc.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe fn drop(data: *const ()) {
+            Arc::decrement_strong_count(data as *const AtomicUsize);
+        }
+
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+
+        unsafe { Waker::from_raw(RawWaker::new(data, &VTABLE)) }
+    }
+
+    fn poll_once<T>(rx: &mut Receiver<T>, waker: &Waker) -> Poll<T> {
+        let mut cx = Context::from_waker(waker);
+        Pin::new(rx).poll(&mut cx)
+    }
+
+    #[test]
+    fn send_before_poll() {
+        let (tx, mut rx) = channel::<u64>();
+        let wake_count = Arc::new(AtomicUsize::new(0));
+        let waker = counting_waker(&wake_count);
+
+        tx.send(42);
+
+        // Value already present — should resolve immediately.
+        match poll_once(&mut rx, &waker) {
+            Poll::Ready(v) => assert_eq!(v, 42),
+            Poll::Pending => panic!("expected Ready"),
+        }
+        // No waker should have been registered or woken.
+        assert_eq!(wake_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn poll_before_send() {
+        let (tx, mut rx) = channel::<u64>();
+        let wake_count = Arc::new(AtomicUsize::new(0));
+        let waker = counting_waker(&wake_count);
+
+        // First poll — no value yet.
+        assert!(poll_once(&mut rx, &waker).is_pending());
+        assert_eq!(wake_count.load(Ordering::SeqCst), 0);
+
+        // Send wakes the registered waker.
+        tx.send(99);
+        assert_eq!(wake_count.load(Ordering::SeqCst), 1);
+
+        // Second poll picks up the value.
+        match poll_once(&mut rx, &waker) {
+            Poll::Ready(v) => assert_eq!(v, 99),
+            Poll::Pending => panic!("expected Ready"),
+        }
+    }
+
+    #[test]
+    fn multiple_polls_replace_waker() {
+        let (tx, mut rx) = channel::<&str>();
+        let count1 = Arc::new(AtomicUsize::new(0));
+        let count2 = Arc::new(AtomicUsize::new(0));
+        let waker1 = counting_waker(&count1);
+        let waker2 = counting_waker(&count2);
+
+        // Register waker1, then replace with waker2.
+        assert!(poll_once(&mut rx, &waker1).is_pending());
+        assert!(poll_once(&mut rx, &waker2).is_pending());
+
+        tx.send("hello");
+
+        // Only the most recent waker should fire.
+        assert_eq!(count1.load(Ordering::SeqCst), 0);
+        assert_eq!(count2.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn send_without_prior_poll() {
+        // No waker registered — send should not panic.
+        let (tx, _rx) = channel::<i32>();
+        tx.send(7);
+    }
+
+    #[test]
+    fn send_from_another_thread() {
+        let (tx, mut rx) = channel::<Vec<u8>>();
+        let wake_count = Arc::new(AtomicUsize::new(0));
+        let waker = counting_waker(&wake_count);
+
+        assert!(poll_once(&mut rx, &waker).is_pending());
+
+        std::thread::spawn(move || {
+            tx.send(vec![1, 2, 3]);
+        })
+        .join()
+        .unwrap();
+
+        match poll_once(&mut rx, &waker) {
+            Poll::Ready(v) => assert_eq!(v, vec![1, 2, 3]),
+            Poll::Pending => panic!("expected Ready"),
+        }
+    }
+
+    #[test]
+    fn zero_sized_type() {
+        let (tx, mut rx) = channel::<()>();
+        let wake_count = Arc::new(AtomicUsize::new(0));
+        let waker = counting_waker(&wake_count);
+
+        assert!(poll_once(&mut rx, &waker).is_pending());
+        tx.send(());
+        assert!(poll_once(&mut rx, &waker).is_ready());
+    }
+
+    #[test]
+    fn drop_sender_without_sending() {
+        // Dropping sender without sending shouldn't panic or wake.
+        let (_tx, _rx) = channel::<String>();
+    }
+}

--- a/src/clients/rust/tests/tests.rs
+++ b/src/clients/rust/tests/tests.rs
@@ -13,6 +13,8 @@ use futures::{Stream, StreamExt};
 
 use tigerbeetle as tb;
 
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
 // Singleton test database.
 // This can be a OnceLock in Rust 1.70+, and LazyLock in 1.80.
 fn get_test_db() -> &'static TestDb {
@@ -56,7 +58,7 @@ fn work_dir() -> &'static str {
 }
 
 impl TestDb {
-    fn new() -> anyhow::Result<TestDb> {
+    fn new() -> Result<TestDb> {
         // NB: There is one test database shared between all tests, and reused
         // between test runs. If the tests choose their IDs correctly there
         // should never be any collisions, and that one database should work
@@ -83,7 +85,7 @@ impl TestDb {
     }
 
     /// Create a unique development-mode server for a specific test.
-    fn new_development(label: &str) -> anyhow::Result<TestDb> {
+    fn new_development(label: &str) -> Result<TestDb> {
         let database_name = format!("0_0.{label}.tigerbeetle");
 
         // Always start fresh for development instances.
@@ -107,7 +109,7 @@ impl TestDb {
         Ok(server)
     }
 
-    fn start(args: &[&str]) -> anyhow::Result<TestDb> {
+    fn start(args: &[&str]) -> Result<TestDb> {
         let mut server = Command::new(tigerbeetle_bin())
             .current_dir(work_dir())
             // magic address 0: tell us the port to use,
@@ -141,7 +143,7 @@ static DB_LOCK: RwLock<()> = RwLock::new(());
 
 /// Returns the client and a read guard that must be held for the test's
 /// duration. The guard prevents the eviction test from running concurrently.
-fn test_client() -> anyhow::Result<(tb::Client, std::sync::RwLockReadGuard<'static, ()>)> {
+fn test_client() -> Result<(tb::Client, std::sync::RwLockReadGuard<'static, ()>)> {
     let guard = DB_LOCK.read().unwrap();
     let client = tb::Client::new(0, &get_test_db().address())?;
     Ok((client, guard))
@@ -155,7 +157,7 @@ const TEST_LEDGER: u32 = 10;
 const TEST_CODE: u16 = 20;
 
 #[test]
-fn smoke() -> anyhow::Result<()> {
+fn smoke() -> Result<()> {
     let account_id1 = tb::id();
     let account_id2 = tb::id();
     let transfer_id1 = tb::id();
@@ -354,7 +356,7 @@ fn smoke() -> anyhow::Result<()> {
 }
 
 #[test]
-fn ctor_fail() -> anyhow::Result<()> {
+fn ctor_fail() -> Result<()> {
     let client = tb::Client::new(0, "hey");
 
     assert!(matches!(client, Err(tb::InitStatus::AddressInvalid)));
@@ -363,7 +365,7 @@ fn ctor_fail() -> anyhow::Result<()> {
 }
 
 #[test]
-fn dtor() -> anyhow::Result<()> {
+fn dtor() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -375,7 +377,7 @@ fn dtor() -> anyhow::Result<()> {
 }
 
 #[test]
-fn close() -> anyhow::Result<()> {
+fn close() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -388,7 +390,7 @@ fn close() -> anyhow::Result<()> {
 // Send a request and immediately drop the client.
 // Should still clean up correctly.
 #[test]
-fn dtor_no_wait() -> anyhow::Result<()> {
+fn dtor_no_wait() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -399,7 +401,7 @@ fn dtor_no_wait() -> anyhow::Result<()> {
 }
 
 #[test]
-fn close_no_wait() -> anyhow::Result<()> {
+fn close_no_wait() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -410,7 +412,7 @@ fn close_no_wait() -> anyhow::Result<()> {
 }
 
 #[test]
-fn client_drop_before_future_awaited() -> anyhow::Result<()> {
+fn client_drop_before_future_awaited() -> Result<()> {
     let future = {
         let (client, _guard) = test_client()?;
 
@@ -438,7 +440,7 @@ fn client_drop_before_future_awaited() -> anyhow::Result<()> {
 }
 
 #[test]
-fn client_drop_causes_shutdown_status() -> anyhow::Result<()> {
+fn client_drop_causes_shutdown_status() -> Result<()> {
     let futures = {
         let (client, _guard) = test_client()?;
 
@@ -473,7 +475,7 @@ fn client_drop_causes_shutdown_status() -> anyhow::Result<()> {
 }
 
 #[test]
-fn too_many_events() -> anyhow::Result<()> {
+fn too_many_events() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -511,7 +513,7 @@ fn lots_of_accounts() -> Vec<tb::Account> {
 }
 
 #[test]
-fn zero_events_create_accounts() -> anyhow::Result<()> {
+fn zero_events_create_accounts() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -524,7 +526,7 @@ fn zero_events_create_accounts() -> anyhow::Result<()> {
 }
 
 #[test]
-fn zero_events_create_transfers() -> anyhow::Result<()> {
+fn zero_events_create_transfers() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -537,7 +539,7 @@ fn zero_events_create_transfers() -> anyhow::Result<()> {
 }
 
 #[test]
-fn zero_events_lookup_accounts() -> anyhow::Result<()> {
+fn zero_events_lookup_accounts() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -550,7 +552,7 @@ fn zero_events_lookup_accounts() -> anyhow::Result<()> {
 }
 
 #[test]
-fn zero_events_lookup_transfers() -> anyhow::Result<()> {
+fn zero_events_lookup_transfers() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     block_on(async {
@@ -563,7 +565,7 @@ fn zero_events_lookup_transfers() -> anyhow::Result<()> {
 }
 
 #[test]
-fn multithread() -> anyhow::Result<()> {
+fn multithread() -> Result<()> {
     let (client, _guard) = test_client()?;
     let client = Arc::new(client);
 
@@ -575,34 +577,36 @@ fn multithread() -> anyhow::Result<()> {
     let join_handles = std::iter::repeat(()).take(num_threads).map(|_| {
         let client = client.clone();
         let barrier = barrier.clone();
-        std::thread::spawn(move || -> anyhow::Result<()> {
-            barrier.wait();
-            block_on(async {
-                for _ in 0..num_requests {
-                    let results = client
-                        .create_accounts(&[tb::Account {
-                            id: tb::id(),
-                            debits_pending: 0,
-                            debits_posted: 0,
-                            credits_pending: 0,
-                            credits_posted: 0,
-                            user_data_128: 0,
-                            user_data_64: 0,
-                            user_data_32: 0,
-                            reserved: tb::Reserved::default(),
-                            ledger: TEST_LEDGER,
-                            code: TEST_CODE,
-                            flags: tb::AccountFlags::History,
-                            timestamp: 0,
-                        }])
-                        .await?;
+        std::thread::spawn(
+            move || -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                barrier.wait();
+                block_on(async {
+                    for _ in 0..num_requests {
+                        let results = client
+                            .create_accounts(&[tb::Account {
+                                id: tb::id(),
+                                debits_pending: 0,
+                                debits_posted: 0,
+                                credits_pending: 0,
+                                credits_posted: 0,
+                                user_data_128: 0,
+                                user_data_64: 0,
+                                user_data_32: 0,
+                                reserved: tb::Reserved::default(),
+                                ledger: TEST_LEDGER,
+                                code: TEST_CODE,
+                                flags: tb::AccountFlags::History,
+                                timestamp: 0,
+                            }])
+                            .await?;
 
-                    assert_eq!(results.len(), 0);
-                }
+                        assert_eq!(results.len(), 0);
+                    }
 
-                Ok(())
-            })
-        })
+                    Ok(())
+                })
+            },
+        )
     });
 
     // collect the handles to evaluate the thread::spawns
@@ -623,7 +627,7 @@ fn multithread() -> anyhow::Result<()> {
 }
 
 #[test]
-fn concurrent_requests() -> anyhow::Result<()> {
+fn concurrent_requests() -> Result<()> {
     let (client, _guard) = test_client()?;
 
     let mut responses = Vec::new();
@@ -657,7 +661,7 @@ fn concurrent_requests() -> anyhow::Result<()> {
 
 // A potentially suprising behavior, documented in the crate docs.
 #[test]
-fn client_drop_loses_pending_transactions() -> anyhow::Result<()> {
+fn client_drop_loses_pending_transactions() -> Result<()> {
     let mut ids = Vec::new();
 
     // Queue up lots of transactions, drop their futures, drop the client.
@@ -715,7 +719,7 @@ fn client_drop_loses_pending_transactions() -> anyhow::Result<()> {
 fn get_account_transfers_paged(
     client: &tb::Client,
     event: tb::AccountFilter,
-) -> impl Stream<Item = Result<Vec<tb::Transfer>, tb::PacketStatus>> + '_ {
+) -> impl Stream<Item = std::result::Result<Vec<tb::Transfer>, tb::PacketStatus>> + '_ {
     assert!(
         event.limit > 1,
         "paged queries should use an explicit limit"
@@ -791,7 +795,7 @@ struct PagingTestParams {
     transfer_count: usize,
 }
 
-fn make_paging_test_transfers(client: &tb::Client) -> anyhow::Result<PagingTestParams> {
+fn make_paging_test_transfers(client: &tb::Client) -> Result<PagingTestParams> {
     let batch_size: usize = 1234;
     let transfer_count: usize = 5678;
     let account_id1 = tb::id();
@@ -842,7 +846,7 @@ fn make_paging_test_transfers(client: &tb::Client) -> anyhow::Result<PagingTestP
 }
 
 #[test]
-fn paging_forward() -> anyhow::Result<()> {
+fn paging_forward() -> Result<()> {
     let (client, _guard) = test_client()?;
     let test_params = make_paging_test_transfers(&client)?;
 
@@ -874,7 +878,7 @@ fn paging_forward() -> anyhow::Result<()> {
 }
 
 #[test]
-fn paging_reverse() -> anyhow::Result<()> {
+fn paging_reverse() -> Result<()> {
     let (client, _guard) = test_client()?;
     let test_params = make_paging_test_transfers(&client)?;
 
@@ -908,11 +912,11 @@ fn paging_reverse() -> anyhow::Result<()> {
 // NB: This is a runnable version of an example in the `create_accounts` docs.
 // Try to keep them in sync.
 #[test]
-fn example_create_accounts() -> Result<(), Box<dyn std::error::Error>> {
+fn example_create_accounts() -> std::result::Result<(), Box<dyn std::error::Error>> {
     async fn make_create_accounts_request(
         client: &tb::Client,
         accounts: &[tb::Account],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let create_accounts_results = client.create_accounts(accounts).await?;
         let create_accounts_results_merged =
             merge_create_accounts_results(accounts, create_accounts_results);
@@ -950,14 +954,14 @@ fn example_create_accounts() -> Result<(), Box<dyn std::error::Error>> {
     async fn handle_create_account_success(
         _account: &tb::Account,
         _result: tb::CreateAccountResult,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
     async fn handle_create_account_failure(
         _account: &tb::Account,
         _result: tb::CreateAccountResult,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -1029,11 +1033,11 @@ fn example_create_accounts() -> Result<(), Box<dyn std::error::Error>> {
 // NB: This is a runnable version of an example in the `create_transfers` docs.
 // Try to keep them in sync.
 #[test]
-fn example_create_transfers() -> Result<(), Box<dyn std::error::Error>> {
+fn example_create_transfers() -> std::result::Result<(), Box<dyn std::error::Error>> {
     async fn make_create_transfers_request(
         client: &tb::Client,
         transfers: &[tb::Transfer],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let create_transfers_results = client.create_transfers(transfers).await?;
         let create_transfers_results_merged =
             merge_create_transfers_results(transfers, create_transfers_results);
@@ -1070,14 +1074,14 @@ fn example_create_transfers() -> Result<(), Box<dyn std::error::Error>> {
     async fn handle_create_transfer_success(
         _transfer: &tb::Transfer,
         _result: tb::CreateTransferResult,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
     async fn handle_create_transfer_failure(
         _transfer: &tb::Transfer,
         _result: tb::CreateTransferResult,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -1160,11 +1164,11 @@ fn example_create_transfers() -> Result<(), Box<dyn std::error::Error>> {
 // NB: This is a runnable version of an example in the `lookup_accounts` docs.
 // Try to keep them in sync.
 #[test]
-fn example_lookup_accounts() -> Result<(), Box<dyn std::error::Error>> {
+fn example_lookup_accounts() -> std::result::Result<(), Box<dyn std::error::Error>> {
     async fn make_lookup_accounts_request(
         client: &tb::Client,
         accounts: &[u128],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let lookup_accounts_results = client.lookup_accounts(accounts).await?;
         let lookup_accounts_results_merged =
             merge_lookup_accounts_results(accounts, lookup_accounts_results);
@@ -1195,13 +1199,13 @@ fn example_lookup_accounts() -> Result<(), Box<dyn std::error::Error>> {
 
     async fn handle_lookup_accounts_success(
         _account: tb::Account,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
     async fn handle_lookup_accounts_failure(
         _account_id: u128,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -1271,11 +1275,11 @@ fn example_lookup_accounts() -> Result<(), Box<dyn std::error::Error>> {
 // NB: This is a runnable version of an example in the `lookup_transfers` docs.
 // Try to keep them in sync.
 #[test]
-fn example_lookup_transfers() -> Result<(), Box<dyn std::error::Error>> {
+fn example_lookup_transfers() -> std::result::Result<(), Box<dyn std::error::Error>> {
     async fn make_lookup_transfers_request(
         client: &tb::Client,
         transfers: &[u128],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let lookup_transfers_results = client.lookup_transfers(transfers).await?;
         let lookup_transfers_results_merged =
             merge_lookup_transfers_results(transfers, lookup_transfers_results);
@@ -1306,13 +1310,13 @@ fn example_lookup_transfers() -> Result<(), Box<dyn std::error::Error>> {
 
     async fn handle_lookup_transfers_success(
         _transfer: tb::Transfer,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
     async fn handle_lookup_transfers_failure(
         _transfer_id: u128,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -1403,7 +1407,7 @@ fn example_lookup_transfers() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn client_evicted() -> anyhow::Result<()> {
+fn client_evicted() -> Result<()> {
     const CLIENTS_MAX: usize = 64;
 
     // Hold the write lock so no other database is running concurrently.

--- a/src/clients/rust/tests/tests.rs
+++ b/src/clients/rust/tests/tests.rs
@@ -5,7 +5,7 @@ use std::io::{BufRead as _, BufReader};
 use std::mem;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Barrier, Once};
+use std::sync::{Arc, Barrier, Once, RwLock};
 
 use futures::executor::block_on;
 use futures::pin_mut;
@@ -135,9 +135,16 @@ impl TestDb {
     }
 }
 
-fn test_client() -> anyhow::Result<tb::Client> {
+// Only one database server should run at a time. Normal tests share a read
+// lock; the eviction test takes a write lock so it runs exclusively.
+static DB_LOCK: RwLock<()> = RwLock::new(());
+
+/// Returns the client and a read guard that must be held for the test's
+/// duration. The guard prevents the eviction test from running concurrently.
+fn test_client() -> anyhow::Result<(tb::Client, std::sync::RwLockReadGuard<'static, ()>)> {
+    let guard = DB_LOCK.read().unwrap();
     let client = tb::Client::new(0, &get_test_db().address())?;
-    Ok(client)
+    Ok((client, guard))
 }
 
 fn assert_send<T: Send>(t: T) -> T {
@@ -157,7 +164,7 @@ fn smoke() -> anyhow::Result<()> {
     let transfer_id1_user_data_128 = tb::id();
 
     block_on(async {
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         {
             let fut = client.create_accounts(&[
@@ -357,7 +364,7 @@ fn ctor_fail() -> anyhow::Result<()> {
 
 #[test]
 fn dtor() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         // Let's at least talk to the server before dropping
@@ -369,7 +376,7 @@ fn dtor() -> anyhow::Result<()> {
 
 #[test]
 fn close() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let _ = client.create_accounts(&[]).await?;
@@ -382,7 +389,7 @@ fn close() -> anyhow::Result<()> {
 // Should still clean up correctly.
 #[test]
 fn dtor_no_wait() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let _ = client.create_accounts(&[]);
@@ -393,7 +400,7 @@ fn dtor_no_wait() -> anyhow::Result<()> {
 
 #[test]
 fn close_no_wait() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let _ = client.create_accounts(&[]);
@@ -405,7 +412,7 @@ fn close_no_wait() -> anyhow::Result<()> {
 #[test]
 fn client_drop_before_future_awaited() -> anyhow::Result<()> {
     let future = {
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         let account = tb::Account {
             id: tb::id(),
@@ -433,7 +440,7 @@ fn client_drop_before_future_awaited() -> anyhow::Result<()> {
 #[test]
 fn client_drop_causes_shutdown_status() -> anyhow::Result<()> {
     let futures = {
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         let mut futures = Vec::new();
         for _ in 0..10 {
@@ -467,7 +474,7 @@ fn client_drop_causes_shutdown_status() -> anyhow::Result<()> {
 
 #[test]
 fn too_many_events() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let accounts = lots_of_accounts();
@@ -505,7 +512,7 @@ fn lots_of_accounts() -> Vec<tb::Account> {
 
 #[test]
 fn zero_events_create_accounts() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let result = client.create_accounts(&[]).await?;
@@ -518,7 +525,7 @@ fn zero_events_create_accounts() -> anyhow::Result<()> {
 
 #[test]
 fn zero_events_create_transfers() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let result = client.create_transfers(&[]).await?;
@@ -531,7 +538,7 @@ fn zero_events_create_transfers() -> anyhow::Result<()> {
 
 #[test]
 fn zero_events_lookup_accounts() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let result = client.lookup_accounts(&[]).await?;
@@ -544,7 +551,7 @@ fn zero_events_lookup_accounts() -> anyhow::Result<()> {
 
 #[test]
 fn zero_events_lookup_transfers() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     block_on(async {
         let result = client.lookup_transfers(&[]).await?;
@@ -557,7 +564,7 @@ fn zero_events_lookup_transfers() -> anyhow::Result<()> {
 
 #[test]
 fn multithread() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
     let client = Arc::new(client);
 
     let num_threads = 16;
@@ -617,7 +624,7 @@ fn multithread() -> anyhow::Result<()> {
 
 #[test]
 fn concurrent_requests() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     let mut responses = Vec::new();
 
@@ -655,7 +662,7 @@ fn client_drop_loses_pending_transactions() -> anyhow::Result<()> {
 
     // Queue up lots of transactions, drop their futures, drop the client.
     {
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         // Timing-sensitive - trying to create enough pending transactions that
         // not all will be completed. I think test is unlikely to fail because
@@ -675,7 +682,7 @@ fn client_drop_loses_pending_transactions() -> anyhow::Result<()> {
     }
 
     // Some of those transactions will have been dropped by tb_client.
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
 
     // Reverse because later transactions most likely to be lost.
     ids.reverse();
@@ -836,7 +843,7 @@ fn make_paging_test_transfers(client: &tb::Client) -> anyhow::Result<PagingTestP
 
 #[test]
 fn paging_forward() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
     let test_params = make_paging_test_transfers(&client)?;
 
     let query_results = get_account_transfers_paged(
@@ -868,7 +875,7 @@ fn paging_forward() -> anyhow::Result<()> {
 
 #[test]
 fn paging_reverse() -> anyhow::Result<()> {
-    let client = test_client()?;
+    let (client, _guard) = test_client()?;
     let test_params = make_paging_test_transfers(&client)?;
 
     let query_results = get_account_transfers_paged(
@@ -994,7 +1001,7 @@ fn example_create_accounts() -> Result<(), Box<dyn std::error::Error>> {
             tb::CreateAccountResult::CodeMustNotBeZero,
         ];
 
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         // Test the example.
         make_create_accounts_request(&client, &gen_accounts()).await?;
@@ -1077,7 +1084,7 @@ fn example_create_transfers() -> Result<(), Box<dyn std::error::Error>> {
     block_on(async {
         let account_id1 = tb::id();
         let account_id2 = tb::id();
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         let accounts = [
             tb::Account {
@@ -1234,7 +1241,7 @@ fn example_lookup_accounts() -> Result<(), Box<dyn std::error::Error>> {
             (account_bogus3, None),
         ];
 
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         let _ = client.create_accounts(accounts).await?;
 
@@ -1367,7 +1374,7 @@ fn example_lookup_transfers() -> Result<(), Box<dyn std::error::Error>> {
             (transfer_bogus3, None),
         ];
 
-        let client = test_client()?;
+        let (client, _guard) = test_client()?;
 
         let _ = client.create_accounts(accounts).await?;
         let _ = client.create_transfers(transfers).await?;
@@ -1398,6 +1405,9 @@ fn example_lookup_transfers() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn client_evicted() -> anyhow::Result<()> {
     const CLIENTS_MAX: usize = 64;
+
+    // Hold the write lock so no other database is running concurrently.
+    let _guard = DB_LOCK.write().unwrap();
 
     // Use a separate server to avoid evicting the shared test client.
     let server = TestDb::new_development("client_evicted")?;

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -179,8 +179,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
 
     // Check all the client releases to ensure the latest published release is what it should be.
     inline for (comptime std.enums.values(Language)) |language| {
-        if ((language == language_requested or language_requested == null) and
-            language != .rust) // Rust isn't published yet.
+        if (language == language_requested or language_requested == null)
         {
             const ci = @field(LanguageCI, @tagName(language));
             const release_published_latest = try ci.release_published_latest(shell);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -179,7 +179,8 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
 
     // Check all the client releases to ensure the latest published release is what it should be.
     inline for (comptime std.enums.values(Language)) |language| {
-        if (language == language_requested or language_requested == null)
+        if ((language == language_requested or language_requested == null) and
+            language != .rust) // Rust isn't published yet.
         {
             const ci = @field(LanguageCI, @tagName(language));
             const release_published_latest = try ci.release_published_latest(shell);

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -244,6 +244,7 @@ fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo, devhub: bool)
 
     if (languages.contains(.rust)) {
         // Currently disabled.
+        _ = &build_rust;
     }
 }
 
@@ -587,6 +588,62 @@ fn build_python(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
     );
 }
 
+fn build_rust(shell: *Shell, info: VersionInfo, dist_dir: std.fs.Dir) !void {
+    var section = try shell.open_section("build rust");
+    defer section.close();
+
+    try shell.pushd("./src/clients/rust");
+    defer shell.popd();
+
+    const cargo_version = shell.exec_stdout("cargo --version", .{}) catch {
+        return error.NoCargo;
+    };
+    log.info("{s}", .{cargo_version});
+
+    try shell.exec_zig(
+        \\build clients:rust -Drelease -Dconfig-release={release_triple}
+        \\ -Dconfig-release-client-min={release_triple_client_min}
+    , .{
+        .release_triple = info.release_triple,
+        .release_triple_client_min = info.release_triple_client_min,
+    });
+
+    try backup_create(shell.cwd, "Cargo.toml");
+    defer backup_restore(shell.cwd, "Cargo.toml");
+
+    const cargo_toml = try shell.cwd.readFileAlloc(
+        shell.arena.allocator(),
+        "Cargo.toml",
+        1 * MiB,
+    );
+    const version_line = try shell.fmt(
+        "version = \"{s}\"",
+        .{info.tag},
+    );
+    const cargo_toml_updated = try std.mem.replaceOwned(
+        u8,
+        shell.arena.allocator(),
+        cargo_toml,
+        "version = \"0.0.0\"",
+        version_line,
+    );
+    assert(std.mem.indexOf(u8, cargo_toml_updated, version_line) != null);
+
+    try shell.cwd.writeFile(.{
+        .sub_path = "Cargo.toml",
+        .data = cargo_toml_updated,
+    });
+
+    try shell.exec("cargo package --allow-dirty", .{});
+
+    try Shell.copy_path(
+        shell.cwd,
+        try shell.fmt("target/package/tigerbeetle-{s}.crate", .{info.tag}),
+        dist_dir,
+        try shell.fmt("tigerbeetle-{s}.crate", .{info.tag}),
+    );
+}
+
 fn publish(
     shell: *Shell,
     languages: LanguageSet,
@@ -736,6 +793,8 @@ fn publish(
     if (languages.contains(.java)) try publish_java(shell, info);
     if (languages.contains(.node)) try publish_node(shell, info);
     if (languages.contains(.python)) try publish_python(shell, info);
+    // Currently disabled.
+    _ = &publish_rust;
 
     if (languages.contains(.zig)) {
         try shell.exec(
@@ -901,6 +960,56 @@ fn publish_python(shell: *Shell, info: VersionInfo) !void {
         .package = try shell.fmt("zig-out/dist/python/tigerbeetle-{s}-py3-none-any.whl", .{
             info.tag,
         }),
+    });
+}
+
+fn publish_rust(shell: *Shell, info: VersionInfo) !void {
+    var section = try shell.open_section("publish rust");
+    defer section.close();
+
+    assert(try shell.dir_exists("zig-out/dist/rust"));
+
+    const token = try shell.env_get("CRATES_IO_TOKEN");
+
+    try shell.pushd("./src/clients/rust");
+    defer shell.popd();
+
+    try shell.exec_zig(
+        \\build clients:rust -Drelease -Dconfig-release={release_triple}
+        \\ -Dconfig-release-client-min={release_triple_client_min}
+    , .{
+        .release_triple = info.release_triple,
+        .release_triple_client_min = info.release_triple_client_min,
+    });
+
+    try backup_create(shell.cwd, "Cargo.toml");
+    defer backup_restore(shell.cwd, "Cargo.toml");
+
+    const cargo_toml = try shell.cwd.readFileAlloc(
+        shell.arena.allocator(),
+        "Cargo.toml",
+        1 * MiB,
+    );
+    const version_line = try shell.fmt(
+        "version = \"{s}\"",
+        .{info.tag},
+    );
+    const cargo_toml_updated = try std.mem.replaceOwned(
+        u8,
+        shell.arena.allocator(),
+        cargo_toml,
+        "version = \"0.0.0\"",
+        version_line,
+    );
+    assert(std.mem.indexOf(u8, cargo_toml_updated, version_line) != null);
+
+    try shell.cwd.writeFile(.{
+        .sub_path = "Cargo.toml",
+        .data = cargo_toml_updated,
+    });
+
+    try shell.exec("cargo publish --token {token} --allow-dirty", .{
+        .token = token,
     });
 }
 

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -243,8 +243,10 @@ fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo, devhub: bool)
     }
 
     if (languages.contains(.rust)) {
-        // Currently disabled.
-        _ = &build_rust;
+        var dist_dir_rust = try dist_dir.makeOpenPath("rust", .{});
+        defer dist_dir_rust.close();
+
+        try build_rust(shell, info, dist_dir_rust);
     }
 }
 
@@ -745,6 +747,7 @@ fn publish(
             \\  to `{[tag]s}`.
             \\* Node.js: `npm install --save-exact tigerbeetle-node@{[tag]s}`
             \\* Python: `pip install tigerbeetle=={[tag]s}`
+            \\* Rust: `cargo add tigerbeetle@{[tag]s}`
             \\
             \\## Changelog
             \\
@@ -793,8 +796,7 @@ fn publish(
     if (languages.contains(.java)) try publish_java(shell, info);
     if (languages.contains(.node)) try publish_node(shell, info);
     if (languages.contains(.python)) try publish_python(shell, info);
-    // Currently disabled.
-    _ = &publish_rust;
+    if (languages.contains(.rust)) try publish_rust(shell, info);
 
     if (languages.contains(.zig)) {
         try shell.exec(

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -243,10 +243,8 @@ fn build(shell: *Shell, languages: LanguageSet, info: VersionInfo, devhub: bool)
     }
 
     if (languages.contains(.rust)) {
-        var dist_dir_rust = try dist_dir.makeOpenPath("rust", .{});
-        defer dist_dir_rust.close();
-
-        try build_rust(shell, info, dist_dir_rust);
+        // Currently disabled.
+        _ = &build_rust;
     }
 }
 
@@ -747,7 +745,6 @@ fn publish(
             \\  to `{[tag]s}`.
             \\* Node.js: `npm install --save-exact tigerbeetle-node@{[tag]s}`
             \\* Python: `pip install tigerbeetle=={[tag]s}`
-            \\* Rust: `cargo add tigerbeetle@{[tag]s}`
             \\
             \\## Changelog
             \\
@@ -796,7 +793,8 @@ fn publish(
     if (languages.contains(.java)) try publish_java(shell, info);
     if (languages.contains(.node)) try publish_node(shell, info);
     if (languages.contains(.python)) try publish_python(shell, info);
-    if (languages.contains(.rust)) try publish_rust(shell, info);
+    // Currently disabled.
+    _ = &publish_rust;
 
     if (languages.contains(.zig)) {
         try shell.exec(


### PR DESCRIPTION
A few more things for the rust client:

- Prevent the test suite from running multiple dbs concurrently to save ram.
- Remove the anyhow dependency
- Remove the futures-channel dependency by polyfilling, reducing one allocation per request
- Readd the rust release code but don't enable

Finally the last two commits enable then revert the rust client publication, so that code is in tree and ready to go. Not super confident in the release code since it can't be tested, but I've written it a few times and this looks more or less right.

This resolves all remaining comments from https://github.com/tigerbeetle/tigerbeetle/pull/3254/changes except that there are still futures subcrate dependencies in the main crate, and futures and tokio deps in the examples. The reason I haven't removed these is because they have a negative impact on the examples and their docs, with visible polyfills.

The reason the Rust client is not enabled continues to be that its test suite crashes the windows CI. The windows crash is almost certainly because of a bug in the windows-specific I/O shutdown and cancellation path.

The other remaining issue is that the API forces an internal clone of all input buffers. An API that perfectly reuses buffers is significantly less ergonomic. My inclination is not to resolve this unless there is some reported performance issue down the road.

