### PR TITLE
vsr: jitter repair timeouts

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -754,6 +754,22 @@ pub const Timeout = struct {
         log.debug("{}: {s} reset", .{ self.id, self.name });
     }
 
+    pub fn reset_with_jitter(self: *Timeout, prng: *stdx.PRNG) void {
+        self.attempts = 0;
+        self.ticks = 0;
+        assert(self.ticking);
+
+        // Uniformly between [0.5 * timeout, 1.5 * timeout].
+        self.after_dynamic = prng.range_inclusive(
+            u64,
+            @divTrunc(self.after, 2),
+            @divTrunc(self.after, 2) + self.after,
+        );
+        assert(self.after_dynamic.? > 0);
+
+        log.debug("{}: {s} reset", .{ self.id, self.name });
+    }
+
     /// Sets the value of `after` as a function of `rtt` and `attempts`.
     /// Adds exponential backoff and jitter.
     /// May be called only after a timeout has been stopped or reset, to prevent backward jumps.

--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -20,7 +20,7 @@ pub const RepairBudgetJournal = struct {
     //
     // Repair latency is calculated as the duration elapsed between when a prepare is requested from
     // a remote replica, and when it is either received from the remote replica (see `decrement`),
-    // or expired (see `maybe_expire_requested_prepares`).
+    // or expired (see `reap_expired_requests`).
     replicas_repair_latency: []stdx.Duration,
 
     // Probability of choosing a random replica with available budget, as opposed to one with the
@@ -214,10 +214,11 @@ pub const RepairBudgetJournal = struct {
     /// remote replica crashing doesn't cause an op to get stuck in the queue for a remote replica.
     /// We avoid spurious expiry due to transient network hiccups like increased latency by waiting
     /// for twice the measured repair latency.
-    pub fn maybe_expire_requested_prepares(budget: *RepairBudgetJournal, now: stdx.Instant) void {
+    pub fn reap_expired_requests(budget: *RepairBudgetJournal, now: stdx.Instant) bool {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
+        const budget_before = budget.available;
         for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
             var requested_prepares_index: u32 = 0;
 
@@ -241,6 +242,7 @@ pub const RepairBudgetJournal = struct {
                 }
             }
         }
+        return budget.available > budget_before;
     }
 
     fn assert_invariants(budget: *const RepairBudgetJournal) void {
@@ -443,10 +445,11 @@ pub const RepairBudgetGrid = struct {
         }
     }
 
-    pub fn maybe_expire_requested_blocks(budget: *RepairBudgetGrid, now: stdx.Instant) void {
+    pub fn reap_expired_requests(budget: *RepairBudgetGrid, now: stdx.Instant) bool {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
+        const budget_before = budget.available;
         for (budget.replicas_requested_blocks) |*requested_blocks| {
             var requested_blocks_index: u32 = 0;
 
@@ -462,5 +465,6 @@ pub const RepairBudgetGrid = struct {
                 }
             }
         }
+        return budget.available > budget_before;
     }
 };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3773,12 +3773,20 @@ pub fn ReplicaType(
             assert(self.status != .recovering);
 
             self.repair_budget_timeout.reset();
-            self.journal_repair_message_budget.maybe_expire_requested_prepares(
-                self.clock.monotonic(),
-            );
-            self.grid_repair_message_budget.maybe_expire_requested_blocks(
-                self.clock.monotonic(),
-            );
+
+            if (self.journal_repair_message_budget.reap_expired_requests(self.clock.monotonic())) {
+                self.repair();
+            }
+
+            if (self.grid_repair_message_budget.reap_expired_requests(self.clock.monotonic())) {
+                if (self.grid.callback != .cancel) {
+                    if (self.grid_repair_message_budget
+                        .next_destination(&self.prng)) |replica_index|
+                    {
+                        self.send_request_blocks(replica_index);
+                    }
+                }
+            }
         }
 
         fn on_journal_repair_timeout(self: *Replica) void {

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3783,7 +3783,7 @@ pub fn ReplicaType(
 
         fn on_journal_repair_timeout(self: *Replica) void {
             assert(self.status == .normal or self.status == .view_change);
-            self.journal_repair_timeout.reset();
+            self.journal_repair_timeout.reset_with_jitter(&self.prng);
 
             self.repair();
         }
@@ -3828,7 +3828,7 @@ pub fn ReplicaType(
             assert(self.grid_repair_timeout.ticking);
             maybe(self.state_machine_opened);
 
-            self.grid_repair_timeout.reset();
+            self.grid_repair_timeout.reset_with_jitter(&self.prng);
 
             if (self.grid.callback != .cancel) {
                 if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
@@ -10567,11 +10567,11 @@ pub fn ReplicaType(
             // order to start committing again.
             self.journal_repair_message_budget.refill();
             if (self.journal_repair_timeout.ticking) {
-                self.journal_repair_timeout.reset();
+                self.journal_repair_timeout.reset_with_jitter(&self.prng);
             }
 
             self.grid_repair_message_budget.refill();
-            self.grid_repair_timeout.reset();
+            self.grid_repair_timeout.reset_with_jitter(&self.prng);
 
             log.info("{}: sync: ops={}..{}/{}..{}", .{
                 self.log_prefix(),

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2065,12 +2065,15 @@ test "Cluster: backups prepare past prepare_max if the next checkpoint is durabl
     const b1 = t.replica(.B1);
     const b2 = t.replica(.B2);
 
-    b2.drop(.R_, .incoming, .start_view);
     const b2_replica = &t.cluster.replicas[b2.replicas.get(0)];
 
-    // Stall commit pipeline on b2, forcing it to accept prepares but advance its checkpoint past 0.
-    // Meanwhile, the rest of the cluster moves to checkpoint=checkpoint_2.
-    b2_replica.commit_stage = .compact;
+    // Stall commit pipeline on b2, forcing it to accept prepares
+    // but not advance its checkpoint past 0. Meanwhile, the rest
+    // of the cluster moves to checkpoint=checkpoint_2. Setting the
+    // stage to checkpoint_superblock also ensures that if we receive
+    // any start_view message from the primary, we don't use it to
+    // start state sync (see `on_start_view_set_checkpoint`).
+    b2_replica.commit_stage = .checkpoint_superblock;
 
     try c.request(checkpoint_2_prepare_max, checkpoint_2_prepare_max);
 
@@ -2079,24 +2082,26 @@ test "Cluster: backups prepare past prepare_max if the next checkpoint is durabl
     try expectEqual(a0.op_head(), checkpoint_2_prepare_max);
     try expectEqual(b1.op_head(), checkpoint_2_prepare_max);
 
-    // Since checkpoint_1 is durable on a0, b1 (a commit quorum of replicas), b2 is able to accept
-    // some prepares from the next checkpoint, overwriting some of its committed prepares.
-    // However, even though ops [checkpoint_1, checkpoint_1_trigger - 1] are committed on b2,
-    // they are not overwritten as they are required during checkpointing & upgrade.
+    // Since checkpoint_1 is durable on a0, b1 (a commit quorum of
+    // replicas), b2 is able to accept some prepares from the next
+    // checkpoint, overwriting some of its committed prepares.
+    // However, even though ops [checkpoint_1, checkpoint_1_trigger - 1]
+    // are committed on b2, they are not overwritten as they are
+    // required during checkpointing & upgrade.
     try expectEqual(b2.op_head(), checkpoint_1 + constants.journal_slot_count - 1);
 
     try expectEqual(a0.op_checkpoint(), checkpoint_2);
     try expectEqual(b1.op_checkpoint(), checkpoint_2);
     try expectEqual(b2.op_checkpoint(), 0);
 
-    // b2 crashes and restarts, and truncates all prepares that past checkpoint_1_prepare_max,
-    // since all prepares in checkpoint=0 must be replayed after restart.
+    // b2 crashes and restarts, and truncates all prepares that past
+    // checkpoint_1_prepare_max, since all prepares in checkpoint=0
+    // must be replayed after restart.
     b2.stop();
     try b2.open();
 
     try expectEqual(b2.op_head(), checkpoint_1_prepare_max);
 
-    b2.pass(.R_, .incoming, .start_view);
     t.run();
 
     try expectEqual(t.replica(.R_).op_head(), checkpoint_2_prepare_max);


### PR DESCRIPTION
Best reviewed commit-by-commit as the second commit is an orthogonal improvement.

---

The VOPR recently found a resonance during liveness mode in a solo cluster with two standbys, where:

* R0 and R2 are in the core, R1 asymmetrically partitioned
* R1 and R2 try to request their missing prepares
* R0 always processes R1's request, drops R2's request
* R0 is not able to send through the prepare to R1, due to asymmetric partition
* Repeats over & over

Due to this, R2 is not able to repair a prepare that R1 has.

One of the root causes here is PR #3415, which significantly reduced
network and storage latency jitter during liveness mode. In an exponential
distribution with with these parameters, we get 1ms latencies with ~86% probability:

```C
    network.packet_simulator.options.one_way_delay_min = .ms(1);
    network.packet_simulator.options.one_way_delay_mean = .ms(1);
```

However, instead of tweaking these parameters, and implicitly relying on
network/storage-level jitters, we decided to inject jitter at the protocol-level,
for the grid repair & journal repair timeouts. Consequently, this commit jitters
those two timeouts, randomly choosing a value between [0.5T, 1.5T].

Seed: ./zig/zig build vopr -Drelease -Dvopr-state-machine=testing -- 10804441512568862577