### PR TITLE
vsr: make repair less eager

### DIFF
--- a/src/vopr.zig
+++ b/src/vopr.zig
@@ -165,6 +165,12 @@ pub fn main() !void {
         options.requests_max = requests_max;
     }
 
+    if (options.replica_missing_until_request != null and
+        options.requests_max < options.replica_missing_until_request.?)
+    {
+        return vsr.fatal(.cli, "--requests-max < --replica-missing-until-request", .{});
+    }
+
     log.info(
         \\
         \\          SEED={}
@@ -282,10 +288,28 @@ pub fn main() !void {
         if (requests_done and upgrades_done) break;
     }
 
-    if (cli_args.lite or
-        (cli_args.performance and cli_args.replica_missing_until_request == null))
-    {
+    if (cli_args.lite) {
         // Don't care about convergence.
+    } else if (cli_args.performance) {
+        assert(requests_done and upgrades_done);
+
+        var core = full_core(
+            simulator.options.cluster.replica_count,
+            simulator.options.cluster.standby_count,
+        );
+        if (cli_args.replica_missing) |replica_missing| {
+            // If replica is permanently missing then exclude it from the core.
+            if (cli_args.replica_missing_until_request == null) core.unset(replica_missing);
+        }
+        simulator.transition_to_liveness_mode(core);
+
+        tick = 0;
+        while (tick < cli_args.ticks_max_convergence) : (tick += 1) {
+            simulator.tick();
+            tick_total += 1;
+            if (simulator.pending() == null) break;
+        }
+        assert(simulator.pending() == null);
     } else {
         const core = if (requests_done and upgrades_done)
             // Liveness: a core set of replicas is up and fully connected. The rest of the replicas
@@ -832,7 +856,7 @@ pub const Simulator = struct {
         if (simulator.options.replica_missing_until_request) |request| {
             if (simulator.requests_replied >= request) {
                 simulator.options.replica_missing_until_request = null;
-                simulator.replica_crash_stability[simulator.options.replica_missing.?] = 1;
+                simulator.replica_restart(simulator.options.replica_missing.?, false);
             }
         }
     }

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -755,7 +755,7 @@ pub const Timeout = struct {
     }
 
     pub fn reset_with_jitter(self: *Timeout, prng: *stdx.PRNG) void {
-        self.attempts = 0;
+        self.attempts +%= 1;
         self.ticks = 0;
         assert(self.ticking);
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -506,11 +506,6 @@ pub fn ReplicaType(
         /// Unique join_view messages for the same view from ALL replicas (including ourself).
         join_view_from_all_replicas: JVQuorumMessages = jv_quorum_messages_null,
 
-        // The op number which should be set as op_min for the next request_headers call.
-        // This is an optimization that ensures op_min is not always set to op_repair_min (reducing
-        // the number of headers requested).
-        repair_header_op_next: u64 = 0,
-
         /// Whether the primary has received a quorum of join_view messages for the view
         /// change. Determines whether the primary may effect repairs according to the CTRL
         /// protocol.
@@ -7570,6 +7565,28 @@ pub fn ReplicaType(
                 }
             }
 
+            const repair_op_max: u64 = repair: {
+                // Every 50 timeouts, unconditionally repair. This
+                // allows backups to repair journal faults in an idle
+                // cluster where the the head op does not progress.
+                if (self.journal_repair_timeout.attempts % 50 == 0) break :repair self.op;
+
+                // View changing replicas must unconditionally repair,
+                // as transitioning to normal status requires them to
+                // repair their journal.
+                if (self.status == .view_change) break :repair self.op;
+
+                // Missing prepares/headers are expected during normal
+                // processing. This is by virtue of experimental ops in
+                // adaptive replication routing (see routing.zig), which
+                // cause replicas that usually receive ops in 2 hops to
+                // receive *some* ops in 1 hop (and vice versa). So, if a
+                // missing prepare/header exists within a pipeline of ops
+                // from the head, wait for it to arrive via normal
+                // replication, instead of eagerly repairing it.
+                break :repair self.op -| constants.pipeline_prepare_queue_max;
+            };
+
             const header_break = self.journal.find_latest_headers_break_between(
                 self.op_repair_min(),
                 self.op,
@@ -7581,37 +7598,53 @@ pub fn ReplicaType(
                 assert(range.op_min >= self.op_repair_min());
                 assert(range.op_max < self.op);
 
-                log.debug(
-                    "{}: repair: break: view={} break={}..{} (commit={}..{} op={})",
-                    .{
-                        self.log_prefix(),
-                        self.view,
-                        range.op_min,
-                        range.op_max,
-                        self.commit_min,
-                        self.commit_max,
-                        self.op,
-                    },
-                );
+                if (range.op_min <= repair_op_max) {
+                    const op_min = range.op_min;
+                    const op_max = @min(range.op_max, repair_op_max);
+                    assert(op_min <= op_max);
 
-                self.send_header_to_replica(
-                    self.choose_any_other_replica(),
-                    @bitCast(Header.RequestHeaders{
-                        .command = .request_headers,
-                        .cluster = self.cluster,
-                        .replica = self.replica,
-                        // Pessimistically request extra headers. Requesting/sending extra
-                        // headers is inexpensive, and it may save us extra round-trips to
-                        // repair earlier breaks.
-                        .op_min = @min(range.op_min, self.repair_header_op_next),
-                        .op_max = range.op_max,
-                    }),
-                );
-                self.repair_header_op_next = @max(self.repair_header_op_next, range.op_max + 1);
+                    log.debug(
+                        "{}: repair: break: view={} break={}..{} (commit={}..{} op={})",
+                        .{
+                            self.log_prefix(),
+                            self.view,
+                            op_min,
+                            op_max,
+                            self.commit_min,
+                            self.commit_max,
+                            self.op,
+                        },
+                    );
+                    self.send_header_to_replica(
+                        self.choose_any_other_replica(),
+                        @bitCast(Header.RequestHeaders{
+                            .command = .request_headers,
+                            .cluster = self.cluster,
+                            .replica = self.replica,
+                            // Pessimistically request extra headers. Requesting/sending extra
+                            // headers is inexpensive, and it may save us extra round-trips to
+                            // repair earlier breaks.
+                            .op_min = op_min,
+                            .op_max = op_max,
+                        }),
+                    );
+                }
             }
 
-            // Request and repair any missing, dirty, or faulty prepares.
-            self.repair_prepares();
+            // Iterate through [op_repair_min, self.op], but make sure to first iterate through
+            // [commit_min+1, self.op] and then [op_repair_min, commit_min]:
+            // - our first priority is to commit further,
+            // - afterwards, repair committed prepares which are at risk of getting evicted from
+            //   the journal, to help repair any lagging replicas.
+            if (self.commit_min + 1 <= repair_op_max) {
+                self.repair_prepares_between(self.commit_min + 1, repair_op_max);
+            }
+
+            if (self.op_repair_min() <= self.commit_min) {
+                self.repair_prepares_between(self.op_repair_min(), self.commit_min);
+            }
+
+            self.repair_clean_out_of_bound_prepares();
 
             if (self.commit_min < self.commit_max) {
                 // Try to the commit prepares we already have, even if we don't have all of them.
@@ -8173,61 +8206,25 @@ pub fn ReplicaType(
             }
         }
 
-        fn repair_prepares(self: *Replica) void {
+        fn repair_clean_out_of_bound_prepares(self: *Replica) void {
             assert(self.status == .normal or self.status == .view_change);
             assert(self.repairs_allowed());
             maybe(self.journal.dirty.count > 0);
             assert(self.op >= self.commit_min);
             assert(self.op - self.commit_min <= constants.journal_slot_count);
 
-            if (self.op < constants.journal_slot_count) {
-                // The op is known, and this is the first WAL cycle.
-                // Therefore, any faulty ops to the right of `replica.op` are corrupt reserved
-                // entries from the initial format, or corrupt prepares which were since truncated.
-                var op: usize = self.op + 1;
-                while (op < constants.journal_slot_count) : (op += 1) {
-                    const slot = self.journal.slot_for_op(op);
-                    assert(slot.index == op);
-
-                    if (self.journal.faulty.bit(slot)) {
-                        assert(self.journal.headers[op].operation == .reserved);
-                        assert(self.journal.headers_redundant[op].operation == .reserved);
-                        self.journal.dirty.clear(slot);
-                        self.journal.faulty.clear(slot);
-                        log.debug("{}: repair_prepares: remove slot={} " ++
-                            "(faulty, op known, first cycle)", .{
-                            self.log_prefix(),
-                            slot.index,
-                        });
-                    }
-                }
-            }
-
-            // Iterate through [op_repair_min, self.op], but make sure to first iterate through
-            // [commit_min+1, self.op] and then [op_repair_min, commit_min]:
-            // - our first priority is to commit further,
-            // - afterwards, repair committed prepares which are at risk of getting evicted from
-            //   the journal, to help repair any lagging replicas.
-            if (self.commit_min + 1 <= self.op) {
-                self.repair_prepares_between(self.commit_min + 1, self.op);
-            }
-
-            if (self.op_repair_min() <= self.commit_min) {
-                self.repair_prepares_between(self.op_repair_min(), self.commit_min);
-            }
-
             // Clean up out-of-bounds dirty slots so repair() can finish.
             const slots_repaired = vsr.SlotRange{
                 .head = self.journal.slot_for_op(self.op_repair_min()),
                 .tail = self.journal.slot_with_op(self.op).?,
             };
-            var slot_index: usize = 0;
-            while (slot_index < constants.journal_slot_count) : (slot_index += 1) {
+            for (0..constants.journal_slot_count) |slot_index| {
                 const slot = self.journal.slot_for_op(slot_index);
                 if (slots_repaired.head.index == slots_repaired.tail.index or
                     slots_repaired.contains(slot))
                 {
-                    // In-bounds — handled by the previous loop. The slot is either already
+                    // In-bounds — handled by the repair_prepares_between invocations
+                    // before this function is invoked. The slot is either already
                     // repaired, or we sent a request_prepare and are waiting for a reply.
                 } else {
                     // This op must be either:

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -2269,7 +2269,7 @@ const TestContext = struct {
     }
 
     pub fn run(t: *TestContext) void {
-        const tick_max = 4_100;
+        const tick_max = 8_200;
         var tick_count: usize = 0;
         while (tick_count < tick_max) : (tick_count += 1) {
             if (t.tick()) tick_count = 0;


### PR DESCRIPTION
Missing prepares/headers are expected during normal processing.
This is by virtue of experimental ops in adaptive replication routing
which cause replicas that usually receive ops in 2 hops to receive
*some* ops in 1 hop (and vice versa).

Currently, we do a lot of repair work (request_prepares, request_headers)
even during normal processing. This is because our repair is triggered
on *every prepare* we receive, so it is very eager to repair the 
aforementioned missing headers/prepares.

Now, if a missing prepare/header exists within a pipeline of ops
from the head, we wait for it to arrive via normal replication,
instead of eagerly repairing it. We use the distance between
our head op and the closest missing prepare/header as a proxy
for how much time has passed. Specifically, if we get >= pipeline
new prepares atop the missing prepare/header, it means that the
prepare may actually have been dropped/delayed on the network.

However, this distance may not increase in an idle cluster, so
we unconditionally trigger repair once every 50 journal_repair_timeout
attempts. Since journal_repair_timeout is between [75ms, 150ms], it
means we unconditionaly repair every [3.75s, 7.5s]. One caveat
of relying on attempts here is that we spuriously trigger
unconditional repair via other code paths (on_prepare, for example)
on every 50th journal_repair_timeout attempt.

---

### DPT results

<details>
  <summary><b>./zig/zig build -Drelease vopr -- --performance --requests-max=15000</b></summary>
<br>
Results over a 100 runs, massive reduction in `request_prepare`, `request_headers`, _and_ `prepares`, with only a minor, ~2% performance overhead:


Metric | Old | New | Avg Δ
-- | -- | -- | --
request_prepare | 73,334 | 10,177 | -86.1%
request_headers | 49,668 | 4,180 | -91.6%
headers | 44,725 | 3,759 | -91.6%
prepare | 153,819 | 102,337 | -33.5%
ticks | 94,348 | 96,431 | +2.2%

</details>


<details>
  <summary><b>./zig/zig build -Drelease vopr -- --performance --replica-missing=3 --replica-missing-until-request=7500 --requests-max=15000</b></summary>
<br>

Results over a 100 runs, there are 3 sets of buckets, in 23/100 runs `main` did some extra state sync (signaled by -50% Δ), and 19/100 runs where `cbb/repair_less_eager` did some extra state sync (signaled by +103.4% Δ), and finally 58/100 runs where there were no spurious state syncs by either, and block traffic was stable. The 3rd bucket, we see similar trends as above:

##### 1. Block traffic decreased (23/100)

Metric | Old | New | Avg Δ
-- | -- | -- | --
block | 29,762 | 14,722 | -50.5%
ticks | 141,180 | 130,223 | -7.8%

##### 2. Block traffic increased (19/100)

Metric | Old | New | Avg Δ
-- | -- | -- | --
block | 14,645 | 29,790 | +103.4%
ticks | 126,553 | 144,645 | +14.3%

##### 3. Block traffic stable (58/100)

Metric | Old | New | Avg Δ
-- | -- | -- | --
request_prepare | 61,030 | 19,508 | -68.0%
request_headers | 35,708 | 4,681 | -86.9%
headers | 27,709 | 3,608 | -87.0%
prepare | 133,767 | 104,314 | -22.0%
block | 15,069 | 15,036 | -0.2%
ticks | 126,163 | 129,796 | +2.9%


</details>



