### PR TITLE
CFO: Remove deprecated "supervisor" subcommand

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -153,7 +153,6 @@ const Fuzzer = enum {
             .vopr, .vopr_debug, .vopr_testing => &.{},
             .vopr_lite, .vopr_testing_lite => &.{"--lite"},
             .vortex, .vortex_debug => &.{
-                "supervisor",
                 "--log-debug",
                 "--replica-count=3",
                 "--test-duration=10m",


### PR DESCRIPTION
Remove legacy "supervisor" subcommand now that `release` branch has the updated Vortex where it is optional.

We need to merge this prior to https://github.com/tigerbeetle/tigerbeetle/pull/3637 to avoid CFO failing.