### PR TITLE
Client metric fixes

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -206,16 +206,16 @@ pub fn ContextType(
         } = .user;
 
         gpa: GPA,
-        time_os: TimeOS,
+        time_os: TimeOS = .{},
         client_id: u128,
         cluster_id: u128,
         addresses_owned: []const u8,
 
-        addresses: stdx.BoundedArrayType(std.net.Address, constants.replicas_max),
+        addresses: stdx.BoundedArrayType(std.net.Address, constants.replicas_max) = .{},
         io: IO,
         message_pool: MessagePool,
         client: Client,
-        batch_size_limit: ?u32,
+        batch_size_limit: ?u32 = null,
 
         completion_callback: CompletionCallback,
         completion_context: usize,
@@ -225,7 +225,7 @@ pub fn ContextType(
         pending: Packet.Queue,
 
         signal: Signal,
-        eviction_reason: ?vsr.Header.Eviction.Reason,
+        eviction_reason: ?vsr.Header.Eviction.Reason = null,
         thread: std.Thread,
 
         previous_request_instant: ?stdx.Instant = null,
@@ -263,12 +263,36 @@ pub fn ContextType(
             }
 
             const allocator = context.gpa.allocator();
-            context.client_id = stdx.unique_u128();
-            context.cluster_id = cluster_id;
+
+            context.* = .{
+                .gpa = context.gpa,
+
+                .client_id = stdx.unique_u128(),
+                .cluster_id = cluster_id,
+
+                .completion_callback = completion_callback,
+                .completion_context = completion_ctx,
+
+                .interface = client_out,
+                .submitted = Packet.Queue.init(.{
+                    .name = null,
+                    .verify_push = builtin.is_test,
+                }),
+                .pending = Packet.Queue.init(.{
+                    .name = null,
+                    .verify_push = builtin.is_test,
+                }),
+
+                .addresses_owned = undefined,
+                .io = undefined,
+                .message_pool = undefined,
+                .client = undefined,
+                .signal = undefined,
+                .thread = undefined,
+            };
             context.addresses_owned = try allocator.dupe(u8, addresses);
             errdefer allocator.free(context.addresses_owned);
 
-            context.time_os = .{};
             const time = context.time_os.time();
 
             log.debug("{}: init: parsing vsr addresses: {s}", .{ context.client_id, addresses });
@@ -345,24 +369,11 @@ pub fn ContextType(
                 .deinit_fn = &vtable_deinit_fn,
                 .init_parameters_fn = &vtable_init_parameters_fn,
             });
-            context.interface = client_out;
-            context.submitted = Packet.Queue.init(.{
-                .name = null,
-                .verify_push = builtin.is_test,
-            });
-            context.pending = Packet.Queue.init(.{
-                .name = null,
-                .verify_push = builtin.is_test,
-            });
-            context.completion_context = completion_ctx;
-            context.completion_callback = completion_callback;
-            context.eviction_reason = null;
 
             log.debug("{}: init: initializing signal", .{context.client_id});
             try context.signal.init(&context.io, Context.signal_notify_callback);
             errdefer context.signal.deinit();
 
-            context.batch_size_limit = null;
             context.client.register(client_register_callback, @intFromPtr(context));
 
             log.debug("{}: init: spawning thread", .{context.client_id});

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -723,7 +723,7 @@ pub fn ContextType(
                 .operation = operation.to_vsr(),
                 .size = @sizeOf(vsr.Header) + request_size,
                 .previous_request_latency = @intCast(@min(
-                    previous_request_latency.ns,
+                    previous_request_latency.to_us(),
                     std.math.maxInt(u32),
                 )),
             };

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -228,7 +228,7 @@ pub fn ContextType(
         eviction_reason: ?vsr.Header.Eviction.Reason = null,
         thread: std.Thread,
 
-        previous_request_instant: ?stdx.Instant = null,
+        previous_request_instant: stdx.Instant,
         previous_request_latency: ?stdx.Duration = null,
 
         pub fn init(
@@ -289,6 +289,7 @@ pub fn ContextType(
                 .client = undefined,
                 .signal = undefined,
                 .thread = undefined,
+                .previous_request_instant = undefined,
             };
             context.addresses_owned = try allocator.dupe(u8, addresses);
             errdefer allocator.free(context.addresses_owned);
@@ -374,6 +375,7 @@ pub fn ContextType(
             try context.signal.init(&context.io, Context.signal_notify_callback);
             errdefer context.signal.deinit();
 
+            context.previous_request_instant = context.client.time.monotonic();
             context.client.register(client_register_callback, @intFromPtr(context));
 
             log.debug("{}: init: spawning thread", .{context.client_id});
@@ -726,8 +728,6 @@ pub fn ContextType(
                 )),
             };
 
-            assert((self.previous_request_instant == null) ==
-                (self.previous_request_latency == null));
             self.previous_request_instant = .{ .ns = packet_list.multi_batch_time_monotonic };
 
             packet_list.phase = .sent;
@@ -799,6 +799,10 @@ pub fn ContextType(
             assert(self.batch_size_limit == null);
             assert(result.batch_size_limit > 0);
 
+            const current_timestamp = self.client.time.monotonic();
+            self.previous_request_latency =
+                current_timestamp.duration_since(self.previous_request_instant);
+
             // The client might have a smaller message size limit.
             maybe(constants.message_body_size_max < result.batch_size_limit);
             self.batch_size_limit = @min(result.batch_size_limit, constants.message_body_size_max);
@@ -853,7 +857,7 @@ pub fn ContextType(
 
             const current_timestamp = self.client.time.monotonic();
             self.previous_request_latency =
-                current_timestamp.duration_since(self.previous_request_instant.?);
+                current_timestamp.duration_since(self.previous_request_instant);
 
             // Submit the next pending packet (if any) now that VSR has completed this one.
             assert(self.client.request_inflight == null);

--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -26,6 +26,10 @@ pub const Instant = struct {
 pub const Duration = struct {
     ns: u64,
 
+    pub fn us(amount_us: u64) Duration {
+        return .{ .ns = amount_us * std.time.ns_per_us };
+    }
+
     pub fn ms(amount_ms: u64) Duration {
         return .{ .ns = amount_ms * std.time.ns_per_ms };
     }

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -612,9 +612,9 @@ pub const Header = extern struct {
         request: u32,
         operation: Operation,
         previous_request_latency_padding: [3]u8 = @splat(0),
-        /// Nanosecond interval measuring the time between when the client first began to construct
-        /// the previous request's body and the time that the client received the corresponding
-        /// reply.
+        /// Microsecond (0.17.0+) / Nanosecond interval measuring the time between when the client
+        /// first began to construct the previous request's body and the time that the client
+        /// received the corresponding reply.
         previous_request_latency: u32,
         reserved: [52]u8 = @splat(0),
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7237,9 +7237,23 @@ pub fn ReplicaType(
                     if (session_entry) |entry| {
                         const operation = entry.header.operation;
 
+                        // Starting from 0.17.0, the previous_request_latency field encodes
+                        // microseconds and not nanoseconds.
+                        const release_duration_us = vsr.Release.from(.{
+                            .major = 0,
+                            .minor = 17,
+                            .patch = 0,
+                        });
+
+                        const duration = if (request.message.header.release.value <
+                            release_duration_us.value)
+                            stdx.Duration{ .ns = request.message.header.previous_request_latency }
+                        else
+                            Duration.us(request.message.header.previous_request_latency);
+
                         self.trace.timing(
                             .{ .client_request_round_trip = .from(operation) },
-                            .{ .ns = request.message.header.previous_request_latency },
+                            duration,
                         );
                     }
                 }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7228,15 +7228,20 @@ pub fn ReplicaType(
                 request.message.header.checksum,
                 request.message.header.client,
             });
+
             if (request.message.header.previous_request_latency != 0) {
                 if (StateMachine.Operation == @import("../tigerbeetle.zig").Operation and
                     self.status == .normal)
                 {
-                    const operation = request.message.header.operation;
-                    self.trace.timing(
-                        .{ .client_request_round_trip = .from(operation) },
-                        .{ .ns = request.message.header.previous_request_latency },
-                    );
+                    const session_entry = self.client_sessions.get(request.message.header.client);
+                    if (session_entry) |entry| {
+                        const operation = entry.header.operation;
+
+                        self.trace.timing(
+                            .{ .client_request_round_trip = .from(operation) },
+                            .{ .ns = request.message.header.previous_request_latency },
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
This fixes 3 issues with our client based metrics:

- The first request will always have a `intMax(u32)` latency, due to a bug in initialization of the `Context` struct.
- The operation that gets timed will be incorrect, since the replica logs the current operation with the previous latency.
- Nanosecond resolution is used, but with a `u32`, that caps out at ~4 seconds which is a value that could be exceeded in normal(ish!) operation.

Best reviewed per commit.