### PR TITLE
CPO: Continuous Performance Orchestrator

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,7 +106,7 @@ pub fn build(b: *std.Build) !void {
         .vopr_build = b.step("vopr:build", "Build the VOPR"),
     };
 
-    const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .Debug });
+    const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseSafe });
 
     // Build options passed with `-D` flags.
     const build_options = .{

--- a/build.zig
+++ b/build.zig
@@ -106,7 +106,7 @@ pub fn build(b: *std.Build) !void {
         .vopr_build = b.step("vopr:build", "Build the VOPR"),
     };
 
-    const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseSafe });
+    const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .Debug });
 
     // Build options passed with `-D` flags.
     const build_options = .{

--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -236,16 +236,36 @@ async function main_seeds() {
 async function main_metrics() {
   const data_url =
     "https://raw.githubusercontent.com/tigerbeetle/devhubdb/main/devhub/data.json";
-  const data = await (await fetch(data_url)).text();
+  const cpo_long_data_url =
+    "https://raw.githubusercontent.com/tigerbeetle/devhubdb-cpo/main/long/data.json";
   const max_batches = 200;
-  const batches = data.split("\n")
-    .filter((it) => it.length > 0)
-    .map((it) => JSON.parse(it))
-    .slice(-1 * max_batches)
-    .reverse();
 
+  const batches = await fetch_batches(data_url, max_batches);
   const series = batches_to_series(batches);
   plot_series(series, document.querySelector("#charts"), batches.length);
+
+  try {
+    const cpo_long_batches = await fetch_batches(
+      cpo_long_data_url,
+      max_batches,
+    );
+    const cpo_long_tps_batches = filter_batches_metrics(cpo_long_batches, [
+      "long TPS",
+      "long batch p100",
+    ]);
+    const cpo_long_tps_series = batches_to_series(cpo_long_tps_batches);
+    plot_series(
+      cpo_long_tps_series,
+      document.querySelector("#cpo-charts"),
+      cpo_long_tps_batches.length,
+      {
+        group: "devhub-cpo",
+        outlier_count: 0,
+      },
+    );
+  } catch (error) {
+    console.error("Failed to load CPO metrics", error);
+  }
 }
 
 function is_main(record) {
@@ -267,6 +287,27 @@ function pull_request_number(record) {
     return parseInt(pr_number, 10);
   }
   return undefined;
+}
+
+async function fetch_batches(url, max_batches) {
+  const data = await (await fetch(url, { cache: "no-cache" })).text();
+  return data.split("\n")
+    .filter((it) => it.length > 0)
+    .map((it) => JSON.parse(it))
+    .slice(-1 * max_batches)
+    .reverse();
+}
+
+function filter_batches_metrics(batches, metric_names) {
+  const metric_names_set = new Set(metric_names);
+  return batches
+    .map((batch) => ({
+      ...batch,
+      metrics: batch.metrics.filter((metric) =>
+        metric_names_set.has(metric.name)
+      ),
+    }))
+    .filter((batch) => batch.metrics.length > 0);
 }
 
 function format_duration(duration_ms) {
@@ -359,9 +400,10 @@ function batches_to_series(batches) {
   return Array.from(results.values());
 }
 
-function plot_series(series_list, root_node, batch_count) {
+function plot_series(series_list, root_node, batch_count, options_extra = {}) {
   const now_seconds = Date.now() / 1000;
-  const outlier_count = 3;
+  const outlier_count = options_extra.outlier_count ?? 3;
+  const group = options_extra.group ?? "devhub";
 
   const outile_indices = series_list.map(
     (series, index) => ({
@@ -386,7 +428,7 @@ function plot_series(series_list, root_node, batch_count) {
       },
       chart: {
         id: series.name,
-        group: "devhub",
+        group: group,
         type: "line",
         height: "400px",
         animations: {

--- a/src/devhub/index.html
+++ b/src/devhub/index.html
@@ -76,13 +76,20 @@
       </table>
     </section>
 
-    <section id="metrics">
+    <section id="metrics" class="metrics">
       <h2>Metrics
         <a href="https://nyrkio.com/public/https%3A%2F%2Fgithub.com%2Ftigerbeetle%2Ftigerbeetle/main/devhub"
           target="_blank">Nyrkiö</a>
         <a href="https://github.com/tigerbeetle/devhubdb/tree/main/devhub">Raw data</a>
       </h2>
-      <div id="charts"></div>
+      <div id="charts" class="charts"></div>
+    </section>
+
+    <section id="cpo-metrics" class="metrics">
+      <h2>CPO Metrics
+        <a href="https://github.com/tigerbeetle/devhubdb-cpo/tree/main/long">Raw data</a>
+      </h2>
+      <div id="cpo-charts" class="charts"></div>
     </section>
   </main>
 

--- a/src/devhub/style.css
+++ b/src/devhub/style.css
@@ -178,12 +178,12 @@ section#fuzz-runs {
     }
 }
 
-section#metrics {
+section.metrics {
     display: flex;
     flex-direction: column;
     gap: 12px;
 
-    #charts {
+    .charts {
         border: 1px solid var(--gray-4);
         border-radius: 6px;
         display: flex;
@@ -199,7 +199,7 @@ section#metrics {
 }
 
 @media (prefers-color-scheme: dark) {
-    #charts {
+    .charts {
         color: var(--gray-1);
 
         >div {

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -18,6 +18,7 @@ const cfo = @import("./scripts/cfo.zig");
 const ci = @import("./scripts/ci.zig");
 const release = @import("./scripts/release.zig");
 const devhub = @import("./scripts/devhub.zig");
+const cpo = @import("./scripts/cpo.zig");
 const changelog = @import("./scripts/changelog.zig");
 const amqp = @import("./scripts/amqp.zig");
 
@@ -38,6 +39,7 @@ const CLIArgs = union(enum) {
     ci: ci.CLIArgs,
     release: release.CLIArgs,
     devhub: devhub.CLIArgs,
+    cpo: cpo.CLIArgs,
     changelog: void,
     amqp: amqp.CLIArgs,
 
@@ -54,6 +56,8 @@ const CLIArgs = union(enum) {
         \\                          [--build-docs]
         \\
         \\  zig build scripts -- devhub --sha=<commit>
+        \\
+        \\  zig build scripts -- cpo [--sha=<commit>]
         \\
         \\  zig build scripts -- release --sha=<commit>
         \\
@@ -99,6 +103,7 @@ pub fn main() !void {
         .ci => |args_ci| try ci.main(shell, gpa, args_ci),
         .release => |args_release| try release.main(shell, gpa, args_release),
         .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
+        .cpo => |args_cpo| try cpo.main(shell, gpa, args_cpo),
         .changelog => try changelog.main(shell, gpa),
         .amqp => |args_amqp| try amqp.main(shell, gpa, args_amqp),
     }

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -57,7 +57,7 @@ const CLIArgs = union(enum) {
         \\
         \\  zig build scripts -- devhub --sha=<commit>
         \\
-        \\  zig build scripts -- cpo [--sha=<commit>]
+        \\  zig build scripts -- cpo [--sha=<commit>] [--long-benchmark-timeout=<duration>]
         \\
         \\  zig build scripts -- release --sha=<commit>
         \\

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -1,0 +1,435 @@
+//! Runs a set of macro-benchmarks whose result is displayed at <https://devhub.tigerbeetle.com/>.
+//!
+//! Specifically:
+//!
+//! - This script is run by the CPO infrastructure.
+//! - It runs the regular DevHub benchmark batch, then a long-running benchmark.
+//! - The results of all measurements are serialized as a single JSON object, `Run`.
+//! - The key part: this JSON is then stored in a "distributed database" for our visualization
+//!   front-end to pick up. This "database" is just a newline-delimited JSON file in a git repo
+//!
+//! To generate a DEVHUBDB_PAT (used by cfo and CI):
+//! 1. Go to https://github.com/settings/personal-access-tokens/new
+//! 2. Fill out token name (e.g. "cfo/ci devhubdb token").
+//! 3. Resource owner: "tigerbeetle"
+//! 4. Expiry: "366 days" (maximum available)
+//! 5. Repository access: "Only select repositories"
+//! 6. Select repositories: "tigerbeetle/devhubdb"
+//! 7. Add permissions: "Metadata"
+//! 8. Add permissions: "Contents"; Access: "Read and write".
+//! 9. "Generate token".
+//! 10. (Copy token.)
+//!
+//! To update token in TigerBeetle CI:
+//! 1. https://github.com/tigerbeetle/tigerbeetle/settings/environments
+//! 2. Click "devhub".
+//! 3. Environment Secrets > Edit DEVHUBDB_PAT
+//! 4. Paste token; "Update secret"
+//!
+//! (Also need to update the DEVHUBDB_PAT environment variable passed to the CFO supervisors.)
+const std = @import("std");
+const assert = std.debug.assert;
+
+const stdx = @import("stdx");
+const Shell = @import("../shell.zig");
+const Release = @import("../multiversion.zig").Release;
+
+const log = std.log;
+
+pub const CLIArgs = struct {
+    sha: ?[]const u8 = null,
+    skip_kcov: bool = true,
+};
+
+pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
+    const sha = cli_args.sha orelse try shell.exec_stdout("git rev-parse HEAD", .{});
+    try cpo_metrics(shell, sha);
+
+    if (!cli_args.skip_kcov) {
+        try devhub_coverage(shell);
+    } else {
+        log.info("--skip-kcov enabled, not computing coverage.", .{});
+    }
+}
+
+fn devhub_coverage(shell: *Shell) !void {
+    var section = try shell.open_section("coverage");
+    defer section.close();
+
+    const kcov_version = shell.exec_stdout("kcov --version", .{}) catch {
+        return error.NoKcov;
+    };
+    log.info("kcov version {s}", .{kcov_version});
+
+    try shell.exec_zig("build test:unit:build", .{});
+    try shell.exec_zig("build vopr:build", .{});
+    try shell.exec_zig("build fuzz:build", .{});
+
+    // Put results into src/devhub, as that folder is deployed as GitHub pages.
+    try shell.project_root.deleteTree("./src/devhub/coverage");
+    try shell.project_root.makePath("./src/devhub/coverage");
+
+    const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./src/devhub/coverage" };
+    inline for (.{
+        "{kcov} ./zig-out/bin/test-unit",
+        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92",
+        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92",
+        "{kcov} ./zig-out/bin/vopr 92",
+    }) |command| {
+        try shell.exec(command, .{ .kcov = kcov });
+    }
+
+    var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
+    defer coverage_dir.close();
+
+    // kcov adds some symlinks to the output, which prevents upload to GitHub actions from working.
+    var it = coverage_dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind == .sym_link) {
+            try coverage_dir.deleteFile(entry.name);
+        }
+    }
+}
+
+fn cpo_metrics(shell: *Shell, sha: []const u8) !void {
+    var section = try shell.open_section("metrics");
+    defer section.close();
+
+    const commit_timestamp_str =
+        try shell.exec_stdout("git show -s --format=%ct {sha}", .{ .sha = sha });
+    const commit_timestamp = try std.fmt.parseInt(u64, commit_timestamp_str, 10);
+
+    try cpo_short_benchmark(shell, sha, commit_timestamp);
+
+    try cpo_long_benchmark(shell, sha, commit_timestamp);
+}
+
+fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !void {
+
+    // Only build the TigerBeetle binary to test build speed and build size. Keep the release build
+    // to run both cpo benchmarks.
+    var timer = try std.time.Timer.start();
+    const build_time_debug_ms = blk: {
+        timer.reset();
+        try shell.exec_zig("build install", .{});
+        defer shell.project_root.deleteFile("tigerbeetle") catch unreachable;
+
+        break :blk timer.read() / std.time.ns_per_ms;
+    };
+
+    const build_time_ms, const executable_size_bytes = blk: {
+        timer.reset();
+        try shell.project_root.deleteTree(".zig-cache/tmp/devhub_cache");
+        try shell.exec_zig("build -Drelease install", .{});
+
+        break :blk .{
+            timer.lap() / std.time.ns_per_ms,
+            (try shell.cwd.statFile("tigerbeetle")).size,
+        };
+    };
+    defer shell.project_root.deleteFile("tigerbeetle") catch {};
+    // `--log-debug-replica` is explicitly enabled, to measure the performance hit from debug
+    // logging and count the log lines.
+    // TODO: make useful benchmark (tbid etc.) and remove performance.
+    const benchmark_result, const benchmark_stderr = try shell.exec_stdout_stderr(
+        "./tigerbeetle benchmark --validate --checksum-performance --log-debug-replica " ++
+            "--file=datafile-devhub",
+        .{},
+    );
+
+    const integrity_time_ms = blk: {
+        timer.reset();
+
+        try shell.exec(
+            "./tigerbeetle inspect integrity datafile-devhub",
+            .{},
+        );
+
+        break :blk timer.read() / std.time.ns_per_ms;
+    };
+
+    shell.cwd.deleteFile("datafile-devhub") catch unreachable;
+
+    const replica_log_lines = std.mem.count(u8, benchmark_stderr, "\n");
+    const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
+    const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
+    const query_p100_ms = try get_measurement(benchmark_result, "query latency p100", "ms");
+    const rss_bytes = try get_measurement(benchmark_result, "rss", "bytes");
+    const datafile_bytes = try get_measurement(benchmark_result, "datafile", "bytes");
+    const datafile_empty_bytes = try get_measurement(benchmark_result, "datafile empty", "bytes");
+    const checksum_message_size_max_us = try get_measurement(
+        benchmark_result,
+        "checksum message size max",
+        "us",
+    );
+    const format_time_ms = blk: {
+        timer.reset();
+
+        try shell.exec(
+            "./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 datafile-devhub",
+            .{},
+        );
+
+        break :blk timer.read() / std.time.ns_per_ms;
+    };
+    defer shell.cwd.deleteFile("datafile-devhub") catch unreachable;
+
+    const stats_count = blk: {
+        const stats_inspect_result = try shell.exec_stdout("./tigerbeetle inspect metrics", .{});
+        var stats_count: u32 = 0;
+        var lines = std.mem.splitScalar(
+            u8,
+            stats_inspect_result,
+            '\n',
+        );
+        while (lines.next()) |line| {
+            // line looks like
+            // timing: compact_mutable_suffix(tree)=136
+            if (line.len != 0) {
+                _, const value_string = stdx.cut(line, "=").?;
+                stats_count += try std.fmt.parseInt(u32, value_string, 10);
+            }
+        }
+        break :blk stats_count;
+    };
+
+    const startup_time_ms, const repl_single_command_ms = blk: {
+        timer.reset();
+
+        var process = try shell.spawn(
+            .{
+                .stdin_behavior = .Pipe,
+                .stdout_behavior = .Pipe,
+                .stderr_behavior = .Ignore,
+            },
+            "./tigerbeetle start --addresses=0 --cache-grid=8GiB datafile-devhub",
+            .{},
+        );
+
+        defer {
+            process.stdin.?.close();
+            process.stdin = null;
+            _ = process.wait() catch {};
+        }
+
+        var port_buffer: [std.fmt.count("{}\n", .{std.math.maxInt(u16)})]u8 = undefined;
+        const port_buffer_len = try process.stdout.?.readAll(&port_buffer);
+        const port = try std.fmt.parseInt(u16, port_buffer[0 .. port_buffer_len - 1], 10);
+
+        // TODO: This sends a ping manually; once register connection speed has been fixed, this can
+        // use the benchmark or repl via CLI.
+        //
+        // Use Header directly with a blocking TCP connection here, to avoid pulling in half of TB.
+        const Header = @import("../vsr/message_header.zig").Header;
+
+        var ping = Header.PingClient{
+            .command = .ping_client,
+            .cluster = 0,
+            .release = Release.minimum,
+            .client = 1,
+            .ping_timestamp_monotonic = 0,
+        };
+        ping.set_checksum_body(&[0]u8{});
+        ping.set_checksum();
+
+        // The release of the built binary is not readily available, since it's set by
+        // `zig build scripts -- release`. Instead, the ping above is sent with
+        // .release == Release.minimum. This will always be below a release build's
+        // release_client_min, so expect the eviction.
+        var eviction: Header.Eviction = undefined;
+
+        const peer = try std.net.Address.parseIp4("127.0.0.1", port);
+        const stream = try std.net.tcpConnectToAddress(peer);
+        defer stream.close();
+
+        var writer = stream.writer();
+        try writer.writeAll(std.mem.asBytes(&ping)[0..@sizeOf(Header)]);
+
+        const reader = stream.reader();
+        _ = try reader.readAll(std.mem.asBytes(&eviction)[0..@sizeOf(Header)]);
+
+        assert(eviction.command == .eviction);
+        assert(eviction.valid_checksum());
+        assert(eviction.valid_checksum_body(&[0]u8{}));
+
+        const startup_time_ms = timer.read() / std.time.ns_per_ms;
+
+        // While there's a running instance, check how long the repl takes to connect and run a
+        // command.
+        timer.reset();
+
+        try shell.exec(
+            "./tigerbeetle repl --addresses={port} --cluster=0 --command={command}",
+            .{ .port = port, .command = "create_accounts id=1 ledger=1 code=1" },
+        );
+
+        const repl_single_command_ms = timer.read() / std.time.ns_per_ms;
+
+        break :blk .{ startup_time_ms, repl_single_command_ms };
+    };
+
+    const batch = MetricBatch{
+        .timestamp = commit_timestamp,
+        .attributes = .{
+            .git_repo = "https://github.com/tigerbeetle/tigerbeetle",
+            .git_commit = sha,
+            .branch = "main",
+        },
+        .metrics = &[_]Metric{
+            .{ .name = "executable size", .value = executable_size_bytes, .unit = "bytes" },
+            .{ .name = "TPS", .value = tps, .unit = "count" },
+            .{ .name = "batch p100", .value = batch_p100_ms, .unit = "ms" },
+            .{ .name = "query p100", .value = query_p100_ms, .unit = "ms" },
+            .{ .name = "RSS", .value = rss_bytes, .unit = "bytes" },
+            .{ .name = "datafile", .value = datafile_bytes, .unit = "bytes" },
+            .{ .name = "datafile empty", .value = datafile_empty_bytes, .unit = "bytes" },
+            .{ .name = "replica log lines", .value = replica_log_lines, .unit = "count" },
+            .{
+                .name = "checksum(message_size_max)",
+                .value = checksum_message_size_max_us,
+                .unit = "us",
+            },
+            .{ .name = "build time debug", .value = build_time_debug_ms, .unit = "ms" },
+            .{ .name = "build time", .value = build_time_ms, .unit = "ms" },
+            .{ .name = "format time", .value = format_time_ms, .unit = "ms" },
+            .{ .name = "startup time - 8GiB grid cache", .value = startup_time_ms, .unit = "ms" },
+            .{ .name = "stats count", .value = stats_count, .unit = "count" },
+            .{ .name = "repl single command", .value = repl_single_command_ms, .unit = "ms" },
+            .{ .name = "inspect integrity time", .value = integrity_time_ms, .unit = "ms" },
+        },
+    };
+
+    for (batch.metrics) |metric| {
+        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
+    }
+
+    upload_run(shell, &batch) catch |err| {
+        log.err("failed to upload devhubdb metrics: {}", .{err});
+    };
+}
+
+fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !void {
+    var section = try shell.open_section("long benchmark");
+    defer section.close();
+
+    const block_device = "/dev/md0";
+
+    // overwrite the first 96 bytes for block device
+    try shell.exec(
+        \\dd if=/dev/zero of={block_device} bs=1K count=96
+    , .{ .block_device = block_device });
+
+    try shell.project_root.deleteTree(".zig-cache/tmp/devhub_cache");
+    try shell.exec_zig("build -Drelease install", .{});
+    defer shell.project_root.deleteFile("tigerbeetle") catch {};
+
+    const benchmark_result = try shell.exec_stdout(
+        "./tigerbeetle benchmark --transfer-count=1_000_000 --file={block_device}",
+        .{ .block_device = block_device },
+    );
+
+    // TODO: track more metrics here.
+    const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
+    const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
+
+    const batch = MetricBatch{
+        .timestamp = commit_timestamp,
+        .attributes = .{
+            .git_repo = "https://github.com/tigerbeetle/tigerbeetle",
+            .git_commit = sha,
+            .branch = "main",
+        },
+        .metrics = &[_]Metric{
+            .{ .name = "long TPS", .value = tps, .unit = "count" },
+            .{ .name = "long batch p100", .value = batch_p100_ms, .unit = "ms" },
+        },
+    };
+
+    for (batch.metrics) |metric| {
+        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
+    }
+
+    upload_run(shell, &batch) catch |err| {
+        log.err("failed to upload long benchmark devhubdb metrics: {}", .{err});
+    };
+}
+
+fn get_measurement(
+    benchmark_stdout: []const u8,
+    comptime label: []const u8,
+    comptime unit: []const u8,
+) !u64 {
+    errdefer {
+        std.log.err("can't extract '" ++ label ++ "' measurement", .{});
+    }
+
+    _, const rest = stdx.cut(benchmark_stdout, label ++ " = ") orelse
+        return error.BadMeasurement;
+    const value_string, _ = stdx.cut(rest, " " ++ unit) orelse return error.BadMeasurement;
+
+    return try std.fmt.parseInt(u64, value_string, 10);
+}
+
+fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
+    const token = shell.env_get_option("DEVHUBDB_PAT");
+    try shell.cwd.deleteTree("./devhubdb");
+    try shell.exec(
+        \\git clone --single-branch --depth 1
+        \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb-cpo.git
+        \\  devhubdb
+    , .{
+        .token = token orelse "",
+    });
+
+    try shell.pushd("./devhubdb");
+    defer shell.popd();
+
+    for (0..32) |_| {
+        try shell.exec("git fetch origin main", .{});
+        try shell.exec("git reset --hard origin/main", .{});
+
+        {
+            const file = try shell.cwd.openFile("./data.json", .{
+                .mode = .write_only,
+            });
+            defer file.close();
+
+            try file.seekFromEnd(0);
+            try std.json.stringify(batch, .{}, file.writer());
+            try file.writeAll("\n");
+        }
+
+        try shell.exec("git add data.json", .{});
+        try shell.git_env_setup(.{ .use_hostname = false });
+        try shell.exec("git commit -m 📈", .{});
+        if (token) |_| {
+            if (shell.exec("git push", .{})) {
+                log.info("metrics uploaded", .{});
+                break;
+            } else |_| {
+                log.info("conflict, retrying", .{});
+            }
+        } else {
+            return error.NoToken;
+        }
+    } else {
+        log.err("can't push new data to devhub", .{});
+        return error.CanNotPush;
+    }
+}
+
+const Metric = struct {
+    name: []const u8,
+    unit: []const u8,
+    value: u64,
+};
+
+const MetricBatch = struct {
+    timestamp: u64,
+    metrics: []const Metric,
+    attributes: struct {
+        git_repo: []const u8,
+        branch: []const u8,
+        git_commit: []const u8,
+    },
+};

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -1,4 +1,5 @@
-//! Runs a set of macro-benchmarks whose result is displayed at <https://devhub.tigerbeetle.com/>.
+//! Runs a set of continously macro-benchmarks whose result is displayed at
+//! <https://devhub.tigerbeetle.com/>. The goal is to have a short and long benchmark.
 //!
 //! Specifically:
 //!
@@ -91,6 +92,9 @@ fn metrics_collect(
 }
 
 fn benchmark_short(shell: *Shell, commit: Commit) !void {
+    var section = try shell.open_section("short benchmark");
+    defer section.close();
+
     // Only build the TigerBeetle binary to test build speed and build size. Keep the release build
     // to run both cpo benchmarks.
     var timer = try std.time.Timer.start();

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -99,7 +99,7 @@ fn cpo_metrics(shell: *Shell, sha: []const u8) !void {
         try shell.exec_stdout("git show -s --format=%ct {sha}", .{ .sha = sha });
     const commit_timestamp = try std.fmt.parseInt(u64, commit_timestamp_str, 10);
 
-    try cpo_short_benchmark(shell, sha, commit_timestamp);
+    // try cpo_short_benchmark(shell, sha, commit_timestamp);
 
     try cpo_long_benchmark(shell, sha, commit_timestamp);
 }
@@ -130,7 +130,7 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
     // `--log-debug-replica` is explicitly enabled, to measure the performance hit from debug
     // logging and count the log lines.
-    // TODO: make useful benchmark (tbid etc.) and remove performance.
+    // TODO: make useful benchmark (tbid etc.) and remove checksum once we replace devhub.
     const benchmark_result, const benchmark_stderr = try shell.exec_stdout_stderr(
         "./tigerbeetle benchmark --validate --checksum-performance --log-debug-replica " ++
             "--file=datafile-devhub",
@@ -313,7 +313,7 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer section.close();
 
     const block_device = "/dev/md0";
-    const transfer_count = 100_000_000;
+    const transfer_count = 10_000_000_000;
 
     // overwrite the first 96 bytes for block device
     try shell.exec(
@@ -325,8 +325,8 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
     const benchmark_result = try shell.exec_stdout(
-        "./tigerbeetle benchmark --transfer-count={transfer_count}" ++
-            "--file={block_device} --cache-grid=32GiB",
+        "./tigerbeetle benchmark --transfer-count={transfer_count} " ++
+            "--file={block_device} --cache-grid=32GiB --query-count=100",
         .{
             .transfer_count = transfer_count,
             .block_device = block_device,
@@ -337,6 +337,11 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     const batch_p50_ms = try get_measurement(benchmark_result, "batch latency p50 ", "ms");
     const batch_p99_ms = try get_measurement(benchmark_result, "batch latency p99 ", "ms");
     const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
+
+    const query_p1_ms = try get_measurement(benchmark_result, "query latency p1  ", "ms");
+    const query_p50_ms = try get_measurement(benchmark_result, "query latency p50 ", "ms");
+    const query_p99_ms = try get_measurement(benchmark_result, "query latency p99 ", "ms");
+    const query_p100_ms = try get_measurement(benchmark_result, "query latency p100", "ms");
     const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
 
     const batch = MetricBatch{
@@ -352,6 +357,10 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
             .{ .name = "long batch p50", .value = batch_p50_ms, .unit = "ms" },
             .{ .name = "long batch p99", .value = batch_p99_ms, .unit = "ms" },
             .{ .name = "long batch p100", .value = batch_p100_ms, .unit = "ms" },
+            .{ .name = "long query p1", .value = query_p1_ms, .unit = "ms" },
+            .{ .name = "long query p50", .value = query_p50_ms, .unit = "ms" },
+            .{ .name = "long query p99", .value = query_p99_ms, .unit = "ms" },
+            .{ .name = "long query p100", .value = query_p100_ms, .unit = "ms" },
             .{ .name = "transfer count", .value = transfer_count, .unit = "count" },
         },
     };

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -313,7 +313,7 @@ fn benchmark_long(
     defer section.close();
 
     const block_device = "/dev/md0";
-    const transfer_count = 10_000;
+    const transfer_count = 10_000_000_000;
 
     // overwrite the first 96 bytes for block device
     try shell.exec(

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -325,7 +325,7 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
     const benchmark_result = try shell.exec_stdout(
-        "./tigerbeetle benchmark --transfer-count={transfer_count} --file={block_device}",
+        "./tigerbeetle benchmark --transfer-count={transfer_count} --file={block_device} --cache-grid=32GiB",
         .{
             .transfer_count = transfer_count,
             .block_device = block_device,

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -324,11 +324,13 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
     const benchmark_result = try shell.exec_stdout(
-        "./tigerbeetle benchmark --transfer-count=1_000_000 --file={block_device}",
+        "./tigerbeetle benchmark --transfer-count=1_000_000_000 --file={block_device}",
         .{ .block_device = block_device },
     );
 
-    // TODO: track more metrics here.
+    const batch_p1_ms = try get_measurement(benchmark_result, "batch latency p1  ", "ms");
+    const batch_p50_ms = try get_measurement(benchmark_result, "batch latency p50 ", "ms");
+    const batch_p99_ms = try get_measurement(benchmark_result, "batch latency p99 ", "ms");
     const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
     const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
 
@@ -341,6 +343,9 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
         },
         .metrics = &[_]Metric{
             .{ .name = "long TPS", .value = tps, .unit = "count" },
+            .{ .name = "long batch p1", .value = batch_p1_ms, .unit = "ms" },
+            .{ .name = "long batch p50", .value = batch_p50_ms, .unit = "ms" },
+            .{ .name = "long batch p99", .value = batch_p99_ms, .unit = "ms" },
             .{ .name = "long batch p100", .value = batch_p100_ms, .unit = "ms" },
         },
     };

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -32,79 +32,65 @@ const assert = std.debug.assert;
 
 const stdx = @import("stdx");
 const Shell = @import("../shell.zig");
+const devhub_common = @import("./devhub_common.zig");
 const Release = @import("../multiversion.zig").Release;
+
+const Metric = devhub_common.Metric;
+const MetricBatch = devhub_common.MetricBatch;
 
 const log = std.log;
 
 pub const CLIArgs = struct {
     sha: ?[]const u8 = null,
     skip_kcov: bool = false,
+    benchmark_long_timeout: stdx.Duration = .minutes(120),
 };
 
 pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
     const sha = cli_args.sha orelse try shell.exec_stdout("git rev-parse HEAD", .{});
-    try cpo_metrics(shell, sha);
+    try metrics_collect(shell, sha, .{
+        .long_benchmark_timeout = cli_args.benchmark_long_timeout,
+    });
 
     if (!cli_args.skip_kcov) {
-        try devhub_coverage(shell);
+        try devhub_common.devhub_coverage(shell);
     } else {
         log.info("--skip-kcov enabled, not computing coverage.", .{});
     }
 }
 
-fn devhub_coverage(shell: *Shell) !void {
-    var section = try shell.open_section("coverage");
-    defer section.close();
+const Commit = struct {
+    sha: [40]u8,
+    timestamp: u64,
+};
 
-    const kcov_version = shell.exec_stdout("kcov --version", .{}) catch {
-        return error.NoKcov;
-    };
-    log.info("kcov version {s}", .{kcov_version});
-
-    try shell.exec_zig("build test:unit:build", .{});
-    try shell.exec_zig("build vopr:build", .{});
-    try shell.exec_zig("build fuzz:build", .{});
-
-    // Put results into src/devhub, as that folder is deployed as GitHub pages.
-    try shell.project_root.deleteTree("./src/devhub/coverage");
-    try shell.project_root.makePath("./src/devhub/coverage");
-
-    const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./src/devhub/coverage" };
-    inline for (.{
-        "{kcov} ./zig-out/bin/test-unit",
-        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92",
-        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92",
-        "{kcov} ./zig-out/bin/vopr 92",
-    }) |command| {
-        try shell.exec(command, .{ .kcov = kcov });
-    }
-
-    var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
-    defer coverage_dir.close();
-
-    // kcov adds some symlinks to the output, which prevents upload to GitHub actions from working.
-    var it = coverage_dir.iterate();
-    while (try it.next()) |entry| {
-        if (entry.kind == .sym_link) {
-            try coverage_dir.deleteFile(entry.name);
-        }
-    }
+fn commit_info(shell: *Shell, sha: []const u8) !Commit {
+    assert(sha.len == 40);
+    const commit_sha = sha[0..40].*;
+    const commit_timestamp = try shell.git_commit_timestamp(&commit_sha);
+    return .{ .sha = commit_sha, .timestamp = commit_timestamp.to_seconds() };
 }
 
-fn cpo_metrics(shell: *Shell, sha: []const u8) !void {
+fn metrics_collect(
+    shell: *Shell,
+    sha: []const u8,
+    options: struct {
+        benchmark_long_timeout: stdx.Duration,
+    },
+) !void {
     var section = try shell.open_section("metrics");
     defer section.close();
 
-    const commit_timestamp_str =
-        try shell.exec_stdout("git show -s --format=%ct {sha}", .{ .sha = sha });
-    const commit_timestamp = try std.fmt.parseInt(u64, commit_timestamp_str, 10);
+    const commit = try commit_info(shell, sha);
 
-    // try cpo_short_benchmark(shell, sha, commit_timestamp);
+    try benchmark_short(shell, commit);
 
-    try cpo_long_benchmark(shell, sha, commit_timestamp);
+    try benchmark_long(shell, commit, .{
+        .timeout = options.benchmark_long_timeout,
+    });
 }
 
-fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !void {
+fn benchmark_short(shell: *Shell, commit: Commit) !void {
 
     // Only build the TigerBeetle binary to test build speed and build size. Keep the release build
     // to run both cpo benchmarks.
@@ -114,7 +100,7 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
         try shell.exec_zig("build install", .{});
         defer shell.project_root.deleteFile("tigerbeetle") catch unreachable;
 
-        break :blk timer.read() / std.time.ns_per_ms;
+        break :blk devhub_common.timer_ms(&timer);
     };
 
     const build_time_ms, const executable_size_bytes = blk: {
@@ -123,7 +109,7 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
         try shell.exec_zig("build -Drelease install", .{});
 
         break :blk .{
-            timer.lap() / std.time.ns_per_ms,
+            devhub_common.timer_ms(&timer),
             (try shell.cwd.statFile("tigerbeetle")).size,
         };
     };
@@ -145,19 +131,23 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
             .{},
         );
 
-        break :blk timer.read() / std.time.ns_per_ms;
+        break :blk devhub_common.timer_ms(&timer);
     };
 
     shell.cwd.deleteFile("datafile-devhub") catch unreachable;
 
     const replica_log_lines = std.mem.count(u8, benchmark_stderr, "\n");
-    const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
-    const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
-    const query_p100_ms = try get_measurement(benchmark_result, "query latency p100", "ms");
-    const rss_bytes = try get_measurement(benchmark_result, "rss", "bytes");
-    const datafile_bytes = try get_measurement(benchmark_result, "datafile", "bytes");
-    const datafile_empty_bytes = try get_measurement(benchmark_result, "datafile empty", "bytes");
-    const checksum_message_size_max_us = try get_measurement(
+    const tps = try devhub_common.get_measurement(benchmark_result, "load accepted", "tx/s");
+    const batch_p100_ms =
+        try devhub_common.get_measurement(benchmark_result, "batch latency p100", "ms");
+    const query_p100_ms =
+        try devhub_common.get_measurement(benchmark_result, "query latency p100", "ms");
+    const rss_bytes = try devhub_common.get_measurement(benchmark_result, "rss", "bytes");
+    const datafile_bytes =
+        try devhub_common.get_measurement(benchmark_result, "datafile", "bytes");
+    const datafile_empty_bytes =
+        try devhub_common.get_measurement(benchmark_result, "datafile empty", "bytes");
+    const checksum_message_size_max_us = try devhub_common.get_measurement(
         benchmark_result,
         "checksum message size max",
         "us",
@@ -170,7 +160,7 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
             .{},
         );
 
-        break :blk timer.read() / std.time.ns_per_ms;
+        break :blk devhub_common.timer_ms(&timer);
     };
     defer shell.cwd.deleteFile("datafile-devhub") catch unreachable;
 
@@ -252,7 +242,7 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
         assert(eviction.valid_checksum());
         assert(eviction.valid_checksum_body(&[0]u8{}));
 
-        const startup_time_ms = timer.read() / std.time.ns_per_ms;
+        const startup_time_ms = devhub_common.timer_ms(&timer);
 
         // While there's a running instance, check how long the repl takes to connect and run a
         // command.
@@ -263,16 +253,16 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
             .{ .port = port, .command = "create_accounts id=1 ledger=1 code=1" },
         );
 
-        const repl_single_command_ms = timer.read() / std.time.ns_per_ms;
+        const repl_single_command_ms = devhub_common.timer_ms(&timer);
 
         break :blk .{ startup_time_ms, repl_single_command_ms };
     };
 
     const batch = MetricBatch{
-        .timestamp = commit_timestamp,
+        .timestamp = commit.timestamp,
         .attributes = .{
             .git_repo = "https://github.com/tigerbeetle/tigerbeetle",
-            .git_commit = sha,
+            .git_commit = commit.sha[0..],
             .branch = "main",
         },
         .metrics = &[_]Metric{
@@ -299,16 +289,23 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
         },
     };
 
-    for (batch.metrics) |metric| {
-        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
-    }
+    devhub_common.log_metrics(&batch);
 
-    upload_run(shell, &batch, "./short/data.json") catch |err| {
+    devhub_common.upload_run(shell, &batch, .{
+        .repo = "devhubdb-cpo",
+        .data_file = "./short/data.json",
+    }) catch |err| {
         log.err("failed to upload devhubdb metrics: {}", .{err});
     };
 }
 
-fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !void {
+fn benchmark_long(
+    shell: *Shell,
+    commit: Commit,
+    options: struct {
+        timeout: stdx.Duration,
+    },
+) !void {
     var section = try shell.open_section("long benchmark");
     defer section.close();
 
@@ -324,7 +321,8 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     try shell.exec_zig("build -Drelease install", .{});
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
-    const benchmark_result = try shell.exec_stdout(
+    const benchmark_result = try shell.exec_stdout_options(
+        .{ .timeout = options.timeout },
         "./tigerbeetle benchmark --transfer-count={transfer_count} " ++
             "--file={block_device} --cache-grid=32GiB --query-count=100",
         .{
@@ -333,123 +331,87 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
         },
     );
 
-    const batch_p1_ms = try get_measurement(benchmark_result, "batch latency p1  ", "ms");
-    const batch_p50_ms = try get_measurement(benchmark_result, "batch latency p50 ", "ms");
-    const batch_p99_ms = try get_measurement(benchmark_result, "batch latency p99 ", "ms");
-    const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
-
-    const query_p1_ms = try get_measurement(benchmark_result, "query latency p1  ", "ms");
-    const query_p50_ms = try get_measurement(benchmark_result, "query latency p50 ", "ms");
-    const query_p99_ms = try get_measurement(benchmark_result, "query latency p99 ", "ms");
-    const query_p100_ms = try get_measurement(benchmark_result, "query latency p100", "ms");
-    const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
-
     const batch = MetricBatch{
-        .timestamp = commit_timestamp,
+        .timestamp = commit.timestamp,
         .attributes = .{
             .git_repo = "https://github.com/tigerbeetle/tigerbeetle",
-            .git_commit = sha,
+            .git_commit = commit.sha[0..],
             .branch = "main",
         },
         .metrics = &[_]Metric{
-            .{ .name = "long TPS", .value = tps, .unit = "count" },
-            .{ .name = "long batch p1", .value = batch_p1_ms, .unit = "ms" },
-            .{ .name = "long batch p50", .value = batch_p50_ms, .unit = "ms" },
-            .{ .name = "long batch p99", .value = batch_p99_ms, .unit = "ms" },
-            .{ .name = "long batch p100", .value = batch_p100_ms, .unit = "ms" },
-            .{ .name = "long query p1", .value = query_p1_ms, .unit = "ms" },
-            .{ .name = "long query p50", .value = query_p50_ms, .unit = "ms" },
-            .{ .name = "long query p99", .value = query_p99_ms, .unit = "ms" },
-            .{ .name = "long query p100", .value = query_p100_ms, .unit = "ms" },
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long TPS",
+                "load accepted",
+                "tx/s",
+                "count",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long batch p1",
+                "batch latency p1  ",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long batch p50",
+                "batch latency p50 ",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long batch p99",
+                "batch latency p99 ",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long batch p100",
+                "batch latency p100",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long query p1",
+                "query latency p1  ",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long query p50",
+                "query latency p50 ",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long query p99",
+                "query latency p99 ",
+                "ms",
+                "ms",
+            ),
+            try devhub_common.benchmark_metric(
+                benchmark_result,
+                "long query p100",
+                "query latency p100",
+                "ms",
+                "ms",
+            ),
             .{ .name = "transfer count", .value = transfer_count, .unit = "count" },
         },
     };
 
-    for (batch.metrics) |metric| {
-        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
-    }
+    devhub_common.log_metrics(&batch);
 
-    upload_run(shell, &batch, "./long/data.json") catch |err| {
+    devhub_common.upload_run(shell, &batch, .{
+        .repo = "devhubdb-cpo",
+        .data_file = "./long/data.json",
+    }) catch |err| {
         log.err("failed to upload long benchmark devhubdb metrics: {}", .{err});
     };
 }
-
-fn get_measurement(
-    benchmark_stdout: []const u8,
-    comptime label: []const u8,
-    comptime unit: []const u8,
-) !u64 {
-    errdefer {
-        std.log.err("can't extract '" ++ label ++ "' measurement", .{});
-    }
-
-    _, const rest = stdx.cut(benchmark_stdout, label ++ " = ") orelse
-        return error.BadMeasurement;
-    const value_string, _ = stdx.cut(rest, " " ++ unit) orelse return error.BadMeasurement;
-
-    return try std.fmt.parseInt(u64, value_string, 10);
-}
-
-fn upload_run(shell: *Shell, batch: *const MetricBatch, data_file: []const u8) !void {
-    const token = shell.env_get_option("DEVHUBDB_PAT");
-    try shell.cwd.deleteTree("./devhubdb");
-    try shell.exec(
-        \\git clone --single-branch --depth 1
-        \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb-cpo.git
-        \\  devhubdb
-    , .{
-        .token = token orelse "",
-    });
-
-    try shell.pushd("./devhubdb");
-    defer shell.popd();
-
-    for (0..32) |_| {
-        try shell.exec("git fetch origin main", .{});
-        try shell.exec("git reset --hard origin/main", .{});
-
-        {
-            const file = try shell.cwd.openFile(data_file, .{
-                .mode = .write_only,
-            });
-            defer file.close();
-
-            try file.seekFromEnd(0);
-            try std.json.stringify(batch, .{}, file.writer());
-            try file.writeAll("\n");
-        }
-
-        try shell.exec("git add {data_file}", .{ .data_file = data_file });
-        try shell.git_env_setup(.{ .use_hostname = false });
-        try shell.exec("git commit -m 📈", .{});
-        if (token) |_| {
-            if (shell.exec("git push", .{})) {
-                log.info("metrics uploaded", .{});
-                break;
-            } else |_| {
-                log.info("conflict, retrying", .{});
-            }
-        } else {
-            return error.NoToken;
-        }
-    } else {
-        log.err("can't push new data to devhub", .{});
-        return error.CanNotPush;
-    }
-}
-
-const Metric = struct {
-    name: []const u8,
-    unit: []const u8,
-    value: u64,
-};
-
-const MetricBatch = struct {
-    timestamp: u64,
-    metrics: []const Metric,
-    attributes: struct {
-        git_repo: []const u8,
-        branch: []const u8,
-        git_commit: []const u8,
-    },
-};

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -38,7 +38,7 @@ const log = std.log;
 
 pub const CLIArgs = struct {
     sha: ?[]const u8 = null,
-    skip_kcov: bool = true,
+    skip_kcov: bool = false,
 };
 
 pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
@@ -303,7 +303,7 @@ fn cpo_short_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !v
         log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
     }
 
-    upload_run(shell, &batch) catch |err| {
+    upload_run(shell, &batch, "./short/data.json") catch |err| {
         log.err("failed to upload devhubdb metrics: {}", .{err});
     };
 }
@@ -349,7 +349,7 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
         log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
     }
 
-    upload_run(shell, &batch) catch |err| {
+    upload_run(shell, &batch, "./long/data.json") catch |err| {
         log.err("failed to upload long benchmark devhubdb metrics: {}", .{err});
     };
 }
@@ -370,7 +370,7 @@ fn get_measurement(
     return try std.fmt.parseInt(u64, value_string, 10);
 }
 
-fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
+fn upload_run(shell: *Shell, batch: *const MetricBatch, data_file: []const u8) !void {
     const token = shell.env_get_option("DEVHUBDB_PAT");
     try shell.cwd.deleteTree("./devhubdb");
     try shell.exec(
@@ -389,7 +389,7 @@ fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
         try shell.exec("git reset --hard origin/main", .{});
 
         {
-            const file = try shell.cwd.openFile("./data.json", .{
+            const file = try shell.cwd.openFile(data_file, .{
                 .mode = .write_only,
             });
             defer file.close();
@@ -399,7 +399,7 @@ fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
             try file.writeAll("\n");
         }
 
-        try shell.exec("git add data.json", .{});
+        try shell.exec("git add {data_file}", .{ .data_file = data_file });
         try shell.git_env_setup(.{ .use_hostname = false });
         try shell.exec("git commit -m 📈", .{});
         if (token) |_| {

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -49,7 +49,7 @@ pub const CLIArgs = struct {
 pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
     const sha = cli_args.sha orelse try shell.exec_stdout("git rev-parse HEAD", .{});
     try metrics_collect(shell, sha, .{
-        .long_benchmark_timeout = cli_args.benchmark_long_timeout,
+        .benchmark_long_timeout = cli_args.benchmark_long_timeout,
     });
 
     if (!cli_args.skip_kcov) {
@@ -91,7 +91,6 @@ fn metrics_collect(
 }
 
 fn benchmark_short(shell: *Shell, commit: Commit) !void {
-
     // Only build the TigerBeetle binary to test build speed and build size. Keep the release build
     // to run both cpo benchmarks.
     var timer = try std.time.Timer.start();
@@ -310,7 +309,7 @@ fn benchmark_long(
     defer section.close();
 
     const block_device = "/dev/md0";
-    const transfer_count = 10_000_000_000;
+    const transfer_count = 10_000;
 
     // overwrite the first 96 bytes for block device
     try shell.exec(
@@ -331,6 +330,11 @@ fn benchmark_long(
         },
     );
 
+    const benchmark_metrics = try devhub_common.benchmark_metrics(benchmark_result);
+    const metrics = benchmark_metrics ++ [_]Metric{
+        .{ .name = "transfer count", .value = transfer_count, .unit = "count" },
+    };
+
     const batch = MetricBatch{
         .timestamp = commit.timestamp,
         .attributes = .{
@@ -338,72 +342,7 @@ fn benchmark_long(
             .git_commit = commit.sha[0..],
             .branch = "main",
         },
-        .metrics = &[_]Metric{
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long TPS",
-                "load accepted",
-                "tx/s",
-                "count",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long batch p1",
-                "batch latency p1  ",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long batch p50",
-                "batch latency p50 ",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long batch p99",
-                "batch latency p99 ",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long batch p100",
-                "batch latency p100",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long query p1",
-                "query latency p1  ",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long query p50",
-                "query latency p50 ",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long query p99",
-                "query latency p99 ",
-                "ms",
-                "ms",
-            ),
-            try devhub_common.benchmark_metric(
-                benchmark_result,
-                "long query p100",
-                "query latency p100",
-                "ms",
-                "ms",
-            ),
-            .{ .name = "transfer count", .value = transfer_count, .unit = "count" },
-        },
+        .metrics = &metrics,
     };
 
     devhub_common.log_metrics(&batch);

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -325,7 +325,8 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
     const benchmark_result = try shell.exec_stdout(
-        "./tigerbeetle benchmark --transfer-count={transfer_count} --file={block_device} --cache-grid=32GiB",
+        "./tigerbeetle benchmark --transfer-count={transfer_count}" ++
+            "--file={block_device} --cache-grid=32GiB",
         .{
             .transfer_count = transfer_count,
             .block_device = block_device,

--- a/src/scripts/cpo.zig
+++ b/src/scripts/cpo.zig
@@ -313,6 +313,7 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer section.close();
 
     const block_device = "/dev/md0";
+    const transfer_count = 100_000_000;
 
     // overwrite the first 96 bytes for block device
     try shell.exec(
@@ -324,8 +325,11 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
     defer shell.project_root.deleteFile("tigerbeetle") catch {};
 
     const benchmark_result = try shell.exec_stdout(
-        "./tigerbeetle benchmark --transfer-count=1_000_000_000 --file={block_device}",
-        .{ .block_device = block_device },
+        "./tigerbeetle benchmark --transfer-count={transfer_count} --file={block_device}",
+        .{
+            .transfer_count = transfer_count,
+            .block_device = block_device,
+        },
     );
 
     const batch_p1_ms = try get_measurement(benchmark_result, "batch latency p1  ", "ms");
@@ -347,6 +351,7 @@ fn cpo_long_benchmark(shell: *Shell, sha: []const u8, commit_timestamp: u64) !vo
             .{ .name = "long batch p50", .value = batch_p50_ms, .unit = "ms" },
             .{ .name = "long batch p99", .value = batch_p99_ms, .unit = "ms" },
             .{ .name = "long batch p100", .value = batch_p100_ms, .unit = "ms" },
+            .{ .name = "transfer count", .value = transfer_count, .unit = "count" },
         },
     };
 

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -34,9 +34,12 @@ const assert = std.debug.assert;
 const stdx = @import("stdx");
 const Shell = @import("../shell.zig");
 const changelog = @import("./changelog.zig");
+const devhub_common = @import("./devhub_common.zig");
 const Release = @import("../multiversion.zig").Release;
 
 const MiB = stdx.MiB;
+const Metric = devhub_common.Metric;
+const MetricBatch = devhub_common.MetricBatch;
 
 const log = std.log;
 
@@ -49,48 +52,9 @@ pub fn main(shell: *Shell, _: std.mem.Allocator, cli_args: CLIArgs) !void {
     try devhub_metrics(shell, cli_args);
 
     if (!cli_args.skip_kcov) {
-        try devhub_coverage(shell);
+        try devhub_common.devhub_coverage(shell);
     } else {
         log.info("--skip-kcov enabled, not computing coverage.", .{});
-    }
-}
-
-fn devhub_coverage(shell: *Shell) !void {
-    var section = try shell.open_section("coverage");
-    defer section.close();
-
-    const kcov_version = shell.exec_stdout("kcov --version", .{}) catch {
-        return error.NoKcov;
-    };
-    log.info("kcov version {s}", .{kcov_version});
-
-    try shell.exec_zig("build test:unit:build", .{});
-    try shell.exec_zig("build vopr:build", .{});
-    try shell.exec_zig("build fuzz:build", .{});
-
-    // Put results into src/devhub, as that folder is deployed as GitHub pages.
-    try shell.project_root.deleteTree("./src/devhub/coverage");
-    try shell.project_root.makePath("./src/devhub/coverage");
-
-    const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./src/devhub/coverage" };
-    inline for (.{
-        "{kcov} ./zig-out/bin/test-unit",
-        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92",
-        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92",
-        "{kcov} ./zig-out/bin/vopr 92",
-    }) |command| {
-        try shell.exec(command, .{ .kcov = kcov });
-    }
-
-    var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
-    defer coverage_dir.close();
-
-    // kcov adds some symlinks to the output, which prevents upload to GitHub actions from working.
-    var it = coverage_dir.iterate();
-    while (try it.next()) |entry| {
-        if (entry.kind == .sym_link) {
-            try coverage_dir.deleteFile(entry.name);
-        }
     }
 }
 
@@ -111,7 +75,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         try shell.exec_zig("build install", .{});
         defer shell.project_root.deleteFile("tigerbeetle") catch unreachable;
 
-        break :blk timer.read() / std.time.ns_per_ms;
+        break :blk devhub_common.timer_ms(&timer);
     };
 
     const build_time_ms, const executable_size_bytes = blk: {
@@ -121,7 +85,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         defer shell.project_root.deleteFile("tigerbeetle") catch unreachable;
 
         break :blk .{
-            timer.lap() / std.time.ns_per_ms,
+            devhub_common.timer_ms(&timer),
             (try shell.cwd.statFile("tigerbeetle")).size,
         };
     };
@@ -185,19 +149,23 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             .{},
         );
 
-        break :blk timer.read() / std.time.ns_per_ms;
+        break :blk devhub_common.timer_ms(&timer);
     };
 
     shell.cwd.deleteFile("datafile-devhub") catch unreachable;
 
     const replica_log_lines = std.mem.count(u8, benchmark_stderr, "\n");
-    const tps = try get_measurement(benchmark_result, "load accepted", "tx/s");
-    const batch_p100_ms = try get_measurement(benchmark_result, "batch latency p100", "ms");
-    const query_p100_ms = try get_measurement(benchmark_result, "query latency p100", "ms");
-    const rss_bytes = try get_measurement(benchmark_result, "rss", "bytes");
-    const datafile_bytes = try get_measurement(benchmark_result, "datafile", "bytes");
-    const datafile_empty_bytes = try get_measurement(benchmark_result, "datafile empty", "bytes");
-    const checksum_message_size_max_us = try get_measurement(
+    const tps = try devhub_common.get_measurement(benchmark_result, "load accepted", "tx/s");
+    const batch_p100_ms =
+        try devhub_common.get_measurement(benchmark_result, "batch latency p100", "ms");
+    const query_p100_ms =
+        try devhub_common.get_measurement(benchmark_result, "query latency p100", "ms");
+    const rss_bytes = try devhub_common.get_measurement(benchmark_result, "rss", "bytes");
+    const datafile_bytes =
+        try devhub_common.get_measurement(benchmark_result, "datafile", "bytes");
+    const datafile_empty_bytes =
+        try devhub_common.get_measurement(benchmark_result, "datafile empty", "bytes");
+    const checksum_message_size_max_us = try devhub_common.get_measurement(
         benchmark_result,
         "checksum message size max",
         "us",
@@ -210,7 +178,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             .{},
         );
 
-        break :blk timer.read() / std.time.ns_per_ms;
+        break :blk devhub_common.timer_ms(&timer);
     };
     defer shell.cwd.deleteFile("datafile-devhub") catch unreachable;
 
@@ -292,7 +260,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         assert(eviction.valid_checksum());
         assert(eviction.valid_checksum_body(&[0]u8{}));
 
-        const startup_time_ms = timer.read() / std.time.ns_per_ms;
+        const startup_time_ms = devhub_common.timer_ms(&timer);
 
         // While there's a running instance, check how long the repl takes to connect and run a
         // command.
@@ -303,7 +271,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             .{ .port = port, .command = "create_accounts id=1 ledger=1 code=1" },
         );
 
-        const repl_single_command_ms = timer.read() / std.time.ns_per_ms;
+        const repl_single_command_ms = devhub_common.timer_ms(&timer);
 
         break :blk .{ startup_time_ms, repl_single_command_ms };
     };
@@ -366,11 +334,12 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         },
     };
 
-    for (batch.metrics) |metric| {
-        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
-    }
+    devhub_common.log_metrics(&batch);
 
-    upload_run(shell, &batch) catch |err| {
+    devhub_common.upload_run(shell, &batch, .{
+        .repo = "devhubdb",
+        .data_file = "./devhub/data.json",
+    }) catch |err| {
         log.err("failed to upload devhubdb metrics: {}", .{err});
     };
 
@@ -378,85 +347,6 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         log.err("failed to upload Nyrkiö metrics: {}", .{err});
     };
 }
-
-fn get_measurement(
-    benchmark_stdout: []const u8,
-    comptime label: []const u8,
-    comptime unit: []const u8,
-) !u64 {
-    errdefer {
-        std.log.err("can't extract '" ++ label ++ "' measurement", .{});
-    }
-
-    _, const rest = stdx.cut(benchmark_stdout, label ++ " = ") orelse
-        return error.BadMeasurement;
-    const value_string, _ = stdx.cut(rest, " " ++ unit) orelse return error.BadMeasurement;
-
-    return try std.fmt.parseInt(u64, value_string, 10);
-}
-
-fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
-    const token = shell.env_get_option("DEVHUBDB_PAT");
-    try shell.exec(
-        \\git clone --single-branch --depth 1
-        \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb.git
-        \\  devhubdb
-    , .{
-        .token = token orelse "",
-    });
-
-    try shell.pushd("./devhubdb");
-    defer shell.popd();
-
-    for (0..32) |_| {
-        try shell.exec("git fetch origin main", .{});
-        try shell.exec("git reset --hard origin/main", .{});
-
-        {
-            const file = try shell.cwd.openFile("./devhub/data.json", .{
-                .mode = .write_only,
-            });
-            defer file.close();
-
-            try file.seekFromEnd(0);
-            try std.json.stringify(batch, .{}, file.writer());
-            try file.writeAll("\n");
-        }
-
-        try shell.exec("git add ./devhub/data.json", .{});
-        try shell.git_env_setup(.{ .use_hostname = false });
-        try shell.exec("git commit -m 📈", .{});
-        if (token) |_| {
-            if (shell.exec("git push", .{})) {
-                log.info("metrics uploaded", .{});
-                break;
-            } else |_| {
-                log.info("conflict, retrying", .{});
-            }
-        } else {
-            return error.NoToken;
-        }
-    } else {
-        log.err("can't push new data to devhub", .{});
-        return error.CanNotPush;
-    }
-}
-
-const Metric = struct {
-    name: []const u8,
-    unit: []const u8,
-    value: u64,
-};
-
-const MetricBatch = struct {
-    timestamp: u64,
-    metrics: []const Metric,
-    attributes: struct {
-        git_repo: []const u8,
-        branch: []const u8,
-        git_commit: []const u8,
-    },
-};
 
 fn upload_nyrkio(shell: *Shell, batch: *const MetricBatch) !void {
     const url = "https://nyrkio.com/api/v0/result/devhub";

--- a/src/scripts/devhub_common.zig
+++ b/src/scripts/devhub_common.zig
@@ -60,6 +60,74 @@ pub fn get_measurement(
     return try std.fmt.parseInt(u64, value_string, 10);
 }
 
+pub fn benchmark_metrics(benchmark_result: []const u8) ![9]Metric {
+    return .{
+        try benchmark_metric(
+            benchmark_result,
+            "long TPS",
+            "load accepted",
+            "tx/s",
+            "count",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long batch p1",
+            "batch latency p1  ",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long batch p50",
+            "batch latency p50 ",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long batch p99",
+            "batch latency p99 ",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long batch p100",
+            "batch latency p100",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long query p1",
+            "query latency p1  ",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long query p50",
+            "query latency p50 ",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long query p99",
+            "query latency p99 ",
+            "ms",
+            "ms",
+        ),
+        try benchmark_metric(
+            benchmark_result,
+            "long query p100",
+            "query latency p100",
+            "ms",
+            "ms",
+        ),
+    };
+}
+
 pub fn benchmark_metric(
     benchmark_stdout: []const u8,
     comptime name: []const u8,

--- a/src/scripts/devhub_common.zig
+++ b/src/scripts/devhub_common.zig
@@ -1,0 +1,157 @@
+const std = @import("std");
+
+const stdx = @import("stdx");
+const Shell = @import("../shell.zig");
+
+const log = std.log;
+
+pub fn devhub_coverage(shell: *Shell) !void {
+    var section = try shell.open_section("coverage");
+    defer section.close();
+
+    const kcov_version = shell.exec_stdout("kcov --version", .{}) catch {
+        return error.NoKcov;
+    };
+    log.info("kcov version {s}", .{kcov_version});
+
+    try shell.exec_zig("build test:unit:build", .{});
+    try shell.exec_zig("build vopr:build", .{});
+    try shell.exec_zig("build fuzz:build", .{});
+
+    // Put results into src/devhub, as that folder is deployed as GitHub pages.
+    try shell.project_root.deleteTree("./src/devhub/coverage");
+    try shell.project_root.makePath("./src/devhub/coverage");
+
+    const kcov: []const []const u8 = &.{ "kcov", "--include-path=./src", "./src/devhub/coverage" };
+    inline for (.{
+        "{kcov} ./zig-out/bin/test-unit",
+        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_tree 92",
+        "{kcov} ./zig-out/bin/fuzz --events-max=500000 lsm_forest 92",
+        "{kcov} ./zig-out/bin/vopr 92",
+    }) |command| {
+        try shell.exec(command, .{ .kcov = kcov });
+    }
+
+    var coverage_dir = try shell.cwd.openDir("./src/devhub/coverage", .{ .iterate = true });
+    defer coverage_dir.close();
+
+    // kcov adds some symlinks to the output, which prevents upload to GitHub actions from working.
+    var it = coverage_dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind == .sym_link) {
+            try coverage_dir.deleteFile(entry.name);
+        }
+    }
+}
+
+pub fn get_measurement(
+    benchmark_stdout: []const u8,
+    comptime label: []const u8,
+    comptime unit: []const u8,
+) !u64 {
+    errdefer {
+        std.log.err("can't extract '" ++ label ++ "' measurement", .{});
+    }
+
+    _, const rest = stdx.cut(benchmark_stdout, label ++ " = ") orelse
+        return error.BadMeasurement;
+    const value_string, _ = stdx.cut(rest, " " ++ unit) orelse return error.BadMeasurement;
+
+    return try std.fmt.parseInt(u64, value_string, 10);
+}
+
+pub fn benchmark_metric(
+    benchmark_stdout: []const u8,
+    comptime name: []const u8,
+    comptime label: []const u8,
+    comptime benchmark_unit: []const u8,
+    comptime metric_unit: []const u8,
+) !Metric {
+    return .{
+        .name = name,
+        .value = try get_measurement(benchmark_stdout, label, benchmark_unit),
+        .unit = metric_unit,
+    };
+}
+
+pub fn timer_ms(timer: *std.time.Timer) u64 {
+    return (stdx.Duration{ .ns = timer.read() }).to_ms();
+}
+
+pub fn log_metrics(batch: *const MetricBatch) void {
+    for (batch.metrics) |metric| {
+        log.info("{s} = {} {s}", .{ metric.name, metric.value, metric.unit });
+    }
+}
+
+pub fn upload_run(
+    shell: *Shell,
+    batch: *const MetricBatch,
+    options: struct {
+        repo: []const u8,
+        data_file: []const u8,
+    },
+) !void {
+    const token = shell.env_get_option("DEVHUBDB_PAT");
+    try shell.cwd.deleteTree("./devhubdb");
+    try shell.exec(
+        \\git clone --single-branch --depth 1
+        \\  https://oauth2:{token}@github.com/tigerbeetle/{repo}.git
+        \\  devhubdb
+    , .{
+        .token = token orelse "",
+        .repo = options.repo,
+    });
+
+    try shell.pushd("./devhubdb");
+    defer shell.popd();
+
+    for (0..32) |_| {
+        try shell.exec("git fetch origin main", .{});
+        try shell.exec("git reset --hard origin/main", .{});
+
+        {
+            const file = try shell.cwd.openFile(options.data_file, .{
+                .mode = .write_only,
+            });
+            defer file.close();
+
+            try file.seekFromEnd(0);
+            try std.json.stringify(batch, .{}, file.writer());
+            try file.writeAll("\n");
+        }
+
+        try shell.exec("git add {data_file}", .{ .data_file = options.data_file });
+        try shell.git_env_setup(.{ .use_hostname = false });
+        try shell.exec("git commit -m 📈", .{});
+        if (token) |_| {
+            if (shell.exec("git push", .{})) {
+                log.info("metrics uploaded", .{});
+                break;
+            } else |_| {
+                log.info("conflict, retrying", .{});
+            }
+        } else {
+            return error.NoToken;
+        }
+    } else {
+        log.err("can't push new data to devhub", .{});
+        return error.CanNotPush;
+    }
+}
+
+pub const Metric = struct {
+    name: []const u8,
+    unit: []const u8,
+    value: u64,
+};
+
+pub const MetricBatch = struct {
+    timestamp: u64,
+    metrics: []const Metric,
+    attributes: struct {
+        git_repo: []const u8,
+        branch: []const u8,
+        git_commit: []const u8,
+    },
+};

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -449,6 +449,7 @@ pub fn exec_stdout_options(
     shell: *Shell,
     options: struct {
         stdin_slice: ?[]const u8 = null,
+        timeout: stdx.Duration = .minutes(10),
     },
     comptime cmd: []const u8,
     cmd_args: anytype,
@@ -460,6 +461,7 @@ pub fn exec_stdout_options(
     try exec_inner(shell, argv.slice(), .{
         .stdin_slice = options.stdin_slice,
         .capture_stdout = &captured_stdout,
+        .timeout = options.timeout,
     });
     return captured_stdout;
 }


### PR DESCRIPTION
This PR introduces the single-node CPO benchmark runner.

The goal is to expand our benchmarking landscape with the following (planned) runners:

Single-node benchmarks

* **CPO short benchmark**: Primarily stresses CPU performance and is intended to catch CPU regressions / improvements (This is intended to replace devhub in CI and tracks all the metrics continiously).
* **CPO multi-day benchmark**: Primarily stresses I/O during compaction and is intended to catch regressions / improvements in compaction algorithms and storage I/O performance.
* **Fast CI micro-benchmark / very fast benchmark**: Designed to catch regressions early in CI before they are merged (e.g., regressions such as #3703, which had to be caught manually by me running the benchmark). Focuses mainly on micro-benchmark and CPU regressions.

Multi-node benchmarks

* **CSO**: A medium-length distributed benchmark that stresses replication and consensus, making it suitable for detecting regressions in the distributed protocol.
* **TBA**.
