### PR TITLE
Grid: Remove broken assert

### DIFF
--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -502,7 +502,7 @@ pub fn GridType(comptime Storage: type) type {
 
             var write_queue_iterator = grid.write_queue.iterate();
             while (write_queue_iterator.next()) |write| {
-                assert(write.repair);
+                maybe(write.repair);
                 assert(!grid.free_set.is_free(write.address));
                 assert(!grid.free_set.to_be_freed_at_checkpoint_durability(write.address));
             }


### PR DESCRIPTION
## Bug

CFO on https://github.com/tigerbeetle/tigerbeetle/pull/3258 discovered a crash which also exists in `main` (see https://github.com/tigerbeetle/tigerbeetle/commit/6b926dd0a05fd8aeca52612b4f024a765f80697e):

```
/var/home/djg/C/bin/zig-x86_64-linux-0.14.1/lib/std/debug.zig:550:14: 0x1219dfd in assert (vopr)
    if (!ok) unreachable; // assertion failure
             ^
/var/home/djg/C/t/db/a/src/vsr/grid.zig:508:23: 0x161da24 in checkpoint_durable_join (vopr)
                assert(write.repair);
                      ^
/var/home/djg/C/t/db/a/src/vsr/grid.zig:490:45: 0x15afb98 in checkpoint_durable (vopr)
                grid.checkpoint_durable_join();
                                            ^
/var/home/djg/C/t/db/a/src/vsr/replica.zig:4963:41: 0x1539371 in commit_checkpoint_durable (vopr)
            self.grid.checkpoint_durable(commit_checkpoint_durable_grid_callback);
                                        ^
...
```

We call `grid.checkpoint`, but some of our in-progress writes are not repairs.

Initially I thought this was due to https://github.com/tigerbeetle/tigerbeetle/pull/3553 which removes the write stall at the end of beats. However, I think that change just makes the crash easier to hit, but it already existed.

Before checkpointing superblock, we do all of the following concurrently:
- checkpoint forest
- checkpoint grid
- write trailers to grid (client sessions, etc)

Before #3553 we were implicitly relying on the trailer writes never overflowing grid's iops into the write queue. This happened to be true in the VOPR, but is not true in general. Now that compaction writes are allowed to run later, this bug can occur even in relatively small data sizes like the VOPR uses.

## Fix

Convert the crashing `assert()` into a `maybe()`.

After we are done writing trailers + LSM to grid, replica still (correctly) asserts `self.grid.assert_only_repairing();`, which is the actual correctness condition, to ensure that don't write the superblock before the grid is clean.