### PR TITLE
lsm: improve compaction table-selection complexity.

### DIFF
--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -522,6 +522,8 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             assert(manifest_level_a.table_count_visible <= table_count_visible_max + 1);
             if (manifest_level_a.table_count_visible < table_count_visible_max) return null;
 
+            assert(manifest_level_a.table_count_visible > 0);
+
             const least_overlap_table = manifest_level_a.table_with_least_overlap(
                 manifest_level_b,
                 snapshot_latest,

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -526,7 +526,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                 manifest_level_b,
                 snapshot_latest,
                 growth_factor,
-            ) orelse return null;
+            );
             assert(least_overlap_table.range.tables.count() <= growth_factor);
 
             const compaction_table_range = CompactionTableRange{

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -621,11 +621,6 @@ pub fn ManifestLevelType(
                 var optimal_table: ?*TableInfo = null;
                 var optimal_overlap: usize = max_overlapping_tables + 1;
                 var iterations: usize = 0;
-                defer {
-                    assert(iterations > 0);
-                    assert(iterations == level_a.table_count_visible or optimal_overlap == 0);
-                    assert(optimal_overlap <= max_overlapping_tables);
-                }
 
                 while (a_iterator.next()) |a_table| {
                     iterations += 1;
@@ -654,6 +649,10 @@ pub fn ManifestLevelType(
                         optimal_overlap = overlap;
                     }
                 }
+                assert(iterations > 0);
+                assert(iterations == level_a.table_count_visible or optimal_overlap == 0);
+                assert(optimal_overlap <= max_overlapping_tables);
+
                 break :optimal .{ optimal_table.?, optimal_overlap };
             };
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -572,6 +572,7 @@ pub fn ManifestLevelType(
         ///
         /// * Exits early if it finds a table that doesn't overlap with any
         ///   tables in the second level.
+        /// * Tier breaking happens from left to right.
         pub fn table_with_least_overlap(
             level_a: *const ManifestLevel,
             level_b: *const ManifestLevel,
@@ -1356,4 +1357,163 @@ test "ManifestLevel" {
 
         try context.run();
     }
+}
+
+test "fuzz: table_with_least_overlap" {
+    const TestContext = TestContextType(256, u64, 1024);
+    const Level = TestContext.TestLevel;
+    const Pool = TestContext.TestPool;
+    const TableInfo = TestContext.TableInfo;
+    const node_count = Level.Keys.node_count_max + Level.Tables.node_count_max;
+    const b_tables_max = constants.lsm_growth_factor * 3 + 3;
+
+    var prng = stdx.PRNG.from_seed_testing();
+
+    for (0..50) |_| {
+        var pool_a: Pool = undefined;
+        var pool_b: Pool = undefined;
+        try pool_a.init(std.testing.allocator, node_count);
+        defer pool_a.deinit(std.testing.allocator);
+
+        try pool_b.init(std.testing.allocator, node_count);
+        defer pool_b.deinit(std.testing.allocator);
+
+        var level_a: Level = undefined;
+        var level_b: Level = undefined;
+        try level_a.init(std.testing.allocator, &pool_a);
+        defer level_a.deinit(std.testing.allocator, &pool_a);
+
+        try level_b.init(std.testing.allocator, &pool_b);
+        defer level_b.deinit(std.testing.allocator, &pool_b);
+
+        // Build one invalid candidate and two equally good valid candidates.
+        // The left valid candidate should win, and the returned B range
+        // should match the brute-force overlap set.
+        // This encodes the current behaviour that we tie break from left to right.
+        // Note that this is more "accidental" and we might want to change this in the future.
+        const max_overlap = prng.range_inclusive(
+            usize,
+            1,
+            constants.lsm_growth_factor,
+        );
+        const valid_overlap = prng.range_inclusive(usize, 1, max_overlap);
+        const too_many_overlap_last = max_overlap;
+        const first_valid_start = too_many_overlap_last + 2;
+        const second_valid_start = first_valid_start + valid_overlap + 1;
+        const count_b = second_valid_start + valid_overlap;
+
+        assert(count_b <= b_tables_max);
+
+        var b_tables: [b_tables_max]TableInfo = undefined;
+        var key: u64 = prng.int_inclusive(u64, 500);
+        for (b_tables[0..count_b]) |*table| {
+            key += prng.range_inclusive(u64, 1, 31);
+            const key_min = key;
+            key += prng.int_inclusive(u64, 32);
+            table.* = random_table(key_min, key, &prng);
+            level_b.insert_table(&pool_b, table);
+        }
+
+        var too_many_overlap = random_table(
+            b_tables[0].key_min,
+            b_tables[too_many_overlap_last].key_max,
+            &prng,
+        );
+        level_a.insert_table(&pool_a, &too_many_overlap);
+
+        var first_valid = random_table(
+            b_tables[first_valid_start].key_min,
+            b_tables[first_valid_start + valid_overlap - 1].key_max,
+            &prng,
+        );
+        level_a.insert_table(&pool_a, &first_valid);
+
+        var second_valid = random_table(
+            b_tables[second_valid_start].key_min,
+            b_tables[second_valid_start + valid_overlap - 1].key_max,
+            &prng,
+        );
+        level_a.insert_table(&pool_a, &second_valid);
+
+        const expected = brute_force_least_overlap(&level_a, &level_b, max_overlap);
+        const result = Level.table_with_least_overlap(
+            &level_a,
+            &level_b,
+            lsm.snapshot_latest,
+            max_overlap,
+        );
+
+        try std.testing.expectEqual(valid_overlap, result.range.tables.count());
+        try std.testing.expectEqual(expected.table.key_min, result.table.table_info.key_min);
+        try std.testing.expectEqual(expected.table.key_max, result.table.table_info.key_max);
+        try std.testing.expectEqual(expected.b_tables.count(), result.range.tables.count());
+        for (expected.b_tables.const_slice(), 0..) |expected_b, j| {
+            const actual_b = result.range.tables.get(j).table_info;
+            try std.testing.expectEqual(expected_b.key_min, actual_b.key_min);
+            try std.testing.expectEqual(expected_b.key_max, actual_b.key_max);
+        }
+    }
+}
+
+const BruteForceLeastOverlapResult = struct {
+    table: *TestContextType(256, u64, 1024).TableInfo,
+    b_tables: stdx.BoundedArrayType(
+        *TestContextType(256, u64, 1024).TableInfo,
+        constants.lsm_growth_factor,
+    ),
+};
+
+fn brute_force_least_overlap(
+    level_a: *const TestContextType(256, u64, 1024).TestLevel,
+    level_b: *const TestContextType(256, u64, 1024).TestLevel,
+    max_overlap: usize,
+) BruteForceLeastOverlapResult {
+    const TableInfo = TestContextType(256, u64, 1024).TableInfo;
+    const snapshots = [1]u64{lsm.snapshot_latest};
+    var best_table: ?*TableInfo = null;
+    var best_overlap: usize = math.maxInt(usize);
+    var best_b_tables: stdx.BoundedArrayType(*TableInfo, constants.lsm_growth_factor) = .{};
+
+    var it_a = level_a.iterator(.visible, &snapshots, .ascending, null);
+    while (it_a.next()) |table_a| {
+        var overlap: usize = 0;
+        var it_b = level_b.iterator(.visible, &snapshots, .ascending, null);
+        while (it_b.next()) |table_b| {
+            if (table_b.key_max >= table_a.key_min and table_b.key_min <= table_a.key_max) {
+                overlap += 1;
+            }
+        }
+        if (overlap <= max_overlap and overlap < best_overlap) {
+            best_table = table_a;
+            best_overlap = overlap;
+            best_b_tables.clear();
+
+            var it_b2 = level_b.iterator(.visible, &snapshots, .ascending, null);
+            while (it_b2.next()) |table_b| {
+                if (table_b.key_max >= table_a.key_min and
+                    table_b.key_min <= table_a.key_max)
+                {
+                    best_b_tables.push(table_b);
+                }
+            }
+        }
+        if (best_overlap == 0) break;
+    }
+
+    return .{ .table = best_table.?, .b_tables = best_b_tables };
+}
+
+fn random_table(
+    key_min: u64,
+    key_max: u64,
+    prng: *stdx.PRNG,
+) TestContextType(256, u64, 1024).TableInfo {
+    return .{
+        .checksum = prng.int(u128),
+        .address = prng.int(u64),
+        .snapshot_min = 1,
+        .key_min = key_min,
+        .key_max = key_max,
+        .value_count = prng.int(u32),
+    };
 }

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -664,7 +664,6 @@ pub fn ManifestLevelType(
                 snapshot,
                 max_overlapping_tables,
             ).?;
-
             assert(range.tables.count() == table_a_overlap_count);
             assert(range.tables.count() <= max_overlapping_tables);
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -1354,53 +1354,69 @@ test "ManifestLevel" {
     }
 }
 
-test "fuzz: table_with_least_overlap" {
+const BruteForceLeastOverlapResult = struct {
+    table: *TestContextType(256, u64, 1024).TableInfo,
+    b_tables: stdx.BoundedArrayType(
+        *TestContextType(256, u64, 1024).TableInfo,
+        constants.lsm_growth_factor,
+    ),
+};
+test "fuzz: table_with_least_overlap random levels" {
     const TestContext = TestContextType(256, u64, 1024);
     const Level = TestContext.TestLevel;
     const Pool = TestContext.TestPool;
     const TableInfo = TestContext.TableInfo;
     const node_count = Level.Keys.node_count_max + Level.Tables.node_count_max;
-    const b_tables_max = constants.lsm_growth_factor * 3 + 3;
+    const a_tables_max = 20;
+    const b_tables_max = a_tables_max * constants.lsm_growth_factor;
 
     var prng = stdx.PRNG.from_seed_testing();
 
-    for (0..50) |_| {
+    for (0..100) |_| {
         var pool_a: Pool = undefined;
-        var pool_b: Pool = undefined;
         try pool_a.init(std.testing.allocator, node_count);
         defer pool_a.deinit(std.testing.allocator);
 
+        var pool_b: Pool = undefined;
         try pool_b.init(std.testing.allocator, node_count);
         defer pool_b.deinit(std.testing.allocator);
 
         var level_a: Level = undefined;
-        var level_b: Level = undefined;
         try level_a.init(std.testing.allocator, &pool_a);
         defer level_a.deinit(std.testing.allocator, &pool_a);
 
+        var level_b: Level = undefined;
         try level_b.init(std.testing.allocator, &pool_b);
         defer level_b.deinit(std.testing.allocator, &pool_b);
 
-        // Build one invalid candidate and two equally good valid candidates.
-        // The left valid candidate should win, and the returned B range
-        // should match the brute-force overlap set.
-        // This encodes the current behaviour that we tie break from left to right.
-        // Note that this is more "accidental" and we might want to change this in the future.
+        const count_a = prng.range_inclusive(usize, 1, a_tables_max);
+        // Skew count_b <= count_a * growth_factor so that by the pigeonhole
+        // principle at least one A table has overlap <= growth_factor in most
+        // iterations. This mirrors the real LSM invariant.
+        const count_b = prng.int_inclusive(
+            usize,
+            count_a * constants.lsm_growth_factor,
+        );
         const max_overlap = prng.range_inclusive(
             usize,
             1,
             constants.lsm_growth_factor,
         );
-        const valid_overlap = prng.range_inclusive(usize, 1, max_overlap);
-        const too_many_overlap_last = max_overlap;
-        const first_valid_start = too_many_overlap_last + 2;
-        const second_valid_start = first_valid_start + valid_overlap + 1;
-        const count_b = second_valid_start + valid_overlap;
 
-        assert(count_b <= b_tables_max);
-
-        var b_tables: [b_tables_max]TableInfo = undefined;
+        // Generate non-overlapping tables for level A.
+        var a_tables: [a_tables_max]TableInfo = undefined;
         var key: u64 = prng.int_inclusive(u64, 500);
+        for (a_tables[0..count_a]) |*table| {
+            key += prng.range_inclusive(u64, 1, 31);
+            const key_min = key;
+            key += prng.int_inclusive(u64, 32);
+            table.* = random_table(key_min, key, &prng);
+            level_a.insert_table(&pool_a, table);
+        }
+
+        // Generate non-overlapping tables for level B.
+        var b_tables: [b_tables_max]TableInfo = undefined;
+        key = prng.int_inclusive(u64, 500);
         for (b_tables[0..count_b]) |*table| {
             key += prng.range_inclusive(u64, 1, 31);
             const key_min = key;
@@ -1409,28 +1425,14 @@ test "fuzz: table_with_least_overlap" {
             level_b.insert_table(&pool_b, table);
         }
 
-        var too_many_overlap = random_table(
-            b_tables[0].key_min,
-            b_tables[too_many_overlap_last].key_max,
-            &prng,
-        );
-        level_a.insert_table(&pool_a, &too_many_overlap);
-
-        var first_valid = random_table(
-            b_tables[first_valid_start].key_min,
-            b_tables[first_valid_start + valid_overlap - 1].key_max,
-            &prng,
-        );
-        level_a.insert_table(&pool_a, &first_valid);
-
-        var second_valid = random_table(
-            b_tables[second_valid_start].key_min,
-            b_tables[second_valid_start + valid_overlap - 1].key_max,
-            &prng,
-        );
-        level_a.insert_table(&pool_a, &second_valid);
-
-        const expected = brute_force_least_overlap(&level_a, &level_b, max_overlap);
+        // Skip iterations where no A table has overlap <= max_overlap.
+        // With the pigeonhole skew above this is rare but can still happen
+        // since the levels are fully random.
+        const expected = brute_force_least_overlap(
+            &level_a,
+            &level_b,
+            max_overlap,
+        ) orelse continue;
 
         const result = Level.table_with_least_overlap(
             &level_a,
@@ -1439,31 +1441,31 @@ test "fuzz: table_with_least_overlap" {
             max_overlap,
         );
 
-        try std.testing.expectEqual(valid_overlap, result.range.tables.count());
-        try std.testing.expectEqual(expected.table.key_min, result.table.table_info.key_min);
-        try std.testing.expectEqual(expected.table.key_max, result.table.table_info.key_max);
-        try std.testing.expectEqual(expected.b_tables.count(), result.range.tables.count());
-        for (expected.b_tables.const_slice(), 0..) |expected_b, j| {
-            const actual_b = result.range.tables.get(j).table_info;
+        try std.testing.expectEqual(
+            expected.table.key_min,
+            result.table.table_info.key_min,
+        );
+        try std.testing.expectEqual(
+            expected.table.key_max,
+            result.table.table_info.key_max,
+        );
+        try std.testing.expectEqual(
+            expected.b_tables.count(),
+            result.range.tables.count(),
+        );
+        for (expected.b_tables.const_slice(), 0..) |expected_b, i| {
+            const actual_b = result.range.tables.get(i).table_info;
             try std.testing.expectEqual(expected_b.key_min, actual_b.key_min);
             try std.testing.expectEqual(expected_b.key_max, actual_b.key_max);
         }
     }
 }
 
-const BruteForceLeastOverlapResult = struct {
-    table: *TestContextType(256, u64, 1024).TableInfo,
-    b_tables: stdx.BoundedArrayType(
-        *TestContextType(256, u64, 1024).TableInfo,
-        constants.lsm_growth_factor,
-    ),
-};
-
 fn brute_force_least_overlap(
     level_a: *const TestContextType(256, u64, 1024).TestLevel,
     level_b: *const TestContextType(256, u64, 1024).TestLevel,
     max_overlap: usize,
-) BruteForceLeastOverlapResult {
+) ?BruteForceLeastOverlapResult {
     const TableInfo = TestContextType(256, u64, 1024).TableInfo;
     const snapshots = [1]u64{lsm.snapshot_latest};
     var best_table: ?*TableInfo = null;
@@ -1496,7 +1498,10 @@ fn brute_force_least_overlap(
         if (best_overlap == 0) break;
     }
 
-    return .{ .table = best_table.?, .b_tables = best_b_tables };
+    if (best_table) |table| {
+        return .{ .table = table, .b_tables = best_b_tables };
+    }
+    return null;
 }
 
 fn random_table(

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -3,14 +3,14 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
-const maybe = stdx.maybe;
 
 const stdx = @import("stdx");
-const constants = @import("../constants.zig");
-const lsm = @import("tree.zig");
-const binary_search = @import("binary_search.zig");
+const maybe = stdx.maybe;
 
+const constants = @import("../constants.zig");
 const Direction = @import("../direction.zig").Direction;
+const binary_search = @import("binary_search.zig");
+const lsm = @import("tree.zig");
 const SortedSegmentedArrayType = @import("segmented_array.zig").SortedSegmentedArrayType;
 
 pub fn ManifestLevelType(
@@ -566,6 +566,10 @@ pub fn ManifestLevelType(
         /// is invoked and B is the other level), finds a table in Level A that
         /// overlaps with the least number of tables in Level B.
         ///
+        /// Uses a two-pointer sweep over both levels for O(n_a + n_b) overlap
+        /// counting, then a single binary search to retrieve the full overlap
+        /// range for the chosen table.
+        ///
         /// * Exits early if it finds a table that doesn't overlap with any
         ///   tables in the second level.
         pub fn table_with_least_overlap(
@@ -573,47 +577,108 @@ pub fn ManifestLevelType(
             level_b: *const ManifestLevel,
             snapshot: u64,
             max_overlapping_tables: usize,
-        ) ?LeastOverlapTable {
+        ) LeastOverlapTable {
             assert(max_overlapping_tables <= constants.lsm_growth_factor);
 
-            var optimal: ?LeastOverlapTable = null;
             const snapshots = [1]u64{snapshot};
-            var iterations: usize = 0;
-            var it = level_a.iterator(
-                .visible,
-                &snapshots,
-                .ascending,
-                null, // All visible tables in the level therefore no KeyRange filter.
-            );
 
-            while (it.next()) |table| {
-                iterations += 1;
+            // Two-pointer sweep to count overlaps in O(n_a + n_b).
+            //
+            // Both levels are sorted. As we advance through A left-to-right,
+            // the B pointers only move forward (monotonic), so total work
+            // across all A-tables is O(n_b) for each pointer.
+            //
+            // For each table_a, we maintain two counts into B:
+            //
+            //   count_b_min: B-tables with key_max  < table_a.key_min  (left of A)
+            //   count_b_max: B-tables with key_min <= table_a.key_max  (started before A ends)
+            //
+            //   overlap = count_b_max - count_b_min
+            //
+            // Example: 4 B-tables, table_a overlaps B2 and B3:
+            //        Level A:               |= table_a ===|
+            //        Level B:  |=B0=| |=B1=| |==B2==| |==B3==|  |=B4=|
+            //                  ├───────────┤              :
+            //                  count_b_min = 2            :
+            //                  (B0, B1 end before         :
+            //                   table_a starts)           :
+            //                  ├──────────────────────────┤
+            //                  count_b_max = 4
+            //                  (B0, B1, B2, B3 start before table_a ends)
+            //                  overlap = 4 - 2 = 2  (B2, B3)
+            var iterator_a = level_a.iterator(.visible, &snapshots, .ascending, null);
+            var iterator_b_min = level_b.iterator(.visible, &snapshots, .ascending, null);
+            var iterator_b_max = level_b.iterator(.visible, &snapshots, .ascending, null);
+            var count_b_min: usize = 0;
+            var count_b_max: usize = 0;
+            var maybe_table_b_min: ?*TableInfo = iterator_b_min.next();
+            var maybe_table_b_max: ?*TableInfo = iterator_b_max.next();
 
-                const range = level_b.tables_overlapping_with_key_range(
-                    table.key_min,
-                    table.key_max,
-                    snapshot,
-                    max_overlapping_tables,
-                ) orelse continue;
-                assert(range.tables.count() <= max_overlapping_tables);
-
-                if (optimal == null or range.tables.count() < optimal.?.range.tables.count()) {
-                    optimal = LeastOverlapTable{
-                        .table = TableInfoReference{
-                            .table_info = table,
-                            .generation = level_a.generation,
-                        },
-                        .range = range,
-                    };
+            const table_a_optimal, const table_a_overlap_count = optimal: {
+                var optimal_table: ?*TableInfo = null;
+                var optimal_overlap: usize = max_overlapping_tables + 1;
+                var iterations: usize = 0;
+                defer {
+                    assert(iterations > 0);
+                    assert(iterations == level_a.table_count_visible or optimal_overlap == 0);
+                    assert(optimal_overlap <= max_overlapping_tables);
                 }
-                // If the table can be moved directly between levels then that is already optimal.
-                if (optimal.?.range.tables.empty()) break;
-            }
-            assert(iterations > 0);
-            assert(iterations == level_a.table_count_visible or
-                optimal.?.range.tables.empty());
 
-            return optimal.?;
+                while (iterator_a.next()) |table_a| {
+                    iterations += 1;
+
+                    // Advance `count_b_min`.
+                    while (maybe_table_b_min) |table_b_min| {
+                        if (table_b_min.key_max < table_a.key_min) {
+                            count_b_min += 1; // TODO move this to continuation.
+                            maybe_table_b_min = iterator_b_min.next();
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // Advance `count_b_max`.
+                    while (maybe_table_b_max) |table_b_max| {
+                        if (table_b_max.key_min <= table_a.key_max) {
+                            count_b_max += 1; // TODO move this to continuation.
+                            maybe_table_b_max = iterator_b_max.next();
+                        } else {
+                            break;
+                        }
+                    }
+
+                    const overlap = count_b_max - count_b_min;
+                    if (overlap > max_overlapping_tables) continue;
+
+                    if (overlap < optimal_overlap) {
+                        optimal_table = table_a;
+                        optimal_overlap = overlap;
+                    }
+
+                    // Zero overlap is already optimal.
+                    if (optimal_overlap == 0) break;
+                }
+                break :optimal .{ optimal_table.?, optimal_overlap };
+            };
+
+            // Retrieve the full OverlapRange for the chosen table.
+            const range = level_b.tables_overlapping_with_key_range(
+                table_a_optimal.key_min,
+                table_a_optimal.key_max,
+                snapshot,
+                max_overlapping_tables,
+            ).?;
+
+            assert(range.tables.count() == table_a_overlap_count);
+            assert(range.tables.count() <= max_overlapping_tables);
+
+            return LeastOverlapTable{
+                .table = TableInfoReference{
+                    .table_info = table_a_optimal,
+                    .generation = level_a.generation,
+                },
+                .range = range,
+            };
         }
 
         /// Returns the next table in the range, after `key_exclusive` if provided.

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -572,7 +572,7 @@ pub fn ManifestLevelType(
         ///
         /// * Exits early if it finds a table that doesn't overlap with any
         ///   tables in the second level.
-        /// * Tier breaking happens from left to right.
+        /// * Ties are resolved by smaller key and then smaller snapshot.
         pub fn table_with_least_overlap(
             level_a: *const ManifestLevel,
             level_b: *const ManifestLevel,
@@ -580,6 +580,7 @@ pub fn ManifestLevelType(
             max_overlapping_tables: usize,
         ) LeastOverlapTable {
             assert(max_overlapping_tables <= constants.lsm_growth_factor);
+            assert(level_a.table_count_visible > 0);
 
             const snapshots = [1]u64{snapshot};
 
@@ -589,31 +590,32 @@ pub fn ManifestLevelType(
             // the B pointers only move forward (monotonic), so total work
             // across all A-tables is O(n_b) for each pointer.
             //
-            // For each table_a, we maintain two counts into B:
+            // For each a_table, we maintain two counts into B:
             //
-            //   count_b_min: B-tables with key_max  < table_a.key_min  (left of A)
-            //   count_b_max: B-tables with key_min <= table_a.key_max  (started before A ends)
+            //   b_lower_count: B-tables with key_max  < a_table.key_min  (left of A)
+            //   b_upper_count: B-tables with key_min <= a_table.key_max  (started before A ends)
             //
-            //   overlap = count_b_max - count_b_min
+            //   overlap = b_upper_count - b_lower_count
             //
-            // Example: 4 B-tables, table_a overlaps B2 and B3:
-            //        Level A:               |= table_a ===|
+            // Example: 4 B-tables, a_table overlaps B2 and B3:
+            //        Level A:               |= a_table ===|
             //        Level B:  |=B0=| |=B1=| |==B2==| |==B3==|  |=B4=|
             //                  ├───────────┤              :
-            //                  count_b_min = 2            :
+            //                  b_lower_count = 2          :
             //                  (B0, B1 end before         :
-            //                   table_a starts)           :
+            //                   a_table starts)           :
             //                  ├──────────────────────────┤
-            //                  count_b_max = 4
-            //                  (B0, B1, B2, B3 start before table_a ends)
+            //                  b_upper_count = 4
+            //                  (B0, B1, B2, B3 start before a_table ends)
             //                  overlap = 4 - 2 = 2  (B2, B3)
-            var iterator_a = level_a.iterator(.visible, &snapshots, .ascending, null);
-            var iterator_b_min = level_b.iterator(.visible, &snapshots, .ascending, null);
-            var iterator_b_max = level_b.iterator(.visible, &snapshots, .ascending, null);
-            var count_b_min: usize = 0;
-            var count_b_max: usize = 0;
-            var maybe_table_b_min: ?*TableInfo = iterator_b_min.next();
-            var maybe_table_b_max: ?*TableInfo = iterator_b_max.next();
+            var a_iterator = level_a.iterator(.visible, &snapshots, .ascending, null);
+
+            var b_lower_iterator = level_b.iterator(.visible, &snapshots, .ascending, null);
+            var b_lower_count: usize = 0;
+            var b_lower: ?*TableInfo = b_lower_iterator.next();
+            var b_upper_iterator = level_b.iterator(.visible, &snapshots, .ascending, null);
+            var b_upper_count: usize = 0;
+            var b_upper: ?*TableInfo = b_upper_iterator.next();
 
             const table_a_optimal, const table_a_overlap_count = optimal: {
                 var optimal_table: ?*TableInfo = null;
@@ -625,39 +627,32 @@ pub fn ManifestLevelType(
                     assert(optimal_overlap <= max_overlapping_tables);
                 }
 
-                while (iterator_a.next()) |table_a| {
+                while (a_iterator.next()) |a_table| {
                     iterations += 1;
 
-                    // Advance `count_b_min`.
-                    while (maybe_table_b_min) |table_b_min| {
-                        if (table_b_min.key_max < table_a.key_min) {
-                            count_b_min += 1; // TODO move this to continuation.
-                            maybe_table_b_min = iterator_b_min.next();
-                        } else {
-                            break;
-                        }
+                    while (b_lower != null and b_lower.?.key_max < a_table.key_min) {
+                        b_lower_count += 1; // TODO move this to continuation.
+                        b_lower = b_lower_iterator.next();
                     }
+                    if (b_lower != null) assert(a_table.key_min <= b_lower.?.key_max);
 
-                    // Advance `count_b_max`.
-                    while (maybe_table_b_max) |table_b_max| {
-                        if (table_b_max.key_min <= table_a.key_max) {
-                            count_b_max += 1; // TODO move this to continuation.
-                            maybe_table_b_max = iterator_b_max.next();
-                        } else {
-                            break;
-                        }
+                    while (b_upper != null and b_upper.?.key_min <= a_table.key_max) {
+                        b_upper_count += 1; // TODO move this to continuation.
+                        b_upper = b_upper_iterator.next();
                     }
+                    if (b_upper != null) assert(a_table.key_max < b_upper.?.key_min);
 
-                    const overlap = count_b_max - count_b_min;
+                    const overlap = b_upper_count - b_lower_count;
+
                     if (overlap > max_overlapping_tables) continue;
-
-                    if (overlap < optimal_overlap) {
-                        optimal_table = table_a;
-                        optimal_overlap = overlap;
-                    }
 
                     // Zero overlap is already optimal.
                     if (optimal_overlap == 0) break;
+
+                    if (overlap < optimal_overlap) {
+                        optimal_table = a_table;
+                        optimal_overlap = overlap;
+                    }
                 }
                 break :optimal .{ optimal_table.?, optimal_overlap };
             };
@@ -1436,6 +1431,7 @@ test "fuzz: table_with_least_overlap" {
         level_a.insert_table(&pool_a, &second_valid);
 
         const expected = brute_force_least_overlap(&level_a, &level_b, max_overlap);
+
         const result = Level.table_with_least_overlap(
             &level_a,
             &level_b,

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -1318,6 +1318,159 @@ pub fn TestContextType(
         inline fn key_min_from_table(table: *const TableInfo) Key {
             return table.key_min;
         }
+
+        fn run_fuzz_overlap() !void {
+            const Level = TestContext.TestLevel;
+            const Pool = TestContext.TestPool;
+
+            const node_count = Level.Keys.node_count_max + Level.Tables.node_count_max;
+            const a_tables_max = 20;
+            const b_tables_max = a_tables_max * constants.lsm_growth_factor;
+
+            var prng = stdx.PRNG.from_seed_testing();
+
+            for (0..100) |_| {
+                var pool_a: Pool = undefined;
+                try pool_a.init(std.testing.allocator, node_count);
+                defer pool_a.deinit(std.testing.allocator);
+
+                var pool_b: Pool = undefined;
+                try pool_b.init(std.testing.allocator, node_count);
+                defer pool_b.deinit(std.testing.allocator);
+
+                var level_a: Level = undefined;
+                try level_a.init(std.testing.allocator, &pool_a);
+                defer level_a.deinit(std.testing.allocator, &pool_a);
+
+                var level_b: Level = undefined;
+                try level_b.init(std.testing.allocator, &pool_b);
+                defer level_b.deinit(std.testing.allocator, &pool_b);
+
+                const count_a = prng.range_inclusive(usize, 1, a_tables_max);
+                // Skew count_b <= count_a * growth_factor so that by the pigeonhole
+                // principle at least one A table has overlap <= growth_factor in most
+                // iterations. This mirrors the real LSM invariant.
+                const count_b = prng.int_inclusive(
+                    usize,
+                    count_a * constants.lsm_growth_factor,
+                );
+                const max_overlap = constants.lsm_growth_factor;
+
+                // Generate non-overlapping tables for level A.
+                var a_tables: [a_tables_max]TableInfo = undefined;
+                var key: u64 = prng.int_inclusive(u64, 500);
+                for (a_tables[0..count_a]) |*table| {
+                    key += prng.range_inclusive(u64, 1, 31);
+                    const key_min = key;
+                    key += prng.int_inclusive(u64, 32);
+                    table.* = random_table(key_min, key, &prng);
+                    level_a.insert_table(&pool_a, table);
+                }
+
+                // Generate non-overlapping tables for level B.
+                var b_tables: [b_tables_max]TableInfo = undefined;
+                key = prng.int_inclusive(u64, 500);
+                for (b_tables[0..count_b]) |*table| {
+                    key += prng.range_inclusive(u64, 1, 31);
+                    const key_min = key;
+                    key += prng.int_inclusive(u64, 32);
+                    table.* = random_table(key_min, key, &prng);
+                    level_b.insert_table(&pool_b, table);
+                }
+
+                const expected = brute_force_least_overlap(
+                    &level_a,
+                    &level_b,
+                    max_overlap,
+                );
+
+                const result = Level.table_with_least_overlap(
+                    &level_a,
+                    &level_b,
+                    lsm.snapshot_latest,
+                    max_overlap,
+                );
+
+                try std.testing.expectEqual(
+                    expected.table.key_min,
+                    result.table.table_info.key_min,
+                );
+                try std.testing.expectEqual(
+                    expected.table.key_max,
+                    result.table.table_info.key_max,
+                );
+                try std.testing.expectEqual(
+                    expected.b_tables.count(),
+                    result.range.tables.count(),
+                );
+                for (expected.b_tables.const_slice(), 0..) |expected_b, i| {
+                    const actual_b = result.range.tables.get(i).table_info;
+                    try std.testing.expectEqual(expected_b.key_min, actual_b.key_min);
+                    try std.testing.expectEqual(expected_b.key_max, actual_b.key_max);
+                }
+            }
+        }
+
+        const BruteForceLeastOverlapResult = struct {
+            table: *TableInfo,
+            b_tables: stdx.BoundedArrayType(
+                *TableInfo,
+                constants.lsm_growth_factor,
+            ),
+        };
+
+        fn brute_force_least_overlap(
+            level_a: *const TestLevel,
+            level_b: *const TestLevel,
+            max_overlap: usize,
+        ) BruteForceLeastOverlapResult {
+            const snapshots = [1]u64{lsm.snapshot_latest};
+            var best_table: ?*TableInfo = null;
+            var best_overlap: usize = math.maxInt(usize);
+            var best_b_tables: stdx.BoundedArrayType(*TableInfo, constants.lsm_growth_factor) = .{};
+
+            var it_a = level_a.iterator(.visible, &snapshots, .ascending, null);
+            while (it_a.next()) |table_a| {
+                var overlap: usize = 0;
+                var it_b = level_b.iterator(.visible, &snapshots, .ascending, null);
+                while (it_b.next()) |table_b| {
+                    if (table_b.key_max >= table_a.key_min and table_b.key_min <= table_a.key_max) {
+                        overlap += 1;
+                    }
+                }
+                if (overlap <= max_overlap and overlap < best_overlap) {
+                    best_table = table_a;
+                    best_overlap = overlap;
+                    best_b_tables.clear();
+
+                    var it_b2 = level_b.iterator(.visible, &snapshots, .ascending, null);
+                    while (it_b2.next()) |table_b| {
+                        if (table_b.key_max >= table_a.key_min and
+                            table_b.key_min <= table_a.key_max)
+                        {
+                            best_b_tables.push(table_b);
+                        }
+                    }
+                }
+                if (best_overlap == 0) break;
+            }
+            return .{ .table = best_table.?, .b_tables = best_b_tables };
+        }
+
+        fn random_table(
+            key_min: u64,
+            key_max: u64,
+            prng: *stdx.PRNG,
+        ) TableInfo {
+            return .{
+                .checksum = prng.int(u128),
+                .address = prng.int(u64),
+                .snapshot_min = 1,
+                .key_min = key_min,
+                .key_max = key_max,
+                .value_count = prng.int(u32),
+            };
+        }
     };
 }
 
@@ -1352,157 +1505,6 @@ test "ManifestLevel" {
     }
 }
 
-const BruteForceLeastOverlapResult = struct {
-    table: *TestContextType(256, u64, 1024).TableInfo,
-    b_tables: stdx.BoundedArrayType(
-        *TestContextType(256, u64, 1024).TableInfo,
-        constants.lsm_growth_factor,
-    ),
-};
-
 test "fuzz: table_with_least_overlap random levels" {
-    const TestContext = TestContextType(256, u64, 1024);
-    const Level = TestContext.TestLevel;
-    const Pool = TestContext.TestPool;
-    const TableInfo = TestContext.TableInfo;
-    const node_count = Level.Keys.node_count_max + Level.Tables.node_count_max;
-    const a_tables_max = 20;
-    const b_tables_max = a_tables_max * constants.lsm_growth_factor;
-
-    var prng = stdx.PRNG.from_seed_testing();
-
-    for (0..100) |_| {
-        var pool_a: Pool = undefined;
-        try pool_a.init(std.testing.allocator, node_count);
-        defer pool_a.deinit(std.testing.allocator);
-
-        var pool_b: Pool = undefined;
-        try pool_b.init(std.testing.allocator, node_count);
-        defer pool_b.deinit(std.testing.allocator);
-
-        var level_a: Level = undefined;
-        try level_a.init(std.testing.allocator, &pool_a);
-        defer level_a.deinit(std.testing.allocator, &pool_a);
-
-        var level_b: Level = undefined;
-        try level_b.init(std.testing.allocator, &pool_b);
-        defer level_b.deinit(std.testing.allocator, &pool_b);
-
-        const count_a = prng.range_inclusive(usize, 1, a_tables_max);
-        // Skew count_b <= count_a * growth_factor so that by the pigeonhole
-        // principle at least one A table has overlap <= growth_factor in most
-        // iterations. This mirrors the real LSM invariant.
-        const count_b = prng.int_inclusive(
-            usize,
-            count_a * constants.lsm_growth_factor,
-        );
-        const max_overlap = constants.lsm_growth_factor;
-
-        // Generate non-overlapping tables for level A.
-        var a_tables: [a_tables_max]TableInfo = undefined;
-        var key: u64 = prng.int_inclusive(u64, 500);
-        for (a_tables[0..count_a]) |*table| {
-            key += prng.range_inclusive(u64, 1, 31);
-            const key_min = key;
-            key += prng.int_inclusive(u64, 32);
-            table.* = random_table(key_min, key, &prng);
-            level_a.insert_table(&pool_a, table);
-        }
-
-        // Generate non-overlapping tables for level B.
-        var b_tables: [b_tables_max]TableInfo = undefined;
-        key = prng.int_inclusive(u64, 500);
-        for (b_tables[0..count_b]) |*table| {
-            key += prng.range_inclusive(u64, 1, 31);
-            const key_min = key;
-            key += prng.int_inclusive(u64, 32);
-            table.* = random_table(key_min, key, &prng);
-            level_b.insert_table(&pool_b, table);
-        }
-
-        const expected = brute_force_least_overlap(
-            &level_a,
-            &level_b,
-            max_overlap,
-        );
-
-        const result = Level.table_with_least_overlap(
-            &level_a,
-            &level_b,
-            lsm.snapshot_latest,
-            max_overlap,
-        );
-
-        try std.testing.expectEqual(
-            expected.table.key_min,
-            result.table.table_info.key_min,
-        );
-        try std.testing.expectEqual(
-            expected.table.key_max,
-            result.table.table_info.key_max,
-        );
-        try std.testing.expectEqual(
-            expected.b_tables.count(),
-            result.range.tables.count(),
-        );
-        for (expected.b_tables.const_slice(), 0..) |expected_b, i| {
-            const actual_b = result.range.tables.get(i).table_info;
-            try std.testing.expectEqual(expected_b.key_min, actual_b.key_min);
-            try std.testing.expectEqual(expected_b.key_max, actual_b.key_max);
-        }
-    }
-}
-
-fn brute_force_least_overlap(
-    level_a: *const TestContextType(256, u64, 1024).TestLevel,
-    level_b: *const TestContextType(256, u64, 1024).TestLevel,
-    max_overlap: usize,
-) BruteForceLeastOverlapResult {
-    const TableInfo = TestContextType(256, u64, 1024).TableInfo;
-    const snapshots = [1]u64{lsm.snapshot_latest};
-    var best_table: ?*TableInfo = null;
-    var best_overlap: usize = math.maxInt(usize);
-    var best_b_tables: stdx.BoundedArrayType(*TableInfo, constants.lsm_growth_factor) = .{};
-
-    var it_a = level_a.iterator(.visible, &snapshots, .ascending, null);
-    while (it_a.next()) |table_a| {
-        var overlap: usize = 0;
-        var it_b = level_b.iterator(.visible, &snapshots, .ascending, null);
-        while (it_b.next()) |table_b| {
-            if (table_b.key_max >= table_a.key_min and table_b.key_min <= table_a.key_max) {
-                overlap += 1;
-            }
-        }
-        if (overlap <= max_overlap and overlap < best_overlap) {
-            best_table = table_a;
-            best_overlap = overlap;
-            best_b_tables.clear();
-
-            var it_b2 = level_b.iterator(.visible, &snapshots, .ascending, null);
-            while (it_b2.next()) |table_b| {
-                if (table_b.key_max >= table_a.key_min and
-                    table_b.key_min <= table_a.key_max)
-                {
-                    best_b_tables.push(table_b);
-                }
-            }
-        }
-        if (best_overlap == 0) break;
-    }
-    return .{ .table = best_table.?, .b_tables = best_b_tables };
-}
-
-fn random_table(
-    key_min: u64,
-    key_max: u64,
-    prng: *stdx.PRNG,
-) TestContextType(256, u64, 1024).TableInfo {
-    return .{
-        .checksum = prng.int(u128),
-        .address = prng.int(u64),
-        .snapshot_min = 1,
-        .key_min = key_min,
-        .key_max = key_max,
-        .value_count = prng.int(u32),
-    };
+    try TestContextType(256, u64, 1024).run_fuzz_overlap();
 }

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -1359,6 +1359,7 @@ const BruteForceLeastOverlapResult = struct {
         constants.lsm_growth_factor,
     ),
 };
+
 test "fuzz: table_with_least_overlap random levels" {
     const TestContext = TestContextType(256, u64, 1024);
     const Level = TestContext.TestLevel;
@@ -1395,11 +1396,7 @@ test "fuzz: table_with_least_overlap random levels" {
             usize,
             count_a * constants.lsm_growth_factor,
         );
-        const max_overlap = prng.range_inclusive(
-            usize,
-            1,
-            constants.lsm_growth_factor,
-        );
+        const max_overlap = constants.lsm_growth_factor;
 
         // Generate non-overlapping tables for level A.
         var a_tables: [a_tables_max]TableInfo = undefined;
@@ -1423,14 +1420,11 @@ test "fuzz: table_with_least_overlap random levels" {
             level_b.insert_table(&pool_b, table);
         }
 
-        // Skip iterations where no A table has overlap <= max_overlap.
-        // With the pigeonhole skew above this is rare but can still happen
-        // since the levels are fully random.
         const expected = brute_force_least_overlap(
             &level_a,
             &level_b,
             max_overlap,
-        ) orelse continue;
+        );
 
         const result = Level.table_with_least_overlap(
             &level_a,
@@ -1463,7 +1457,7 @@ fn brute_force_least_overlap(
     level_a: *const TestContextType(256, u64, 1024).TestLevel,
     level_b: *const TestContextType(256, u64, 1024).TestLevel,
     max_overlap: usize,
-) ?BruteForceLeastOverlapResult {
+) BruteForceLeastOverlapResult {
     const TableInfo = TestContextType(256, u64, 1024).TableInfo;
     const snapshots = [1]u64{lsm.snapshot_latest};
     var best_table: ?*TableInfo = null;
@@ -1495,11 +1489,7 @@ fn brute_force_least_overlap(
         }
         if (best_overlap == 0) break;
     }
-
-    if (best_table) |table| {
-        return .{ .table = table, .b_tables = best_b_tables };
-    }
-    return null;
+    return .{ .table = best_table.?, .b_tables = best_b_tables };
 }
 
 fn random_table(


### PR DESCRIPTION
This PR optimizes the algorithm for selecting tables with the least overlap during compaction. 
The previous approach had sub-quadratic time complexity (`O(a * log b)`). The new implementation achieves linear time, reducing overhead as the number of tables grows ( `O(a + b)`).

The improvement becomes particularly noticeable in large-scale experiments (20TB+).

We plot the latency of the first beat, as this (and half bar) is where table selection occurs:

<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/b12f3ef1-623f-4946-999a-bd62694c4d40" />

One can clearly see that the old version (right plot) exhibits significantly higher latency and a steeper slope.

Here is the latency of the table selection isolated after 2.5e6 batches (i.e. 20 billion transactions)

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/d635cd7e-2902-40f1-bcd6-edda05355995" />
 