### PR TITLE
CI: Fetch tags on release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 2147483647
+          fetch-tags: true # Fetch full history for tidy.
           ref: release # Use the 'release' branch even if triggered manually
 
       - uses: actions/setup-dotnet@v4


### PR DESCRIPTION
So that we don't fail with:

```
fatal: malformed object name HEAD^
unable to spawn the following command: ExitCodeFailure
git tag --merged HEAD^ --sort=-committerdate --list [0-9]*.[0-9]*.[0-9]*
error: the following build command failed with exit code 1:
```