### PR TITLE
CFO: Run vortex with subcommand until next release

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -153,6 +153,7 @@ const Fuzzer = enum {
             .vopr, .vopr_debug, .vopr_testing => &.{},
             .vopr_lite, .vopr_testing_lite => &.{"--lite"},
             .vortex, .vortex_debug => &.{
+                "supervisor",
                 "--log-debug",
                 "--replica-count=3",
                 "--test-duration=10m",


### PR DESCRIPTION
Run vortex with `supervisor` subcommand until next release, to prevent release branch vortex from failing until then. Vortex already accepts it as an optional subcommand, in anticipation of this problem!