### PR TITLE
ci: fix windows cache flake under setup-java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,16 @@ jobs:
 
       - if: matrix.language == 'java'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with: { java-version: "${{ matrix.language_version }}", distribution: 'temurin', cache: 'maven'}
+        with: { java-version: "${{ matrix.language_version }}", distribution: 'temurin'}
+
+      - if: matrix.language == 'java'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        # actions/cache (as of v5.0.5) routinely flakes under windows -- it just prints
+        # "Cache hit for: Windows-X64-(hash)" and then exits with no other info.
+        continue-on-error: ${{ startsWith(runner.os, 'Windows') }}
+        with:
+            path: ~/.m2/repository
+            key: setup-java-${{ runner.os }}-${{ runner.arch }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - if: matrix.language == 'node'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
We added a cache to the setup-java step as part of https://github.com/tigerbeetle/tigerbeetle/pull/3451,
 to reduce the number of hits against maven central repo
and thereby reduce 500s against maven central. setup-java
internally uses the actions cache to do the caching, which is
known to be flaky on windows (due to which we took up
https://github.com/tigerbeetle/tigerbeetle/pull/3678). As a result, we also see the following on the setup-java [step](https://github.com/tigerbeetle/tigerbeetle/actions/runs/26125145080/job/76836805548):
```C
Creating settings.xml with server-id: github
Writing to C:\Users\runneradmin\.m2\settings.xml
Cache hit for: setup-java-Windows-x64-maven-6c0f6f35690bde870aceecc1d548b680e6585a71534405465ab0deffe2331347
```

This commit adds a step to explicitly [cache](https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---maven) the maven directory.
