### PR TITLE
docs: don’t use custom table in api changes

### DIFF
--- a/docs/coding/api-changes.md
+++ b/docs/coding/api-changes.md
@@ -51,21 +51,14 @@ The result types <code>CreateAccount<b>s</b>Result</code> and
 <code>CreateTransfer<b>s</b>Result</code> were renamed to the singular form,
 <code>CreateAccountResult</code> and <code>CreateTransferResult</code>.
 
-<table>
-<tr><th>Before</th><th>After</th></tr>
-<tr><td>
-
 ```zig
+// Before:
 pub const CreateAccountsResult = extern struct {
     index: u32,
     result: CreateAccountResult,
 };
 
-```
-
-</td><td>
-
-```zig
+// After:
 pub const CreateAccountResult = extern struct {
     timestamp: u64,
     status: CreateAccountStatus,
@@ -73,30 +66,20 @@ pub const CreateAccountResult = extern struct {
 };
 ```
 
-</td></tr>
-<tr><!-- Empty row to avoid the zebra stripe style--></tr>
-<tr><td>
-
 ```zig
+// Before:
 pub const CreateTransfersResult = extern struct {
     index: u32,
     result: CreateTransferResult,
 };
 
-```
-
-</td><td>
-
-```zig
+// After:
 pub const CreateTransferResult = extern struct {
     timestamp: u64,
     status: CreateTransferStatus,
     reserved: u32 = 0,
 };
 ```
-
-</td></tr>
-</table>
 
 ### Query limits.
 


### PR DESCRIPTION
The table for the code comparison is unfortunately too wide and is cut off on docs.tigerbeetle.com:

Before:
<img width="894" height="465" alt="image" src="https://github.com/user-attachments/assets/a349887d-d6e9-4989-b6dd-92c946249d40" />

After:
<img width="1824" height="1496" alt="image" src="https://github.com/user-attachments/assets/f951fcbc-ec2d-41b5-aa2e-cadd26d9a137" />
