### PR TITLE
stdx: include shell.

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -6,7 +6,7 @@ const assert = std.debug.assert;
 
 const multiversion = @import("./multiversion.zig");
 const stdx = @import("stdx");
-const Shell = @import("shell.zig");
+const Shell = stdx.Shell;
 
 const multiversion_binary_size_max = multiversion.multiversion_binary_size_max;
 const MultiversionHeader = multiversion.MultiversionHeader;

--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../../shell.zig");
+const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../../shell.zig");
+const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../../shell.zig");
+const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../../shell.zig");
+const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {

--- a/src/clients/python/ci.zig
+++ b/src/clients/python/ci.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../../shell.zig");
+const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const log = std.log;
 
-const Shell = @import("../../shell.zig");
+const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -11,7 +11,7 @@ const builtin = @import("builtin");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("./shell.zig");
+const Shell = stdx.Shell;
 const Snap = stdx.Snap;
 const snap = Snap.snap_fn("src");
 const TmpTigerBeetle = @import("./testing/tmp_tigerbeetle.zig");

--- a/src/scripts.zig
+++ b/src/scripts.zig
@@ -12,7 +12,7 @@
 const std = @import("std");
 
 const stdx = @import("stdx");
-const Shell = @import("shell.zig");
+const Shell = stdx.Shell;
 
 const cfo = @import("./scripts/cfo.zig");
 const ci = @import("./scripts/ci.zig");

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -16,7 +16,7 @@ const vsr = @import("../vsr.zig");
 const amqp = @import("../cdc/amqp.zig");
 
 const JSONMessage = @import("../cdc/runner.zig").Message;
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 const TmpTigerBeetle = @import("../testing/tmp_tigerbeetle.zig");
 
 pub const CLIArgs = struct {

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -52,7 +52,7 @@ const assert = std.debug.assert;
 const maybe = stdx.maybe;
 
 const stdx = @import("stdx");
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 
 const MiB = stdx.MiB;
 const log_size_max = 4 * stdx.MiB;

--- a/src/scripts/changelog.zig
+++ b/src/scripts/changelog.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 
 const Release = @import("../multiversion.zig").Release;
 const ReleaseTriple = @import("../multiversion.zig").ReleaseTriple;

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -9,7 +9,7 @@ const log = std.log;
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 
 const client_readmes = @import("./client_readmes.zig");
 

--- a/src/scripts/client_readmes.zig
+++ b/src/scripts/client_readmes.zig
@@ -11,7 +11,7 @@ const log = std.log;
 
 const stdx = @import("stdx");
 const MiB = stdx.MiB;
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 const Docs = @import("../clients/docs_types.zig").Docs;
 const Sample = @import("../clients/docs_types.zig").Sample;
 const samples = @import("../clients/docs_samples.zig").samples;

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -32,7 +32,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 const changelog = @import("./changelog.zig");
 const Release = @import("../multiversion.zig").Release;
 

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -21,7 +21,7 @@ const stdx = @import("stdx");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 const multiversion = @import("../multiversion.zig");
 const changelog = @import("./changelog.zig");
 

--- a/src/stdx/shell.zig
+++ b/src/stdx/shell.zig
@@ -15,11 +15,11 @@
 //!     the right defaults.
 
 const std = @import("std");
+const stdx = @import("stdx.zig");
 const log = std.log;
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
-const stdx = @import("stdx");
 const Shell = @This();
 
 const MiB = stdx.MiB;
@@ -901,7 +901,7 @@ fn discover_project_root() !std.fs.Dir {
     errdefer current.close(); // Caller is responsible for closing on success.
 
     for (0..16) |_| {
-        if (current.statFile("src/shell.zig")) |_| {
+        if (current.statFile("src/stdx/shell.zig")) |_| {
             return current;
         } else |err| switch (err) {
             error.FileNotFound => {

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -23,6 +23,7 @@ pub const aegis = @import("vendored/aegis.zig");
 pub const dbg = @import("debug.zig").dbg;
 pub const Flags = @import("flags.zig");
 pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
+pub const Shell = @import("shell.zig");
 pub const timeit = @import("debug.zig").timeit;
 pub const unshare = @import("unshare.zig");
 pub const windows = @import("windows.zig");
@@ -1129,4 +1130,5 @@ comptime {
     _ = @import("unshare.zig");
     _ = @import("vendored/aegis.zig");
     _ = @import("zipfian.zig");
+    _ = @import("shell.zig");
 }

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -6,7 +6,7 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
-const Shell = @import("../shell.zig");
+const Shell = stdx.Shell;
 
 const MiB = stdx.MiB;
 

--- a/src/testing/vortex/java_driver/ci.zig
+++ b/src/testing/vortex/java_driver/ci.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const log = std.log;
 const assert = std.debug.assert;
 
-const Shell = @import("../../../shell.zig");
+const Shell = @import("stdx").Shell;
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     _ = gpa;

--- a/src/testing/vortex/rust_driver/ci.zig
+++ b/src/testing/vortex/rust_driver/ci.zig
@@ -2,7 +2,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 const log = std.log;
 
-const Shell = @import("../../../shell.zig");
+const Shell = @import("stdx").Shell;
 
 pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
     _ = gpa;

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -43,7 +43,7 @@ const RingBufferType = stdx.RingBufferType;
 const Network = @import("./faulty_network.zig").Network;
 const constants = @import("constants.zig");
 const ratio = stdx.PRNG.ratio;
-const Shell = @import("../../shell.zig");
+const Shell = stdx.Shell;
 
 const assert = std.debug.assert;
 const maybe = stdx.maybe;

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -8,7 +8,7 @@ const mem = std.mem;
 const Ast = std.zig.Ast;
 
 const stdx = @import("stdx");
-const Shell = @import("./shell.zig");
+const Shell = stdx.Shell;
 
 const Snap = stdx.Snap;
 const module_path = "src";

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -38,7 +38,6 @@ comptime {
     _ = @import("repl/terminal.zig");
     _ = @import("scripts/cfo.zig");
     _ = @import("scripts/changelog.zig");
-    _ = @import("shell.zig");
     _ = @import("stack.zig");
     _ = @import("state_machine.zig");
     _ = @import("state_machine_fuzz.zig");


### PR DESCRIPTION
This PR moves `shell.zig` to `stdx`. This improves our ability to script with zig.