### PR TITLE
inspect: print table size in values

### DIFF
--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -413,7 +413,7 @@ fn print_objects(output: std.io.AnyWriter) !void {
         try print_size_count(output, size_total, 1);
 
         try print_header(output, 1, "object");
-        try print_size_count(output, object_size, 1);
+        try print_size_count(output, object_size, ObjectTree.Table.value_count_max);
 
         try print_header(output, 1, "id");
         try print_size_count(output, id_size, 1);


### PR DESCRIPTION
Example output:

```
$ ./zig/zig build run -- inspect constants
...
Transfer                        416B
  object                        128B x262080
  id                            32B
  debit_account_id              32B
  credit_account_id             32B
```

The `x262080` is new. 

That is, Transfer with all indexes takes 416 bytes, and there are 262080 transfer per table.