### PR TITLE
Revert "Revert the release_validate to use the checkout the latest tag"

### DIFF
--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -20,11 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: release
+          ref: lewis/release-validate-override
+          fetch-depth: 0
       # Run on the latest tag. The release branch is ahead of release tag over the weekend.
+      # NB: Temporarily overriden to lewis/release-validate-override - make sure to revert back
+      # before the next release!
       - run: |
-          TAG=$(gh release list --limit 1 | cut -f1)
-          git fetch origin $TAG && git switch -d FETCH_HEAD
+          git fetch origin lewis/release-validate-override
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Reverts tigerbeetle/tigerbeetle#3594

I was too eager to click merge; this should wait until the new release is out!