### PR TITLE
lsm: borrow scratch for manifest_log.tables_removed

### DIFF
--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -211,6 +211,13 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         pub const manifest_log_blocks_released_half_bar_max =
             manifest_log_compaction_pace.half_bar_compact_blocks_max;
 
+        // Bytes that `ManifestLog.open()` needs for its `tables_removed` FBA, which we lend it
+        // for the duration of `open()` from `radix_buffer`. The two uses do not overlap in time
+        // (compaction does not start until after `open()` completes), so they share one
+        // allocation. See `ManifestLog.tables_removed_scratch_size`.
+        const tables_removed_fba_size_bytes: usize =
+            ManifestLog.tables_removed_scratch_size(manifest_log_compaction_pace.tables_max);
+
         pub const Options = struct {
             node_count: u32,
             /// The amount of blocks allocated for compactions. Compactions will be deterministic
@@ -223,7 +230,12 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         const ResourcePool = ResourcePoolType(Grid);
 
         progress: ?union(enum) {
-            open: struct { callback: Callback },
+            open: struct {
+                callback: Callback,
+                // Scratch slice borrowed from `radix_buffer` for the lifetime of
+                // `manifest_log.open()`, released when the open callback fires.
+                tables_removed_scratch: []u8,
+            },
             checkpoint: struct {
                 callback: Callback,
                 manifest_log_done: bool,
@@ -308,7 +320,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                     assert(size > 0);
                     size_max = @max(size_max, size);
                 }
-                break :blk size_max;
+                break :blk @max(size_max, tables_removed_fba_size_bytes);
             };
 
             forest.radix_buffer = try .init(allocator, radix_buffer_size);
@@ -382,13 +394,24 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         pub fn open(forest: *Forest, callback: Callback) void {
             assert(forest.progress == null);
 
-            forest.progress = .{ .open = .{ .callback = callback } };
+            // Released in `manifest_log_open_callback` once `manifest_log.open()` is done.
+            const tables_removed_scratch =
+                forest.radix_buffer.acquire(u8, tables_removed_fba_size_bytes);
+
+            forest.progress = .{ .open = .{
+                .callback = callback,
+                .tables_removed_scratch = tables_removed_scratch,
+            } };
 
             inline for (std.meta.fields(Grooves)) |field| {
                 @field(forest.grooves, field.name).open_commence(&forest.manifest_log);
             }
 
-            forest.manifest_log.open(manifest_log_open_event, manifest_log_open_callback);
+            forest.manifest_log.open(
+                tables_removed_scratch,
+                manifest_log_open_event,
+                manifest_log_open_callback,
+            );
         }
 
         fn manifest_log_open_event(
@@ -415,6 +438,9 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         fn manifest_log_open_callback(manifest_log: *ManifestLog) void {
             const forest: *Forest = @fieldParentPtr("manifest_log", manifest_log);
             assert(forest.progress.? == .open);
+
+            forest.radix_buffer.release(u8, forest.progress.?.open.tables_removed_scratch);
+
             forest.verify_tables_recovered();
 
             inline for (std.meta.fields(Grooves)) |field| {

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -349,6 +349,15 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         }
 
         pub fn deinit(forest: *Forest, allocator: mem.Allocator) void {
+            // If we are torn down mid-open (e.g. a replica crash in the simulator,
+            // or shutdown before `manifest_log.open()` completes), release the
+            // scratch slice we borrowed from `radix_buffer` so that
+            // `radix_buffer.deinit`'s `state == .free` assertion holds.
+            if (forest.progress) |progress| switch (progress) {
+                .open => |o| forest.radix_buffer.release(u8, o.tables_removed_scratch),
+                else => {},
+            };
+
             inline for (std.meta.fields(Grooves)) |field| {
                 const Groove = field.type;
                 const groove: *Groove = &@field(forest.grooves, field.name);
@@ -365,6 +374,14 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         pub fn reset(forest: *Forest) void {
             // Components using the node_pool must release all nodes they acquired upon reset.
             defer assert(forest.node_pool.free.count() == forest.node_pool.free.bit_length);
+
+            // If a sync recovery interrupts an in-progress `open()`, the scratch slice we
+            // borrowed from `radix_buffer` for `manifest_log.tables_removed` was never returned
+            // by the open callback. Release it here so the next `open()` can acquire again.
+            if (forest.progress) |progress| switch (progress) {
+                .open => |o| forest.radix_buffer.release(u8, o.tables_removed_scratch),
+                else => {},
+            };
 
             inline for (std.meta.fields(Grooves)) |field| {
                 @field(forest.grooves, field.name).reset();
@@ -394,7 +411,8 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         pub fn open(forest: *Forest, callback: Callback) void {
             assert(forest.progress == null);
 
-            // Released in `manifest_log_open_callback` once `manifest_log.open()` is done.
+            // Released in `manifest_log_open_callback` once `manifest_log.open()` is done,
+            // or in `reset()` if a sync recovery interrupts the open before then.
             const tables_removed_scratch =
                 forest.radix_buffer.acquire(u8, tables_removed_fba_size_bytes);
 

--- a/src/lsm/manifest_log.zig
+++ b/src/lsm/manifest_log.zig
@@ -55,6 +55,18 @@ pub fn ManifestLogType(comptime Storage: type) type {
 
         pub const OpenEvent = *const fn (manifest_log: *ManifestLog, table: *const TableInfo) void;
 
+        /// Bytes required to back `tables_removed.ensureTotalCapacity(forest_table_count_max)`.
+        /// Used by `Forest.open()` and the LSM fuzzers to size the scratch slice they pass to
+        /// `open()`. Returns a conservative power-of-two upper bound (16 bytes per slot, 80%
+        /// load factor) so the FBA cannot run out at construction time.
+        pub fn tables_removed_scratch_size(forest_table_count_max: u32) usize {
+            assert(forest_table_count_max > 0);
+            const minimum: u64 = (@as(u64, forest_table_count_max) * 5 + 3) / 4;
+            var cap: u64 = 1;
+            while (cap < minimum) cap <<= 1;
+            return @as(usize, @intCast(cap)) * 16;
+        }
+
         const Write = struct {
             manifest_log: *ManifestLog,
             write: Grid.Write = undefined,
@@ -134,10 +146,12 @@ pub fn ManifestLogType(comptime Storage: type) type {
         /// not yet been encountered. Given that the maximum number of tables in the forest at any
         /// given moment is `forest_table_count_max`, there are likewise at most
         /// `forest_table_count_max` "unpaired" removes to track.
-        // TODO(Optimization) This memory (~35MiB) is only needed during open() – maybe borrow it
-        // from the grid cache or node pool instead so that we don't pay for it during normal
-        // operation.
+        ///
+        /// Only live during `open()`. Its backing storage comes from `tables_removed_fba`, which
+        /// the caller of `open()` installs over a scratch slice (in production borrowed from
+        /// `Forest.radix_buffer`, idle while `open()` runs).
         tables_removed: TablesRemoved,
+        tables_removed_fba: std.heap.FixedBufferAllocator,
 
         pub fn init(
             manifest_log: *ManifestLog,
@@ -155,7 +169,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 .blocks = undefined,
                 .writes = undefined,
                 .table_extents = undefined,
-                .tables_removed = undefined,
+                .tables_removed = .{},
+                .tables_removed_fba = std.heap.FixedBufferAllocator.init(&.{}),
             };
 
             inline for (std.meta.fields(Pace)) |pace_field| {
@@ -169,7 +184,6 @@ pub fn ManifestLogType(comptime Storage: type) type {
             manifest_log.log_block_checksums =
                 try RingBufferType(u128, .slice).init(allocator, manifest_log.pace.log_blocks_max);
             errdefer manifest_log.log_block_checksums.deinit(allocator);
-
             manifest_log.log_block_addresses =
                 try RingBufferType(u64, .slice).init(allocator, manifest_log.pace.log_blocks_max);
             errdefer manifest_log.log_block_addresses.deinit(allocator);
@@ -208,17 +222,9 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 manifest_log.forest_table_count_max + 1,
             );
             errdefer manifest_log.table_extents.deinit(allocator);
-
-            manifest_log.tables_removed = TablesRemoved{};
-            try manifest_log.tables_removed.ensureTotalCapacity(
-                allocator,
-                manifest_log.forest_table_count_max,
-            );
-            errdefer manifest_log.tables_removed.deinit(allocator);
         }
 
         pub fn deinit(manifest_log: *ManifestLog, allocator: mem.Allocator) void {
-            manifest_log.tables_removed.deinit(allocator);
             manifest_log.table_extents.deinit(allocator);
             allocator.free(manifest_log.writes);
             for (manifest_log.blocks.buffer) |block| allocator.free(block);
@@ -230,6 +236,7 @@ pub fn ManifestLogType(comptime Storage: type) type {
         pub fn reset(manifest_log: *ManifestLog) void {
             assert(manifest_log.log_block_checksums.count ==
                 manifest_log.log_block_addresses.count);
+            assert(manifest_log.tables_removed.count() == 0);
 
             manifest_log.grid.trace.cancel(.compact_manifest);
 
@@ -237,7 +244,6 @@ pub fn ManifestLogType(comptime Storage: type) type {
             manifest_log.log_block_addresses.clear();
             for (manifest_log.blocks.buffer) |block| @memset(block, 0);
             manifest_log.table_extents.clearRetainingCapacity();
-            manifest_log.tables_removed.clearRetainingCapacity();
 
             manifest_log.* = .{
                 .superblock = manifest_log.superblock,
@@ -249,7 +255,8 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 .blocks = .{ .buffer = manifest_log.blocks.buffer },
                 .writes = manifest_log.writes,
                 .table_extents = manifest_log.table_extents,
-                .tables_removed = manifest_log.tables_removed,
+                .tables_removed = .{},
+                .tables_removed_fba = std.heap.FixedBufferAllocator.init(&.{}),
             };
         }
 
@@ -262,7 +269,15 @@ pub fn ManifestLogType(comptime Storage: type) type {
         // TODO(Optimization): Accumulate tables unordered, then sort all at once to splice into the
         // ManifestLevels' SegmentedArrays. (Constructing SegmentedArrays by repeated inserts is
         // expensive.)
-        pub fn open(manifest_log: *ManifestLog, event: OpenEvent, callback: Callback) void {
+        //
+        // `tables_removed_scratch` is a caller-owned slice that backs `tables_removed`'s hash
+        // table for the duration of `open()`. Size it via `tables_removed_scratch_size()`.
+        pub fn open(
+            manifest_log: *ManifestLog,
+            tables_removed_scratch: []u8,
+            event: OpenEvent,
+            callback: Callback,
+        ) void {
             assert(!manifest_log.opened);
             assert(!manifest_log.reading);
             assert(!manifest_log.writing);
@@ -275,7 +290,15 @@ pub fn ManifestLogType(comptime Storage: type) type {
             assert(manifest_log.entry_count == 0);
             assert(manifest_log.table_extents.count() == 0);
             assert(manifest_log.tables_removed.count() == 0);
+            assert(manifest_log.tables_removed_fba.buffer.len == 0);
 
+            manifest_log.tables_removed_fba =
+                std.heap.FixedBufferAllocator.init(tables_removed_scratch);
+            manifest_log.tables_removed = .{};
+            manifest_log.tables_removed.ensureTotalCapacity(
+                manifest_log.tables_removed_fba.allocator(),
+                manifest_log.forest_table_count_max,
+            ) catch @panic("manifest_log: tables_removed scratch undersized");
             manifest_log.open_event = event;
             manifest_log.reading = true;
             manifest_log.read_callback = callback;
@@ -439,6 +462,12 @@ pub fn ManifestLogType(comptime Storage: type) type {
                 manifest_log.log_block_checksums.count,
                 manifest_log.table_extents.count(),
             });
+
+            // Any orphaned removes still in the set correspond to tables whose insert lived
+            // in a manifest block older than `manifest_oldest_address`, and are discarded.
+            assert(manifest_log.tables_removed.count() <= manifest_log.forest_table_count_max);
+            manifest_log.tables_removed = .{};
+            manifest_log.tables_removed_fba = std.heap.FixedBufferAllocator.init(&.{});
 
             const callback = manifest_log.read_callback.?;
             manifest_log.opened = true;

--- a/src/lsm/manifest_log_fuzz.zig
+++ b/src/lsm/manifest_log_fuzz.zig
@@ -267,6 +267,9 @@ const Environment = struct {
     manifest_log_model: ManifestLogModel,
     manifest_log_opening: ?ManifestLogModel.TableMap,
     pending: u32,
+    // In production this slice is borrowed from `Forest.radix_buffer`; here we own it.
+    // Reused by both `manifest_log` and `manifest_log_verify`, whose opens never overlap.
+    tables_removed_scratch: []u8,
 
     fn init(
         env: *Environment, // In-place construction for stable addresses.
@@ -344,11 +347,19 @@ const Environment = struct {
         fields_initialized += 1;
         env.pending = 0;
 
+        fields_initialized += 1;
+        env.tables_removed_scratch = try gpa.alloc(
+            u8,
+            ManifestLog.tables_removed_scratch_size(manifest_log_compaction_pace.tables_max),
+        );
+        errdefer gpa.free(env.tables_removed_scratch);
+
         comptime assert(fields_initialized == std.meta.fields(@This()).len);
     }
 
     fn deinit(env: *Environment) void {
         assert(env.manifest_log_opening == null);
+        env.gpa.free(env.tables_removed_scratch);
         env.manifest_log_model.deinit();
         env.manifest_log_verify.deinit(env.gpa);
         env.manifest_log.deinit(env.gpa);
@@ -373,7 +384,7 @@ const Environment = struct {
         assert(env.pending == 0);
 
         env.pending += 1;
-        env.manifest_log.open(open_event, open_callback);
+        env.manifest_log.open(env.tables_removed_scratch, open_event, open_callback);
     }
 
     fn open_event(manifest_log: *ManifestLog, table: *const TableInfo) void {
@@ -532,7 +543,11 @@ const Environment = struct {
         }
 
         env.pending += 1;
-        env.manifest_log_verify.open(verify_manifest_open_event, verify_manifest_open_callback);
+        env.manifest_log_verify.open(
+            env.tables_removed_scratch,
+            verify_manifest_open_event,
+            verify_manifest_open_callback,
+        );
         env.wait(&env.manifest_log_verify);
 
         try std.testing.expect(hash_map_equals(

--- a/src/lsm/tree_fuzz.zig
+++ b/src/lsm/tree_fuzz.zig
@@ -255,7 +255,18 @@ fn EnvironmentType(comptime table_usage: TableUsage) type {
             env.change_state(.tree_init, .manifest_log_open);
 
             env.tree.open_commence(&env.manifest_log);
-            env.manifest_log.open(manifest_log_open_event, manifest_log_open_callback);
+            // In production this slice is borrowed from `Forest.radix_buffer`; here we own it.
+            const tables_removed_scratch = try gpa.alloc(
+                u8,
+                ManifestLog.tables_removed_scratch_size(table_count_max),
+            );
+            defer gpa.free(tables_removed_scratch);
+
+            env.manifest_log.open(
+                tables_removed_scratch,
+                manifest_log_open_event,
+                manifest_log_open_callback,
+            );
 
             env.tick_until_state_change(.manifest_log_open, .fuzzing);
             env.tree.open_complete();


### PR DESCRIPTION
Implements the TODO at src/lsm/manifest_log.zig:137. tables_removed is only live during open() but used to own ~36 MiB permanently. Now an FBA over a slice borrowed from Forest.radix_buffer for the duration of open(). 

Now, Compaction is the only other consumer of radix_buffer and can't start until open() returns, so the two don't race. radix_buffer's size is the max of the two.

10M-transfer benchmark, default config, 1 replica:
  ```
      Allocated at init: 3021 -> 2985 MiB  (-36)
      Peak RSS:          3174 -> 3139 MB   (-35)
  ```
  Tested with zig build test, fuzz:build, vopr:build, and fuzz -- smoke.