### PR TITLE
vsr: fix repair timeout jitter neutralized by repair_budget_timeout

### DIFF
--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -4,6 +4,8 @@ const constants = @import("../constants.zig");
 
 const vsr = @import("../vsr.zig");
 const stdx = @import("stdx");
+const maybe = stdx.maybe;
+
 const ratio = stdx.PRNG.ratio;
 const Ratio = stdx.PRNG.Ratio;
 
@@ -107,18 +109,19 @@ pub const RepairBudgetJournal = struct {
     /// one exists. Otherwise, returns null. For a fraction of ops (guided by `experiment_chance`),
     /// diverges from this heuristic and returns the index of a random replica with budget
     /// availability, using reservoir sampling.
-    pub fn decrement(budget: *RepairBudgetJournal, options: struct {
+    pub fn decrement(
+        budget: *RepairBudgetJournal,
         op: u64,
         now: stdx.Instant,
         prng: *stdx.PRNG,
-    }) ?u8 {
+    ) ?u8 {
         assert(budget.capacity > 0);
-        assert(budget.available > 0);
+        maybe(budget.available == 0);
 
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        const experiment = options.prng.chance(budget.experiment_chance);
+        const experiment = prng.chance(budget.experiment_chance);
         var experiment_replica_index: ?u8 = null;
         var reservoir = stdx.PRNG.Reservoir.init();
 
@@ -131,7 +134,7 @@ pub const RepairBudgetJournal = struct {
             // Enforce per-replica budget.
             if (requested_prepares.count() == repair_messages_inflight_count_max) continue;
             // Disallow requesting from a replica from which this op has already been requested.
-            if (requested_prepares.get(options.op) != null) continue;
+            if (requested_prepares.get(op) != null) continue;
 
             const replica_repair_latency = budget.replicas_repair_latency[replica_index];
 
@@ -142,7 +145,7 @@ pub const RepairBudgetJournal = struct {
 
             // Reservoir sampling with an arbitrarily chosen weight of 1 for each item suffices
             // our use case, as the goal is to get some degree of randomness during experiments.
-            if (reservoir.replace(options.prng, 1)) {
+            if (reservoir.replace(prng, 1)) {
                 experiment_replica_index = @intCast(replica_index);
             }
         }
@@ -156,11 +159,7 @@ pub const RepairBudgetJournal = struct {
 
         if (replica_index_maybe) |replica_index| {
             assert(replica_index != budget.replica_index);
-            budget.replicas_requested_prepares[replica_index].putAssumeCapacityNoClobber(
-                options.op,
-                options.now,
-            );
-
+            budget.replicas_requested_prepares[replica_index].putAssumeCapacityNoClobber(op, now);
             budget.available -= 1;
         }
 
@@ -169,15 +168,12 @@ pub const RepairBudgetJournal = struct {
 
     /// Increments the budget by 1 for each replica that this prepare op has been requested from.
     /// Also refines the repair latency for each of these replicas.
-    pub fn increment(budget: *RepairBudgetJournal, options: struct {
-        op: u64,
-        now: stdx.Instant,
-    }) void {
+    pub fn increment(budget: *RepairBudgetJournal, op: u64, now: stdx.Instant) void {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
         for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
-            if (requested_prepares.fetchSwapRemove(options.op)) |requested_prepare| {
+            if (requested_prepares.fetchSwapRemove(op)) |requested_prepare| {
                 budget.available += 1;
 
                 // We have no information about the replica that sent this prepare, as the message
@@ -190,7 +186,7 @@ pub const RepairBudgetJournal = struct {
                 // to a new checkpoint), in which case we request a unique op from each replica.
                 budget.replicas_repair_latency[replica_index] = ewma_add_duration(
                     budget.replicas_repair_latency[replica_index],
-                    options.now.duration_since(requested_prepare.value),
+                    now.duration_since(requested_prepare.value),
                 );
             }
         }
@@ -214,11 +210,10 @@ pub const RepairBudgetJournal = struct {
     /// remote replica crashing doesn't cause an op to get stuck in the queue for a remote replica.
     /// We avoid spurious expiry due to transient network hiccups like increased latency by waiting
     /// for twice the measured repair latency.
-    pub fn reap_expired_requests(budget: *RepairBudgetJournal, now: stdx.Instant) bool {
+    pub fn reap_expired_requests(budget: *RepairBudgetJournal, now: stdx.Instant) void {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        const budget_before = budget.available;
         for (budget.replicas_requested_prepares, 0..) |*requested_prepares, replica_index| {
             var requested_prepares_index: u32 = 0;
 
@@ -242,7 +237,6 @@ pub const RepairBudgetJournal = struct {
                 }
             }
         }
-        return budget.available > budget_before;
     }
 
     fn assert_invariants(budget: *const RepairBudgetJournal) void {
@@ -346,6 +340,7 @@ pub const RepairBudgetGrid = struct {
 
     pub fn next_destination(budget: *RepairBudgetGrid, prng: *stdx.PRNG) ?u8 {
         budget.assert_invariants();
+        defer budget.assert_invariants();
 
         const replica_count = budget.replicas_requested_blocks.len;
         var replica_indexes: [constants.replicas_max]u8 = undefined;
@@ -362,7 +357,7 @@ pub const RepairBudgetGrid = struct {
         return null;
     }
 
-    pub fn budget_available(budget: *RepairBudgetGrid, replica_index: u8) u32 {
+    pub fn budget_available(budget: *const RepairBudgetGrid, replica_index: u8) u32 {
         budget.assert_invariants();
 
         assert(budget.replica_index != replica_index);
@@ -372,24 +367,25 @@ pub const RepairBudgetGrid = struct {
         return @intCast(replica_blocks_requested_max - replica_requested_blocks.count());
     }
 
-    pub fn decrement(budget: *RepairBudgetGrid, options: struct {
+    pub fn decrement(
+        budget: *RepairBudgetGrid,
         block_identifier: vsr.BlockReference,
         replica_index: u8,
         now: stdx.Instant,
-    }) bool {
+    ) bool {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
         assert(budget.available > 0);
-        assert(options.block_identifier.address > 0);
-        assert(options.replica_index != budget.replica_index);
+        assert(block_identifier.address > 0);
+        assert(replica_index != budget.replica_index);
 
         var duration_since_requested_min: ?stdx.Duration = null;
 
-        for (budget.replicas_requested_blocks, 0..) |requested_blocks, replica_index| {
-            if (requested_blocks.get(options.block_identifier)) |requested_at| {
-                assert(replica_index != budget.replica_index);
-                const duration_since_requested = options.now.duration_since(requested_at);
+        for (budget.replicas_requested_blocks, 0..) |requested_blocks, index| {
+            if (requested_blocks.get(block_identifier)) |requested_at| {
+                assert(index != budget.replica_index);
+                const duration_since_requested = now.duration_since(requested_at);
                 if (duration_since_requested_min == null or
                     duration_since_requested.ns < duration_since_requested_min.?.ns)
                 {
@@ -403,12 +399,12 @@ pub const RepairBudgetGrid = struct {
         }
 
         var replica_requested_blocks =
-            &budget.replicas_requested_blocks[options.replica_index];
+            &budget.replicas_requested_blocks[replica_index];
 
         assert(replica_requested_blocks.count() < replica_blocks_requested_max);
 
-        const gop = replica_requested_blocks.getOrPutAssumeCapacity(options.block_identifier);
-        gop.value_ptr.* = options.now;
+        const gop = replica_requested_blocks.getOrPutAssumeCapacity(block_identifier);
+        gop.value_ptr.* = now;
 
         if (!gop.found_existing) budget.available -= 1;
 
@@ -445,11 +441,10 @@ pub const RepairBudgetGrid = struct {
         }
     }
 
-    pub fn reap_expired_requests(budget: *RepairBudgetGrid, now: stdx.Instant) bool {
+    pub fn reap_expired_requests(budget: *RepairBudgetGrid, now: stdx.Instant) void {
         budget.assert_invariants();
         defer budget.assert_invariants();
 
-        const budget_before = budget.available;
         for (budget.replicas_requested_blocks) |*requested_blocks| {
             var requested_blocks_index: u32 = 0;
 
@@ -465,6 +460,5 @@ pub const RepairBudgetGrid = struct {
                 }
             }
         }
-        return budget.available > budget_before;
     }
 };

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -566,11 +566,6 @@ pub fn ReplicaType(
         /// (status=view-change backup)
         request_start_view_message_timeout: Timeout,
 
-        /// The number of ticks before peeking into the journal/block repair budget and expiring
-        /// prepare/block requests that haven't been responded to.
-        /// (status=normal or status=view-change or status=recovering_head).
-        repair_budget_timeout: Timeout,
-
         /// The number of ticks before repairing missing/disconnected headers, dirty/missing
         /// prepares, and replenishing the repair budget.
         /// (status=normal or (status=view-change and primary)).
@@ -1387,11 +1382,6 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 1_000 / constants.tick_ms,
                 },
-                .repair_budget_timeout = Timeout{
-                    .name = "repair_budget_timeout",
-                    .id = replica_index,
-                    .after = 20 / constants.tick_ms,
-                },
                 .journal_repair_timeout = Timeout{
                     .name = "journal_repair_timeout",
                     .id = replica_index,
@@ -1552,7 +1542,6 @@ pub fn ReplicaType(
                     &self.request_start_view_message_timeout,
                     on_request_start_view_message_timeout,
                 },
-                .{ &self.repair_budget_timeout, on_repair_budget_timeout },
                 .{ &self.journal_repair_timeout, on_journal_repair_timeout },
 
                 .{ &self.repair_sync_timeout, on_repair_sync_timeout },
@@ -2516,10 +2505,10 @@ pub fn ReplicaType(
             if (self.repair_header(message.header) and self.write_prepare(message)) {
                 assert(self.journal.has_dirty(message.header));
 
-                self.journal_repair_message_budget.increment(.{
-                    .op = message.header.op,
-                    .now = self.clock.monotonic(),
-                });
+                self.journal_repair_message_budget.increment(
+                    message.header.op,
+                    self.clock.monotonic(),
+                );
 
                 log.debug("{}: on_repair: repairing journal op={}", .{
                     self.log_prefix(),
@@ -3769,30 +3758,11 @@ pub fn ReplicaType(
             );
         }
 
-        fn on_repair_budget_timeout(self: *Replica) void {
-            assert(self.status != .recovering);
-
-            self.repair_budget_timeout.reset();
-
-            if (self.journal_repair_message_budget.reap_expired_requests(self.clock.monotonic())) {
-                self.repair();
-            }
-
-            if (self.grid_repair_message_budget.reap_expired_requests(self.clock.monotonic())) {
-                if (self.grid.callback != .cancel) {
-                    if (self.grid_repair_message_budget
-                        .next_destination(&self.prng)) |replica_index|
-                    {
-                        self.send_request_blocks(replica_index);
-                    }
-                }
-            }
-        }
-
         fn on_journal_repair_timeout(self: *Replica) void {
             assert(self.status == .normal or self.status == .view_change);
-            self.journal_repair_timeout.reset_with_jitter(&self.prng);
 
+            self.journal_repair_timeout.reset_with_jitter(&self.prng);
+            self.journal_repair_message_budget.reap_expired_requests(self.clock.monotonic());
             self.repair();
         }
 
@@ -3837,6 +3807,7 @@ pub fn ReplicaType(
             maybe(self.state_machine_opened);
 
             self.grid_repair_timeout.reset_with_jitter(&self.prng);
+            self.grid_repair_message_budget.reap_expired_requests(self.clock.monotonic());
 
             if (self.grid.callback != .cancel) {
                 if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
@@ -8167,11 +8138,6 @@ pub fn ReplicaType(
                 return;
             }
 
-            if (self.journal_repair_message_budget.available == 0) {
-                log.debug("{}: repair_prepares: waiting for repair budget", .{self.log_prefix()});
-                return;
-            }
-
             for (op_min..op_max + 1) |op| {
                 const slot_with_op_maybe = self.journal.slot_with_op(op);
                 if (slot_with_op_maybe == null or self.journal.dirty.bit(slot_with_op_maybe.?)) {
@@ -8180,16 +8146,15 @@ pub fn ReplicaType(
                     if (self.repair_prepare(op)) {
                         io_budget -= 1;
 
-                        if (self.journal_repair_message_budget.available == 0) {
-                            log.debug("{}: repair_prepares: repair budget used", .{
-                                self.log_prefix(),
-                            });
-                            break;
-                        }
                         if (io_budget == 0) {
                             log.debug("{}: repair_prepares: IO budget used", .{self.log_prefix()});
                             break;
                         }
+                    } else if (self.journal_repair_message_budget.available == 0) {
+                        log.debug("{}: repair_prepares: repair budget used", .{
+                            self.log_prefix(),
+                        });
+                        break;
                     }
                 }
             }
@@ -8296,7 +8261,8 @@ pub fn ReplicaType(
             assert(self.repairs_allowed());
             assert(slot_with_op_maybe == null or self.journal.dirty.bit(slot_with_op_maybe.?));
             assert(self.journal.writes.available() > 0);
-            assert(self.journal_repair_message_budget.available > 0);
+            maybe(self.journal_repair_message_budget.available == 0);
+
             if (self.journal.header_with_op(op)) |header| {
                 // We may be appending to or repairing the journal concurrently.
                 // We do not want to re-request any of these prepares unnecessarily.
@@ -8354,11 +8320,11 @@ pub fn ReplicaType(
                 }
             }
 
-            if (self.journal_repair_message_budget.decrement(.{
-                .op = op,
-                .now = self.clock.monotonic(),
-                .prng = &self.prng,
-            })) |replica_index| {
+            if (self.journal_repair_message_budget.decrement(
+                op,
+                self.clock.monotonic(),
+                &self.prng,
+            )) |replica_index| {
                 assert(replica_index != self.replica);
                 const request_prepare = Header.RequestPrepare{
                     .command = .request_prepare,
@@ -9920,13 +9886,11 @@ pub fn ReplicaType(
             assert(!self.do_view_change_message_timeout.ticking);
             assert(!self.request_start_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
-            assert(!self.repair_budget_timeout.ticking);
             assert(!self.journal_repair_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
             assert(!self.upgrade_timeout.ticking);
 
             self.ping_timeout.start();
-            self.repair_budget_timeout.start();
             self.grid_repair_timeout.start();
             self.grid_scrub_timeout.start();
 
@@ -9963,7 +9927,6 @@ pub fn ReplicaType(
             assert(!self.do_view_change_message_timeout.ticking);
             assert(!self.request_start_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
-            assert(!self.repair_budget_timeout.ticking);
             assert(!self.journal_repair_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
             assert(!self.upgrade_timeout.ticking);
@@ -9981,7 +9944,6 @@ pub fn ReplicaType(
                 self.ping_timeout.start();
                 self.start_view_change_message_timeout.start();
                 self.commit_message_timeout.start();
-                self.repair_budget_timeout.start();
                 self.journal_repair_timeout.start();
                 self.grid_repair_timeout.start();
                 self.grid_scrub_timeout.start();
@@ -10004,7 +9966,6 @@ pub fn ReplicaType(
                 self.ping_timeout.start();
                 self.start_view_change_message_timeout.start();
                 self.journal_repair_timeout.start();
-                self.repair_budget_timeout.start();
                 self.repair_sync_timeout.start();
                 self.grid_repair_timeout.start();
                 self.grid_scrub_timeout.start();
@@ -10062,7 +10023,6 @@ pub fn ReplicaType(
 
             self.ping_timeout.start();
             self.start_view_change_message_timeout.start();
-            self.repair_budget_timeout.start();
             self.journal_repair_timeout.start();
             self.repair_sync_timeout.start();
             self.grid_repair_timeout.start();
@@ -10154,7 +10114,6 @@ pub fn ReplicaType(
                 self.repair_sync_timeout.start();
             }
 
-            assert(self.repair_budget_timeout.ticking);
             self.journal_repair_timeout.start();
             self.grid_repair_timeout.start();
             self.grid_scrub_timeout.start();
@@ -10245,7 +10204,6 @@ pub fn ReplicaType(
             self.grid_scrub_timeout.start();
             self.upgrade_timeout.stop();
             self.journal_repair_timeout.stop();
-            if (!self.repair_budget_timeout.ticking) self.repair_budget_timeout.start();
 
             if (self.primary_index(self.view) == self.replica) {
                 self.request_start_view_message_timeout.stop();
@@ -11275,6 +11233,8 @@ pub fn ReplicaType(
             assert(request_faults_count_max <= requests_buffer.len);
             assert(request_faults_count_max >= @divFloor(requests_buffer.len, 2));
 
+            const now = self.clock.monotonic();
+
             var grid_faults = self.grid.read_global_queue.iterate();
             while (grid_faults.next()) |read_fault| {
                 if (requests_count >= request_faults_count_max) break;
@@ -11284,11 +11244,11 @@ pub fn ReplicaType(
                     .checksum = read_fault.checksum,
                 };
 
-                if (self.grid_repair_message_budget.decrement(.{
-                    .block_identifier = block_identifier,
-                    .replica_index = destination_replica_index,
-                    .now = self.clock.monotonic(),
-                })) {
+                if (self.grid_repair_message_budget.decrement(
+                    block_identifier,
+                    destination_replica_index,
+                    now,
+                )) {
                     requests_buffer[requests_count] = .{
                         .block_address = read_fault.address,
                         .block_checksum = read_fault.checksum,
@@ -11306,11 +11266,11 @@ pub fn ReplicaType(
                         .checksum = missing_request.block_checksum,
                     };
 
-                    if (self.grid_repair_message_budget.decrement(.{
-                        .block_identifier = block_identifier,
-                        .replica_index = destination_replica_index,
-                        .now = self.clock.monotonic(),
-                    })) {
+                    if (self.grid_repair_message_budget.decrement(
+                        block_identifier,
+                        destination_replica_index,
+                        now,
+                    )) {
                         requests_buffer[requests_count] = missing_request;
                         requests_count += 1;
                     }


### PR DESCRIPTION
https://github.com/tigerbeetle/tigerbeetle/pull/3618 introduced jitter in the journal & block repair timeouts, so that the
protocol doesn't have to rely on network/storage latency jitter to make
progress. However, it also introduced https://github.com/tigerbeetle/tigerbeetle/commit/6fa8c150087d17cf69604b2fcfea62b4346ac0a4, where we invoke repair
every time we expire some requests and reclaim the budget. However,
as it turns out, as this expiry duration can be fixed (500ms), it can cause
cause repair to _always_ be triggered by `repair_budget_timeout`, effectively
neutralizing our timeout-level jitter.

This PR simply removes `repair_budget_timeout` and makes request
expiry just-in-time. In other words, we now expire stuck requests
when the repair timeouts are invoked. Since these timeouts are
jittered, we now expect the expiry to be jittered as well. Specifically,
expiry is now best effort and takes [500ms, 650ms] as repair timeouts
take [50ms, 150ms].

Commit: https://github.com/tigerbeetle/tigerbeetle/commit/251dfee187903b7bedd8f79bd4e5070cd52f9249
Seed: /zig/zig build vopr -Drelease -Dvopr-state-machine=testing -- 6327431374245116930

---

Here, we can see that in a solo cluster with two standbys (R0, R1, R2),
the requests from R1 (asymmetrically partitioned, requesting op=100, 101)
and R2 (connected ) arrive in the same order, at the same tick, every
520ms. This allows R1 to cause a denial of repair service for R2:

```C
9999449 [debug] (replica) 0N: on_message: view=1 status=normal RequestPrepare op=100
9999449 [debug] (replica) 0N: on_message: view=1 status=normal RequestPrepare op=102
9999449 [info] (journal) 0: read_prepare: op=102: waiting for IOP
9999449 [debug] (replica) 0N: on_message: view=1 op=101
9999449 [info] (journal) 0: read_prepare: op=101: waiting for IOP
9999450 [debug] (replica) 0N: sending prepare to replica 1: op=100
9999501 [debug] (replica) 0N: on_message: view=1 status=normal RequestPrepare op=100
9999501 [debug] (replica) 0N: on_message: view=1 status=normal RequestPrepare op=102
9999501 [info] (journal) 0: read_prepare: op=102: waiting for IOP
9999501 [debug] (replica) 0N: on_message: view=1 status=normal RequestPrepare op=101
9999501 [info] (journal)0: read_prepare: op=101: waiting for IOP
9999502 [debug] (replica)0N: sending prepare to replica 1: op=100
9999553 [debug] (replica)0N: on_message: view=1 status=normal RequestPrepare op=100
9999553 [debug] (replica)0N: on_message: view=1 status=normal RequestPrepare op=102
9999553 [info] (journal)0: read_prepare: op=102: waiting for IOP
9999553 [debug] (replica)0N: on_message: view=1 status=normal RequestPrepare op=101
9999553 [info] (journal)0: read_prepare: op=101 waiting for IOP
9999554 [debug] (replica)0N: sending prepare to replica 1:  op=100
```