### PR TITLE
build: remove outdated comment

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,10 +48,11 @@ const zig_version = std.SemanticVersion{
 };
 
 comptime {
-    const zig_version_eq = zig_version.major == builtin.zig_version.major and
+    const zig_version_equal =
+        zig_version.major == builtin.zig_version.major and
         zig_version.minor == builtin.zig_version.minor and
         zig_version.patch == builtin.zig_version.patch;
-    if (!zig_version_eq) {
+    if (!zig_version_equal) {
         @compileError(std.fmt.comptimePrint(
             "unsupported zig version: expected {}, found {}",
             .{ zig_version, builtin.zig_version },

--- a/build.zig
+++ b/build.zig
@@ -48,10 +48,9 @@ const zig_version = std.SemanticVersion{
 };
 
 comptime {
-    // Compare versions while allowing different pre/patch metadata.
     const zig_version_eq = zig_version.major == builtin.zig_version.major and
         zig_version.minor == builtin.zig_version.minor and
-        (zig_version.patch == builtin.zig_version.patch);
+        zig_version.patch == builtin.zig_version.patch;
     if (!zig_version_eq) {
         @compileError(std.fmt.comptimePrint(
             "unsupported zig version: expected {}, found {}",


### PR DESCRIPTION
We don’t allow different Zig patch versions.

```
tigerbeetle/build.zig:56:9: error: unsupported zig version: expected 0.14.1, found 0.14.0
```