### PR TITLE
vsr: enforce per-replica budget for block repair

### DIFF
--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -33,11 +33,11 @@ pub const RepairBudgetJournal = struct {
     experiment_chance: Ratio = ratio(1, 10),
 
     // Multiple of repair latency used to determine expiry duration, which is the time we wait
-    // before reclaiming the budget for an inflight repair request.
+    // before restoring the budget for an inflight repair request if the prepare has not arrived.
     repair_latency_multiple_expiry: u8 = 2,
 
     // The maximum amount of time we wait before reclaiming the budget for an inflight repair
-    // request.
+    // request if the prepare has not arrived.
     //
     // Capped at 500ms to avoid an unbounded increase in the tracked repair latency for remote
     // replicas. Specifically, helps avoid the case where a partitioned replica with missing
@@ -60,12 +60,10 @@ pub const RepairBudgetJournal = struct {
         replica_index: u8,
         replica_count: u8,
     }) !RepairBudgetJournal {
-        const remote_replica_count = if (options.replica_index < options.replica_count)
-            // Replicas can repair from all replicas but themselves.
-            options.replica_count - 1
-        else
-            // Standbys can repair from all replicas.
-            options.replica_count;
+        // Replicas can repair from all replicas but themselves,
+        // while standbys can repair from all replicas.
+        const remote_replica_count =
+            options.replica_count - @intFromBool(options.replica_index < options.replica_count);
 
         var replicas_requested_prepares = try gpa.alloc(RequestedPrepares, options.replica_count);
         errdefer gpa.free(replicas_requested_prepares);
@@ -128,12 +126,12 @@ pub const RepairBudgetJournal = struct {
         var repair_latency_min_replica_index: ?u8 = null;
 
         for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
-            // Disallow requesting from a replica from which this op has already been requested.
-            if (requested_prepares.get(options.op) != null) continue;
             // Disallow requests to self.
             if (replica_index == budget.replica_index) continue;
             // Enforce per-replica budget.
             if (requested_prepares.count() == repair_messages_inflight_count_max) continue;
+            // Disallow requesting from a replica from which this op has already been requested.
+            if (requested_prepares.get(options.op) != null) continue;
 
             const replica_repair_latency = budget.replicas_repair_latency[replica_index];
 
@@ -273,8 +271,8 @@ pub const RepairBudgetGrid = struct {
     // Tracks the blocks requested from each remote replica.
     replicas_requested_blocks: []RequestedBlocks,
 
-    // The amount of time we wait before reclaiming the budget for an
-    // inflight repair request.
+    // The amount of time we wait before restoring the budget for an
+    // inflight repair request if the block has not arrived.
     const duration_expiry: stdx.Duration = .ms(250);
 
     // Maximum blocks that can be requested per remote replica.
@@ -283,7 +281,9 @@ pub const RepairBudgetGrid = struct {
     // remote replica is saturated by multiple replicas, overflowing
     // the egress `send_queue` (which leads to dropped messages, and
     // wasted network & storage IO) on the remote replica is unlikely.
-    const repair_blocks_inflight_count_max = constants.grid_repair_request_max;
+    // The +1 allows us to send a full `request_blocks` even when
+    // all but one request has been responded to.
+    const replica_blocks_requested_max = constants.grid_repair_request_max + 1;
 
     const RequestedBlocks = std.AutoArrayHashMapUnmanaged(vsr.BlockReference, stdx.Instant);
 
@@ -291,12 +291,10 @@ pub const RepairBudgetGrid = struct {
         replica_index: u8,
         replica_count: u8,
     }) !RepairBudgetGrid {
-        const remote_replica_count = if (options.replica_index < options.replica_count)
-            // Replicas can repair from all replicas but themselves.
-            options.replica_count - 1
-        else
-            // Standbys can repair from all replicas.
-            options.replica_count;
+        // Replicas can repair from all replicas but themselves,
+        // while standbys can repair from all replicas.
+        const remote_replica_count =
+            options.replica_count - @intFromBool(options.replica_index < options.replica_count);
 
         var replicas_requested_blocks = try gpa.alloc(RequestedBlocks, options.replica_count);
         errdefer gpa.free(replicas_requested_blocks);
@@ -305,14 +303,14 @@ pub const RepairBudgetGrid = struct {
             errdefer for (replicas_requested_blocks[0..replica]) |*m| m.deinit(gpa);
             requested_blocks.* = .{};
 
-            try requested_blocks.ensureTotalCapacity(gpa, repair_blocks_inflight_count_max);
+            try requested_blocks.ensureTotalCapacity(gpa, replica_blocks_requested_max);
             errdefer requested_blocks.deinit(gpa);
         }
         errdefer for (replicas_requested_blocks) |*m| m.deinit(gpa);
 
         return RepairBudgetGrid{
-            .capacity = repair_blocks_inflight_count_max * remote_replica_count,
-            .available = repair_blocks_inflight_count_max * remote_replica_count,
+            .capacity = replica_blocks_requested_max * remote_replica_count,
+            .available = replica_blocks_requested_max * remote_replica_count,
             .replica_index = options.replica_index,
             .replicas_requested_blocks = replicas_requested_blocks,
         };
@@ -325,7 +323,7 @@ pub const RepairBudgetGrid = struct {
         gpa.free(budget.replicas_requested_blocks);
     }
 
-    fn assert_invariants(budget: *RepairBudgetGrid) void {
+    fn assert_invariants(budget: *const RepairBudgetGrid) void {
         assert(budget.available <= budget.capacity);
 
         if (budget.replica_index < budget.replicas_requested_blocks.len) {
@@ -340,19 +338,18 @@ pub const RepairBudgetGrid = struct {
         assert(budget.available + requested_blocks_count == budget.capacity);
     }
 
-    pub fn full_budget_random(budget: *RepairBudgetGrid, prng: *stdx.PRNG) ?u8 {
+    pub fn next_destination(budget: *RepairBudgetGrid, prng: *stdx.PRNG) ?u8 {
         budget.assert_invariants();
-        defer budget.assert_invariants();
 
         const replica_count = budget.replicas_requested_blocks.len;
-        const start = prng.int_inclusive(u8, @intCast(replica_count - 1));
+        var replica_indexes: [constants.replicas_max]u8 = undefined;
+        for (replica_indexes[0..replica_count], 0..) |*replica, i| replica.* = @intCast(i);
+        prng.shuffle(u8, replica_indexes[0..replica_count]);
 
-        for (0..replica_count) |i| {
-            const replica_index: u8 =
-                @intCast((start + i) % budget.replicas_requested_blocks.len);
-
-            if (replica_index == budget.replica_index) continue;
-            if (budget.replicas_requested_blocks[replica_index].count() == 0) {
+        for (replica_indexes[0..replica_count]) |replica_index| {
+            if (replica_index != budget.replica_index and
+                budget.budget_available(replica_index) >= constants.grid_repair_request_max)
+            {
                 return replica_index;
             }
         }
@@ -361,24 +358,12 @@ pub const RepairBudgetGrid = struct {
 
     pub fn budget_available(budget: *RepairBudgetGrid, replica_index: u8) u32 {
         budget.assert_invariants();
-        defer budget.assert_invariants();
 
         assert(budget.replica_index != replica_index);
 
         const replica_requested_blocks = budget.replicas_requested_blocks[replica_index];
 
-        return @intCast(repair_blocks_inflight_count_max - replica_requested_blocks.count());
-    }
-
-    pub fn requested(
-        budget: *RepairBudgetGrid,
-        block_identifier: vsr.BlockReference,
-        replica_index: u8,
-    ) bool {
-        budget.assert_invariants();
-        defer budget.assert_invariants();
-
-        return budget.replicas_requested_blocks[replica_index].get(block_identifier) != null;
+        return @intCast(replica_blocks_requested_max - replica_requested_blocks.count());
     }
 
     pub fn decrement(budget: *RepairBudgetGrid, options: struct {
@@ -389,19 +374,26 @@ pub const RepairBudgetGrid = struct {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        var replica_requested_blocks =
-            &budget.replicas_requested_blocks[options.replica_index];
-
-        assert(replica_requested_blocks.count() < repair_blocks_inflight_count_max);
         assert(budget.available > 0);
         assert(options.block_identifier.address > 0);
         assert(options.replica_index != budget.replica_index);
 
-        // Disallow requesting from a replica from which
-        // this block has already been requested.
-        if (replica_requested_blocks.get(options.block_identifier) != null) return false;
+        for (budget.replicas_requested_blocks, 0..) |requested_blocks, replica_index| {
+            if (requested_blocks.get(options.block_identifier) != null) {
+                assert(replica_index != budget.replica_index);
+                return false;
+            }
+        }
 
-        replica_requested_blocks.putAssumeCapacityNoClobber(options.block_identifier, options.now);
+        var replica_requested_blocks =
+            &budget.replicas_requested_blocks[options.replica_index];
+
+        assert(replica_requested_blocks.count() < replica_blocks_requested_max);
+
+        replica_requested_blocks.putAssumeCapacityNoClobber(
+            options.block_identifier,
+            options.now.add(duration_expiry),
+        );
 
         budget.available -= 1;
 
@@ -446,10 +438,8 @@ pub const RepairBudgetGrid = struct {
             var requested_blocks_index: u32 = 0;
 
             while (requested_blocks_index < requested_blocks.entries.len) {
-                const requested_at = requested_blocks.values()[requested_blocks_index];
-                const duration_since_requested_at = now.duration_since(requested_at);
-
-                if (duration_since_requested_at.ns > duration_expiry.ns) {
+                const expires_at = requested_blocks.values()[requested_blocks_index];
+                if (now.ns > expires_at.ns) {
                     requested_blocks.swapRemoveAt(requested_blocks_index);
                     budget.available += 1;
                 } else {

--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -275,6 +275,10 @@ pub const RepairBudgetGrid = struct {
     // inflight repair request if the block has not arrived.
     const duration_expiry: stdx.Duration = .ms(250);
 
+    // The amount of time we wait before re-requesting a block
+    // which has not yet arrived.
+    const duration_retry: stdx.Duration = .ms(100);
+
     // Maximum blocks that can be requested per remote replica.
     //
     // We use a small number to ensure that even if the budget to a
@@ -378,11 +382,22 @@ pub const RepairBudgetGrid = struct {
         assert(options.block_identifier.address > 0);
         assert(options.replica_index != budget.replica_index);
 
+        var duration_since_requested_min: ?stdx.Duration = null;
+
         for (budget.replicas_requested_blocks, 0..) |requested_blocks, replica_index| {
-            if (requested_blocks.get(options.block_identifier) != null) {
+            if (requested_blocks.get(options.block_identifier)) |requested_at| {
                 assert(replica_index != budget.replica_index);
-                return false;
+                const duration_since_requested = options.now.duration_since(requested_at);
+                if (duration_since_requested_min == null or
+                    duration_since_requested.ns < duration_since_requested_min.?.ns)
+                {
+                    duration_since_requested_min = duration_since_requested;
+                }
             }
+        }
+
+        if (duration_since_requested_min) |duration| {
+            if (duration.ns < duration_retry.ns) return false;
         }
 
         var replica_requested_blocks =
@@ -390,12 +405,10 @@ pub const RepairBudgetGrid = struct {
 
         assert(replica_requested_blocks.count() < replica_blocks_requested_max);
 
-        replica_requested_blocks.putAssumeCapacityNoClobber(
-            options.block_identifier,
-            options.now.add(duration_expiry),
-        );
+        const gop = replica_requested_blocks.getOrPutAssumeCapacity(options.block_identifier);
+        gop.value_ptr.* = options.now;
 
-        budget.available -= 1;
+        if (!gop.found_existing) budget.available -= 1;
 
         return true;
     }
@@ -438,8 +451,10 @@ pub const RepairBudgetGrid = struct {
             var requested_blocks_index: u32 = 0;
 
             while (requested_blocks_index < requested_blocks.entries.len) {
-                const expires_at = requested_blocks.values()[requested_blocks_index];
-                if (now.ns > expires_at.ns) {
+                const requested_at = requested_blocks.values()[requested_blocks_index];
+                const duration_since_requested_at = now.duration_since(requested_at);
+
+                if (duration_since_requested_at.ns > duration_expiry.ns) {
                     requested_blocks.swapRemoveAt(requested_blocks_index);
                     budget.available += 1;
                 } else {

--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const assert = std.debug.assert;
+const constants = @import("../constants.zig");
 
+const vsr = @import("../vsr.zig");
 const stdx = @import("stdx");
 const ratio = stdx.PRNG.ratio;
 const Ratio = stdx.PRNG.Ratio;
@@ -126,7 +128,7 @@ pub const RepairBudgetJournal = struct {
         var repair_latency_min_replica_index: ?u8 = null;
 
         for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
-            // Disallow requesting from a replica from which this op already been requested.
+            // Disallow requesting from a replica from which this op has already been requested.
             if (requested_prepares.get(options.op) != null) continue;
             // Disallow requests to self.
             if (replica_index == budget.replica_index) continue;
@@ -264,62 +266,164 @@ pub const RepairBudgetJournal = struct {
 };
 
 pub const RepairBudgetGrid = struct {
-    capacity: u16,
-    available: u16,
-    refill_max: u16,
-    requested: std.AutoArrayHashMapUnmanaged(BlockIdentifier, void),
+    capacity: u32,
+    available: u32,
+    replica_index: u8,
 
-    const BlockIdentifier = struct { address: u64, checksum: u128 };
+    // Tracks the blocks requested from each remote replica.
+    replicas_requested_blocks: []RequestedBlocks,
+
+    // The amount of time we wait before reclaiming the budget for an
+    // inflight repair request.
+    const duration_expiry: stdx.Duration = .ms(250);
+
+    // Maximum blocks that can be requested per remote replica.
+    //
+    // We use a small number to ensure that even if the budget to a
+    // remote replica is saturated by multiple replicas, overflowing
+    // the egress `send_queue` (which leads to dropped messages, and
+    // wasted network & storage IO) on the remote replica is unlikely.
+    const repair_blocks_inflight_count_max = constants.grid_repair_request_max;
+
+    const RequestedBlocks = std.AutoArrayHashMapUnmanaged(vsr.BlockReference, stdx.Instant);
 
     pub fn init(gpa: std.mem.Allocator, options: struct {
-        capacity: u16,
-        refill_max: u16,
+        replica_index: u8,
+        replica_count: u8,
     }) !RepairBudgetGrid {
-        assert(options.refill_max <= options.capacity);
+        const remote_replica_count = if (options.replica_index < options.replica_count)
+            // Replicas can repair from all replicas but themselves.
+            options.replica_count - 1
+        else
+            // Standbys can repair from all replicas.
+            options.replica_count;
 
-        var requested: std.AutoArrayHashMapUnmanaged(BlockIdentifier, void) = .{};
-        try requested.ensureTotalCapacity(gpa, options.capacity);
-        errdefer requested.deinit(gpa);
+        var replicas_requested_blocks = try gpa.alloc(RequestedBlocks, options.replica_count);
+        errdefer gpa.free(replicas_requested_blocks);
+
+        for (replicas_requested_blocks, 0..) |*requested_blocks, replica| {
+            errdefer for (replicas_requested_blocks[0..replica]) |*m| m.deinit(gpa);
+            requested_blocks.* = .{};
+
+            try requested_blocks.ensureTotalCapacity(gpa, repair_blocks_inflight_count_max);
+            errdefer requested_blocks.deinit(gpa);
+        }
+        errdefer for (replicas_requested_blocks) |*m| m.deinit(gpa);
 
         return RepairBudgetGrid{
-            .capacity = options.capacity,
-            .available = options.capacity,
-            .refill_max = options.refill_max,
-            .requested = requested,
+            .capacity = repair_blocks_inflight_count_max * remote_replica_count,
+            .available = repair_blocks_inflight_count_max * remote_replica_count,
+            .replica_index = options.replica_index,
+            .replicas_requested_blocks = replicas_requested_blocks,
         };
     }
 
     pub fn deinit(budget: *RepairBudgetGrid, gpa: std.mem.Allocator) void {
-        budget.requested.deinit(gpa);
+        for (budget.replicas_requested_blocks) |*requested_blocks| {
+            requested_blocks.deinit(gpa);
+        }
+        gpa.free(budget.replicas_requested_blocks);
     }
 
     fn assert_invariants(budget: *RepairBudgetGrid) void {
         assert(budget.available <= budget.capacity);
-        assert(budget.available + budget.requested.count() <= budget.capacity);
-    }
 
-    pub fn decrement(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) bool {
-        budget.assert_invariants();
-        defer budget.assert_invariants();
-
-        assert(budget.available > 0);
-        assert(block_identifier.address > 0);
-
-        const gop = budget.requested.getOrPutAssumeCapacity(block_identifier);
-        if (gop.found_existing) {
-            return false;
-        } else {
-            budget.available -= 1;
-            return true;
+        if (budget.replica_index < budget.replicas_requested_blocks.len) {
+            assert(budget.replicas_requested_blocks[budget.replica_index].count() == 0);
         }
+
+        var requested_blocks_count: u32 = 0;
+        for (budget.replicas_requested_blocks) |*requested_blocks| {
+            requested_blocks_count += @intCast(requested_blocks.count());
+        }
+
+        assert(budget.available + requested_blocks_count == budget.capacity);
     }
 
-    pub fn increment(budget: *RepairBudgetGrid, block_identifier: BlockIdentifier) void {
+    pub fn full_budget_random(budget: *RepairBudgetGrid, prng: *stdx.PRNG) ?u8 {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        if (budget.requested.swapRemove(block_identifier)) {
-            budget.available = @min((budget.available + 1), budget.capacity);
+        const replica_count = budget.replicas_requested_blocks.len;
+        const start = prng.int_inclusive(u8, @intCast(replica_count - 1));
+
+        for (0..replica_count) |i| {
+            const replica_index: u8 =
+                @intCast((start + i) % budget.replicas_requested_blocks.len);
+
+            if (replica_index == budget.replica_index) continue;
+            if (budget.replicas_requested_blocks[replica_index].count() == 0) {
+                return replica_index;
+            }
+        }
+        return null;
+    }
+
+    pub fn budget_available(budget: *RepairBudgetGrid, replica_index: u8) u32 {
+        budget.assert_invariants();
+        defer budget.assert_invariants();
+
+        assert(budget.replica_index != replica_index);
+
+        const replica_requested_blocks = budget.replicas_requested_blocks[replica_index];
+
+        return @intCast(repair_blocks_inflight_count_max - replica_requested_blocks.count());
+    }
+
+    pub fn requested(
+        budget: *RepairBudgetGrid,
+        block_identifier: vsr.BlockReference,
+        replica_index: u8,
+    ) bool {
+        budget.assert_invariants();
+        defer budget.assert_invariants();
+
+        return budget.replicas_requested_blocks[replica_index].get(block_identifier) != null;
+    }
+
+    pub fn decrement(budget: *RepairBudgetGrid, options: struct {
+        block_identifier: vsr.BlockReference,
+        replica_index: u8,
+        now: stdx.Instant,
+    }) bool {
+        budget.assert_invariants();
+        defer budget.assert_invariants();
+
+        var replica_requested_blocks =
+            &budget.replicas_requested_blocks[options.replica_index];
+
+        assert(replica_requested_blocks.count() < repair_blocks_inflight_count_max);
+        assert(budget.available > 0);
+        assert(options.block_identifier.address > 0);
+        assert(options.replica_index != budget.replica_index);
+
+        // Disallow requesting from a replica from which
+        // this block has already been requested.
+        if (replica_requested_blocks.get(options.block_identifier) != null) return false;
+
+        replica_requested_blocks.putAssumeCapacityNoClobber(options.block_identifier, options.now);
+
+        budget.available -= 1;
+
+        return true;
+    }
+
+    pub fn increment(budget: *RepairBudgetGrid, block_identifier: vsr.BlockReference) void {
+        budget.assert_invariants();
+        defer budget.assert_invariants();
+
+        // We have no information about the replica that sent
+        // this block, as storing each replica's index in the
+        // block header would make storage non-deterministic.
+        // Consequently, we increase the budget for all replicas
+        // this block was requested from. This is safe to do as
+        // we only invoke `increment` *once* -- when the replica
+        // either uses the block to serve a read that's waiting
+        // on this block, or a repair write (see `on_block`).
+        for (budget.replicas_requested_blocks) |*requested_blocks| {
+            if (requested_blocks.swapRemove(block_identifier)) {
+                budget.available += 1;
+            }
         }
     }
 
@@ -327,7 +431,31 @@ pub const RepairBudgetGrid = struct {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        budget.available = @min((budget.available + budget.refill_max), budget.capacity);
-        budget.requested.clearRetainingCapacity();
+        budget.available = budget.capacity;
+
+        for (budget.replicas_requested_blocks) |*replicas_requested_blocks| {
+            replicas_requested_blocks.clearRetainingCapacity();
+        }
+    }
+
+    pub fn maybe_expire_requested_blocks(budget: *RepairBudgetGrid, now: stdx.Instant) void {
+        budget.assert_invariants();
+        defer budget.assert_invariants();
+
+        for (budget.replicas_requested_blocks) |*requested_blocks| {
+            var requested_blocks_index: u32 = 0;
+
+            while (requested_blocks_index < requested_blocks.entries.len) {
+                const requested_at = requested_blocks.values()[requested_blocks_index];
+                const duration_since_requested_at = now.duration_since(requested_at);
+
+                if (duration_since_requested_at.ns > duration_expiry.ns) {
+                    requested_blocks.swapRemoveAt(requested_blocks_index);
+                    budget.available += 1;
+                } else {
+                    requested_blocks_index += 1;
+                }
+            }
+        }
     }
 };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7456,6 +7456,12 @@ pub fn ReplicaType(
 
             if (self.syncing == .updating_checkpoint) return;
 
+            if (self.grid.callback != .cancel) {
+                if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
+                    self.send_request_blocks(replica_index);
+                }
+            }
+
             if (!self.state_machine_opened) return;
 
             assert(self.status == .normal or self.status == .view_change);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -569,7 +569,7 @@ pub fn ReplicaType(
         /// The number of ticks before peeking into the journal repair budget and expiring
         /// prepare requests that haven't been responded to.
         /// (status=normal or status=view-change).
-        journal_repair_budget_timeout: Timeout,
+        repair_budget_timeout: Timeout,
 
         /// The number of ticks before repairing missing/disconnected headers, dirty/missing
         /// prepares, and replenishing the repair budget.
@@ -588,7 +588,7 @@ pub fn ReplicaType(
 
         /// The number of ticks before replenishing the command=request_blocks budget.
         /// (always running)
-        grid_repair_budget_timeout: Timeout,
+        grid_repair_timeout: Timeout,
         grid_repair_message_budget: RepairBudgetGrid,
 
         /// (always running)
@@ -1119,24 +1119,11 @@ pub fn ReplicaType(
             assert(self.journal_repair_message_budget.available ==
                 self.journal_repair_message_budget.capacity);
 
-            // Ensure each replica can have a maximum of two inflight grid repair messages
-            // (`request_blocks`) per remote replica, at any point of time. This is merely an
-            // approximation that is loosely enforced by randomizing the remote replica we choose
-            // for repair, instead of strictly by ensuring that there are *exactly* two inflight
-            // repair messages to a specific replica.
-            // We track the number of requested blocks instead of the number of inflight
-            // `request_blocks` messages, since the response for each `request_blocks` message is
-            // potentially multiple blocks (up to `grid_repair_request_max`).
-            const grid_repair_message_budget_max =
-                2 * constants.grid_repair_request_max *
-                (replica_count - @intFromBool(!self.standby()));
-            const grid_repair_message_budget_refill =
-                @divFloor(grid_repair_message_budget_max, 2);
             self.grid_repair_message_budget = try RepairBudgetGrid.init(
                 allocator,
                 .{
-                    .capacity = grid_repair_message_budget_max,
-                    .refill_max = grid_repair_message_budget_refill,
+                    .replica_index = replica_index,
+                    .replica_count = replica_count,
                 },
             );
             errdefer self.grid_repair_message_budget.deinit(allocator);
@@ -1152,9 +1139,6 @@ pub fn ReplicaType(
 
                 assert(self.grid_repair_message_budget.capacity > 0);
                 assert(self.grid_repair_message_budget.capacity >=
-                    constants.grid_repair_request_max);
-                assert(self.grid_repair_message_budget.refill_max > 0);
-                assert(self.grid_repair_message_budget.refill_max >=
                     constants.grid_repair_request_max);
             }
 
@@ -1398,8 +1382,8 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 1_000 / constants.tick_ms,
                 },
-                .journal_repair_budget_timeout = Timeout{
-                    .name = "journal_repair_budget_timeout",
+                .repair_budget_timeout = Timeout{
+                    .name = "repair_budget_timeout",
                     .id = replica_index,
                     .after = 20 / constants.tick_ms,
                 },
@@ -1413,11 +1397,11 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 5_000 / constants.tick_ms,
                 },
-                .grid_repair_budget_timeout = Timeout{
-                    .name = "grid_repair_budget_timeout",
+                .grid_repair_timeout = Timeout{
+                    .name = "grid_repair_timeout",
                     .id = replica_index,
                     .after = options.timeout_grid_repair_message_ticks orelse
-                        (500 / constants.tick_ms),
+                        (100 / constants.tick_ms),
                 },
                 .grid_scrub_timeout = Timeout{
                     .name = "grid_scrub_timeout",
@@ -1563,11 +1547,11 @@ pub fn ReplicaType(
                     &self.request_start_view_message_timeout,
                     on_request_start_view_message_timeout,
                 },
-                .{ &self.journal_repair_budget_timeout, on_journal_repair_budget_timeout },
+                .{ &self.repair_budget_timeout, on_repair_budget_timeout },
                 .{ &self.journal_repair_timeout, on_journal_repair_timeout },
 
                 .{ &self.repair_sync_timeout, on_repair_sync_timeout },
-                .{ &self.grid_repair_budget_timeout, on_grid_repair_budget_timeout },
+                .{ &self.grid_repair_timeout, on_grid_repair_timeout },
                 .{ &self.upgrade_timeout, on_upgrade_timeout },
                 .{ &self.pulse_timeout, on_pulse_timeout },
                 .{ &self.grid_scrub_timeout, on_grid_scrub_timeout },
@@ -3507,11 +3491,10 @@ pub fn ReplicaType(
                     .checksum = message.header.checksum,
                 });
 
-                // Attempt to send full batches to amortize the network cost of fetching blocks.
-                if (self.grid_repair_message_budget.available >=
-                    constants.grid_repair_request_max)
-                {
-                    self.send_request_blocks();
+                if (self.grid_repair_message_budget.full_budget_random(
+                    &self.prng,
+                )) |replica_index| {
+                    self.send_request_blocks(replica_index);
                 }
             } else {
                 log.debug("{}: on_block: ignoring; block not needed " ++
@@ -3763,11 +3746,14 @@ pub fn ReplicaType(
             );
         }
 
-        fn on_journal_repair_budget_timeout(self: *Replica) void {
-            assert(self.status == .normal or self.status == .view_change);
+        fn on_repair_budget_timeout(self: *Replica) void {
+            assert(self.status != .recovering);
 
-            self.journal_repair_budget_timeout.reset();
+            self.repair_budget_timeout.reset();
             self.journal_repair_message_budget.maybe_expire_requested_prepares(
+                self.clock.monotonic(),
+            );
+            self.grid_repair_message_budget.maybe_expire_requested_blocks(
                 self.clock.monotonic(),
             );
         }
@@ -3815,21 +3801,18 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_grid_repair_budget_timeout(self: *Replica) void {
-            assert(self.grid_repair_budget_timeout.ticking);
+        fn on_grid_repair_timeout(self: *Replica) void {
+            assert(self.grid_repair_timeout.ticking);
             maybe(self.state_machine_opened);
 
-            self.grid_repair_budget_timeout.reset();
-            self.grid_repair_message_budget.refill();
-            assert(self.solo() or
-                self.grid_repair_message_budget.available >= constants.grid_repair_request_max);
+            self.grid_repair_timeout.reset();
 
-            // Proactively send a block request, because:
-            // - we definitely have enough budget for it now, and
-            // - to ensure that view-changing backups still request blocks (even though they are not
-            //   repairing their WAL via repair()).
             if (self.grid.callback != .cancel) {
-                self.send_request_blocks();
+                if (self.grid_repair_message_budget.full_budget_random(
+                    &self.prng,
+                )) |replica_index| {
+                    self.send_request_blocks(replica_index);
+                }
             }
         }
 
@@ -7477,14 +7460,6 @@ pub fn ReplicaType(
 
             if (self.syncing == .updating_checkpoint) return;
 
-            if (self.grid.callback != .cancel) {
-                if (self.grid_repair_message_budget.available >=
-                    constants.grid_repair_request_max)
-                {
-                    self.send_request_blocks();
-                }
-            }
-
             if (!self.state_machine_opened) return;
 
             assert(self.status == .normal or self.status == .view_change);
@@ -9882,13 +9857,14 @@ pub fn ReplicaType(
             assert(!self.do_view_change_message_timeout.ticking);
             assert(!self.request_start_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
-            assert(!self.journal_repair_budget_timeout.ticking);
+            assert(!self.repair_budget_timeout.ticking);
             assert(!self.journal_repair_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
             assert(!self.upgrade_timeout.ticking);
 
             self.ping_timeout.start();
-            self.grid_repair_budget_timeout.start();
+            self.repair_budget_timeout.start();
+            self.grid_repair_timeout.start();
             self.grid_scrub_timeout.start();
 
             log.warn("{}: transition_to_recovering_head_from_recovering_status: " ++
@@ -9924,7 +9900,7 @@ pub fn ReplicaType(
             assert(!self.do_view_change_message_timeout.ticking);
             assert(!self.request_start_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
-            assert(!self.journal_repair_budget_timeout.ticking);
+            assert(!self.repair_budget_timeout.ticking);
             assert(!self.journal_repair_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
             assert(!self.upgrade_timeout.ticking);
@@ -9942,9 +9918,9 @@ pub fn ReplicaType(
                 self.ping_timeout.start();
                 self.start_view_change_message_timeout.start();
                 self.commit_message_timeout.start();
-                self.journal_repair_budget_timeout.start();
+                self.repair_budget_timeout.start();
                 self.journal_repair_timeout.start();
-                self.grid_repair_budget_timeout.start();
+                self.grid_repair_timeout.start();
                 self.grid_scrub_timeout.start();
                 if (!self.aof_recovery) self.pulse_timeout.start();
                 self.upgrade_timeout.start();
@@ -9965,9 +9941,9 @@ pub fn ReplicaType(
                 self.ping_timeout.start();
                 self.start_view_change_message_timeout.start();
                 self.journal_repair_timeout.start();
-                self.journal_repair_budget_timeout.start();
+                self.repair_budget_timeout.start();
                 self.repair_sync_timeout.start();
-                self.grid_repair_budget_timeout.start();
+                self.grid_repair_timeout.start();
                 self.grid_scrub_timeout.start();
             }
         }
@@ -10023,10 +9999,10 @@ pub fn ReplicaType(
 
             self.ping_timeout.start();
             self.start_view_change_message_timeout.start();
-            self.journal_repair_budget_timeout.start();
+            self.repair_budget_timeout.start();
             self.journal_repair_timeout.start();
             self.repair_sync_timeout.start();
-            self.grid_repair_budget_timeout.start();
+            self.grid_repair_timeout.start();
             self.grid_scrub_timeout.start();
         }
 
@@ -10115,9 +10091,9 @@ pub fn ReplicaType(
                 self.repair_sync_timeout.start();
             }
 
-            assert(self.journal_repair_budget_timeout.ticking);
+            assert(self.repair_budget_timeout.ticking);
             self.journal_repair_timeout.start();
-            self.grid_repair_budget_timeout.start();
+            self.grid_repair_timeout.start();
             self.grid_scrub_timeout.start();
 
             self.heartbeat_timestamp = 0;
@@ -10202,11 +10178,11 @@ pub fn ReplicaType(
             self.prepare_timeout.stop();
             self.primary_abdicate_timeout.stop();
             self.pulse_timeout.stop();
-            self.grid_repair_budget_timeout.start();
+            self.grid_repair_timeout.start();
             self.grid_scrub_timeout.start();
             self.upgrade_timeout.stop();
             self.journal_repair_timeout.stop();
-            if (!self.journal_repair_timeout.ticking) self.journal_repair_budget_timeout.start();
+            if (!self.repair_budget_timeout.ticking) self.repair_budget_timeout.start();
 
             if (self.primary_index(self.view) == self.replica) {
                 self.request_start_view_message_timeout.stop();
@@ -10559,7 +10535,9 @@ pub fn ReplicaType(
             }
 
             self.grid_repair_message_budget.refill();
-            self.grid_repair_budget_timeout.reset();
+            if (self.grid_repair_timeout.ticking) {
+                self.grid_repair_timeout.reset();
+            }
 
             log.info("{}: sync: ops={}..{}/{}..{}", .{
                 self.log_prefix(),
@@ -11197,14 +11175,17 @@ pub fn ReplicaType(
             self.flush_loopback_queue();
         }
 
-        fn send_request_blocks(self: *Replica) void {
-            assert(self.grid_repair_budget_timeout.ticking);
+        fn send_request_blocks(self: *Replica, destination_replica_index: u8) void {
+            assert(self.grid_repair_timeout.ticking);
             assert(self.grid.callback != .cancel);
             maybe(self.state_machine_opened);
-            if (!self.solo()) {
-                assert(self.grid_repair_message_budget.available >=
+
+            assert(self.solo() or
+                self.grid_repair_message_budget.budget_available(destination_replica_index) ==
                     constants.grid_repair_request_max);
-            }
+
+            if (self.grid.blocks_missing.faulty_blocks.count() == 0 and
+                self.grid.read_global_queue.count() == 0) return;
 
             var message = self.message_bus.get_message(.request_blocks);
             defer self.message_bus.unref(message);
@@ -11216,10 +11197,12 @@ pub fn ReplicaType(
             assert(requests_buffer.len > 0);
             var requests_count: u32 = 0;
 
-            // Prioritize requests for blocks with stalled Grid reads, so that commit/compaction can
-            // continue. We divide the buffer up between `read_global_queue` and
-            // `blocks_missing.faulty_blocks` so that we always request blocks from both queues.
-            // Surplus from `blocks_missing.faulty_blocks` may be used by `read_global_queue`.
+            // Prioritize requests for blocks with stalled Grid reads,
+            // so that commit/compaction can continue. We divide the
+            // buffer up between `read_global_queue` and
+            // `blocks_missing.faulty_blocks` so that we always request
+            // blocks from both queues. Surplus from `blocks_missing.faulty_blocks`
+            // may be used by `read_global_queue`.
             const request_faults_count_max = requests_buffer.len - @min(
                 @divFloor(requests_buffer.len, 2),
                 self.grid.blocks_missing.faulty_blocks.count(),
@@ -11232,10 +11215,26 @@ pub fn ReplicaType(
             while (grid_faults.next()) |read_fault| {
                 if (requests_count >= request_faults_count_max) break;
 
-                if (self.grid_repair_message_budget.decrement(.{
+                const block_identifier = vsr.BlockReference{
                     .address = read_fault.address,
                     .checksum = read_fault.checksum,
-                })) {
+                };
+
+                for (0..self.replica_count) |replica_index| {
+                    if (self.grid_repair_message_budget.requested(
+                        block_identifier,
+                        @intCast(replica_index),
+                    )) {
+                        assert(replica_index != self.replica);
+                        break;
+                    }
+                } else {
+                    assert(self.grid_repair_message_budget.decrement(.{
+                        .block_identifier = block_identifier,
+                        .replica_index = destination_replica_index,
+                        .now = self.clock.monotonic(),
+                    }));
+
                     requests_buffer[requests_count] = .{
                         .block_address = read_fault.address,
                         .block_checksum = read_fault.checksum,
@@ -11248,10 +11247,25 @@ pub fn ReplicaType(
                 if (requests_count >= requests_buffer.len) break;
 
                 if (self.grid.blocks_missing.next_request()) |missing_request| {
-                    if (self.grid_repair_message_budget.decrement(.{
+                    const block_identifier = vsr.BlockReference{
                         .address = missing_request.block_address,
                         .checksum = missing_request.block_checksum,
-                    })) {
+                    };
+
+                    for (0..self.replica_count) |replica_index| {
+                        if (self.grid_repair_message_budget.requested(
+                            block_identifier,
+                            @intCast(replica_index),
+                        )) {
+                            assert(replica_index != self.replica);
+                            break;
+                        }
+                    } else {
+                        assert(self.grid_repair_message_budget.decrement(.{
+                            .block_identifier = block_identifier,
+                            .replica_index = destination_replica_index,
+                            .now = self.clock.monotonic(),
+                        }));
                         requests_buffer[requests_count] = missing_request;
                         requests_count += 1;
                     }
@@ -11260,6 +11274,7 @@ pub fn ReplicaType(
 
             assert(requests_count <= constants.grid_repair_request_max);
             if (requests_count == 0) return;
+
             assert(!self.solo());
 
             for (requests_buffer[0..requests_count]) |*request| {
@@ -11281,7 +11296,7 @@ pub fn ReplicaType(
             message.header.set_checksum_body(message.body_used());
             message.header.set_checksum();
 
-            self.send_message_to_replica(self.choose_any_other_replica(), message);
+            self.send_message_to_replica(destination_replica_index, message);
         }
 
         fn send_commit(self: *Replica, now: Instant) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -566,9 +566,9 @@ pub fn ReplicaType(
         /// (status=view-change backup)
         request_start_view_message_timeout: Timeout,
 
-        /// The number of ticks before peeking into the journal repair budget and expiring
-        /// prepare requests that haven't been responded to.
-        /// (status=normal or status=view-change).
+        /// The number of ticks before peeking into the journal/block repair budget and expiring
+        /// prepare/block requests that haven't been responded to.
+        /// (status=normal or status=view-change or status=recovering_head).
         repair_budget_timeout: Timeout,
 
         /// The number of ticks before repairing missing/disconnected headers, dirty/missing
@@ -586,7 +586,7 @@ pub fn ReplicaType(
         /// (status=normal backup)
         repair_sync_timeout: Timeout,
 
-        /// The number of ticks before replenishing the command=request_blocks budget.
+        /// The number of ticks before requesting missing/corrupt grid blocks.
         /// (always running)
         grid_repair_timeout: Timeout,
         grid_repair_message_budget: RepairBudgetGrid,
@@ -3491,9 +3491,7 @@ pub fn ReplicaType(
                     .checksum = message.header.checksum,
                 });
 
-                if (self.grid_repair_message_budget.full_budget_random(
-                    &self.prng,
-                )) |replica_index| {
+                if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
                     self.send_request_blocks(replica_index);
                 }
             } else {
@@ -3808,9 +3806,7 @@ pub fn ReplicaType(
             self.grid_repair_timeout.reset();
 
             if (self.grid.callback != .cancel) {
-                if (self.grid_repair_message_budget.full_budget_random(
-                    &self.prng,
-                )) |replica_index| {
+                if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
                     self.send_request_blocks(replica_index);
                 }
             }
@@ -10535,9 +10531,7 @@ pub fn ReplicaType(
             }
 
             self.grid_repair_message_budget.refill();
-            if (self.grid_repair_timeout.ticking) {
-                self.grid_repair_timeout.reset();
-            }
+            self.grid_repair_timeout.reset();
 
             log.info("{}: sync: ops={}..{}/{}..{}", .{
                 self.log_prefix(),
@@ -11179,10 +11173,13 @@ pub fn ReplicaType(
             assert(self.grid_repair_timeout.ticking);
             assert(self.grid.callback != .cancel);
             maybe(self.state_machine_opened);
+            assert(destination_replica_index != self.replica);
 
-            assert(self.solo() or
-                self.grid_repair_message_budget.budget_available(destination_replica_index) ==
-                    constants.grid_repair_request_max);
+            if (!self.solo()) {
+                assert(self.grid_repair_message_budget.budget_available(
+                    destination_replica_index,
+                ) >= constants.grid_repair_request_max);
+            }
 
             if (self.grid.blocks_missing.faulty_blocks.count() == 0 and
                 self.grid.read_global_queue.count() == 0) return;
@@ -11220,21 +11217,11 @@ pub fn ReplicaType(
                     .checksum = read_fault.checksum,
                 };
 
-                for (0..self.replica_count) |replica_index| {
-                    if (self.grid_repair_message_budget.requested(
-                        block_identifier,
-                        @intCast(replica_index),
-                    )) {
-                        assert(replica_index != self.replica);
-                        break;
-                    }
-                } else {
-                    assert(self.grid_repair_message_budget.decrement(.{
-                        .block_identifier = block_identifier,
-                        .replica_index = destination_replica_index,
-                        .now = self.clock.monotonic(),
-                    }));
-
+                if (self.grid_repair_message_budget.decrement(.{
+                    .block_identifier = block_identifier,
+                    .replica_index = destination_replica_index,
+                    .now = self.clock.monotonic(),
+                })) {
                     requests_buffer[requests_count] = .{
                         .block_address = read_fault.address,
                         .block_checksum = read_fault.checksum,
@@ -11252,20 +11239,11 @@ pub fn ReplicaType(
                         .checksum = missing_request.block_checksum,
                     };
 
-                    for (0..self.replica_count) |replica_index| {
-                        if (self.grid_repair_message_budget.requested(
-                            block_identifier,
-                            @intCast(replica_index),
-                        )) {
-                            assert(replica_index != self.replica);
-                            break;
-                        }
-                    } else {
-                        assert(self.grid_repair_message_budget.decrement(.{
-                            .block_identifier = block_identifier,
-                            .replica_index = destination_replica_index,
-                            .now = self.clock.monotonic(),
-                        }));
+                    if (self.grid_repair_message_budget.decrement(.{
+                        .block_identifier = block_identifier,
+                        .replica_index = destination_replica_index,
+                        .now = self.clock.monotonic(),
+                    })) {
                         requests_buffer[requests_count] = missing_request;
                         requests_count += 1;
                     }
@@ -11274,7 +11252,6 @@ pub fn ReplicaType(
 
             assert(requests_count <= constants.grid_repair_request_max);
             if (requests_count == 0) return;
-
             assert(!self.solo());
 
             for (requests_buffer[0..requests_count]) |*request| {


### PR DESCRIPTION
Currently, our budget for repairing grid blocks is not aware
of the # of blocks that have been requested for each replica,
i.e. it is just a global budget. This budget is replenished at every
`grid_repair_budget_timeout`, which is 500ms. This could lead
to a scenario that a slow/down replica holds up the entire repair
budget, reducing state sync performance.

Now, we enforce that there can be only 4 blocks requested from
each remote replica (corresponds to 1 full `request_blocks` message).
This puts an upper bound on how much of the budget can be held up 
by a slow/down replica, solving the aforementioned issue.

### DPT results

`./zig/zig build -Drelease vopr -- --performance 
--replica-missing-permanently=2 --replica-missing-temporarily=3 
--replica-missing-until-request=3000 --requests-max=6000`


I added `--replica-missing-permanently` to VOPR locally to test the
scenario where we have one replica down while another one is in state
sync. These are the results over `499 runs`:



Metric | Direction | Count | Mean | Median
-- | -- | -- | -- | --
ticks | decrease | 498/498 | -25.0% | -24.7%
block | decrease | 482/498 | -29.6% | -28.4%
block | increase | 16/498 | +16.5% | +14.7%
request_blocks | decrease | 440/498 | -12.2% | -8.9%
request_blocks | increase | 57/498 | +10.8% | +4.3%


Here is the distribution for `request_blocks` from one run, we can
see that there are _fewer_ requests directed towards R2, the 
dead replica:


Receiver | Status | Old | New 
-- | -- |  -- | -- 
0 | 🌱 | 743 | 680 
1 | 🌱 | 739 | 668 
2 |💀 | 765 | 620 
4 | 🌱 | 744 | 693 
5 | 🌱| 775 | 669 
Total | | 3766 | 3330 





