### PR TITLE
Vortex: wait() after kill(SIGKILL)

### DIFF
--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -571,6 +571,10 @@ pub const Supervisor = struct {
         assert(replica.state == .running or replica.state == .paused);
 
         try std.posix.kill(replica.process.?.id, std.posix.SIG.KILL);
+
+        const term = try replica.process.?.wait();
+        assert(std.meta.eql(term, .{ .Signal = std.posix.SIG.KILL }));
+
         replica.process = null;
         replica.state = .terminated;
     }


### PR DESCRIPTION
Otherwise `flock` collides even more than usual. `LoggedProcess` use to handle this but I missed that when I copied this over.