### PR TITLE
[Node.js] Fix possible integer overflow panic.

### DIFF
--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -278,7 +278,7 @@ fn request(
             // Avoid allocating memory for requests that are known to be too large.
             // However, the final validation happens in `tb_client` against the runtime-known
             // maximum size.
-            if (array_length * @sizeOf(Event) > constants.message_body_size_max) {
+            if (array_length * @as(u64, @sizeOf(Event)) > constants.message_body_size_max) {
                 return request_error(env, .ERR_TOO_MUCH_DATA);
             }
 

--- a/src/clients/node/node.zig
+++ b/src/clients/node/node.zig
@@ -278,7 +278,10 @@ fn request(
             // Avoid allocating memory for requests that are known to be too large.
             // However, the final validation happens in `tb_client` against the runtime-known
             // maximum size.
-            if (array_length * @as(u64, @sizeOf(Event)) > constants.message_body_size_max) {
+            const event_max: u32 = comptime operation_comptime.event_max(
+                constants.message_body_size_max,
+            );
+            if (array_length > event_max) {
                 return request_error(env, .ERR_TOO_MUCH_DATA);
             }
 

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -153,6 +153,17 @@ test('batch max size', async (): Promise<void> => {
   })
 })
 
+test('batch invalid size', async (): Promise<void> => {
+  const transfers: Transfer[] = [];
+  transfers.length = 0xffffffff;
+
+  assert.rejects(async() => await client.createTransfers(transfers), (err) => {
+    assert.ok(err instanceof RequestError)
+    assert.strictEqual(err.code,  ErrorCodes.ERR_TOO_MUCH_DATA)
+    return true
+  })
+})
+
 test('can lookup accounts', async (): Promise<void> => {
   const accounts = await client.lookupAccounts([accountA.id, accountB.id])
 


### PR DESCRIPTION
Fix a possible integer overflow panic in the Node.js client.
Other uses of `@sizeOf` do not multiply directly by user-provided integers.

Closes #3731