### PR TITLE
Remove slack references from README.md and search results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 * [Redesigning OLTP for a New Order of Magnitude (QCon SF)](https://www.infoq.com/presentations/redesign-oltp/)
   talk with a deeper dive into TigerBeetle’s local storage engine and global consensus protocol.
 * [TIGER_STYLE.md](./docs/TIGER_STYLE.md), the engineering methodology behind TigerBeetle.
-* [Slack](https://slack.tigerbeetle.com/join), say hello!
 
 ## Start
 

--- a/src/docs_website/src/html/search-results.html
+++ b/src/docs_website/src/html/search-results.html
@@ -5,8 +5,4 @@
           <source width="160" height="119" srcset="$url_prefix/img/notfound-dark.webp" media="(prefers-color-scheme: dark)">
           <img width="158" height="119" src="$url_prefix/img/notfound-light.webp" alt="Result not found illustration">
         </picture>
-        <p>
-          Still haven't found what you're looking for?<br>
-          <a href="https://slack.tigerbeetle.com/join">Ask the TigerBeetle Slack Community.</a>
-        </p>
       </div>


### PR DESCRIPTION
I'm open for suggestions for a nice caption under the search beetle, he looks a little lonely there without any text:

<img width="339" height="471" alt="Screenshot 2026-03-30 at 20 27 28" src="https://github.com/user-attachments/assets/133f70ce-7f1f-43c5-abac-9fd526ee4ead" />
