### PR TITLE
Grid: Don't skip reading from the write queue

### DIFF
--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1117,6 +1117,18 @@ pub fn GridType(comptime Storage: type) type {
 
             assert(read.address > 0);
 
+            // Check the write queue before checking the read queue, since otherwise:
+            // 1. Read block. (coherent=false, i.e. via repair)
+            // 2. Create block. (start)
+            // 3. Read block again. (coherent=true)
+            // We must ensure that the second read succeeds, so that it doesn't just queue up behind
+            // the first read.
+            if (grid.read_block_from_write_queues(read.address, read.checksum)) |block| {
+                grid.assert_coherent(read.address, read.checksum);
+                grid.read_block_resolve(read, .{ .valid = block });
+                return;
+            }
+
             // Check if a read is already processing/recovering and merge with it.
             for ([_]*const QueueType(Read){
                 &grid.read_queue,
@@ -1139,12 +1151,6 @@ pub fn GridType(comptime Storage: type) type {
                         }
                     }
                 }
-            }
-
-            if (grid.read_block_from_write_queues(read.address, read.checksum)) |block| {
-                grid.assert_coherent(read.address, read.checksum);
-                grid.read_block_resolve(read, .{ .valid = block });
-                return;
             }
 
             // When Read.cache_read is set, the caller of read_block()


### PR DESCRIPTION
(Related: https://github.com/tigerbeetle/tigerbeetle/pull/3567)

Check the write queue _before_ checking the read queue, since otherwise:

1. Read block. (coherent=false, e.g. via `command=request_blocks`)
2. Create block. (start)
3. Read block again. (coherent=true, e.g. via compaction)

Currently the second read queues up behind the first read, leading to us trying to repair the block while we are currently writing it.

This fixes the following crash:
```
thread 8269 panic: reached unreachable code
/var/home/djg/C/bin/zig-x86_64-linux-0.14.1/lib/std/debug.zig:550:14: 0x1217b5d in assert (vopr)
    if (!ok) unreachable; // assertion failure
             ^
/var/home/djg/C/t/db/perf/src/vsr/grid.zig:772:19: 0x142ce38 in repair_block (vopr)
            assert(grid.writing(block_header.address, block.*) == .not_writing);
                  ^
/var/home/djg/C/t/db/perf/src/vsr/replica.zig:3501:39: 0x13b7c46 in on_block (vopr)
                self.grid.repair_block(grid_repair_block_callback, &write.write, write_block);
                                      ^
/var/home/djg/C/t/db/perf/src/vsr/replica.zig:1794:44: 0x136a7af in on_message (vopr)
                .block => |m| self.on_block(m),
                                           ^
```

Seed: ./zig/zig build vopr -Drelease -- 12080135933729495254