### PR TITLE
main: switch allocator to DebugAllocator

### DIFF
--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -33,6 +33,8 @@ const ReplicaReformat =
     vsr.ReplicaReformatType(StateMachine, MessageBus, Storage);
 const data_file_size_min = vsr.superblock.data_file_size_min;
 
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator(.{});
+
 const KiB = stdx.KiB;
 const MiB = stdx.MiB;
 const GiB = stdx.GiB;
@@ -63,11 +65,16 @@ pub const std_options: std.Options = .{
 pub fn main() !void {
     if (builtin.os.tag == .windows) try vsr.multiversion.wait_for_parent_to_exit();
 
-    var arena_instance = std.heap.ArenaAllocator.init(stdx.huge_page_allocator);
-    defer arena_instance.deinit();
-
-    // Arena is an implementation detail, all memory must be freed.
-    const gpa = arena_instance.allocator();
+    var allocator = GeneralPurposeAllocator.init;
+    allocator.backing_allocator = stdx.huge_page_allocator;
+    const gpa = allocator.allocator();
+    defer {
+        _ = allocator.detectLeaks();
+        switch (allocator.deinit()) {
+            .ok => {},
+            .leak => @panic("memory leaked"),
+        }
+    }
 
     var flags = stdx.Flags.init(gpa);
     defer flags.deinit(gpa);


### PR DESCRIPTION
Currently, we use an ArenaAllocator for all allocations. The
initial rationale for doing so was so we could report memory
usage at startup. However, since then, we implemented a
CountingAllocator to track the amount of memory allocated
on startup. Additionally, we now noticed that ArenaAllocator
rounds up large allocations by large amounts (specifically,
we saw that after https://github.com/tigerbeetle/tigerbeetle/pull/3686, a grid cache of 86GiB was not 
working on a 128GiB machine due to this rounding up):
```C
fn createNode(self: *ArenaAllocator, prev_len: usize, minimum_size: usize) ?*BufNode {
        const actual_min_size = minimum_size + (@sizeof(BufNode) + 16);
        const big_enough_len = prev_len + actual_min_size;
        const len = big_enough_len + big_enough_len / 2;
```

This commit switches to DebugAllocator. Although DebugAllocator is
inefficient for very small allocations, we don't have very many
of those (memory utilization increases by ~900KiB):
```C
// ArenaAllocator
2026-05-26 17:23:08.264Z info(main): 0: Allocated 3223214KiB during replica init
// DebugAllocator
2026-05-26 17:25:01.403Z info(main): 0: Allocated 3224132KiB during replica init
```

Double checked `./tigerbeetle start --addresses=3000 --cache-grid=100GiB`
with and without this patch, on a 128GiB machine:
```C
// ArenaAllocator
2026-05-26 17:54:22.763Z error: OutOfMemory
// DebugAllocator
2026-05-26 17:47:37.165Z info(main): 0: Allocated 106970452KiB during replica init
```