### PR TITLE
Forest fuzz: Reduce `event_max` to prevent timeout.

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -1121,8 +1121,8 @@ pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     var prng = stdx.PRNG.from_seed(fuzz_args.seed);
 
     const fuzz_op_count = @min(
-        fuzz_args.events_max orelse @as(usize, 1E7),
-        fuzz.random_int_exponential(&prng, usize, 1E6),
+        fuzz_args.events_max orelse @as(usize, 1E6),
+        fuzz.random_int_exponential(&prng, usize, 1E5),
     );
 
     const fuzz_ops = try generate_fuzz_ops(gpa, &prng, fuzz_op_count);


### PR DESCRIPTION
Fix [this CFO timeout](https://devhub.tigerbeetle.com/?fuzzer=lsm_forest&commit=6b5a2e9016a02587e929699d84a0ab585b2b46c8) when fuzzing the LSM forest with events_max == `1E7`.