### PR TITLE
IO/Linux: Add another attempt to flock() retry loop

### DIFF
--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1618,7 +1618,7 @@ pub const IO = struct {
         // can see "another process holds the data file lock" errors, even though the process really
         // has terminated.
         const lock_acquired = blk: {
-            for (0..2) |_| {
+            for (0..3) |_| {
                 posix.flock(fd, posix.LOCK.EX | posix.LOCK.NB) catch |err| switch (err) {
                     error.WouldBlock => {
                         std.time.sleep(50 * std.time.ns_per_ms);


### PR DESCRIPTION
Vortex (via CFO) has been occasionally panicking at:

```
another process holds the data file lock
```

...when it kills and then restarts a replica in quick succession.

Since Vortex terminates replicas via `kill(SIGKILL)` then `waitpid()`, this is probably the same io_uring+flock scenario as described in https://github.com/tigerbeetle/tigerbeetle/pull/2578.

Add an extra `flock` retry, and we'll see if that solves it in CFO.