### PR TITLE
[Go] Make the API more idiomatic using `*big.Int`

### DIFF
--- a/docs/coding/api-changes.md
+++ b/docs/coding/api-changes.md
@@ -280,6 +280,14 @@ The TigerBeetle Go Client `0.17.0` introduced the following breaking changes:
   The `Err` types were removed in favor of simple value declarations for error codes,
   allowing the use of idiomatic constructions such as `errors.Is(err, ErrTooMuchData)`.
 
+- Conversions between `UInt128` and `big.Int` now return and accept a pointer to a big integer
+  `*big.Int`, making the API more idiomatic.
+
+  |Type      |Before                                  | After                                   |
+  |----------|----------------------------------------|-----------------------------------------|
+  |Function  |`BigInt() big.Int`                      |`BigInt() *big.Int`                      |
+  |Function  |`BigIntToUint128(value big.Int) Uint128`|`BigIntToUint128(value *big.Int) Uint128`|
+
 ### Example:
 
 Before:

--- a/src/clients/go/tb_client_test.go
+++ b/src/clients/go/tb_client_test.go
@@ -132,7 +132,7 @@ func doTestClient(t *testing.T, client Client) {
 			0xb2, 0xb1,
 			0xa4, 0xa3, 0xa2, 0xa1,
 		}
-		decimal, ok := big.NewInt(0).SetString("214850178493633095719753766415838275046", 10)
+		decimal, ok := new(big.Int).SetString("214850178493633095719753766415838275046", 10)
 		if !ok {
 			t.Fatal()
 		}
@@ -140,8 +140,12 @@ func doTestClient(t *testing.T, client Client) {
 		u128 := BytesToUint128(binary)
 
 		assert.Equal(t, u128.Bytes(), binary)
-		assert.Equal(t, u128.BigInt(), *decimal)
-		assert.Equal(t, BigIntToUint128(*decimal).Bytes(), u128.Bytes())
+		assert.Equal(t, u128.BigInt(), decimal)
+		assert.Equal(t, BigIntToUint128(decimal).Bytes(), u128.Bytes())
+
+		lo, hi := u128.Uint64()
+		assert.True(t, lo == 15119395263638463974)
+		assert.True(t, hi == 11647051514084770242)
 	})
 
 	t.Run("can create accounts", func(t *testing.T) {
@@ -436,8 +440,8 @@ func doTestClient(t *testing.T, client Client) {
 
 		// Each transfer moves ONE unit,
 		// so the credit/debit must differ from TRANSFERS_MAX units:
-		assert.Equal(t, TASKS_MAX/2, big.NewInt(0).Sub(&accountACreditsAfter, &accountACredits).Int64())
-		assert.Equal(t, TASKS_MAX/2, big.NewInt(0).Sub(&accountBDebitsAfter, &accountBDebits).Int64())
+		assert.Equal(t, TASKS_MAX/2, big.NewInt(0).Sub(accountACreditsAfter, accountACredits).Int64())
+		assert.Equal(t, TASKS_MAX/2, big.NewInt(0).Sub(accountBDebitsAfter, accountBDebits).Int64())
 	})
 
 	t.Run("can create concurrent linked chains", func(t *testing.T) {

--- a/src/clients/go/uint128.go
+++ b/src/clients/go/uint128.go
@@ -42,14 +42,21 @@ func (value Uint128) String() string {
 	return s[lastNonZero:]
 }
 
-func (value Uint128) BigInt() big.Int {
+func (value Uint128) BigInt() *big.Int {
 	// big.Int uses bytes in big-endian but Uint128 stores bytes in little endian, so reverse it.
 	bytes := value.Bytes()
 	swapEndian(bytes[:])
 
 	ret := big.Int{}
 	ret.SetBytes(bytes[:])
-	return ret
+	return &ret
+}
+
+// Returns two 64-bit integers representing the least significant (first 8 bytes) value
+// and the most significant (last 8 bytes) value of the 128-bit integer.
+func (value Uint128) Uint64() (uint64, uint64) {
+	parts := (*[2]uint64)(unsafe.Pointer(&value))
+	return parts[0], parts[1]
 }
 
 // BytesToUint128 converts a raw [16]byte value to Uint128.
@@ -82,7 +89,7 @@ func HexStringToUint128(value string) (Uint128, error) {
 }
 
 // BigIntToUint128 converts a [math/big.Int] to a Uint128.
-func BigIntToUint128(value big.Int) Uint128 {
+func BigIntToUint128(value *big.Int) Uint128 {
 	if value.Sign() < 0 {
 		panic("cannot convert negative big.Int to Uint128")
 	}

--- a/src/clients/go/uint128_test.go
+++ b/src/clients/go/uint128_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/tigerbeetle/tigerbeetle-go/assert"
 )
 
 func Test_HexStringToUint128(t *testing.T) {
@@ -71,10 +73,22 @@ func Test_BigIntToUint128(t *testing.T) {
 	}
 }
 
+func Test_ToUint64(t *testing.T) {
+	zero := ToUint128(0)
+	lo, hi := zero.Uint64()
+	assert.True(t, lo == 0)
+	assert.True(t, hi == 0)
+
+	maxUint64 := ToUint128(^uint64(0))
+	lo, hi = maxUint64.Uint64()
+	assert.True(t, lo == ^uint64(0))
+	assert.True(t, hi == 0)
+}
+
 func Test_BigIntToUint128_Negative(t *testing.T) {
 	negative := new(big.Int).SetInt64(-1)
 	testFunc := func() {
-		BigIntToUint128(*negative)
+		BigIntToUint128(negative)
 	}
 
 	defer func() {
@@ -100,7 +114,7 @@ func Test_ID(t *testing.T) {
 			// Verify idB and idA are monotonic using BigInts.
 			a := idA.BigInt()
 			b := idB.BigInt()
-			if b.Cmp(&a) != 1 {
+			if b.Cmp(a) != 1 {
 				t.Fatalf("Expected ID %v to be greater than ID %v", b, a)
 			}
 


### PR DESCRIPTION
Make the Go Client API more idiomatic using `*big.Int` instead of `big.Int`.

Despite the best intentions of the previous API not to allocate memory, many languages (including Go) expect dynamic allocation for `BigInteger`s.

Related #3473