### PR TITLE
Revert the release_validate to use the checkout the latest tag

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -20,13 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: lewis/release-validate-override
-          fetch-depth: 0
+          ref: release
       # Run on the latest tag. The release branch is ahead of release tag over the weekend.
-      # NB: Temporarily overriden to lewis/release-validate-override - make sure to revert back
-      # before the next release!
       - run: |
-          git fetch origin lewis/release-validate-override
+          TAG=$(gh release list --limit 1 | cut -f1)
+          git fetch origin $TAG && git switch -d FETCH_HEAD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
instead of the `lewis/release-validate-override` branch.