### PR TITLE
flags: refactor to own the allocator

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -929,19 +929,19 @@ const CLIArgs = union(enum) {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator(); // FIXME: rename
+    var gpa_instance: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    const gpa = gpa_instance.allocator();
 
     var time_os: vsr.time.TimeOS = .{};
     const time = time_os.time();
 
-    var flags = stdx.Flags.init(allocator);
-    defer flags.deinit(allocator);
+    var flags = stdx.Flags.init(gpa);
+    defer flags.deinit(gpa);
 
     const args = flags.parse(CLIArgs);
 
-    const target = try allocator.create(AOFEntry);
-    defer allocator.destroy(target);
+    const target = try gpa.create(AOFEntry);
+    defer gpa.destroy(target);
 
     const IO = @import("io.zig").IO;
     var io = try IO.init(32, 0);
@@ -959,8 +959,8 @@ pub fn main() !void {
             var addresses_buffer: [constants.replicas_max]std.net.Address = undefined;
             const addresses_parsed = try vsr.parse_addresses(command.addresses, &addresses_buffer);
             var replay =
-                try AOFReplayClient.init(&io, allocator, time, command.cluster, addresses_parsed);
-            defer replay.deinit(allocator);
+                try AOFReplayClient.init(&io, gpa, time, command.cluster, addresses_parsed);
+            defer replay.deinit(gpa);
 
             try replay.replay(&it);
         },
@@ -998,7 +998,7 @@ pub fn main() !void {
 
             assert(merge.paths.len > 0);
             assert(merge.paths.len <= constants.members_max);
-            try AOF.merge(&io, allocator, merge.paths, "prepared.aof");
+            try AOF.merge(&io, gpa, merge.paths, "prepared.aof");
         },
     }
 }

--- a/src/aof.zig
+++ b/src/aof.zig
@@ -603,7 +603,7 @@ pub fn AOFType(comptime IO: type) type {
             var aof_count: usize = 0;
             defer for (aofs[0..aof_count]) |*it| it.close();
 
-            assert(input_paths.len < aofs.len);
+            assert(input_paths.len <= aofs.len);
 
             const EntryInfo = struct {
                 aof: *Iterator,
@@ -629,6 +629,8 @@ pub fn AOFType(comptime IO: type) type {
                 aofs[aof_count] = try Iterator.init(io, input_path);
                 aof_count += 1;
             }
+            assert(aof_count > 0);
+            assert(aof_count <= constants.members_max);
 
             var output_aof = try AOF.init(io, output_path);
 
@@ -882,7 +884,7 @@ const CLIArgs = union(enum) {
     },
     merge: struct {
         @"--": void,
-        // (One or more AOF file paths.)
+        paths: []const []const u8,
     },
 
     pub const help =
@@ -928,15 +930,15 @@ const CLIArgs = union(enum) {
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
+    const allocator = gpa.allocator(); // FIXME: rename
 
     var time_os: vsr.time.TimeOS = .{};
     const time = time_os.time();
 
-    var args_iterator = try std.process.argsWithAllocator(allocator);
-    defer args_iterator.deinit();
+    var flags = stdx.Flags.init(allocator);
+    defer flags.deinit(allocator);
 
-    const args = stdx.flags(&args_iterator, CLIArgs);
+    const args = flags.parse(CLIArgs);
 
     const target = try allocator.create(AOFEntry);
     defer allocator.destroy(target);
@@ -990,17 +992,13 @@ pub fn main() !void {
                 .{@as(u128, @bitCast(data_checksum[0..@sizeOf(u128)].*))},
             );
         },
-        .merge => |_| {
-            var paths: [constants.members_max][:0]const u8 = undefined;
-            var paths_count: u32 = 0;
-            for (&paths) |*path| {
-                path.* = args_iterator.next() orelse break;
-                paths_count += 1;
-            }
-            if (paths_count == 0) vsr.fatal(.cli, "missing paths", .{});
-            if (args_iterator.next()) |_| vsr.fatal(.cli, "too many paths", .{});
+        .merge => |merge| {
+            if (merge.paths.len == 0) vsr.fatal(.cli, "missing paths", .{});
+            if (merge.paths.len > constants.members_max) vsr.fatal(.cli, "too many paths", .{});
 
-            try AOF.merge(&io, allocator, paths[0..paths_count], "prepared.aof");
+            assert(merge.paths.len > 0);
+            assert(merge.paths.len <= constants.members_max);
+            try AOF.merge(&io, allocator, merge.paths, "prepared.aof");
         },
     }
 }

--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -61,10 +61,10 @@ pub fn main() !void {
     const shell = try Shell.create(gpa);
     defer shell.destroy();
 
-    var args = try std.process.argsWithAllocator(gpa);
-    defer args.deinit();
+    var flags = stdx.Flags.init(gpa);
+    defer flags.deinit(gpa);
 
-    const cli_args = stdx.flags(&args, CLIArgs);
+    const cli_args = flags.parse(CLIArgs);
 
     const tmp_dir_path = try shell.fmt("{s}/{d}", .{
         cli_args.tmp,

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -51,9 +51,10 @@ pub fn main() !void {
 
     const allocator = arena.allocator();
 
-    var args = try std.process.argsWithAllocator(allocator);
+    var flags = stdx.Flags.init(allocator);
+    defer flags.deinit(allocator);
 
-    const cli_args = stdx.flags(&args, CLIArgs);
+    const cli_args = flags.parse(CLIArgs);
 
     const line_buffer = try allocator.alloc(u8, MiB);
     const func_buf = try allocator.alloc(u8, 4096);

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -98,10 +98,10 @@ pub fn main() !void {
     };
     const gpa = gpa_allocator.allocator();
 
-    var args = try std.process.argsWithAllocator(gpa);
-    defer args.deinit();
+    var flags = stdx.Flags.init(gpa);
+    defer flags.deinit(gpa);
 
-    const cli_args = stdx.flags(&args, CLIArgs);
+    const cli_args = flags.parse(CLIArgs);
 
     switch (cli_args.fuzzer) {
         .smoke => {

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -89,10 +89,10 @@ pub fn main() !void {
     const shell = try Shell.create(gpa);
     defer shell.destroy();
 
-    var args = try std.process.argsWithAllocator(gpa);
-    defer args.deinit();
+    var flags = stdx.Flags.init(gpa);
+    defer flags.deinit(gpa);
 
-    const cli_args = stdx.flags(&args, CLIArgs);
+    const cli_args = flags.parse(CLIArgs);
 
     switch (cli_args) {
         .cfo => |args_cfo| try cfo.main(shell, gpa, args_cfo),

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -110,7 +110,11 @@ pub fn parse(flags: *Flags, comptime CLIArgs: type) CLIArgs {
     return parse_flags(arena, &args, CLIArgs);
 }
 
-fn parse_commands(arena: Allocator, args: *std.process.ArgIterator, comptime Commands: type) Commands {
+fn parse_commands(
+    arena: Allocator,
+    args: *std.process.ArgIterator,
+    comptime Commands: type,
+) Commands {
     comptime assert(@typeInfo(Commands) == .@"union");
     comptime assert(std.meta.fields(Commands).len >= 2);
 
@@ -153,32 +157,29 @@ fn parse_flags(arena: Allocator, args: *std.process.ArgIterator, comptime CLIArg
     assert(@typeInfo(CLIArgs) == .@"struct");
 
     const fields = std.meta.fields(CLIArgs);
-    comptime var fields_named, const fields_positional, const field_extended: ?std.builtin.Type.StructField =
+    comptime var fields_named, var fields_positional: []const std.builtin.Type.StructField =
         for (fields, 0..) |field, index| {
             if (std.mem.eql(u8, field.name, "--")) {
                 assert(field.type == void);
                 const positional_count = fields.len - index - 1;
                 if (positional_count == 0) @panic("expected positional fields");
 
-                if (positional_count == 1 and fields[index + 1].type == []const []const u8) {
-                    break .{
-                        fields[0..index].*,
-                        fields[index + 2 ..].*, // Empty
-                        fields[index + 1],
-                    };
-                }
-
                 break .{
                     fields[0..index].*,
-                    fields[index + 1 ..].*,
-                    null,
+                    fields[index + 1 ..],
                 };
             }
         } else .{
             fields[0..fields.len].*,
-            [_]std.builtin.Type.StructField{},
-            null,
+            &.{},
         };
+
+    comptime var field_extended: ?std.builtin.Type.StructField = null;
+    if (fields_positional.len == 1 and fields_positional[0].type == []const []const u8) {
+        field_extended = fields_positional[0];
+        fields_positional = fields_positional[1..];
+        assert(fields_positional.len == 0);
+    }
 
     var arg_extended: if (field_extended == null) void else std.ArrayListUnmanaged([]const u8) =
         if (field_extended == null) {} else .empty;

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -42,6 +42,24 @@ const stdx = @import("stdx.zig");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
+const Allocator = std.mem.Allocator;
+
+arena: std.heap.ArenaAllocator,
+
+const Flags = @This();
+
+pub fn init(gpa: Allocator) Flags {
+    return .{
+        .arena = std.heap.ArenaAllocator.init(gpa),
+    };
+}
+
+pub fn deinit(flags: *Flags, gpa: Allocator) void {
+    assert(std.meta.eql(flags.arena.child_allocator, gpa));
+    flags.arena.deinit();
+    flags.* = undefined;
+}
+
 /// Format and print an error message to stderr, then exit with an exit code of 1.
 fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
     const stderr = std.io.getStdErr().writer();
@@ -51,6 +69,10 @@ fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
     // the implementation of fatal function, but let's be pragmatic here and just match the behavior
     // manually.
     std.process.exit(1);
+}
+
+fn oom(_: error{OutOfMemory}) noreturn {
+    fatal("error: out of memory when parsing cli", .{});
 }
 
 /// Parse CLI arguments for subcommands specified as Zig `struct` or `union(enum)`:
@@ -77,10 +99,15 @@ fn fatal(comptime fmt_string: []const u8, args: anytype) noreturn {
 /// If `pub const help` declaration is present, it is used to implement `-h/--help` argument.
 ///
 /// Value parsing can be customized on per-type basis via `parse_flag_value` customization point.
-pub fn parse(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
+pub fn parse(flags: *Flags, comptime CLIArgs: type) CLIArgs {
     comptime assert(CLIArgs != void);
-    assert(args.skip()); // Discard executable name.
-    return parse_flags(args, CLIArgs);
+
+    const arena = flags.arena.allocator();
+
+    var args = std.process.argsWithAllocator(arena) catch |err| oom(err);
+    if (!args.skip()) fatal("executable name missing", .{});
+
+    return parse_flags(&args, CLIArgs);
 }
 
 fn parse_commands(args: *std.process.ArgIterator, comptime Commands: type) Commands {
@@ -109,23 +136,23 @@ fn parse_commands(args: *std.process.ArgIterator, comptime Commands: type) Comma
     fatal("unknown subcommand: '{s}'", .{first_arg});
 }
 
-fn parse_flags(args: *std.process.ArgIterator, comptime Flags: type) Flags {
+fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
     @setEvalBranchQuota(5_000);
 
-    if (Flags == void) {
+    if (CLIArgs == void) {
         if (args.next()) |arg| {
             fatal("unexpected argument: '{s}'", .{arg});
         }
         return {};
     }
 
-    if (@typeInfo(Flags) == .@"union") {
-        return parse_commands(args, Flags);
+    if (@typeInfo(CLIArgs) == .@"union") {
+        return parse_commands(args, CLIArgs);
     }
 
-    assert(@typeInfo(Flags) == .@"struct");
+    assert(@typeInfo(CLIArgs) == .@"struct");
 
-    const fields = std.meta.fields(Flags);
+    const fields = std.meta.fields(CLIArgs);
     comptime var fields_named, const fields_positional, const fields_extended =
         for (fields, 0..) |field, index| {
             if (std.mem.eql(u8, field.name, "--")) {
@@ -203,8 +230,8 @@ fn parse_flags(args: *std.process.ArgIterator, comptime Flags: type) Flags {
         }
     }
 
-    var counts: std.enums.EnumFieldStruct(std.meta.FieldEnum(Flags), u32, 0) = .{};
-    var result: Flags = undefined;
+    var counts: std.enums.EnumFieldStruct(std.meta.FieldEnum(CLIArgs), u32, 0) = .{};
+    var result: CLIArgs = undefined;
     var parsed_positional = false;
     next_arg: while (args.next()) |arg| {
         comptime var field_len_prev = std.math.maxInt(usize);

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -107,10 +107,10 @@ pub fn parse(flags: *Flags, comptime CLIArgs: type) CLIArgs {
     var args = std.process.argsWithAllocator(arena) catch |err| oom(err);
     if (!args.skip()) fatal("executable name missing", .{});
 
-    return parse_flags(&args, CLIArgs);
+    return parse_flags(arena, &args, CLIArgs);
 }
 
-fn parse_commands(args: *std.process.ArgIterator, comptime Commands: type) Commands {
+fn parse_commands(arena: Allocator, args: *std.process.ArgIterator, comptime Commands: type) Commands {
     comptime assert(@typeInfo(Commands) == .@"union");
     comptime assert(std.meta.fields(Commands).len >= 2);
 
@@ -130,13 +130,13 @@ fn parse_commands(args: *std.process.ArgIterator, comptime Commands: type) Comma
     inline for (comptime std.meta.fields(Commands)) |field| {
         comptime assert(std.mem.indexOfScalar(u8, field.name, '_') == null);
         if (std.mem.eql(u8, first_arg, field.name)) {
-            return @unionInit(Commands, field.name, parse_flags(args, field.type));
+            return @unionInit(Commands, field.name, parse_flags(arena, args, field.type));
         }
     }
     fatal("unknown subcommand: '{s}'", .{first_arg});
 }
 
-fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
+fn parse_flags(arena: Allocator, args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
     @setEvalBranchQuota(5_000);
 
     if (CLIArgs == void) {
@@ -147,35 +147,50 @@ fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
     }
 
     if (@typeInfo(CLIArgs) == .@"union") {
-        return parse_commands(args, CLIArgs);
+        return parse_commands(arena, args, CLIArgs);
     }
 
     assert(@typeInfo(CLIArgs) == .@"struct");
 
     const fields = std.meta.fields(CLIArgs);
-    comptime var fields_named, const fields_positional, const fields_extended =
+    comptime var fields_named, const fields_positional, const field_extended: ?std.builtin.Type.StructField =
         for (fields, 0..) |field, index| {
             if (std.mem.eql(u8, field.name, "--")) {
                 assert(field.type == void);
+                const positional_count = fields.len - index - 1;
+                if (positional_count == 0) @panic("expected positional fields");
+
+                if (positional_count == 1 and fields[index + 1].type == []const []const u8) {
+                    break .{
+                        fields[0..index].*,
+                        fields[index + 2 ..].*, // Empty
+                        fields[index + 1],
+                    };
+                }
+
                 break .{
                     fields[0..index].*,
                     fields[index + 1 ..].*,
-                    index == fields.len - 1,
+                    null,
                 };
             }
         } else .{
             fields[0..fields.len].*,
             [_]std.builtin.Type.StructField{},
-            false,
+            null,
         };
 
+    var arg_extended: if (field_extended == null) void else std.ArrayListUnmanaged([]const u8) =
+        if (field_extended == null) {} else .empty;
+
     comptime {
-        if (fields_positional.len == 0) {
-            assert(fields.len == fields_named.len + @intFromBool(fields_extended));
-        } else {
-            assert(fields.len == fields_named.len + 1 + fields_positional.len);
-            assert(!fields_extended);
-        }
+        assert(
+            fields.len == fields_named.len +
+                fields_positional.len +
+                @intFromBool(field_extended != null) +
+                if (field_extended != null or fields_positional.len > 0) 1 else 0, // The @"--"
+        );
+        if (field_extended != null) assert(fields_positional.len == 0);
 
         // When parsing named arguments, we must consider longer arguments first, such that
         // `--foo-bar=92` is not confused for a misspelled `--foo=92`. Using `std.sort` for
@@ -253,7 +268,7 @@ fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
         }
 
         if (fields_positional.len > 0) {
-            assert(!fields_extended);
+            assert(field_extended == null);
             counts.@"--" += 1;
             switch (counts.@"--" - 1) {
                 inline 0...fields_positional.len - 1 => |field_index| {
@@ -274,7 +289,7 @@ fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
                 else => {}, // Fall-through to the unexpected argument error.
             }
         } else {
-            if (fields_extended) {
+            if (field_extended != null) {
                 if (std.mem.eql(u8, arg, "--")) {
                     break;
                 } else {
@@ -285,7 +300,13 @@ fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
 
         fatal("unexpected argument: '{s}'", .{arg});
     }
-    if (!fields_extended) assert(args.next() == null);
+    if (field_extended != null) {
+        while (args.next()) |arg| {
+            arg_extended.append(arena, arg) catch |err| oom(err);
+        }
+    }
+
+    assert(args.next() == null);
 
     inline for (fields_named) |field| {
         const flag = flag_name(field);
@@ -301,6 +322,7 @@ fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
     }
 
     if (fields_positional.len > 0) {
+        assert(field_extended == null);
         assert(counts.@"--" <= fields_positional.len);
         inline for (fields_positional, 0..) |field, field_index| {
             if (field_index >= counts.@"--") {
@@ -312,6 +334,11 @@ fn parse_flags(args: *std.process.ArgIterator, comptime CLIArgs: type) CLIArgs {
                 }
             }
         }
+    }
+
+    if (field_extended) |field| {
+        assert(fields_positional.len == 0);
+        @field(result, field.name) = arg_extended.items;
     }
 
     return result;
@@ -649,6 +676,7 @@ pub const main =
             extended: struct {
                 flag: bool = false,
                 @"--": void,
+                rest: []const []const u8,
             },
             required: struct {
                 foo: u8,
@@ -682,10 +710,10 @@ pub const main =
             var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
             const gpa = gpa_allocator.allocator();
 
-            var args = try std.process.argsWithAllocator(gpa);
-            defer args.deinit();
+            var flags = Flags.init(gpa);
+            defer flags.deinit(gpa);
 
-            const cli_args = parse(&args, CLIArgs);
+            const cli_args = flags.parse(CLIArgs);
 
             const stdout = std.io.getStdOut();
             const out_stream = stdout.writer();
@@ -706,7 +734,7 @@ pub const main =
                 },
                 .extended => |values| {
                     try out_stream.print("flag: {}\n", .{values.flag});
-                    while (args.next()) |arg| try out_stream.print("arg: {s}\n", .{arg});
+                    for (values.rest) |arg| try out_stream.print("arg: {s}\n", .{arg});
                 },
                 .required => |required| {
                     try out_stream.print("foo: {}\n", .{required.foo});
@@ -1435,6 +1463,19 @@ test "flags" {
         \\flag: true
         \\arg: a
         \\arg: b
+        \\
+    ));
+    try t.check(&.{ "extended", "--", "--flag" }, snap(@src(),
+        \\stdout:
+        \\flag: false
+        \\arg: --flag
+        \\
+    ));
+    try t.check(&.{ "extended", "--", "--", "--" }, snap(@src(),
+        \\stdout:
+        \\flag: false
+        \\arg: --
+        \\arg: --
         \\
     ));
 }

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -83,7 +83,7 @@ pub const Ratio = struct {
 };
 
 test "Ratio.parse_flag_value" {
-    try stdx.parse_flag_value_fuzz(Ratio, Ratio.parse_flag_value, .{
+    try stdx.Flags.parse_flag_value_fuzz(Ratio, Ratio.parse_flag_value, .{
         .ok = &.{
             .{ "0", .zero() },
             .{ "3/4", ratio(3, 4) },

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -22,7 +22,6 @@ pub const huge_page_allocator = @import("huge_page_allocator.zig").huge_page_all
 pub const aegis = @import("vendored/aegis.zig");
 pub const dbg = @import("debug.zig").dbg;
 pub const Flags = @import("flags.zig");
-pub const parse_flag_value_fuzz = @import("flags.zig").parse_flag_value_fuzz;
 pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
 pub const timeit = @import("debug.zig").timeit;
 pub const unshare = @import("unshare.zig");
@@ -1072,7 +1071,7 @@ pub const ByteSize = struct {
 };
 
 test "ByteSize.parse_flag_value" {
-    try parse_flag_value_fuzz(ByteSize, ByteSize.parse_flag_value, .{
+    try Flags.parse_flag_value_fuzz(ByteSize, ByteSize.parse_flag_value, .{
         .ok = &.{
             .{ "0", .{ .value = 0, .unit = .bytes } },
             .{ "1", .{ .value = 1, .unit = .bytes } },

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -21,7 +21,7 @@ pub const huge_page_allocator = @import("huge_page_allocator.zig").huge_page_all
 
 pub const aegis = @import("vendored/aegis.zig");
 pub const dbg = @import("debug.zig").dbg;
-pub const flags = @import("flags.zig").parse;
+pub const Flags = @import("flags.zig");
 pub const parse_flag_value_fuzz = @import("flags.zig").parse_flag_value_fuzz;
 pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
 pub const timeit = @import("debug.zig").timeit;

--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -180,7 +180,7 @@ test "Instant/Duration" {
 }
 
 test "Duration.parse_flag_value" {
-    try stdx.parse_flag_value_fuzz(Duration, Duration.parse_flag_value, .{
+    try stdx.Flags.parse_flag_value_fuzz(Duration, Duration.parse_flag_value, .{
         .ok = &.{
             .{ "1h", .{ .ns = std.time.ns_per_hour } },
             .{ "1m", .{ .ns = std.time.ns_per_min } },

--- a/src/testing/vortex/zig_driver.zig
+++ b/src/testing/vortex/zig_driver.zig
@@ -36,10 +36,10 @@ pub fn main() !void {
     };
 
     const allocator = gpa_allocator.allocator();
-    var args_iterator = try std.process.argsWithAllocator(allocator);
-    defer args_iterator.deinit();
+    var flags = stdx.Flags.init(allocator);
+    defer flags.deinit(allocator);
 
-    const args = stdx.flags(&args_iterator, CLIArgs);
+    const args = flags.parse(CLIArgs);
     log.info("addresses: {s}", .{args.addresses});
 
     var tb_client: c.tb_client_t = undefined;

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -697,8 +697,8 @@ pub const Command = union(enum) {
 
 /// Parse the command line arguments passed to the `tigerbeetle` binary.
 /// Exits the program with a non-zero exit code if an error is found.
-pub fn parse_args(args_iterator: *std.process.ArgIterator) Command {
-    const cli_args = stdx.flags(args_iterator, CLIArgs);
+pub fn parse_args(flags: *stdx.Flags) Command {
+    const cli_args = flags.parse(CLIArgs);
 
     return switch (cli_args) {
         .format => |format| .{ .format = parse_args_format(format) },

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -69,10 +69,10 @@ pub fn main() !void {
     // Arena is an implementation detail, all memory must be freed.
     const gpa = arena_instance.allocator();
 
-    var arg_iterator = try std.process.argsWithAllocator(gpa);
-    defer arg_iterator.deinit();
+    var flags = stdx.Flags.init(gpa);
+    defer flags.deinit(gpa);
 
-    var command = cli.parse_args(&arg_iterator);
+    var command = cli.parse_args(&flags);
 
     if (command == .version) {
         try command_version(gpa, command.version.verbose);

--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -108,10 +108,10 @@ pub fn main() !void {
 
     const gpa = gpa_instance.allocator();
 
-    var args = try std.process.argsWithAllocator(gpa);
-    defer args.deinit();
+    var flags = stdx.Flags.init(gpa);
+    defer flags.deinit();
 
-    const cli_args = stdx.flags(&args, CLIArgs);
+    const cli_args = flags.parse(CLIArgs);
     if (cli_args.lite and cli_args.performance) {
         return vsr.fatal(.cli, "--lite and --performance are mutually exclusive", .{});
     }

--- a/src/vortex.zig
+++ b/src/vortex.zig
@@ -58,21 +58,10 @@ pub fn main() !void {
 
     const allocator = gpa_allocator.allocator();
 
-    var args_iterator = try std.process.argsWithAllocator(allocator);
-    defer args_iterator.deinit();
+    var flags = stdx.Flags.init(allocator);
+    defer flags.deinit(allocator);
 
-    // TODO Remove after merging https://github.com/tigerbeetle/tigerbeetle/pull/3612.
-    // (Stopgap for CFO).
-    {
-        const args_list = try std.process.argsAlloc(allocator);
-        defer std.process.argsFree(allocator, args_list);
-
-        if (std.mem.eql(u8, args_list[1], "supervisor")) {
-            assert(args_iterator.skip());
-        }
-    }
-
-    const args = stdx.flags(&args_iterator, CLIArgs);
+    const args = flags.parse(CLIArgs);
 
     if (args.log) |log_path| {
         const log_file = try std.fs.cwd().createFile(log_path, .{});


### PR DESCRIPTION
```zig
    var args = try std.process.argsWithAllocator(gpa);
    defer args.deinit();

    const cli_args = stdx.flags(&args, CLIArgs);
```

=>

```zig
    var flags = stdx.Flags.init(gpa);
    defer flags.deinit(gpa);

    const cli_args = flags.parse(CLIArgs);
```

Several motivations here. None are _particularly_ strong, but I wanted to do this for ages. 

* First, we hide `std.process.ArgIterator` dependency, so that we are isolated from churn in Zig std. 
* Second, we gain access to arena used by ArgIterator, which I think is going to be useful one day, when we'd love to allocate something during CLI parsing (e.g, I think we could use use `--addresses` or other similar use-cases)
* Third, make the trailing argument API a tad more intuitive, by returning a slice, rather than requiring the caller to drive the iterator. 

```zig
    merge: struct {
        @"--": void,
        // (One or more AOF file paths.)
    },
```

=>

```zig
    merge: struct {
        @"--": void,
        paths: []const []const u8,
    },
```

* Fourth, `stdx.Flags.parse_flag_value_fuzz` is a tiny-tiny bit better nested that way :) 


The extending argument argument one was actually the final straw --- I was building a little tiny tool, and I really wanted the "rest" arguments as a slice!