### PR TITLE
vsr: fix resonance in block repair

### DIFF
--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -94,12 +94,6 @@ pub const GridBlocksMissing = struct {
     /// Invariants:
     /// - For every block address in faulty_blocks, ¬free_set.is_free(address).
     faulty_blocks: FaultyBlocks,
-    /// Index within `faulty_blocks`, used to cycle through block-repair requests.
-    ///
-    /// Invariants:
-    /// - faulty_blocks.count() > 0 implies faulty_blocks_repair_index < faulty_blocks.count()
-    /// - faulty_blocks.count() = 0 implies faulty_blocks_repair_index = faulty_blocks.count()
-    faulty_blocks_repair_index: usize = 0,
 
     /// On `sync_jump_commence()` and `sync_complete()`, swap this with `faulty_blocks` so that the
     /// (possibly invalid) table blocks don't interfere.
@@ -182,8 +176,6 @@ pub const GridBlocksMissing = struct {
     pub fn verify(queue: *const GridBlocksMissing) void {
         assert(queue.faulty_blocks.count() + queue.syncing_faulty_blocks.count() ==
             queue.enqueued_blocks_repair + queue.enqueued_blocks_sync);
-        assert(queue.faulty_blocks_repair_index == 0 or
-            queue.faulty_blocks_repair_index < queue.faulty_blocks.count());
 
         var enqueued_blocks_repair: u32 = 0;
         var enqueued_blocks_sync: u32 = 0;
@@ -235,15 +227,12 @@ pub const GridBlocksMissing = struct {
     }
 
     /// Note that returning `null` doesn't necessarily indicate that there are no more blocks.
-    pub fn next_request(queue: *GridBlocksMissing) ?vsr.BlockRequest {
+    pub fn fault_at_index(queue: *const GridBlocksMissing, fault_index: usize) ?vsr.BlockRequest {
         assert(queue.faulty_blocks.count() > 0);
-        assert(queue.faulty_blocks_repair_index < queue.faulty_blocks.count());
+        assert(fault_index < queue.faulty_blocks.count());
 
         const fault_addresses = queue.faulty_blocks.keys();
         const fault_data = queue.faulty_blocks.values();
-        const fault_index = queue.faulty_blocks_repair_index;
-
-        queue.faulty_blocks_repair_index = (fault_index + 1) % queue.faulty_blocks.count();
 
         return switch (fault_data[fault_index].state) {
             .waiting => .{
@@ -437,6 +426,7 @@ pub const GridBlocksMissing = struct {
         const fault_index = queue.faulty_blocks.getIndex(block_header.address).?;
         const fault_address = queue.faulty_blocks.keys()[fault_index];
         const fault: FaultyBlock = queue.faulty_blocks.values()[fault_index];
+
         assert(fault_address == block_header.address);
         assert(fault.checksum == block_header.checksum);
         assert(fault.state == .aborting or fault.state == .writing);
@@ -528,18 +518,12 @@ pub const GridBlocksMissing = struct {
     }
 
     fn release_fault(queue: *GridBlocksMissing, fault_index: usize) void {
-        assert(queue.faulty_blocks_repair_index < queue.faulty_blocks.count());
-
         switch (queue.faulty_blocks.values()[fault_index].cause) {
             .repair => queue.enqueued_blocks_repair -= 1,
             .sync => queue.enqueued_blocks_sync -= 1,
         }
 
         queue.faulty_blocks.swapRemoveAt(fault_index);
-
-        if (queue.faulty_blocks_repair_index == queue.faulty_blocks.count()) {
-            queue.faulty_blocks_repair_index = 0;
-        }
     }
 
     pub fn cancel(queue: *GridBlocksMissing) void {
@@ -598,7 +582,6 @@ pub const GridBlocksMissing = struct {
 
             assert(queue.syncing_faulty_blocks.count() == 0);
             std.mem.swap(FaultyBlocks, &queue.faulty_blocks, &queue.syncing_faulty_blocks);
-            queue.faulty_blocks_repair_index = 0;
         }
         assert(queue.faulty_blocks.count() == 0);
         assert(queue.syncing_faulty_blocks.count() == queue.enqueued_blocks_sync);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -11270,10 +11270,14 @@ pub fn ReplicaType(
                 }
             }
 
-            for (0..self.grid.blocks_missing.faulty_blocks.count()) |_| {
+            const faulty_blocks_count = self.grid.blocks_missing.faulty_blocks.count();
+            const faulty_index_offset = self.prng.int_inclusive(usize, faulty_blocks_count -| 1);
+            for (0..faulty_blocks_count) |index| {
                 if (requests_count >= requests_buffer.len) break;
 
-                if (self.grid.blocks_missing.next_request()) |missing_request| {
+                if (self.grid.blocks_missing.fault_at_index(
+                    (faulty_index_offset + index) % faulty_blocks_count,
+                )) |missing_request| {
                     const block_identifier = vsr.BlockReference{
                         .address = missing_request.block_address,
                         .checksum = missing_request.block_checksum,


### PR DESCRIPTION
The way we currently cycle through `faulty_blocks` is prone to resonance. 

Imagine a 3-replica cluster R0, R1, R2 where R2 has 8 blocks B0 → B7
missing (and in `faulty_blocks`). Let's say only B0 out of these is
available, on R0, and all the other blocks are missing. Now, we _could_ 
get stuck in a resonance where we keep sending [B0, B1, B2, B3] to R1,
and [B4, B5, B6, B7] to R2 over and over, since the expiry timeout on R0,
even if jittered, as per #3618.

To clarify, this was only made possible because of #3599, as before that,
we used to randomly selected replicas for repair with no regard for how
many requests we have underway to a particular replica.

So, we change the way we iterate over `faulty_blocks`. send_request_blocks
already iterates over the entire list of blocks, with the starting index cycling
through. Instead of this, we now choose a random start index in send_request_blocks.
This keeps the semantics the same as they are right now, we  *still* iterate over the
entirety of `faulty_blocks`, except with a random start index. This should help us 
break resonances like the one mentioned above. 