### PR TITLE
stdx: allow enums with custom parse_flag_value function

### DIFF
--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -353,9 +353,7 @@ fn parse_value(comptime T: type, flag: []const u8, value: [:0]const u8) T {
     if (V == []const u8 or V == [:0]const u8) return value;
     if (V == bool) return parse_value_bool(flag, value);
     if (@typeInfo(V) == .int) return parse_value_int(V, flag, value);
-    if (@typeInfo(V) == .@"enum") return parse_value_enum(V, flag, value);
     if (@hasDecl(V, "parse_flag_value")) {
-
         // Contracts:
         // - Input string is guaranteed to be not empty.
         // - Output diagnostic must point to statically-allocated data.
@@ -380,6 +378,7 @@ fn parse_value(comptime T: type, flag: []const u8, value: [:0]const u8) T {
             },
         }
     }
+    if (@typeInfo(V) == .@"enum") return parse_value_enum(V, flag, value);
     comptime unreachable;
 }
 


### PR DESCRIPTION
This is useful if you want to parse newtyped `const Spam = enum(u32) { _ }`.

So, check if `fn parse_flag_value` is defined first, before fallingback to normal name matching logic.